### PR TITLE
[rollout] fix: incorrect value assignment while trying to access call_tool_result

### DIFF
--- a/verl/tools/mcp_base_tool.py
+++ b/verl/tools/mcp_base_tool.py
@@ -63,19 +63,24 @@ class MCPBaseTool(BaseTool):
 
     async def _call_tool(self, instance_id, parameters) -> tuple[str, dict]:
         err_msg = ""
+        metadata = {}
         try:
             call_tool_result = await ClientManager.call_tool(self.name, parameters, self.timeout)
+            logger.debug(f"Tool result for instance {instance_id} with tool {self.name}: {call_tool_result.content}")
+            result, metadata = self._parse_tool_result(call_tool_result.content)
         except ClientError as e:
             err_msg = f"\n Tool call failed: {e}"
         except ConnectionError as e:
             err_msg = f"\n Connection failed: {e}"
         except Exception as e:
             err_msg = f"\n An unexpected error occurred: {e}"
-
-        logger.debug(f"Tool result for instance {instance_id} with tool {self.name}: {call_tool_result.content}")
-        result, metadata = self._parse_tool_result(call_tool_result.content)
-        metadata["api_request_error"] = None if not err_msg else err_msg
-        return result, metadata
+        finally:
+            if err_msg:
+                result = err_msg
+                metadata["api_request_error"] = err_msg
+            else:
+                metadata["api_request_error"] = None
+            return result, metadata
 
     @rollout_trace_op
     async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs) -> tuple[ToolResponse, float, dict]:


### PR DESCRIPTION
### What does this PR do?

Right now, when call_tool_result fails, there is a log that attempts to access the value when it's not declared. When this happens, the training run hangs.

The log will hang at

```
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:22:11,371:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:24:14,933:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:24:27,976:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:24:41,475:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:24:41,476:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
[36m(task, pid=10095)[0m verl-sglang-trainer  | [36m(AgentLoopWorker pid=34997)[0m ERROR:2025-10-23 06:24:43,487:[MCPBaseTool] Execution failed: local variable 'call_tool_result' referenced before assignment
```

nvidia-smi shows the following:

```
Thu Oct 23 18:12:10 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 570.148.08             Driver Version: 570.148.08     CUDA Version: 12.8     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-80GB          On  |   00000000:06:00.0 Off |                    0 |
| N/A   35C    P0             70W /  400W |   51082MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA A100-SXM4-80GB          On  |   00000000:07:00.0 Off |                    0 |
| N/A   34C    P0             69W /  400W |   51112MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA A100-SXM4-80GB          On  |   00000000:08:00.0 Off |                    0 |
| N/A   34C    P0             70W /  400W |   51004MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA A100-SXM4-80GB          On  |   00000000:09:00.0 Off |                    0 |
| N/A   35C    P0             68W /  400W |   50976MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA A100-SXM4-80GB          On  |   00000000:0A:00.0 Off |                    0 |
| N/A   35C    P0             69W /  400W |   50954MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA A100-SXM4-80GB          On  |   00000000:0B:00.0 Off |                    0 |
| N/A   34C    P0             69W /  400W |   51028MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA A100-SXM4-80GB          On  |   00000000:0C:00.0 Off |                    0 |
| N/A   34C    P0             71W /  400W |   51140MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA A100-SXM4-80GB          On  |   00000000:0D:00.0 Off |                    0 |
| N/A   37C    P0             72W /  400W |   51098MiB /  81920MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A           97766      C   ray::WorkerDict                        5216MiB |
|    0   N/A  N/A          101047      C   sglang::scheduler                     45852MiB |
|    1   N/A  N/A           97767      C   ray::WorkerDict                        5362MiB |
|    1   N/A  N/A          100904      C   sglang::scheduler                     45736MiB |
|    2   N/A  N/A           97768      C   ray::WorkerDict                        5358MiB |
|    2   N/A  N/A          101008      C   sglang::scheduler                     45632MiB |
|    3   N/A  N/A           97769      C   ray::WorkerDict                        5362MiB |
|    3   N/A  N/A          101236      C   sglang::scheduler                     45600MiB |
|    4   N/A  N/A           97770      C   ray::WorkerDict                        5364MiB |
|    4   N/A  N/A          101539      C   sglang::scheduler                     45576MiB |
|    5   N/A  N/A           97771      C   ray::WorkerDict                        5358MiB |
|    5   N/A  N/A          101190      C   sglang::scheduler                     45656MiB |
|    6   N/A  N/A           97772      C   ray::WorkerDict                        5358MiB |
|    6   N/A  N/A          101333      C   sglang::scheduler                     45768MiB |
|    7   N/A  N/A           97773      C   ray::WorkerDict                        5214MiB |
|    7   N/A  N/A          101478      C   sglang::scheduler                     45870MiB |
+-----------------------------------------------------------------------------------------+
```
