### PR TITLE
[trainer] feat: enhance the feature of asynchronous computing rewards

### DIFF
--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -241,7 +241,8 @@ class RaySPPOTrainer(RayPPOTrainer):
                         batch = batch.union(reward_tensor)
 
                     if self.config.reward_model.launch_reward_fn_async:
-                        future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                        future_reward = compute_reward_async.options(
+                            num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
                     else:
                         reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -241,8 +241,7 @@ class RaySPPOTrainer(RayPPOTrainer):
                         batch = batch.union(reward_tensor)
 
                     if self.config.reward_model.launch_reward_fn_async:
-                        future_reward = compute_reward_async.options(
-                            num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
+                        future_reward = compute_reward_async.options(num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
                     else:
                         reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -241,7 +241,9 @@ class RaySPPOTrainer(RayPPOTrainer):
                         batch = batch.union(reward_tensor)
 
                     if self.config.reward_model.launch_reward_fn_async:
-                        future_reward = compute_reward_async.options(num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
+                        future_reward = compute_reward_async.options(
+                            num_cpus=self.config.reward_model.num_cpus_for_compute_score
+                        ).remote(batch, self.reward_fn)
                     else:
                         reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/verl/trainer/config/reward_model/reward_model.yaml
+++ b/verl/trainer/config/reward_model/reward_model.yaml
@@ -53,6 +53,9 @@ reward_manager: naive
 # custom reward function executed async on CPU, during log_prob
 launch_reward_fn_async: False
 
+# The number of CPUs used by the ray worker when launching an asynchronous custom reward function.
+num_cpus_for_compute_score: 1
+
 # Cloud/local sandbox fusion configuration for custom reward logic
 sandbox_fusion:
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1208,8 +1208,7 @@ class RayPPOTrainer:
                             batch = batch.union(reward_tensor)
 
                         if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.options(
-                                num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
+                            future_reward = compute_reward_async.options(num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
                         else:
                             reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1208,7 +1208,8 @@ class RayPPOTrainer:
                             batch = batch.union(reward_tensor)
 
                         if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                            future_reward = compute_reward_async.options(
+                                num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
                         else:
                             reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1208,7 +1208,9 @@ class RayPPOTrainer:
                             batch = batch.union(reward_tensor)
 
                         if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.options(num_cpus=self.config.reward_model.num_cpus_for_compute_score).remote(batch, self.reward_fn)
+                            future_reward = compute_reward_async.options(
+                                num_cpus=self.config.reward_model.num_cpus_for_compute_score
+                            ).remote(batch, self.reward_fn)
                         else:
                             reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
 

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -160,10 +160,13 @@ def compute_reward(data: DataProto, reward_fn):
 
 
 @ray.remote(num_cpus=1)
-def compute_reward_async(data: DataProto, config, tokenizer):
+def compute_reward_async(data: DataProto, reward_fn):
     """
-    Load the reward manager and compute the reward for a batch of data.
-    This is meant to be run in a separate Ray worker.
+    Compute reward for a batch of data in a separate Ray worker.
+    Args:
+        data: DataProto object containing the input data.
+        reward_fn: Reward function to compute the reward.
+    Returns:
+        Tuple future of reward tensor and extra info dictionary.
     """
-    reward_fn = load_reward_manager(config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {}))
     return compute_reward(data, reward_fn)


### PR DESCRIPTION
### What does this PR do?
I did two things:
1. Remove redundant `load_reward_manager` from `compute_reward_async` function.
2. Added a new configuration parameter `num_cpus_for_compute_score`. The reason is that `compute_score` function can be user-defined. In my scenario, `compute_score` is time-consuming, and I want use multiple CPUs to accelerate it. However, due to the fact that the Ray worker executing `compute_reward_async` function only has one CPU resource by default, I am restricted.

### Checklist Before Starting

- [x] Search for similar PRs.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).