### PR TITLE
[sglang] feat: Enable LangGraph-based rollout with per-message chat template arguments and sampling param overrides

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -484,11 +484,26 @@ actor_rollout_ref:
       # set to True for multi-turn tool interaction tasks; should set rollout.name to sglang as well
       enable: False
 
+      # Chat template kwargs that will be passed to chat template renderer. Example: {"enable_thinking": False}
+      chat_template_kwargs: null
+
       # null for no limit (default max_length // 3)
       max_turns: null
 
       # null for no tool
       tool_config_path: null
+
+      # LangGraph script for multiturn rollout.
+      langgraph:
+
+        # Path to the LangGraph script file.
+        path: null
+
+        # The name of the graph object. Default is 'graph'.
+        name: graph
+
+        # Runnable config for LangGraph.
+        graph_config: {}
 
       # null for default callback
       completion_callback: null

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -460,7 +460,11 @@ class RayPPOTrainer:
 
         # check multi_turn with tool config
         if config.actor_rollout_ref.rollout.multi_turn.enable:
-            assert config.actor_rollout_ref.rollout.multi_turn.tool_config_path is not None, "tool_config_path must be set when enabling multi_turn with tool, due to no role-playing support"
+            if "sglang" in config.actor_rollout_ref.rollout.name:
+                multiturn_settings_cnt = (config.actor_rollout_ref.rollout.multi_turn.tool_config_path is not None) + (config.actor_rollout_ref.rollout.multi_turn.langgraph.path is not None)
+                assert multiturn_settings_cnt == 1, f"One and only one of tool_config_path or langgraph.path must be set when enabling multi_turn with tool. Got {multiturn_settings_cnt} of them set."
+            else:
+                assert config.actor_rollout_ref.rollout.multi_turn.tool_config_path is not None, "tool_config_path must be set when enabling multi_turn with tool, due to no role-playing support"
             assert config.algorithm.adv_estimator in [AdvantageEstimator.GRPO], "only GRPO is tested for multi-turn with tool"
 
         print("[validate_config] All configuration checks passed successfully!")
@@ -614,6 +618,8 @@ class RayPPOTrainer:
                 non_tensor_batch_keys_to_pop.append("raw_prompt")
             if "tools_kwargs" in test_batch.non_tensor_batch:
                 non_tensor_batch_keys_to_pop.append("tools_kwargs")
+            if "langgraph_input_kwargs" in test_batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("langgraph_input_kwargs")
             test_gen_batch = test_batch.pop(
                 batch_keys=batch_keys_to_pop,
                 non_tensor_batch_keys=non_tensor_batch_keys_to_pop,
@@ -946,6 +952,8 @@ class RayPPOTrainer:
                     non_tensor_batch_keys_to_pop.append("raw_prompt")
                 if "tools_kwargs" in batch.non_tensor_batch:
                     non_tensor_batch_keys_to_pop.append("tools_kwargs")
+                if "langgraph_input_kwargs" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("langgraph_input_kwargs")
                 gen_batch = batch.pop(
                     batch_keys=batch_keys_to_pop,
                     non_tensor_batch_keys=non_tensor_batch_keys_to_pop,

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -300,11 +300,13 @@ class RLHFDataset(Dataset):
         # add index for each prompt
         index = row_dict.get("extra_info", {}).get("index", 0)
         tools_kwargs = row_dict.get("extra_info", {}).get("tools_kwargs", {})
+        langgraph_input_kwargs = row_dict.get("extra_info", {}).get("langgraph_input_kwargs", {})
         need_tools_kwargs = row_dict.get("extra_info", {}).get("need_tools_kwargs", self.need_tools_kwargs)
         if need_tools_kwargs and not tools_kwargs:
             logger.warning("tools_kwargs is empty for index {}, data source: {}", index, row_dict["data_source"])
         row_dict["index"] = index
         row_dict["tools_kwargs"] = tools_kwargs
+        row_dict["langgraph_input_kwargs"] = langgraph_input_kwargs
         return row_dict
 
     def __getstate__(self):

--- a/verl/workers/rollout/schemas.py
+++ b/verl/workers/rollout/schemas.py
@@ -15,10 +15,10 @@
 import logging
 import os
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import torch
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 from transformers import PreTrainedTokenizer
 
 from verl.tools.schemas import OpenAIFunctionToolCall, OpenAIFunctionToolSchema
@@ -50,9 +50,11 @@ class FinishReasonTypeEnum(str, Enum):
 
 
 class Message(BaseModel):
-    role: str
+    role: Literal["user", "assistant", "system", "tool"]
     content: str
     tool_calls: Optional[List[OpenAIFunctionToolCall]] = None
+
+    metadata: Dict[str, Any] = Field(default_factory=dict, exclude=True)
 
 
 class AsyncRolloutRequestStateEnum(str, Enum):
@@ -75,6 +77,7 @@ class AsyncRolloutRequest(BaseModel):
     messages: List[Message]
     tool_schemas: Optional[List[OpenAIFunctionToolSchema]] = None
     tools_kwargs: Dict[str, Any] = {}
+    langgraph_input_kwargs: Dict[str, Any] = {}
     input_ids: List[int]
     prompt_ids: List[int]
     response_ids: List[int]
@@ -92,12 +95,10 @@ class AsyncRolloutRequest(BaseModel):
     max_response_len: int = 8192
     max_model_len: int = 32768
     metrics: Dict[str, List[Any]] = {}
+    chat_template_kwargs: Dict[str, Any] = {}
 
     use_inference_chat_template: bool
     enable_tokenization_sanity_check: bool
-    generation_prompt_ids: List[int]
-    base_conv_wo_gen_prompt_end_pos: int
-    base_conv_with_gen_prompt_end_pos: int
 
     @model_validator(mode="before")
     @classmethod
@@ -111,10 +112,9 @@ class AsyncRolloutRequest(BaseModel):
 
         values["messages"] = [Message.model_validate(msg) for msg in messages]
 
-        tools = [tool.model_dump() for tool in tool_schemas] if (tool_schemas := values.get("tool_schemas", [])) else None
-        tokens_without_prompt = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=False, tokenize=True)
+        tools = [tool.model_dump() for tool in tool_schemas] if (tool_schemas := values.get("tool_schemas")) else None
         if not values.get("input_ids") or not values.get("attention_mask"):
-            tokenization_dict_with_prompt = tokenizer.apply_chat_template(messages, tools=[tool.model_dump() for tool in tool_schemas], add_generation_prompt=True, tokenize=True, return_dict=True)
+            tokenization_dict_with_prompt = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=False, tokenize=True, return_dict=True, **values.get("chat_template_kwargs", {}))
             values["input_ids"], values["attention_mask"] = tokenization_dict_with_prompt["input_ids"], tokenization_dict_with_prompt["attention_mask"]
             if len(values["input_ids"]) > max_prompt_len:
                 # Only log the warning to avoid truncating in the middle of generation prompt. Consider raising an error for this case in the future.
@@ -123,9 +123,6 @@ class AsyncRolloutRequest(BaseModel):
         values["prompt_ids"], values["prompt_attention_mask"] = values["input_ids"], values["attention_mask"]
         values["position_ids"] = values["prompt_position_ids"] = compute_position_id_with_mask(torch.tensor(values["attention_mask"])).tolist()
         values["loss_mask"] = values["prompt_loss_mask"] = [0] * len(values["input_ids"])
-        values["generation_prompt_ids"] = values["input_ids"][len(tokens_without_prompt) :]
-        values["base_conv_wo_gen_prompt_end_pos"] = len(tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=False, tokenize=False))
-        values["base_conv_with_gen_prompt_end_pos"] = len(tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=True, tokenize=False))
         return values
 
     def _update_input_ids(self, new_input_ids: List[int], attention_mask: bool, loss_mask: bool) -> None:
@@ -141,34 +138,62 @@ class AsyncRolloutRequest(BaseModel):
         assert len(self.input_ids) == len(self.attention_mask) == len(self.position_ids) == len(self.loss_mask), f"""Request {self.request_id} has different length of {len(self.input_ids)=}, 
             {len(self.attention_mask)=}, {len(self.position_ids)=}, {len(self.loss_mask)=}"""
 
-    def get_generation_prompt_ids(self, tokenizer: PreTrainedTokenizer) -> list[int]:
-        generation_prompt_ids = [] if self.input_ids[-len(self.generation_prompt_ids) :] == self.generation_prompt_ids else self.generation_prompt_ids
-        if generation_prompt_ids:
+    def get_generation_prompt_ids(self, tokenizer: PreTrainedTokenizer, chat_template_kwargs: Optional[dict[str, Any]] = None) -> list[int]:
+        chat_template_kwargs = chat_template_kwargs if chat_template_kwargs is not None else self.chat_template_kwargs
+        tools = [tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None
+
+        base_end_pos = len(tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=False, tokenize=False, **chat_template_kwargs))
+        generation_prompt = tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=True, tokenize=False, **chat_template_kwargs)[base_end_pos:]
+        generation_prompt_ids = tokenizer.encode(generation_prompt, add_special_tokens=False)
+        if self.input_ids[-len(generation_prompt_ids) :] != generation_prompt_ids:
             self._update_input_ids(generation_prompt_ids, attention_mask=True, loss_mask=False)
 
         if self.use_inference_chat_template:
-            return tokenizer.apply_chat_template([msg.model_dump() for msg in self.messages], tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None), add_generation_prompt=True, tokenize=True)
+            return tokenizer.apply_chat_template([msg.model_dump() for msg in self.messages], tools=tools, add_generation_prompt=True, tokenize=True, **chat_template_kwargs)
         else:
             return self.input_ids
+
+    def add_messages(self, tokenizer: PreTrainedTokenizer, messages: list[Message], loss_mask: bool = False, exclude_generation_prompt: bool = False, chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        self.messages.extend(messages)
+        chat_template_kwargs = chat_template_kwargs if chat_template_kwargs is not None else self.chat_template_kwargs
+        tools = [tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None
+        content = tokenizer.apply_chat_template(
+            [*BASE_CHAT_HISTORY, *messages],
+            tools=tools,
+            add_generation_prompt=False,
+            tokenize=False,
+            **chat_template_kwargs,
+        )
+        base_end_pos = len(
+            tokenizer.apply_chat_template(
+                BASE_CHAT_HISTORY,
+                tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None),
+                add_generation_prompt=exclude_generation_prompt,
+                tokenize=False,
+                **chat_template_kwargs,
+            )
+        )
+        content_ids = tokenizer.encode(content[base_end_pos:], add_special_tokens=False)
+        self._update_input_ids(content_ids, attention_mask=True, loss_mask=loss_mask)
 
     def add_assistant_message(
         self,
         tokenizer: PreTrainedTokenizer,
         content: str,
         tool_calls: Optional[List[OpenAIFunctionToolCall]] = None,
+        chat_template_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
-        self.messages.append(Message(role="assistant", content=content, tool_calls=tool_calls))
-        content = tokenizer.apply_chat_template([*BASE_CHAT_HISTORY, self.messages[-1]], tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None), add_generation_prompt=False, tokenize=False)
-        content_ids = tokenizer.encode(content[self.base_conv_with_gen_prompt_end_pos :], add_special_tokens=False)
-        self._update_input_ids(content_ids, attention_mask=True, loss_mask=True)
+        self.add_messages(tokenizer, [Message(role="assistant", content=content, tool_calls=tool_calls)], loss_mask=True, exclude_generation_prompt=True, chat_template_kwargs=chat_template_kwargs)
 
-    def add_tool_response_messages(self, tokenizer: PreTrainedTokenizer, contents: list[str]) -> None:
-        if not contents:
-            return
-        self.messages.extend([Message(role="tool", content=content) for content in contents])
-        content = tokenizer.apply_chat_template([*BASE_CHAT_HISTORY, *self.messages[-len(contents) :]], tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None), add_generation_prompt=False, tokenize=False)
-        content_ids = tokenizer.encode(content[self.base_conv_wo_gen_prompt_end_pos :], add_special_tokens=False)
-        self._update_input_ids(content_ids, attention_mask=True, loss_mask=False)
+    def add_tool_response_messages(self, tokenizer: PreTrainedTokenizer, contents: list[str], chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        if contents:
+            self.add_messages(tokenizer, [Message(role="tool", content=content) for content in contents], chat_template_kwargs=chat_template_kwargs)
+
+    def add_user_message(self, tokenizer: PreTrainedTokenizer, content: str, chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        self.add_messages(tokenizer, [Message(role="user", content=content)], chat_template_kwargs=chat_template_kwargs)
+
+    def add_system_message(self, tokenizer: PreTrainedTokenizer, content: str, chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        self.add_messages(tokenizer, [Message(role="system", content=content)], chat_template_kwargs=chat_template_kwargs)
 
     def update_metrics(self, metrics: Any, tool_id: str) -> None:
         """
@@ -177,6 +202,53 @@ class AsyncRolloutRequest(BaseModel):
         if self.metrics.get(tool_id) is None:
             self.metrics[tool_id] = []
         self.metrics[tool_id].append(metrics)
+
+    def add_full_conversation(self, tokenizer: PreTrainedTokenizer, prompt_message_cnt: int, full_conversation: list[dict], tools: list[dict] = None) -> "AsyncRolloutRequest":
+        req = AsyncRolloutRequest(
+            request_id=self.request_id,
+            batch_data_id=self.batch_data_id,
+            rollout_offset=self.rollout_offset,
+            state=AsyncRolloutRequestStateEnum.COMPLETED,
+            messages=full_conversation[:prompt_message_cnt],
+            tool_schemas=[OpenAIFunctionToolSchema.model_validate(tool) for tool in tools] if tools else None,
+            tools_kwargs=self.tools_kwargs,
+            langgraph_input_kwargs=self.langgraph_input_kwargs,
+            chat_template_kwargs=self.chat_template_kwargs,
+            response_ids=[],
+            response_attention_mask=[],
+            response_position_ids=[],
+            response_loss_mask=[],
+            reward_scores={},
+            max_prompt_len=self.max_prompt_len,
+            max_response_len=self.max_response_len,
+            max_model_len=self.max_model_len,
+            use_inference_chat_template=self.use_inference_chat_template,
+            enable_tokenization_sanity_check=self.enable_tokenization_sanity_check,
+            tokenizer=tokenizer,
+        )
+
+        messages = [Message.model_validate(msg) for msg in full_conversation[prompt_message_cnt:]]
+        tool_messages = []
+        for message in messages:
+            if message.role == "tool":
+                tool_messages.append(message)
+                continue
+
+            if tool_messages:
+                req.add_tool_response_messages(tokenizer, [tool_message.content for tool_message in tool_messages], tool_messages[0].metadata.get("chat_template_kwargs"))
+                tool_messages = []
+
+            match message.role:
+                case "assistant":
+                    req.get_generation_prompt_ids(tokenizer, chat_template_kwargs=message.metadata.get("chat_template_kwargs"))
+                    req.add_assistant_message(tokenizer, message.content, tool_calls=message.tool_calls, chat_template_kwargs=message.metadata.get("chat_template_kwargs"))
+                case "user":
+                    req.add_user_message(tokenizer, message.content, chat_template_kwargs=message.metadata.get("chat_template_kwargs"))
+                case "system":
+                    req.add_system_message(tokenizer, message.content, chat_template_kwargs=message.metadata.get("chat_template_kwargs"))
+                case _:
+                    raise ValueError(f"Unsupported message role: {message.role}")
+        return req
 
     def finalize(
         self,
@@ -187,17 +259,21 @@ class AsyncRolloutRequest(BaseModel):
         self.state = AsyncRolloutRequestStateEnum.COMPLETED
         self.reward_scores = reward_scores
         if self.enable_tokenization_sanity_check:
-            full_tokens = tokenizer.apply_chat_template([msg.model_dump() for msg in self.messages], tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None), add_generation_prompt=False, tokenize=True)
+            full_tokens = tokenizer.apply_chat_template([msg.model_dump() for msg in self.messages], tools=([tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None), add_generation_prompt=False, tokenize=True, **self.chat_template_kwargs)
             if self.input_ids != full_tokens:
                 logger.warning("Inconsistent training and inference tokenization detected. This may lead to unexpected behavior during training. Please review your chat template to determine if this is intentional. For more information, refer to the multiturn README.md.")
                 logger.info(f"Inference tokenization result:\n{tokenizer.decode(full_tokens, skip_special_tokens=False)}\ntraining content:\n{tokenizer.decode(self.input_ids, skip_special_tokens=False)}")
 
         # In case we failed to generate the assistant message and the generation prompt ids were already added to input_ids, remove them from the end of input_ids
-        if self.input_ids[-len(self.generation_prompt_ids) :] == self.generation_prompt_ids:
-            self.input_ids = self.input_ids[: -len(self.generation_prompt_ids)]
-            self.attention_mask = self.attention_mask[: -len(self.generation_prompt_ids)]
-            self.position_ids = self.position_ids[: -len(self.generation_prompt_ids)]
-            self.loss_mask = self.loss_mask[: -len(self.generation_prompt_ids)]
+        tools = [tool.model_dump() for tool in self.tool_schemas] if self.tool_schemas else None
+        base_end_pos = len(tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=False, tokenize=False, **self.chat_template_kwargs))
+        generation_prompt = tokenizer.apply_chat_template(BASE_CHAT_HISTORY, tools=tools, add_generation_prompt=True, tokenize=False, **self.chat_template_kwargs)[base_end_pos:]
+        generation_prompt_ids = tokenizer.encode(generation_prompt, add_special_tokens=False)
+        if self.input_ids[-len(generation_prompt_ids) :] == generation_prompt_ids:
+            self.input_ids = self.input_ids[: -len(generation_prompt_ids)]
+            self.attention_mask = self.attention_mask[: -len(generation_prompt_ids)]
+            self.position_ids = self.position_ids[: -len(generation_prompt_ids)]
+            self.loss_mask = self.loss_mask[: -len(generation_prompt_ids)]
 
         self.response_ids = self.input_ids[len(self.prompt_ids) :]
         if finish_reason_type == FinishReasonTypeEnum.STOP:

--- a/verl/workers/rollout/sglang_rollout/sglang_langchain.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_langchain.py
@@ -1,0 +1,119 @@
+import asyncio
+import inspect
+import logging
+import os
+from json import JSONDecodeError
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
+
+from langchain_core.callbacks import AsyncCallbackManagerForLLMRun, CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, convert_to_openai_messages
+from langchain_core.messages.tool import invalid_tool_call, tool_call
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from omegaconf import DictConfig
+from pydantic import Field
+from sglang.srt.entrypoints.engine import Engine
+from sglang.srt.openai_api.protocol import Tool
+from sglang.srt.sampling.sampling_params import SamplingParams
+from transformers import PreTrainedTokenizerBase
+
+from verl.tools.schemas import OpenAIFunctionCallSchema
+
+try:
+    from sglang.srt.function_call.function_call_parser import FunctionCallParser
+except ImportError:
+    from sglang.srt.function_call_parser import FunctionCallParser
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+sampling_params_names = set(inspect.signature(SamplingParams.__init__).parameters)
+sampling_params_names.discard("self")
+
+
+class SGLangChatModel(BaseChatModel):
+    """LangChain ChatModel wrapper for SGLang engine."""
+
+    engine: Engine = Field(description="SGLang engine instance")
+    sampling_params: Dict[str, Any] = Field(description="Detault sampling parameters for generation")
+    chat_template_kwargs: Dict[str, Any] = Field(default_factory=dict, description="Additional kwargs for chat template rendering")
+    tokenizer: PreTrainedTokenizerBase = Field(description="Tokenizer for the model")
+    tool_call_parser_type: str = Field(description="Type of tool call parser to use")
+    rollout_config: DictConfig = Field(description="Rollout configuration")
+
+    # Disable LangChain cache for SGLang models - not configurable by users
+    cache: Literal[False] = Field(default=False, exclude=True, init=False, description="Cache setting (always disabled)")
+
+    @property
+    def _llm_type(self) -> str:
+        return "sglang"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        return asyncio.run(self._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs))
+
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        *,
+        chat_template_kwargs: Optional[Dict[str, Any]] = None,
+        sampling_params: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        result_metadata = {"chat_template_kwargs": {**self.chat_template_kwargs, **(chat_template_kwargs or {})}}
+
+        input_ids = self.tokenizer.apply_chat_template(convert_to_openai_messages(messages), tools=kwargs.get("tools"), add_generation_prompt=True, tokenize=True, **result_metadata["chat_template_kwargs"])
+        max_new_tokens = min(self.rollout_config.response_length, self.rollout_config.max_model_len - len(input_ids) - 1)
+        if max_new_tokens <= 0:
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content=""))], llm_output={"meta_info": {"finish_reason": {"type": "length"}}, **result_metadata})
+
+        # Update sampling params with any additional kwargs
+        result_metadata["sampling_params"] = sampling_params = {k: v for k, v in {**self.sampling_params, **(sampling_params or {})}.items() if k in sampling_params_names}
+        if stop:
+            sampling_params["stop"] = stop
+        sampling_params["max_new_tokens"] = max_new_tokens
+        output = await self.engine.async_generate(input_ids=input_ids, sampling_params=sampling_params)
+
+        # Parse tool calls
+        content, meta_info, tool_calls, invalid_tool_calls = output["text"], output["meta_info"], [], []
+        message = AIMessage(content=content)
+        if (tool_call_parser := kwargs.get("tool_call_parser")) and tool_call_parser.has_tool_call(content):
+            try:
+                normed_content, raw_tool_calls = tool_call_parser.parse_non_stream(content)
+                for i, raw_tool_call in enumerate(raw_tool_calls):
+                    tool_call_id = f"{meta_info['id']}-{i}"
+                    tool_call_schema = OpenAIFunctionCallSchema(name=raw_tool_call.name, arguments=raw_tool_call.parameters)
+                    if tool_call_schema.has_decode_error:
+                        logger.warning(f"{raw_tool_call.name} has invalid tool call arguments: {repr(raw_tool_call.parameters)}")
+                        invalid_tool_calls.append(invalid_tool_call(id=tool_call_id, name=raw_tool_call.name, args=raw_tool_call.parameters))
+                    else:
+                        tool_calls.append(tool_call(id=tool_call_id, name=tool_call_schema.name, args=tool_call_schema.arguments))
+                message = AIMessage(content=normed_content, tool_calls=tool_calls, invalid_tool_calls=invalid_tool_calls)
+            except (JSONDecodeError, AttributeError) as e:
+                logger.warning(f"Failed to parse tool calls: {e}", exc_info=True)
+
+        return ChatResult(generations=[ChatGeneration(message=message)], llm_output={**meta_info, **result_metadata})
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        *,
+        strict: bool = False,
+        tool_choice: Optional[Union[str]] = None,
+        **kwargs: Any,
+    ) -> Runnable:
+        tools = [convert_to_openai_tool(tool, strict=strict) for tool in tools]
+        return super().bind(
+            tools=tools,
+            tool_call_parser=FunctionCallParser(tools=[Tool.model_validate(tool) for tool in tools], tool_call_parser=self.tool_call_parser_type),
+        )


### PR DESCRIPTION
### Checklist Before Starting

- [x] Searched for similar PR(s).
- [x] Checked PR Title format
  - In format of: [modules] type: Title
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data`
  - type is in `feat, fix, refactor, chore, test`
  - can involve multiple modules, seperated by `,` or space, like `[megatron, fsdp, doc] feat: xxx`

### What does this PR do?

1. Support rollout with user provided LangGraph script
2. Allow custom chat template kwargs for SGLang rollout. kwargs passed via `ppo_trainer.config` are used as the default settings for the chat template rendering of all converstaions
3. users can also override chat template kwargs and sampling params for different turns during their LangGraph execution.

### Test

WIP

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### API

> Demonstrate how the API changes if any.

### Usage Example

hydra config:
```yaml
actor_rollout_ref:
  rollout:
    multi_turn:
      chat_template_kwargs: {"enable_thinking": False}
      langgraph:
        path: /path/to/graph.py
        graph_config: {"recursion_limit": 100}
```

LangGraph example:

```python
from typing import Annotated, Optional

from langchain_core.messages import AnyMessage
from langchain_core.runnables import RunnableSerializable
from langchain_core.tools import tool
from langgraph.graph import add_messages, StateGraph, START, END
from langgraph.prebuilt import ToolNode
from pydantic import BaseModel


class GraphState(BaseModel):
    actor: RunnableSerializable  # SGLangChatModel is a BaseChatModel but bind_tools returns a RunnableBinding
    messages: Annotated[list[AnyMessage], add_messages]

    max_turn: int = 30
    turn_count: int = 0

    next: Optional[str] = None

# 1. Define tools
@tool
def ...

# 2. Define tool node
tools = [...]
tool_node = ToolNode(tools)


# 3. bind tools to the model
def bind_tools(state: GraphState) -> dict:
    return {"actor": state.actor.bind_tools(tools)}


# 4. define agent node
def agent(state: GraphState) -> dict:
    if state.turn_count >= state.max_turn:
        return {"next": END}

    response = state.actor.invoke(state.messages, chat_template_kwargs={"enable_thinking": False})
    if response.tool_calls and response.response_metadata["finish_reason"]["type"] == "stop":
        return {"next": "tools", "messages": response, "turn_count": state.turn_count + 1}
    elif response.content:
        return {"next": END, "messages": response, "turn_count": state.turn_count + 1}
    return {"next": END, "turn_count": state.turn_count + 1}


# 5. Build the graph
builder = StateGraph(GraphState)
builder.add_node("bind_tools", bind_tools)
builder.add_node("agent", agent)
builder.add_node("tools", tool_node)
builder.add_edge(START, "bind_tools")
builder.add_edge("bind_tools", "agent")
builder.add_conditional_edges("agent", lambda x: x.next)
builder.add_edge("tools", "agent")
graph = builder.compile()
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting).
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
