### PR TITLE
[rollout] fix: numpy.int64 serialization error in Weave tracing during validation

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -315,7 +315,7 @@ class AgentLoopWorker:
             index = np.arange(len(batch))
 
         trajectory_info = await get_trajectory_info(
-            batch.meta_info.get("global_steps", -1), index, batch.meta_info.get("validate", False)
+            batch.meta_info.get("global_steps", -1), index.tolist(), batch.meta_info.get("validate", False)
         )
 
         tasks = []


### PR DESCRIPTION
### What does this PR do?

During validation steps, the following Pydantic serialization error occurs when Weave tracing is enabled:
```bash
(AgentLoopWorker pid=2278557, ip=x) weave: Task failed: PydanticSerializationError: Unable to serialize unknown type: <class 'numpy.int64'> [repeated 16286x across cluster]
(AgentLoopWorker pid=2278557, ip=x) ERROR:2025-08-18 16:45:08,385:Task failed: PydanticSerializationError: Unable to serialize unknown type: <class 'numpy.int64'> [repeated 16279x across cluster]
```
The issue occurs in:
https://github.com/volcengine/verl/blob/313366fd85e95ad43d567a808dd647089723a255/verl/experimental/agent_loop/agent_loop.py#L315

When the batch doesn't contain an "index" field (which commonly happens during validation), `np.arange()` creates a numpy array with numpy.int64 elements. These values are then passed through the following chain:

1. `get_trajectory_info()` → `trajectory_info` dict with `sample_index`: `numpy.int64`
2. `rollout_trace_attr()` → `attributes` dict with `sample_index`: `numpy.int64`
3. `weave.attributes(attributes)` → `Pydantic serialization fails`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Design & Code Changes

Convert numpy array to Python native integers to ensure Pydantic compatibility.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
