### PR TITLE
[data] fix: Remove duplicated bos tokens in `RLHFDataset`

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -256,7 +256,7 @@ class RLHFDataset(Dataset):
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 
             model_inputs = self.processor(
-                text=[raw_prompt.removeprefix(self.tokenizer.bos_token)],
+                text=[raw_prompt.removeprefix(self.tokenizer.bos_token or "")],
                 images=images,
                 videos=videos,
                 return_tensors="pt",

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -255,7 +255,7 @@ class RLHFDataset(Dataset):
                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 
-            model_inputs = self.processor(text=[raw_prompt], images=images, videos=videos, return_tensors="pt")
+            model_inputs = self.processor(text=[raw_prompt.removeprefix(self.tokenizer.bos_token)], images=images, videos=videos, return_tensors="pt")
 
             input_ids = model_inputs.pop("input_ids")
             attention_mask = model_inputs.pop("attention_mask")

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -255,7 +255,12 @@ class RLHFDataset(Dataset):
                 # link: https://github.com/vllm-project/vllm/blob/3c545c0c3b98ee642373a308197d750d0e449403/vllm/multimodal/parse.py#L205
                 multi_modal_data["video"] = [video.numpy() for video in videos]
 
-            model_inputs = self.processor(text=[raw_prompt.removeprefix(self.tokenizer.bos_token)], images=images, videos=videos, return_tensors="pt")
+            model_inputs = self.processor(
+                text=[raw_prompt.removeprefix(self.tokenizer.bos_token)],
+                images=images,
+                videos=videos,
+                return_tensors="pt",
+            )
 
             input_ids = model_inputs.pop("input_ids")
             attention_mask = model_inputs.pop("attention_mask")

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -288,7 +288,11 @@ class RLHFDataset(Dataset):
             raw_prompt = self.tokenizer.apply_chat_template(
                 messages, add_generation_prompt=True, tokenize=False, **self.apply_chat_template_kwargs
             )
-            model_inputs = self.tokenizer(raw_prompt, return_tensors="pt", add_special_tokens=False)
+            model_inputs = self.tokenizer(
+                raw_prompt.removeprefix(self.tokenizer.bos_token or ""),
+                return_tensors="pt",
+                add_special_tokens=False,
+            )
             input_ids = model_inputs.pop("input_ids")
             attention_mask = model_inputs.pop("attention_mask")
 


### PR DESCRIPTION
### What does this PR do?

Currently, `RLHFDataset` first retrieves the raw prompt as a string here:

https://github.com/volcengine/verl/blob/327e813136c117a564f99995f6000dc685b19351/verl/utils/dataset/rl_dataset.py#L235-L237

https://github.com/volcengine/verl/blob/327e813136c117a564f99995f6000dc685b19351/verl/utils/dataset/rl_dataset.py#L283-L285

and later obtains `input_ids` by invoking the processor again here:

https://github.com/volcengine/verl/blob/327e813136c117a564f99995f6000dc685b19351/verl/utils/dataset/rl_dataset.py#L258-L261

https://github.com/volcengine/verl/blob/327e813136c117a564f99995f6000dc685b19351/verl/utils/dataset/rl_dataset.py#L286-L288

However, both of these operations prepend a BOS token, resulting in duplication.

This PR fixes the issue by removing the leading BOS token from the input of the second invocation.

<br/>


> [!NOTE]
> We should not remove the bos token from the raw prompt itself, since it is used later here:
> https://github.com/volcengine/verl/blob/327e813136c117a564f99995f6000dc685b19351/verl/utils/dataset/rl_dataset.py#L335



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
