### PR TITLE
Enhance `load_extern_type` to support direct module imports

### DIFF
--- a/verl/utils/import_utils.py
+++ b/verl/utils/import_utils.py
@@ -64,10 +64,14 @@ def load_extern_type(file_path: Optional[str], type_name: Optional[str]):
     if not file_path:
         return None
 
-    if not os.path.exists(file_path):
-        raise FileNotFoundError(f"Custom type file '{file_path}' not found.")
-
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
+    # try load spec directly
+    spec = importlib.util.find_spec(file_path)
+    if spec is None:
+        # try to load spec from file
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Custom type file '{file_path}' not found.")
+        spec = importlib.util.spec_from_file_location("custom_module", file_path)
+        
     module = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(module)

--- a/verl/utils/import_utils.py
+++ b/verl/utils/import_utils.py
@@ -71,7 +71,7 @@ def load_extern_type(file_path: Optional[str], type_name: Optional[str]):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"Custom type file '{file_path}' not found.")
         spec = importlib.util.spec_from_file_location("custom_module", file_path)
-        
+
     module = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(module)


### PR DESCRIPTION
This enhancement updates `load_extern_type` in `import_utils.py` to support importing modules directly by name in addition to the existing file path method.

### Motivation  
Previously, specifying an external class required an explicit file path:
```yaml
custom_cls:
    path: /root/code/verl/verl/utils/dataset/rl_agent_dataset.py
    name: RLAgentDataset
```

This update allows using standard Python module paths instead:
```yaml
custom_cls:
    path: verl.utils.dataset.rl_agent_dataset
    name: RLAgentDataset
```

This improves portability and readability of config files, especially when working across different environments or repos.

### Code Changes  
Modified `load_extern_type` logic:
- First, attempt to load the module using `importlib.util.find_spec()`.
- If that fails, fall back to the original behavior of loading via file path using `spec_from_file_location`.