### PR TITLE
[ci] feat: assignment type annotation except for assignment

### DIFF
--- a/tests/special_sanity/type_coverage_check.py
+++ b/tests/special_sanity/type_coverage_check.py
@@ -43,41 +43,45 @@ def get_changed_lines(file_path: Path) -> Set[int]:
     return lines
 
 
-def has_type_annotations(node: ast.AST) -> bool:
+CHECK_SUCCESS = 0
+CHECK_WARNING = 1
+CHECK_FAILURE = -1
+
+
+def has_type_annotations(node: ast.AST) -> int:
     if isinstance(node, ast.FunctionDef):
         has_ann = all(arg.annotation is not None for arg in node.args.args if arg.arg != "self") and node.returns is not None
         return has_ann
-    elif isinstance(node, ast.AnnAssign):
-        if isinstance(node.value, ast.Call):
-            return node.annotation is not None
-        elif not isinstance(node.value, ast.Constant):
-            return node.annotation is not None
     elif isinstance(node, ast.Assign):
         if not isinstance(node.value, ast.Constant):
-            return False
-    return True
+            return CHECK_WARNING
+    return CHECK_SUCCESS
 
 
-def check_file(file_path: Path, changed_lines: Set[int]) -> Tuple[int, int, List[Tuple[Path, int, str]]]:
+def check_file(file_path: Path, changed_lines: Set[int]) -> Tuple[int, int, List[Tuple[Path, int, str]], List[Tuple[Path, int, str]]]:
     with open(file_path) as f:
         source: str = f.read()
     tree = ast.parse(source, filename=str(file_path))
 
     annotated = 0
     total = 0
-    failures: List[Tuple[Path, int, str]] = []
+    warning_lines: List[Tuple[Path, int, str]] = []
+    failure_lines: List[Tuple[Path, int, str]] = []
 
     for node in ast.walk(tree):
         if hasattr(node, "lineno") and node.lineno in changed_lines:
             if isinstance(node, (ast.FunctionDef, ast.Assign, ast.AnnAssign)):
                 total += 1
-                if has_type_annotations(node):
+                result = has_type_annotations(node)
+                if result == CHECK_SUCCESS or result == CHECK_WARNING:
                     annotated += 1
+                    if result == CHECK_WARNING:
+                        warning_lines.append((file_path, node.lineno, linecache.getline(str(file_path), node.lineno).strip()))
                 else:
                     source_line = linecache.getline(str(file_path), node.lineno).strip()
-                    failures.append((file_path, node.lineno, source_line))
+                    failure_lines.append((file_path, node.lineno, source_line))
 
-    return annotated, total, failures
+    return annotated, total, warning_lines, failure_lines
 
 
 def main() -> None:
@@ -87,21 +91,28 @@ def main() -> None:
 
     total_changed = 0
     total_annotated = 0
+    all_warnings: List[Tuple[Path, int, str]] = []
     all_failures: List[Tuple[Path, int, str]] = []
 
     for fpath in get_changed_files():
         changed_lines = get_changed_lines(fpath)
-        annotated, total, failures = check_file(fpath, changed_lines)
+        annotated, total, warning_lines, failure_lines = check_file(fpath, changed_lines)
         total_annotated += annotated
         total_changed += total
-        all_failures.extend(failures)
+        all_warnings.extend(warning_lines)
+        all_failures.extend(failure_lines)
 
     ratio = (total_annotated / total_changed) if total_changed else 1.0
 
     print(f"🔍 Type coverage on changed lines: {total_annotated}/{total_changed} = {ratio:.2%}")
 
+    if all_warnings:
+        print("\n⚠️ Suggest Improve: Lines missing type annotations:\n")
+        for fname, lineno, line in all_failures:
+            print(f"{fname}:{lineno}: {line}")
+
     if all_failures:
-        print("\n⚠️ Lines missing type annotations:\n")
+        print("\n⚠️ [ERROR] Lines missing type annotations:\n")
         for fname, lineno, line in all_failures:
             print(f"{fname}:{lineno}: {line}")
 


### PR DESCRIPTION
### Checklist Before Starting

- [ ] Searched for similar PR(s).
- [ ] Checked PR Title format
  - In format of: [modules] type: Title
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc`
  - type is in `feat, fix, refactor, chore`
  - can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

Type checking seems to be too strict.

```py
a = 0
data = data.to("cpu")
```

seems have no need for annotation.

Assignment only print warnings.

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

> Provide usage example(s) for easier usage.

```python
# Add code snippet or script demonstrating how to use this 
```

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [ ] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [ ] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [ ] Rely on existing unit tests on CI that covers the code path.
