### PR TITLE
Fix: handle leading zeros in numeric string equivalence for AIME 2024…

### DIFF
--- a/tests/utils/reward_score/test_numeric_canonicalization_on_cpu.py
+++ b/tests/utils/reward_score/test_numeric_canonicalization_on_cpu.py
@@ -1,0 +1,55 @@
+# Unit tests for numeric canonicalization helpers:
+# - legal integer strings      -> normalized form
+# - illegal / non-integer str. -> unchanged
+# - end-to-end `is_equiv` on boxed answers
+
+import pytest
+from verl.utils.reward_score.math import _canonical_int_if_safe, is_equiv, remove_boxed
+
+
+# ----- legal integers -------------------------------------------------
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("033", "33"),
+        ("+033", "33"),
+        ("-0",  "0"),
+        ("000", "0"),
+    ],
+)
+def test_canonical_int_legal(raw, expected):
+    """Legal integer strings should be canonicalised."""
+    assert _canonical_int_if_safe(raw) == expected
+
+
+# ----- illegal / non-integer ------------------------------------------
+@pytest.mark.parametrize(
+    "illegal",
+    [
+        "3.3",      # decimal
+        "foo",      # letters
+        "--33",     # malformed sign
+        "",         # empty
+        "+",        # sign only
+        "33a",      # alphanumeric
+    ],
+)
+def test_canonical_int_illegal(illegal):
+    """Illegal strings must stay untouched."""
+    assert _canonical_int_if_safe(illegal) == illegal
+
+
+# ----- end-to-end boxed answers ---------------------------------------
+@pytest.mark.parametrize(
+    "gt, pred",
+    [
+        ("\\boxed{033}", "33"),
+        ("\\boxed{+033}", "33"),
+        ("\\boxed{-0}",  "0"),
+        ("\\boxed{000}", "0"),
+    ],
+)
+def test_is_equiv_boxed(gt, pred):
+    """`is_equiv` should treat canonicalised values as equal."""
+    gt_val = remove_boxed(gt)
+    assert is_equiv(gt_val, pred) is True

--- a/verl/utils/reward_score/math.py
+++ b/verl/utils/reward_score/math.py
@@ -29,6 +29,18 @@ def compute_score(solution_str, ground_truth) -> float:
 
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
+import re
+def _canonical_int_if_safe(s: str) -> str:
+    """
+    If s is an integer (±digits), drop leading zeros; else return unchanged.
+    """
+    if re.fullmatch(r'[-+]?\d+', s):
+        sign = s[0] if s[0] in '+-' else ''
+        num  = s[1:] if sign else s
+        num  = num.lstrip('0') or '0'
+        return sign + num
+    return s
+
 def is_equiv(str1, str2, verbose=False):
     if str1 is None and str2 is None:
         print("WARNING: Both None")
@@ -37,8 +49,8 @@ def is_equiv(str1, str2, verbose=False):
         return False
 
     try:
-        ss1 = strip_string(str1)
-        ss2 = strip_string(str2)
+        ss1 = _canonical_int_if_safe(strip_string(str1))
+        ss2 = _canonical_int_if_safe(strip_string(str2))
         if verbose:
             print(ss1, ss2)
         return ss1 == ss2

--- a/verl/utils/reward_score/math.py
+++ b/verl/utils/reward_score/math.py
@@ -30,15 +30,10 @@ def compute_score(solution_str, ground_truth) -> float:
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
 import re
+
 def _canonical_int_if_safe(s: str) -> str:
-    """
-    If s is an integer (±digits), drop leading zeros; else return unchanged.
-    """
     if re.fullmatch(r'[-+]?\d+', s):
-        sign = s[0] if s[0] in '+-' else ''
-        num  = s[1:] if sign else s
-        num  = num.lstrip('0') or '0'
-        return sign + num
+        return str(int(s))
     return s
 
 def is_equiv(str1, str2, verbose=False):


### PR DESCRIPTION
[data] fix: handle leading zeros in numeric string equivalence for AIME 2024 data

Some ground truth answers in the AIME 2024 dataset on HuggingFace are formatted
with leading zeros (e.g., '033'), which can cause equivalence checks to fail
if the model outputs '33'. This patch adds a normalization step to strip
leading zeros from purely numeric strings to ensure fair comparison.

### What does this PR do?

- Normalizes numeric strings by stripping leading zeros in `is_equiv` inside `verl/utils/reward_score/math.py`.
- Ensures that model outputs like `"33"` are correctly matched to ground truths like `"033"` in AIME 2024 datasets.
- Improves robustness of math evaluation metrics.

### Checklist Before Starting

- [x] Searched for similar PRs. Related code area is small, no similar PR found.
- [x] Formatted PR title as `[data] fix: handle leading zeros in numeric string equivalence for AIME 2024 data`.

### Test

- Added simple unit tests to ensure `"033"` and `"33"` are considered equivalent.
- Existing tests pass locally.

### API and Usage Example

No API signature changed. This is purely an internal robustness improvement in reward evaluation.

### Design & Code Changes

- Added helper `normalize_leading_zeros()` to `verl/utils/reward_score/math.py`.
- Called it inside `is_equiv()` after `strip_string()`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Ran pre-commit: `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] No documentation needed as this is an internal evaluation function.
- [x] Added unit tests inside existing test suite.
- [x] Will notify in Slack `#ci-request` channel once ready.
