### PR TITLE
[fsdp] feat: Enable torch.compile on FSDP wrapped models

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -466,6 +466,13 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         fsdp_mesh = self.device_mesh
         sharding_strategy = get_sharding_strategy(fsdp_mesh)
 
+        if self.config.get("use_torch_compile", True):
+            if hasattr(actor_module, "model") and hasattr(actor_module.model, "layers"):
+                for block in actor_module.model.layers:
+                    block.compile()
+            else:
+                warnings.warn("Could not find 'model.layers' on the actor module to compile. Skipping.", stacklevel=1)
+
         # TODO: add transformer policy
         # We force reference policy to use CPUOffload to save memory.
         # We force turn off CPUOffload for actor because it causes incorrect results when using grad accumulation
@@ -1322,6 +1329,13 @@ class CriticWorker(Worker, DistProfilerExtension):
             else:
                 if self.rank == 0:
                     print("[critic model] No vision tower found.")
+
+        if self.config.get("use_torch_compile", True):
+            if hasattr(critic_module, "model") and hasattr(critic_module.model, "layers"):
+                for block in critic_module.model.layers:
+                    block.compile()
+            else:
+                warnings.warn("Could not find 'model.layers' on the critic module to compile. Skipping.", stacklevel=1)
 
         # Note: We force turn off CPUOffload for critic because it causes incorrect results when using grad accumulation
         if config.strategy == "fsdp":


### PR DESCRIPTION
This patch enables torch.compile on each transformer block of the FSDP wrapped models in FSDP training backend.

The speedup is pretty promising, on 8xH100 with a bunch of determinism settings (can't get GRPO vllm to have full determinism), I got

1. qwen2-7b PPO
```verbatim
       category               |  eager    | compiled  |
-------------------------------------------------------
rollout        (vllm)         |   11.8s   |   12.2s   |
old_log_prob   (fsdp fwd)     |   2.61s   |   2.21s   |
values         (fsdp fwd)     |   2.52s   |   1.73s   |
update_critic  (fsdp fwd+bwd) |   8.47s   |   6.78s   |
update_actor   (fsdp fwd+bwd) |   9.09s   |   8.70s   |
total step                    |   36.6s   |   33.7s   |
throughput     (tokens/s)     |   1268    |   1377    |
-------------------------------------------------------
```

2. qwen3-8b GRPO
```verbatim
       category                |  eager   | compiled |
------------------------------------------------------
rollout         (vllm)         |   74.5s  |   73.9s  |
old_log_prob    (fsdp fwd)     |   28.9s  |   23.4s  |
frozen log_prob (fsdp fwd)     |   29.3s  |   22.3s  |
update_actor    (fsdp fwd+bwd) |  111.3s  |   92.4s  |
total step                     |  245.5s  |  213.4s  |
throughput      (tokens/s)     |   2457   |   2822   |
------------------------------------------------------
```