### PR TITLE
Revert "[worker] fix: create a new event loop if none exists when building rollouts"

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -630,7 +630,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # For sync mode, we directly switch to trainer mode here.
         # For async mode, we can't call run_until_complete here, so we will switch to trainer mode in AgentLoopManager.
         if rollout_config.mode == "sync" and self._is_actor:
-            asyncio.run(self.trainer_mode())
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(self.trainer_mode())
 
     async def rollout_mode(self):
         """Context switch hybridengine to rollout mode."""


### PR DESCRIPTION
Reverts volcengine/verl#3803