### PR TITLE
WIP: FP8 train

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -31,7 +31,7 @@ actor_rollout_ref:
     use_liger: False
     trust_remote_code: False
   actor:
-    strategy: fsdp  # [fsdp, fsdp2], This is for backward-compatibility
+    strategy: fsdp2  # [fsdp, fsdp2], This is for backward-compatibility
     ppo_mini_batch_size: 256
     ppo_micro_batch_size: null # will be deprecated, use ppo_micro_batch_size_per_gpu
     ppo_micro_batch_size_per_gpu: null
@@ -63,6 +63,7 @@ actor_rollout_ref:
       total_training_steps: -1  # must be override by program
       weight_decay: 0.01
     fsdp_config:
+      fp8: True
       wrap_policy:
         # transformer_layer_cls_to_wrap: None
         min_num_params: 0
@@ -72,8 +73,9 @@ actor_rollout_ref:
       reshard_after_forward: True # only for fsdp2, [True, False, int between 1 and fsdp_size]
       fsdp_size: -1
   ref:
-    strategy: fsdp
+    strategy: fsdp2
     fsdp_config:
+      fp8: True
       param_offload: False
       reshard_after_forward: True # only for fsdp2, [True, False, int between 1 and fsdp_size]
       wrap_policy:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -181,6 +181,12 @@ class ActorRolloutRefWorker(Worker):
         else:
             torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
+        use_fp8 = fsdp_config.get('fp8', False)
+        if use_fp8:
+            print(f"Using FP8 for {role}")
+            assert self.config.actor.strategy == 'fsdp2'
+            from torchao.float8 import convert_to_float8_training, Float8LinearConfig
+
         # override model kwargs
         actor_model_config = AutoConfig.from_pretrained(local_path, trust_remote_code=trust_remote_code)
 
@@ -227,6 +233,20 @@ class ActorRolloutRefWorker(Worker):
 
             # some parameters may not in torch_dtype. TODO(zhangchi.usc1992) remove this after we switch to fsdp2
             actor_module.to(torch_dtype)
+
+            if use_fp8:
+                # TODO: fix fp8 config
+                fp8_config = Float8LinearConfig(
+                    enable_fsdp_float8_all_gather=True,
+                    force_recompute_fp8_weight_in_bwd=True,
+                    pad_inner_dim=True,
+                    round_scales_to_power_of_2=True,
+                )
+                convert_to_float8_training(
+                    actor_module,
+                    config=fp8_config,
+                    module_filter_fn=lambda mod, fqn: fqn != "lm_head",
+                )
 
             if enable_gradient_checkpointing:
                 actor_module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
@@ -315,6 +335,12 @@ class ActorRolloutRefWorker(Worker):
                 betas=optim_config.get("betas", (0.9, 0.999)),
                 weight_decay=optim_config.get("weight_decay", 1e-2),
             )
+
+            if use_fp8:
+                from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
+                actor_optimizer.register_step_post_hook(
+                    lambda *args, **kwargs: precompute_float8_dynamic_scale_for_fsdp(actor_module_fsdp)
+                )
 
             total_steps = optim_config.get("total_training_steps", 0)
             num_warmup_steps = int(optim_config.get("lr_warmup_steps", -1))
@@ -787,6 +813,10 @@ class CriticWorker(Worker):
         torch_dtype = self.config.model.fsdp_config.get("model_dtype", "fp32")
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
+        use_fp8 = self.config.model.fsdp_config.get('fp8', False)
+        if use_fp8:
+            from torchao.float8 import convert_to_float8_training, Float8LinearConfig
+
         from transformers import AutoConfig, AutoModelForTokenClassification
 
         critic_model_config = AutoConfig.from_pretrained(local_path, trust_remote_code=config.model.get("trust_remote_code", False))
@@ -814,6 +844,20 @@ class CriticWorker(Worker):
 
             # some parameters may not in torch_dtype
             critic_module.to(torch_dtype)
+
+            if use_fp8:
+                # TODO: fix fp8 config
+                fp8_config = Float8LinearConfig(
+                    enable_fsdp_float8_all_gather=True,
+                    force_recompute_fp8_weight_in_bwd=True,
+                    pad_inner_dim=True,
+                    round_scales_to_power_of_2=True,
+                )
+                convert_to_float8_training(
+                    critic_module,
+                    config=fp8_config,
+                    module_filter_fn=lambda mod, fqn: fqn != "dropout" and fqn != "score",
+                )
 
             if config.model.get("enable_gradient_checkpointing", False):
                 critic_module.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": False})
@@ -886,6 +930,12 @@ class CriticWorker(Worker):
             betas=config.optim.get("betas", (0.9, 0.999)),
             weight_decay=config.optim.get("weight_decay", 1e-2),
         )
+
+        if use_fp8:
+            from torchao.float8 import precompute_float8_dynamic_scale_for_fsdp
+            critic_optimizer.register_step_post_hook(
+                lambda *args, **kwargs: precompute_float8_dynamic_scale_for_fsdp(critic_module)
+            )
 
         total_steps = config.optim.get("total_training_steps", 0)
         num_warmup_steps = int(config.optim.get("lr_warmup_steps", -1))


### PR DESCRIPTION
A draft for FP8 training.
It currently depends on fsdp2 and torchao to train with per-tensor FP8 quantization.
To enable it, install torchao and set strategy=fsdp2 and fsdp_config.fp8=True.
Note: it cannot ensure convergence now