### PR TITLE
WIP: support agent with mockek llm server and buffer dataset

### DIFF
--- a/verl/utils/dataset/buffer_dataset.py
+++ b/verl/utils/dataset/buffer_dataset.py
@@ -1,0 +1,159 @@
+from copy import deepcopy
+import logging
+import multiprocessing
+import random
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
+
+from torch.utils.data import Dataset
+
+from verl import DataProto
+from verl.utils.model import compute_position_id_with_mask
+import verl.utils.torch_functional as verl_F
+
+
+class BufferDataset(Dataset):
+
+    def __init__(self,
+                 tokenizer,
+                 buffer=None,
+                 processor=None,
+                 prompt_key="prompt",
+                 max_prompt_length=1024,
+                 request_id_key="request_id",
+                 truncation='error',
+                 length=1000000) -> None:
+        super().__init__()
+        self.buffer = buffer if buffer else multiprocessing.Queue()
+        self.prompt_key = prompt_key
+        self.request_id_key = request_id_key
+        self.processor = processor
+        self.tokenizer = tokenizer
+        self.length = length
+        self.max_prompt_length = max_prompt_length
+        self.truncation = truncation
+
+    def __len__(self):
+        return self.length
+
+    # override this method to support various message format
+    def process_messages(self, messages: List):
+        if messages[0]['role'] == 'system':
+            raw_prompt = "\n".join([x['content'] for x in messages[1:]])
+        else:
+            raw_prompt = "\n".join([x['content'] for x in messages])
+        return raw_prompt
+
+    # by default, BufferDataset is designed as a Prompt Dataset
+    def __getitem__(self, index):
+        request_id, request = self.buffer.get()
+        row_dict = dict()
+        row_dict[self.request_id_key] = request_id
+
+        if request_id != "":
+            messages = deepcopy(request.messages)
+            raw_prompt = self.process_messages(messages)
+        else:
+            row_dict = request
+            chat = row_dict.pop(self.prompt_key)
+            raw_prompt = self.tokenizer.apply_chat_template(chat, add_generation_prompt=True, tokenize=False)
+
+        input_ids, attention_mask = verl_F.tokenize_and_postprocess_data(prompt=raw_prompt,
+                                                                         tokenizer=self.tokenizer,
+                                                                         max_length=self.max_prompt_length,
+                                                                         pad_token_id=self.tokenizer.pad_token_id,
+                                                                         left_pad=True,
+                                                                         truncation=self.truncation)
+        position_ids = compute_position_id_with_mask(attention_mask)
+
+        row_dict['input_ids'] = input_ids[0]
+        row_dict['attention_mask'] = attention_mask[0]
+        row_dict['position_ids'] = position_ids[0]
+        row_dict['raw_prompt_ids'] = self.tokenizer.encode(raw_prompt, add_special_tokens=False)
+
+        # add index for each prompt
+        index = row_dict.get("extra_info", {}).get("index", 0)
+        row_dict["index"] = index
+
+        return row_dict
+
+
+class MultiRoundBufferDataset(BufferDataset):
+    _manager = multiprocessing.Manager()
+
+    def __init__(self, *args, max_concurrent_wait=16, score_key="score", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.finish_dict = self._manager.dict()
+        self.multi_round_buffer = self._manager.dict()
+        self.executor = ThreadPoolExecutor(max_workers=max_concurrent_wait)
+        self.score_key = score_key
+
+    def put_batch(self, data_proto: DataProto):
+        request_ids = data_proto.non_tensor_batch.pop("request_id")
+
+        list_of_tensordict = list(data_proto.batch.unbind(0))
+        keys = data_proto.non_tensor_batch.keys()
+        meta_info = data_proto.meta_info
+
+        enqueue_count = 0
+        buffer_count = 0
+        for idx, request_id, td in zip(range(len(request_ids)), request_ids, list_of_tensordict):
+            non_tensor_dict = {key: data_proto.non_tensor_batch[key][idx] for key in keys}
+            if request_id == "":
+                # single-round item
+                self.buffer.put((td, non_tensor_dict, meta_info))
+                # logging.info(f"enqueue a regular prompt with td = {td}")
+                enqueue_count += 1
+            else:
+                # multi-round item
+                if request_id not in self.multi_round_buffer:
+                    self.multi_round_buffer[request_id] = [(td, non_tensor_dict, meta_info)]
+                    buffer_count += 1
+                else:
+                    trajectory = self.multi_round_buffer[request_id]
+                    trajectory.append((td, non_tensor_dict, meta_info))
+                    self.multi_round_buffer[request_id] = trajectory
+                    buffer_count += 1
+        logging.info(f"enqueue_count = {enqueue_count}, {self.buffer.qsize()}")
+        logging.info(f"buffer_count = {buffer_count}, {len(self.multi_round_buffer)}")
+
+    def _wait_sample_ready_and_enqueue(self, request_id, score, total_round):
+        max_retry = 300
+        for i in range(max_retry):
+            if request_id not in self.multi_round_buffer:
+                time.sleep(10)
+                continue
+            trajectory = self.multi_round_buffer[request_id]
+            if len(trajectory) > total_round:
+                self.multi_round_buffer.pop(request_id)
+                return
+            if len(trajectory) < total_round:
+                time.sleep(10)
+                continue
+            for td, non_tensor_batch, meta_info in trajectory:
+                td[self.score_key] = score
+                self.buffer.put((td, non_tensor_batch, meta_info))
+            self.multi_round_buffer.pop(request_id)
+            return
+
+    def notify_score(self, request_id, score, total_round_count=None):
+        self.finish_dict[request_id] = score
+        if total_round_count is not None:
+            self.executor.submit(self._wait_sample_ready_and_enqueue, request_id, score, total_round_count)
+        return {}
+
+    # by default, MultiRoundBufferDataset is designed as a Train Dataset
+    def __getitem__(self, idx):
+        while True:
+            if self.buffer.empty():
+                logging.debug("buffer is empty")
+                time.sleep(1)
+            else:
+                try:
+                    item = self.buffer.get(timeout=1)
+                    if self.score_key not in item[0]:
+                        item[0][self.score_key] = -1
+                    return item
+                except Exception as e:
+                    logging.warning(f"failed to get sample from buffer: {e}")

--- a/verl/utils/mocked_server.py
+++ b/verl/utils/mocked_server.py
@@ -1,0 +1,149 @@
+import logging
+import socket
+import multiprocessing
+import queue
+import uuid
+import time
+import threading
+from typing import List
+from collections import defaultdict
+
+import uvicorn
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+
+class ChatCompletionRequest(BaseModel):
+    messages: List[dict]
+    model: str
+
+
+class TaskScore(BaseModel):
+    request_id: str
+    score: float
+
+
+def get_ip():
+    try:
+        # 获取本地主机名
+        hostname = socket.gethostname()
+        # 获取本地 IP 地址
+        local_ip = socket.gethostbyname(hostname)
+        return local_ip
+    except socket.gaierror as e:
+        print(f"获取本地 IP 地址时出错: {e}")
+        return None
+
+
+class MockedServer:
+
+    def __init__(self, port, ip, notify_score_fn=None):
+        self.app = FastAPI()
+        self.port = port
+        self.notify_score_fn = notify_score_fn
+
+        self.prompt_queue = multiprocessing.Queue()
+        self.response_dict = {}
+        self.rounds_dict = defaultdict(int)
+
+        self.ip = ip
+        assert self.ip is not None, f"ip for llm_base_url cannot be None"
+        self.llm_base_url = (f"[{self.ip}]" if ":" in self.ip else f"{self.ip}") + f":{self.port}"
+
+        self._define_routes()
+
+    def _define_routes(self):
+        # mocked openai api for chat completion
+        @self.app.post("/v1chat/completions")
+        def chat(request: ChatCompletionRequest):
+            request_id = str(uuid.uuid4()) if request.model == "" else request.model
+            self.rounds_dict[request_id] += 1
+            self.add_response_endpoint(request_id)
+            return self.chat(request_id, request)
+
+        @self.app.post("/scores")
+        def score(request: TaskScore):
+            if self.notify_score_fn is not None:
+                request_id = request.request_id
+                round_count = self.rounds_dict.pop(request_id)
+                self.notify_score_fn(request_id, request.score, round_count)
+
+    def chat(self, request_id: str, request: ChatCompletionRequest):
+        self.prompt_queue.put((request_id, request))
+        return {"id": request_id, "object": "chat.completion", "model": "", "created": int(time.time()), "choices": []}
+
+    def get_result(self, request_id: str):
+        if request_id in self.response_dict:
+            raw_result = self.response_dict.pop(request_id)
+            logprobs = raw_result["logprobs"]
+            response = raw_result["response"]
+            input_ids = raw_result["input_ids"]
+
+            result = {
+                "id": request_id,
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": "",
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": response,
+                        "reasoning_content": "",
+                    },
+                    "finish_reason": "stop",
+                    "logprobs": logprobs,
+                    "input_ids": input_ids,
+                }],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                }
+            }
+            return result
+        else:
+            return {}
+
+    def add_response_endpoint(self, request_id):
+        full_endpoint = f"/v1chat/completions/{request_id}"
+        self.app.add_api_route(full_endpoint, self.get_result, methods=["GET"], name=request_id)
+
+    def update_result(self, batched_results):
+        self.response_dict.update(batched_results)
+
+
+class ServerWithTask(MockedServer):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.task_queue = queue.Queue()
+
+    def _add_task_route(self):
+
+        @self.app.get("/tasks")
+        def get_task():
+            try:
+                result = self.task_queue.get(block=False)
+                return result
+            except Exception as e:
+                return {"task": {}, "error": "No tasks available"}
+
+
+def create_and_launch_task_pool(port, ip=None, notify_score_fn=None, with_task=False):
+    server_cls = ServerWithTask if with_task else MockedServer
+    mocked_server = server_cls(port=port, ip=ip, notify_score_fn=notify_score_fn)
+
+    if ip is None:
+        ip = get_ip()
+
+    # launch Uvicorn server thread
+    logging.info(f"using port: {mocked_server.port}")
+    server_thread = threading.Thread(target=lambda: uvicorn.run(mocked_server.app,
+                                                                host="::" if ":" in ip else "0.0.0.0",
+                                                                port=mocked_server.port,
+                                                                limit_concurrency=2000,
+                                                                log_level="info"))
+    server_thread.daemon = True
+    server_thread.start()
+
+    return mocked_server, server_thread

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -96,7 +96,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             model = self.inference_engine.llm_engine.model_executor.driver_worker.worker.model_runner.model
             loaded_params = model.load_weights(
                 ((name, param.full_tensor() if world_size != 1 else param) for name, param in params.items()))
-            logger.info(f"vLLM load wegiths, loaded_params: {len(loaded_params)}")
+            logger.info(f"vLLM load weights, loaded_params: {len(loaded_params)}")
 
         log_gpu_memory_usage('After sync model weights in sharding manager', logger=logger)
 


### PR DESCRIPTION
Introducing a single-controller approach to integrating agent, game and other env in rl for llm.

Features:
1. Support multi-round environments e.g. Agentless
2. Support OpenAI API to call llm inference server (create + keep trying retrieve)
3. Maintain the single-controller programming paradigm in verl
4. Support mixed batch (a batch mixed with prompts from both parquet and envs)

doc: https://bytedance.larkoffice.com/docx/EyoKd00VsoPgLuxut8vcRRtLn4U

Will add demo soon.