### PR TITLE
[fsdp] fix: add missing mixed precision configuration to FSDPEngineConfig

### DIFF
--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -92,6 +92,7 @@ class FSDPEngineConfig(BaseConfig):
         forward_prefetch (bool): Whether to prefetch parameters for next forward pass, default False
         model_dtype (str): Model data type used to initialize the transformers model. default "fp32"
         use_orig_params (bool): Whether to use original parameters when initialize FSDP1, default False
+        mixed_precision (Optional[dict[str, Any]]): Mixed precision configuration for FSDP, default None
     """
 
     wrap_policy: dict[str, Any] = field(default_factory=dict)
@@ -103,3 +104,4 @@ class FSDPEngineConfig(BaseConfig):
     forward_prefetch: bool = False
     model_dtype: str = "fp32"
     use_orig_params: bool = False
+    mixed_precision: Optional[dict[str, Any]] = None


### PR DESCRIPTION
### What does this PR do?

The `FSDPEngineConfig` dataclass was missing the `mixed_precision` field that the runtime code expected. By adding:

```python
mixed_precision: Optional[dict[str, Any]] = None
```

The dataclass now properly supports the mixed precision configuration that the FSDP workers code uses with `fsdp_config.get("mixed_precision", None).`

https://github.com/volcengine/verl/blob/55e3c5bc09c85dba09f736eef476f110ad641b75/verl/workers/fsdp_workers.py#L371


Otherwise, if we run with:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.actor.fsdp_config.mixed_precision.param_dtype=bf16 \
    actor_rollout_ref.actor.fsdp_config.mixed_precision.reduce_dtype=fp32 \
    actor_rollout_ref.actor.fsdp_config.mixed_precision.buffer_dtype=fp32 \
    # ... other parameters
```

The following error may occur:

```bash
raise InstantiationException(msg) from e
hydra.errors.InstantiationException: Error in call to target 'verl.workers.config.engine.FSDPEngineConfig':
TypeError("FSDPEngineConfig.__init__() got an unexpected keyword argument 'mixed_precision'")
full_key: actor_rollout_ref.actor.fsdp_config
```

### Backward compatibility

No behavior change for existing configs (default remains None).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=mixed_precision
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
