### PR TITLE
Add async vllm backend support for one-step-off-policy training in disaggregated architecture

### DIFF
--- a/recipe/one_step_off_policy/ray_trainer.py
+++ b/recipe/one_step_off_policy/ray_trainer.py
@@ -271,10 +271,10 @@ class OneStepOffRayTrainer(RayPPOTrainer):
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
         if self.config.actor_rollout_ref.rollout.mode == "async" and self._is_rollout:
-            from verl.workers.rollout.async_server import AsyncLLMServerManager
+            from verl.experimental.agent_loop import AgentLoopManager
 
             self.async_rollout_mode = True
-            self.async_rollout_manager = AsyncLLMServerManager(
+            self.async_rollout_manager = AgentLoopManager(
                 config=self.config,
                 worker_group=self.rollout_wg,
             )
@@ -305,26 +305,34 @@ class OneStepOffRayTrainer(RayPPOTrainer):
             print(f"Error in async_gen_next_batch: {e}")
             return None
         batch = DataProto.from_single_dict(batch_dict)
-        # pop those keys for generation
-        batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
-        non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
-        if "multi_modal_data" in batch.non_tensor_batch:
-            non_tensor_batch_keys_to_pop.append("multi_modal_data")
-        if "raw_prompt" in batch.non_tensor_batch:
-            non_tensor_batch_keys_to_pop.append("raw_prompt")
-        if "tools_kwargs" in batch.non_tensor_batch:
-            non_tensor_batch_keys_to_pop.append("tools_kwargs")
-        if "interaction_kwargs" in batch.non_tensor_batch:
-            non_tensor_batch_keys_to_pop.append("interaction_kwargs")
-        gen_batch = batch.pop(
-            batch_keys=batch_keys_to_pop,
-            non_tensor_batch_keys=non_tensor_batch_keys_to_pop,
-        )
+
+        if not self.async_rollout_mode:
+            # pop those keys for generation
+            batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
+            non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
+            if "multi_modal_data" in batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("multi_modal_data")
+            if "raw_prompt" in batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("raw_prompt")
+            if "tools_kwargs" in batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("tools_kwargs")
+            if "interaction_kwargs" in batch.non_tensor_batch:
+                non_tensor_batch_keys_to_pop.append("interaction_kwargs")
+            gen_batch = batch.pop(
+                batch_keys=batch_keys_to_pop,
+                non_tensor_batch_keys=non_tensor_batch_keys_to_pop,
+            )
+        else:
+            gen_batch = self._get_gen_batch(batch)
+            
         gen_batch = gen_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
         # sync weights from actor to rollout
         self.sync_rollout_weights()
         # async generation
-        gen_batch_output = self.rollout_wg.async_generate_sequences(gen_batch)
+        if not self.async_rollout_mode:
+            gen_batch_output = self.rollout_wg.async_generate_sequences(gen_batch)
+        else:
+            gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
         return GenerationBatchFuture(epoch, batch, gen_batch_output)
 
     def fit(self):

--- a/recipe/one_step_off_policy/vllm_rollout_spmd_recipe.py
+++ b/recipe/one_step_off_policy/vllm_rollout_spmd_recipe.py
@@ -1,0 +1,117 @@
+# recipe/one_step_off_policy/vllm_rollout_spmd_recipe.py
+from verl.workers.rollout.vllm_rollout import (
+    vLLMRollout as _BaseSync,
+    vLLMAsyncRollout as _BaseAsync,
+)
+
+import asyncio
+import getpass
+import logging
+import os
+import pickle
+import socket
+from contextlib import contextmanager
+from types import MethodType
+from typing import Any
+
+import numpy as np
+import ray
+import torch
+import torch.distributed
+import zmq
+import zmq.asyncio
+from filelock import FileLock
+from omegaconf import DictConfig, ListConfig
+from tensordict import TensorDict
+from vllm import LLM, SamplingParams
+from vllm.config import CompilationConfig, CompilationLevel
+from vllm.distributed import parallel_state as vllm_ps
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.worker.worker_base import WorkerWrapperBase
+
+from verl import DataProto
+from verl.third_party.vllm import VLLM_SLEEP_LEVEL
+from verl.utils.profiler import GPUMemoryLogger
+from verl.utils.ray_utils import ray_noset_visible_devices
+from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
+from verl.workers.config import RolloutConfig
+from verl.workers.rollout.base import BaseRollout
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+class RecipevLLMAsyncRollout(_BaseAsync):
+    def __init__(self, model_path: str, config: DictConfig, tokenizer, model_hf_config, **kwargs):
+        self.tokenizer = tokenizer
+
+        # Engine is deferred to be initialized in init_worker
+        self.config = config
+        self.inference_engine: WorkerWrapperBase = None
+        self.sharding_manager = None
+        self.is_sleep = False
+
+        # weight staging (last-write-wins)
+        self._lock = asyncio.Lock()
+        self._pending = None
+        self._applied_version = -1
+
+        self.address = self._init_zeromq()
+    
+    def execute_method(self, method: str | bytes, *args, **kwargs):
+        """Client-side call: send REQ to our server (_loop_forever) and wait for reply."""
+
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError("Calling execute_method in the same event-loop can lead to deadlock - use asyncio.to_thread(...) to avoid blocking.")
+        except RuntimeError:
+            logger.warning("Calling execute_method in the same event-loop can lead to deadlock - use asyncio.to_thread(...) to avoid blocking.")
+            pass
+
+        ctx = zmq.Context.instance()
+        with ctx.socket(zmq.REQ) as s:
+            s.connect(self.address)  # set by _init_zeromq()
+            s.send(pickle.dumps((method, args, kwargs)))
+            reply = s.recv()
+        return pickle.loads(reply)
+
+    async def _apply_if_any(self):
+        async with self._lock:
+            item = self._pending
+            self._pending = None
+        if not item:
+            return
+        version, pairs = item
+
+        model = self.inference_engine.worker.model_runner.model
+
+        # TODO mirror sync path if you patch MoE loader
+        # from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+        # patch_vllm_moe_model_weight_loader(model)
+
+        model.load_weights(pairs)
+        self._applied_version = version
+
+    async def _execute_method(self, method: str | bytes, *args, **kwargs):
+        if method == "init_worker":
+            return self._init_worker(*args, **kwargs)
+        elif method == "load_model":
+            ret = self._load_model(*args, **kwargs)
+            await self._apply_if_any()
+            return ret
+        elif method == "sleep":
+            return await self.sleep(*args, **kwargs)
+        elif method == "wake_up":
+            return await self.wake_up(*args, **kwargs)
+        elif method == "load_weights_from_tensors":
+            # Expect: kwargs["pairs"] = [(name: str, cpu_tensor), ...]
+            pairs = kwargs.get("pairs", [])
+            assert pairs != [], "weights pairs detected to be None when calling load_weights_from_tensors. This should not happen and can lead to weights updating failure."
+            async with self._lock:
+                # last-write-wins; bump version monotonically per-process
+                self._pending = (self._applied_version + 1, pairs)
+            if self.inference_engine is not None:
+                await self._apply_if_any()
+            return True
+        else:
+            return self.inference_engine.execute_method(method, *args, **kwargs)


### PR DESCRIPTION
### What does this PR do?

The current one-step-off-policy recipe supports sync vllm backend. In this PR, we add the support for async vllm backend to further accelerate agentic tasks.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

It has been tested on 2 rollout + 2 train machines each with 8 H800 GPUs.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
