### PR TITLE
[megatron] fix: VLMs using fused kernels

### DIFF
--- a/.github/workflows/.deprecate/e2e_prime.yml
+++ b/.github/workflows/.deprecate/e2e_prime.yml
@@ -47,7 +47,7 @@ jobs:
       HF_ENDPOINT: "https://hf-mirror.com"
       HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
     container:
-      image: whatcanyousee/verl:ngc-cu124-vllm0.8.5-sglang0.4.6.post5-mcore0.12.0-te2.3
+      image: "verl-ci-cn-beijing.cr.volces.com/verlai/verl:app-verl0.6-transformers4.56.1-sglang0.5.2-mcore0.13.0-te2.2"
       options: --gpus all --shm-size=10g
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,7 +31,7 @@ permissions:
   contents: read
 
 env:
-  IMAGE: "your vemlp image" # e.g. "verl-ci-cn-beijing.cr.volces.com/verlai/verl:app-verl0.4-vllm0.8.5-mcore0.12.2"
+  IMAGE: "your vemlp image" # e.g. "verl-ci-cn-beijing.cr.volces.com/verlai/verl:app-verl0.6-transformers4.56.1-sglang0.5.2-mcore0.13.0-te2.2"
   DYNAMIC_RUNNER_URL: "https://sd10g3clalm04ug7alq90.apigateway-cn-beijing.volceapi.com/runner" # public veFaas api
 
 jobs:

--- a/docker/Dockerfile.extention.awsefa
+++ b/docker/Dockerfile.extention.awsefa
@@ -1,6 +1,6 @@
 # Base Image support aws EFA
 # Build Image with frameworks based on this
-FROM verlai/verl:app-verl0.5-sglang0.4.6.post5-mcore0.12.2
+FROM verlai/verl:app-verl0.6-transformers4.56.1-sglang0.5.2-mcore0.13.0-te2.2
 
 # For aws instances with EFA net interface (Sagemaker AI Pod)
 #     install EFA driver:

--- a/docs/start/multinode.rst
+++ b/docs/start/multinode.rst
@@ -334,7 +334,7 @@ Once the fleet is created, define a Ray cluster task, e.g. in ``ray-cluster.dsta
         - PYTHONUNBUFFERED=1
         - CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
     
-    image: whatcanyousee/verl:ngc-cu124-vllm0.8.5-sglang0.4.6-mcore0.12.0-te2.2
+    image: verlai/verl:app-verl0.6-transformers4.56.1-sglang0.5.2-mcore0.13.0-te2.2
     commands:
         - git clone https://github.com/volcengine/verl
         - cd verl

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -21,35 +21,41 @@ from .util import (
     postprocess_packed_seqs_no_padding,
     preprocess_packed_seqs,
     preprocess_packed_seqs_no_padding,
-    recover_left_padding,
-    remove_left_padding,
 )
 
 
-def gptmodel_forward(
-    model,
-    input_ids,
-    attention_mask,
-    position_ids,
-    sequence_parallel,
-    value_model=False,
-    pack_seqs=True,
-    logits_processor=None,
-    logits_processor_args: dict = None,
-    **kwargs,
-):
-    """Default forward pass for GPT models with optional sequence packing."""
-    pre_process = unwrap_model(model).pre_process
-    post_process = unwrap_model(model).post_process
-    if pack_seqs:
+def model_forward_gen(vision_model: bool = False):
+    def model_forward(
+        model,
+        input_ids,
+        attention_mask,
+        position_ids,
+        multi_modal_inputs: dict,
+        logits_processor=None,
+        logits_processor_args: dict = None,
+        value_model=False,
+    ):
+        """Forward pass for models with sequence packing."""
+        pre_process = (
+            unwrap_model(model).pre_process if not vision_model else True
+        )  # vision model always needs pre_process
+        post_process = unwrap_model(model).post_process
+
+        model_kwargs = {}
+        if "pixel_values" in multi_modal_inputs:
+            model_kwargs["pixel_values"] = multi_modal_inputs["pixel_values"].to(input_ids.device)
+        if "image_grid_thw" in multi_modal_inputs:
+            model_kwargs["image_grid_thw"] = multi_modal_inputs["image_grid_thw"].to(input_ids.device)
+
         batch_size, seq_len = attention_mask.shape[:2]
         input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=pre_process)
         input_ids_rmpad = input_ids_rmpad.contiguous()
         output_orig = model(
             input_ids=input_ids_rmpad,
             attention_mask=None,
-            position_ids=position_ids,
+            position_ids=position_ids if not vision_model else None,  # vision models will calculate position_ids
             packed_seq_params=packed_seq_params,
+            **model_kwargs,
         )
         if post_process and logits_processor is not None:
             args = {
@@ -67,135 +73,55 @@ def gptmodel_forward(
             output = postprocess_packed_seqs(
                 output_orig, packed_seq_params, attention_mask, batch_size, seq_len, post_process=post_process
             )
-    else:
-        batch_size, sequence_length = attention_mask.shape
-        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(
-            input_ids, attention_mask, position_ids, sequence_parallel, pre_process=pre_process
-        )
-        output = model(input_ids=new_input_ids, attention_mask=new_attention_mask, position_ids=new_position_ids)
-        if post_process:
-            output = logits_processor(output, **logits_processor_args)
-        output = recover_left_padding(
-            output, new_attention_mask, attention_mask, sequence_length, post_process=post_process
-        )
-    if value_model and post_process:
-        output = output[..., 0]
-    return output
+        if value_model and post_process:
+            output = output[..., 0]
+        return output
 
-
-def gptmodel_forward_qwen2_5_vl(
-    model,
-    input_ids,
-    attention_mask,
-    position_ids,
-    sequence_parallel,
-    value_model=False,
-    pack_seqs=True,
-    multi_modal_inputs=None,
-    logits_processor=None,
-    logits_processor_args: dict = None,
-    **kwargs,
-):
-    from megatron.core import parallel_state as mpu
-
-    assert mpu.get_context_parallel_world_size() == 1, "qwen2_5_vl's context parallel is not accurate yet"
-    pre_process = unwrap_model(model).pre_process
-    post_process = unwrap_model(model).post_process
-    pixel_values = (
-        multi_modal_inputs["pixel_values"].to(input_ids.device) if "pixel_values" in multi_modal_inputs else None
-    )
-    image_grid_thw = (
-        multi_modal_inputs["image_grid_thw"].to(input_ids.device) if "image_grid_thw" in multi_modal_inputs else None
-    )
-    if pack_seqs:
-        batch_size, seq_len = attention_mask.shape[:2]
-        input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=True)
-        input_ids_rmpad = input_ids_rmpad.contiguous()
-        output_orig = model(
-            input_ids=input_ids_rmpad,
-            attention_mask=None,
-            position_ids=None,  # model will calculate position_ids
-            packed_seq_params=packed_seq_params,
-            pixel_values=pixel_values,
-            image_grid_thw=image_grid_thw,
-        )
-
-        if post_process and logits_processor is not None:
-            args = {
-                k: preprocess_packed_seqs(v, attention_mask, pre_process=True)[0]
-                for k, v in logits_processor_args.items()
-            }
-            output_dict = logits_processor(output_orig, **args)
-            output = {
-                k: postprocess_packed_seqs(
-                    v, packed_seq_params, attention_mask, batch_size, seq_len, post_process=post_process
-                )
-                for k, v in output_dict.items()
-            }
-        else:
-            output = postprocess_packed_seqs(
-                output_orig, packed_seq_params, attention_mask, batch_size, seq_len, post_process=post_process
-            )
-    else:
-        batch_size, sequence_length = attention_mask.shape
-        new_input_ids, new_attention_mask, new_position_ids = remove_left_padding(
-            input_ids, attention_mask, position_ids, sequence_parallel, pre_process=pre_process
-        )
-        output = model(
-            input_ids=new_input_ids,
-            position_ids=new_position_ids,
-            attention_mask=new_attention_mask,
-            pixel_values=pixel_values,
-            image_grid_thw=image_grid_thw,
-        )
-        output = recover_left_padding(
-            output, new_attention_mask, attention_mask, sequence_length, post_process=post_process
-        )
-    if value_model and post_process:
-        output = output[..., 0]
-    return output
+    return model_forward
 
 
 def gptmodel_forward_no_padding(
     model,
     input_ids,
-    value_model=False,
-    pack_seqs=True,
+    multi_modal_inputs: dict,
     logits_processor=None,
     logits_processor_args: dict = None,
-    **kwargs,
+    value_model=False,
 ):
     """Default forward pass for GPT models with optional sequence packing."""
     pre_process = unwrap_model(model).pre_process
     post_process = unwrap_model(model).post_process
-    if pack_seqs:
-        batch_size = input_ids.shape[0]
-        input_ids_rmpad, packed_seq_params = preprocess_packed_seqs_no_padding(input_ids, pre_process=pre_process)
-        input_ids_rmpad = input_ids_rmpad.contiguous()
-        output_orig = model(
-            input_ids=input_ids_rmpad,
-            attention_mask=None,
-            position_ids=None,
-            packed_seq_params=packed_seq_params,
-        )
 
-        if post_process and logits_processor is not None:
-            args = {
-                k: preprocess_packed_seqs_no_padding(v, pre_process=True)[0] for k, v in logits_processor_args.items()
-            }
-            output_dict = logits_processor(output_orig, **args)
-            output = {
-                k: postprocess_packed_seqs_no_padding(
-                    v, packed_seq_params, input_ids, batch_size, post_process=post_process
-                )
-                for k, v in output_dict.items()
-            }
-        else:
-            output = postprocess_packed_seqs_no_padding(
-                output_orig, packed_seq_params, input_ids, batch_size, post_process=post_process
+    model_kwargs = {}
+    if "pixel_values" in multi_modal_inputs:
+        model_kwargs["pixel_values"] = multi_modal_inputs["pixel_values"].to(input_ids.device)
+    if "image_grid_thw" in multi_modal_inputs:
+        model_kwargs["image_grid_thw"] = multi_modal_inputs["image_grid_thw"].to(input_ids.device)
+
+    batch_size = input_ids.shape[0]
+    input_ids_rmpad, packed_seq_params = preprocess_packed_seqs_no_padding(input_ids, pre_process=pre_process)
+    input_ids_rmpad = input_ids_rmpad.contiguous()
+    output_orig = model(
+        input_ids=input_ids_rmpad,
+        attention_mask=None,
+        position_ids=None,
+        packed_seq_params=packed_seq_params,
+        **model_kwargs,
+    )
+
+    if post_process and logits_processor is not None:
+        args = {k: preprocess_packed_seqs_no_padding(v, pre_process=True)[0] for k, v in logits_processor_args.items()}
+        output_dict = logits_processor(output_orig, **args)
+        output = {
+            k: postprocess_packed_seqs_no_padding(
+                v, packed_seq_params, input_ids, batch_size, post_process=post_process
             )
+            for k, v in output_dict.items()
+        }
     else:
-        raise NotImplementedError("gptmodel_forward_no_padding only supports packed sequences")
+        output = postprocess_packed_seqs_no_padding(
+            output_orig, packed_seq_params, input_ids, batch_size, post_process=post_process
+        )
 
     if value_model and post_process:
         # output = output[..., 0]

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -17,6 +17,7 @@
 from collections import OrderedDict
 from typing import Optional
 
+import megatron.core as mcore
 import torch
 from megatron.core import parallel_state
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
@@ -24,6 +25,7 @@ from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.packed_seq_params import PackedSeqParams
 from megatron.core.tensor_parallel.mappings import gather_from_sequence_parallel_region
+from megatron.core.utils import deprecate_inference_params
 from torch import Tensor
 
 from verl.models.mcore.util import preprocess_packed_seqs
@@ -31,7 +33,6 @@ from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 from verl.utils.megatron_utils import unwrap_model
 from verl.utils.model import CausalLMOutputForPPO
 
-from .qwen2_5_vl.model import Qwen2_5VLModel
 from .util import postprocess_packed_seqs_for_dict_output
 
 
@@ -48,6 +49,7 @@ def _get_patching_model(model: torch.nn.Module):
 
 
 def patch_fused_forward(model: torch.nn.Module):
+    assert mcore.__version__ >= "0.13.0", "Fused forward patching requires mecore >= 0.13.0"
     model = _get_patching_model(model)
     if model is not None:
         model.forward_backup = model.forward
@@ -60,106 +62,66 @@ def unpatch_fused_forward(model: torch.nn.Module):
         model.forward = model.forward_backup
 
 
-def fused_forward_gptmodel(
-    model: GPTModel,
-    input_ids: Tensor,
-    position_ids: Tensor,
-    attention_mask: Tensor,
-    labels: Tensor,
-    labels_mask: Tensor,
-    temperature: float = 1.0,
-    **kwargs,
-):
-    pre_process: bool = unwrap_model(model).pre_process
-    post_process: bool = unwrap_model(model).post_process
+def fused_forward_model_gen(vision_model: bool = False):
+    def fused_forward_model(
+        model,
+        input_ids: Tensor,
+        position_ids: Tensor,
+        attention_mask: Tensor,
+        labels: Tensor,
+        labels_mask: Tensor,
+        temperature: float,
+        multi_modal_inputs: dict,
+    ):
+        pre_process: bool = (
+            unwrap_model(model).pre_process if not vision_model else True
+        )  # vision model always needs pre_process
+        post_process: bool = unwrap_model(model).post_process
 
-    batch_size, seq_len = attention_mask.shape[:2]
-    input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=pre_process)
-    input_ids_rmpad = input_ids_rmpad.contiguous()
-    labels_rmpad, _ = preprocess_packed_seqs(labels, attention_mask, pre_process=True)
-    labels_mask_rmpad, _ = preprocess_packed_seqs(labels_mask, attention_mask, pre_process=True)
-    labels_rmpad = labels_rmpad.contiguous()
-    labels_mask_rmpad = labels_mask_rmpad.contiguous()
+        model_kwargs = {}
+        if "pixel_values" in multi_modal_inputs:
+            model_kwargs["pixel_values"] = multi_modal_inputs["pixel_values"].to(input_ids.device)
+        if "image_grid_thw" in multi_modal_inputs:
+            model_kwargs["image_grid_thw"] = multi_modal_inputs["image_grid_thw"].to(input_ids.device)
 
-    output_orig: CausalLMOutputForPPO = model(
-        input_ids=input_ids_rmpad,
-        attention_mask=None,
-        position_ids=position_ids,
-        labels=labels_rmpad,
-        packed_seq_params=packed_seq_params,
-        temperature=temperature,
-    )
+        batch_size, seq_len = attention_mask.shape[:2]
+        input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=pre_process)
+        input_ids_rmpad = input_ids_rmpad.contiguous()
+        labels_rmpad, _ = preprocess_packed_seqs(labels, attention_mask, pre_process=True)
+        labels_mask_rmpad, _ = preprocess_packed_seqs(labels_mask, attention_mask, pre_process=True)
+        labels_rmpad = labels_rmpad.contiguous()
+        labels_mask_rmpad = labels_mask_rmpad.contiguous()
 
-    if post_process:
-        # output_orig is in type of CausalLMOutputForPPO
-        output = postprocess_packed_seqs_for_dict_output(
-            labels_mask_rmpad,
-            output_orig,
-            packed_seq_params,
-            attention_mask,
-            batch_size,
-            seq_len,
-            post_process=post_process,
+        output_orig: CausalLMOutputForPPO = model(
+            input_ids=input_ids_rmpad,
+            attention_mask=None,
+            position_ids=position_ids if not vision_model else None,  # vision models will calculate position_ids
+            labels=labels_rmpad,
+            packed_seq_params=packed_seq_params,
+            temperature=temperature,
+            **model_kwargs,
         )
-    else:
-        output = output_orig
-    return output
 
+        if post_process:
+            # output_orig is in type of CausalLMOutputForPPO
+            output = postprocess_packed_seqs_for_dict_output(
+                labels_mask_rmpad,
+                output_orig,
+                packed_seq_params,
+                attention_mask,
+                batch_size,
+                seq_len,
+                post_process=post_process,
+            )
+        else:
+            output = output_orig
+        return output
 
-def fused_forward_qwen2_5_vl(
-    model: Qwen2_5VLModel,
-    input_ids: Tensor,
-    position_ids: Tensor,
-    attention_mask: Tensor,
-    labels: Tensor,
-    labels_mask: Tensor,
-    multi_modal_inputs=None,
-    **kwargs,
-):
-    # pre_process = unwrap_model(model).pre_process
-    post_process = unwrap_model(model).post_process
-
-    pixel_values = (
-        multi_modal_inputs["pixel_values"].to(input_ids.device) if "pixel_values" in multi_modal_inputs else None
-    )
-    image_grid_thw = (
-        multi_modal_inputs["image_grid_thw"].to(input_ids.device) if "image_grid_thw" in multi_modal_inputs else None
-    )
-
-    batch_size, seq_len = attention_mask.shape[:2]
-    input_ids_rmpad, packed_seq_params = preprocess_packed_seqs(input_ids, attention_mask, pre_process=True)
-    labels_rmpad, _ = preprocess_packed_seqs(labels, attention_mask, pre_process=True)
-    labels_mask_rmpad, _ = preprocess_packed_seqs(labels_mask, attention_mask, pre_process=True)
-    labels_rmpad = labels_rmpad.contiguous()
-    labels_mask_rmpad = labels_mask_rmpad.contiguous()
-    input_ids_rmpad = input_ids_rmpad.contiguous()
-    output_orig: CausalLMOutputForPPO = model(
-        input_ids=input_ids_rmpad,
-        attention_mask=None,
-        position_ids=position_ids,
-        packed_seq_params=packed_seq_params,
-        pixel_values=pixel_values,
-        image_grid_thw=image_grid_thw,
-        labels=labels_rmpad,
-    )
-    if post_process:
-        # output_orig is in type of CausalLMOutputForPPO
-        output = postprocess_packed_seqs_for_dict_output(
-            labels_mask_rmpad,
-            output_orig,
-            packed_seq_params,
-            attention_mask,
-            batch_size,
-            seq_len,
-            post_process=post_process,
-        )
-    else:
-        output = output_orig
-    return output
+    return fused_forward_model
 
 
 def _fused_GPTModel_forward(
-    self,
+    model,
     input_ids: Tensor,
     position_ids: Tensor,
     attention_mask: Tensor,
@@ -173,76 +135,30 @@ def _fused_GPTModel_forward(
     inference_params: Optional[BaseInferenceContext] = None,
     loss_mask: Optional[Tensor] = None,
     temperature: float = 1.0,
+    **kwargs,
 ) -> CausalLMOutputForPPO:
     """
-    Forward pass for GPT models with fused kernel support.
+    Patch self._postprocess in forward for GPT models to enable fused kernel support.
+    https://github.com/NVIDIA/Megatron-LM/blob/core_v0.13.0/megatron/core/models/gpt/gpt_model.py
 
-    Patch https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/models/gpt/gpt_model.py
+    TODO: Currently we still need to patch `forward` because we need to pass `temperature`
+    explicitly to `self._postprocess` when calling, maybe there can be a better way to handle this?
     """
 
-    # If decoder_input is provided (not None), then input_ids and position_ids are ignored.
-    # Otherwise, apply embedding layer on input_ids and position_ids to get decoder_input.
+    inference_context = deprecate_inference_params(inference_context, inference_params)
 
-    # Decoder embedding.
-    if decoder_input is not None:
-        pass
-    elif self.pre_process:
-        decoder_input = self.embedding(input_ids=input_ids, position_ids=position_ids)
-    else:
-        # intermediate stage of pipeline
-        # decoder will get hidden_states from encoder.input_tensor
-        decoder_input = None
+    preproc_output = model._preprocess(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        decoder_input=decoder_input,
+        inference_context=inference_context,
+        packed_seq_params=packed_seq_params,
+    )
 
-    # Rotary positional embeddings (embedding is None for PP intermediate devices)
-    rotary_pos_emb = None
-    rotary_pos_cos = None
-    rotary_pos_sin = None
-    if self.position_embedding_type == "rope" and not self.config.multi_latent_attention:
-        if not self.training and self.config.flash_decode and inference_context:
-            assert inference_context.is_static_batching(), "GPTModel currently only supports static inference batching."
-            # Flash decoding uses precomputed cos and sin for RoPE
-            rotary_pos_cos, rotary_pos_sin = self.rotary_pos_emb_cache.setdefault(
-                inference_context.max_sequence_length,
-                self.rotary_pos_emb.get_cos_sin(inference_context.max_sequence_length),
-            )
-        else:
-            rotary_seq_len = self.rotary_pos_emb.get_rotary_seq_len(
-                inference_context, self.decoder, decoder_input, self.config, packed_seq_params
-            )
-            rotary_pos_emb = self.rotary_pos_emb(
-                rotary_seq_len,
-                packed_seq=packed_seq_params is not None and packed_seq_params.qkv_format == "thd",
-            )
-    elif self.position_embedding_type == "mrope" and not self.config.multi_latent_attention:
-        if self.training or not self.config.flash_decode:
-            rotary_pos_emb = self.rotary_pos_emb(position_ids, self.mrope_section)
-        else:
-            # Flash decoding uses precomputed cos and sin for RoPE
-            raise NotImplementedError(
-                "Flash decoding uses precomputed cos and sin for RoPE, not implmented in MultimodalRotaryEmbedding yet."
-            )
-
-    if (
-        (self.config.enable_cuda_graph or self.config.flash_decode)
-        and rotary_pos_cos is not None
-        and inference_context
-        and inference_context.is_static_batching()
-        and not self.training
-    ):
-        sequence_len_offset = torch.tensor(
-            [inference_context.sequence_len_offset] * inference_context.current_batch_size,
-            dtype=torch.int32,
-            device=rotary_pos_cos.device,  # Co-locate this with the rotary tensors
-        )
-    else:
-        sequence_len_offset = None
-
-    # Wrap decoder_input to allow the decoder (TransformerBlock) to delete the
-    # reference held by this caller function, enabling early garbage collection for
-    # skip inference
+    (decoder_input, rotary_pos_emb, rotary_pos_cos, rotary_pos_sin, sequence_len_offset) = preproc_output[:5]
 
     # Run decoder.
-    hidden_states = self.decoder(
+    hidden_states = model.decoder(
         hidden_states=decoder_input,
         attention_mask=attention_mask,
         inference_context=inference_context,
@@ -252,40 +168,10 @@ def _fused_GPTModel_forward(
         packed_seq_params=packed_seq_params,
         sequence_len_offset=sequence_len_offset,
         **(extra_block_kwargs or {}),
+        **kwargs,
     )
 
-    # Process inference output.
-    if inference_context and not inference_context.is_static_batching():
-        hidden_states = inference_context.last_token_logits(hidden_states.squeeze(1).unsqueeze(0)).unsqueeze(1)
-
-    # logits and loss
-    output_weight = None
-    if self.share_embeddings_and_output_weights:
-        output_weight = self.shared_embedding_or_output_weight()
-
-    if self.mtp_process:
-        hidden_states = self.mtp(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            labels=labels,
-            loss_mask=loss_mask,
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            inference_params=inference_params,
-            rotary_pos_emb=rotary_pos_emb,
-            rotary_pos_cos=rotary_pos_cos,
-            rotary_pos_sin=rotary_pos_sin,
-            packed_seq_params=packed_seq_params,
-            sequence_len_offset=sequence_len_offset,
-            embedding=self.embedding,
-            output_layer=self.output_layer,
-            output_weight=output_weight,
-            runtime_gather_output=runtime_gather_output,
-            compute_language_model_loss=self.compute_language_model_loss,
-            **(extra_block_kwargs or {}),
-        )
-
-    if not self.post_process:
+    if not model.post_process:
         return hidden_states
 
     output = CausalLMOutputForPPO(
@@ -296,18 +182,18 @@ def _fused_GPTModel_forward(
         attentions=None,
     )
 
-    if self.config.sequence_parallel:
+    if model.config.sequence_parallel:
         hidden_states = gather_from_sequence_parallel_region(hidden_states)
     logprobs, entropy = linear_cross_entropy(
         hidden_states,
-        self.output_layer.weight,
+        model.output_layer.weight,
         labels,
         temperature,
         "none",
         parallel_state.get_tensor_model_parallel_group(),
     )
 
-    if has_config_logger_enabled(self.config):
+    if has_config_logger_enabled(model.config):
         payload = OrderedDict(
             {
                 "input_ids": input_ids,
@@ -318,7 +204,7 @@ def _fused_GPTModel_forward(
                 "entropy": entropy,
             }
         )
-        log_config_to_disk(self.config, payload, prefix="input_and_logits")
+        log_config_to_disk(model.config, payload, prefix="input_and_logits")
 
     output.entropy = entropy
     output.log_probs = logprobs

--- a/verl/models/mcore/qwen2_5_vl/model.py
+++ b/verl/models/mcore/qwen2_5_vl/model.py
@@ -203,6 +203,7 @@ class Qwen2_5VLModel(MegatronModule):
         pixel_values_videos: torch.Tensor = None,
         image_grid_thw: torch.Tensor = None,
         video_grid_thw: torch.Tensor = None,
+        **kwargs,
     ) -> torch.Tensor:
         """Forward function of the Qwen2VL model.
 
@@ -335,6 +336,7 @@ class Qwen2_5VLModel(MegatronModule):
             # inference_params=inference_params,  # currently always None
             packed_seq_params=packed_seq_params,  # currently always None
             **(extra_block_kwargs or {}),
+            **kwargs,
         )
 
         return output

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -33,8 +33,8 @@ from .config_converter import (
     hf_to_mcore_config_qwen2moe,
     hf_to_mcore_config_qwen3moe,
 )
-from .model_forward import gptmodel_forward, gptmodel_forward_no_padding, gptmodel_forward_qwen2_5_vl
-from .model_forward_fused import fused_forward_gptmodel, fused_forward_qwen2_5_vl
+from .model_forward import gptmodel_forward_no_padding, model_forward_gen
+from .model_forward_fused import fused_forward_model_gen
 from .model_initializer import (
     BaseModelInitializer,
     DeepseekV3Model,
@@ -82,7 +82,6 @@ MODEL_CONFIG_CONVERTER_REGISTRY: dict[SupportedModel, Callable[[PretrainedConfig
     SupportedModel.LLAMA4: hf_to_mcore_config_llama4,
     SupportedModel.QWEN3: hf_to_mcore_config_dense,
     SupportedModel.QWEN3_MOE: hf_to_mcore_config_qwen3moe,
-    SupportedModel.QWEN2_5_VL: hf_to_mcore_config_qwen2_5_vl,
     SupportedModel.QWEN3_TOKEN_CLASSIFICATION: hf_to_mcore_config_dense,
 }
 
@@ -97,27 +96,25 @@ MODEL_INITIALIZER_REGISTRY: dict[SupportedModel, type[BaseModelInitializer]] = {
     SupportedModel.LLAMA4: DenseModel,
     SupportedModel.QWEN3: DenseModel,
     SupportedModel.QWEN3_MOE: Qwen3MoEModel,
-    SupportedModel.QWEN2_5_VL: Qwen25VLModel,
     SupportedModel.QWEN3_TOKEN_CLASSIFICATION: DenseModel,
 }
 
 # Registry for model forward functions
 MODEL_FORWARD_REGISTRY: dict[SupportedModel, Callable] = {
-    SupportedModel.LLAMA: gptmodel_forward,
-    SupportedModel.QWEN2: gptmodel_forward,
-    SupportedModel.QWEN2_MOE: gptmodel_forward,
-    SupportedModel.MIXTRAL: gptmodel_forward,
-    SupportedModel.DEEPSEEK_V3: gptmodel_forward,
-    SupportedModel.QWEN2_5_VL: gptmodel_forward,
-    SupportedModel.LLAMA4: gptmodel_forward,
-    SupportedModel.QWEN3: gptmodel_forward,
-    SupportedModel.QWEN3_MOE: gptmodel_forward,
-    SupportedModel.QWEN2_5_VL: gptmodel_forward_qwen2_5_vl,
-    SupportedModel.QWEN3_MOE_VL: gptmodel_forward_qwen2_5_vl,
-    SupportedModel.QWEN3_VL: gptmodel_forward_qwen2_5_vl,
-    SupportedModel.DEEPSEEK_V3: gptmodel_forward,
-    SupportedModel.GLM4_MOE: gptmodel_forward,
-    SupportedModel.QWEN3_TOKEN_CLASSIFICATION: gptmodel_forward,
+    SupportedModel.LLAMA: model_forward_gen(),
+    SupportedModel.QWEN2: model_forward_gen(),
+    SupportedModel.QWEN2_MOE: model_forward_gen(),
+    SupportedModel.MIXTRAL: model_forward_gen(),
+    SupportedModel.DEEPSEEK_V3: model_forward_gen(),
+    SupportedModel.LLAMA4: model_forward_gen(),
+    SupportedModel.QWEN3: model_forward_gen(),
+    SupportedModel.QWEN3_MOE: model_forward_gen(),
+    SupportedModel.QWEN2_5_VL: model_forward_gen(True),
+    SupportedModel.QWEN3_MOE_VL: model_forward_gen(True),
+    SupportedModel.QWEN3_VL: model_forward_gen(True),
+    SupportedModel.DEEPSEEK_V3: model_forward_gen(),
+    SupportedModel.GLM4_MOE: model_forward_gen(),
+    SupportedModel.QWEN3_TOKEN_CLASSIFICATION: model_forward_gen(),
 }
 
 # Registry for model forward functions
@@ -133,7 +130,6 @@ MODEL_FORWARD_NOPAD_REGISTRY: dict[SupportedModel, Callable] = {
     SupportedModel.LLAMA4: gptmodel_forward_no_padding,
     SupportedModel.QWEN3: gptmodel_forward_no_padding,
     SupportedModel.QWEN3_MOE: gptmodel_forward_no_padding,
-    # SupportedModel.QWEN2_5_VL: gptmodel_forward_qwen2_5_vl,
     SupportedModel.DEEPSEEK_V3: gptmodel_forward_no_padding,
     SupportedModel.GLM4_MOE: gptmodel_forward_no_padding,
     SupportedModel.QWEN3_TOKEN_CLASSIFICATION: gptmodel_forward_no_padding,
@@ -141,19 +137,19 @@ MODEL_FORWARD_NOPAD_REGISTRY: dict[SupportedModel, Callable] = {
 
 # Registry for model forward functions
 MODEL_FORWARD_FUSED_REGISTRY: dict[SupportedModel, Callable] = {
-    SupportedModel.LLAMA: fused_forward_gptmodel,
-    SupportedModel.QWEN2: fused_forward_gptmodel,
-    SupportedModel.QWEN2_MOE: fused_forward_gptmodel,
-    SupportedModel.MIXTRAL: fused_forward_gptmodel,
-    SupportedModel.DEEPSEEK_V3: fused_forward_gptmodel,
-    SupportedModel.QWEN2_5_VL: fused_forward_qwen2_5_vl,
-    SupportedModel.QWEN3_MOE_VL: fused_forward_qwen2_5_vl,
-    SupportedModel.QWEN3_VL: fused_forward_qwen2_5_vl,
-    SupportedModel.LLAMA4: fused_forward_gptmodel,
-    SupportedModel.QWEN3: fused_forward_gptmodel,
-    SupportedModel.QWEN3_MOE: fused_forward_gptmodel,
-    SupportedModel.DEEPSEEK_V3: fused_forward_gptmodel,
-    SupportedModel.GLM4_MOE: fused_forward_gptmodel,
+    SupportedModel.LLAMA: fused_forward_model_gen(),
+    SupportedModel.QWEN2: fused_forward_model_gen(),
+    SupportedModel.QWEN2_MOE: fused_forward_model_gen(),
+    SupportedModel.MIXTRAL: fused_forward_model_gen(),
+    SupportedModel.DEEPSEEK_V3: fused_forward_model_gen(),
+    SupportedModel.QWEN2_5_VL: fused_forward_model_gen(True),
+    SupportedModel.QWEN3_MOE_VL: fused_forward_model_gen(True),
+    SupportedModel.QWEN3_VL: fused_forward_model_gen(True),
+    SupportedModel.LLAMA4: fused_forward_model_gen(),
+    SupportedModel.QWEN3: fused_forward_model_gen(),
+    SupportedModel.QWEN3_MOE: fused_forward_model_gen(),
+    SupportedModel.DEEPSEEK_V3: fused_forward_model_gen(),
+    SupportedModel.GLM4_MOE: fused_forward_model_gen(),
 }
 
 # Registry for model weight converters

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -526,11 +526,10 @@ class MegatronPPOActor(BasePPOActor):
                     input_ids,
                     position_ids,
                     attention_mask,
-                    sequence_parallel=self.tf_config.sequence_parallel,
-                    multi_modal_inputs=multi_modal_inputs,
-                    labels=label,
-                    labels_mask=label_mask,
-                    temperature=temperature,
+                    label,
+                    label_mask,
+                    temperature,
+                    multi_modal_inputs,
                 )
             else:
                 forward_fn = get_mcore_forward_fn(self.hf_config)
@@ -562,8 +561,7 @@ class MegatronPPOActor(BasePPOActor):
                     input_ids,
                     attention_mask,
                     position_ids,
-                    sequence_parallel=self.tf_config.sequence_parallel,
-                    multi_modal_inputs=multi_modal_inputs,
+                    multi_modal_inputs,
                     logits_processor=logits_processor,
                     logits_processor_args=logits_processor_args,
                 )

--- a/verl/workers/critic/megatron_critic.py
+++ b/verl/workers/critic/megatron_critic.py
@@ -256,7 +256,7 @@ class MegatronPPOCritic(BasePPOCritic):
                 input_ids,
                 attention_mask,
                 position_ids,
-                sequence_parallel=self.tf_config.sequence_parallel,
+                {},  # multi_modal_inputs
                 value_model=True,
             )
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -613,7 +613,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
         output = forward_fn(
             model,
             input_ids,
-            multi_modal_inputs=multi_modal_inputs,
+            multi_modal_inputs,
             logits_processor=logits_processor,
             logits_processor_args=logits_processor_args,
         )
@@ -668,8 +668,7 @@ class MegatronEngineWithValueHead(MegatronEngineWithLMHead):
         output = forward_fn(
             model,
             input_ids,
-            sequence_parallel=self.tf_config.sequence_parallel,
-            multi_modal_inputs=multi_modal_inputs,
+            multi_modal_inputs,
             value_model=True,
         )
 

--- a/verl/workers/reward_model/megatron/reward_model.py
+++ b/verl/workers/reward_model/megatron/reward_model.py
@@ -290,9 +290,8 @@ class MegatronRewardModel(BasePPORewardModel):
                 input_ids,
                 attention_mask,
                 position_ids,
-                sequence_parallel=self.tf_config.sequence_parallel,
+                multi_modal_inputs,
                 value_model=True,
-                multi_modal_inputs=multi_modal_inputs,
             )
 
             return output, loss_func


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Currently, we will have error regarding to unexpected keyword argument 'visual_pos_masks', this is because mbridge did some customization of the `GPTModel` forward as well for Qwen3VL to support deepstack:
https://github.com/ISEEKYAN/mbridge/blob/ecbdfbdfdc8027004702149d6dc87fbad7417708/mbridge/models/qwen3_vl/gpt_model.py#L84

Since mcore v0.13.0 introduced `_postprocess` and `_preprocess`, and our patch focuses on `_postprocess`, I also cleaned up the function for better maintainability and to fix this extra deepstack argument issue. We can't simply patch `_postprocess` as we will need to pass `temperature` argument as well:

```logs
output = self.forward_backward_batch(
/verl_megatron/verl/workers/actor/megatron_actor.py", line 598, in forward_backward_batch
    losses_reduced = forward_backward_func(
miniconda/envs/qwenvl/lib/python3.10/site-packages/megatron/core/pipeline_parallel/schedules.py", line 500, in forward_backward_no_pipelining
    output_tensor, num_tokens = forward_step(
.......
verl_megatron/verl/models/mcore/model_forward_fused.py", line 136, in fused_forward_qwen2_5_vl
    output_orig: CausalLMOutputForPPO = model(
......
mbridge-main/mbridge/models/qwen3_vl/model.py", line 323, in forward
    output = self.language_model(
envs/qwenvl/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
/envs/qwenvl/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
    return forward_call(*args, **kwargs)
TypeError: _fused_GPTModel_forward() got an unexpected keyword argument 'visual_pos_masks'
```

In addition, there will be shape mismatch error when calculating `mrope`, if we pass `position_ids` in `fused_forward_qwen2_5_vl`, I tried to debug but the shape passed here doesn't make sense, and since according to https://github.com/volcengine/verl/blob/981d781db932ff53a0c584fd501dcd73ce2a8077/verl/models/mcore/model_forward.py#L117 it says model will calculate position_ids, I just follow the code there to not pass the position ids, and it works both for Qwen2.5VL and Qwen3VL without throwing further errors.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
