### PR TITLE
[algo] feat:  A more Efficient implementation of GAE

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -186,7 +186,7 @@ def compute_gae_advantage_return(
         device = values.device
         values_pad = pad(values, (0, 1), mode="constant", value=0.0)
         delta = token_level_rewards + gamma * values_pad[:, 1:] - values
-        delta_padded = pad(delta, (0, delta.shape[-1] - 1)).unsqueeze(1)    # (batch, 1, gen_len)
+        delta_padded = pad(delta, (0, delta.shape[-1] - 1)).unsqueeze(1)  # (batch, 1, gen_len)
         decay = (lam * gamma) ** torch.arange(gen_len, device=device)[None, None, :]  # (1, 1, gen_len)
 
         advantages = torch.conv1d(delta_padded, decay).squeeze(1)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -25,6 +25,7 @@ from enum import Enum
 
 import numpy as np
 import torch
+from torch.nn.functional import pad
 
 import verl.utils.torch_functional as verl_F
 
@@ -180,16 +181,15 @@ def compute_gae_advantage_return(
 
     """
     with torch.no_grad():
-        lastgaelam = 0
-        advantages_reversed = []
         gen_len = token_level_rewards.shape[-1]
 
-        for t in reversed(range(gen_len)):
-            nextvalues = values[:, t + 1] if t < gen_len - 1 else 0.0
-            delta = token_level_rewards[:, t] + gamma * nextvalues - values[:, t]
-            lastgaelam = delta + gamma * lam * lastgaelam
-            advantages_reversed.append(lastgaelam)
-        advantages = torch.stack(advantages_reversed[::-1], dim=1)
+        device = values.device
+        values_pad = pad(values, (0, 1), mode="constant", value=0.0)
+        delta = token_level_rewards + gamma * values_pad[:, 1:] - values
+        delta_padded = pad(delta, (0, delta.shape[-1] - 1)).unsqueeze(1)    # (batch, 1, gen_len)
+        decay = (lam * gamma) ** torch.arange(gen_len, device=device)[None, None, :]  # (1, 1, gen_len)
+
+        advantages = torch.conv1d(delta_padded, decay).squeeze(1)
 
         returns = advantages + values
         advantages = verl_F.masked_whiten(advantages, response_mask)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -162,7 +162,7 @@ def compute_gae_advantage_return(
     """This implementation is efficient but not that easy to understand.
     For easier understanding, please refer to a simpler equivalent implementation in
     https://github.com/huggingface/trl/blob/559a99f053e5bda892dd19e9283831be5b90c46b/trl/trainer/ppo_trainer.py#L524-L532
-    
+
     Args:
         token_level_rewards: `(torch.Tensor)`
             shape is (bs, response_length)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -189,7 +189,7 @@ def compute_gae_advantage_return(
         values_pad = pad(values, (0, 1), mode="constant", value=0.0)
         delta = token_level_rewards + gamma * values_pad[:, 1:] - values
         delta_padded = pad(delta, (0, delta.shape[-1] - 1)).unsqueeze(1)  # (batch, 1, gen_len)
-        decay = (lam * gamma) ** torch.arange(gen_len, device=device)[None, None, :]  # (1, 1, gen_len)
+        decay = (lam * gamma) ** torch.arange(gen_len, dtype=values.dtype, device=device)[None, None, :]  # (1, 1, gen_len)
 
         advantages = torch.conv1d(delta_padded, decay).squeeze(1)
 

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -159,8 +159,10 @@ def compute_gae_advantage_return(
     gamma: torch.Tensor,
     lam: torch.Tensor,
 ):
-    """Adapted from https://github.com/huggingface/trl/blob/main/trl/trainer/ppo_trainer.py
-
+    """This implementation is efficient but not that easy to understand.
+    For easier understanding, please refer to a simpler equivalent implementation in
+    https://github.com/huggingface/trl/blob/559a99f053e5bda892dd19e9283831be5b90c46b/trl/trainer/ppo_trainer.py#L524-L532
+    
     Args:
         token_level_rewards: `(torch.Tensor)`
             shape is (bs, response_length)


### PR DESCRIPTION
### What does this PR do?

Find the inefficiency in current GAE implementation using "for loop".  Reformulate it as conv1d and implement it.

### Checklist Before Describing the Details

- [x] Searched for similar PR(s).
- [x] PR title is in the format of: `[modules] type: Title`
  - modules are in `fsdp, megatron, sglang, vllm, rollout, trainer, ci, training_utils, recipe, hardware, deployment, ray, worker, single_controller, misc, perf, model, algo, env, tool, ckpt, doc, data, cfg`
  - type is in `feat, fix, refactor, chore, test`
  - multiple modules are seperated by `,` or space, such as `[megatron, fsdp, doc] feat: xxx`

### Test
On single A100 GPU. The settings for tensor size are below:
```python
batch_size = 4, seq_len = 128
```
Result (first 10 elements):
```python
# print(advantages[0,:10])
Using conv: 
tensor([-0.1061,  0.3279,  0.7977,  0.6851,  0.8231,  0.7337,  1.0778, -0.1774,
         0.0533,  0.2212], device='cuda:0')
Original implementation: 
tensor([-0.1061,  0.3279,  0.7977,  0.6851,  0.8231,  0.7337,  1.0778, -0.1774,
         0.0533,  0.2212], device='cuda:0')
```

Time (print in terminal, 100 runs)
```
Using conv: 0.2193572111427784
Original implementation: 0.8121056966483593
```
> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluatuion results, etc.

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

Only in 1 file. See commit details below.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this 
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit run --show-diff-on-failure --color=always --all-files`
- [x] Add `[BREAKING]` to the PR title `description` if it breaks any API.
- [x] Update the documentation about your changes in the [docs](https://github.com/volcengine/verl/tree/main/docs).
- [x] New CI unit test(s) are added to cover the code path.
- [x] Rely on existing unit tests on CI that covers the code path.
