### PR TITLE
[Feat] accelerate reward_fn execution via parallel ray task

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -393,6 +393,8 @@ Reward Model
      micro_batch_size_per_gpu: 16
      max_length: null
      reward_manager: naive
+     launch_reward_fn_async: False
+     reward_fn_parallel_size: 1
 
 - ``reward_model.enable``: Whether to enable reward model. If False, we
   compute the reward only with the user-defined reward functions. In
@@ -414,6 +416,8 @@ Reward Model
   of computing rule-based reward and handling different reward sources. Default
   is ``naive``. If all verification functions are multiprocessing-safe, the reward
   manager can be set to ``prime`` for parallel verification.
+- ``launch_reward_fn_async``: custom reward function executed async on CPU, during log_prob.
+- ``reward_fn_parallel_size``: parallel size for async reward function exectuion.
 
 Customized Reward Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -19,6 +19,7 @@ This trainer supports model-agonistic model initialization with huggingface
 """
 
 import uuid
+from collections import defaultdict
 from copy import deepcopy
 from pprint import pprint
 from typing import Optional
@@ -227,7 +228,8 @@ class RaySPPOTrainer(RayPPOTrainer):
                         batch = batch.union(reward_tensor)
 
                     if self.config.reward_model.launch_reward_fn_async:
-                        future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                        assert len(batch) % self.config.reward_model.reward_fn_parallel_size == 0
+                        reward_futures = [compute_reward_async.remote(data, self.config, self.tokenizer) for data in batch.chunk(self.config.reward_model.reward_fn_parallel_size)]
                     else:
                         reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 
@@ -259,7 +261,14 @@ class RaySPPOTrainer(RayPPOTrainer):
                     # we combine with rule-based rm
                     reward_extra_infos_dict: dict[str, list]
                     if self.config.reward_model.launch_reward_fn_async:
-                        reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                        reward_tensor_list = []
+                        reward_extra_infos_dict = defaultdict(list)
+                        reward_results = ray.get(reward_futures)
+                        for reward_t, extra_infos in reward_results:
+                            reward_tensor_list.append(reward_t)
+                            for k, v in extra_infos.items():
+                                reward_extra_infos_dict[k].extend(v)
+                        reward_tensor = torch.cat(reward_tensor_list, dim=0)
                     batch.batch["token_level_scores"] = reward_tensor
 
                     print(f"{list(reward_extra_infos_dict.keys())=}")

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -251,6 +251,7 @@ reward_model:
   max_length: null
   reward_manager: naive
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  reward_fn_parallel_size: 1 # parallel size for async reward function exectuion
   sandbox_fusion:
     url: null # faas url to run code in cloud sandbox
     max_concurrent: 64 # max concurrent requests to sandbox

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -207,6 +207,7 @@ reward_model:
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   reward_manager: naive
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  reward_fn_parallel_size: 1 # parallel size for async reward function exectuion
   sandbox_fusion:
     url: null # faas url to run code in cloud sandbox
     max_concurrent: 64 # max concurrent requests to sandbox

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -962,7 +962,8 @@ class RayPPOTrainer:
                             batch = batch.union(reward_tensor)
 
                         if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                            assert len(batch) % self.config.reward_model.reward_fn_parallel_size == 0
+                            reward_futures = [compute_reward_async.remote(data, self.config, self.tokenizer) for data in batch.chunk(self.config.reward_model.reward_fn_parallel_size)]
                         else:
                             reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 
@@ -994,7 +995,14 @@ class RayPPOTrainer:
                         # we combine with rule-based rm
                         reward_extra_infos_dict: dict[str, list]
                         if self.config.reward_model.launch_reward_fn_async:
-                            reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                            reward_tensor_list = []
+                            reward_extra_infos_dict = defaultdict(list)
+                            reward_results = ray.get(reward_futures)
+                            for reward_t, extra_infos in reward_results:
+                                reward_tensor_list.append(reward_t)
+                                for k, v in extra_infos.items():
+                                    reward_extra_infos_dict[k].extend(v)
+                            reward_tensor = torch.cat(reward_tensor_list, dim=0)
                         batch.batch["token_level_scores"] = reward_tensor
 
                         print(f"{list(reward_extra_infos_dict.keys())=}")


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

> Utilize multiple Ray tasks to execute the reward function asynchronously in parallel, which can significantly reduce execution time.

### Usage Example

> add config in your training script

```bash
    reward_model.launch_reward_fn_async=True \
    reward_model.reward_fn_parallel_size=8  \
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.
