### PR TITLE
[PPO] feat: Add LoRA support for PPO 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ tests/e2e/toy_examples/deepspeed/synchronous/output.txt
 
 # vim
 *.swp
+
+.venv/

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -18,6 +18,9 @@ actor_rollout_ref:
     override_config: { }
     enable_gradient_checkpointing: True
     use_remove_padding: False
+    lora_rank: 0  # Set to positive value to enable LoRA (e.g., 32)
+    lora_alpha: 16  # LoRA scaling factor
+    target_modules: all-linear  # Target modules for LoRA adaptation
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256
@@ -48,9 +51,6 @@ actor_rollout_ref:
       grad_offload: False
       optimizer_offload: False
       fsdp_size: -1
-    lora_rank: 0  # Set to positive value to enable LoRA (e.g., 32)
-    lora_alpha: 16  # LoRA scaling factor
-    target_modules: all-linear  # Target modules for LoRA adaptation
   ref:
     fsdp_config:
       param_offload: False

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -48,6 +48,9 @@ actor_rollout_ref:
       grad_offload: False
       optimizer_offload: False
       fsdp_size: -1
+    lora_rank: 0  # Set to positive value to enable LoRA (e.g., 32)
+    lora_alpha: 16  # LoRA scaling factor
+    target_modules: all-linear  # Target modules for LoRA adaptation
   ref:
     fsdp_config:
       param_offload: False
@@ -110,6 +113,9 @@ critic:
         # transformer_layer_cls_to_wrap: None
         min_num_params: 0
       fsdp_size: -1
+    lora_rank: 0  # Set to positive value to enable LoRA (e.g., 32)
+    lora_alpha: 16  # LoRA scaling factor
+    target_modules: all-linear  # Target modules for LoRA adaptation
   ppo_mini_batch_size: ${actor_rollout_ref.actor.ppo_mini_batch_size}
   ppo_micro_batch_size: null # will be deprecated, use ppo_micro_batch_size_per_gpu
   ppo_micro_batch_size_per_gpu: null

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -323,6 +323,10 @@ class RayPPOTrainer(object):
         self.use_rm = Role.RewardModel in role_worker_mapping
         self.ray_worker_group_cls = ray_worker_group_cls
 
+        # if ref_in_actor is True, the reference policy will be actor without lora applied
+        self.ref_in_actor = config.actor_rollout_ref.model.get('lora_rank', 0) > 0
+        
+
         # define KL control
         if self.use_reference_policy:
             if config.algorithm.kl_ctrl.type == 'fixed':
@@ -474,7 +478,7 @@ class RayPPOTrainer(object):
             raise NotImplementedError
 
         # create reference policy if needed
-        if self.use_reference_policy:
+        if self.use_reference_policy and not self.ref_in_actor:
             resource_pool = self.resource_pool_manager.get_resource_pool(Role.RefPolicy)
             ref_policy_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.RefPolicy],
                                                   config=self.config.actor_rollout_ref,
@@ -506,7 +510,7 @@ class RayPPOTrainer(object):
             self.critic_wg = all_wg['critic']
             self.critic_wg.init_model()
 
-        if self.use_reference_policy:
+        if self.use_reference_policy and not self.ref_in_actor:
             self.ref_policy_wg = all_wg['ref']
             self.ref_policy_wg.init_model()
 
@@ -614,7 +618,10 @@ class RayPPOTrainer(object):
                     if self.use_reference_policy:
                         # compute reference log_prob
                         with _timer('ref', timing_raw):
-                            ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                            if not self.ref_in_actor:
+                                ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                            else:
+                                ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
                             batch = batch.union(ref_log_prob)
 
                     # compute values

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -710,7 +710,7 @@ class CriticWorker(Worker):
 
         mixed_precision = MixedPrecision(param_dtype=param_dtype, reduce_dtype=reduce_dtype, buffer_dtype=buffer_dtype)
 
-        auto_wrap_policy = get_fsdp_wrap_policy(module=critic_module, config=self.config.model.fsdp_config.wrap_policy)
+        auto_wrap_policy = get_fsdp_wrap_policy(module=critic_module, config=self.config.model.fsdp_config.wrap_policy, is_lora=self.config.model.get('lora_rank', 0) > 0)
 
         log_gpu_memory_usage('Before critic FSDP', logger=None)
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -390,15 +390,7 @@ class ActorRolloutRefWorker(Worker):
                                               actor_optimizer=self.actor_optimizer)
 
         if self._is_rollout:
-            if self._is_lora:
-                print("Merge adapter")
-                print(self.actor_module_fsdp._fsdp_wrapped_module)
-                import ipdb; ipdb.set_trace()
-                self.actor_module_fsdp.merge_adapter()
             self.rollout, self.rollout_sharding_manager = self._build_rollout()
-            if self._is_lora:
-                print("Unmerge adapter")
-                self.actor_module_fsdp.unmerge_adapter()
 
         if self._is_ref:
             self.ref_module_fsdp = self._build_model_optimizer(model_path=self.config.model.path,

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -525,12 +525,13 @@ class ActorRolloutRefWorker(Worker):
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_ref_log_prob(self, data: DataProto):
-        assert self._is_ref
         if self._is_lora:
-            # TODO
-            pass
             # if _is_lora, actor without lora applied is the ref
-            # return self.compute_log_prob(data, no_lora=True)
+            data = self.compute_log_prob(data, no_lora=True)
+            # this old_log_probs is in fact ref_log_prob
+            data = DataProto.from_dict(tensors={'ref_log_prob': data.batch['old_log_probs']})
+            return data
+        assert self._is_ref
         # else:
         # otherwise, the class have a standalone ref model
         data = data.to('cuda')

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -74,7 +74,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         if isinstance(self.module._fsdp_wrapped_module, PeftModel):
             # the model to sync weights to is a vLLM model (not a peft model), so we need to merge the adapters
             with FSDP.summon_full_params(self.module):
-                self.module._fsdp_wrapped_module.merge_adapter()
+                self.module.merge_adapter()
                 params = self.module._fsdp_wrapped_module.base_model.model.state_dict()
             # FIXME: use more rigorous way to filter out the adapter weights
             params = OrderedDict((k.replace(".base_layer.", "."), v) for k, v in params.items() if not ".lora_" in k)

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -89,7 +89,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
 
         if isinstance(self.module._fsdp_wrapped_module, PeftModel):
             with FSDP.summon_full_params(self.module):
-                self.module._fsdp_wrapped_module.unmerge_adapter()
+                self.module.unmerge_adapter()
         del params
         torch.cuda.empty_cache()
         log_gpu_memory_usage('After del state_dict and empty_cache in sharding manager', logger=logger)


### PR DESCRIPTION
This PR adds LoRA (Low-Rank Adaptation) support for PPO (#159)

## Changes
- Added LoRA support to actor and critic configuration (see #127)
- Merge the PEFT adapter before serving the model with vLLM and unmerge afterward.

## Features
- Configurable LoRA rank and alpha parameters
- Target module specification for selective adaptation
- Compatible with FSDP sharding strategy

## Some known issues:
- Merge Ref and Actor when LoRA is on requires modifying ppo_trainer logic, we need some help
- No thorough testing yet
- Line 80 of fsdp_vllm.py needs to be cleaned up
`params = OrderedDict((k.replace(".base_layer.", "."), v) for k, v in params.items() if not ".lora_" in k)`