### PR TITLE
[doc] style: change resize handle from gradient to plain color

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -178,7 +178,7 @@ html {
     right: 0;
     width: 8px;
     height: 100%;
-    background: linear-gradient(to right, transparent, #ccc, transparent);
+    background: #ccc;
     cursor: col-resize;
     z-index: 1001;
     opacity: 0.3;
@@ -187,7 +187,7 @@ html {
 
 .resize-handle:hover {
     opacity: 0.8;
-    background: linear-gradient(to right, transparent, #999, transparent);
+    background: #999;
 }
 
 .resize-handle::before {


### PR DESCRIPTION
 ## Summary
  Changes the resizable sidebar handle from gradient background to solid colors for a cleaner appearance, as suggested by @eric-haibin-lin.

  ## Changes
  - Replace `linear-gradient(to right, transparent, #ccc, transparent)` with solid `#ccc` color
  - Replace `linear-gradient(to right, transparent, #999, transparent)` with solid `#999` for hover state
  - Maintains the same visual structure while providing cleaner styling

  ## Context
  This addresses feedback from @eric-haibin-lin in PR #2577: "one nit pick: is it possible to make the split bar plain color instead of
  gradient ?"