### PR TITLE
[trainer] feat: Self-Normalized Importance Sampling

### DIFF
--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -405,15 +405,23 @@ def compute_rollout_correction_weights(
     # Apply batch normalization if requested
     if rollout_is_batch_normalize:
         # Compute mean based on aggregation level
+        mask_float = response_mask.to(dtype=rollout_is_weights.dtype)
         if rollout_is == "token":
             # Token-level: normalize over all token weights
-            weights_mean = verl_F.masked_mean(rollout_is_weights, response_mask)
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                weights_mean = verl_F.distributed_masked_mean(rollout_is_weights, mask_float)
+            else:
+                weights_mean = verl_F.masked_mean(rollout_is_weights, response_mask)
         elif rollout_is == "sequence":
             # Sequence-level: normalize over sequence weights (one weight per sequence)
             # For each sequence, compute mean over valid tokens (they all have the same weight)
             # then average across sequences
-            seq_weights_mean = verl_F.masked_mean(rollout_is_weights, response_mask, axis=-1)  # (batch_size,)
-            weights_mean = seq_weights_mean.mean()
+            seq_weights = verl_F.masked_mean(rollout_is_weights, response_mask, axis=-1)  # (batch_size,)
+            seq_mask = (response_mask.sum(dim=-1) > 0).to(dtype=rollout_is_weights.dtype)
+            if torch.distributed.is_available() and torch.distributed.is_initialized():
+                weights_mean = verl_F.distributed_masked_mean(seq_weights, seq_mask)
+            else:
+                weights_mean = (seq_weights * seq_mask).sum() / seq_mask.sum().clamp_min(1e-8)
         else:
             raise ValueError(f"Unsupported rollout_is: {rollout_is}")
 


### PR DESCRIPTION
Self-Normalized Importance Sampling for rollout:backwards mismatch, adds `algorithm.rollout_is_self_norm`

SNIS applied to `rollout_is_weights`
  • `geo_mean`: per-sequence geometric mean
  • `seq-mean-token-mean` / `seq-mean-token-sum`: per-sequence masked mean/sum
  • `token-mean`, `seq-mean-token-sum-norm`: global denominator

Given $w_i=\dfrac{p(x_i)}{q(x_i)}$,  the self-normalized estimator is

$$\widehat{\mu}_{\text{SNIS}}=\frac{\sum_{i=1}^{N} w_i\cdot f(x_i)}{\sum_{i=1}^{N} w_i}$$

```yaml
algorithm:
  rollout_is: true
  rollout_is_self_norm: true
```

Example
<img width="1443" height="987" alt="image" src="https://github.com/user-attachments/assets/7ce88eb4-7eb5-4ce6-83e4-b61803d45536" />

Experimental, only `geo_mean` has been properly tested, please test yourself, most of these are not standard SNIS

Sequence index $b$, token $t$, mask $m_{b t}\in{0,1}$, per-token IS weights $w_{b t}>0$

Per-sequence $`w'_{bt}=\tfrac{w_{bt}}{d_b}`$
- `geo_mean` $\quad d_b=\exp\Bigg(\frac{\sum_t m_{bt}\cdot \log w_{bt}}{\sum_t m_{bt}}\Bigg)$
- `seq-mean-token-mean` $\quad d_b=\frac{\sum_t m_{bt}\cdot w_{bt}}{\sum_t m_{bt}}$
- `seq-mean-token-sum` $\quad d_b=\sum_t m_{bt}\cdot w_{bt}$

Global $`w'_{bt}=\tfrac{w_{bt}}{d}`$
- `token_mean` $\quad d=\frac{\sum_{b,t} m_{bt}\cdot w_{bt}}{\sum_{b,t} m_{bt}}$
- `seq-mean-token-sum-norm` given $T$ token dimension length `weights_full.shape[-1]` $\quad d=\frac{\sum_{b,t} m_{bt}\cdot w_{bt}}{T}$