### PR TITLE
[misc] single_controller: support assign blocking value in runtime

### DIFF
--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import logging
 from functools import wraps
 from types import FunctionType
 from typing import Dict, List, Tuple
@@ -507,7 +508,15 @@ def register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL, blocki
             return await func(*args, **kwargs)
 
         wrapper = async_inner if inspect.iscoroutinefunction(func) else inner
-        attrs = {"dispatch_mode": dispatch_mode, "execute_mode": execute_mode, "blocking": blocking}
+
+        blocking_key = "blocking_v2"
+        sig = inspect.signature(func)
+        if "blocking" in sig.parameters:
+            logging.warning(f"method {func.__name__} hack \'blocking\' keyword in parameters, falling back to old mode")
+            blocking_key = "blocking"
+
+        attrs = {"dispatch_mode": dispatch_mode, "execute_mode": execute_mode, blocking_key: blocking}
+
         setattr(wrapper, MAGIC_ATTR, attrs)
         return wrapper
 

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -162,7 +162,8 @@ class WorkerGroup:
 
                 dispatch_mode = attribute["dispatch_mode"]
                 execute_mode = attribute["execute_mode"]
-                blocking = attribute["blocking"]
+                blocking = attribute.get("blocking", None)
+                blocking_v2 = attribute.get("blocking_v2", None)
 
                 # get dispatch fn
                 if isinstance(dispatch_mode, Dispatch):
@@ -197,6 +198,7 @@ class WorkerGroup:
                     collect_fn=collect_fn,
                     execute_fn=execute_fn,
                     blocking=blocking,
+                    blocking_v2=blocking_v2
                 )
 
                 try:

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -40,12 +40,17 @@ def get_random_string(length: int) -> str:
     return "".join(random.choice(letters_digits) for _ in range(length))
 
 
-def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, blocking):
+def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, blocking, blocking_v2):
+    if blocking is not None:
+        assert blocking_v2 is None, f"blocking and blocking_v2 cannot be not None at the same time"
     def func(*args, **kwargs):
         args, kwargs = dispatch_fn(self, *args, **kwargs)
         padding_count = kwargs.pop(_padding_size_key, 0)
+        blocking_effect = blocking
+        if blocking_v2 is not None:
+            blocking_effect = kwargs.pop("blocking_v2", blocking_v2)
         output = execute_fn(method_name, *args, **kwargs)
-        if blocking:
+        if blocking_effect:
             output = ray.get(output)
         output = collect_fn(self, output)
         if padding_count > 0:


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Allow users to specify `blocking` in runtime( and turns the blocking value in register as the default value for blocking).

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

1. `register` decorator
2. `_bind_worker_method`
3. `func_generator` in ray

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.

@vermouth1992 per our discussion, PTAL.
