### PR TITLE
[data] fix: add __setstate__ method to properly restore RLHFDataset

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -337,3 +337,9 @@ class RLHFDataset(Dataset):
             return state
 
         return self.__dict__.copy()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        # Reconstruct dataframe if it was removed during serialization
+        if not self.serialize_dataset and not hasattr(self, 'dataframe'):
+            self.resume_dataset_state()


### PR DESCRIPTION
### What does this PR do?

The RLHFDataset class had an incomplete serialization/deserialization mechanism.
The existing getstate method removes the 'dataframe' attribute when serialize_dataset=False to avoid serializing large dataframes, but there was no corresponding setstate method to restore the dataset state properly during checkpoint resumption.

This commit adds a setstate method that:

Restores the object state from the serialized data
Detects when the dataframe attribute is missing (removed during serialization)
Automatically calls resume_dataset_state() to restore the dataframe
Fixes dataset resume errors when loading from checkpoints with serialize_dataset=False.



### Checklist Before Starting


### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### High-Level Design

> Demonstrate the high-level design if this PR is complex.

### Specific Changes

> List the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl?tab=readme-ov-file#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
