### PR TITLE
Fix a bug in loss mask calculation in sft_dataset.py

### DIFF
--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -148,7 +148,7 @@ class SFTDataset(Dataset):
             if self.truncation == 'left':
                 # actually, left truncation may not be reasonable
                 truncated_prompt_length = sequence_length - max_length
-                prompt_length = max(0, prompt_length - tokens_to_remove)
+                prompt_length = max(0, prompt_length - truncated_prompt_length)
                 input_ids = input_ids[-self.max_length:]
                 attention_mask = attention_mask[-self.max_length:]
             elif self.truncation == 'right':

--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -147,7 +147,7 @@ class SFTDataset(Dataset):
         elif sequence_length > self.max_length:
             if self.truncation == 'left':
                 # actually, left truncation may not be reasonable
-                tokens_to_remove = sequence_length - max_length
+                truncated_prompt_length = sequence_length - max_length
                 prompt_length = max(0, prompt_length - tokens_to_remove)
                 input_ids = input_ids[-self.max_length:]
                 attention_mask = attention_mask[-self.max_length:]

--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -147,6 +147,8 @@ class SFTDataset(Dataset):
         elif sequence_length > self.max_length:
             if self.truncation == 'left':
                 # actually, left truncation may not be reasonable
+                tokens_to_remove = sequence_length - max_length
+                prompt_length = max(0, prompt_length - tokens_to_remove)
                 input_ids = input_ids[-self.max_length:]
                 attention_mask = attention_mask[-self.max_length:]
             elif self.truncation == 'right':


### PR DESCRIPTION
It seems that there is a bug in the SFTDataset.

While it is uncommon to truncate sequence from the left side, but it is often used for SFT the base model (no chat template used). When the truncation is set as "left", the current loss_mask calculation seems incorrect. It does not consider the prompt_length changing by the truncation operation. This PR is used to fix this.  