### PR TITLE
Add RoPE scaling feature to SFT trainer

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -212,6 +212,15 @@ class FSDPSFTTrainer:
             use_meta_tensor=not config.tie_word_embeddings, mesh=self.device_mesh
         )
 
+        # Perform RoPE scaling when self.config.model.rope_scaling is not None
+        from verl.utils.model import print_model_size, update_model_config
+        override_config_kwargs = {}
+        if 'rope_scaling' in self.config.model and self.config.model.rope_scaling is not None:
+            override_config_kwargs['rope_scaling'] = dict(self.config.model.rope_scaling)
+            print(f'rope_scaling setted. rope_scaling={override_config_kwargs["rope_scaling"]}')
+        update_model_config(config, override_config_kwargs=override_config_kwargs)
+        print(f'Model config after override: {config}')
+
         with init_context():
             self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
                 local_model_path,


### PR DESCRIPTION
# Add RoPE Scaling Feature to SFT Trainer

## Description
This PR adds support for RoPE (Rotary Position Embedding) scaling in the SFT trainer. RoPE scaling is a technique that allows models to handle longer context lengths than they were originally trained on by scaling the position embeddings.

## Changes
- Added RoPE scaling configuration support in the FSDP SFT trainer
- Implemented model config override mechanism for RoPE scaling parameters
- Added appropriate logging for RoPE scaling configuration

## Usage
To use this feature, add a `rope_scaling` configuration in your model config:

```yaml
model:
  rope_scaling:
    type: "linear"  # or "dynamic"
    factor: 2.0     # scaling factor
```

Testing
Tested with various models that support RoPE scaling, including Llama and Qwen models.
