### PR TITLE
[rollout]fix: vllm_rollout_spmd.py when return_raw_chat=True

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -319,6 +319,8 @@ class vLLMRollout(BaseRollout):
                     non_tensor_batch["tools_kwargs"] = _repeat_interleave(non_tensor_batch["tools_kwargs"], self.sampling_params.n)
                 if "interaction_kwargs" in non_tensor_batch.keys():
                     non_tensor_batch["interaction_kwargs"] = _repeat_interleave(non_tensor_batch["interaction_kwargs"], self.sampling_params.n)
+                if "raw_prompt" in non_tensor_batch.keys():
+                    non_tensor_batch["raw_prompt"] = _repeat_interleave(non_tensor_batch["raw_prompt"], self.sampling_params.n)
 
             seq = torch.cat([idx, response], dim=-1)
 


### PR DESCRIPTION
### What does this PR do?

> fix : batch size and the size of raw_prompt unmatching when setting `data.return_raw_chat=True`

fix bug when using `data.return_raw_chat=True` in GRPO algorithm with reward model:
`  File "/ossfs/workspace/repository/verl/verl/single_controller/ray/base.py", line 625, in func
    return getattr(self.worker_dict[key], name)(*args, **kwargs)
  File "/ossfs/workspace/repository/verl/verl/single_controller/base/decorator.py", line 534, in inner
    return func(*args, **kwargs)
  File "/ossfs/workspace/repository/verl/verl/workers/fsdp_workers.py", line 634, in generate_sequences
    output = self.rollout.generate_sequences(prompts=prompts)
  File "/ossfs/workspace/repository/verl/verl/utils/debug/performance.py", line 78, in f
    return self.log(decorated_function, *args, **kwargs)
  File "/ossfs/workspace/repository/verl/verl/utils/debug/performance.py", line 88, in log
    output = func(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/ossfs/workspace/repository/verl/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py", line 346, in generate_sequences
    return DataProto(batch=batch, non_tensor_batch=non_tensor_batch)
  File "<string>", line 6, in __init__
  File "/ossfs/workspace/repository/verl/verl/protocol.py", line 214, in __post_init__
    self.check_consistency()
  File "/ossfs/workspace/repository/verl/verl/protocol.py", line 325, in check_consistency
    assert val.shape[0] == batch_size, f"key {key} length {len(val)} is not equal to batch size {batch_size}"
AssertionError: key raw_prompt length 128 is not equal to batch size 640`


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
