### PR TITLE
[trainer] fix: Handle None sandbox_config in load_reward_manager

### DIFF
--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -142,7 +142,7 @@ def load_reward_manager(
     if compute_score is None:
         sandbox_config = config.reward_model.get("sandbox_fusion")
         sandbox_url = sandbox_config.get("url") if sandbox_config else None
-        memory_limit_mb = sandbox_config.get("memory_limit_mb", 1024)
+        memory_limit_mb = sandbox_config.get("memory_limit_mb", 1024) if sandbox_config else 1024
         if sandbox_url:
             sandbox_manager = multiprocessing.Manager()
             # Create a semaphore to control concurrent access to the sandbox


### PR DESCRIPTION
### What does this PR do?

- Fix AttributeError when sandbox_fusion is not configured
- Apply same None-safe pattern used on line 144 to line 145  
- Makes sandbox functionality truly optional

## Problem
When `sandbox_fusion` is not configured in the reward_model config, the code crashes with:

AttributeError: 'NoneType' object has no attribute 'get'


**Root Cause**: In `verl/trainer/ppo/reward.py` line 145, the code doesn't handle the case where `sandbox_config` is None:
- Line 144 correctly handles the None case: `sandbox_config.get("url") if sandbox_config else None`
- Line 145 fails to do the same: `sandbox_config.get("memory_limit_mb", 1024)`

### Checklist Before Starting

- [x] Format the PR title as `[trainer] fix: Handle None sandbox_config in load_reward_manager`

### Test

Tested by running PPO training without sandbox_fusion configuration in the config file. Previously this would crash with AttributeError, now it works correctly and uses the default reward function.

### API and Usage Example

No API changes. This fix allows users to run PPO training without needing to specify sandbox_fusion configuration:

```yaml
# This config now works (previously crashed)
reward_model:
  enable: true
  strategy: fsdp
  # sandbox_fusion: not required anymore
```

### Design & Code Changes

__File Changed__: `verl/trainer/ppo/reward.py` __Line Changed__: 145

__Before__:

```python
memory_limit_mb = sandbox_config.get("memory_limit_mb", 1024)
```

__After__:

```python
memory_limit_mb = sandbox_config.get("memory_limit_mb", 1024) if sandbox_config else 1024
```

This applies the same None-safe pattern already used on line 144 for consistency.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (Documentation update not needed for this bug fix)
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a simple null-check fix, existing tests cover the functionality when sandbox_config is properly configured.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

