### PR TITLE
[worker] feat: Support Async reward calculation.

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -465,7 +465,9 @@ Reward Model
 - ``reward_model.reward_manager``:  Reward Manager. This defines the mechanism
   of computing rule-based reward and handling different reward sources. Default
   is ``naive``. If all verification functions are multiprocessing-safe, the reward
-  manager can be set to ``prime`` for parallel verification.
+  manager can be set to ``prime`` for parallel verification. If your reward function
+  is IO bound, you can defined an async reward function for ``naive`` or ``dapo``
+  for async calculation.
 
 Customized Reward Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/recipe/dapo/main_dapo.py
+++ b/recipe/dapo/main_dapo.py
@@ -169,6 +169,9 @@ class TaskRunner:
             num_examine=0,
             compute_score=compute_score,
             reward_fn_key=config.data.reward_fn_key,
+            qps=config.reward_model.qps,
+            max_concurrency=config.reward_model.max_concurrency,
+            timeout=config.reward_model.timeout,
             max_resp_len=config.data.max_response_length,
             overlong_buffer_cfg=config.reward_model.overlong_buffer,
         )
@@ -179,6 +182,9 @@ class TaskRunner:
             num_examine=1,
             compute_score=compute_score,
             reward_fn_key=config.data.reward_fn_key,
+            qps=config.reward_model.qps,
+            max_concurrency=config.reward_model.max_concurrency,
+            timeout=config.reward_model.timeout,
             max_resp_len=config.data.max_response_length,
             overlong_buffer_cfg=config.reward_model.overlong_buffer,
         )

--- a/recipe/prime/main_prime.py
+++ b/recipe/prime/main_prime.py
@@ -125,10 +125,10 @@ def main_task(config, compute_score=None):
         reward_manager_cls = PrimeRewardManager
     else:
         raise NotImplementedError
-    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score)
+    reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=0, compute_score=compute_score, qps=config.reward_model.qps, max_concurrency=config.reward_model.max_concurrency, timeout=config.reward_model.timeout)
 
     # Note that we always use function-based RM for validation
-    val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=1, compute_score=compute_score)
+    val_reward_fn = reward_manager_cls(tokenizer=tokenizer, num_examine=1, compute_score=compute_score, qps=config.reward_model.qps, max_concurrency=config.reward_model.max_concurrency, timeout=config.reward_model.timeout)
 
     resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
 

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -420,7 +420,7 @@ class RayPRIMETrainer(RayPPOTrainer):
 
                     # verify
                     with simple_timer("verify", timing_raw):
-                        scores = self.reward_fn.verify(batch)
+                        scores = self.reward_fn(batch, return_dict=True)["reward_extra_info"]["score"]
                         metrics["acc"] = statistics.mean(scores)
 
                     # filter the batch. 1/oversample_factor samples will be kept.

--- a/recipe/spin/main_spin.py
+++ b/recipe/spin/main_spin.py
@@ -126,17 +126,27 @@ class TaskRunner:
 
         compute_score = get_custom_reward_fn(config)
         reward_kwargs = dict(config.reward_model.get("reward_kwargs", {}))
+
         reward_fn = reward_manager_cls(
             tokenizer=tokenizer,
             num_examine=0,
             compute_score=compute_score,
             reward_fn_key=config.data.reward_fn_key,
+            qps=config.reward_model.qps,
+            max_concurrency=config.reward_model.max_concurrency,
+            timeout=config.reward_model.timeout,
             **reward_kwargs,
         )
 
         # Note that we always use function-based RM for validation
         val_reward_fn = reward_manager_cls(
-            tokenizer=tokenizer, num_examine=1, compute_score=compute_score, reward_fn_key=config.data.reward_fn_key
+            tokenizer=tokenizer,
+            num_examine=1,
+            compute_score=compute_score,
+            reward_fn_key=config.data.reward_fn_key,
+            qps=config.reward_model.qps,
+            max_concurrency=config.reward_model.max_concurrency,
+            timeout=config.reward_model.timeout,
         )
         resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
 

--- a/tests/workers/reward_manager/test_batch_reward_manager_on_cpu.py
+++ b/tests/workers/reward_manager/test_batch_reward_manager_on_cpu.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Individual Contributor: Lianyu Yao
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+
+from verl import DataProto
+from verl.workers.reward_manager import BatchRewardManager
+
+
+def compute_score(data_sources: str, solution_strs: str, ground_truths, extra_infos: dict):
+    return [len(solution_str) for solution_str in solution_strs]
+
+
+def test_batch_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+
+    manager = BatchRewardManager(tokenizer, 0, compute_score, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+if __name__ == "__main__":
+    test_batch_reward_manager()

--- a/tests/workers/reward_manager/test_dapo_reward_manager_on_cpu.py
+++ b/tests/workers/reward_manager/test_dapo_reward_manager_on_cpu.py
@@ -1,0 +1,75 @@
+# Copyright 2025 Individual Contributor: Lianyu Yao
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+from transformers import AutoTokenizer
+
+from verl import DataProto
+from verl.workers.reward_manager import DAPORewardManager
+
+
+def compute_score(data_source: str, solution_str: str, ground_truth, extra_info: dict):
+    return len(solution_str)
+
+
+async def async_compute_score(data_source: str, solution_str: str, ground_truth, extra_info: dict):
+    await asyncio.sleep(1)
+    return len(solution_str)
+
+
+def test_dapo_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+    overlong_buffer_cfg = OmegaConf.create({"enable": True, "len": 10, "penalty_factor": 1.0, "log": False})
+
+    manager = DAPORewardManager(tokenizer, 0, compute_score, max_resp_len=20, overlong_buffer_cfg=overlong_buffer_cfg, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+def test_async_dapo_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+    overlong_buffer_cfg = OmegaConf.create({"enable": True, "len": 10, "penalty_factor": 1.0, "log": False})
+
+    manager = DAPORewardManager(tokenizer, 0, async_compute_score, max_resp_len=20, overlong_buffer_cfg=overlong_buffer_cfg, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+if __name__ == "__main__":
+    test_dapo_reward_manager()
+    test_async_dapo_reward_manager()

--- a/tests/workers/reward_manager/test_naive_reward_manager_on_cpu.py
+++ b/tests/workers/reward_manager/test_naive_reward_manager_on_cpu.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Individual Contributor: Lianyu Yao
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+
+from verl import DataProto
+from verl.workers.reward_manager import NaiveRewardManager
+
+
+def compute_score(data_source: str, solution_str: str, ground_truth, extra_info: dict):
+    return len(solution_str)
+
+
+async def async_compute_score(data_source: str, solution_str: str, ground_truth, extra_info: dict):
+    await asyncio.sleep(1)
+    return len(solution_str)
+
+
+def test_naive_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+
+    manager = NaiveRewardManager(tokenizer, 0, compute_score, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+def test_async_naive_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+
+    manager = NaiveRewardManager(tokenizer, 0, async_compute_score, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+if __name__ == "__main__":
+    test_naive_reward_manager()
+    test_async_naive_reward_manager()

--- a/tests/workers/reward_manager/test_prime_reward_manager_on_cpu.py
+++ b/tests/workers/reward_manager/test_prime_reward_manager_on_cpu.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Individual Contributor: Lianyu Yao
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+from transformers import AutoTokenizer
+
+from verl import DataProto
+from verl.workers.reward_manager import PrimeRewardManager
+
+
+def compute_score(data_sources: str, solution_strs: str, ground_truths, extra_infos: dict):
+    return len(solution_strs)
+
+
+def test_prime_reward_manager():
+    local_model_path = "Qwen/Qwen2.5-0.5B"
+    tokenizer = AutoTokenizer.from_pretrained(local_model_path, padding_side="left")
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.tensor([[1, 2, 3], [7, 8, 9]]),
+            "responses": torch.tensor([[4, 5, 6], [7, 8, 9]]),
+            "attention_mask": torch.tensor([[0, 1, 1, 1, 1, 0], [0, 1, 1, 1, 0, 0]]),
+            "reward_model": np.array([{}, {}], dtype=object),
+            "data_source": np.array(["source1", "source2"], dtype=object),
+        }
+    )
+
+    manager = PrimeRewardManager(tokenizer, 0, compute_score, return_dict=False)
+    reward = manager(data)
+    assert reward[0][1].item() == 2 and reward[1][0].item() == 1, f"Wrong reward_tensor: {reward}"
+
+
+if __name__ == "__main__":
+    test_prime_reward_manager()

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -389,6 +389,11 @@ reward_model:
   forward_max_token_len_per_gpu: ${critic.forward_max_token_len_per_gpu}
   max_length: null
   reward_manager: naive
+  # Only effective in async reward function configurations
+  qps: null # Number of task being created / sec. No limit will be set if this is null.
+  max_concurrency: null # max number of concurrent tasks that can be run in parallel. No limit will be set if this is null.
+  timeout: null # max time an asyncio task will wait before quitting, null means task will wait infinitely.
+  # end of async reward function configurations
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
   sandbox_fusion:
     url: null # faas url to run code in cloud sandbox
@@ -405,6 +410,7 @@ reward_model:
 custom_reward_function:
   path: null
   name: compute_score
+  reward_kwargs: {}
 
 algorithm:
   # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs in the entrypoint

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -859,6 +859,15 @@ reward_model:
   # the reward manager can be set to prime for parallel verification.
   reward_manager: naive
 
+  # [async reward only] The configuration for asynchronous reward calculation.
+  async_reward:
+      # Number of task being created / sec. No limit will be set if this is null.
+      qps: null
+      # max number of concurrent tasks that can be run in parallel. No limit will be set if this is null.
+      max_concurrency: null
+      # max time in seconds an asyncio task will wait before quitting, null means task will wait infinitely.
+      timeout: null
+
   # Whether to launch custom reward function asynchronously during log_prob
   launch_reward_fn_async: False
 
@@ -898,6 +907,9 @@ custom_reward_function:
 
   # The name of the reward function within the specified file. Default is 'compute_score'.
   name: compute_score
+
+  # optional arguments to pass to the custom reward function
+  reward_kwargs: {}
 
 # config for the algorithm
 algorithm:

--- a/verl/workers/reward_manager/__init__.py
+++ b/verl/workers/reward_manager/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from .registry import get_reward_manager_cls, register  # noqa: I001
+from .naive import NaiveRewardManager
 from .batch import BatchRewardManager
 from .dapo import DAPORewardManager
-from .naive import NaiveRewardManager
 from .prime import PrimeRewardManager
 
 # Note(haibin.lin): no need to include all reward managers here in case of complicated dependencies

--- a/verl/workers/reward_manager/base.py
+++ b/verl/workers/reward_manager/base.py
@@ -1,0 +1,129 @@
+# Copyright 2025 Individual Contributor: Lianyu Yao
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Optional
+
+import numpy as np
+import torch
+
+from verl import DataProto
+from verl.utils.reward_score import default_compute_score
+
+
+class BaseRewardManager(ABC):
+    """
+    Base class for reward managers.
+    """
+
+    def __init__(
+        self,
+        tokenizer,
+        num_examine,
+        compute_score=None,
+        reward_fn_key="data_source",
+        qps: Optional[int | float] = None,
+        max_concurrency: Optional[int] = None,
+        timeout: Optional[int | float] = None,
+        **reward_kwargs,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
+        self.user_defined_compute_scores = compute_score or default_compute_score
+        self.reward_fn_key = reward_fn_key
+        self.qps = qps
+        self.max_concurrency = max_concurrency
+        self.timeout = timeout
+
+    def preprocess_reward_data(self, data: DataProto) -> DataProto:
+        prompt_ids = data.batch["prompts"]
+        response_ids = data.batch["responses"]
+        prompt_len = prompt_ids.shape[-1]
+        valid_prompt_length = data.batch["attention_mask"][:, prompt_len:].sum(dim=-1)
+        valid_response_lengths = data.batch["attention_mask"][:, prompt_len:].sum(dim=-1)
+
+        prompt_strs = np.array([self.tokenizer.decode(prompt_ids[i][-valid_len.item() :], skip_special_tokens=True) for i, valid_len in enumerate(valid_prompt_length)])
+        solution_strs = np.array([self.tokenizer.decode(response_ids[i][: valid_len.item()], skip_special_tokens=True) for i, valid_len in enumerate(valid_response_lengths)])
+
+        return DataProto.from_single_dict(
+            {
+                "prompt_strs": prompt_strs,
+                "response_ids": response_ids,
+                "solution_strs": solution_strs,
+                "data_sources": data.non_tensor_batch[self.reward_fn_key],
+                "ground_truths": np.vectorize(lambda reward_model: reward_model.get("ground_truth", None))(data.non_tensor_batch["reward_model"]),
+                "extra_infos": data.non_tensor_batch.get("extra_info", np.full(len(data), None, dtype=object)),
+                "valid_response_lengths": valid_response_lengths,
+            }
+        )
+
+    @abstractmethod
+    def compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        """Calculate scores and return a list of scores or dictionaries with additional information."""
+        pass
+
+    def postprocess_scores(self, reward_data: DataProto, training_data: DataProto) -> None:
+        reward_tensor = torch.zeros_like(reward_data.batch["response_ids"], dtype=torch.float32)
+        batch_indices = torch.arange(len(reward_data))
+        seq_indices = reward_data.batch["valid_response_lengths"] - 1
+        reward_tensor[batch_indices, seq_indices] = reward_data.batch["scores"]
+        reward_data.batch["reward_tensor"] = reward_tensor
+
+    def log_data(self, reward_data: DataProto, raw_reward: list[int | float | dict]) -> None:
+        already_print_data_sources = defaultdict(int)
+        for i in range(len(reward_data)):
+            data_item = reward_data[i]
+            data_source = data_item.non_tensor_batch["data_sources"]
+            if already_print_data_sources[data_source] < self.num_examine:
+                already_print_data_sources[data_source] += 1
+                print("[prompt]", data_item.non_tensor_batch["prompt_strs"])
+                print("[response]", data_item.non_tensor_batch["solution_strs"])
+                print("[ground_truth]", data_item.non_tensor_batch["ground_truths"])
+                if isinstance(raw_reward[i], dict):
+                    for key, value in raw_reward[i].items():
+                        print(f"[{key}]", value)
+                else:
+                    print("[score]", raw_reward[i])
+
+    def __call__(self, data: DataProto, return_dict=False):
+        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
+        if "rm_scores" in data.batch.keys():
+            if return_dict:
+                return {"reward_tensor": data.batch["rm_scores"]}
+            else:
+                return data.batch["rm_scores"]
+
+        reward_data = self.preprocess_reward_data(data)
+        raw_rewards = self.compute_scores(reward_data)
+        assert len(raw_rewards) == len(data), f"The number of rewards must match the number of data items. Got {len(raw_rewards)} rewards for {len(data)} data items."
+        reward_data.batch["scores"] = torch.tensor([(raw_reward["score"] if isinstance(raw_reward, dict) else raw_reward) for raw_reward in raw_rewards], dtype=torch.float32)
+        self.postprocess_scores(reward_data, data)
+        self.log_data(reward_data, raw_rewards)
+
+        if return_dict:
+            reward_extra_info = defaultdict(list)
+            for raw_reward in raw_rewards:
+                if isinstance(raw_reward, dict):
+                    for key, value in raw_reward.items():
+                        reward_extra_info[key].append(value)
+                else:
+                    reward_extra_info["score"].append(raw_reward)
+
+            return {
+                "reward_tensor": reward_data.batch["reward_tensor"],
+                "reward_extra_info": reward_extra_info,
+            }
+        else:
+            return reward_data.batch["reward_tensor"]

--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -12,111 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
-
 import torch
 
 from verl import DataProto
 from verl.workers.reward_manager import register
 
+from .base import BaseRewardManager
+
 
 @register("batch")
-class BatchRewardManager:
+class BatchRewardManager(BaseRewardManager):
     """
-    A batch reward manager that computes rewards for a batch of data.
+        A batch reward manager that computes rewards for a batch of data.
 
-    Args:
-        tokenizer (Tokenizer): The tokenizer to use for decoding the responses.
-        num_examine (int): The number of responses to examine.
-        compute_score (callable): The function to compute the rewards.
-        reward_fn_key (str): The key to use for the reward function.
-        reward_kwargs (dict): The keyword arguments to pass to the reward function.
-    """
+        Args:
+            tokenizer (Tokenizer): The tokenizer to use for decoding the responses.
+            num_examine (int): The number of responses to examine.
+            compute_score (callable): The function to compute the rewards.
+            reward_fn_key (str): The key to use for the reward function.
+            reward_kwargs (dict): The keyword arguments to pass to the reward function.
+        """
 
-    def __init__(self, tokenizer, num_examine, compute_score, reward_fn_key="data_source", **reward_kwargs):
-        self.tokenizer = tokenizer
-        self.num_examine = num_examine
-        self.compute_score = compute_score
-        self.reward_fn_key = reward_fn_key
-        self.reward_kwargs = reward_kwargs
-
-    def verify(self, data):
-        prompt_ids = data.batch["prompts"]
-        response_ids = data.batch["responses"]
-        attention_mask = data.batch["attention_mask"]
-
-        prompt_len = prompt_ids.shape[-1]
-        valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
-
-        responses_str = []
-        for i in range(len(data)):
-            valid_len = valid_response_lengths[i]
-            valid_response_ids = response_ids[i][:valid_len]
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
-            responses_str.append(response_str)
-
-        ground_truths = [item.non_tensor_batch["reward_model"].get("ground_truth", None) for item in data]
-        data_sources = data.non_tensor_batch[self.reward_fn_key]
-        extras = data.non_tensor_batch.get("extra_info", [None] * len(data))
-
-        scores = self.compute_score(
-            data_sources=data_sources,
-            solution_strs=responses_str,
-            ground_truths=ground_truths,
-            extra_infos=extras,
-            **self.reward_kwargs,
+    def compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        return self.user_defined_compute_scores(
+            data_sources=reward_data.non_tensor_batch["data_sources"],
+            solution_strs=reward_data.non_tensor_batch["solution_strs"],
+            ground_truths=reward_data.non_tensor_batch["ground_truths"],
+            extra_infos=reward_data.non_tensor_batch["extra_infos"],
         )
 
-        return scores
-
-    def __call__(self, data: DataProto, return_dict=False):
-        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
-        if "rm_scores" in data.batch.keys():
-            if return_dict:
-                return {"reward_tensor": data.batch["rm_scores"]}
-            else:
-                return data.batch["rm_scores"]
-
-        reward_tensor = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
-        reward_extra_info = defaultdict(list)
-        prompt_ids = data.batch["prompts"]
-        prompt_len = prompt_ids.shape[-1]
-        attention_mask = data.batch["attention_mask"]
-        valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
-        data_sources = data.non_tensor_batch[self.reward_fn_key]
-
-        scores = self.verify(data)
-        rewards = []
-        already_printed = {}
-
-        for i in range(len(data)):
-            length = valid_response_lengths[i].item()
-            score = scores[i]
-
-            if isinstance(score, dict):
-                reward = score["score"]
-                for key, value in score.items():
-                    reward_extra_info[key].append(value)
-            else:
-                reward = score
-
-            rewards.append(reward)
-            reward_tensor[i, length - 1] = reward
-
-            data_source = data_sources[i]
-            if already_printed.get(data_source, 0) < self.num_examine:
-                response_str = self.tokenizer.decode(data.batch["responses"][i][:length], skip_special_tokens=True)
-                prompt_str = self.tokenizer.decode(data.batch["prompts"][i], skip_special_tokens=True)
-                ground_truth = data[i].non_tensor_batch["reward_model"].get("ground_truth", None)
-                print("[prompt]", prompt_str)
-                print("[response]", response_str)
-                print("[ground_truth]", ground_truth)
-                print("[score]", scores[i])
-                already_printed[data_source] = already_printed.get(data_source, 0) + 1
-
-        data.batch["acc"] = torch.tensor(rewards, dtype=torch.float32, device=prompt_ids.device)
-
-        if return_dict:
-            return {"reward_tensor": reward_tensor, "reward_extra_info": reward_extra_info}
-        else:
-            return reward_tensor
+    def postprocess_scores(self, reward_data: DataProto, training_data: DataProto) -> None:
+        training_data.batch["acc"] = torch.tensor(reward_data.batch["scores"],
+                                                  device=training_data.batch["prompts"].device)
+        super().postprocess_scores(reward_data, training_data)

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -12,32 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
+from typing import Optional
 
 import torch
 
 from verl import DataProto
-from verl.utils.reward_score import default_compute_score
 from verl.workers.reward_manager import register
+
+from .naive import NaiveRewardManager
 
 
 @register("dapo")
-class DAPORewardManager:
+class DAPORewardManager(NaiveRewardManager):
     """The reward manager."""
 
-    def __init__(
-        self,
-        tokenizer,
-        num_examine,
-        compute_score=None,
-        reward_fn_key="data_source",
-        max_resp_len=None,
-        overlong_buffer_cfg=None,
-    ) -> None:
-        self.tokenizer = tokenizer
-        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
-        self.compute_score = compute_score or default_compute_score
-        self.reward_fn_key = reward_fn_key
+    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source", qps: Optional[int | float] = None, max_concurrency: Optional[int] = None, timeout: Optional[int | float] = None, max_resp_len=None, overlong_buffer_cfg=None, **reward_kwargs) -> None:
+        super().__init__(tokenizer, num_examine, compute_score, reward_fn_key, qps, max_concurrency, timeout, **reward_kwargs)
         self.overlong_buffer_cfg = overlong_buffer_cfg
         self.max_resp_len = max_resp_len
 
@@ -49,97 +39,19 @@ class DAPORewardManager:
                 "max_resp_len must be larger than overlong_buffer.len"
             )
 
-    def __call__(self, data: DataProto, return_dict: bool = False):
-        """We will expand this function gradually based on the available datasets"""
+    def compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        scores = super().compute_scores(reward_data)
 
-        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
-        if "rm_scores" in data.batch.keys():
-            if return_dict:
-                return {"reward_tensor": data.batch["rm_scores"]}
-            else:
-                return data.batch["rm_scores"]
+        if self.overlong_buffer_cfg.enable:
+            overlong_buffer_len = self.overlong_buffer_cfg.len
+            expected_len = self.max_resp_len - overlong_buffer_len
+            exceed_len = reward_data.batch["valid_response_lengths"] - expected_len
+            overlong_rewards = (-torch.clamp(exceed_len, min=0) / overlong_buffer_len * self.overlong_buffer_cfg.penalty_factor).tolist()
 
-        reward_tensor = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
-        reward_extra_info = defaultdict(list)
-
-        already_print_data_sources = {}
-
-        for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
-
-            prompt_ids = data_item.batch["prompts"]
-
-            prompt_length = prompt_ids.shape[-1]
-
-            valid_prompt_length = data_item.batch["attention_mask"][:prompt_length].sum()
-            valid_prompt_ids = prompt_ids[-valid_prompt_length:]
-
-            response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
-            valid_response_ids = response_ids[:valid_response_length]
-
-            # decode
-            prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
-            eos_token = self.tokenizer.eos_token
-            if response_str.endswith(eos_token):
-                response_str = response_str[: -len(eos_token)]
-
-            ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-
-            data_source = data_item.non_tensor_batch[self.reward_fn_key]
-
-            extra_info = data_item.non_tensor_batch.get("extra_info", None)
-
-            result = self.compute_score(
-                data_source=data_source,
-                solution_str=response_str,
-                ground_truth=ground_truth,
-                extra_info=extra_info,
-            )
-
-            score: float
-            if isinstance(result, dict):
-                score = result["score"]
-                # Store the information including original reward
-                for key, value in result.items():
-                    reward_extra_info[key].append(value)
-            else:
-                score = result
-
-            reward = score
-
-            if self.overlong_buffer_cfg.enable:
-                overlong_buffer_len = self.overlong_buffer_cfg.len
-                expected_len = self.max_resp_len - overlong_buffer_len
-                exceed_len = valid_response_length - expected_len
-                overlong_penalty_factor = self.overlong_buffer_cfg.penalty_factor
-                overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
-                reward += overlong_reward
-                if self.overlong_buffer_cfg.log:
-                    reward_extra_info["overlong_reward"].append(overlong_reward)
-                    reward_extra_info["overlong"].append(overlong_reward < 0)
-
-            reward_tensor[i, valid_response_length - 1] = reward
-
-            if data_source not in already_print_data_sources:
-                already_print_data_sources[data_source] = 0
-
-            if already_print_data_sources[data_source] < self.num_examine:
-                already_print_data_sources[data_source] += 1
-                print("[prompt]", prompt_str)
-                print("[response]", response_str)
-                print("[ground_truth]", ground_truth)
-                if isinstance(result, dict):
-                    for key, value in result.items():
-                        print(f"[{key}]", value)
-                else:
-                    print("[score]", score)
-
-        if return_dict:
-            return {
-                "reward_tensor": reward_tensor,
-                "reward_extra_info": reward_extra_info,
-            }
-        else:
-            return reward_tensor
+            scores = [({**score, "score": score["score"] + overlong_reward} if isinstance(score, dict) else score + overlong_reward) for score, overlong_reward in zip(scores, overlong_rewards)]
+            if self.overlong_buffer_cfg.log:
+                for i, score in enumerate(scores):
+                    if isinstance(score, dict):
+                        score["overlong_reward"] = overlong_rewards[i]
+                        score["overlong"] = overlong_rewards[i] < 0
+        return scores

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -11,110 +11,62 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from collections import defaultdict
-
-import torch
+import asyncio
+import time
 
 from verl import DataProto
-from verl.utils.reward_score import default_compute_score
 from verl.workers.reward_manager import register
+
+from .base import BaseRewardManager
 
 
 @register("naive")
-class NaiveRewardManager:
+class NaiveRewardManager(BaseRewardManager):
     """The reward manager."""
 
-    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source") -> None:
-        """
-        Initialize the NaiveRewardManager instance.
+    async def async_compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        semaphore = asyncio.Semaphore(self.max_concurrency) if self.max_concurrency is not None else None
+        min_interval = 1.0 / self.qps if self.qps and self.qps > 0 else None
+        lock = asyncio.Lock()
+        last_called = 0.0
 
-        Args:
-            tokenizer: The tokenizer used to decode token IDs into text.
-            num_examine: The number of batches of decoded responses to print to the console for debugging purpose.
-            compute_score: A function to compute the reward score. If None, `default_compute_score` will be used.
-            reward_fn_key: The key used to access the data source in the non-tensor batch data. Defaults to
-                "data_source".
-        """
-        self.tokenizer = tokenizer  # Store the tokenizer for decoding token IDs
-        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
-        self.compute_score = compute_score or default_compute_score
-        self.reward_fn_key = reward_fn_key  # Store the key for accessing the data source
+        async def throttled_call(data_item):
+            nonlocal last_called
+            if semaphore:
+                await semaphore.acquire()
+            try:
+                if min_interval:
+                    async with lock:
+                        now = time.monotonic()
+                        wait = min_interval - (now - last_called)
+                        if wait > 0:
+                            await asyncio.sleep(wait)
+                        last_called = time.monotonic()
+                return await asyncio.wait_for(
+                    self.user_defined_compute_scores(data_source=data_item.non_tensor_batch["data_sources"],
+                                                     solution_str=data_item.non_tensor_batch["solution_strs"],
+                                                     ground_truth=data_item.non_tensor_batch["ground_truths"],
+                                                     extra_info=data_item.non_tensor_batch["extra_infos"]), self.timeout
+                )
+            finally:
+                if semaphore:
+                    semaphore.release()
 
-    def __call__(self, data: DataProto, return_dict=False):
-        """We will expand this function gradually based on the available datasets"""
+        return await asyncio.gather(*[throttled_call(reward_data[i]) for i in range(len(reward_data))])
 
-        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
-        if "rm_scores" in data.batch.keys():
-            if return_dict:
-                return {"reward_tensor": data.batch["rm_scores"]}
-            else:
-                return data.batch["rm_scores"]
-
-        reward_tensor = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
-        reward_extra_info = defaultdict(list)
-
-        already_print_data_sources = {}
-
-        for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
-
-            prompt_ids = data_item.batch["prompts"]
-
-            prompt_length = prompt_ids.shape[-1]
-
-            valid_prompt_length = data_item.batch["attention_mask"][:prompt_length].sum()
-            valid_prompt_ids = prompt_ids[-valid_prompt_length:]
-
-            response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
-            valid_response_ids = response_ids[:valid_response_length]
-
-            # decode
-            prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
-
-            ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
-            data_source = data_item.non_tensor_batch[self.reward_fn_key]
-            extra_info = data_item.non_tensor_batch.get("extra_info", {})
-            num_turns = data_item.non_tensor_batch.get("__num_turns__", None)
-            extra_info["num_turns"] = num_turns
-
-            score = self.compute_score(
-                data_source=data_source,
-                solution_str=response_str,
-                ground_truth=ground_truth,
-                extra_info=extra_info,
+    def sync_compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        return [
+            self.user_defined_compute_scores(
+                data_source=reward_data.non_tensor_batch["data_sources"][i],
+                solution_str=reward_data.non_tensor_batch["solution_strs"][i],
+                ground_truth=reward_data.non_tensor_batch["ground_truths"][i],
+                extra_info=reward_data.non_tensor_batch["extra_infos"][i],
             )
+            for i in range(len(reward_data))
+        ]
 
-            if isinstance(score, dict):
-                reward = score["score"]
-                # Store the information including original reward
-                for key, value in score.items():
-                    reward_extra_info[key].append(value)
-            else:
-                reward = score
-
-            reward_tensor[i, valid_response_length - 1] = reward
-
-            if data_source not in already_print_data_sources:
-                already_print_data_sources[data_source] = 0
-
-            if already_print_data_sources[data_source] < self.num_examine:
-                already_print_data_sources[data_source] += 1
-                print("[prompt]", prompt_str)
-                print("[response]", response_str)
-                print("[ground_truth]", ground_truth)
-                if isinstance(score, dict):
-                    for key, value in score.items():
-                        print(f"[{key}]", value)
-                else:
-                    print("[score]", score)
-
-        if return_dict:
-            return {
-                "reward_tensor": reward_tensor,
-                "reward_extra_info": reward_extra_info,
-            }
+    def compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
+        if asyncio.iscoroutinefunction(self.user_defined_compute_scores):
+            return asyncio.run(self.async_compute_scores(reward_data))
         else:
-            return reward_tensor
+            return self.sync_compute_scores(reward_data)

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -15,15 +15,14 @@
 import asyncio
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
-from typing import Callable, Optional
 
 import psutil
 import torch
-from transformers import PreTrainedTokenizer
 
 from verl import DataProto
-from verl.utils.reward_score import default_compute_score
 from verl.workers.reward_manager import register
+
+from .base import BaseRewardManager
 
 
 async def single_compute_score(evaluation_func, completion, reference, task, task_extra_info, executor, timeout=300.0):
@@ -98,89 +97,29 @@ def run_reward_scoring(evaluation_func, completions, references, tasks, extra_in
 
 
 @register("prime")
-class PrimeRewardManager:
+class PrimeRewardManager(BaseRewardManager):
     """
     The Reward Manager used in https://github.com/PRIME-RL/PRIME
     """
 
-    def __init__(
-        self,
-        tokenizer: PreTrainedTokenizer,
-        num_examine: int,
-        compute_score: Optional[Callable] = None,
-        reward_fn_key: str = "data_source",
-    ) -> None:
-        self.tokenizer = tokenizer
-        self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
-        self.compute_score = compute_score or default_compute_score
-        self.reward_fn_key = reward_fn_key
-
-    def verify(self, data):
-        """
-        verify the batch and save as ``acc`` tensor
-        """
-        # batched scoring
-        prompt_ids = data.batch["prompts"]
-
-        response_ids = data.batch["responses"]
-        sequences_str = self.tokenizer.batch_decode(response_ids, skip_special_tokens=True)
-        ground_truth = [data_item.non_tensor_batch["reward_model"]["ground_truth"] for data_item in data]
-        data_sources = data.non_tensor_batch[self.reward_fn_key]
-        extra_info = data.non_tensor_batch.get("extra_info", None)
-
-        assert len(sequences_str) == len(ground_truth) == len(data_sources)
+    def compute_scores(self, reward_data: DataProto) -> list[int | float | dict]:
         try:
             scores = run_reward_scoring(
-                self.compute_score,
-                completions=sequences_str,
-                references=ground_truth,
-                tasks=data_sources,
-                extra_info=extra_info,
+                self.user_defined_compute_scores,
+                completions=reward_data.non_tensor_batch["solution_strs"],
+                references=reward_data.non_tensor_batch["ground_truths"],
+                tasks=reward_data.non_tensor_batch["data_sources"],
+                extra_info=reward_data.non_tensor_batch["extra_infos"],
                 num_processes=64,
             )
         except asyncio.TimeoutError:
             print("[Timeout] Global reward scoring timed out. Setting all as 0.")
-            scores = [0.0 for _ in range(len(sequences_str))]
+            scores = [0.0 for _ in range(len(reward_data))]
         except Exception as e:
             print(f"[Error] Unexpected error during scoring. Setting all as 0. {e}")
-            scores = [0.0 for _ in range(len(sequences_str))]
-        data.batch["acc"] = torch.tensor(scores, dtype=torch.float32, device=prompt_ids.device)
+            scores = [0.0 for _ in range(len(reward_data))]
         return scores
 
-    def __call__(self, data: DataProto, return_dict: bool = False):
-        """We will expand this function gradually based on the available datasets"""
-
-        # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
-        if "rm_scores" in data.batch.keys():
-            return data.batch["rm_scores"]
-
-        reward_tensor = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
-
-        already_print_data_sources = {}
-
-        # batched scoring
-        prompt_ids = data.batch["prompts"]
-        prompt_length = prompt_ids.shape[-1]
-
-        response_ids = data.batch["responses"]
-        valid_response_length = data.batch["attention_mask"][:, prompt_length:].sum(dim=-1)
-        sequences_str = self.tokenizer.batch_decode(response_ids, skip_special_tokens=True)
-        data_sources = data.non_tensor_batch["data_source"]
-
-        scores = self.verify(data)
-
-        for i in range(len(data)):
-            data_source = data_sources[i]
-            reward_tensor[i, valid_response_length[i].item() - 1] = scores[i]
-
-            if data_source not in already_print_data_sources:
-                already_print_data_sources[data_source] = 0
-
-            if already_print_data_sources[data_source] < self.num_examine:
-                already_print_data_sources[data_source] += 1
-                print(sequences_str)
-
-        if return_dict:
-            return {"reward_tensor": reward_tensor}
-        else:
-            return reward_tensor
+    def postprocess_scores(self, reward_data: DataProto, training_data: DataProto) -> None:
+        training_data.batch["acc"] = torch.tensor(reward_data.batch["scores"], device=training_data.batch["prompts"].device)
+        super().postprocess_scores(reward_data, training_data)


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PR(s).

### What does this PR do?

Support async reward calculation for IO bound reward functions, refactored reward managers with OOP oriented style.

### Specific Changes

1. Implemented all share logic in the base manager for all reward managers.
2. Support async reward calculation for Naive / DAPO reward managers, detect user async reward function and enable async calculation automatically.
3. Support QPS, max concurrency and timeout for async rewards.

### Test

Executed all 4 reward managers with GSM8K RL, calculated rewards with both new / existing implementations concurrently, then  `assert torch.allclose(new_reward_tensor, original_reward_tensor, rtol=1e-05, atol=1e-08)`

### Additional Info.

- **Issue Number**: Fixes issue #1210
- **Training**: None
- **Inference**: None

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
