### PR TITLE
[fix] rollout: Fix rollout_trace_op not tracing decoded prompt and response

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -33,7 +33,7 @@ from verl.protocol import DataProto
 from verl.single_controller.ray.base import RayWorkerGroup
 from verl.utils import hf_tokenizer
 from verl.utils.fs import copy_to_local
-from verl.utils.rollout_trace import RolloutTraceConfig, rollout_trace_attr, rollout_trace_op
+from verl.utils.rollout_trace import RolloutTraceConfig, rollout_trace_attr
 from verl.workers.rollout.async_server import async_server_class
 
 logger = logging.getLogger(__file__)
@@ -77,7 +77,6 @@ class AsyncLLMServerManager:
         self.request_id_to_server[request_id] = server
         return server
 
-    @rollout_trace_op
     async def generate(
         self,
         request_id,

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
 from verl.utils.profiler import simple_timer
+from verl.utils.rollout_trace import rollout_trace_op
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -32,6 +33,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         self.prompt_length = self.config.actor_rollout_ref.rollout.prompt_length
         self.response_length = self.config.actor_rollout_ref.rollout.response_length
 
+    @rollout_trace_op
     async def run(self, messages: list[dict[str, Any]], sampling_params: dict[str, Any]) -> AgentLoopOutput:
         metrics = {}
         request_id = uuid4().hex

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -108,7 +108,7 @@ def rollout_trace_attr(sample_index=None, step=None, rollout_n=None, name="rollo
     attributes = {}
     if backend:
         if sample_index is not None:
-            attributes["sample_index"] = sample_index
+            attributes["sample_index"] = int(sample_index)
         if step is not None:
             attributes["step"] = step
         if rollout_n is not None:


### PR DESCRIPTION
…f generation

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pull/2345
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Before this change, the https://github.com/volcengine/verl/blob/f252da34cffd66cb2eb48d41005e86e7da0c7120/verl/experimental/agent_loop/agent_loop.py#L81 default used `@rollout_trace_op`, but this can make https://github.com/volcengine/verl/blob/f252da34cffd66cb2eb48d41005e86e7da0c7120/verl/utils/rollout_trace.py#L155 never go into the decoding process, so we can not get any response sentence.

<img width="2124" height="740" alt="image" src="https://github.com/user-attachments/assets/e0bdcf9d-41bf-4f23-afda-f11b70ca1327" />


After removing this  `@rollout_trace_op`  and adding it for the run function of `SingleTurnAgentLoop`, we can get the right output. 
 
<img width="1816" height="748" alt="image" src="https://github.com/user-attachments/assets/d32102f1-f853-457e-820e-cbb3e5dd4ea7" />

### API and Usage Example

    `actor_rollout_ref.rollout.trace.backend=weave \`
    `actor_rollout_ref.rollout.trace.token2text=True \`
### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
