### PR TITLE
[vllm, rollout] fix: Fix training interruptions caused by image token generation during rollout.

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -362,6 +362,12 @@ class vLLMRollout(BaseRollout):
                 ).to(idx.device)
                 rollout_log_probs = rollout_log_probs.to(torch.float32)
 
+            # fix the image token id in response
+            image_token_id = getattr(self.model_hf_config, "image_token_id", None)
+            if image_token_id is not None:
+                # print('fixing image_token_id')
+                response[response == image_token_id] = self.pad_token_id
+
             seq = torch.cat([idx, response], dim=-1)
 
         response_length = response.size(1)
@@ -425,6 +431,7 @@ class vLLMAsyncRollout:
 
         # Engine is deferred to be initialized in init_worker
         self.config = config
+        self.model_hf_config = model_hf_config
         self.inference_engine: WorkerWrapperBase = None
         self.sharding_manager = None
         self.is_sleep = False

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -92,7 +92,7 @@ class vLLMRollout(BaseRollout):
         """
         super().__init__()
         self.config = config
-
+        self.model_hf_config = model_hf_config
         tensor_parallel_size = self.config.get("tensor_model_parallel_size", 1)
         assert tensor_parallel_size <= torch.distributed.get_world_size(), (
             "tensor parallel size should be less than or equal to the world size"
@@ -431,7 +431,6 @@ class vLLMAsyncRollout:
 
         # Engine is deferred to be initialized in init_worker
         self.config = config
-        self.model_hf_config = model_hf_config
         self.inference_engine: WorkerWrapperBase = None
         self.sharding_manager = None
         self.is_sleep = False


### PR DESCRIPTION
### What does this PR do?

**Fix training crashes caused by unexpected image token generation in Qwen2.5-VL.**

When training Qwen2.5-VL using Megatron + vLLM, abnormal interruptions occur after a long period of time.
<img width="975" height="409" alt="image" src="https://github.com/user-attachments/assets/6bd71d91-58c5-4485-9d21-7ca12280c7dc" />

Upon examining the relevant file (verl/verl/models/mcore/qwen2_5_vl/model.py), we identified that the error occurs because `video_start_index` exceeds the bounds of `vision_embeds.shape[0]`. The value of video_start_index is calculated as 
```
video_start_index = image_mask.sum().item().
```
(Our data does not provide video inputs.) Since the model has been trained for multiple epochs: 
<img width="566" height="322" alt="image" src="https://github.com/user-attachments/assets/e194bcdb-e992-4bc8-9d1b-f7e425e9cd90" />
we can largely rule out issues caused by anomalous data. **Therefore, we suspect that the model is outputting image tokens during generation, which in turn leads to an incorrect calculation of the video_start_index**.

Therefore, we added a few lines of code in `vllm_rollout_spmd.py` to replace the generated image tokens with pad tokens. After this fix, the training has been running perfectly, and the same error has never occurred again.

### Checklist Before Starting

- [✅] Search for similar PRs. Paste at least one query link here: ...
- [✅] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [✅] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [✅] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
