### PR TITLE
[ray, worker] feat: DAPO x LLM as a Judge (GenRM)

### DIFF
--- a/recipe/dapo/config/GRM_template.txt
+++ b/recipe/dapo/config/GRM_template.txt
@@ -1,0 +1,1 @@
+The above is a Q&A dialogue between a user and an assistant. It is now known that the standard answer to the user's question is {ground_truth}. Please determine whether the assistant has answered the user's question clearly, precisely, and accurately. Present your reasoning and judgment in the following format:\n\nThink: Content of Thinking\nJudgment: Correct / Incorrect

--- a/recipe/dapo/main_dapo.py
+++ b/recipe/dapo/main_dapo.py
@@ -15,7 +15,6 @@
 Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
 """
 
-
 import hydra
 import ray
 
@@ -89,8 +88,10 @@ class TaskRunner:
         }
 
         global_pool_id = "global_pool"
+        grm_pool_id = "grm_pool"
         resource_pool_spec = {
             global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+            grm_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.get("grm_nnodes", 0),
         }
         mapping = {
             Role.ActorRollout: global_pool_id,
@@ -112,6 +113,10 @@ class TaskRunner:
                 raise NotImplementedError
             role_worker_mapping[Role.RewardModel] = ray.remote(RewardModelWorker)
             mapping[Role.RewardModel] = global_pool_id
+
+        if config.reward_model.grm.enable:
+            role_worker_mapping[Role.GenerativeRewardModel] = ray.remote(ActorRolloutRefWorker)
+            mapping[Role.GenerativeRewardModel] = grm_pool_id
 
         # reference model
         if config.algorithm.use_kl_in_reward or config.actor_rollout_ref.actor.use_kl_loss:

--- a/recipe/dapo/run_dapo_qwen2.5_llm_judge.sh
+++ b/recipe/dapo/run_dapo_qwen2.5_llm_judge.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+project_name='DAPO-GRM'
+date_str=$(date +%Y%m%d%H%M%S)
+model_name="Qwen2.5-7B-Instruct"
+exp_name="DAPO-GRM-${model_name}-${date_str}"
+
+adv_estimator=grpo
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=0.2
+clip_ratio_high=0.28
+
+max_prompt_length=$((1024 * 2))
+max_response_length=$((1024 * 20))
+enable_overlong_buffer=True
+overlong_buffer_len=$((1024 * 4))
+overlong_penalty_factor=1.0
+
+loss_agg_mode="token-mean"
+
+enable_filter_groups=True
+filter_groups_metric=acc
+max_num_gen_batches=10
+train_prompt_bsz=32
+gen_prompt_bsz=$((train_prompt_bsz * 2))
+n_resp_per_prompt=8
+train_prompt_mini_bsz=8
+
+# Ray
+PWD=.
+RAY_ADDRESS=${RAY_ADDRESS:-""}
+WORKING_DIR=${WORKING_DIR:-"${PWD}"}
+RUNTIME_ENV=${RUNTIME_ENV:-"${WORKING_DIR}/verl/trainer/runtime_env.yaml"}
+MAIN_NNODES=${MAIN_NNODES:-8}
+# Paths
+RAY_DATA_HOME=${RAY_DATA_HOME:-"${HOME}/verl"}
+MODEL_PATH=${MODEL_PATH:-"models/${model_name}"}
+CKPTS_DIR=${CKPTS_DIR:-"ckpts/${project_name}/${exp_name}"}
+
+TRAIN_FILE=${TRAIN_FILE:-"data/dapo-math-17k.parquet"}
+TEST_FILE=${TEST_FILE:-"data/aime-2024.parquet"}
+
+# GRM
+enable_grm=True
+grm_name="Qwen2.5-7B-Instruct"
+GRM_PATH=${GRM_PATH:-"models/${grm_name}"}
+GRM_template_file=${GRM_template_file:-"${WORKING_DIR}/recipe/dapo/config/GRM_template.txt"}
+GRM_NNODES=${GRM_NNODES:-4}
+GRM_max_response_length=$((1024 * 2))
+GRM_sp_size=4
+GRM_tp=4
+
+# Sample Write
+enable_sample_write=False
+sample_write_dir=${sample_write_dir:-"${CKPTS_DIR}/sample"}
+sample_write_max_rows=1000
+
+# Algorithm
+temperature=1.0
+top_p=1.0
+top_k=-1 # 0 for HF rollout, -1 for vLLM rollout
+
+# Performance Related Parameter
+sp_size=4
+use_dynamic_bsz=True
+actor_ppo_max_token_len=$((max_prompt_length + max_response_length))
+infer_ppo_max_token_len=$((max_prompt_length + max_response_length))
+offload=True
+gen_tp=4
+
+ray job submit --no-wait --runtime-env="${RUNTIME_ENV}" \
+    --working-dir "${WORKING_DIR}" \
+    --address "${RAY_ADDRESS}" \
+    -- python3 -m recipe.dapo.main_dapo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.prompt_key=prompt \
+    data.truncation='left' \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.gen_batch_size=${gen_prompt_bsz} \
+    data.train_batch_size=${train_prompt_bsz} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    algorithm.filter_groups.enable=${enable_filter_groups} \
+    algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
+    algorithm.filter_groups.metric=${filter_groups_metric} \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    +actor_rollout_ref.model.override_config.attention_dropout=0. \
+    +actor_rollout_ref.model.override_config.embd_pdrop=0. \
+    +actor_rollout_ref.model.override_config.resid_pdrop=0. \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=${offload} \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${offload} \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.grad_clip=1.0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.80 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k="${top_k}" \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=${offload} \
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=-1 \
+    reward_model.reward_manager=dapo \
+    reward_model.overlong_buffer.enable=${enable_overlong_buffer} \
+    reward_model.overlong_buffer.len=${overlong_buffer_len} \
+    reward_model.overlong_buffer.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.grm.enable=${enable_grm} \
+    +reward_model.grm.model.path="${GRM_PATH}" \
+    +reward_model.grm.rollout.prompt_length=$((actor_ppo_max_token_len - GRM_max_response_length)) \
+    +reward_model.grm.rollout.response_length=${GRM_max_response_length} \
+    +reward_model.grm.rollout.max_num_batched_tokens=${actor_ppo_max_token_len} \
+    +reward_model.grm.rollout.n=1 \
+    +reward_model.grm.rollout.ulysses_sequence_parallel_size=${GRM_sp_size} \
+    +reward_model.grm.rollout.tensor_model_parallel_size=${GRM_tp} \
+    +reward_model.grm.rollout.fsdp_config.fsdp_size=-1 \
+    +reward_model.grm.rollout.template_file="${GRM_template_file}" \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}" \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes="${MAIN_NNODES}" \
+    +trainer.grm_nnodes="${GRM_NNODES}" \
+    trainer.val_before_train=False \
+    trainer.test_freq=5 \
+    trainer.save_freq=50 \
+    trainer.total_epochs=1 \
+    trainer.log_val_generations=10 \
+    +trainer.log_train_generations=10 \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.resume_mode=auto 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -20,6 +20,7 @@ This trainer supports model-agonistic model initialization with huggingface
 
 import json
 import os
+import random
 import uuid
 from collections import defaultdict
 from copy import deepcopy
@@ -74,6 +75,7 @@ class Role(Enum):
     RefPolicy = 4
     RewardModel = 5
     ActorRolloutRef = 6
+    GenerativeRewardModel = 7
 
 
 @dataclass
@@ -257,14 +259,15 @@ def compute_advantage(data: DataProto, adv_estimator, gamma=1.0, lam=1.0, num_re
     else:
         # handle all other adv estimator type other than GAE and GRPO
         adv_estimator_fn = core_algos.get_adv_estimator_fn(adv_estimator)
-        adv_kwargs = {"token_level_rewards": data.batch["token_level_rewards"],
-                      "response_mask": data.batch["response_mask"],
-                      "config": config,
+        adv_kwargs = {
+            "token_level_rewards": data.batch["token_level_rewards"],
+            "response_mask": data.batch["response_mask"],
+            "config": config,
         }
-        if "uid" in data.non_tensor_batch: # optional
-            adv_kwargs['index'] = data.non_tensor_batch["uid"]
-        if "reward_baselines" in data.batch:# optional
-            adv_kwargs['reward_baselines'] = data.batch["reward_baselines"]
+        if "uid" in data.non_tensor_batch:  # optional
+            adv_kwargs["index"] = data.non_tensor_batch["uid"]
+        if "reward_baselines" in data.batch:  # optional
+            adv_kwargs["reward_baselines"] = data.batch["reward_baselines"]
 
         # calculate advantage estimator
         advantages, returns = adv_estimator_fn(**adv_kwargs)
@@ -314,6 +317,7 @@ class RayPPOTrainer:
         self.resource_pool_manager = resource_pool_manager
         self.use_reference_policy = Role.RefPolicy in role_worker_mapping
         self.use_rm = Role.RewardModel in role_worker_mapping
+        self.use_grm = Role.GenerativeRewardModel in role_worker_mapping
         self.ray_worker_group_cls = ray_worker_group_cls
         self.device_name = device_name
         self.validation_generations_logger = ValidationGenerationsLogger()
@@ -553,29 +557,96 @@ class RayPPOTrainer:
 
         print(f"Dumped generations to {filename}")
 
-    def _maybe_log_val_generations(self, inputs, outputs, scores):
+    def _maybe_log_val_generations(self, batch: DataProto):
         """Log a table of validation samples to the configured logger (wandb or swanlab)"""
-
         generations_to_log = self.config.trainer.log_val_generations
 
         if generations_to_log == 0:
             return
+        prompts, response = batch.batch["prompts"], batch.batch["responses"]
+        prompts = self.tokenizer.batch_decode(prompts, skip_special_tokens=True)
+        response = self.tokenizer.batch_decode(response, skip_special_tokens=True)
 
-        import numpy as np
+        if batch.batch.get("prompts_grm", None) is not None:
+            prompts_grm = batch.batch["prompts_grm"]
+            prompts_grm = self.tokenizer.batch_decode(prompts_grm, skip_special_tokens=True)
+        if batch.batch.get("responses_grm", None) is not None:
+            response_grm = batch.batch["responses_grm"]
+            response_grm = self.tokenizer.batch_decode(response_grm, skip_special_tokens=True)
 
-        # Create tuples of (input, output, score) and sort by input text
-        samples = list(zip(inputs, outputs, scores))
-        samples.sort(key=lambda x: x[0])  # Sort by input text
+        res_ids = list(range(len(prompts)))
+        sample_ids = random.sample(res_ids, generations_to_log)
 
-        # Use fixed random seed for deterministic shuffling
-        rng = np.random.RandomState(42)
-        rng.shuffle(samples)
+        sample_inputs = []
+        sample_outputs = []
+        sample_scores = []
+        sample_inputs_grm = []
+        sample_outputs_grm = []
+        for idx in sample_ids:
+            sample_inputs.append(prompts[idx])
+            sample_outputs.append(response[idx])
+            sample_scores.append(f"{batch.non_tensor_batch['acc'][idx]:.2f}")
+            if batch.batch.get("prompts_grm", None) is not None:
+                sample_inputs_grm.append(prompts_grm[idx])
+                sample_outputs_grm.append(response_grm[idx])
 
-        # Take first N samples after shuffling
-        samples = samples[:generations_to_log]
-
+        # Create samples as dict[dict] format
+        samples = {}
+        for i, idx in enumerate(sample_ids):
+            sample_key = f"sample_{i + 1}"
+            sample_data = {"input": prompts[idx], "output": response[idx], "score": f"{batch.non_tensor_batch['acc'][idx]:.2f}"}
+            if batch.batch.get("prompts_grm", None) is not None:
+                sample_data["input_grm"] = prompts_grm[idx]
+                sample_data["output_grm"] = response_grm[idx]
+            samples[sample_key] = sample_data
         # Log to each configured logger
         self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+
+    def _maybe_log_train_generations(self, batch: DataProto):
+        """Log a table of training samples to the configured logger (wandb or swanlab)"""
+        generations_to_log = self.config.trainer.log_train_generations
+
+        if generations_to_log == 0:
+            return
+        prompts, response = batch.batch["prompts"], batch.batch["responses"]
+        prompts = self.tokenizer.batch_decode(prompts, skip_special_tokens=True)
+        response = self.tokenizer.batch_decode(response, skip_special_tokens=True)
+
+        if batch.batch.get("prompts_grm", None) is not None:
+            prompts_grm = batch.batch["prompts_grm"]
+            prompts_grm = self.tokenizer.batch_decode(prompts_grm, skip_special_tokens=True)
+        if batch.batch.get("responses_grm", None) is not None:
+            response_grm = batch.batch["responses_grm"]
+            response_grm = self.tokenizer.batch_decode(response_grm, skip_special_tokens=True)
+
+        res_ids = list(range(len(prompts)))
+        sample_ids = random.sample(res_ids, generations_to_log)
+
+        sample_inputs = []
+        sample_outputs = []
+        sample_scores = []
+        sample_inputs_grm = []
+        sample_outputs_grm = []
+        for idx in sample_ids:
+            sample_inputs.append(prompts[idx])
+            sample_outputs.append(response[idx])
+            sample_scores.append(f"{batch.non_tensor_batch['acc'][idx]:.2f}")
+            if batch.batch.get("prompts_grm", None) is not None:
+                sample_inputs_grm.append(prompts_grm[idx])
+                sample_outputs_grm.append(response_grm[idx])
+
+        # Create samples as dict[dict] format
+        samples = {}
+        for i, idx in enumerate(sample_ids):
+            sample_key = f"sample_{i + 1}"
+            sample_data = {"input": prompts[idx], "output": response[idx], "score": f"{batch.non_tensor_batch['acc'][idx]:.2f}"}
+            if batch.batch.get("prompts_grm", None) is not None:
+                sample_data["input_grm"] = prompts_grm[idx]
+                sample_data["output_grm"] = response_grm[idx]
+            samples[sample_key] = sample_data
+
+        # Log to each configured logger
+        self.training_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
 
     def _validate(self):
         data_source_lst = []
@@ -733,6 +804,37 @@ class RayPPOTrainer:
             rm_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.RewardModel], config=self.config.reward_model)
             self.resource_pool_to_cls[resource_pool]["rm"] = rm_cls
 
+        if self.use_grm:
+
+            def copy_missing_params_to_grm(config):
+                """只复制grm中缺失的参数"""
+                with open_dict(config):
+                    # 确保grm配置存在
+                    if "grm" not in config.reward_model:
+                        config.reward_model.grm = {}
+
+                    rollout_config = config.actor_rollout_ref.rollout
+                    grm_config = config.reward_model.grm.rollout
+
+                    # 遍历actor配置，只复制grm中没有的字段
+                    for key, value in rollout_config.items():
+                        if key not in grm_config:
+                            grm_config[key] = value
+                            print(f"Copied {key} to grm: {value}")
+                        else:
+                            print(f"Skipped {key} (already exists in grm): {grm_config[key]}")
+                    config.reward_model.grm.rollout = grm_config
+
+                return config
+
+            # 使用
+            self.config = copy_missing_params_to_grm(self.config)
+            print(f"GRM config: {self.config.reward_model.grm}")
+            print(f"Actor rollout ref config: {self.config.actor_rollout_ref}")
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.GenerativeRewardModel)
+            grm_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.GenerativeRewardModel], config=self.config.reward_model.grm, role="grm")
+            self.resource_pool_to_cls[resource_pool]["grm"] = grm_cls
+
         # initialize WorkerGroup
         # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
         # you should not use `create_colocated_worker_cls`.
@@ -742,6 +844,8 @@ class RayPPOTrainer:
         wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
         if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
             wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+
+        print(f"resource_pool_to_cls: {self.resource_pool_to_cls}")
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
@@ -760,6 +864,10 @@ class RayPPOTrainer:
         if self.use_rm:
             self.rm_wg = all_wg["rm"]
             self.rm_wg.init_model()
+
+        if self.use_grm:
+            self.grm_wg = all_wg["grm"]
+            self.grm_wg.init_model()
 
         # we should create rollout at the end so that vllm can have a better estimation of kv cache memory
         self.actor_rollout_wg = all_wg["actor_rollout"]
@@ -1071,7 +1179,7 @@ class RayPPOTrainer:
                             num_repeat=self.config.actor_rollout_ref.rollout.n,
                             norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
                             multi_turn=self.config.actor_rollout_ref.rollout.multi_turn.enable,
-                            config=self.config.algorithm
+                            config=self.config.algorithm,
                         )
 
                     # update critic

--- a/verl/trainer/runtime_env.yaml
+++ b/verl/trainer/runtime_env.yaml
@@ -4,3 +4,5 @@ env_vars:
   TORCH_NCCL_AVOID_RECORD_STREAMS: "1"
   # If you are using vllm<=0.6.3, you might need to set the following environment variable to avoid bugs:
   # VLLM_ATTENTION_BACKEND: "XFORMERS"
+pip:
+  - "peft"

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -16,11 +16,12 @@ A unified tracking interface that supports logging data to different backend
 """
 
 import dataclasses
+import os
 from enum import Enum
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Union
-import os
+
 
 class Tracking:
     """A unified tracking interface for logging experiment data to multiple backends.
@@ -257,6 +258,35 @@ def _flatten_dict(raw: Dict[str, Any], *, sep: str) -> Dict[str, Any]:
     return ans
 
 
+def _generate_table_columns(samples):
+    """Generate table columns based on samples format.
+
+    Args:
+        samples: dict[dict] format where each key is sample_id and value is a dict of fields
+
+    Returns:
+        list: Column names for the table
+    """
+    if not samples:
+        return ["step"]
+
+    # Get all unique field names from all samples
+    all_fields = set()
+    for sample_data in samples.values():
+        all_fields.update(sample_data.keys())
+
+    # Sort fields for consistent ordering
+    sorted_fields = sorted(all_fields)
+
+    # Create columns: step + sample_1_field1, sample_1_field2, ..., sample_2_field1, sample_2_field2, ...
+    columns = ["step"]
+    for sample_key in sorted(samples.keys(), key=lambda x: int(x.split("_")[1])):  # Sort by sample number
+        for field in sorted_fields:
+            columns.append(f"{sample_key}_{field}")
+
+    return columns
+
+
 @dataclasses.dataclass
 class ValidationGenerationsLogger:
     def log(self, loggers, samples, step):
@@ -271,13 +301,13 @@ class ValidationGenerationsLogger:
             self.log_generations_to_clearml(samples, step)
         if "tensorboard" in loggers:
             self.log_generations_to_tensorboard(samples, step)
-            
+
     def log_generations_to_wandb(self, samples, step):
         """Log samples to wandb as a table"""
         import wandb
 
         # Create column names for all samples
-        columns = ["step"] + sum([[f"input_{i + 1}", f"output_{i + 1}", f"score_{i + 1}"] for i in range(len(samples))], [])
+        columns = _generate_table_columns(samples)
 
         if not hasattr(self, "validation_table"):
             # Initialize the table on first call
@@ -290,8 +320,11 @@ class ValidationGenerationsLogger:
         # Add new row with all data
         row_data = []
         row_data.append(step)
-        for sample in samples:
-            row_data.extend(sample)
+        for sample_key in sorted(samples.keys(), key=lambda x: int(x.split("_")[1])):  # Sort by sample number
+            sample_data = samples[sample_key]
+            sorted_fields = sorted(sample_data.keys())
+            for field in sorted_fields:
+                row_data.append(sample_data[field])
 
         new_table.add_data(*row_data)
 
@@ -304,17 +337,17 @@ class ValidationGenerationsLogger:
         import swanlab
 
         swanlab_text_list = []
-        for i, sample in enumerate(samples):
+        for i, sample in enumerate(samples.values()):
             row_text = f"""
-            input: {sample[0]}
+            input: {sample["input"]}
             
             ---
             
-            output: {sample[1]}
+            output: {sample["output"]}
             
             ---
             
-            score: {sample[2]}
+            score: {sample["score"]}
             """
             swanlab_text_list.append(swanlab.Text(row_text, caption=f"sample {i + 1}"))
 
@@ -334,8 +367,8 @@ class ValidationGenerationsLogger:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 validation_gen_step_file = Path(tmp_dir, f"val_step{step}.json")
                 row_data = []
-                for sample in samples:
-                    data = {"input": sample[0], "output": sample[1], "score": sample[2]}
+                for sample in samples.values():
+                    data = {"input": sample["input"], "output": sample["output"], "score": sample["score"]}
                     row_data.append(data)
                 with open(validation_gen_step_file, "w") as file:
                     json.dump(row_data, file)
@@ -370,36 +403,37 @@ class ValidationGenerationsLogger:
             table_plot=pd.DataFrame.from_records(table),
             iteration=step,
         )
- 
+
     def log_generations_to_tensorboard(self, samples, step):
         """Log samples to tensorboard as text"""
         # Initialize tensorboard writer if not exists
         if not hasattr(self, "writer"):
             from torch.utils.tensorboard import SummaryWriter
+
             tensorboard_dir = os.environ.get("TENSORBOARD_DIR", "tensorboard_log")
             os.makedirs(tensorboard_dir, exist_ok=True)
             self.writer = SummaryWriter(log_dir=tensorboard_dir)
-        
+
         # Format the samples data into readable text
         text_content = f"**Generation Results - Step {step}**\n\n"
-        
+
         for i, sample in enumerate(samples):
             text_content += f"### Sample {i + 1}\n"
-            
+
             # Assuming sample contains [input, output, score]
             if len(sample) >= 3:
                 input_text, output_text, score = sample[0], sample[1], sample[2]
-                
+
                 text_content += f"**Input:** {input_text}\n\n"
                 text_content += f"**Output:** {output_text}\n\n"
                 text_content += f"**Score:** {score}\n\n"
             else:
                 # Handle cases where sample format might be different
                 text_content += f"**Data:** {sample}\n\n"
-            
+
             text_content += "---\n\n"
-        
+
         # Log to tensorboard as text
-        self.writer.add_text('val/generations', text_content, step)
+        self.writer.add_text("val/generations", text_content, step)
         # Flush to ensure data is written
         self.writer.flush()


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - [x] In format of: [modules] type: Title
  - [x] modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, tests, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt`
  - [x] type is in `feat, fix, doc, refactor, chore`
  - [x] can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp] feat: xxx`

### What does this PR do?

> Add one-line overview of what this PR aims to achieve or accomplish.

- Use GenerativeRewardModel as a verifier

### Specific Changes

> List the specific changes.

- Add a new role named: GenerativeRewardModel
- Create a new ray resource pool for GenerativeRewardModel rollout process
- The GRM template is easily adaptable to a variety of tasks (see recipe/dapo/config/GRM_template.txt)
- Rewrite train / validation logger, make it easier to add new key to logger

### Usage Example

> Provide usage example(s) for easier usage.

- Just run "verl/recipe/dapo/run_dapo_qwen2.5_llm_judge.sh"

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.
- A sample from validation ( AIME)

prompt | response | GRM_prompt | GRM_response | GRM_score
-- | -- | -- | -- | --
systemYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.userSolve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.There exist real numbers $x$ and $y$, both greater than 1, such that $\log_x\left(y^x\right)=\log_y\left(x^{4y}\right)=10$. Find $xy$.Remember to put your answer on its own line after "Answer:".assistant | To solve the given problem, let's start by analyzing the given equations:1. \(\log_x(y^x) = 10\)2. \(\log_y(x^{4y}) = 10\)(reasoning process...)Thus, the value of \(xy\) is:\[\boxed{25}\] | systemYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.userSolve the following math problem step by step. The last line of your response should be of the form Answer: $Answer (without quotes) where $Answer is the answer to the problem.There exist real numbers $x$ and $y$, both greater than 1, such that $\log_x\left(y^x\right)=\log_y\left(x^{4y}\right)=10$. Find $xy$.Remember to put your answer on its own line after "Answer:".assistantTo solve the given problem, let's start by analyzing the given equations:1. \(\log_x(y^x) = 10\)2. \(\log_y(x^{4y}) = 10\)(reasoning process...)Multiply both sides by \(2xy\):\[50 = 2xy \quad \Rightarrow \quad xy = 25\]Thus, the value of \(xy\) is:\[\boxed{25}\]userThe above is a Q&A dialogue between a user and an assistant. It is now known that the standard answer to the user's question is 25. Please determine whether the assistant has answered the user's question clearly, precisely, and accurately. Present your reasoning and judgment in the following format:Think: Content of ThinkingJudgment: Correct / Incorrectassistant | Think: The assistant's response to the user's question follows a systematic approach to solving the given logarithmic problem. The assistant correctly uses properties of logarithms and the change of base formula to equate the expressions for \(\log_x(y)\) and \(\log_y(x)\). The assistant then multiplies these expressions and solves for \(xy\), arriving at the correct answer of 25. The steps provided are clear, logical, and mathematically sound.Judgment: Correct | 1

### Additional Info.

- **Issue Number**: https://github.com/volcengine/verl/issues/229
- **Training**: FSDP
- **Inference**: vLLM

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [ ] Rely on existing unit tests on CI that covers the code path.
