### PR TITLE
[rollout, trainer] feat: Enabling Request Skewness Scheduler towards near-equal generated token in rollout

### DIFF
--- a/recipe/req_sched/ReqScheduler.py
+++ b/recipe/req_sched/ReqScheduler.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipe/req_sched/ReqScheduler.py
+++ b/recipe/req_sched/ReqScheduler.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import glob
 import heapq
 import json

--- a/recipe/req_sched/ReqScheduler.py
+++ b/recipe/req_sched/ReqScheduler.py
@@ -1,0 +1,288 @@
+import glob
+import heapq
+import json
+import os
+
+import numpy as np
+import torch
+
+from verl import DataProto
+from verl.utils.seqlen_balancing import karmarkar_karp
+
+
+def unpad_responses(padded_tensor, pad_token_id):
+    if isinstance(pad_token_id, list):
+        # from all worker
+        if len(set(pad_token_id)) > 1:
+            raise ValueError("pad_token_id is not the same across all workers")
+        pad_token_id = pad_token_id[0]
+
+    padded_tensor = padded_tensor.cpu()
+    # Convert tensor to list if it's a tensor
+    if isinstance(padded_tensor, torch.Tensor):
+        padded_list = padded_tensor.tolist()
+    else:
+        padded_list = padded_tensor
+
+    # Reconstruct original responses by removing padding tokens
+    unpadded_responses = []
+    for padded_response in padded_list:
+        try:
+            pad_start_idx = padded_response.index(pad_token_id)
+            original_response = padded_response[:pad_start_idx]
+        except ValueError:
+            original_response = padded_response
+
+        unpadded_responses.append(original_response)
+    return unpadded_responses
+
+
+class ReqScheduler:
+    def __init__(self, config):
+        self.config = config
+
+        # prompt_ids -> len(reponse)
+        self.table: dict[tuple[int], int] = self.load_table()
+
+    def _aggregate_table(self, table: dict[tuple, list]) -> dict[tuple, int]:
+        agg_method = self.config.get("agg", "mean")
+
+        agg_functions = {
+            "max": max,
+            "min": min,
+            "mean": lambda v: int(np.mean(v)),
+            "median": lambda v: int(np.median(v)),
+            "sum": sum,
+        }
+
+        if agg_method not in agg_functions:
+            raise ValueError(f"Unknown agg method: {agg_method}")
+
+        agg_func = agg_functions[agg_method]
+        return {k: agg_func(v) for k, v in table.items()}
+
+    def load_table(self):
+        """
+        {
+            "prompts": [
+                [prompt_token_ids_1],
+                [prompt_token_ids_2],
+                ...
+            ],
+            "lengths": [
+                [120, 88, 85, 92, 95, 100, 90, 110],  // prompt 1(n samples)
+                [105, 90, 95, 92, 100, 94, 90, 88],   // prompt 2
+                ...
+            ],
+            "stats": [
+                {"max": 120, "min": 85, "mean": 97.5, "std": 10.2, "sum": 780},
+                {"max": 105, "min": 88, "mean": 94.3, "std": 5.6, "sum": 754},
+                ...
+            ]
+        }
+        """
+        if self.config.seq_dir is None:
+            return {}
+
+        json_files = glob.glob(os.path.join(self.config.seq_dir, "*.json"))
+        print(f"[ReqScheduler] Found {len(json_files)} JSON files to process")
+
+        ans = {}
+        for json_file in json_files:
+            filename = os.path.basename(json_file)
+            try:
+                with open(json_file) as f:
+                    data = json.load(f)
+
+                print(f"[ReqScheduler] data keys = {data.keys()} in {filename}")
+
+                ps = data["prompts"]
+                ls = data["lengths"]
+                for p, length in zip(ps, ls, strict=False):
+                    p = tuple(p)
+                    if p not in ans:
+                        ans[p] = length
+                print(f"[ReqScheduler] Processed {filename}, found {len(ans)} unique prompts")
+            except Exception as e:
+                print(f"[ReqScheduler] Error processing {filename}: {str(e)}")
+                raise e
+
+        ans = self._aggregate_table(ans)
+        print(f"[ReqScheduler] Table-Size: {len(ans)=}")
+        return ans
+
+    def lookup_table(self, prompt):
+        if isinstance(prompt, list):
+            prompt = tuple(prompt)
+        assert isinstance(prompt, tuple), f"prompt type {type(prompt)} is not supported"
+        if prompt in self.table:
+            return self.table[prompt]
+        return None
+
+    def update_table(self, raw_prompt_ids, responses):
+        new_table = {}
+        for p, r in zip(raw_prompt_ids, responses, strict=False):
+            p = tuple(p)
+            r = tuple(r)
+            if p not in new_table:
+                new_table[p] = []
+            new_table[p].append(len(r))
+
+        new_table = self._aggregate_table(new_table)
+
+        for k, v in new_table.items():
+            self.table[k] = v
+        print(f"[ReqScheduler] in update_table, Table-Size: {len(self.table)=}")
+
+    def log_seqlen(self, raw_prompt_ids, responses, prefix):
+        print(
+            f"[ReqScheduler] in log_seqlen, {type(raw_prompt_ids)},"
+            f"{type(responses)}, {len(raw_prompt_ids)}, {len(responses)}"
+        )
+        assert len(raw_prompt_ids) == len(responses), f"{len(raw_prompt_ids)}, {len(responses)}"
+        prompts_dict = {}
+        for p, r in zip(raw_prompt_ids, responses, strict=True):
+            if tuple(p) not in prompts_dict:
+                prompts_dict[tuple(p)] = []
+            prompts_dict[tuple(p)].append(len(r))
+
+        prompts = list(prompts_dict.keys())
+        response = list(prompts_dict.values())
+
+        log_dir = self.config.log_dir
+        os.makedirs(log_dir, exist_ok=True)
+        data_files = glob.glob(f"{log_dir}/{prefix}_*.json")
+        file_num = len(data_files) + 1
+        output_file = f"{log_dir}/{prefix}_{file_num}.json"
+        with open(output_file, "w") as f:
+            json.dump({"prompts": prompts, "lengths": response}, f)
+
+    def restore_order(
+        self,
+        gen_batch_output: DataProto,
+        reqs_idx,
+        n_samples,
+    ):
+        bs = len(gen_batch_output)
+        assert bs % n_samples == 0, f"bs {bs} must be divisible by n_samples {n_samples}"
+        assert bs // n_samples == len(reqs_idx), f"bs//n_samples {bs // n_samples} != len(reqs_idx) {len(reqs_idx)}"
+        print(f"[ReqScheduler] restore_order, {bs=}, {n_samples=}, {len(reqs_idx)=}")
+        expanded_reqs_idx = np.repeat(reqs_idx, n_samples)
+        perm = np.argsort(expanded_reqs_idx, kind="stable")
+        inv_perm = np.empty_like(perm)
+        inv_perm[perm] = np.arange(bs)
+
+        assert len(inv_perm) == bs, f"len(global_idx) {len(inv_perm)} != bs {bs}"
+
+        global_idx = torch.tensor(inv_perm)
+        gen_batch_output.reorder(global_idx)
+
+    def sched(
+        self,
+        batch_dict: dict,
+        world_size: int,
+        config,
+    ):
+        print(f"[ReqScheduler] sched, {world_size=}, {config=}")
+
+        pre_outlens = []
+        for raw_prompt_ids in batch_dict["raw_prompt_ids"]:
+            outlen = self.lookup_table(raw_prompt_ids)
+            pre_outlens.append(outlen)
+
+        # sched
+        tp_size = config.rollout.tensor_model_parallel_size
+        assert world_size % tp_size == 0, f"world_size {world_size} must be divisible by tp_size {tp_size}"
+        dp_size = world_size // tp_size
+        res = self._sched(pre_outlens, dp_size, tp_size)
+
+        batch_dict["reqs_idx"] = res
+        batch_dict["pre_outlens"] = np.array(pre_outlens, dtype=np.int32)
+
+    def print_stats(self, outlens, res):
+        longest = max(outlens)
+        shortest = min(outlens)
+        avg = np.mean(outlens)
+        std = np.std(outlens)
+        print(f"[ReqScheduler] Stats: {longest=}, {shortest=}, avg: {avg:.2f}, std: {std:.2f}")
+        num_group = np.unique(res)
+        group = [0 for _ in range(len(num_group))]
+        for v in res:
+            group[v] += 1
+        print(f"[ReqScheduler] Group: {group}")
+
+    def _sched(self, outlens, dp_size, tp_size):
+        algo = self.config.algo
+
+        has_none = False
+        for outlen in outlens:
+            if outlen is None:
+                has_none = True
+                break
+
+        agg = self.config.get("agg", "mean")
+        if has_none:
+            print(f"[ReqScheduler] has None, reset {algo} to even_prompt; {agg=}")
+            algo = "even_prompt"
+
+            for i in range(len(outlens)):
+                outlens[i] = -1
+        else:
+            print(f"[ReqScheduler] algo: {algo}, {agg=}")
+
+        method = getattr(self, algo)
+        res = method(outlens, dp_size)
+        self.print_stats(outlens, res)
+        return res
+
+    def even_prompt(self, outlens: list[int], dp_size: int):
+        num_prompts = len(outlens)
+        if num_prompts == 0:
+            return np.array([], dtype=np.int32)
+        if dp_size <= 0:
+            raise ValueError("dp_size must be a positive integer.")
+
+        base_prompts_per_dp = num_prompts // dp_size
+        remainder_prompts = num_prompts % dp_size
+        res = []
+        for i in range(dp_size):
+            num_in_group = base_prompts_per_dp + (1 if i < remainder_prompts else 0)
+            res.extend([i] * num_in_group)
+        return np.array(res, dtype=np.int32)
+
+    def even_token(self, outlens: list[int], dp_size: int):
+        prompt_indices = list(range(len(outlens)))
+        sorted_pairs = sorted(zip(outlens, prompt_indices, strict=False), reverse=True)
+        heap = [(0, i) for i in range(dp_size)]
+        heapq.heapify(heap)
+        res = [None] * len(outlens)
+        for token_len, orig_idx in sorted_pairs:
+            total, group = heapq.heappop(heap)
+            res[orig_idx] = group
+            heapq.heappush(heap, (total + token_len, group))
+        return np.array(res, dtype=np.int32)
+
+    def even_token_kk(self, outlens: list[int], dp_size: int):
+        """
+        Schedules requests to balance the total number of tokens per DP group
+        using the Karmarkar-Karp (KK) number partitioning algorithm.
+        """
+        if not outlens:
+            return np.array([], dtype=np.int32)
+
+        print(f"[ReqScheduler] Running Karmarkar-Karp for {len(outlens)} prompts into {dp_size} groups.")
+
+        partitions = karmarkar_karp(
+            seqlen_list=outlens,
+            k_partitions=dp_size,
+            equal_size=False,  # We want to balance sum of tokens, not count of prompts
+        )
+
+        res = [None] * len(outlens)
+        for group_idx, partition_indices in enumerate(partitions):
+            for original_prompt_idx in partition_indices:
+                res[original_prompt_idx] = group_idx
+
+        assert None not in res, "Karmarkar-Karp scheduling failed: not all prompts were assigned a group."
+
+        return np.array(res, dtype=np.int32)

--- a/recipe/req_sched/config/req_sched_trainer.yaml
+++ b/recipe/req_sched/config/req_sched_trainer.yaml
@@ -16,4 +16,4 @@ req_scheduler:
   seq_dir: null
   log_dir: null
   agg: mean
-  algo: even_prompt_kk
+  algo: even_token_kk

--- a/recipe/req_sched/config/req_sched_trainer.yaml
+++ b/recipe/req_sched/config/req_sched_trainer.yaml
@@ -12,6 +12,7 @@ data:
 trainer:
   project_name: verl-req_sched
 
+# Configuration for the request scheduler
 req_scheduler:
   seq_dir: null
   log_dir: null

--- a/recipe/req_sched/config/req_sched_trainer.yaml
+++ b/recipe/req_sched/config/req_sched_trainer.yaml
@@ -1,0 +1,19 @@
+hydra:
+  searchpath:
+    - file://verl/trainer/config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+data:
+  gen_batch_size: ${data.train_batch_size}
+    
+trainer:
+  project_name: verl-req_sched
+
+req_scheduler:
+  seq_dir: null
+  log_dir: null
+  agg: mean
+  algo: even_prompt_kk

--- a/recipe/req_sched/fsdp_workers.py
+++ b/recipe/req_sched/fsdp_workers.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The main entry point to run the PPO algorithm
+"""
+
+
+import logging
+import os
+
+from verl import DataProto
+
+from verl.single_controller.base.decorator import Dispatch, register
+from verl.utils.device import (
+    get_device_id,
+    get_torch_device,
+)
+
+from verl.utils.profiler import DistProfiler, log_gpu_memory_usage, simple_timer
+from verl.utils.profiler.performance import reduce_timing
+from verl.workers.fsdp_workers import ActorRolloutRefWorker as ARRWorker
+
+#import for log
+import numpy as np
+import torch
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class ActorRolloutRefWorker(ARRWorker):
+    """
+    This worker can be instantiated as a standalone actor or a standalone rollout or a standalone reference policy
+    or a hybrid engine based on the config.rollout
+    """
+
+    @register(dispatch_mode=Dispatch.REQ_DISTRIBUTION)
+    @DistProfiler.annotate(color="red", role="rollout_generate")
+    def generate_sequences(self, prompts: DataProto):
+        # Support all hardwares
+        rank = torch.distributed.get_rank()
+        config = self.config.rollout
+        tp_size = config.get('tensor_model_parallel_size', 1)
+
+        my_req_idx = rank // tp_size
+        if rank % tp_size == 0:
+            is_first_tp_rank = True
+        else:
+            is_first_tp_rank = False
+        
+        reqs_idx = prompts.non_tensor_batch.pop('reqs_idx')
+        pre_outlens = prompts.non_tensor_batch.pop('pre_outlens')
+
+        my_idx = [i for i, idx in enumerate(reqs_idx) if idx == my_req_idx]
+        if len(my_idx) == 0:
+            raise RuntimeError(f'Empty reqs {rank} {tp_size=} {my_req_idx=} {reqs_idx=}')
+        
+        prompts = prompts.select_idxs(my_idx)
+        pre_outlens = [pre_outlens[i] for i in my_idx]
+
+        pre_longest = max(pre_outlens)
+        pre_shortest = min(pre_outlens)
+        pre_avg = np.mean(pre_outlens)
+        pre_std = np.std(pre_outlens)
+
+        ps = prompts.non_tensor_batch['raw_prompt_ids']
+        inlens = [len(i) for i in ps]
+        predict_totallens = [i + j for i, j in zip(inlens, pre_outlens)]
+        if is_first_tp_rank:
+            print(
+                f"[GEN]:\n"
+                f"  {rank=}, len(my_idx)={len(my_idx)}, pre_longest={pre_longest}, pre_shortest={pre_shortest}, pre_avg={pre_avg:.2f}, pre_std={pre_std:.2f}\n"
+            )
+        prompts = prompts.to(get_device_id())
+
+        assert self._is_rollout
+
+        meta_info = {
+            "eos_token_id": self.generation_config.eos_token_id if self.generation_config is not None else self.tokenizer.eos_token_id,
+            "pad_token_id": self.generation_config.pad_token_id if self.generation_config is not None else self.tokenizer.pad_token_id,
+        }
+        prompts.meta_info.update(meta_info)
+        timing_generate = {}
+        with self.rollout_sharding_manager:
+            log_gpu_memory_usage("After entering rollout sharding manager", logger=logger)
+            
+            with simple_timer("generate_sequences", timing_generate):
+                
+                output = self.rollout.generate_sequences(prompts=prompts)
+            log_gpu_memory_usage("After rollout generation", logger=logger)
+            if is_first_tp_rank:
+                # just printing
+                inlongest = max(inlens)
+                inshortest = min(inlens)
+                inavg = np.mean(inlens)
+                instd = np.std(inlens)
+
+                predict_tlongest = max(predict_totallens)
+                predict_tshortest = min(predict_totallens)
+                predict_tavg = np.mean(predict_totallens)
+                predict_tstd = np.std(predict_totallens)
+
+                pre_osum  = sum(pre_outlens)
+                predict_tsum = sum(predict_totallens)
+                insum = sum(inlens)
+
+                # actual out
+                responses = output.batch['responses']
+                pad_id = self.tokenizer.pad_token_id
+                padded_tensor = responses.cpu()
+                # Convert tensor to list if it's a tensor
+                if isinstance(padded_tensor, torch.Tensor):
+                    padded_list = padded_tensor.tolist()
+                else:
+                    padded_list = padded_tensor
+                unpadded_responses = []
+                for padded_response in padded_list:
+                    try:
+                        pad_start_idx = padded_response.index(pad_id)
+                        original_response = padded_response[:pad_start_idx]
+                    except ValueError:
+                        original_response = padded_response
+                    unpadded_responses.append(original_response)
+                
+                actual_outlen = [len(resp) for resp in unpadded_responses]
+                actual_sum = np.sum(actual_outlen)
+                actual_mean = np.mean(actual_outlen)
+                actual_max = np.max(actual_outlen)
+                actual_min = np.min(actual_outlen)
+                #breakpoint()
+                print(f"[GENTIME] {rank=}, {timing_generate['generate_sequences']:.2f}s; Sum: predict_totallens={predict_tsum}, pre_outlens={pre_osum}, insum={insum} ; Total: {predict_tlongest=}, {predict_tshortest=}, {predict_tavg=}, {predict_tstd=}; In: {inlongest=}, {inshortest=}, inavg={inavg:.0f}, instd={instd:.0f}; ACTUAL: {actual_sum=}, {actual_mean=}, {actual_max=}, {actual_min=}")
+            output = self.rollout_sharding_manager.postprocess_data(output)
+
+        timing_generate.update(self.rollout_sharding_manager.timing)
+        # We calculate the average timing across all ranks
+        # to make sure meta_info["timing"] is the same
+        timing_generate = reduce_timing(timing_generate)
+        output.meta_info["timing"] = timing_generate
+        output = output.to("cpu")
+        get_torch_device().empty_cache()
+        return output

--- a/recipe/req_sched/main_sched_ppo.py
+++ b/recipe/req_sched/main_sched_ppo.py
@@ -22,6 +22,7 @@ import hydra
 import ray
 from omegaconf import OmegaConf
 
+from verl.trainer.constants_ppo import PPO_RAY_RUNTIME_ENV
 from verl.trainer.ppo.reward import load_reward_manager
 
 from .sched_ray_trainer import RaySchedTrainer
@@ -41,14 +42,7 @@ def run_ppo(config) -> None:
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
         ray.init(
-            runtime_env={
-                "env_vars": {
-                    "TOKENIZERS_PARALLELISM": "true",
-                    "NCCL_DEBUG": "WARN",
-                    "VLLM_LOGGING_LEVEL": "WARN",
-                    "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true",
-                }
-            },
+            runtime_env=PPO_RAY_RUNTIME_ENV,
             num_cpus=config.ray_init.num_cpus,
         )
 
@@ -101,17 +95,9 @@ class TaskRunner:
         # Used for multimodal LLM, could be None
         processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
 
-        # Version validation for vllm.
-        if config.actor_rollout_ref.rollout.name in ["vllm"]:
-            from verl.utils.vllm_utils import is_version_ge
-
-            if config.actor_rollout_ref.model.get("lora_rank", 0) > 0:
-                if not is_version_ge(pkg="vllm", minver="0.7.3"):
-                    raise NotImplementedError("PPO LoRA is not supported before vllm 0.7.3")
-
         # Define worker classes based on the actor strategy.
-        if config.actor_rollout_ref.actor.strategy in ["fsdp", "fsdp2"]:
-            assert config.critic.strategy in ["fsdp", "fsdp2"]
+        if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
+            assert config.critic.strategy in {"fsdp", "fsdp2"}
             from verl.single_controller.ray import RayWorkerGroup
             from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker, CriticWorker
 
@@ -165,7 +151,7 @@ class TaskRunner:
         # finally, we combine all the rewards together
         # The reward type depends on the tag of the data
         if config.reward_model.enable:
-            if config.reward_model.strategy in ["fsdp", "fsdp2"]:
+            if config.reward_model.strategy in {"fsdp", "fsdp2"}:
                 from verl.workers.fsdp_workers import RewardModelWorker
             elif config.reward_model.strategy == "megatron":
                 from verl.workers.megatron_workers import RewardModelWorker

--- a/recipe/req_sched/main_sched_ppo.py
+++ b/recipe/req_sched/main_sched_ppo.py
@@ -47,7 +47,8 @@ def run_ppo(config) -> None:
 
     # Create a remote instance of the TaskRunner class, and
     # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
-    if OmegaConf.select(config.trainer, "profile_steps") is not None and len(OmegaConf.select(config.trainer, "profile_steps")) > 0:
+    if (OmegaConf.select(config.trainer, "profile_steps") is not None 
+        and len(OmegaConf.select(config.trainer, "profile_steps")) > 0):
         nsight_options = OmegaConf.to_container(config.trainer.controller_nsight_options)
         runner = TaskRunner.options(runtime_env={"nsight": nsight_options}).remote()
     else:
@@ -79,7 +80,8 @@ class TaskRunner:
 
         # Download the checkpoint from HDFS to the local machine.
         # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
-        local_path = copy_to_local(config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False))
+        local_path = copy_to_local(
+            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False))
 
         # Instantiate the tokenizer and processor.
         from verl.utils import hf_processor, hf_tokenizer
@@ -104,7 +106,11 @@ class TaskRunner:
             from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker, CriticWorker
             from .fsdp_workers import ActorRolloutRefWorker
 
-            actor_rollout_cls = AsyncActorRolloutRefWorker if config.actor_rollout_ref.rollout.mode == "async" else ActorRolloutRefWorker
+            actor_rollout_cls = (
+                AsyncActorRolloutRefWorker 
+                if config.actor_rollout_ref.rollout.mode == "async" 
+                else ActorRolloutRefWorker
+            )
             ray_worker_group_cls = RayWorkerGroup
 
         elif config.actor_rollout_ref.actor.strategy == "megatron":
@@ -112,7 +118,11 @@ class TaskRunner:
             from verl.single_controller.ray.megatron import NVMegatronRayWorkerGroup
             from verl.workers.megatron_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker, CriticWorker
 
-            actor_rollout_cls = AsyncActorRolloutRefWorker if config.actor_rollout_ref.rollout.mode == "async" else ActorRolloutRefWorker
+            actor_rollout_cls = (
+                AsyncActorRolloutRefWorker 
+                if config.actor_rollout_ref.rollout.mode == "async" 
+                else ActorRolloutRefWorker
+            )
             ray_worker_group_cls = NVMegatronRayWorkerGroup
 
         else:
@@ -159,8 +169,12 @@ class TaskRunner:
             mapping[Role.RefPolicy] = global_pool_id
 
         # Load the reward manager for training and validation.
-        reward_fn = load_reward_manager(config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {}))
-        val_reward_fn = load_reward_manager(config, tokenizer, num_examine=1, **config.reward_model.get("reward_kwargs", {}))
+        reward_fn = load_reward_manager(
+            config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {})
+        )
+        val_reward_fn = load_reward_manager(
+            config, tokenizer, num_examine=1, **config.reward_model.get("reward_kwargs", {})
+        )
         resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
 
         from verl.utils.dataset.rl_dataset import collate_fn
@@ -216,7 +230,10 @@ def create_rl_dataset(data_paths, data_config, tokenizer, processor):
         dataset_cls = load_extern_type(data_config.custom_cls.path, data_config.custom_cls.name)
         # Verify that the custom dataset class inherits from torch.utils.data.Dataset
         if not issubclass(dataset_cls, Dataset):
-            raise TypeError(f"The custom dataset class '{data_config.custom_cls.name}' from '{data_config.custom_cls.path}' must inherit from torch.utils.data.Dataset")
+            raise TypeError(
+                f"The custom dataset class '{data_config.custom_cls.name}' from "
+                f"'{data_config.custom_cls.path}' must inherit from torch.utils.data.Dataset"
+            )
     else:
         # Use the default RLHFDataset class if no custom class is specified
         #dataset_cls = RLHFDataset

--- a/recipe/req_sched/main_sched_ppo.py
+++ b/recipe/req_sched/main_sched_ppo.py
@@ -1,0 +1,264 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
+"""
+
+import os
+import socket
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+
+from .sched_ray_trainer import RaySchedTrainer
+from verl.trainer.ppo.reward import load_reward_manager
+
+
+@hydra.main(config_path="config", config_name="ppo_trainer", version_base=None)
+def main(config):
+    run_ppo(config)
+
+
+# Define a function to run the PPO-like training process
+def run_ppo(config) -> None:
+    # Check if Ray is not initialized
+    if not ray.is_initialized():
+        # Initialize Ray with a local cluster configuration
+        # Set environment variables in the runtime environment to control tokenizer parallelism,
+        # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
+        # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
+        ray.init(
+            runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN",
+                                       "VLLM_LOGGING_LEVEL": "WARN", "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true"}},
+            num_cpus=config.ray_init.num_cpus,
+        )
+
+    # Create a remote instance of the TaskRunner class, and
+    # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
+    if OmegaConf.select(config.trainer, "profile_steps") is not None and len(OmegaConf.select(config.trainer, "profile_steps")) > 0:
+        nsight_options = OmegaConf.to_container(config.trainer.controller_nsight_options)
+        runner = TaskRunner.options(runtime_env={"nsight": nsight_options}).remote()
+    else:
+        runner = TaskRunner.remote()
+    ray.get(runner.run.remote(config))
+
+    # [Optional] get the path of the timeline trace file from the configuration, default to None
+    # This file is used for performance analysis
+    timeline_json_file = config.ray_init.get("timeline_json_file", None)
+    if timeline_json_file:
+        ray.timeline(filename=timeline_json_file)
+
+
+@ray.remote(num_cpus=1)  # please make sure main_task is not scheduled on head
+class TaskRunner:
+    def run(self, config):
+        # Print the initial configuration. `resolve=True` will evaluate symbolic values.
+        from pprint import pprint
+
+        from omegaconf import OmegaConf
+
+        from verl.utils.fs import copy_to_local
+
+        print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+
+        pprint(OmegaConf.to_container(config, resolve=True))
+
+        OmegaConf.resolve(config)
+
+        # Download the checkpoint from HDFS to the local machine.
+        # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
+        local_path = copy_to_local(config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False))
+
+        # Instantiate the tokenizer and processor.
+        from verl.utils import hf_processor, hf_tokenizer
+
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        # Used for multimodal LLM, could be None
+        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        # Version validation for vllm.
+        if config.actor_rollout_ref.rollout.name in ["vllm"]:
+            from verl.utils.vllm_utils import is_version_ge
+
+            if config.actor_rollout_ref.model.get("lora_rank", 0) > 0:
+                if not is_version_ge(pkg="vllm", minver="0.7.3"):
+                    raise NotImplementedError("PPO LoRA is not supported before vllm 0.7.3")
+
+        # Define worker classes based on the actor strategy.
+        if config.actor_rollout_ref.actor.strategy in ["fsdp", "fsdp2"]:
+            assert config.critic.strategy in ["fsdp", "fsdp2"]
+            from verl.single_controller.ray import RayWorkerGroup
+            from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker, CriticWorker
+            from .fsdp_workers import ActorRolloutRefWorker
+
+            actor_rollout_cls = AsyncActorRolloutRefWorker if config.actor_rollout_ref.rollout.mode == "async" else ActorRolloutRefWorker
+            ray_worker_group_cls = RayWorkerGroup
+
+        elif config.actor_rollout_ref.actor.strategy == "megatron":
+            assert config.actor_rollout_ref.actor.strategy == config.critic.strategy
+            from verl.single_controller.ray.megatron import NVMegatronRayWorkerGroup
+            from verl.workers.megatron_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker, CriticWorker
+
+            actor_rollout_cls = AsyncActorRolloutRefWorker if config.actor_rollout_ref.rollout.mode == "async" else ActorRolloutRefWorker
+            ray_worker_group_cls = NVMegatronRayWorkerGroup
+
+        else:
+            raise NotImplementedError
+
+        from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
+
+        # Map roles to their corresponding remote worker classes.
+        role_worker_mapping = {
+            Role.ActorRollout: ray.remote(actor_rollout_cls),
+            Role.Critic: ray.remote(CriticWorker),
+        }
+
+        # Define the resource pool specification.
+        # Map roles to the resource pool.
+        global_pool_id = "global_pool"
+        resource_pool_spec = {
+            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+        }
+        mapping = {
+            Role.ActorRollout: global_pool_id,
+            Role.Critic: global_pool_id,
+        }
+
+        # We should adopt a multi-source reward function here:
+        # - for rule-based rm, we directly call a reward score
+        # - for model-based rm, we call a model
+        # - for code related prompt, we send to a sandbox if there are test cases
+        # finally, we combine all the rewards together
+        # The reward type depends on the tag of the data
+        if config.reward_model.enable:
+            if config.reward_model.strategy in ["fsdp", "fsdp2"]:
+                from verl.workers.fsdp_workers import RewardModelWorker
+            elif config.reward_model.strategy == "megatron":
+                from verl.workers.megatron_workers import RewardModelWorker
+            else:
+                raise NotImplementedError
+            role_worker_mapping[Role.RewardModel] = ray.remote(RewardModelWorker)
+            mapping[Role.RewardModel] = global_pool_id
+
+        # Add a reference policy worker if KL loss or KL reward is used.
+        if config.algorithm.use_kl_in_reward or config.actor_rollout_ref.actor.use_kl_loss:
+            role_worker_mapping[Role.RefPolicy] = ray.remote(ActorRolloutRefWorker)
+            mapping[Role.RefPolicy] = global_pool_id
+
+        # Load the reward manager for training and validation.
+        reward_fn = load_reward_manager(config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {}))
+        val_reward_fn = load_reward_manager(config, tokenizer, num_examine=1, **config.reward_model.get("reward_kwargs", {}))
+        resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
+
+        from verl.utils.dataset.rl_dataset import collate_fn
+
+
+        train_dataset = create_rl_dataset(config.data.train_files, config.data, tokenizer, processor)
+        val_dataset = create_rl_dataset(config.data.val_files, config.data, tokenizer, processor)
+        train_sampler = create_rl_sampler(config.data, train_dataset)
+
+        trainer = RaySchedTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            reward_fn=reward_fn,
+            val_reward_fn=val_reward_fn,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+            device_name=config.trainer.device,
+        )
+        # Initialize the workers of the trainer.
+        trainer.init_workers()
+        # Start the training process.
+        trainer.fit()
+
+
+def create_rl_dataset(data_paths, data_config, tokenizer, processor):
+    """Create a dataset.
+
+    Arguments:
+        data_paths: List of paths to data files.
+        data_config: The data config.
+        tokenizer (Tokenizer): The tokenizer.
+        processor (Processor): The processor.
+
+    Returns:
+        dataset (Dataset): The dataset.
+    """
+    from torch.utils.data import Dataset
+
+    from verl.utils.dataset.rl_dataset import RLHFDataset
+
+    # Check if a custom dataset class is specified in the data configuration
+    # and if the path to the custom class is provided
+    if "custom_cls" in data_config and data_config.custom_cls.get("path", None) is not None:
+        from verl.utils.import_utils import load_extern_type
+
+        # Dynamically load the custom dataset class
+        dataset_cls = load_extern_type(data_config.custom_cls.path, data_config.custom_cls.name)
+        # Verify that the custom dataset class inherits from torch.utils.data.Dataset
+        if not issubclass(dataset_cls, Dataset):
+            raise TypeError(f"The custom dataset class '{data_config.custom_cls.name}' from '{data_config.custom_cls.path}' must inherit from torch.utils.data.Dataset")
+    else:
+        # Use the default RLHFDataset class if no custom class is specified
+        #dataset_cls = RLHFDataset
+        dataset_cls = RLHFDataset
+    print(f"Using dataset class: {dataset_cls.__name__}")
+
+    # Instantiate the dataset using the determined dataset class
+    dataset = dataset_cls(
+        data_files=data_paths,
+        tokenizer=tokenizer,
+        processor=processor,
+        config=data_config,
+    )
+
+    return dataset
+
+
+def create_rl_sampler(data_config, dataset):
+    """Create a sampler for the dataset.
+
+    Arguments:
+        data_config: The data config.
+        dataset (Dataset): The dataset.
+
+    Returns:
+        sampler (Sampler): The sampler.
+    """
+    import torch
+    from torch.utils.data import RandomSampler, SequentialSampler
+
+    # Use a sampler to facilitate checkpoint resumption.
+    # If shuffling is enabled in the data configuration, create a random sampler.
+    if data_config.shuffle:
+        train_dataloader_generator = torch.Generator()
+        train_dataloader_generator.manual_seed(data_config.get("seed", 1))
+        sampler = RandomSampler(data_source=dataset, generator=train_dataloader_generator)
+    else:
+        # If shuffling is disabled, use a sequential sampler to iterate through the dataset in order.
+        sampler = SequentialSampler(data_source=dataset)
+
+    return sampler
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/req_sched/sched_ray_trainer.py
+++ b/recipe/req_sched/sched_ray_trainer.py
@@ -232,7 +232,7 @@ class ReqScheduler:
         cnt = 0
         global_idx = [None for _ in range(bs)]
         group_idx = 0
-        max_id = max(reqs_idx)
+        max_id = max(reqs_idx) if reqs_idx else -1
         while group_idx <= max_id:
             for i, idx in enumerate(reqs_idx):
                 if idx == group_idx:

--- a/recipe/req_sched/sched_ray_trainer.py
+++ b/recipe/req_sched/sched_ray_trainer.py
@@ -330,6 +330,7 @@ class RaySchedTrainer(RayPPOTrainer):
                 with marked_timer("step", timing_raw):
                     with marked_timer("gen", timing_raw, color="red"):
                         # [ReqScheduler] scheduling for bacth generation
+                        # [ReqScheduler] Note that we repeat dataproto in workers not here
                         gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
                         timing_raw.update(gen_batch_output.meta_info["timing"])
                         gen_batch_output.meta_info.pop("timing", None)

--- a/recipe/req_sched/sched_ray_trainer.py
+++ b/recipe/req_sched/sched_ray_trainer.py
@@ -1,0 +1,857 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+FSDP PPO Trainer with Ray-based single controller.
+This trainer supports model-agonistic model initialization with huggingface
+"""
+
+import json
+import os
+import uuid
+import heapq
+from collections import defaultdict
+from copy import deepcopy
+from pprint import pprint
+from typing import Optional, Type, Dict
+from codetiming import Timer
+from contextlib import contextmanager
+import glob
+
+import numpy as np
+import ray
+import torch
+from torch.utils.data import Dataset, Sampler
+from tqdm import tqdm
+
+from verl import DataProto
+from verl.protocol import pad_dataproto_to_divisor
+from verl.single_controller.base import Worker
+from verl.single_controller.ray import RayWorkerGroup
+from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
+from verl.trainer.ppo.metric_utils import (
+    compute_data_metrics,
+    compute_throughout_metrics,
+    compute_timing_metrics,
+    process_validation_metrics,
+)
+from verl.trainer.ppo.reward import compute_reward, compute_reward_async
+from verl.utils.debug import marked_timer
+from verl.utils.metric import (
+    reduce_metrics,
+)
+from verl.utils.seqlen_balancing import karmarkar_karp
+from verl.trainer.ppo.ray_trainer import AdvantageEstimator, RayPPOTrainer, Role, ResourcePoolManager, apply_kl_penalty, compute_advantage, compute_response_mask
+from verl.utils.debug import marked_timer
+WorkerType = Type[Worker]
+
+
+
+def unpad_responses(padded_tensor, pad_token_id):
+    if isinstance(pad_token_id, list):
+        # from all worker
+        pid = pad_token_id[0]
+        for worker_pad_token_id in pad_token_id:
+            if worker_pad_token_id != pid:
+                raise ValueError("pad_token_id is not the same across all workers")
+        pad_token_id = pid
+
+    padded_tensor = padded_tensor.cpu()
+    # Convert tensor to list if it's a tensor
+    if isinstance(padded_tensor, torch.Tensor):
+        padded_list = padded_tensor.tolist()
+    else:
+        padded_list = padded_tensor
+    
+    # Reconstruct original responses by removing padding tokens
+    unpadded_responses = []
+    for padded_response in padded_list:
+        # Find where padding starts (first occurrence of pad_token_id)
+        try:
+            pad_start_idx = padded_response.index(pad_token_id)
+            # Get only the tokens before padding
+            original_response = padded_response[:pad_start_idx]
+        except ValueError:
+            # No padding found, use the full response
+            original_response = padded_response
+        
+        unpadded_responses.append(original_response)
+    return unpadded_responses
+
+class ReqScheduler:
+    def __init__(self, config):
+        self.config = config
+
+        # prompt_ids -> len(reponse)
+        self.table: dict[tuple[int], int] = self.load_table()
+    
+    def load_table(self):
+        ''' 
+        {
+            "prompts": [
+                [prompt_token_ids_1], 
+                [prompt_token_ids_2], 
+                ...
+            ],
+            "lengths": [
+                [120, 88, 85, 92, 95, 100, 90, 110],  // prompt 1 对应 sample n 个 response 长度
+                [105, 90, 95, 92, 100, 94, 90, 88],   // prompt 2
+                ...
+            ],
+            "stats": [ // 初始预计算存储，仍可保留便于快速调用
+                {"max": 120, "min": 85, "mean": 97.5, "std": 10.2, "sum": 780}, 
+                {"max": 105, "min": 88, "mean": 94.3, "std": 5.6, "sum": 754}, 
+                ...
+            ]
+        }
+        '''
+        if self.config.seq_dir is None:
+            return {}
+
+        json_files = glob.glob(os.path.join(self.config.seq_dir, "*.json"))
+        print(f"[ReqScheduler] Found {len(json_files)} JSON files to process")
+
+        ans = {}
+        for json_file in json_files:
+            filename = os.path.basename(json_file)
+            try:
+                with open(json_file, 'r') as f:
+                    data = json.load(f)
+                
+                print(f"[ReqScheduler] data keys = {data.keys()} in {filename}")
+
+                ps = data['prompts']
+                ls = data['lengths']
+                for p, l in zip(ps, ls):
+                    p = tuple(p)
+                    if p not in ans:
+                        ans[p] = l
+                print(f"[ReqScheduler] Processed {filename}, found {len(ans)} unique prompts")
+            except Exception as e:
+                print(f"[ReqScheduler] Error processing {filename}: {str(e)}")
+                raise e
+                
+
+        agg = self.config.get('agg', 'mean')
+        if agg == 'max':
+            ans = {k: max(v) for k, v in ans.items()}
+        elif agg == 'min':
+            ans = {k: min(v) for k, v in ans.items()}
+        elif agg == 'mean':
+            ans = {k: int(np.mean(v)) for k, v in ans.items()}
+        elif agg =='median':
+            ans = {k: int(np.median(v)) for k, v in ans.items()}
+        elif agg == 'sum':
+            ans = {k: sum(v) for k, v in ans.items()}
+        else:
+            raise ValueError(f"Unknown agg {agg}")
+        print(f'[ReqScheduler] Table-Size: {len(ans)=}')
+        return ans
+
+    def lookup_table(self, prompt):
+        if isinstance(prompt, list):
+            prompt = tuple(prompt)
+        assert isinstance(prompt, tuple), f"prompt type {type(prompt)} is not supported"
+        if prompt in self.table:
+            return self.table[prompt]
+        return None
+
+    def update_table(self, raw_prompt_ids, responses):
+        new_table = {}
+        for p, r in zip(raw_prompt_ids, responses):
+            p = tuple(p)
+            r = tuple(r)
+            if p not in new_table:
+                new_table[p] = []
+            new_table[p].append(len(r))
+
+        agg = self.config.get('agg', 'mean')
+        if agg == 'max':
+            new_table = {k: max(v) for k, v in new_table.items()}
+        elif agg == 'min':
+            new_table = {k: min(v) for k, v in new_table.items()}
+        elif agg == 'mean':
+            new_table = {k: int(np.mean(v)) for k, v in new_table.items()}
+        elif agg =='median':
+            new_table = {k: int(np.median(v)) for k, v in new_table.items()}
+        elif agg == 'sum':
+            new_table = {k: sum(v) for k, v in new_table.items()}
+        else:
+            raise ValueError(f"Unknown agg {agg}")
+        
+        for k, v in new_table.items():
+            self.table[k] = v
+        print(f'[ReqScheduler] in update_table, Table-Size: {len(self.table)=}')
+
+    def log_seqlen(self, raw_prompt_ids, responses, prefix):
+        print(f'[ReqScheduler] in log_seqlen, {type(raw_prompt_ids)}, {type(responses)}, {len(raw_prompt_ids)}, {len(responses)}')
+        assert len(raw_prompt_ids) == len(responses), f'{len(raw_prompt_ids)}, {len(responses)}'
+        prompts_dict = {}
+        prompts, response = [], []
+        for p, r in zip(raw_prompt_ids, responses):
+            if tuple(p) not in prompts_dict:
+                prompts_dict[tuple(p)] = []
+            prompts_dict[tuple(p)].append(len(r))
+        
+        for pid in prompts_dict:
+            prompts.append(list(pid))
+            response.append(prompts_dict[pid])
+
+        log_dir = self.config.log_dir
+        os.makedirs(log_dir, exist_ok=True)
+        data_files = glob.glob(f"{log_dir}/{prefix}_*.json")
+        file_num = len(data_files) + 1
+        output_file = f"{log_dir}/{prefix}_{file_num}.json"
+        with open(output_file, 'w') as f:
+            json.dump({
+                'prompts': prompts, 
+                'lengths': response
+            }, f)
+    
+    def restore_order(self,
+                      gen_batch_output: DataProto,
+                      reqs_idx,
+                      n_samples,
+                    ):
+        bs = len(gen_batch_output)
+        assert bs % n_samples == 0, f'bs {bs} must be divisible by n_samples {n_samples}'
+        assert bs//n_samples == len(reqs_idx), f'bs//n_samples {bs//n_samples} != len(reqs_idx) {len(reqs_idx)}'
+        print(f"[ReqScheduler] restore_order, {bs=}, {n_samples=}, {len(reqs_idx)=}")
+        cnt = 0
+        global_idx = [None for _ in range(bs)]
+        group_idx = 0
+        max_id = max(reqs_idx)
+        while group_idx <= max_id:
+            for i, idx in enumerate(reqs_idx):
+                if idx == group_idx:
+                    start_position = i * n_samples
+                    end_position = start_position + n_samples
+                    global_idx[start_position: end_position] = [j for j in range(cnt, cnt+n_samples)]
+                    cnt += n_samples
+            group_idx += 1
+
+        assert len(global_idx) == bs, f'len(global_idx) {len(global_idx)} != bs {bs}'
+
+        global_idx = torch.tensor(global_idx)
+        gen_batch_output.reorder(global_idx)
+
+    def sched(self, batch_dict: dict,
+            world_size: int,
+            config,
+        ):
+        print(f"[ReqScheduler] sched, {world_size=}, {config=}")
+
+        pre_outlens = []
+        for raw_prompt_ids in batch_dict['raw_prompt_ids']:
+            outlen = self.lookup_table(raw_prompt_ids)
+            pre_outlens.append(outlen)
+
+        # sched
+        tp_size = config.rollout.tensor_model_parallel_size
+        assert world_size % tp_size == 0, f'world_size {world_size} must be divisible by tp_size {tp_size}'
+        dp_size = world_size // tp_size
+        res = self._sched(pre_outlens, dp_size, tp_size)
+
+        batch_dict['reqs_idx'] = res
+        batch_dict['pre_outlens'] = np.array(pre_outlens, dtype=np.int32)
+        
+        
+    def print_stats(self, outlens, res):
+        longest = max(outlens)
+        shortest = min(outlens)
+        avg = np.mean(outlens)
+        std = np.std(outlens)
+        print(f"[ReqScheduler] Stats: {longest=}, {shortest=}, avg: {avg:.2f}, std: {std:.2f}")
+        num_group = np.unique(res)
+        group = [0 for _ in range(len(num_group))]
+        for v in res:
+            group[v] += 1
+        print(f"[ReqScheduler] Group: {group}")
+    
+    def _sched(self, outlens, dp_size, tp_size):
+        algo = self.config.algo
+
+        has_none = False
+        for outlen in outlens:
+            if outlen is None:
+                has_none = True
+                break
+        
+        agg = self.config.get('agg', 'mean')
+        if has_none:
+            print(f"[ReqScheduler] has None, reset {algo} to even_prompt; {agg=}")
+            algo = 'even_prompt'
+
+            for i in range(len(outlens)):
+                outlens[i] = -1
+        else:
+            print(f"[ReqScheduler] algo: {algo}, {agg=}")
+        
+        method = getattr(self, algo)
+        res = method(outlens, dp_size, tp_size, self.config)
+        self.print_stats(outlens, res)
+        return res
+    
+    def dummy(self, outlens, dp_size, tp_size, config):
+        res = [0] * (len(outlens) - 1) + [1]
+        res = np.array(res, dtype=np.int32)
+        return res
+
+    def even_prompt(self, outlens: list[int], dp_size, tp_size, config):
+        num_prompts = len(outlens)
+        if num_prompts == 0:
+            return np.array([], dtype=np.int32)
+        if dp_size <= 0:
+            raise ValueError("dp_size must be a positive integer.")
+        
+        base_prompts_per_dp = num_prompts // dp_size
+        remainder_prompts = num_prompts % dp_size
+        res = []
+        for i in range(dp_size):
+            num_in_group = base_prompts_per_dp + (1 if i < remainder_prompts else 0)
+            res.extend([i] * num_in_group)
+        return np.array(res, dtype=np.int32)
+    
+    def even_token(self, outlens, dp_size, tp_size, config):
+        prompt_indices = list(range(len(outlens)))
+        sorted_pairs = sorted(zip(outlens, prompt_indices), reverse=True)
+        heap = [(0, i) for i in range(dp_size)]
+        heapq.heapify(heap)
+        res = [None] * len(outlens)
+        for token_len, orig_idx in sorted_pairs:
+            total, group = heapq.heappop(heap)
+            res[orig_idx] = group
+            heapq.heappush(heap, (total + token_len, group))
+        return np.array(res, dtype=np.int32)
+    
+    def even_token_kk(self, outlens: list[int], dp_size: int, tp_size: int, config):
+        """
+        Schedules requests to balance the total number of tokens per DP group
+        using the Karmarkar-Karp (KK) number partitioning algorithm.
+        """
+        if not outlens:
+            return np.array([], dtype=np.int32)
+        
+        print(f"[ReqScheduler] Running Karmarkar-Karp for {len(outlens)} prompts into {dp_size} groups.")
+        
+        partitions = karmarkar_karp(
+            seqlen_list=outlens, 
+            k_partitions=dp_size, 
+            equal_size=False  # We want to balance sum of tokens, not count of prompts
+        )
+
+        res = [None] * len(outlens)
+        for group_idx, partition_indices in enumerate(partitions):
+            for original_prompt_idx in partition_indices:
+                res[original_prompt_idx] = group_idx
+
+        assert None not in res, "Karmarkar-Karp scheduling failed: not all prompts were assigned a group."
+
+        return np.array(res, dtype=np.int32)
+
+@contextmanager
+def _timer(name: str, timing_raw: Dict[str, float]):
+    with Timer(name=name, logger=None) as timer:
+        yield
+    if name not in timing_raw:
+        timing_raw[name] = 0
+    timing_raw[name] += timer.last
+
+
+
+class RaySchedTrainer(RayPPOTrainer):
+    def __init__(
+        self,
+        config,
+        tokenizer,
+        role_worker_mapping: dict[Role, WorkerType],
+        resource_pool_manager: ResourcePoolManager,
+        ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
+        processor=None,
+        reward_fn=None,
+        val_reward_fn=None,
+        train_dataset: Optional[Dataset] = None,
+        val_dataset: Optional[Dataset] = None,
+        collate_fn=None,
+        train_sampler: Optional[Sampler] = None,
+        device_name="cuda",
+    ):
+        super().__init__(
+            config=config,
+            tokenizer=tokenizer,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            processor=processor,
+            reward_fn=reward_fn,
+            val_reward_fn=val_reward_fn,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+            device_name=device_name,
+        )
+
+        self.req_scheduler = ReqScheduler(
+            config=self.config.req_scheduler,
+        )
+
+    def _validate(self):
+        data_source_lst = []
+        reward_extra_infos_dict: dict[str, list] = defaultdict(list)
+
+        sample_inputs = []
+        sample_outputs = []
+        sample_scores = []
+
+        for test_data in self.val_dataloader:
+            self.req_scheduler.sched(
+                test_data, self.actor_rollout_wg.world_size, self.config.actor_rollout_ref,
+            )
+            print(">> test_data = ", test_data.keys())
+            test_batch = DataProto.from_single_dict(test_data)
+
+            # repeat test batch
+            test_batch = test_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.val_kwargs.n, interleave=True)
+
+            # we only do validation on rule-based rm
+            if self.config.reward_model.enable and test_batch[0].non_tensor_batch["reward_model"]["style"] == "model":
+                return {}
+
+            # Store original inputs
+            input_ids = test_batch.batch["input_ids"]
+            # TODO: Can we keep special tokens except for padding tokens?
+            input_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in input_ids]
+            sample_inputs.extend(input_texts)
+
+            batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
+            non_tensor_batch_keys_to_pop = ["raw_prompt_ids", "reqs_idx", "pre_outlens"]
+            if "multi_modal_data" in test_batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("multi_modal_data")
+            if "raw_prompt" in test_batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("raw_prompt")
+            if "tools_kwargs" in test_batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("tools_kwargs")
+            if "interaction_kwargs" in test_batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("interaction_kwargs")
+            test_gen_batch = test_batch.pop(
+                batch_keys=batch_keys_to_pop,
+                non_tensor_batch_keys=non_tensor_batch_keys_to_pop,
+            )
+
+            test_reqs_idx = test_gen_batch.non_tensor_batch['reqs_idx']
+            test_gen_batch.meta_info = {
+                "eos_token_id": self.tokenizer.eos_token_id,
+                "pad_token_id": self.tokenizer.pad_token_id,
+                "recompute_log_prob": False,
+                "do_sample": self.config.actor_rollout_ref.rollout.val_kwargs.do_sample,
+                "validate": True,
+            }
+            print(f"test_gen_batch meta info: {test_gen_batch.meta_info}")
+
+            test_gen_batch_padded, _ = pad_dataproto_to_divisor(test_gen_batch, self.actor_rollout_wg.world_size)
+
+            test_output_gen_batch = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
+            
+            self.req_scheduler.restore_order(
+                test_output_gen_batch, 
+                test_reqs_idx, 
+                n_samples=self.config.actor_rollout_ref.rollout.val_kwargs.n
+            )
+            
+            print("validation generation end")
+
+            # Store generated outputs
+            output_ids = test_output_gen_batch.batch["responses"]
+            output_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in output_ids]
+            sample_outputs.extend(output_texts)
+
+            test_batch = test_batch.union(test_output_gen_batch)
+
+            # evaluate using reward_function
+            result = self.val_reward_fn(test_batch, return_dict=True)
+            reward_tensor = result["reward_tensor"]
+            scores = reward_tensor.sum(-1).cpu().tolist()
+            sample_scores.extend(scores)
+
+            reward_extra_infos_dict["reward"].extend(scores)
+            print(f"len reward_extra_infos_dict['reward']: {len(reward_extra_infos_dict['reward'])}")
+            if "reward_extra_info" in result:
+                for key, lst in result["reward_extra_info"].items():
+                    reward_extra_infos_dict[key].extend(lst)
+                    print(f"len reward_extra_infos_dict['{key}']: {len(reward_extra_infos_dict[key])}")
+
+            data_source_lst.append(test_batch.non_tensor_batch.get("data_source", ["unknown"] * reward_tensor.shape[0]))
+
+        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
+
+        # dump generations
+        val_data_dir = self.config.trainer.get("validation_data_dir", None)
+        if val_data_dir:
+            self._dump_generations(
+                inputs=sample_inputs,
+                outputs=sample_outputs,
+                scores=sample_scores,
+                reward_extra_infos_dict=reward_extra_infos_dict,
+                dump_path=val_data_dir,
+            )
+
+        for key_info, lst in reward_extra_infos_dict.items():
+            assert len(lst) == 0 or len(lst) == len(sample_scores), f"{key_info}: {len(lst)=}, {len(sample_scores)=}"
+
+        data_sources = np.concatenate(data_source_lst, axis=0)
+
+        data_src2var2metric2val = process_validation_metrics(data_sources, sample_inputs, reward_extra_infos_dict)
+        metric_dict = {}
+        for data_source, var2metric2val in data_src2var2metric2val.items():
+            core_var = "acc" if "acc" in var2metric2val else "reward"
+            for var_name, metric2val in var2metric2val.items():
+                n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
+                for metric_name, metric_val in metric2val.items():
+                    if (var_name == core_var) and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"]) and (f"@{n_max}" in metric_name):
+                        metric_sec = "val-core"
+                    else:
+                        metric_sec = "val-aux"
+                    pfx = f"{metric_sec}/{data_source}/{var_name}/{metric_name}"
+                    metric_dict[pfx] = metric_val
+
+        return metric_dict
+
+    def fit(self):
+        """
+        The training loop of PPO.
+        The driver process only need to call the compute functions of the worker group through RPC
+        to construct the PPO dataflow.
+        The light-weight advantage computation is done on the driver process.
+        """
+        from omegaconf import OmegaConf
+
+        from verl.utils.tracking import Tracking
+
+        logger = Tracking(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+            default_backend=self.config.trainer.logger,
+            config=OmegaConf.to_container(self.config, resolve=True),
+        )
+
+        self.global_steps = 0
+
+        # load checkpoint before doing anything
+        self._load_checkpoint()
+
+        # perform validation before training
+        # currently, we only support validation using the reward_function.
+        if self.val_reward_fn is not None and self.config.trainer.get("val_before_train", True):
+            val_metrics = self._validate()
+            assert val_metrics, f"{val_metrics=}"
+            pprint(f"Initial validation metrics: {val_metrics}")
+            logger.log(data=val_metrics, step=self.global_steps)
+            if self.config.trainer.get("val_only", False):
+                return
+
+        # add tqdm
+        progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
+
+        # we start from step 1
+        self.global_steps += 1
+        last_val_metrics = None
+
+        for epoch in range(self.config.trainer.total_epochs):
+            for bs_idx, batch_dict in enumerate(self.train_dataloader):
+                self.req_scheduler.sched(batch_dict,
+                    self.actor_rollout_wg.world_size,
+                    self.config.actor_rollout_ref,
+                )
+
+                do_profile = self.global_steps in self.config.trainer.profile_steps if self.config.trainer.profile_steps is not None else False
+                if do_profile:
+                    self.actor_rollout_wg.start_profile()
+                    if self.use_reference_policy:
+                        self.ref_policy_wg.start_profile()
+                    if self.use_critic:
+                        self.critic_wg.start_profile()
+                    if self.use_rm:
+                        self.rm_wg.start_profile()
+
+                metrics = {}
+                timing_raw = {}
+                batch: DataProto = DataProto.from_single_dict(batch_dict)
+
+                # pop those keys for generation
+                batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
+                non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
+                if "multi_modal_data" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("multi_modal_data")
+                if "raw_prompt" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("raw_prompt")
+                if "tools_kwargs" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("tools_kwargs")
+                if "interaction_kwargs" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("interaction_kwargs")
+                if "reqs_idx" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("reqs_idx")
+                if "pre_outlens" in batch.non_tensor_batch:
+                    non_tensor_batch_keys_to_pop.append("pre_outlens")
+
+                print(f"> {non_tensor_batch_keys_to_pop=}")
+                gen_batch = batch.pop(
+                    batch_keys=batch_keys_to_pop,
+                    non_tensor_batch_keys=non_tensor_batch_keys_to_pop,
+                )
+
+                is_last_step = self.global_steps >= self.total_training_steps
+
+                idx = gen_batch.batch['input_ids']  # (bs, prompt_length)
+                reqs_idx = gen_batch.non_tensor_batch['reqs_idx']
+                raw_prompt_ids = gen_batch.non_tensor_batch['raw_prompt_ids'] # (bs, varlen)
+                batch.non_tensor_batch['raw_prompt_ids'] = raw_prompt_ids
+                print(
+                    f'[BATCH INPUT]: {idx.shape}, {gen_batch.non_tensor_batch.keys()=}, raw_prompt_ids = {type(raw_prompt_ids)}'
+                )
+
+                with marked_timer("step", timing_raw):
+                    with marked_timer("gen", timing_raw, color="red"):
+                        gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+                        timing_raw.update(gen_batch_output.meta_info["timing"])
+                        gen_batch_output.meta_info.pop("timing", None)
+                    if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                        with marked_timer("gen_max", timing_raw, color="purple"):
+                            gen_baseline_batch = deepcopy(gen_batch)
+                            gen_baseline_batch.meta_info["do_sample"] = False
+                            gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+
+                            batch = batch.union(gen_baseline_output)
+                            reward_baseline_tensor = self.reward_fn(batch)
+                            reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                            batch.pop(batch_keys=list(gen_baseline_output.batch.keys()))
+
+                            batch.batch["reward_baselines"] = reward_baseline_tensor
+
+                            del gen_baseline_batch, gen_baseline_output
+
+                    self.req_scheduler.restore_order(
+                        gen_batch_output, 
+                        reqs_idx,
+                        self.config.actor_rollout_ref.rollout.n,
+                    )
+                    batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
+                    # repeat to align with repeated responses in rollout
+                    batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+                    batch = batch.union(gen_batch_output)
+
+
+                    response = batch.batch['responses']
+                    raw_prompt_ids = batch.non_tensor_batch['raw_prompt_ids']
+                    
+                    pad_ids = self.tokenizer.pad_token_id
+                    model = self.config.actor_rollout_ref.model.path.split('/')[-1]
+                    dataset = self.config.data.train_files[0].split('/')[-1]
+                    prefix = f'{dataset}_{model}_E{epoch}B{bs_idx}_data'
+                    unpadded = unpad_responses(response, pad_ids)
+                    self.req_scheduler.log_seqlen(
+                        raw_prompt_ids, 
+                        unpadded,
+                        prefix, 
+                    )
+                    self.req_scheduler.update_table(
+                        raw_prompt_ids,
+                        unpadded,
+                    )
+
+                    batch.batch["response_mask"] = compute_response_mask(batch)
+                    # Balance the number of valid tokens across DP ranks.
+                    # NOTE: This usually changes the order of data in the `batch`,
+                    # which won't affect the advantage calculation (since it's based on uid),
+                    # but might affect the loss calculation (due to the change of mini-batching).
+                    # TODO: Decouple the DP balancing and mini-batching.
+                    if self.config.trainer.balance_batch:
+                        self._balance_batch(batch, metrics=metrics)
+
+                    # compute global_valid tokens
+                    batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+
+                    with marked_timer("reward", timing_raw, color="yellow"):
+                        # compute reward model score
+                        if self.use_rm:
+                            reward_tensor = self.rm_wg.compute_rm_score(batch)
+                            batch = batch.union(reward_tensor)
+
+                        if self.config.reward_model.launch_reward_fn_async:
+                            future_reward = compute_reward_async.remote(batch, self.config, self.tokenizer)
+                        else:
+                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
+
+                    # recompute old_log_probs
+                    with marked_timer("old_log_prob", timing_raw, color="blue"):
+                        old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
+                        entropys = old_log_prob.batch["entropys"]
+                        response_masks = batch.batch["response_mask"]
+                        loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
+                        entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                        old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
+                        metrics.update(old_log_prob_metrics)
+                        old_log_prob.batch.pop("entropys")
+                        batch = batch.union(old_log_prob)
+
+                        if "rollout_log_probs" in batch.batch.keys():
+                            # TODO: we may want to add diff of probs too.
+                            rollout_old_log_probs = batch.batch["rollout_log_probs"]
+                            actor_old_log_probs = batch.batch["old_log_probs"]
+                            attention_mask = batch.batch["attention_mask"]
+                            responses = batch.batch["responses"]
+                            response_length = responses.size(1)
+                            response_mask = attention_mask[:, -response_length:]
+
+                            rollout_probs = torch.exp(rollout_old_log_probs)
+                            actor_probs = torch.exp(actor_old_log_probs)
+                            rollout_probs_diff = torch.abs(rollout_probs - actor_probs)
+                            rollout_probs_diff = torch.masked_select(rollout_probs_diff, response_mask.bool())
+                            rollout_probs_diff_max = torch.max(rollout_probs_diff)
+                            rollout_probs_diff_mean = torch.mean(rollout_probs_diff)
+                            rollout_probs_diff_std = torch.std(rollout_probs_diff)
+                            metrics.update(
+                                {
+                                    "training/rollout_probs_diff_max": rollout_probs_diff_max.detach().item(),
+                                    "training/rollout_probs_diff_mean": rollout_probs_diff_mean.detach().item(),
+                                    "training/rollout_probs_diff_std": rollout_probs_diff_std.detach().item(),
+                                }
+                            )
+
+                    if self.use_reference_policy:
+                        # compute reference log_prob
+                        with marked_timer("ref", timing_raw, color="olive"):
+                            if not self.ref_in_actor:
+                                ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                            else:
+                                ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
+                            batch = batch.union(ref_log_prob)
+
+                    # compute values
+                    if self.use_critic:
+                        with marked_timer("values", timing_raw, color="cyan"):
+                            values = self.critic_wg.compute_values(batch)
+                            batch = batch.union(values)
+
+                    with marked_timer("adv", timing_raw, color="brown"):
+                        # we combine with rule-based rm
+                        reward_extra_infos_dict: dict[str, list]
+                        if self.config.reward_model.launch_reward_fn_async:
+                            reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                        batch.batch["token_level_scores"] = reward_tensor
+
+                        if reward_extra_infos_dict:
+                            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
+
+                        # compute rewards. apply_kl_penalty if available
+                        if self.config.algorithm.use_kl_in_reward:
+                            batch, kl_metrics = apply_kl_penalty(batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty)
+                            metrics.update(kl_metrics)
+                        else:
+                            batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
+
+                        # compute advantages, executed on the driver process
+
+                        norm_adv_by_std_in_grpo = self.config.algorithm.get("norm_adv_by_std_in_grpo", True)  # GRPO adv normalization factor
+
+                        batch = compute_advantage(
+                            batch,
+                            adv_estimator=self.config.algorithm.adv_estimator,
+                            gamma=self.config.algorithm.gamma,
+                            lam=self.config.algorithm.lam,
+                            num_repeat=self.config.actor_rollout_ref.rollout.n,
+                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                            config=self.config.algorithm,
+                        )
+
+                    # update critic
+                    if self.use_critic:
+                        with marked_timer("update_critic", timing_raw, color="pink"):
+                            critic_output = self.critic_wg.update_critic(batch)
+                        critic_output_metrics = reduce_metrics(critic_output.meta_info["metrics"])
+                        metrics.update(critic_output_metrics)
+
+                    # implement critic warmup
+                    if self.config.trainer.critic_warmup <= self.global_steps:
+                        # update actor
+                        with marked_timer("update_actor", timing_raw, color="red"):
+                            batch.meta_info["multi_turn"] = self.config.actor_rollout_ref.rollout.multi_turn.enable
+                            actor_output = self.actor_rollout_wg.update_actor(batch)
+                        actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                        metrics.update(actor_output_metrics)
+
+                    # Log rollout generations if enabled
+                    rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
+                    if rollout_data_dir:
+                        with marked_timer("dump_rollout_generations", timing_raw, color="green"):
+                            print(batch.batch.keys())
+                            inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
+                            outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
+                            scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
+                            self._dump_generations(
+                                inputs=inputs,
+                                outputs=outputs,
+                                scores=scores,
+                                reward_extra_infos_dict=reward_extra_infos_dict,
+                                dump_path=rollout_data_dir,
+                            )
+
+                    # validate
+                    if self.val_reward_fn is not None and self.config.trainer.test_freq > 0 and (is_last_step or self.global_steps % self.config.trainer.test_freq == 0):
+                        with marked_timer("testing", timing_raw, color="green"):
+                            val_metrics: dict = self._validate()
+                            if is_last_step:
+                                last_val_metrics = val_metrics
+                        metrics.update(val_metrics)
+
+                    if self.config.trainer.save_freq > 0 and (is_last_step or self.global_steps % self.config.trainer.save_freq == 0):
+                        with marked_timer("save_checkpoint", timing_raw, color="green"):
+                            self._save_checkpoint()
+
+                # training metrics
+                metrics.update(
+                    {
+                        "training/global_step": self.global_steps,
+                        "training/epoch": epoch,
+                    }
+                )
+                # collect metrics
+                metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
+                metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+                # TODO: implement actual tflpo and theoretical tflpo
+                n_gpus = self.resource_pool_manager.get_n_gpus()
+                metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+
+                # TODO: make a canonical logger that supports various backend
+                logger.log(data=metrics, step=self.global_steps)
+                print(timing_raw)
+                timing_raw = {}
+                progress_bar.update(1)
+                self.global_steps += 1
+
+                if do_profile:
+                    self.actor_rollout_wg.stop_profile()
+                    if self.use_reference_policy:
+                        self.ref_policy_wg.stop_profile()
+                    if self.use_critic:
+                        self.critic_wg.stop_profile()
+                    if self.use_rm:
+                        self.rm_wg.stop_profile()
+
+                if is_last_step:
+                    pprint(f"Final validation metrics: {last_val_metrics}")
+                    progress_bar.close()
+                    return

--- a/recipe/req_sched/test_reqsched_DeepSeek-R1-Distill-Qwen-7B_ppo.sh
+++ b/recipe/req_sched/test_reqsched_DeepSeek-R1-Distill-Qwen-7B_ppo.sh
@@ -1,0 +1,169 @@
+set -x
+train_files="['$dapo_train_path']"
+test_files="['$aime2024_test_path']"
+
+# resume config
+export resume_mode=${resume_mode:-auto}
+export resume_from_path=${resume_from_path:-null}
+export model_path=${model_path:-models/DeepSeek-R1-Distill-Qwen-7B}
+export model_name=${model_name:-DeepSeek-R1-Distill-Qwen-7B}
+# project config
+export project_name=${project_name:-verl_dapo_math_grpo_dapo_req_sched}
+# train params
+export total_epochs=${total_epochs:-10}
+export vllm_tp=${vllm_tp:-1}
+
+export train_prompt_batch_size=${train_prompt_batch_size:-512}
+export grpo_rollout_n=${grpo_rollout_n:-16}
+# model params
+export max_response_length=${max_response_length:-20000}
+export prompt_key=${prompt_key:-prompt}
+export resume_type=${resume_type:-no_resume}
+# env config
+export nnode=${WORLD_SIZE:-1}
+
+export ulysses_sequence_parallel_size=${ulysses_sequence_parallel_size:-1}
+export filter_score_high=${filter_score_high:-0.7}
+export filter_score_low=${filter_score_low:-0.2}
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=0.2
+clip_ratio_high=0.28
+
+loss_agg_mode="token-mean"
+
+enable_filter_groups=True
+filter_groups_metric=acc
+max_num_gen_batches=10
+
+use_dynamic_bsz=True
+infer_micro_batch_size=null
+
+max_prompt_length=$((1024 * 2))
+
+enable_overlong_buffer=True
+overlong_buffer_len=$((1024 * 4))
+overlong_penalty_factor=1.0
+
+gen_prompt_bsz=$((train_prompt_batch_size * 1))
+real_train_batch_size=$((train_prompt_batch_size * grpo_rollout_n))
+ppo_mini_batch_size=32
+
+n_gpus_per_node=8
+lr=1e-6
+
+# Algorithm
+temperature=1.0
+top_p=1.0
+top_k=-1 # 0 for HF rollout, -1 for vLLM rollout
+
+shuffle=False
+
+offload=False
+max_tokens=$((max_prompt_length  + max_response_length))
+gen_max_tokens=$((max_tokens * 2))
+log_prob_max_tokens=$((max_tokens * 2))
+
+
+export seq_dir=${seq_dir:-/workspace/seq_init}
+export log_dir=${log_dir:-/workspace/seq_log}
+
+cap_dataset_size=$((1024 * 80000))
+filter_overlong_prompts=False
+
+# req_algo="even_prompt"
+# req_algo="even_token"
+# req_algo="even_token_kk"
+# agg="max" # sum / max
+
+export req_algo=${req_algo:-even_token_kk}
+export agg=${agg:-max}
+export suffix_name=${suffix_name:-reqsched}
+
+percentile=90
+export TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+echo "real_train_batch_size = $real_train_batch_size, train_prompt_batch_size = $train_prompt_batch_size, nnode = $nnode, offload = $offload, max_tokens = $max_tokens, model = $model, vllm_tp = $vllm_tp, vllm_mem = $vllm_mem, seq_dir = $seq_dir, log_dir = $log_dir, cap_dataset_size = $cap_dataset_size, filter_overlong_prompts = $filter_overlong_prompts, min_prompt_length = $min_prompt_length max_prompt_length = $max_prompt_length, max_response_length = $max_response_length, min_response_length = $min_response_length, req_algo = $req_algo, percentile = $percentile, agg = $agg"
+
+sleep 1
+
+export experiment_name=${model_name}_grpo_math_${suffix_name}-${req_algo}-${agg}_${nnode}node_reward_rollout${grpo_rollout_n}_bs${train_prompt_batch_size}_minibatch${ppo_mini_batch_size}_lr${lr}_sp${ulysses_sequence_parallel_size}_tp${vllm_tp}_maxlen${max_response_length}_all_dapo_trick_${resume_type}_filter_data_${TIMESTAMP}
+mkdir /workspace/logs_sensecore
+rm -rf /workspace/tmp_tensorboard/*
+
+export TENSORBOARD_DIR=/workspace/${project_name}/${experiment_name}
+
+python3 -u -m recipe.req_sched.main_sched_ppo \
+    --config-path=config \
+    --config-name='req_sched_trainer.yaml' \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.prompt_key=${prompt_key} \
+    data.train_batch_size=${train_prompt_batch_size} \
+    actor_rollout_ref.rollout.n=${grpo_rollout_n} \
+    data.shuffle=False \
+    data.filter_overlong_prompts=${filter_overlong_prompts} \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    req_scheduler.seq_dir="$seq_dir" \
+    req_scheduler.log_dir="$log_dir" \
+    req_scheduler.agg="$agg" \
+    req_scheduler.algo="$req_algo" \
+    data.truncation='left' \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_micro_batch_size=${infer_micro_batch_size} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${max_tokens} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${log_prob_max_tokens} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${log_prob_max_tokens} \
+    actor_rollout_ref.model.path=${model_path} \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=${lr} \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=${ulysses_sequence_parallel_size} \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=${offload} \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${offload} \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.grad_clip=1.0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${vllm_tp} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=${gen_max_tokens} \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=${offload} \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=-1 \
+    trainer.resume_mode=${resume_mode} \
+    trainer.resume_from_path=${resume_from_path} \
+    trainer.logger=['tensorboard'] \
+    trainer.default_local_dir=/workspace/${project_name}/${experiment_name} \
+    trainer.project_name=${project_name} \
+    trainer.experiment_name=${experiment_name} \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=${nnode} \
+    trainer.save_freq=10 \
+    trainer.test_freq=5 \
+    trainer.total_epochs=${total_epochs}

--- a/recipe/req_sched/test_reqsched_DeepSeek-R1-Distill-Qwen-7B_ppo.sh
+++ b/recipe/req_sched/test_reqsched_DeepSeek-R1-Distill-Qwen-7B_ppo.sh
@@ -78,7 +78,7 @@ filter_overlong_prompts=False
 # req_algo="even_prompt"
 # req_algo="even_token"
 # req_algo="even_token_kk"
-# agg="max" # sum / max
+# agg="max" # sum / max / mean / median / min
 
 export req_algo=${req_algo:-even_token_kk}
 export agg=${agg:-max}

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -84,7 +84,14 @@ def pad_dataproto_to_divisor(data: "DataProto", size_divisor: int):
         remaining_pad = pad_size
         while remaining_pad > 0:
             take_size = min(remaining_pad, len(data))
-            padding_protos.append(data[:take_size])
+            slice_data = data[:take_size]
+
+            if slice_data.non_tensor_batch is None:
+                slice_data.non_tensor_batch = {}
+
+            slice_data.non_tensor_batch["reqs_idx"] = np.full(take_size, -1, dtype=object)
+
+            padding_protos.append(slice_data)
             remaining_pad -= take_size
         data_padded = DataProto.concat([data] + padding_protos)
     else:

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -84,6 +84,8 @@ def pad_dataproto_to_divisor(data: "DataProto", size_divisor: int):
         remaining_pad = pad_size
         while remaining_pad > 0:
             take_size = min(remaining_pad, len(data))
+
+            # [ReqScheduler] if ReqSchduler is enabled, the req_idx of padding data should be -1
             if "reqs_idx" in data.non_tensor_batch:
                 slice_data = data[:take_size]
                 if slice_data.non_tensor_batch is None:

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -84,14 +84,14 @@ def pad_dataproto_to_divisor(data: "DataProto", size_divisor: int):
         remaining_pad = pad_size
         while remaining_pad > 0:
             take_size = min(remaining_pad, len(data))
-            slice_data = data[:take_size]
-
-            if slice_data.non_tensor_batch is None:
-                slice_data.non_tensor_batch = {}
-
-            slice_data.non_tensor_batch["reqs_idx"] = np.full(take_size, -1, dtype=object)
-
-            padding_protos.append(slice_data)
+            if "reqs_idx" in data.non_tensor_batch:
+                slice_data = data[:take_size]
+                if slice_data.non_tensor_batch is None:
+                    slice_data.non_tensor_batch = {}
+                slice_data.non_tensor_batch["reqs_idx"] = np.full(take_size, -1, dtype=object)
+                padding_protos.append(slice_data)
+            else:
+                padding_protos.append(data[:take_size])
             remaining_pad -= take_size
         data_padded = DataProto.concat([data] + padding_protos)
     else:

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -50,6 +50,7 @@ def init_predefined_dispatch_mode():
     Dispatch.register("DP_COMPUTE_METRIC")
     # This is a special dispatch mode for vllm ExternalRayDistributedExecutor
     Dispatch.register("DIRECT_ROLLOUT_METHOD")
+    # This is a special dispatch mode for recpie: ReqScheduler
     Dispatch.register("REQ_DISTRIBUTION")
 
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -52,6 +52,7 @@ def init_predefined_dispatch_mode():
     Dispatch.register("DIRECT_ROLLOUT_METHOD")
     Dispatch.register("REQ_DISTRIBUTION")
 
+
 class Execute(DynamicEnum):
     """Enum class defining different execution modes for distributed computation.
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -50,7 +50,7 @@ def init_predefined_dispatch_mode():
     Dispatch.register("DP_COMPUTE_METRIC")
     # This is a special dispatch mode for vllm ExternalRayDistributedExecutor
     Dispatch.register("DIRECT_ROLLOUT_METHOD")
-
+    Dispatch.register("REQ_DISTRIBUTION")
 
 class Execute(DynamicEnum):
     """Enum class defining different execution modes for distributed computation.
@@ -414,6 +414,10 @@ DISPATCH_MODE_FN_REGISTRY = {
     Dispatch.DIRECT_ROLLOUT_METHOD: {
         "dispatch_fn": dummy_direct_rollout_call,
         "collect_fn": dummy_direct_rollout_call,
+    },
+    Dispatch.REQ_DISTRIBUTION: {
+        "dispatch_fn": dispatch_one_to_all,
+        "collect_fn": collect_dp_compute_data_proto,
     },
 }
 

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -311,7 +311,7 @@ class vLLMRollout(BaseRollout):
             }
 
         if len(prompts.non_tensor_batch.pop('reqs_idx', [])):
-            self.sampling_params.n = self.config.rollout.get('n', 1)
+            self.sampling_params.n = self.config.get('n', 1)
 
         lora_requests = None
         if self.lora_kwargs:

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -310,7 +310,7 @@ class vLLMRollout(BaseRollout):
                 "temperature": self.config.val_kwargs.temperature,
                 "n": 1,  # if validate, already repeat in ray_trainer
             }
-
+        # [ReqScheduler] Note that we repeat dataproto in workers not in ray_trainer
         if len(prompts.non_tensor_batch.pop("reqs_idx", [])):
             self.sampling_params.n = self.config.get("n", 1)
 

--- a/verl/workers/sharding_manager/fsdp_vllm.py
+++ b/verl/workers/sharding_manager/fsdp_vllm.py
@@ -266,7 +266,7 @@ class FSDPVLLMShardingManager(BaseShardingManager):
         """Get chunk data of this tp rank since we do all gather in preprocess."""
         if self.tp_size == 1:
             return data
-        
+
         if len(data) % self.tp_size != 0:
             chunk_size = (len(data) + self.tp_size - 1) // self.tp_size
             start = self.tp_rank * chunk_size


### PR DESCRIPTION
### What does this PR do?

We've observed severe workload imbalance during the rollout phase of verl, particularly when setting a large `data.max_response_length`.

<img width="8025" height="2656" alt="image" src="https://github.com/user-attachments/assets/5a526b32-fb13-4294-941c-c10a64e65e4f" />

and in some case showing below, the workload **varies greatly** across DP ranks and the time gap between the fastest and slowest DP instances can exceed 1800s (e.g., between rank-5 and rank-4), leading to NCCL timeouts and significant GPU resource waste.

<img width="1490" height="182" alt="image" src="https://github.com/user-attachments/assets/2ce38621-d9da-4b7b-8ac2-702698ea3f52" />

To mitigate this, this PR provides a batch-based, simple but efficient, implementation of request skewness scheduler. As shown below, the proposed request skewness scheduler dramatically reduces idle time between DP ranks in long-tail batches, resolving the NCCL timeouts and boosing both GPU utilization and rollout efficiency.
<img id="scheduler-design" width="1878" height="937" alt="411f9234-8ce4-4720-8ad2-397864c1bce8" src="https://github.com/user-attachments/assets/940b1ac8-2a96-41d8-9c93-07cc8a4066c5" />

### Proposed Design

We observe a strong positive correlation between the load on a DP rank and the number of tokens it generates. Consequently, a greater disparity in the final token counts across these ranks leads to a significant variance in their execution times.

To this end, in contrast to the conventional even_prompt policy, we propose a new load-balancing strategy, `even_token`, and the architectural concept of a `Request Scheduler`.

The core objective of this strategy is to **ensure that the total number of generated tokens handled by each DP instance within a batch is approximately equal.** This, in turn, minimizes the completion time disparity among different DP instances ([see scheduler diagram](#scheduler-design)).

To achieve this, the key is to estimate the generation length for each request. We have opted for a more direct statistical method for its engineering simplicity, rather than training a separate prediction model. 

The implementation is as follows:
* **Length Estimation**: We maintain a lookup table that records the actual response length for each request from the previous episode (Note the lookup table can be maintained and saved as a json file for feature experiments).

* **Scheduling Execution**: When distributing a new batch, the scheduler references this historical length data to estimate the computational load of each request. It then dynamically distributes the requests, aiming to make the sum of estimated generation lengths nearly identical for every DP instance.

* **Order Restoration**: After all DP instances have completed generation, a `reorder` operation is performed to restore the outputs to their original sequence, ensuring data integrity for subsequent stages.

By leveraging the actual generation lengths from the previous episode to balance the current batch's load, the even_token strategy can effectively reduce the computational "bubbles" caused by length disparities, leading to a significant improvement in overall training efficiency and resource utilization.

### Evaluation
* dataset: DAPO-Math-17k
* max_response_length: 20k
* model: DeepSeek-R1-Distill-Qwen-7B
* 8*powerful GPUs in Hopper architecture，DP_size=8
* algorithm base: DAPO

<img width="9650" height="4150" alt="绘图2" src="https://github.com/user-attachments/assets/3559b67a-b347-4b66-84fe-8a2fcf909664" />

* As the results demonstrate, enabling the Request Skewness Scheduler provides a significant performance uplift, which becomes more pronounced as the workload imbalance increases. At training step 7, for example, the scheduler achieves a 25% performance improvement.
* Critically, the baseline run without the scheduler fails during training step 8 due to an `NCCL timeout`, leading to a crucial challenge for training stability. In contrast, our method with the scheduler maintains training stability even with severe "long-tail" batch issues, highlighting its effectiveness in improving both performance and robustness.

-----

* As already demonstrated in  ([scheduler diagram](#scheduler-design)), by balancing the token generation load across GPUs, our scheduling strategy achieves uniform generation times, reducing idle time among data-parallel workers and boosts GPU utilization especially when handling batches with a severe long-tail distribution.

-----
|  |  |
|:---:|:---:|
| <img width="583" height="773" alt="image-20250717182347698" src="https://github.com/user-attachments/assets/e8fe0d7b-1465-427b-ad6e-9de52e0805e7" /> | <img width="575" height="650" alt="image-20250717182459552" src="https://github.com/user-attachments/assets/9e2762fa-01c6-4603-85c8-60927ed32267" /> |

* Enabling the Request Skewness Scheduler yields no significant difference for subsequent stages, which is attributable to our Order Restoration function.

### Discussion
In our design, we repeat DataProto (when n > 1) in rollout workers instead of the driver[(#2324)](https://github.com/volcengine/verl/pull/2324). This choice is motivated by two primary considerations:

*  **Reduced Communication Overhead:** Repeating the data on the driver would introduce more communication cost between driver and worker, which is particularly pronounced in our architecture.
*  **Optimized KV Cache Utilization:** Performing request scheduling on pre-repeated DataProto could lead to identical prompts being assigned to different DP rank. This would necessitate redundant KV cache computations, undermining performance. 

Regarding the issues raised in pr[#2324](https://github.com/volcengine/verl/pull/2324), we acknowledge them and have designated their resolution as future work.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

You can find a script  example to train `DeepSeek-R1-Distill-Qwen-7B` with 8 GPUs in verl\recipe\req_shced\

And you can enable the Request Skewness Scheduler in your training script with following few simple steps:

```
# Initialize the scheduler once before the training loop
req_scheduler = ReqScheduler()

for batch in dataloader:
	# 1. BEFORE generation: Schedule the batch
	req_scheduler.sched()
	
	# --- Your Existing Code ---
        # The model generates on the efficiently sorted batch
        generated_sequences = model.generate()
        ......
        # ---
	
	# 2. AFTER generation: Restore order and update scheduler state
	req_scheduler.restore_order()
	req_scheduler.update_table # restore order and update table after ROLLOUT
	
        # --- Integration End ---
        # Your existing RL logic (reward calculation, PPO update, etc.)
        # remains completely untouched and works as before.
```

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).

### CC
[hgl71964](https://github.com/hgl71964) , [HyperdriveHustle](https://github.com/HyperdriveHustle), [FortPercent](https://github.com/FortPercent), [qzweng](https://github.com/qzweng)
