### PR TITLE
[misc] fix: fix megatron entropy

### DIFF
--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -375,12 +375,16 @@ class MegatronPPOActor(BasePPOActor):
             def logits_processor(logits, label, label_mask):
                 assert logits.shape[:2] == label.shape[:2]
                 assert label.shape == label_mask.shape
-                log_probs = vocab_parallel_log_probs_from_logits(logits, label)
-                log_probs = log_probs.masked_fill(~label_mask, 0.0)
-                ret = {"log_probs": log_probs}
+
+                ret = {}
+
                 if calculate_entropy:
                     entropy = vocab_parallel_entropy(logits)
                     ret["entropy"] = entropy
+
+                log_probs = vocab_parallel_log_probs_from_logits(logits, label)
+                log_probs = log_probs.masked_fill(~label_mask, 0.0)
+                ret["log_probs"] = log_probs
                 return ret
 
             logits_processor_args = {"label": label, "label_mask": label_mask}


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Search for similar PR(s).

### What does this PR do?

In megatron-core, `vocab_parallel_log_probs_from_logits` is an inplace operator that would modify the logits in place to save memory. This makes the `vocab_parallel_entropy` produces incorrect results if `vocab_parallel_entropy` is computed after `vocab_parallel_log_probs_from_logits`. We swap the order to make sure the result is correct.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### Additional Info.

- **Issue Number**: Fixes issue # or discussion # if any.
- **Training**: [Note which backend this PR will affect: FSDP, Megatron, both, or none]
- **Inference**: [Note which backend this PR will affect: vLLM, SGLang, both, or none]

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add CI test(s) if necessary.
