### PR TITLE
[trainer] fix: avoid loading duplicated custom reward function to fix issue #3150

### DIFF
--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -82,8 +82,8 @@ def get_custom_reward_fn(config: DictConfig) -> Optional[RawRewardFn]:
         except Exception as e:
             raise RuntimeError(f"Error loading module from '{file_path}': {e}") from e
 
-        if not hasattr(module, function_name):
-            raise AttributeError(f"Reward function '{function_name}' not found in '{module.__file__}'.")
+    if not hasattr(module, function_name):
+        raise AttributeError(f"Reward function '{function_name}' not found in '{module.__file__}'.")
 
     print(f"using customized reward function '{function_name}' from '{module.__file__}'")
     raw_fn = getattr(module, function_name)


### PR DESCRIPTION
### What does this PR do?

This PR attempts to fix issue #3150, where custom reward function cannot be used with `reward_model.reward_manager=prime`.

The main cause of issue #3150 is that when using `verl.trainer.ppo.reward.get_custom_reward_fn` to create `reward_fn` and `val_reward_fn` for the `RayPPOTrainer`, the custom reward code file is loaded twice under the same module name "custom_module".

This results in the actual reward functions `reward_fn.compute_score` and `val_reward_fn.compute_score` having the same module-function name (i.e., "custom_module") but different `id()` values in memory, and only `val_reward_fn.compute_score` has the correct, latest `id()` address.

Therefore, when using the "prime" reward manager, since it tries to use `concurrent.futures.ProcessPoolExecutor` to pickle the reward functions for multiprocessing, the `ProcessPoolExecutor` finds that `reward_fn.compute_score` has an incorrect `id()` compared to its global "custom_module"'s recorded `id()`, and thus fails to pickle `reward_fn.compute_score`.

The solution for this bug is to simply avoid loading duplicate modules from the same custom file in `verl.trainer.ppo.reward.get_custom_reward_fn`.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
