### PR TITLE
[trainer] fix: missing offload parameter and optimizer to cpu when no checkpoint

### DIFF
--- a/examples/grpo_trainer/run_deepseek671b_math_megatron_80gb.sh
+++ b/examples/grpo_trainer/run_deepseek671b_math_megatron_80gb.sh
@@ -74,7 +74,7 @@ python3 -m verl.trainer.main_ppo --config-path=./config --config-name='ppo_megat
     actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
     actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
     actor_rollout_ref.rollout.name=vllm \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     actor_rollout_ref.rollout.temperature=1.0 \
     actor_rollout_ref.rollout.top_p=1.0 \
@@ -94,6 +94,7 @@ python3 -m verl.trainer.main_ppo --config-path=./config --config-name='ppo_megat
     actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
     actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
     actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.actor.megatron.override_transformer_config.attention_backend='fused' \
     +actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_first_pipeline_stage=4 \
     +actor_rollout_ref.actor.megatron.override_transformer_config.num_layers_in_last_pipeline_stage=1 \
     actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=$PP \

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -834,6 +834,8 @@ class RayPPOTrainer:
 
     def _load_checkpoint(self):
         if self.config.trainer.resume_mode == "disable":
+            # NOTE: while there is no checkpoint to load, we still need to offload the model and optimizer to CPU
+            self.actor_rollout_wg.load_checkpoint(None)
             return 0
 
         # load from hdfs
@@ -850,6 +852,7 @@ class RayPPOTrainer:
         if self.config.trainer.resume_mode == "auto":
             if global_step_folder is None:
                 print("Training from scratch")
+                self.actor_rollout_wg.load_checkpoint(None)
                 return 0
         else:
             if self.config.trainer.resume_mode == "resume_path":

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -15,7 +15,6 @@
 Utilities to create common models from huggingface
 """
 
-import os
 import re
 import warnings
 from dataclasses import dataclass
@@ -395,7 +394,7 @@ def _get_parallel_model_architecture_from_config(config: PretrainedConfig, value
     )
 
 
-def _load_hf_model(config, model_config, is_value_model, local_cache_path):
+def _load_hf_model(config, model_config, is_value_model):
     """Helper function containing the loading hf model logic"""
     from accelerate import init_empty_weights
     from megatron.core import parallel_state as mpu
@@ -404,7 +403,6 @@ def _load_hf_model(config, model_config, is_value_model, local_cache_path):
 
     assert hasattr(model_config, "architectures"), "architectures cannot be empty when load weight!"
     architectures = getattr(model_config, "architectures", [])
-    local_cache_path = os.path.expanduser(local_cache_path)
 
     # get auto class
     auto_cls = get_hf_auto_model_class(model_config)
@@ -413,9 +411,7 @@ def _load_hf_model(config, model_config, is_value_model, local_cache_path):
         from verl.utils.fs import copy_to_local
 
         print(f"start download from {config.model.path}")
-        local_model_path = copy_to_local(
-            src=config.model.path, cache_dir=local_cache_path, use_shm=config.model.get("use_shm", False)
-        )
+        local_model_path = copy_to_local(src=config.model.path, use_shm=config.model.get("use_shm", False))
         print("finish download")
     else:
         local_model_path = config.model.path
@@ -452,26 +448,19 @@ def _load_hf_model(config, model_config, is_value_model, local_cache_path):
     return architectures, model, state_dict, is_value_model
 
 
-def get_hf_model_path(config, local_cache_path="~/.cache/verl/rlhf"):
-    local_cache_path = os.path.expanduser(local_cache_path)
+def get_hf_model_path(config):
     if config.model.path.startswith("hdfs:"):
         from verl.utils.fs import copy_to_local
 
-        local_model_path = copy_to_local(
-            src=config.model.path, cache_dir=local_cache_path, use_shm=config.model.get("use_shm", False)
-        )
+        local_model_path = copy_to_local(src=config.model.path, use_shm=config.model.get("use_shm", False))
     else:
         local_model_path = config.model.path
     return local_model_path
 
 
-def load_megatron_model_weights(
-    config, model_config, parallel_model, params_dtype, is_value_model=False, local_cache_path="~/.cache/verl/rlhf"
-):
+def load_megatron_model_weights(config, model_config, parallel_model, params_dtype, is_value_model=False):
     """Load weights for verl customized model."""
-    architectures, model, state_dict, is_value_model = _load_hf_model(
-        config, model_config, is_value_model, local_cache_path
-    )
+    architectures, model, state_dict, is_value_model = _load_hf_model(config, model_config, is_value_model)
 
     from verl.models.weight_loader_registry import get_weight_loader
 
@@ -490,11 +479,9 @@ def load_megatron_model_weights(
     return model.config
 
 
-def load_megatron_gptmodel_weights(
-    config, model_config, parallel_model, params_dtype, is_value_model=False, local_cache_path="~/.cache/verl/rlhf"
-):
+def load_megatron_gptmodel_weights(config, model_config, parallel_model, params_dtype, is_value_model=False):
     """Load weights for mcore GPT model."""
-    _, model, state_dict, is_value_model = _load_hf_model(config, model_config, is_value_model, local_cache_path)
+    _, model, state_dict, is_value_model = _load_hf_model(config, model_config, is_value_model)
 
     from verl.models.mcore.loader import load_state_dict_to_megatron_gptmodel
 

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -1071,6 +1071,14 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             f"{self._is_actor} and {self._is_rollout}"
         )
 
+        # No checkpoint to load, just offload the model and optimizer to CPU
+        if local_path is None:
+            if self._is_offload_param:
+                offload_fsdp_model_to_cpu(self.actor_module_fsdp)
+            if self._is_offload_optimizer:
+                offload_fsdp_optimizer(self.actor_optimizer)
+            return
+
         if self._is_offload_param:
             load_fsdp_model_to_gpu(self.actor_module_fsdp)
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -73,6 +73,8 @@ class ExternalZeroMQDistributedExecutor(Executor):
         self.sockets = []
         for address in addresses:
             socket = self.context.socket(zmq.REQ)
+            if address.startswith("tcp://["):
+                socket.setsockopt(zmq.IPV6, 1)
             socket.connect(address)
             self.sockets.append(socket)
 
@@ -217,7 +219,7 @@ class vLLMHttpServerBase:
             "dtype": self.config.dtype,
             "load_format": self.config.load_format,
             "skip_tokenizer_init": False,
-            "trust_remote_code": True,
+            # "trust_remote_code": True,
             "max_model_len": self.config.max_model_len,
             "max_num_seqs": self.config.max_num_seqs,
             "enable_chunked_prefill": self.config.enable_chunked_prefill,

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -32,7 +32,6 @@ import inspect
 import logging
 import os
 import pickle
-import socket
 import time
 from contextlib import contextmanager
 from dataclasses import asdict
@@ -69,6 +68,7 @@ from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack, is_version_ge
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
+from verl.workers.rollout.utils import get_free_port, is_valid_ipv6_address
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
     VLLM_LORA_NAME,
@@ -513,27 +513,25 @@ class vLLMAsyncRollout(BaseRollout):
 
         # File lock to prevent multiple workers listen to same port
         with FileLock(f"/tmp/verl_vllm_zmq_{getpass.getuser()}.lock"):
+            context = zmq.asyncio.Context()
+            self.socket = context.socket(zmq.REP)
             if socket_type == "ipc":
                 pid = os.getpid()
                 address = f"ipc:///tmp/verl_vllm_zmq_{pid}_{getpass.getuser()}.ipc"
             else:
-                ip, port = self._get_free_port()
-                address = f"tcp://{ip}:{port}"
-            context = zmq.asyncio.Context()
-            self.socket = context.socket(zmq.REP)
+                ip = ray.util.get_node_ip_address().strip("[]")
+                port, sock = get_free_port(ip)
+                if is_valid_ipv6_address(ip):
+                    address = f"tcp://[{ip}]:{port}"
+                    self.socket.setsockopt(zmq.IPV6, 1)
+                else:
+                    address = f"tcp://{ip}:{port}"
             self.socket.bind(address)
 
         loop = asyncio.get_running_loop()
         self.zmq_loop_task = loop.create_task(self._loop_forever())
 
         return address
-
-    def _get_free_port(self):
-        ip = ray.util.get_node_ip_address()
-        with socket.socket() as sock:
-            sock.bind(("", 0))
-            port = sock.getsockname()[1]
-        return ip, port
 
     async def _loop_forever(self):
         while True:


### PR DESCRIPTION
### What does this PR do?

Fix a bug introduce in https://github.com/volcengine/verl/pull/3285. Currently the initialization steps are:
1. **build actor**:  init model and optimizer, then offload to cpu
2. **build rollout**: init model and kv cache
3. **switch to `trainer_mode`**: discard rollout weight and kv cache, load actor model and optimizer to gpu
4. **load_checkpoint**: if checkpoint exists, load model and optimizer from checkpoint, then offload to cpu
5. **switch to `rollout_mode`**: load actor model to gpu, resume rollout weight and sync weight, then offload actor model to cpu and resume kv cache
6. **generate_sequences**

The bug is step 4: if checkpoint doesn't exists, then this step is skipped, leading to actor and optimizer both remain in gpu(from step 3), which may cause step 5 cuda oom.
