### PR TITLE
[trainer] Adding multithread_reward_computation

### DIFF
--- a/tests/reward_score/test_compute_reward_multithread.py
+++ b/tests/reward_score/test_compute_reward_multithread.py
@@ -1,0 +1,119 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import ray
+import torch
+
+from verl import DataProto
+from verl.trainer.ppo.reward import compute_reward, compute_reward_async
+
+
+def main():
+    # -------------------------
+    # 1. Build a DataProto
+    # -------------------------
+    tensors = {
+        "input_ids": torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]], dtype=torch.float32),  # shape (4, 3)
+    }
+    non_tensors = {
+        "text": np.array(["a", "b", "c", "d"], dtype=object),
+    }
+    meta_info = {"split": "demo"}
+
+    dp = DataProto.from_dict(
+        tensors=tensors,
+        non_tensors=non_tensors,
+        meta_info=meta_info,
+    )
+
+    # -------------------------
+    # 2. Define a simple reward function
+    # -------------------------
+    def simple_reward_fn(data_proto, return_dict=False):
+        # Sum each row in input_ids → shape (batch_size,)
+        batch = data_proto.batch["input_ids"]
+        rewards = batch.sum(dim=1)
+        if return_dict:
+            return {"reward_tensor": rewards, "reward_extra_info": {"note": "sum_of_inputs"}}
+        return rewards
+
+    # -------------------------
+    # 3. Synchronous: main_process vs multi-thread
+    # -------------------------
+    r_single, info_single = compute_reward(dp, simple_reward_fn, num_workers=0)
+    r_multi, info_multi = compute_reward(dp, simple_reward_fn, num_workers=4)
+
+    # If multi-thread returns a list, concatenate into a Tensor
+    if isinstance(r_multi, list):
+        r_multi = torch.cat(r_multi, dim=0)
+
+    print("Single-worker rewards:", r_single)
+    print("Multi-worker  rewards:", r_multi)
+    print("Single-worker info:", info_single)
+    print("Multi-worker  info:", info_multi)
+
+    assert torch.allclose(r_single, r_multi), "Mismatch between main process and multi-thread outputs!"
+    assert info_single == info_multi, "Mismatch in extra_info between main process and multi-thread!"
+
+    # -------------------------
+    # 4. Asynchronous: Ray remote call
+    # -------------------------
+    ray.init(local_mode=True, ignore_reinit_error=True)
+
+    # Minimal config stub for compute_reward_async.remote
+    class CFG:
+        def __init__(self):
+            self.reward_model = type("M", (), {"get": lambda self, k, default=None: {"reward_manager": "naive", "sandbox_fusion": None, "reward_kwargs": {}}.get(k, default), "reward_fn_workers": 4})()
+            self.data = type("D", (), {"reward_fn_key": "reward_tensor"})
+
+    cfg = CFG()
+    tokenizer = None  # Not used in this example
+
+    # Monkey-patch load_reward_manager to return our simple_reward_fn
+    import verl.trainer.ppo.reward as Rmod
+
+    original_loader = Rmod.load_reward_manager
+    Rmod.load_reward_manager = lambda config, tokenizer, num_examine, **kw: simple_reward_fn
+
+    # Remote invocation
+    obj_ref = compute_reward_async.remote(dp, cfg, tokenizer)
+    r_async, info_async = ray.get(obj_ref)
+
+    # Restore original loader
+    Rmod.load_reward_manager = original_loader
+
+    ray.shutdown()
+
+    # If result is a list, concatenate into a Tensor
+    if isinstance(r_async, list):
+        r_async = torch.cat(r_async, dim=0)
+
+    print("Async-worker rewards:", r_async)
+    print("Async-worker info:", info_async)
+
+    assert torch.allclose(r_single, r_async), "Mismatch between sync and async outputs!"
+    assert info_single == info_async, "Mismatch in extra_info between sync and async!"
+
+    # -------------------------
+    # 5. Final assertion
+    # -------------------------
+    expected = torch.tensor([6.0, 15.0, 24.0, 33.0])
+    assert torch.allclose(r_single, expected), f"Results {r_single} do not match expected {expected}"
+
+    print("All tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/trainer/config/ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/ppo_megatron_trainer.yaml
@@ -287,6 +287,7 @@ reward_model:
   max_length: null
   reward_manager: naive
   launch_reward_fn_async: False # custom reward function executed async on CPU, during log_prob
+  reward_fn_workers: 0 # Number of multithreaded workers to run the reward function; set to 0 to run in the main process.
   sandbox_fusion:
     url: null # faas url to run code in cloud sandbox
     max_concurrent: 64 # max concurrent requests to sandbox

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -702,6 +702,9 @@ reward_model:
   # Whether to launch custom reward function asynchronously during log_prob
   launch_reward_fn_async: False
 
+  # Number of multithreaded workers to run the reward function; set to 0 to run in the main process.
+  reward_fn_workers: 0 
+
   # Cloud/local sandbox fusion configuration for custom reward logic
   sandbox_fusion:
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -990,7 +990,7 @@ class RayPPOTrainer:
                         if self.config.reward_model.launch_reward_fn_async:
                             future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
                         else:
-                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
+                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn, self.config.reward_model.reward_fn_workers)
 
                     # recompute old_log_probs
                     with _timer("old_log_prob", timing_raw):

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -150,11 +150,6 @@ def compute_reward(data: DataProto, reward_fn, num_workers: int) -> tuple:
         tuple:
             - merged_reward (torch.Tensor | list): Concatenated or aggregated rewards from all chunks.
             - merged_info (dict): Merged auxiliary information returned by each chunk.
-
-    Notes:
-        - If `reward_fn` is pickleable, `ProcessPoolExecutor` is used (avoids Python GIL).
-        - Otherwise, `ThreadPoolExecutor` is used (subject to GIL constraints).
-        - Rewards and extra information are aggregated across all chunks.
     """
     if num_workers < 0:
         raise ValueError("num_workers must be non-negative, got {}".format(num_workers))

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -12,93 +12,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import multiprocessing
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 
 import ray
+import torch
 
 from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 
 
-def get_custom_reward_fn(config):
+def get_custom_reward_fn(config):  # 获取自定义奖励函数
     import importlib.util
     import sys
 
-    reward_fn_config = config.get("custom_reward_function") or {}
-    file_path = reward_fn_config.get("path")
+    reward_fn_config = config.get("custom_reward_function") or {}  # 获取奖励函数信息
+    file_path = reward_fn_config.get("path")  # 自定义奖励函数路径
     if not file_path:
         return None
 
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"Reward function file '{file_path}' not found.")
 
-    spec = importlib.util.spec_from_file_location("custom_module", file_path)
-    module = importlib.util.module_from_spec(spec)
+    module_name = os.path.splitext(os.path.basename(file_path))[0]
+    # 把自定义的函数加载到当前的Python环境中
+    # spec = importlib.util.spec_from_file_location("custom_module", file_path)   # 准备加载自定义模块
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)  # 加载自定义模块(效果类似于import)
     try:
-        sys.modules["custom_module"] = module
-        spec.loader.exec_module(module)
+        # sys.modules["custom_module"] = module           # 将模块添加到sys.modules中，以便可以通过模块名访问.
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)  # 执行模块代码
     except Exception as e:
         raise RuntimeError(f"Error loading module from '{file_path}': {e}") from e
 
-    function_name = reward_fn_config.get("name")
+    function_name = reward_fn_config.get("name")  # 获取自定义奖励函数名称(这里是my_reward_fn)
     if not hasattr(module, function_name):
         raise AttributeError(f"Reward function '{function_name}' not found in '{file_path}'.")
 
     print(f"using customized reward function '{function_name}' from '{file_path}'")
-    raw_fn = getattr(module, function_name)
+    raw_fn = getattr(module, function_name)  # 获取函数对象
 
-    reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))
+    reward_kwargs = dict(reward_fn_config.get("reward_kwargs", {}))  # 获取奖励函数的额外参数
 
     def wrapped_fn(*args, **kwargs):
-        return raw_fn(*args, **kwargs, **reward_kwargs)
+        return raw_fn(*args, **kwargs, **reward_kwargs)  # 给自定义奖励函数传入额外参数并封装
 
-    return wrapped_fn
+    return wrapped_fn  # 返回自定义奖励函数
+    # return raw_fn
 
 
 def load_reward_manager(config, tokenizer, num_examine, **reward_kwargs):
-    """
-    Load and initialize a reward manager based on the configuration.
-
-    Args:
-        config: PPO trainer configuration object containing reward_model fields.
-        tokenizer: Tokenizer object used for processing text.
-        num_examine: Number of samples to examine.
-        **reward_kwargs: Additional keyword arguments for the reward manager.
-
-    Returns:
-        An instance of the specified reward manager class.
-    """
-    from verl.workers.reward_manager import get_reward_manager_cls
-
-    # The list of pre-defined reward managers are defined in `verl/workers/reward_manager/`:
-    # naive: NaiveRewardManager
-    # prime: PrimeRewardManager
-    # batch: BatchRewardManager
-    # dapo: DAPORewardManager
-    # Note(haibin.lin): For custom reward managers, please make sure they are imported and
-    # registered via `verl.workers.reward_manager.register`
-    # By default reward_manager is set to naive (NaiveRewardManager)
     reward_manager_name = config.reward_model.get("reward_manager", "naive")
-    reward_manager_cls = get_reward_manager_cls(reward_manager_name)
+    if reward_manager_name == "naive":
+        from verl.workers.reward_manager import NaiveRewardManager
 
-    # Try to get a custom reward function based on the configuration
-    compute_score = get_custom_reward_fn(config)
+        reward_manager_cls = NaiveRewardManager
+    elif reward_manager_name == "prime":
+        from verl.workers.reward_manager import PrimeRewardManager
+
+        reward_manager_cls = PrimeRewardManager
+    elif reward_manager_name == "batch":
+        from verl.workers.reward_manager import BatchRewardManager
+
+        reward_manager_cls = BatchRewardManager
+    elif reward_manager_name == "dapo":
+        from verl.workers.reward_manager import DAPORewardManager
+
+        reward_manager_cls = DAPORewardManager
+    else:
+        raise NotImplementedError
+
+    compute_score = get_custom_reward_fn(config)  # 获取自定义奖励函数
     final_compute_score = compute_score
 
-    if compute_score is None:
-        sandbox_config = config.reward_model.get("sandbox_fusion")
-        sandbox_url = sandbox_config.get("url") if sandbox_config else None
-        if sandbox_url:
-            sandbox_manager = multiprocessing.Manager()
-            # Create a semaphore to control concurrent access to the sandbox
+    # sandbox是它通常指一个专门用于运行模型输出评估逻辑的外部服务或系统, 用于处理模型输出的评分和评估
+    if compute_score is None:  # 如果没有自定义奖励函数，则使用默认的计算分数函数
+        sandbox_config = config.reward_model.get("sandbox_fusion")  # 获取沙箱配置
+        sandbox_url = sandbox_config.get("url") if sandbox_config else None  # 获取沙箱URL
+        if sandbox_url:  # 如果使用沙箱远程打分
+            sandbox_manager = multiprocessing.Manager()  # 创建一个多进程管理器
+            # sandbox_manager.Semaphore是一个信号量, 用于限制并发访问的数量, 这里默认最大64个并发请求
             _concurrent_semaphore = sandbox_manager.Semaphore(sandbox_config.get("max_concurrent", 64))
+            # 使用partial创建一个带默认参数的函数, 以后调用final_compute_score时,
+            # 会自动传入sandbox_fusion_url和_concurrent_semaphore
             final_compute_score = partial(default_compute_score, sandbox_fusion_url=sandbox_url, concurrent_semaphore=_concurrent_semaphore)
         else:
-            final_compute_score = default_compute_score
+            final_compute_score = default_compute_score  # 没有使用沙箱服务, 就使用默认的奖励函数.
 
-    # Instantiate and return the reward manager with the specified parameters
     return reward_manager_cls(
         tokenizer=tokenizer,
         num_examine=num_examine,
@@ -108,25 +112,86 @@ def load_reward_manager(config, tokenizer, num_examine, **reward_kwargs):
     )
 
 
-def compute_reward(data: DataProto, reward_fn):
+def _compute_reward_chunk(chunk: DataProto, reward_fn):
     """
     Compute reward for a batch of data.
     Args:
-        data: DataProto object containing the input data.
-        reward_fn: Reward function to compute the reward.
-    Returns:
-        Tuple of reward tensor and extra info dictionary.
+         data: DataProto object containing the input data.
+         reward_fn: Reward function to compute the reward.
+     Returns:
+         Tuple of reward tensor and extra info dictionary.
     """
     try:
-        reward_result = reward_fn(data, return_dict=True)
+        reward_result = reward_fn(chunk, return_dict=True)
         reward_tensor = reward_result["reward_tensor"]
         reward_extra_infos_dict = reward_result["reward_extra_info"]
     except Exception as e:
         print(f"Error in reward_fn: {e}")
-        reward_tensor = reward_fn(data)
+        reward_tensor = reward_fn(chunk)
         reward_extra_infos_dict = {}
 
     return reward_tensor, reward_extra_infos_dict
+
+
+def compute_reward(data: DataProto, reward_fn, num_workers: int) -> tuple:
+    """
+    Computes rewards for a batch of data by splitting it into chunks and processing them in parallel.
+
+    This function supports multithreading.
+
+    Args:
+        data (DataProto): Input dataset that supports slicing and `len()`.
+        reward_fn (Callable): A function that computes rewards for a batch of data.
+            It should return either a tensor or a dictionary containing the reward information.
+        num_workers (int, optional): Number of parallel workers (threads or processes).
+            Set to 0 to run everything in the main process.
+
+    Returns:
+        tuple:
+            - merged_reward (torch.Tensor | list): Concatenated or aggregated rewards from all chunks.
+            - merged_info (dict): Merged auxiliary information returned by each chunk.
+
+    Notes:
+        - If `reward_fn` is pickleable, `ProcessPoolExecutor` is used (avoids Python GIL).
+        - Otherwise, `ThreadPoolExecutor` is used (subject to GIL constraints).
+        - Rewards and extra information are aggregated across all chunks.
+    """
+    if num_workers < 0:
+        raise ValueError("num_workers must be non-negative, got {}".format(num_workers))
+    elif num_workers == 0:
+        return _compute_reward_chunk(data, reward_fn)  # If num_workers is 0, run in the main process
+
+    total = len(data)
+    if total == 0:
+        return [], {}
+
+    Executor = ThreadPoolExecutor
+
+    # calculate the number of chunks
+    num_chunks = min(num_workers, total)
+    chunk_size = math.ceil(total / num_chunks)
+
+    # Split the data into chunks
+    chunks = [data[i : i + chunk_size] for i in range(0, total, chunk_size)]
+
+    # Initialize rewards and extras
+    rewards, extras = [None] * len(chunks), {}  # Initialize rewards as a list of None, and extras as an empty dict
+    with Executor(max_workers=num_workers) as executor:
+        futures = {executor.submit(_compute_reward_chunk, chunk, reward_fn): i for i, chunk in enumerate(chunks)}
+        for fut in as_completed(futures):
+            idx = futures[fut]  # get the index of the completed future
+            tensor_chunk, info_chunk = fut.result()
+            rewards[idx] = tensor_chunk  # put the result in the corresponding index
+            extras.update(info_chunk)
+
+    # merge reward_tensor
+    first = rewards[0]
+    if isinstance(first, list):
+        merged_reward = sum(rewards, [])
+    else:
+        merged_reward = torch.cat(rewards, dim=0)
+
+    return merged_reward, extras
 
 
 @ray.remote(num_cpus=1)
@@ -136,4 +201,4 @@ def compute_reward_async(data: DataProto, config, tokenizer):
     This is meant to be run in a separate Ray worker.
     """
     reward_fn = load_reward_manager(config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {}))
-    return compute_reward(data, reward_fn)
+    return compute_reward(data, reward_fn, config.reward_model.reward_fn_workers)


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).


### What does this PR do?
In the text-to-SQL domain, reward computation involves querying the database, making CPU processing a performance bottleneck. The compute_reward function has been enhanced with multithreading support.

### Test

<img width="957" alt="736673ca672ebcc67a0d0214a7abc74" src="https://github.com/user-attachments/assets/8fcda2a3-e7d9-4982-951c-17ccd714f3ca" />
This is a comparison of computation efficiency under the same time period. The yellow line represents the number of steps computed by the original compute_reward function, while the blue line represents the steps computed after the modification.

<img width="1252" alt="93e69205642ca7b12e6214b40473f2d" src="https://github.com/user-attachments/assets/8f92411d-c5e2-42f6-8016-a39acf914fa8" />
<img width="1249" alt="1b05e9ca7d14d2ac85c15448434d8f3" src="https://github.com/user-attachments/assets/c5533d6d-121b-422a-9845-f3b1a364a87f" />
This is a comparison of single-step computation efficiency before and after the modification.

### Specific Changes

1. Added multithreading support to the `compute_reward` function for parallel reward computation.
2. Adding `reward_fn_workers: 0` to `ppo_trainer.yml` and `ppo_megatron_trainer.yml`
3. Modified the corresponding interface of the `compute_reward` function in ray_trainer.py.
4. Adding test examples in tests/reward_score/test_compute_reward_multithread.py

### API
Original: compute_reward(data: DataProto, reward_fn)
Modify: compute_reward(data: DataProto, reward_fn, num_workers: int)
`num_workers` is the number of threads.

### Usage Example

> Provide usage example(s) for easier usage.
python -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    ...
   reward_model.reward_fn_workers=16

### NOTE
`reward_model.reward_fn_workers=0` indicates that reward computation is performed in the main process, while `reward_model.reward_fn_workers=n` (where n >= 1) means that n threads are used for reward computation.
It is recommended to use `reward_model.reward_fn_workers`  <= 16 otherwise you may get `ray.exceptions.ActorUnavailableError: The actor xxxxxxxxxxxxxxxx is unavailable: The actor is temporarily unavailable: RpcError: RPC Error message: keepalive watchdog timeout; RPC Error details:  rpc_code: 14. The task may or maynot have been executed on the actor.
`

```python
python -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    .......
    reward_model.reward_fn_workers=16
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
