### PR TITLE
[DataProto] Supporting new operations for `DataProto`

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -436,26 +436,7 @@ def test_dataproto_unfold_column_chunks():
 
     expect_obs1 = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12]])
     expect_obs2 = torch.tensor([[1, 2], [1, 2], [5, 6], [5, 6], [9, 10], [9, 10]])
-    expect_labels = [
-        [
-            "a1",
-        ],
-        [
-            "a2",
-        ],
-        [
-            "b1",
-        ],
-        [
-            "b2",
-        ],
-        [
-            "c1",
-        ],
-        [
-            "c2",
-        ],
-    ]
+    expect_labels = [["a1"], ["a2"], ["b1"], ["b2"], ["c1"], ["c2"]]
     assert torch.all(torch.eq(ret.batch["obs1"], expect_obs1))
     assert torch.all(torch.eq(ret.batch["obs2"], expect_obs2))
     assert (ret.non_tensor_batch["labels"] == expect_labels).all()


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Adding/ Enriching new operations on `DataProto` data class:

1. Making `DataProto` compitable with `self.batch is None`, this is useful when we are using a `DataProto` to contain non-tensor data only, i.e., images for vlm use cases;
2. `sample_level_repeat`： this function repeat the rows in DataProto multiple times in sample level;
3.  `unfold_column_chunks`: this function split along the second dim into `n_splits` folds. Useful in passing grouped tensors that doesn't want to be shuffled in dataset.

### API & Test

Please check the usage from the added unit test files: `tests/test_protocol.py`. There are three unit tests added, which are: `test_dataproto_no_batch`, `test_sample_level_repeat`, and `test_dataproto_unfold_column_chunks`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add CI test(s) if necessary.
