### PR TITLE
[recipe] feat:  Add Load Balancer for Reward Model (RM) Services in Remote Deployment(gen rm)

### DIFF
--- a/recipe/genrm_remote/load_balance.py
+++ b/recipe/genrm_remote/load_balance.py
@@ -19,6 +19,8 @@ DEFAULT_RESPONSE_TIME_S = 0.5
 # Scaling factor to reduce the impact of response time on the score, making it a tie-breaker.
 RESPONSE_TIME_SCALING_FACTOR = 0.15
 
+MAX_ERROR_COUNT = 6
+
 
 # Global service tracker
 class ServiceTracker:
@@ -46,8 +48,8 @@ class ServiceTracker:
                 metrics["error_count"] = 0  # Reset error counter
             else:
                 metrics["error_count"] += 1
-                # Mark as inactive after 5 consecutive errors
-                if metrics["error_count"] > 5:
+                # Mark as inactive after MAX_ERROR_COUNT consecutive errors
+                if metrics["error_count"] > MAX_ERROR_COUNT:
                     metrics["active"] = False
 
     def start_request(self, server):

--- a/recipe/genrm_remote/load_balance.py
+++ b/recipe/genrm_remote/load_balance.py
@@ -1,0 +1,170 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import random
+import threading
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+
+
+# Global service tracker
+class ServiceTracker:
+    def __init__(self, servers):
+        self.servers = servers
+        self.lock = threading.Lock()  # Thread safety for metrics updates
+        # Initialize metrics for each server
+        self.metrics = {
+            server: {
+                "in_flight": 0,  # Current number of processing requests
+                "response_times": deque(maxlen=100),  # Circular buffer of recent response times
+                "error_count": 0,  # Consecutive error counter
+                "active": True,  # Service availability status
+                "complete_requests": 0,  # Total completed requests
+            }
+            for server in servers
+        }
+
+    def update_metrics(self, server, response_time, success):
+        """Update server metrics after request completion"""
+        with self.lock:
+            metrics = self.metrics[server]
+            if success:
+                metrics["response_times"].append(response_time)
+                metrics["error_count"] = 0  # Reset error counter
+            else:
+                metrics["error_count"] += 1
+                # Mark as inactive after 5 consecutive errors
+                if metrics["error_count"] > 5:
+                    metrics["active"] = False
+
+    def start_request(self, server):
+        """Increment in-flight counter before sending request"""
+        with self.lock:
+            self.metrics[server]["in_flight"] += 1
+
+    def complete_request(self, server):
+        """Decrement in-flight counter after request finishes"""
+        with self.lock:
+            self.metrics[server]["in_flight"] -= 1
+            self.metrics[server]["complete_requests"] += 1
+
+    def print_current_state(self):
+        def print_metrics(metrics, width=130):
+            """Prints the current service metrics in a formatted table"""
+            # Print table header
+
+            print("\n" + "=" * width)
+            print(
+                f"{'Service':<50} | {'Active':<6} | {'In Flight':<10} | "
+                f"{'Errors':<6} | {'Avg Resp':<8} | {'completed':<10} | "
+                f"{'Samples':<7} | Recent Response Times"
+            )
+            print("-" * width)
+
+            for server, data in metrics.items():
+                # Calculate average response time if available
+                avg_response = "N/A"
+                sample_count = len(data["response_times"])
+                if sample_count > 0:
+                    avg_ms = sum(data["response_times"]) / sample_count * 1000
+                    avg_response = f"{avg_ms:.2f}ms"
+
+                # Prepare recent response times (last 5 samples)
+                recent = list(data["response_times"])[-5:]
+                recent_times = ", ".join([f"{t * 1000:.1f}ms" for t in recent]) if recent else "None"
+
+                # Print service row
+                print(
+                    f"{server:<50} | "
+                    f"{'✓' if data['active'] else '✗':<6} | "
+                    f"{data['in_flight']:<10} | "
+                    f"{data['error_count']:<6} | "
+                    f"{avg_response:<8} | "
+                    f"{data['complete_requests']:<10} | "
+                    f"{sample_count:<7} | "
+                    f"{recent_times}"
+                )
+            print("=" * width + "\n")
+
+        with self.lock:
+            print_metrics(self.metrics)
+
+    def get_best_server(self):
+        """Select optimal server using weighted scoring algorithm"""
+        with self.lock:
+            # Filter out inactive servers
+            candidates = [s for s in self.servers if self.metrics[s]["active"]]
+
+            # Return none if none available
+            if not candidates:
+                return None  # No servers configured
+
+            # Calculate weighted score for each candidate
+            scores = {}
+            for server in candidates:
+                metrics = self.metrics[server]
+                # Use default response time if no history available
+                avg_time = 0.5  # Default 500ms response time
+                if metrics["response_times"]:
+                    avg_time = (
+                        sum(metrics["response_times"]) / len(metrics["response_times"]) * 0.15
+                    )  # Weight response time by 0.15
+                # Load factor based on current in-flight requests
+                load_factor = metrics["in_flight"]
+                # Composite score (lower is better)
+                scores[server] = avg_time + load_factor
+            # Return server with minimum score
+            return min(scores, key=scores.get)
+
+
+def request_loop():
+    """Continuous request generator"""
+    request_id = 1
+    while True:
+        # Use thread pool for concurrency control
+        with ThreadPoolExecutor(max_workers=500) as executor:
+            # Send batch of requests with random intervals
+            for _ in range(20):
+                executor.submit(send_request, request_id)
+                request_id += 1
+                # Random delay between requests (0-100ms)
+                time.sleep(random.uniform(0, 0.1))
+
+
+def send_request(request_id, tracker):
+    """Send request to backend service with load balancing"""
+    # Select optimal server using scoring algorithm
+    server = tracker.get_best_server()
+    if not server:
+        print(f"Request {request_id} failed: No available servers")
+        return
+
+    # Update in-flight counter
+    tracker.start_request(server)
+    start_time = time.time()
+    success = False
+    try:
+        # Send actual request to backend
+        time.sleep(2 * random.uniform(0.1, 0.5))  # Simulate network delay
+        success = True
+        print(f"Request {request_id} to {server} successful")
+    except Exception as e:
+        print(f"Request {request_id} to {server} failed: {str(e)}")
+    finally:
+        # Always update metrics regardless of success/failure
+        end_time = time.time()
+        response_time = end_time - start_time
+        tracker.update_metrics(server, response_time, success)
+        tracker.complete_request(server)
+        tracker.print_current_state()

--- a/recipe/genrm_remote/reward_function.py
+++ b/recipe/genrm_remote/reward_function.py
@@ -55,12 +55,11 @@ def get_response(problem, solution_str, ground_truth):
         start_time = time.time()
         success = False
         # tracker.print_current_state()
+        # choose the best server based on current metrics
+        base_url = tracker.get_best_server()
+        assert base_url is not None, f"the {BASE_URLS} server is not available, please check the server status."
+        tracker.start_request(base_url)
         try:
-            # choose the best server based on current metrics
-            base_url = tracker.get_best_server()
-            assert base_url is not None, f"the {BASE_URLS} server is not available, please check the server status."
-            tracker.start_request(base_url)
-
             headers = {"Content-Type": "application/json"}
             chat_url = f"{base_url}/v1/chat/completions"
             data = {"model": MODEL_NAME, "messages": messages}
@@ -73,7 +72,6 @@ def get_response(problem, solution_str, ground_truth):
             response_time = end_time - start_time
             tracker.update_metrics(base_url, response_time, success)
             tracker.complete_request(base_url)
-
             return response
         except Exception as e:
             if attempt < MAX_RETRIES - 1:


### PR DESCRIPTION
### What does this PR do?

> This PR introduces a load balancer for the reward system, enabling intelligent request distribution across multiple deployed RM service instances.

When using remote RM services, you can now deploy multiple RM instances. Instead of a single BASE_URL, you provide a list of URLs, for example:
change:
https://github.com/volcengine/verl/blob/4e9d2878ee27e5ff004531b0a65503ed698c2c99/recipe/genrm_remote/reward_function.py#L22
to
```python
BASE_URLS = ["http://localhost:30000", "http://localhost:30001"]
```

The load balancer will automatically distribute requests to the most suitable service instance based on current request counts and response times.

Key Implementation Details

The core logic for selecting the optimal server is implemented in the get_best_server method:

https://github.com/none0663/verl/blob/bc3de52cc3ad4a76058d4c506ef2f01517c6ceef/recipe/genrm_remote/load_balance.py#L103-L128


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
