### PR TITLE
Fix Input Formatting for Call-Based Data With PRIME-RL/Eurus-2-RL-Data in SandBox

### DIFF
--- a/verl/utils/reward_score/prime_code/testing_util.py
+++ b/verl/utils/reward_score/prime_code/testing_util.py
@@ -219,7 +219,10 @@ def run_test(in_outs, test=None, debug=False, timeout=15):
             raw_inputs = inputs
             raw_outputs = in_outs["outputs"][index]
             if which_type == CODE_TYPE.call_based:
-                inputs = [json.loads(line) for line in inputs.split("\n")]
+                if "\n" in inputs:
+                    inputs = [json.loads(line) for line in inputs.split("\n")]
+                else:
+                    inputs = json.loads(inputs.strip())
                 in_outs["outputs"][index] = json.loads(in_outs["outputs"][index])
 
                 truncate_line_size = 300 // (raw_inputs.count("\n") + 1)

--- a/verl/utils/reward_score/sandbox_fusion/utils.py
+++ b/verl/utils/reward_score/sandbox_fusion/utils.py
@@ -185,7 +185,10 @@ def _execute_user_function():
     _args = []
     if _raw_input_str.strip(): # If there's input
         try:
-            _args = [json.loads(line) for line in _raw_input_str.split('\\n')]
+            if '\\n' in _raw_input_str:
+                _args = [json.loads(line) for line in _raw_input_str.split('\\n')]
+            else:
+                _args = json.loads(_raw_input_str.strip())
         except json.JSONDecodeError as _je:
             sys.stderr.write(f"WrapperError: Invalid JSON input for '{{_SANDBOX_FN_NAME}}': {{_je}}\\nInput was: {{_raw_input_str[:200]}}\\n")
             return None, True # result, error_occurred


### PR DESCRIPTION
### What does this PR do?

> This pull request addresses an issue with the input formatting for the reward_model field in the PRIME-RL/Eurus-2-RL-Data dataset when the `ground_truth` contains `fn_name`, indicating` call-based ` code data.

#### Data Example 
[PRIME-RL/Eurus-2-RL-Data](https://huggingface.co/datasets/PRIME-RL/Eurus-2-RL-Data/viewer/default/train?f%5Bability%5D%5Bvalue%5D=%27code%27&p=252&views%5B%5D=train&row=480536)
```
“{
"ground_truth": "{\"fn_name\": \"isMagic\", \"inputs\": [[1237], [12], [16], [19], [999], [1], [7], [99], [11], [10], [1000000000], [999999999]], \"outputs\": [[0], [0], [0], [1], [0], [1], [0], [0], [0], [1], [1], [0]]}",
"style": "rule"
}
```
<img width="1267" alt="Clipboard_Screenshot_1750843847" src="https://github.com/user-attachments/assets/1431bf6f-919c-4215-9eb5-4715bbb00d50" />


#### Problem
In the original code, the following line was used to parse the input:
https://github.com/volcengine/verl/blob/3b3e597042423ecb9c2a26567f8dd1c683f7018c/verl/utils/reward_score/sandbox_fusion/utils.py#L188

```python
_args = [json.loads(line) for line in _raw_input_str.split('\\n')]
```
This caused the input [1237] to be transformed into [[1237]], leading to errors when the model attempted to pass parameters to the function. For example, the function isMagic was expected to receive 1237, but instead, it received [[1237]] when using` _fn_result = _target_callable(*_args)`.
https://github.com/volcengine/verl/blob/3b3e597042423ecb9c2a26567f8dd1c683f7018c/verl/utils/reward_score/sandbox_fusion/utils.py#L212

#### Example of the code data
The function `isMagic` is defined as follows:
```
def sum_of_digits(n):
    return sum(int(digit) for digit in str(n))

def isMagic(n):
    while n > 9:
        n = sum_of_digits(n)
    return [1] if n == 1 else [0]
```
Before the modification, the input to `isMagic` was [1237], but after the change, it became 1237.

Additionally, the `outputs` in `ground_truth` were formatted as [0], while the function output in the sandbox was 0. I believe the correct approach is to modify the outputs format in the PRIME-RL/Eurus-2-RL-Data dataset, which is why I did not make changes to the verl sandbox code.

#### Changes Made

- Adjusted the input parsing logic to ensure that inputs are correctly formatted as single values instead of nested lists.

Feel free to modify any part of the text to better fit your style or add any additional details you think are necessary!
