### PR TITLE
[fsdp, training_utils] Fix: LoRA w/ VLMs when Using Layered Summon

### DIFF
--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -579,10 +579,12 @@ def layered_summon_lora_params(fsdp_module) -> OrderedDict:
         "_fsdp_wrapped_module.base_model.model.",
         "_fsdp_wrapped_module.base_model.model.model.",
         "_fsdp_wrapped_module.base_model.model.model.layers.",
+        "_fsdp_wrapped_module.base_model.model.model.language_model.layers.",
         # fsdp2
         "base_model.model.",
         "base_model.model.model.",
         "base_model.model.model.layers.",
+        "base_model.model.model.language_model.layers.",
     ]
     peft_model = getattr(fsdp_module, "_fsdp_wrapped_module", fsdp_module)
     for prefix in prefix_list:


### PR DESCRIPTION
### What does this PR do?

Currently, LoRA parameters are not correctly streamed when training Qwen 2.5 VL with `layered_summon=True`. This is due to a missing prefix for the Qwen VL models. 

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: "VLM LoRA", "LoRA"
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Without this change, when using (1) Qwen VLM, (2) LoRA, (3) layered summon, we see this log when weight updates are sent to vLLM:
```
[36m(WorkerDict pid=424928)[0m INFO:2025-08-26 22:22:24,788:vLLM load weights, loaded_params: 0
```

After:
```
[36m(WorkerDict pid=424928)[0m INFO:2025-08-26 22:22:24,788:vLLM load weights, loaded_params: 504
```


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
