### PR TITLE
[bug]fix bug on self.prompt_key/self.response_key of SFTDataset

### DIFF
--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -56,8 +56,8 @@ class SFTDataset(Dataset):
             tokenizer = hf_tokenizer(tokenizer)
         self.tokenizer: PreTrainedTokenizer = tokenizer
 
-        self.prompt_key = prompt_key if isinstance(prompt_key, (tuple, list)) else [prompt_key]
-        self.response_key = response_key if isinstance(response_key, (tuple, list)) else [response_key]
+        self.prompt_key = prompt_key[0] if isinstance(prompt_key, (tuple, list)) else prompt_key
+        self.response_key = response_key[0] if isinstance(response_key, (tuple, list)) else response_key
         self.prompt_dict_keys = [] if not prompt_dict_keys else prompt_dict_keys
         self.response_dict_keys = [] if not response_dict_keys else response_dict_keys
 


### PR DESCRIPTION
- change self.prompt_key/self.response_key from list type to str type.
- Otherwise, self.prompts/self.responses will be a Dataframe, and will raise an Exception when calling tolist() : `self.prompts = self.prompts.tolist()`