### PR TITLE
Explicitly initialize optimizer states to prevent OOM during rollout

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -40,6 +40,7 @@ from verl.utils.fsdp_utils import (
     get_fsdp_wrap_policy,
     get_init_weight_context_manager,
     init_fn,
+    init_optimizer_state,
     load_fsdp_model_to_gpu,
     load_fsdp_optimizer,
     offload_fsdp_model_to_cpu,
@@ -303,6 +304,7 @@ class ActorRolloutRefWorker(Worker):
             else:
                 raise NotImplementedError(f"Warmup style {warmup_style} is not supported")
 
+            init_optimizer_state(optimizer=actor_optimizer)
             log_gpu_memory_usage(f"After {role} optimizer init", logger=logger)
         else:
             actor_optimizer = None
@@ -850,6 +852,7 @@ class CriticWorker(Worker):
         else:
             raise NotImplementedError(f"Warmup style {warmup_style} is not supported")
 
+        init_optimizer_state(optimizer=critic_optimizer)
         return critic_module, critic_optimizer, critic_lr_scheduler
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)


### PR DESCRIPTION
# What does this PR do?

Optimizer states are lazily initialized on the first step, which can lead to an over-allocation of the KV cache when `optimizer_offload=False`, potentially causing an out-of-memory (OOM) error during the rollout phase.

# ChangeLog:

- Manually initialize optimizer state before building the rollout.


## Before submitting

- [x] Did you read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide) and finish the [code format check](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting)? 
- [x] Did you make sure to update the documentations with your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs) especially for breaking config etc?
- [x] Did you write any test cases if neccessary? Please add CI tests to your new feature.  

# Additional Info: 
- **Issue Number**: none
- **Training**: FSDP
- **Inference**: none
