### PR TITLE
misc: remove redundant .to(device)

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -423,9 +423,6 @@ class ActorRolloutRefWorker(Worker):
         if self._is_offload_optimizer:
             load_fsdp_optimizer(optimizer=self.actor_optimizer, device_id=torch.cuda.current_device())
 
-        # Support all hardwares
-        data.batch = data.batch.to(torch.cuda.current_device())
-
         log_gpu_memory_usage('Before update policy', logger=logger)
 
         with self.ulysses_sharding_manager:
@@ -466,8 +463,6 @@ class ActorRolloutRefWorker(Worker):
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.actor_module_fsdp)
 
-        # Support all hardwares
-        prompts.batch = prompts.batch.to(torch.cuda.current_device())
         meta_info = {
             'eos_token_id':
                 self.generation_config.eos_token_id


### PR DESCRIPTION
As a `DataProto` instance, calling `to(device)` already moves data.batch to the specified device.

https://github.com/volcengine/verl/blob/329dcfe1dd60f2d736ee55914e2a49e1887718eb/verl/protocol.py#L324-L336