### PR TITLE
[trainer]add:actor evaluates the response it generates and gets a reward

### DIFF
--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -123,7 +123,17 @@ actor_rollout_ref:
 
     # The ranks that will be profiled. [] or [0,1,...]
     ranks: []
-
+  # actor self judgement config
+  actor_self_judgement:
+    enable: False
+    custom_cat_function:
+      path: null
+      name: construct_reward_chat
+    custom_reward_format_validator:
+      path: null
+      name: is_reward_format_valid
+      max_retries: 3
+    gen_num: 1
 # custom reward function definition
 custom_reward_function:
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1160,6 +1160,39 @@ class RayPPOTrainer:
                     batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
 
                     with marked_timer("reward", timing_raw, color="yellow"):
+                        # actor self-critique reward
+                        if self.config.actor_rollout_ref.actor_self_judgement.enable:
+                            print("\n use reward_self_judgement")
+                            reward_prompt_batch=self.actor_rollout_wg.create_reward_prompt(batch)
+
+                            validated_reward_data = self.actor_rollout_wg.generate_and_validate_reward_responses(reward_prompt_batch)
+                            
+                            print("\n Received validated reward responses from worker.")
+                            print(validated_reward_data)
+
+                            validated_responses_grouped = validated_reward_data.non_tensor_batch["validated_reward_responses"]
+
+                            if "extra_info" not in batch.non_tensor_batch:
+                                batch.non_tensor_batch["extra_info"] = np.array([{} for _ in range(batch.batch.batch_size[0])], dtype=object)
+
+                            original_extra_info_array = batch.non_tensor_batch["extra_info"]
+                            new_extra_info_list = []
+
+                            assert len(original_extra_info_array) == len(validated_responses_grouped), \
+                                f"Mismatch in length between extra_info ({len(original_extra_info_array)}) and grouped validated_responses ({len(validated_responses_grouped)})"
+
+                            for i in range(len(validated_responses_grouped)):
+                                old_info_dict = original_extra_info_array[i]
+                                new_info_dict = old_info_dict.copy()
+                                
+                                new_info_dict["validated_reward_responses_list"] = validated_responses_grouped[i]
+                                
+                                new_extra_info_list.append(new_info_dict)
+
+                            batch.non_tensor_batch["extra_info"] = np.array(new_extra_info_list, dtype=object)
+
+                            print("\n Updated 'extra_info' field with a list of validated reward responses.")
+                            print(batch)
                         # compute reward model score
                         if self.use_rm:
                             reward_tensor = self.rm_wg.compute_rm_score(batch)

--- a/verl/trainer/ppo/reward_self.py
+++ b/verl/trainer/ppo/reward_self.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import importlib.util
+from omegaconf import OmegaConf, DictConfig
+
+def get_custom_cat_fn(config: DictConfig):
+    try:
+        cat_fn_config = config.actor_self_judgement.custom_cat_function
+        file_path = cat_fn_config.path
+        function_name = cat_fn_config.name
+    except Exception as e:
+        print(f"[ERROR] Could not access 'config.actor_self_judgement.custom_cat_function': {e}")
+        print("Please ensure the configuration structure is correct and passed completely.")
+        return None
+    
+    if not file_path or not function_name:
+        print(" No custom cat function path or name provided. Skipping.")
+        return None
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Custom cat function file '{file_path}' not found.")
+
+    try:
+        spec = importlib.util.spec_from_file_location("custom_cat_module", file_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["custom_cat_module"] = module
+        spec.loader.exec_module(module)
+    except Exception as e:
+        raise RuntimeError(f"Error loading module from '{file_path}': {e}") from e
+
+    if not hasattr(module, function_name):
+        raise AttributeError(f"Cat function '{function_name}' not found in module '{file_path}'.")
+
+    print(f" Using customized cat function '{function_name}' from '{file_path}'")
+    raw_fn = getattr(module, function_name)
+    cat_kwargs = dict(cat_fn_config.get("cat_kwargs", {}))
+
+    def wrapped_fn(*args, **kwargs):
+        final_kwargs = {**kwargs, **cat_kwargs}
+        return raw_fn(*args, **final_kwargs)
+
+    return wrapped_fn
+
+def get_custom_format_validator(config: DictConfig):
+
+    try:
+        validator_config = config.actor_self_judgement.custom_reward_format_validator
+        file_path = validator_config.path
+        function_name = validator_config.name
+    except Exception as e:
+        print(f"[ERROR] Could not access 'config.actor_self_judgement.custom_reward_format_validator': {e}")
+        return None
+    
+    if not file_path or not function_name:
+        print(" No custom reward format validator path or name provided. Skipping.")
+        return None
+
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Reward format validator file '{file_path}' not found.")
+
+    try:
+        spec = importlib.util.spec_from_file_location("custom_validator_module", file_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["custom_validator_module"] = module
+        spec.loader.exec_module(module)
+    except Exception as e:
+        raise RuntimeError(f"Error loading module from '{file_path}': {e}") from e
+
+    if not hasattr(module, function_name):
+        raise AttributeError(f"Validator function '{function_name}' not found in module '{file_path}'.")
+
+    print(f" Using customized reward format validator '{function_name}' from '{file_path}'")
+    validator_fn = getattr(module, function_name)
+
+    return validator_fn

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -713,7 +713,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         return output
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
-    @DistProfiler.annotate(color="red", role="rollout_generate")
+    @DistProfiler.annostate(color="red", role="rollout_generate")
     def generate_sequences(self, prompts: DataProto):
         # Support all hardwares
         prompts = prompts.to(get_device_id())
@@ -751,7 +751,198 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # clear kv cache
         get_torch_device().empty_cache()
         return output
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def create_reward_prompt(self, data: DataProto):
+        """
+        Constructs a new prompt for reward model evaluation (self-critique).
+        This function takes the initial model generation, combines it with the original
+        prompt and ground truth, and formats it as a structured "evaluation task".
+        """
+        # Decode original prompts and model-generated responses
+        prompt_ids_tensor = data.batch.get("prompts")
+        if prompt_ids_tensor is None:
+            raise ValueError("'prompts' field not found in the batch. Cannot decode prompt text.")
+        decoded_prompts = self.tokenizer.batch_decode(prompt_ids_tensor, skip_special_tokens=True)
+        
+        
+        response_ids_tensor = data.batch.get("responses")
+        response_mask = data.batch.get("response_mask")
+        if response_ids_tensor is None or response_mask is None:
+            raise ValueError("'responses' or 'response_mask' field not found in the batch. Cannot decode response text.")
+        
+        decoded_responses = []
+        for i in range(len(response_ids_tensor)):
+            valid_response_ids = response_ids_tensor[i][response_mask[i] == 1]
+            decoded_responses.append(self.tokenizer.decode(valid_response_ids, skip_special_tokens=True))
 
+        src_max_length = data.batch["attention_mask"].shape[-1]
+        rm_input_ids = []
+        rm_attention_mask = []
+        
+        # Import custom cat function for reward model evaluation
+        from verl.trainer.ppo.reward_self import get_custom_cat_fn
+        cat_fn = get_custom_cat_fn(self.config)
+        if cat_fn is None:
+            raise ValueError("Custom cat function could not be loaded. Please check your configuration.")
+        
+        batch_size = data.batch.batch_size[0]
+
+        for i in range(batch_size):
+            prompt_text = decoded_prompts[i]
+            response_text = decoded_responses[i]
+            ground_truth = data.non_tensor_batch["reward_model"][i]["ground_truth"]
+            
+            chat = cat_fn(
+                prompt_text=prompt_text,
+                response_text=response_text,
+                ground_truth=ground_truth
+            )
+            print(f"\n  - [Sample {i}] Result from custom cat_fn (chat list):")
+            from pprint import pprint
+            pprint(chat)
+            prompt_with_chat_template = self.tokenizer.apply_chat_template(
+                chat,
+                add_generation_prompt=True,
+                tokenize=False
+            )
+            model_inputs = self.tokenizer(
+                prompt_with_chat_template,
+                return_tensors="pt",
+                add_special_tokens=False
+            )
+
+            input_ids, attention_mask = verl_F.postprocess_data(
+                input_ids=model_inputs["input_ids"],
+                attention_mask=model_inputs["attention_mask"],
+                max_length=src_max_length,
+                pad_token_id=self.tokenizer.pad_token_id,
+                left_pad=True,
+                truncation="error"
+            )
+
+            rm_input_ids.append(input_ids)
+            rm_attention_mask.append(attention_mask)
+        # Overwrite the original DataProto batch with the new evaluation prompts    
+        rm_input_ids = torch.cat(rm_input_ids, dim=0)
+        rm_attention_mask = torch.cat(rm_attention_mask, dim=0)
+        rm_position_ids = compute_position_id_with_mask(rm_attention_mask)
+        
+        data.batch["input_ids"] = rm_input_ids
+        data.batch["attention_mask"] = rm_attention_mask
+        data.batch["position_ids"] = rm_position_ids
+        
+        data.batch.pop("prompts", None)
+        data.batch.pop("responses", None)
+        data.batch.pop("response_mask", None)
+
+        print("\n Successfully created new prompts for reward evaluation.")
+        
+        return data
+
+    @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
+    def generate_and_validate_reward_responses(self, reward_prompt_data: DataProto):
+        """
+        Generates `gen_num` valid reward responses for each prompt, with a retry mechanism.
+        This function handles dynamic batching to efficiently regenerate for failed samples.
+        """
+        from verl.trainer.ppo.reward_self import get_custom_format_validator
+        import numpy as np
+        from collections import defaultdict
+        config = self.config 
+        
+        validator_config = config.actor_self_judgement.custom_reward_format_validator
+        gen_num = config.actor_self_judgement.get("gen_num", 1)
+        MAX_RETRIES = validator_config.max_retries
+        
+        reward_format_validator = get_custom_format_validator(config)
+        
+
+        print(f" Starting validation process: gen_num={gen_num}, max_retries={MAX_RETRIES}")
+        batch_size = reward_prompt_data.batch.batch_size[0]
+
+        # State tracking for each original prompt
+        final_responses_grouped = [[] for _ in range(batch_size)] 
+        needs_generating_count = np.full(batch_size, gen_num, dtype=int)
+        retries_left = np.full(batch_size, MAX_RETRIES, dtype=int)
+        
+        original_uids = reward_prompt_data.non_tensor_batch.get("uid", list(range(batch_size)))
+
+        # Main generation loop: continues as long as any prompt needs more responses
+        attempt = 0
+        while np.sum(needs_generating_count) > 0:
+            attempt += 1
+
+            # Identify all prompts that still require generation
+            indices_to_process = np.where(needs_generating_count > 0)[0]
+            
+            if len(indices_to_process) == 0:
+                break
+
+            
+            prompts_to_generate_list = []
+            original_indices_map = [] 
+            
+            print(f"Processing {len(indices_to_process)} prompts that still need responses.")
+            for idx in indices_to_process:
+                num_needed = needs_generating_count[idx]
+                single_prompt_proto = reward_prompt_data.select_idxs([idx])
+                repeated_prompts = single_prompt_proto.repeat(repeat_times=num_needed, interleave=False)
+                prompts_to_generate_list.append(repeated_prompts)
+                original_indices_map.extend([idx] * num_needed)
+            
+            if not prompts_to_generate_list:
+                continue
+            current_prompts_to_process = DataProto.concat(prompts_to_generate_list)
+            
+            # Generate responses for the dynamically constructed batch
+            gen_output = self.generate_sequences(current_prompts_to_process)
+            # Decode responses
+            response_ids_tensor = gen_output.batch["responses"]
+            response_length = response_ids_tensor.shape[1]
+            attention_mask_tensor = gen_output.batch["attention_mask"][:, -response_length:]
+            decoded_texts = [
+                self.tokenizer.decode(resp[mask==1], skip_special_tokens=True) 
+                for resp, mask in zip(response_ids_tensor, attention_mask_tensor)
+            ]
+            
+            # Validate and distribute the newly generated responses
+            failed_counts_this_cycle = defaultdict(int)
+
+            for i, text in enumerate(decoded_texts):
+                original_idx = original_indices_map[i]
+                
+                if needs_generating_count[original_idx] == 0:
+                    continue
+
+                if reward_format_validator(text):
+                    final_responses_grouped[original_idx].append(text)
+                    needs_generating_count[original_idx] -= 1
+                    print(f"[SUCCESS] Prompt {original_idx} got a valid response. Need {needs_generating_count[original_idx]} more.")
+                else:
+                    failed_counts_this_cycle[original_idx] += 1
+                    print(f"[FAIL] Prompt {original_idx} got an invalid response.")
+
+            # Update retry counts and handle prompts that have exhausted their retries
+            for idx in indices_to_process:
+                if failed_counts_this_cycle[idx] > 0:
+                    retries_left[idx] -= 1
+                    
+                    if retries_left[idx] <= 0 and needs_generating_count[idx] > 0:
+                        uid = original_uids[idx]
+                        num_missing = needs_generating_count[idx]
+                        print(f"[WARNING] Prompt {idx} (uid={uid}) has exhausted all retries but still needs {num_missing} more responses.")
+                        print("  -> Filling the rest with empty strings.")
+                        final_responses_grouped[idx].extend([""] * num_missing)
+                        needs_generating_count[idx] = 0
+        
+        print("\n" + "="*30 + " Final Grouped Results " + "="*30)
+        from pprint import pprint
+        pprint(final_responses_grouped)
+        print("="*80 + "\n")
+
+        return DataProto.from_dict(
+            non_tensors={"validated_reward_responses": final_responses_grouped}
+        )
     @register(dispatch_mode=Dispatch.DP_COMPUTE_PROTO)
     @DistProfiler.annotate(color="blue", role="actor_compute_log_prob")
     def compute_log_prob(self, data: DataProto):


### PR DESCRIPTION
### What does this PR do?

> This PR introduces a new Actor Self-Critique mechanism into the PPO training framework. This feature empowers the Actor model to evaluate its own generated responses, providing a more dynamic and potentially more accurate reward signal than a static, external Reward Model (RM).

The core enhancement is a two-step RPC flow integrated into the fit() loop, which allows the Actor to:

Generate an initial response.
Re-evaluate that response against a ground truth or a set of rules.
Generate a structured critique or score.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

>Examples of custom concatenation and format validation functions
```
def construct_reward_chat(
    response_text: str, 
    ground_truth: str, 
    prompt_text: str = "", 
    **kwargs: Any
) -> List[Dict[str, str]]:

    final_user_prompt = f"""Question: {prompt_text}
        Response to grade: {response_text}
        Reference answer: {ground_truth}
        Please provide your score (1-5) wrapped in \\bold{{}}:"""

    chat = [
        {
            "role": "user",
            "content": """You are a grading assistant. Your task is to score the response based on the reference answer.
              Rules:
              1. Score must be between 1 and 5
              2. Your response should ONLY contain the score number wrapped in \\bold{}, nothing else
              3. 5 means perfect match with reference, 1 means completely wrong
              4. Consider accuracy, completeness and reasoning process

              Here is the question and response to grade:"""
        },
        {
            "role": "assistant",
            "content": "I understand. I will only output a score between 1-5 wrapped in \\bold{}."
        },
        {
            "role": "user",
            "content": final_user_prompt
        }
    ]

    return chat


def is_reward_format_valid(decoded_response: str) -> bool:
    
    match = re.search(r"\\bold\{([1-5])\}", decoded_response)
    
    if match:
        score = match.group(1)
        print(f"[Validator] SUCCESS (Loose): Found score '{score}' within the response. Response: '{decoded_response[:100]}...'")
        return True
    
    print(f"[Validator] FAILED (Loose): Could not find '\\bold{{[1-5]}}' pattern in the response. Response: '{decoded_response[:100]}...'")
    return False
```


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.
The user writes a custom reward concatenation function and format verification function, and then adds the following parameters to the training script.

```
TRAIN_DATA = "gsm8k/train_reduced.parquet"
EVAL_DATA = "gsm8k/test_reduced.parquet"

python3 -m verl.trainer.main_ppo
    trainer.default_local_dir=/rl-mnt/checkpoint \
    data.train_files={TRAIN_DATA} \
    data.val_files={EVAL_DATA} \
    data.train_batch_size=12\
    data.val_batch_size=12 \
    data.max_prompt_length=1024 \
    data.max_response_length=512 \
    actor_rollout_ref.actor_self_judgement.enable=True \
    actor_rollout_ref.actor_self_judgement.gen_num=2 \
    actor_rollout_ref.actor_self_judgement.custom_cat_function.path={CUSTOM_SPLIC_FN} \
    actor_rollout_ref.actor_self_judgement.custom_cat_function.name=construct_reward_chat \
    actor_rollout_ref.actor_self_judgement.custom_reward_format_validator.path={CUSTOM_SPLIC_FN} \
    actor_rollout_ref.actor_self_judgement.custom_reward_format_validator.name=is_reward_format_valid \
    actor_rollout_ref.actor_self_judgement.custom_reward_format_validator.max_retries=2 \`
```
```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Stage 1: Prompt Construction (create_reward_prompt)

This new RPC function is called after the initial Actor rollout.
It decodes the original prompt and the Actor's newly generated response.
It loads a user-defined cat_fn to dynamically assemble these texts (along with ground truth) into a new, structured "evaluation prompt" using the model's chat template.
It overwrites the input_ids in the DataProto batch with this new evaluation prompt.
> Stage 2: Generation & Validation (generate_and_validate_reward_responses)

This second RPC function takes the evaluation prompts from Stage 1.
It calls generate_sequences to get the Actor's self-critique.
Key Feature: It implements a robust loop to generate gen_num valid responses per prompt.
It uses state-tracking arrays (needs_generating_count, retries_left) to manage progress for each sample.
It dynamically constructs batches for regeneration using DataProto.select_idxs, repeat, and concat to maximize efficiency.
A user-defined validator_fn checks the format of each generated critique.
Failed samples are retried up to max_retries times.
It returns a nested list of validated critique strings.
> Integration into fit() (ray_trainer.py)

A new if self.config.actor_rollout_ref.actor_self_judgement.enable: block is added.
It orchestrates the calls to create_reward_prompt and generate_and_validate_reward_responses.
The final list of validated responses is integrated into the batch.non_tensor_batch["extra_info"] field, making it available for downstream reward calculation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
