### PR TITLE
[tool] fix: remove duplicate tool initialization

### DIFF
--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -100,7 +100,6 @@ class ToolAgentLoop(AgentLoopBase):
         cls.tool_schemas = [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True) for tool in tool_list]
         cls.tool_parser = ToolParser.get_tool_parser(config.actor_rollout_ref.rollout.multi_turn.format, cls.tokenizer)
         cls.tool_parser_name = config.actor_rollout_ref.rollout.multi_turn.format
-        tool_list = initialize_tools_from_config(tool_config_path) if tool_config_path else []
         print(f"Initialized tools: {cls.tools}")
 
         cls.apply_chat_template_kwargs = config.data.get("apply_chat_template_kwargs", {})


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where tool initialization code was duplicated, causing tools to be initialized twice and tool schemas to be printed twice during startup, which may lead to confusion.

1. Removed duplicate tool_list initialization in tool_agent_loop.py
https://github.com/volcengine/verl/blob/2e5805fbab2fe2baa6f052131d61170271cdbd77/verl/experimental/agent_loop/tool_agent_loop.py#L103
2. This also fixes the duplicate JSON schema printing in `BaseTool.__init__`
<img width="2968" height="1414" alt="duplicate_tool_init" src="https://github.com/user-attachments/assets/082f36e9-049d-4ae5-854d-c16ae6a3adea" />


The duplicate initialization was causing tools to be initialized twice, which resulted in the tool schema JSON being printed twice during startup.

### Checklist Before Starting

- [x] Search for similar PRs. [tool initialization](https://github.com/volcengine/verl/pulls?q=is%3Apr+tool+initialization)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

This is a simple code cleanup fix. The change removes duplicate code that was causing tools to be initialized and printed twice. Testing: 
                                           
- [x] Pre-commit checks passed
- [x] Python syntax validation passed
- No new functionality added, existing CI tests cover tool initialization

### API and Usage Example

No API changes. This is purely a bug fix that removes duplicate code.

### Design & Code Changes

**Root Cause:** https://github.com/volcengine/verl/blob/2e5805fbab2fe2baa6f052131d61170271cdbd77/verl/experimental/agent_loop/tool_agent_loop.py#L98-L103 called `initialize_tools_from_config(tool_config_path)` twice, causing:

1. Tools to be initialized twice
2. JSON schema to be printed twice https://github.com/volcengine/verl/blob/2e5805fbab2fe2baa6f052131d61170271cdbd77/verl/tools/base_tool.py#L41

**Fix:** Removed the duplicate line 103, keeping only the first initialization at line 98.

**Files Changed:**
- `verl/experimental/agent_loop/tool_agent_loop.py`: Removed duplicate tool initialization 

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Existing CI tests cover tool initialization; this is a simple duplicate code removal.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
