### PR TITLE
[logging] feat: wandb entity logging for collaboration in teams

### DIFF
--- a/docs/workers/ray_trainer.rst
+++ b/docs/workers/ray_trainer.rst
@@ -120,6 +120,7 @@ To extend to other RLHF algorithms, such as DPO, GRPO, please refer to
 
        logger = Tracking(project_name=self.config.trainer.project_name,
                            experiment_name=self.config.trainer.experiment_name,
+                           entity=self.config.trainer.get('entity', None),
                            default_backend=self.config.trainer.logger,
                            config=OmegaConf.to_container(self.config, resolve=True))
 

--- a/examples/split_placement/split_monkey_patch.py
+++ b/examples/split_placement/split_monkey_patch.py
@@ -48,6 +48,7 @@ def fit(self):
     logger = Tracking(
         project_name=self.config.trainer.project_name,
         experiment_name=self.config.trainer.experiment_name,
+        entity=self.config.trainer.get('entity', None),
         default_backend=self.config.trainer.logger,
         config=OmegaConf.to_container(self.config, resolve=True),
     )

--- a/recipe/dapo/dapo_ray_trainer.py
+++ b/recipe/dapo/dapo_ray_trainer.py
@@ -55,6 +55,7 @@ class RayDAPOTrainer(RayPPOTrainer):
         logger = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
+            entity=self.config.trainer.get('entity', None),
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
         )

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -317,6 +317,7 @@ class RayPRIMETrainer(RayPPOTrainer):
         logger = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
+            entity=self.config.trainer.get('entity', None),
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
         )

--- a/recipe/spin/spin_trainer.py
+++ b/recipe/spin/spin_trainer.py
@@ -867,7 +867,7 @@ class RaySPINTrainer:
         # Initialize logger
         logger = None
         try:
-            logger = Tracking(project_name=self.config.trainer.project_name, experiment_name=self.config.trainer.experiment_name, default_backend=self.config.trainer.logger, config=OmegaConf.to_container(self.config, resolve=True, throw_on_missing=False))
+            logger = Tracking(project_name=self.config.trainer.project_name, experiment_name=self.config.trainer.experiment_name, entity=self.config.trainer.get('entity', None), default_backend=self.config.trainer.logger, config=OmegaConf.to_container(self.config, resolve=True, throw_on_missing=False))
         except Exception as e:
             print(f"Warning: Failed to initialize logger: {e}")
 

--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -132,6 +132,7 @@ class RaySPPOTrainer(RayPPOTrainer):
         logger = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
+            entity=self.config.trainer.get('entity', None),
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
         )

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -802,6 +802,9 @@ trainer:
   # Logging backends to use: "console", "wandb", etc.
   logger: [ 'console', 'wandb' ]
 
+  # When using wandb, the group name for runs
+  entity: verl
+
   # Number of generations to log during validation
   log_val_generations: 0
 

--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -55,6 +55,7 @@ trainer:
   resume_path: null
   project_name: gsm8k-sft
   experiment_name: test
+  entity: verl
   total_epochs: 4
   total_training_steps: null
   logger: [ 'console', 'wandb' ]

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -888,6 +888,7 @@ class RayPPOTrainer:
         logger = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
+            entity=self.config.trainer.get('entity', None),
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
         )

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -36,7 +36,7 @@ class Tracking:
 
     supported_backend = ["wandb", "mlflow", "swanlab", "vemlp_wandb", "tensorboard", "console", "clearml"]
 
-    def __init__(self, project_name, experiment_name, default_backend: Union[str, List[str]] = "console", config=None):
+    def __init__(self, project_name, experiment_name, entity = None, default_backend: Union[str, List[str]] = "console", config=None):
         if isinstance(default_backend, str):
             default_backend = [default_backend]
         for backend in default_backend:
@@ -55,7 +55,7 @@ class Tracking:
             settings = None
             if config and config["trainer"].get("wandb_proxy", None):
                 settings = wandb.Settings(https_proxy=config["trainer"]["wandb_proxy"])
-            wandb.init(project=project_name, name=experiment_name, config=config, settings=settings)
+            wandb.init(project=project_name, name=experiment_name, entity=entity, config=config, settings=settings)
             self.logger["wandb"] = wandb
 
         if "mlflow" in default_backend:


### PR DESCRIPTION
### Checklist Before Starting

- [✅] Searched for similar PR(s).
- [✅] Checked PR Title format
  - In format of: [modules] type: Title
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data`
  - type is in `feat, fix, refactor, chore`
  - can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

Passes in the `entity` parameter into logging, enabling syncing of wandb logs in teams.


### Specific Changes

Everywhere with logger = Tracking, pass the entity parameter

```python
        logger = Tracking(
            project_name=self.config.trainer.project_name,
            experiment_name=self.config.trainer.experiment_name,
            entity=self.config.trainer.get('entity', None),
            default_backend=self.config.trainer.logger,
            config=OmegaConf.to_container(self.config, resolve=True),
        )
```

### Checklist Before Submitting

- [✅] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [✅] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [✅] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [✅] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [ ] New CI unit test(s) are added to cover the code path.
- [✅] Rely on existing unit tests on CI that covers the code path.
