### PR TITLE
Fix length bias in masked_mean for PPO loss

### DIFF
--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -199,15 +199,17 @@ def masked_mean_unbiased(values, mask, axis=None, max_length=None):
         mask (Tensor): Boolean or numeric mask of the same shape as `values`.
         axis (int or tuple of int, optional): Dimension(s) along which to compute the mean.
             Defaults to None (over all elements).
-        max_length (int or Tensor, optional): Constant normalizer to use instead of actual length.
-            If None, falls back to the biased version.
+        max_length (int or Tensor): Constant normalizer to use instead of actual length.
+            Must be provided to ensure unbiased computation.
     
     Returns:
         Tensor: The mean of `values` over elements selected by `mask` without length bias.
+    
+    Raises:
+        ValueError: If max_length is None.
     """
     if max_length is None:
-        # Fall back to biased version if no max_length provided
-        return masked_mean(values, mask, axis)
+        raise ValueError("max_length must be provided to use the unbiased masked mean.")
     
     if axis is None:
         return (values * mask).sum() / max_length

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -179,10 +179,40 @@ def masked_mean(values, mask, axis=None):
             Defaults to None (over all elements).
 
     Returns:
-        Tensor: Masked mean, with shape equal to `values` reduced over `axis`.
+        Tensor: The mean of `values` over elements selected by `mask`.
     """
-    s = masked_sum(values, mask, axis)
-    return s / (mask.sum(axis=axis) + 1e-8)
+    if axis is None:
+        return (values * mask).sum() / (mask.sum() + 1e-8)
+    else:
+        return (values * mask).sum(axis=axis) / (mask.sum(axis=axis) + 1e-8)
+
+
+def masked_mean_unbiased(values, mask, axis=None, max_length=None):
+    """
+    Compute the mean of `values` over elements selected by `mask` without length bias.
+    
+    This version uses a constant normalizer (max_length) instead of the actual sequence length
+    to avoid the Response-level Length Bias issue described in Dr. GRPO paper.
+    
+    Args:
+        values (Tensor): Input tensor.
+        mask (Tensor): Boolean or numeric mask of the same shape as `values`.
+        axis (int or tuple of int, optional): Dimension(s) along which to compute the mean.
+            Defaults to None (over all elements).
+        max_length (int or Tensor, optional): Constant normalizer to use instead of actual length.
+            If None, falls back to the biased version.
+    
+    Returns:
+        Tensor: The mean of `values` over elements selected by `mask` without length bias.
+    """
+    if max_length is None:
+        # Fall back to biased version if no max_length provided
+        return masked_mean(values, mask, axis)
+    
+    if axis is None:
+        return (values * mask).sum() / max_length
+    else:
+        return (values * mask).sum(axis=axis) / max_length
 
 
 def masked_var(values, mask, unbiased=True):


### PR DESCRIPTION
- Add masked_mean_unbiased function to avoid Response-level Length Bias
- Add token-mean-unbiased mode in agg_loss function
- Update seq-mean-token-sum-norm to use constant normalizer
- Addresses the length bias issue described in Dr. GRPO paper

The original masked_mean function causes:
1. Short correct responses get amplified gradients (1/|o_i|)
2. Long incorrect responses get diluted penalties (1/|o_i|)

This fix uses constant normalizer (max_response_length) instead of actual sequence length to eliminate the bias while maintaining mathematical correctness.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
