### PR TITLE
[docs] Add verl-tool in the list of "awesome works using verl"

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ verl is inspired by the design of Nemo-Aligner, Deepspeed-chat and OpenRLHF. The
 - [all-hands/openhands-lm-32b-v0.1](https://www.all-hands.dev/blog/introducing-openhands-lm-32b----a-strong-open-coding-agent-model): A strong, open coding agent model, trained with [multi-turn fine-tuning](https://github.com/volcengine/verl/pull/195)
 - [RM-R1](https://arxiv.org/abs/2505.02387): RL training of reasoning reward models ![GitHub Repo stars](https://img.shields.io/github/stars/RM-R1-UIUC/RM-R1)
 - [Absolute Zero Reasoner](https://arxiv.org/abs/2505.03335): A no human curated data self-play framework for reasoning![GitHub Repo stars](https://img.shields.io/github/stars/LeapLabTHU/Absolute-Zero-Reasoner)
+- [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool): An unified and easy-to-extend tool-agent training framework based on verl![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)
 
 and many more awesome work listed in [recipe](recipe/README.md).
 ## Contribution Guide


### PR DESCRIPTION
Add one line of mentioning [verl-tool](https://github.com/TIGER-AI-Lab/verl-tool) based on verl, it's an unified and easy-to-extend tool-agent training framework based on verl. We are actively working on this project and it has gathers many github stars. ![GitHub Repo stars](https://img.shields.io/github/stars/TIGER-AI-Lab/verl-tool)

See twitter post [here](https://x.com/DongfuJiang/status/1929198238017720379)