### PR TITLE
[megatron] refactor: support MLATransformerConfig abstraction for DeepSeek V3

### DIFF
--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -109,6 +109,7 @@ def _get_mla_transformer_config(hf_config: PretrainedConfig, mla_rope_config: di
         "v_head_dim": hf_config.v_head_dim,
         "rotary_base": hf_config.rope_theta,
         "rotary_scaling_factor": mla_rope_config["factor"],
+        "rotary_type": mla_rope_config["type"],
         "max_position_embeddings": mla_rope_config["original_max_position_embeddings"],
         "beta_fast": mla_rope_config["beta_fast"],
         "beta_slow": mla_rope_config["beta_slow"],


### PR DESCRIPTION
I encountered an error when training DeepSeek V3 with the latest code due to the TransformerConfig not including q_lora_rank, which is required for DeepSeek V3.

#### Error Message
```
(TaskRunner pid=1256989)   File "/workspace/verl/verl/single_controller/base/megatron/worker.py", line 69, in _init_hf_config_and_tf_config
(TaskRunner pid=1256989)     tf_config = hf_to_mcore_config(hf_config, dtype)
(TaskRunner pid=1256989)   File "/workspace/verl/verl/models/mcore/registry.py", line 131, in hf_to_mcore_config
(TaskRunner pid=1256989)     return MODEL_CONFIG_CONVERTER_REGISTRY[model](hf_config, dtype)
(TaskRunner pid=1256989)   File "/workspace/verl/verl/models/mcore/config_converter.py", line 210, in hf_to_mcore_config_dpskv3
(TaskRunner pid=1256989)     args = _get_base_transformer_config(
(TaskRunner pid=1256989)   File "/workspace/verl/verl/models/mcore/config_converter.py", line 85, in _get_base_transformer_config
(TaskRunner pid=1256989)     return TransformerConfig(**base_config)
(TaskRunner pid=1256989) TypeError: TransformerConfig.__init__() got an unexpected keyword argument 'q_lora_rank'
```

#### Solution
The `hf_to_mcore_config_dpskv3` function should directly create an `MLATransformerConfig` instance instead of going through `_get_base_transformer_config()`, since DeepSeek V3 uses Multi-Latent Attention (MLA) which requires MLA-specific parameters.