### PR TITLE
[bugfix] Training with both text and multimodal dataset

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -163,7 +163,7 @@ class RLHFDataset(Dataset):
 
         prompt_with_chat_template = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=False)
 
-        is_multi_modal = self.image_key in row_dict
+        is_multi_modal = self.image_key in row_dict and not pd.isna(row_dict[self.image_key])
         if is_multi_modal:  # expand image token
             raw_prompt = prompt_with_chat_template.replace('<image>', '<|vision_start|><|image_pad|><|vision_end|>')
             row_dict['multi_modal_data'] = {'image': [process_image(image) for image in row_dict.pop(self.image_key)]}


### PR DESCRIPTION
This PR mainly optimizes the logic for training with a mixture of multimodal and text-only datasets.

Previously, the determination of is_multi_modal solely relied on whether self.image_key was present in row_dict. However, when using pd.concat() to merge datasets, a text-only dataset (which doesn't contain image information) might automatically have an empty "images" key added. As a result, the check self.image_key in row_dict would return True. Subsequently, the code would attempt to iterate over a float value (typically NaN), leading to the error "TypeError: 'float' object is not iterable".

By adding the condition and not pd.isna(row_dict[self.image_key]), we ensure that a dataset is only considered multimodal if self.image_key exists and its value is not NaN. This effectively prevents the aforementioned error, enabling the model to correctly handle mixed datasets and support training with both multimodal data (containing text and images) and text-only data.