### PR TITLE
retain origin dtype in compute log prob for megatron backend

### DIFF
--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -229,7 +229,7 @@ class MegatronPPOActor(BasePPOActor):
                         log_probs = [o[0]["log_probs"] for o in output["output"]]  # (bs, seq_size)
                     else:
                         log_probs = [o["log_probs"] for o in output["output"]]  # (bs, seq_size)
-                    log_probs = torch.cat(log_probs, dim=0).to(torch.float32)
+                    log_probs = torch.cat(log_probs, dim=0)
                     if use_dynamic_bsz:
                         indices = output["indices"]
                         indices = list(itertools.chain.from_iterable(indices))
@@ -238,7 +238,7 @@ class MegatronPPOActor(BasePPOActor):
                         log_probs = log_probs[revert_indices]
                 else:
                     log_probs = torch.empty(
-                        size=(batch_size, response_length), dtype=torch.float32, device=input_ids.device
+                        size=(batch_size, response_length), device=input_ids.device
                     )
                 log_probs = log_probs.to(get_device_id())
                 # broadcast across pp ranks
@@ -253,7 +253,7 @@ class MegatronPPOActor(BasePPOActor):
                     # Note that o[0] is metrics, o[1] is entropy
                     if mpu.is_pipeline_last_stage(ignore_virtual=True):
                         entropys = torch.cat([o[1] for o in output["output"]], dim=0)
-                        entropys = entropys.to(torch.float32)
+                        entropys = entropys
                         if use_dynamic_bsz:
                             indices = output["indices"]
                             indices = list(itertools.chain.from_iterable(indices))
@@ -262,7 +262,7 @@ class MegatronPPOActor(BasePPOActor):
                             entropys = entropys[revert_indices]
                     else:
                         entropys = torch.empty(
-                            size=(batch_size, response_length), dtype=torch.float32, device=input_ids.device
+                            size=(batch_size, response_length), device=input_ids.device
                         )
                     # broadcast across pp ranks
                     entropys = entropys.to(get_device_id())
@@ -295,10 +295,10 @@ class MegatronPPOActor(BasePPOActor):
                 ``responses``: tensor of shape [batch_size, response_length]. torch.int64. Note that
                 responses = input_ids[:, -response_length:]
 
-                ``old_log_probs``: tensor of shape [batch_size, response_length]. torch.float32. The log probability
+                ``old_log_probs``: tensor of shape [batch_size, response_length]. The log probability
                 of responses.
 
-                ``advantages``: tensor of shape [batch_size, response_length]. torch.float32. The advantages of
+                ``advantages``: tensor of shape [batch_size, response_length]. The advantages of
                 responses.
                 See PPO paper for details. https://arxiv.org/abs/1707.06347
 


### PR DESCRIPTION
### What does this PR do?

#3650 
retain origin dtype in compute log prob for megatron backend. And it will reduce cpu usage in ray.get

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
