### PR TITLE
[trainer] fix: Import flash attn utils for Transformers higher than 4.55.0

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -43,7 +43,7 @@ elif is_npu_available:
     try:
         from transformers.integrations.npu_flash_attention import index_first_axis, pad_input, rearrange, unpad_input
     except ImportError:
-        # Since transformers v4.55.1, index_first_axis, pad_input, and unpad_input 
+        # Since transformers v4.55.1, index_first_axis, pad_input, and unpad_input
         # have been consolidated into `transformers.modeling_flash_attention_utils`.
         from einops import rearrange
         from transformers.modeling_flash_attention_utils import _index_first_axis as index_first_axis


### PR DESCRIPTION
Import the index_first_axis, pad_input, unpad_input, etc in a different way to handle the case for Transformers version higher than v4.55.0

<img width="1372" height="58" alt="Screenshot 2025-09-24 at 2 44 30 PM" src="https://github.com/user-attachments/assets/fda7196b-2128-425b-ba15-9951fae39ee2" />

Since the modification of [PR40002](https://github.com/huggingface/transformers/pull/40002) in Transformers, `index_first_axis, pad_input, unpad_input` have been moved to the `transformers.modeling_falsh_attention_utils`. The original import way for NPU cannot handle it.


### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
