### PR TITLE
update __getitem__ and __setitem__ for DataProto

### DIFF
--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -251,11 +251,31 @@ class DataProto:
             tensor_data = self.batch[item]
             non_tensor_data = {key: val[item] for key, val in self.non_tensor_batch.items()}
             return DataProtoItem(batch=tensor_data, non_tensor_batch=non_tensor_data, meta_info=self.meta_info)
-
-        # # Case 4: Unsupported type
+        # Case 4: string - return the column in batch/non_tensor_batch or meta_info
+        elif isinstance(item, str):
+            if item in self.batch:
+                return self.batch[item]
+            elif item in self.non_tensor_batch[item]:
+                return self.non_tensor_batch[item]
+            elif item in self.meta_info:
+                return self.meta_info[item]
+            else:
+                raise KeyError(f'The Proto does not have key {item} in its batch or meta_info')
+        # # Case 5: Unsupported type
         else:
             raise TypeError(f"Indexing with {type(item)} is not supported")
 
+    def __setitem__(self, index, value):
+        extra_keys = (value.batch.keys() - self.batch.keys()) | (value.non_tensor_batch.keys() - self.non_tensor_batch.keys())
+        if extra_keys:
+            raise KeyError(f'Columns {extra_keys} exists in source but not in target, cannot update values in partial rows')
+        if not isinstance(value, (DataProto, DataProtoItem)):
+            raise ValueError('value must be a DataProto or DataProtoItem')
+        for target_key, target_value in value.batch.items():
+            self.batch[target_key][index] = target_value
+        for target_key, target_value in value.non_tensor_batch.items():
+            self.non_tensor_batch[target_key][index] = target_value
+    
     def __getstate__(self):
         import io
 


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).
I found nothing similar

### What does this PR do?
Simplify the usage of DataProto

I modified ```__getitem__``` and ```__setitem__``` so that we can: 
(1) use ```data['input_ids']``` instead of ```data.non_tensor_batch['input_ids']``` or ```data.batch['input_ids']``` if 'input_ids' exists in data's batch, non_tensor_batch or meta_info.
(2) update data by ```data[1:5] = new_data[2:6]``` if there's no extra keys in new_data.



### Specific Changes

(1) Update ```__getitem__``` for DataProto
(2) Add ```__setitem__``` for DataProto

### API
- ```data[key]``` for DataProto data
Before: ```data['key']``` will raise a ValueError
After: it will returns data.batch['key'] or data.non_tensor_batch['key'] or data.meta_info['key'] if key in any of them.

- ```data[index]=other_data``` for DataProto data and other_data
Before: ```data[index]=other_data``` will raise an Exception as there's no ```__setitem__``` method for DataProto
After: the values in rows of index (which could be a integer, ndarray or slice) will updated by other_data.


### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if neccessary.
