### PR TITLE
[BREAKING] feat: decouple PPO epochs from critic

### DIFF
--- a/examples/split_placement/config/ppo_trainer_split.yaml
+++ b/examples/split_placement/config/ppo_trainer_split.yaml
@@ -119,7 +119,7 @@ critic:
   ppo_max_token_len_per_gpu: 32768 # (${actor_rollout_ref.actor.ppo_max_token_len_per_gpu}) * 2
   forward_max_token_len_per_gpu: ${critic.ppo_max_token_len_per_gpu}
   ulysses_sequence_parallel_size: 1 # sp size
-  ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
+  epochs: 1
   shuffle: ${actor_rollout_ref.actor.shuffle}
   grad_clip: 1.0
   cliprange_value: 0.5

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -192,7 +192,7 @@ critic:
   ppo_micro_batch_size: null # will be deprecated, use ppo_micro_batch_size_per_gpu
   ppo_micro_batch_size_per_gpu: null
   use_dynamic_bsz: ${actor_rollout_ref.actor.use_dynamic_bsz}
-  ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
+  epochs: 1
   data_loader_seed: ${actor_rollout_ref.actor.data_loader_seed}
   shuffle: ${actor_rollout_ref.actor.shuffle}
   cliprange_value: 0.5

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -160,7 +160,7 @@ critic:
   ppo_max_token_len_per_gpu: 32768 # (${actor_rollout_ref.actor.ppo_max_token_len_per_gpu}) * 2
   forward_max_token_len_per_gpu: ${critic.ppo_max_token_len_per_gpu}
   ulysses_sequence_parallel_size: 1 # sp size
-  ppo_epochs: ${actor_rollout_ref.actor.ppo_epochs}
+  epochs: 1
   shuffle: ${actor_rollout_ref.actor.shuffle}
   grad_clip: 1.0
   cliprange_value: 0.5

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -186,7 +186,7 @@ class DataParallelPPOCritic(BasePPOCritic):
         else:
             dataloader = batch.split(self.config.ppo_mini_batch_size)
 
-        for epoch in range(self.config.ppo_epochs):
+        for epoch in range(self.config.epochs):
             for batch_idx, data in enumerate(dataloader):
                 # split batch into micro_batches
                 mini_batch = data

--- a/verl/workers/critic/megatron_critic.py
+++ b/verl/workers/critic/megatron_critic.py
@@ -123,7 +123,7 @@ class MegatronPPOCritic(BasePPOCritic):
         data = data.select(batch_keys=select_keys)
         return data.make_iterator(
             mini_batch_size=self.config.ppo_mini_batch_size,
-            epochs=self.config.ppo_epochs,
+            epochs=self.config.epochs,
             seed=self.config.data_loader_seed,
             dataloader_kwargs={"shuffle": self.config.shuffle},
         )

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -921,7 +921,7 @@ class CriticWorker(Worker):
 
             global_num_tokens = data.meta_info["global_token_num"]
             estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
-            metrics["perf/mfu/critic"] = estimated_flops * self.config.ppo_epochs / promised_flops / self.world_size
+            metrics["perf/mfu/critic"] = estimated_flops * self.config.epochs / promised_flops / self.world_size
 
             self.critic_lr_scheduler.step()
             lr = self.critic_lr_scheduler.get_last_lr()[0]

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -653,7 +653,7 @@ class CriticWorker(MegatronWorker):
         delta_time = timer.last
         global_num_tokens = data.meta_info["global_token_num"]
         estimated_flops, promised_flops = self.flops_counter.estimate_flops(global_num_tokens, delta_time)
-        metrics["perf/mfu/critic"] = estimated_flops * self.config.ppo_epochs / promised_flops / self.world_size
+        metrics["perf/mfu/critic"] = estimated_flops * self.config.epochs / promised_flops / self.world_size
         output = DataProto(batch=None, meta_info={"metrics": metrics})
 
         if self._is_offload_param:


### PR DESCRIPTION
### Checklist Before Starting

- [X] Search for similar PR(s).

### What does this PR do?

Currently, `ppo_epochs` is used for both the actor, as well as the critic. While this is the case for many PPO implementations (https://github.com/EdanToledo/Stoix, https://github.com/openai/baselines), there is no inherent reason why this should be the case. This is probably due to historic reasons, since OpenAI's PPO implementation had a single loss for both actor and critic (https://github.com/openai/baselines/blob/ea25b9e8b234e6ee1bca43083f8f3cf974143998/baselines/ppo2/model.py; inherent coupling of `num_epochs` between actor and critic).

This PR simply decouples the actor and critic epochs.

### API

The only API change is that I renamed `critic.ppo_epochs` to `critic.epochs` to reflect the new behaviour.

### Additional Info.

- **Training**: [FSDP, Megatron]
- **Inference**: []

### Checklist Before Submitting

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [X] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
