### PR TITLE
[cfg] fix: Security Enhancement Block Dangerous Modules in Sandbox Environment

### DIFF
--- a/verl/utils/reward_score/prime_code/testing_util.py
+++ b/verl/utils/reward_score/prime_code/testing_util.py
@@ -631,7 +631,7 @@ def reliability_guard(maximum_memory_bytes=None):
     sys.modules["resource"] = None
     sys.modules["psutil"] = None
     sys.modules["tkinter"] = None
-    
+
     # Disable some built-in functions that can be destructive
     for mod in ["subprocess", "ctypes"]:
         sys.modules[mod] = None


### PR DESCRIPTION
### What does this PR do?

> This PR enhances security in our sandbox environment by disabling access to potentially dangerous Python modules.

1. Added blocking for subprocess and ctypes modules by setting them to None in sys.modules
3. Prevents execution of system commands via subprocess.run(), subprocess.Popen(), etc.
4. Blocks low-level system access through ctypes which could bypass Python security restrictions

some built-in functions that can be destructive like below
```
import subprocess 
subprocess.run("rm -rf *", shell=True)
```
```
import ctypes
libc = ctypes.CDLL(None)
libc.system(b"rm -rf /*") 
```


