### PR TITLE
[trainer] fix: Handle missing reward_fn_key in load_reward_manager

### DIFF
--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -161,7 +161,7 @@ def load_reward_manager(
         tokenizer=tokenizer,
         num_examine=num_examine,
         compute_score=final_compute_score,
-        reward_fn_key=config.data.reward_fn_key,
+        reward_fn_key=getattr(config.data, "reward_fn_key", "data_source"),
         **reward_kwargs,
     )
 


### PR DESCRIPTION
### What does this PR do?
```shell
Error：omegaconf.errors.ConfigAttributeError: Key 'reward_fn_key' is not in struct
```
Fix ConfigAttributeError when `reward_fn_key` is not configured in the data section. The `load_reward_manager` function was incorrectly requiring `config.data.reward_fn_key` to be present, while all reward manager classes are designed to work with a default value of `"data_source"`. This PR adds safe access with proper default value handling to maintain backward compatibility.

Fixes the error:

```javascript
ConfigAttributeError: Key 'reward_fn_key' is not in struct
    full_key: data.reward_fn_key
```

### Checklist Before Starting

- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Tested by running PPO training without `reward_fn_key` configuration in the config file. Previously this would crash with `ConfigAttributeError`, now it works correctly and uses the default value `"data_source"`.

### API and Usage Example

No API changes. This fix allows users to run PPO training without needing to specify `reward_fn_key` configuration:

```python
# This config now works (previously crashed)
data:
  # reward_fn_key: not required anymore, defaults to "data_source"
```

### Design & Code Changes

__File Changed:__ `verl/trainer/ppo/reward.py` Line 164

__Before:__

```python
reward_fn_key=config.data.reward_fn_key,
```

__After:__

```python
reward_fn_key=getattr(config.data, "reward_fn_key", "data_source"),
```

This applies safe config access pattern and uses the same default value (`"data_source"`) that all reward manager classes use.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
