### PR TITLE
[misc] change logging prefix for WorkerDict

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -486,7 +486,7 @@ def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):
             use `set()` instead of `list()`, because hybrid engine gives
             `clas_dict = {'ref': ActorRollout, 'actor_rollout': ActorRollout}`
             """
-            names = set(str(user_cls) for _, user_cls in self.worker_dict.items())
+            names = set(type(user_cls).__name__ for _, user_cls in self.worker_dict.items())
             joined_names = ','.join(names)
             return "WorkerDict[{name}]".format(name=joined_names)
         


### PR DESCRIPTION
Net effect is that `(WorkerDict pid=xxx)` becomes `(WorkerDict[ActorRolloutRefWorker] pid=xxx)` in when using `print()` statement with console logging.

changes include:
- move `def _unwrap_ray_remote` to private class method of `class RayClassWithInitArgs`.
- add `def __repr__()` to `class WorkerDict`, according to [guide here](https://docs.ray.io/en/latest/ray-observability/user-guides/configure-logging.html#customizing-prefixes-for-actor-logs)
- refactoring of input validation logic of `def create_colocated_worker_cls()`.
