### PR TITLE
[fsdp] feat: Add fa3 in fsdp for hopper gpu and add a function to check fo…

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -103,7 +103,7 @@ def is_hopper_with_cuda_12_3() -> bool:
     Returns:
         bool: True if device is Hopper with CUDA >= 12.3, False otherwise
     """
-    if not torch.cuda.is_available():
+    if not torch.cuda.is_cuda_available():
         return False
 
     try:


### PR DESCRIPTION
[fsdp worker] feat: Auto-select Flash Attention backend (FA3/FA2) based on hardware/CUDA version

### What does this PR do?

This PR implements auto-selection of the Flash Attention backend within FSDP workers. It introduces a utility function, `is_hopper_with_cuda_12_3()`, to check if the current environment is a Hopper GPU (compute capability 9.x) with CUDA version 12.3 or greater.

- If the condition is met, it uses `flash_attention_3` for potential performance gains.
- Otherwise, it defaults to `flash_attention_2`.

This logic is applied during the configuration of both actor and critic models (`_build_model_optimizer` and `_build_critic_model_optimizer` in `verl/workers/fsdp_workers.py`).

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}`: `fsdp, worker`
  - `{type}`: `feat`
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

The change is a hardware/environment-dependent feature selection. Testing would involve running a workload on a Hopper GPU with CUDA 12.3+ to confirm FA3 is selected, and on other hardware/CUDA versions to confirm FA2 is used.

### API and Usage Example

No external API changes. The internal model configuration logic in `fsdp_workers.py` is updated.

```python
# The configuration automatically selects the attention backend:
# In verl/workers/fsdp_workers.py:
#
# attn_backend = "flash_attention_3" if is_hopper_with_cuda_12_3() else "flash_attention_2"
#
# actor_model_config = AutoConfig.from_pretrained(
#     local_path, trust_remote_code=trust_remote_code, attn_implementation=attn_backend
# )