### PR TITLE
[doc] misc: fix doc that penalty starts when exceeds the `max_response_length - overlong_buffer.len`

### DIFF
--- a/docs/algo/dapo.md
+++ b/docs/algo/dapo.md
@@ -150,7 +150,7 @@ reward_model:
 
 Setting `overlong_buffer.enable` to `True` will penalize the outputs whose lengths are overlong but still within the hard context limit.
 
-Specifically, the penalty increases linearly from `0` to `overlong_buffer.penalty_factor` when the length of the output exceeds the `max_response_length` by `0` to `overlong_buffer.len` tokens.
+Specifically, the penalty increases linearly from `0` to `overlong_buffer.penalty_factor` when the length of the output exceeds the `max_response_length - overlong_buffer.len` by `0` to `overlong_buffer.len` tokens.
 
 Core relevant code:
 

--- a/recipe/dapo/README.md
+++ b/recipe/dapo/README.md
@@ -155,7 +155,7 @@ reward_model:
 
 Setting `overlong_buffer.enable` to `True` will penalize the outputs whose lengths are overlong but still within the hard context limit.
 
-Specifically, the penalty increases linearly from `0` to `overlong_buffer.penalty_factor` when the length of the output exceeds the `max_response_length` by `0` to `overlong_buffer.len` tokens.
+Specifically, the penalty increases linearly from `0` to `overlong_buffer.penalty_factor` when the length of the output exceeds the `max_response_length - overlong_buffer.len` by `0` to `overlong_buffer.len` tokens.
 
 Core relevant code:
 


### PR DESCRIPTION
### What does this PR do?

This PR corrects a minor typo in the documentation for the DAPO algorithm.

It changes the threshold for the `overlong_buffer` penalty from starting at `max_response_length` to `max_response_length - overlong_buffer.len`. This ensures the documentation accurately reflects that the penalty is applied as the response length approaches the maximum limit.

Fixes #3855