### PR TITLE
[misc] feat: read environment for WandB entity (team) name

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -61,8 +61,9 @@ class Tracking:
         self.logger = {}
 
         if "tracking" in default_backend or "wandb" in default_backend:
-            import wandb
             import os
+
+            import wandb
 
             settings = None
             if config and config["trainer"].get("wandb_proxy", None):


### PR DESCRIPTION
### What does this PR do?

Read WANDB_ENTITY from environment variable to support verl logging metrics with different WandB teams.