### PR TITLE
[bugfix] multimodal input length check

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -545,7 +545,8 @@ class RayPPOTrainer(object):
                                          max_prompt_length=self.config.data.max_prompt_length,
                                          filter_prompts=True,
                                          return_raw_chat=self.config.data.get('return_raw_chat', False),
-                                         truncation='error')
+                                         truncation='error',
+                                         filter_overlong_prompts=self.config.data.filter_overlong_prompts)
         # use sampler for better ckpt resume
         if self.config.data.shuffle:
             train_dataloader_generator = torch.Generator()
@@ -569,7 +570,8 @@ class RayPPOTrainer(object):
                                        max_prompt_length=self.config.data.max_prompt_length,
                                        filter_prompts=True,
                                        return_raw_chat=self.config.data.get('return_raw_chat', False),
-                                       truncation='error')
+                                       truncation='error',
+                                       filter_overlong_prompts=self.config.data.filter_overlong_prompts)
         self.val_dataloader = StatefulDataLoader(
             dataset=self.val_dataset,
             # Validation datasets are sent to inference engines as a whole batch,

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -182,11 +182,12 @@ class RLHFDataset(Dataset):
         if self.filter_overlong_prompts:
             from tqdm.auto import tqdm
 
-            tqdm.pandas(desc='Filtering overlong prompts')
-            preprocessed = self.dataframe.progress_apply(lambda x: self._preprocess_fn(x), axis=1)
+            tqdm.pandas(desc="Filtering overlong prompts", mininterval=2.0)
             self.dataframe = self.dataframe[
-                preprocessed.apply(
-                    lambda doc: len(self.tokenizer.tokenize(doc['prompt_with_chat_template'])) <= self.max_prompt_length
+                self.dataframe.progress_apply(
+                    lambda x: len(self.tokenizer.tokenize(self._preprocess_fn(x)["prompt_with_chat_template"]))
+                    <= self.max_prompt_length,
+                    axis=1,
                 )
             ]
             print(f'filter dataset len: {len(self.dataframe)}')


### PR DESCRIPTION
[bugfix] multimodal input length check
[feature] add support for qwen2-vl-utils format image data

When enabled `filter_overlong_prompts` in RLHFDataset, original method will not take image_placeholder into account. This PR use `prompt_with_chat_template` rather than `tokenizer.apply_chat_template(doc[prompt_key], add_generation_prompt=True)`, to count sequence length.
Also, support more diversed image input following qwen-vl-utils.