### PR TITLE
Add Adaptive Entropy Adjustment

### DIFF
--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -48,8 +48,9 @@ actor_rollout_ref:
     loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
     # NOTE: "token-mean" is the default behavior
     entropy_coeff: 0
-    use_adaptive_entropy_adjustment: True # target entropy for adaptive entropy control in Skywork-OR1-32B
+    use_adaptive_entropy_adjustment: True # adaptive entropy control in Skywork-OR1-32B
     target_entropy: 0.5 # target entropy for adaptive entropy control in Skywork-OR1-32B
+    entropy_coeff_delta: 0.00005 # entropy_coeff_delta for adaptive entropy control in Skywork-OR1-32B
     use_kl_loss: False # True for GRPO
     kl_loss_coef: 0.001 # for grpo
     kl_loss_type: low_var_kl # for grpo

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -48,6 +48,8 @@ actor_rollout_ref:
     loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
     # NOTE: "token-mean" is the default behavior
     entropy_coeff: 0
+    use_adaptive_entropy_adjustment: True # target entropy for adaptive entropy control in Skywork-OR1-32B
+    target_entropy: 0.5 # target entropy for adaptive entropy control in Skywork-OR1-32B
     use_kl_loss: False # True for GRPO
     kl_loss_coef: 0.001 # for grpo
     kl_loss_type: low_var_kl # for grpo

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -44,6 +44,8 @@ actor_rollout_ref:
     clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
     loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
     entropy_coeff: 0
+    target_entropy: 0.5 # target entropy for adaptive entropy control in Skywork-OR1-32B
+    use_adaptive_entropy_adjustment: True # target entropy for adaptive entropy control in Skywork-OR1-32B
     use_kl_loss: False # True for GRPO
     use_torch_compile: True # False to disable torch compile
     kl_loss_coef: 0.001 # for grpo

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -45,7 +45,8 @@ actor_rollout_ref:
     loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
     entropy_coeff: 0
     target_entropy: 0.5 # target entropy for adaptive entropy control in Skywork-OR1-32B
-    use_adaptive_entropy_adjustment: True # target entropy for adaptive entropy control in Skywork-OR1-32B
+    use_adaptive_entropy_adjustment: True # adaptive entropy control in Skywork-OR1-32B
+    entropy_coeff_delta: 0.00005 # entropy_coeff_delta for adaptive entropy control in Skywork-OR1-32B
     use_kl_loss: False # True for GRPO
     use_torch_compile: True # False to disable torch compile
     kl_loss_coef: 0.001 # for grpo

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -335,7 +335,6 @@ class DataParallelPPOActor(BasePPOActor):
                     entropy_coeff_delta = self.config.get("entropy_coeff_delta", None)
                     if use_adaptive_entropy_adjustment:
                         assert target_entropy is not None, f"target_entropy must be provided if {use_adaptive_entropy_adjustment=}, but got None."
-                        assert entropy_coeff != 0, f"entropy_coeff must be not 0 if {use_adaptive_entropy_adjustment=}, but got 0."
                         assert entropy_coeff_delta is not None, f"entropy_coeff_delta must be provided if {use_adaptive_entropy_adjustment=}, but got None."
                     # all return: (bsz, response_length)
                     calculate_entropy = False

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -330,10 +330,14 @@ class DataParallelPPOActor(BasePPOActor):
                     clip_ratio_c = self.config.get("clip_ratio_c", 3.0)
                     entropy_coeff = self.config.entropy_coeff
                     loss_agg_mode = self.config.loss_agg_mode
-
+                    use_adaptive_entropy_adjustment = self.config.get("use_adaptive_entropy_adjustment", False)
+                    target_entropy = self.config.get("target_entropy", None)
+                    if use_adaptive_entropy_adjustment:
+                        assert target_entropy is not None, f"target_entropy must be provided if {use_adaptive_entropy_adjustment=}, but got None."
+                        assert entropy_coeff != 0, f"entropy_coeff must be not 0 if {use_adaptive_entropy_adjustment=}, but got 0."
                     # all return: (bsz, response_length)
                     calculate_entropy = False
-                    if entropy_coeff != 0:
+                    if entropy_coeff != 0 or use_adaptive_entropy_adjustment:
                         calculate_entropy = True
                     entropy, log_prob = self._forward_micro_batch(
                         micro_batch=data, temperature=temperature, calculate_entropy=calculate_entropy
@@ -351,14 +355,24 @@ class DataParallelPPOActor(BasePPOActor):
                         loss_agg_mode=loss_agg_mode,
                     )
 
-                    if entropy_coeff != 0:
+                    if use_adaptive_entropy_adjustment:
                         entropy_loss = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
-
+                        if entropy_loss.detach().item() > target_entropy:
+                            entropy_coeff = 0
                         # compute policy loss
-                        policy_loss = pg_loss - entropy_loss * entropy_coeff
+                        if entropy_coeff != 0:
+                            policy_loss = pg_loss - entropy_loss * entropy_coeff
+                        else:
+                            policy_loss = pg_loss
+                        metrics["actor/entropy_coeff"] = entropy_coeff
+                        metrics["actor/entropy_loss"] = entropy_loss.detach().item()
                     else:
-                        policy_loss = pg_loss
-
+                        if entropy_coeff == 0:
+                            policy_loss = pg_loss
+                        else:
+                            entropy_loss = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                            policy_loss = pg_loss - entropy_loss * entropy_coeff
+                    
                     if self.config.use_kl_loss:
                         ref_log_prob = data["ref_log_prob"]
                         # compute kl loss

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -347,9 +347,13 @@ class MegatronPPOActor(BasePPOActor):
                     entropy_coeff = meta_info["entropy_coeff"]
                     target_entropy = meta_info["target_entropy"]
                     use_adaptive_entropy_adjustment = meta_info["use_adaptive_entropy_adjustment"]
+                    entropy_coeff_delta = meta_info["entropy_coeff_delta"]
                     if use_adaptive_entropy_adjustment:
                         if entropy_loss.detach().item() > target_entropy:
                             entropy_coeff = 0
+                        else:
+                            self.config.entropy_coeff += entropy_coeff_delta
+                            entropy_coeff = self.config.entropy_coeff
                         metrics["actor/entropy_coeff"] = entropy_coeff
                         metrics["actor/entropy_loss"] = entropy_loss.detach().item()
                     if entropy_coeff > 0:
@@ -403,15 +407,18 @@ class MegatronPPOActor(BasePPOActor):
                 clip_ratio_c = self.config.get("clip_ratio_c", 3.0)
                 use_adaptive_entropy_adjustment = self.config.get("use_adaptive_entropy_adjustment", False)
                 target_entropy = self.config.get("target_entropy", None)
+                entropy_coeff_delta = self.config.get("entropy_coeff_delta", None)
                 if use_adaptive_entropy_adjustment:
                     assert target_entropy is not None, f"target_entropy must be provided if {use_adaptive_entropy_adjustment=}, but got None."
                     assert self.config.entropy_coeff != 0, f"entropy_coeff must be not 0 if {use_adaptive_entropy_adjustment=}, but got 0."
+                    assert entropy_coeff_delta is not None, f"entropy_coeff_delta must be provided if {use_adaptive_entropy_adjustment=}, but got None."
                 meta_info = {
                     "clip_ratio": self.config.clip_ratio,
                     "entropy_coeff": self.config.entropy_coeff,
                     "clip_ratio_c": clip_ratio_c,
                     "use_adaptive_entropy_adjustment": use_adaptive_entropy_adjustment,
                     "target_entropy": target_entropy,
+                    "entropy_coeff_delta": entropy_coeff_delta
                 }
             return output, partial(loss_func, data=batch, meta_info=meta_info)
 
@@ -465,7 +472,7 @@ class MegatronPPOActor(BasePPOActor):
                 # if use distributed optimizer, zero grad buffer will be handled by optimizer
                 chunk.zero_grad_buffer()
 
-            calculate_entropy = self.config.entropy_coeff != 0
+            calculate_entropy = (self.config.entropy_coeff != 0 or self.config.use_adaptive_entropy_adjustment)
             metric_micro_batch = self.forward_backward_batch(data, calculate_entropy=calculate_entropy)
             for metric in metric_micro_batch:
                 # Note that o[0] is metrics, o[1] is entropy, o[2] is response_mask

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -410,7 +410,6 @@ class MegatronPPOActor(BasePPOActor):
                 entropy_coeff_delta = self.config.get("entropy_coeff_delta", None)
                 if use_adaptive_entropy_adjustment:
                     assert target_entropy is not None, f"target_entropy must be provided if {use_adaptive_entropy_adjustment=}, but got None."
-                    assert self.config.entropy_coeff != 0, f"entropy_coeff must be not 0 if {use_adaptive_entropy_adjustment=}, but got 0."
                     assert entropy_coeff_delta is not None, f"entropy_coeff_delta must be provided if {use_adaptive_entropy_adjustment=}, but got None."
                 meta_info = {
                     "clip_ratio": self.config.clip_ratio,

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -345,10 +345,20 @@ class MegatronPPOActor(BasePPOActor):
                 if not forward_only:
                     entropy_loss = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
                     entropy_coeff = meta_info["entropy_coeff"]
-                    policy_loss = pg_loss - entropy_coeff * entropy_loss
+                    target_entropy = meta_info["target_entropy"]
+                    use_adaptive_entropy_adjustment = meta_info["use_adaptive_entropy_adjustment"]
+                    if use_adaptive_entropy_adjustment:
+                        if entropy_loss.detach().item() > target_entropy:
+                            entropy_coeff = 0
+                        metrics["actor/entropy_coeff"] = entropy_coeff
+                        metrics["actor/entropy_loss"] = entropy_loss.detach().item()
+                    if entropy_coeff > 0:
+                        policy_loss = pg_loss - entropy_coeff * entropy_loss
+                    else:
+                        policy_loss = pg_loss
                 else:
                     ret_entropy = entropy
-
+            
             stats = {}
             if forward_only:
                 policy_loss = torch.tensor(1.0, device=output.device)
@@ -391,10 +401,17 @@ class MegatronPPOActor(BasePPOActor):
                 meta_info = None
             else:
                 clip_ratio_c = self.config.get("clip_ratio_c", 3.0)
+                use_adaptive_entropy_adjustment = self.config.get("use_adaptive_entropy_adjustment", False)
+                target_entropy = self.config.get("target_entropy", None)
+                if use_adaptive_entropy_adjustment:
+                    assert target_entropy is not None, f"target_entropy must be provided if {use_adaptive_entropy_adjustment=}, but got None."
+                    assert self.config.entropy_coeff != 0, f"entropy_coeff must be not 0 if {use_adaptive_entropy_adjustment=}, but got 0."
                 meta_info = {
                     "clip_ratio": self.config.clip_ratio,
                     "entropy_coeff": self.config.entropy_coeff,
                     "clip_ratio_c": clip_ratio_c,
+                    "use_adaptive_entropy_adjustment": use_adaptive_entropy_adjustment,
+                    "target_entropy": target_entropy,
                 }
             return output, partial(loss_func, data=batch, meta_info=meta_info)
 


### PR DESCRIPTION

This update uses the Adaptive Entropy Adjustment proposed in the article found at [Skywork Open Reasoner](https://capricious-hydrogen-41c.notion.site/Skywork-Open-Reasoner-Series-1d0bc9ae823a80459b46c149e4f51680). When using automatic entropy adjustment, a default **target_entropy** needs to be set, similar to what is described in the **Soft Actor-Critic** Algorithms and Applications [paper](https://arxiv.org/abs/1812.05905).


To simplify the optimization strategy for **entropy_coeff**, we set **entropy_coeff=0** when the **current entropy is greater than target_entropy.** At all other times, when entropy < target_entropy, we can consider increasing the value of **entropy_coeff** by **entropy_coeff_delta**.

Ultimately, the goal is to maintain the entropy at the specified target_entropy.

<img width="737" alt="Clipboard_Screenshot_1745465289" src="https://github.com/user-attachments/assets/e0474d8c-e4d4-479d-88db-7809c81203da" />
