### PR TITLE
Completed the missing code for Rolloutconfig

### DIFF
--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -176,6 +176,8 @@ class RolloutConfig(BaseConfig):
 
     limit_images: Optional[int] = None
 
+    limit_videos: Optional[int] = None
+
     skip_tokenizer_init: bool = False
 
     def __post_init__(self):


### PR DESCRIPTION
https://github.com/volcengine/verl/blob/main/verl/workers/config/rollout.py#L177

ray.exceptions.RayTaskError(InstantiationException): ray::WorkerDict.actor_rollout_init_model() (pid=3071998, ip=spencer-cut-capture-h53-fangdong-wang-master-0, actor_id=b10d875d543a1d0a5eda240801000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7f5b81623d00>)
TypeError: RolloutConfig.__init__() got an unexpected keyword argument 'limit_videos'

I think you have lost a line of code
