### PR TITLE
[feat] add continue_final_message option to RLHFDataset

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -13,6 +13,7 @@ data:
   filter_overlong_prompts: False # for large-scale dataset, filtering overlong prompts could be timeconsuming. You should disable this and set `truncation='left'
   truncation: error
   image_key: images
+  continue_final_message: False # will disable addition of assistant-begin-tokens to the tokens and continue the last given message instead of terminating it and starting a new one
 
 actor_rollout_ref:
   hybrid_engine: True

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -401,7 +401,9 @@ class RayPPOTrainer(object):
                                          filter_prompts=True,
                                          return_raw_chat=self.config.data.get('return_raw_chat', False),
                                          truncation=self.config.data.get('truncation', 'error'),
-                                         filter_overlong_prompts=self.config.data.filter_overlong_prompts)
+                                         filter_overlong_prompts=self.config.data.filter_overlong_prompts,
+                                         continue_final_message=self.config.data.get('continue_final_message', False),
+                                         )
         assert self.train_dataset.truncation == self.config.data.get(
             'truncation', 'error'
         ), f'dataset truncation {self.train_dataset.truncation} must be the same as config {self.config.data.get("truncation", "error")}'
@@ -429,7 +431,9 @@ class RayPPOTrainer(object):
                                        filter_prompts=True,
                                        return_raw_chat=self.config.data.get('return_raw_chat', False),
                                        truncation=self.config.data.get('truncation', 'error'),
-                                       filter_overlong_prompts=self.config.data.filter_overlong_prompts)
+                                       filter_overlong_prompts=self.config.data.filter_overlong_prompts,
+                                       continue_final_message=self.config.data.get('continue_final_message', False),
+                                       )
         assert self.val_dataset.truncation == self.config.data.get(
             'truncation', 'error'
         ), f'dataset truncation {self.val_dataset.truncation} must be the same as config {self.config.data.get("truncation", "error")}'


### PR DESCRIPTION
This solves the issue mentioned in #656.

As described there, common implementations for R1-zero append the `\<think>` tokens to the beginning of the assistant output, given the model a strong indication to follow that format. This has been just recently realized and measured by [huggingface](https://www.linkedin.com/posts/lewis-tunstall_todays-discovery-if-you-post-train-a-7b-activity-7307426343749623809-NliI/), for example.

This pr aims to allow this behavior using a new `config.data.continue_final_message` parameter (following the name of the matching tokenizer parameter).

I believe the current implementation achieves that for the `main_ppo` use case. I'll test tomorrow in a real world use case.