### PR TITLE
Make DAPO rollout faster and more efficient (Refactor ShardingManager)

### DIFF
--- a/recipe/dapo/run_dapo_qwen2.5_32b.sh
+++ b/recipe/dapo/run_dapo_qwen2.5_32b.sh
@@ -55,6 +55,8 @@ infer_ppo_max_token_len=$((max_prompt_length + max_response_length))
 offload=True
 gen_tp=4
 
+use_efficient_resharding=False  # Change to True if you want to use efficient resharding
+
 ray job submit --no-wait --runtime-env="${RUNTIME_ENV}" \
     --working-dir "${WORKING_DIR}" \
     -- python3 -m recipe.dapo.src.main_dapo \
@@ -75,6 +77,7 @@ ray job submit --no-wait --runtime-env="${RUNTIME_ENV}" \
     actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
     actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
     actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.model.use_efficient_resharding=${use_efficient_resharding} \
     algorithm.filter_groups.enable=${enable_filter_groups} \
     algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.filter_groups.metric=${filter_groups_metric} \

--- a/recipe/dapo/src/config/dapo_trainer.yaml
+++ b/recipe/dapo/src/config/dapo_trainer.yaml
@@ -24,6 +24,7 @@ actor_rollout_ref:
     override_config: { }
     enable_gradient_checkpointing: True
     use_remove_padding: False
+    use_efficient_resharding: False  # For backward compatibility
   actor:
     strategy: fsdp  # This is for backward-compatibility
     ppo_mini_batch_size: 256

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -522,7 +522,7 @@ class ActorRolloutRefWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def setup_generate_sequences_efficient(self, prompts: DataProto):
+    def setup_generate_sequences_efficient(self, prompts: DataProto) -> DataProto:
         logger.info("Setting up efficient sequence generation.")
         assert self._is_rollout
         if self._is_offload_param:
@@ -539,14 +539,14 @@ class ActorRolloutRefWorker(Worker):
         return prompts  # Dummy return to match the interface
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def teardown_generate_sequences_efficient(self, prompts: DataProto):
+    def teardown_generate_sequences_efficient(self, prompts: DataProto) -> DataProto:
         logger.info("Tearing down efficient sequence generation.")
         self.rollout_sharding_manager.exit_sharding_context()
         log_gpu_memory_usage('After exiting rollout sharding manager', logger=logger)
         return prompts  # Dummy return to match the interface
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    def generate_sequences_efficient(self, prompts: DataProto):
+    def generate_sequences_efficient(self, prompts: DataProto) -> DataProto:
         # Support all hardwares
         prompts = prompts.to(torch.cuda.current_device())
         meta_info = {

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -522,6 +522,50 @@ class ActorRolloutRefWorker(Worker):
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def setup_generate_sequences_efficient(self, prompts: DataProto):
+        logger.info("Setting up efficient sequence generation.")
+        assert self._is_rollout
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.actor_module_fsdp)
+
+        # Reshard FSDP model for rollout
+        self.rollout_sharding_manager.enter_sharding_context()
+        if self._is_offload_param:
+            offload_fsdp_model_to_cpu(self.actor_module_fsdp)
+        if self._is_offload_optimizer:
+            offload_fsdp_optimizer(optimizer=self.actor_optimizer)
+
+        log_gpu_memory_usage('After entering rollout sharding manager', logger=logger)
+        return prompts  # Dummy return to match the interface
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def teardown_generate_sequences_efficient(self, prompts: DataProto):
+        logger.info("Tearing down efficient sequence generation.")
+        self.rollout_sharding_manager.exit_sharding_context()
+        log_gpu_memory_usage('After exiting rollout sharding manager', logger=logger)
+        return prompts  # Dummy return to match the interface
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def generate_sequences_efficient(self, prompts: DataProto):
+        # Support all hardwares
+        prompts = prompts.to(torch.cuda.current_device())
+        meta_info = {
+            'eos_token_id':
+                self.generation_config.eos_token_id
+                if self.generation_config is not None else self.tokenizer.eos_token_id,
+            'pad_token_id':
+                self.generation_config.pad_token_id
+                if self.generation_config is not None else self.tokenizer.pad_token_id,
+        }
+        prompts.meta_info.update(meta_info)
+        prompts = self.rollout_sharding_manager.preprocess_data(prompts)
+        output = self.rollout.generate_sequences(prompts=prompts)
+        log_gpu_memory_usage('After rollout generation', logger=logger)
+        output = self.rollout_sharding_manager.postprocess_data(output)
+        output = output.to('cpu')
+        return output
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def compute_log_prob(self, data: DataProto):
         assert self._is_actor
         if self._is_offload_param:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -541,7 +541,7 @@ class ActorRolloutRefWorker(Worker):
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     def teardown_generate_sequences_efficient(self, prompts: DataProto) -> DataProto:
         logger.info("Tearing down efficient sequence generation.")
-        self.rollout_sharding_manager.exit_sharding_context()
+        self.rollout_sharding_manager.exit_sharding_context(None, None, None)
         log_gpu_memory_usage('After exiting rollout sharding manager', logger=logger)
         return prompts  # Dummy return to match the interface
 

--- a/verl/workers/sharding_manager/base.py
+++ b/verl/workers/sharding_manager/base.py
@@ -14,16 +14,39 @@
 """
 Sharding manager to implement HybridEngine
 """
+import abc
 
 from verl import DataProto
 
 
-class BaseShardingManager:
+class BaseShardingManager(metaclass=abc.ABCMeta):
 
-    def __enter__(self):
+    def __enter__(self) -> None:
+        return self.enter_sharding_context()
+
+    # Put type hints.
+    def __exit__(self,
+                 exc_type: type,
+                 exc_value: Exception,
+                 traceback: object) -> None:
+
+        return self.exit_sharding_context(exc_type, exc_value, traceback)
+
+    @abc.abstractmethod
+    def enter_sharding_context(self) -> None:
+        """
+        For explicitly entering sharding context, e.g., DAPO rollout.
+        """
         pass
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    @abc.abstractmethod
+    def exit_sharding_context(self, 
+                              exc_type: type,
+                              exc_value: Exception,
+                              traceback: object) -> None:
+        """
+        For explicitly exiting sharding context, e.g., DAPO rollout.
+        """
         pass
 
     def preprocess_data(self, data: DataProto) -> DataProto:

--- a/verl/workers/sharding_manager/fsdp_sglang.py
+++ b/verl/workers/sharding_manager/fsdp_sglang.py
@@ -80,7 +80,7 @@ class FSDPSGLangShardingManager(BaseShardingManager):
         else:
             self.gen_random_states = None
 
-    def __enter__(self):
+    def enter_sharding_context(self):
         torch.cuda.empty_cache()
         log_gpu_memory_usage('Before state_dict() in sharding manager memory', logger=logger)
         params = self.module.state_dict()
@@ -107,7 +107,7 @@ class FSDPSGLangShardingManager(BaseShardingManager):
             self.torch_random_states = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(self.gen_random_states)
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def exit_sharding_context(self, exc_type, exc_value, traceback):
         log_gpu_memory_usage('Before SGLang offload in sharding manager', logger=logger)
         self.inference_engine.release_memory_occupation()
         log_gpu_memory_usage('After SGLang offload in sharding manager', logger=logger)

--- a/verl/workers/sharding_manager/fsdp_ulysses.py
+++ b/verl/workers/sharding_manager/fsdp_ulysses.py
@@ -39,7 +39,7 @@ class FSDPUlyssesShardingManager(BaseShardingManager):
         self.device_mesh = device_mesh
         self.seed_offset = 12345
 
-    def __enter__(self):
+    def enter_sharding_context(self):
         if self.device_mesh is not None:
             # We have a global SP group
             # so we have to change to use model-specific sp group
@@ -47,7 +47,7 @@ class FSDPUlyssesShardingManager(BaseShardingManager):
             set_ulysses_sequence_parallel_group(self.device_mesh['sp'].get_group())
             # TODO: check how to set seed for each model
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def exit_sharding_context(self, exc_type, exc_value, traceback):
         # restore random states
         if self.device_mesh is not None:
             # revert to previous sp group

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -73,7 +73,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         else:
             self.gen_random_states = None
 
-    def __enter__(self):
+    def enter_sharding_context(self):
         # NOTE: Basically, we only need `torch.cuda.empty_cache()` before vllm wake_up and
         # after vllm sleep, since vllm has its own caching memory allocator CuMemAllocator.
         # Out of vllm scope, we should avoid empty cache to let pytorch using caching memory
@@ -120,7 +120,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
             self.torch_random_states = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(self.gen_random_states)
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def exit_sharding_context(self, exc_type, exc_value, traceback):
         log_gpu_memory_usage('Before vllm offload in sharding manager', logger=logger)
         # TODO(ZSL): check this
         if vllm_version in ('0.4.2', '0.5.4', '0.6.3'):

--- a/verl/workers/sharding_manager/megatron_vllm.py
+++ b/verl/workers/sharding_manager/megatron_vllm.py
@@ -368,7 +368,7 @@ class MegatronVLLMShardingManager(BaseShardingManager):
 
         return origin_params
 
-    def __enter__(self):
+    def enter_sharding_context(self):
         # create a new cuda space for parameters not in this pp rank
         self.module.load_params_to_cuda()
         # broadcast the parameters from pp rank to other ranks
@@ -383,7 +383,7 @@ class MegatronVLLMShardingManager(BaseShardingManager):
         self.origin_params = self._post_process_params(self.params)
         self.inference_engine.sync_model_weights(self.params, load_format='megatron')
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def exit_sharding_context(self, exc_type, exc_value, traceback):
         # offload parameters doesn't belong to this pp rank
         self.module.offload_params_to_cpu()
 


### PR DESCRIPTION
Thank you for sharing the great codebase.

While experimenting with DAPO, I observed that model resharding/offloading occurs multiple times when `filter_groups` is enabled. This is due to the current ShardingManager context reverting all sharded/offloaded models at `__exit__`, which becomes inefficient - especially with large models, e.g., 70B - when the context is re-entered multiple times without model updates.

To address this, I refactored the lifecycle of ShardingManager into three separate functions: enter, rollout, and exit. This allows the model to be sharded/offloaded and later reverted only once, rather than at every rollout step. `__enter__` and `__exit__` operates as same as before.

To minimize interface changes, I kept some dummy arguments (e.g., dummy input to `setup_generate_sequences_efficient` and `teardown_generate_sequences_efficient`), which can be revisited later. Feedback on this approach or implementation details is highly appreciated.

Note: This PR is not yet ready to be merged. Pending tasks include:
- Add support for Megatron (currently FSDP-only)
- Test & benchmark performance improvements
- Polish the implementation for readability and maintainability

Please let me know if I overlooked anything. Thanks in advance!