### PR TITLE
[training_utils] fix: improve null handling and type safety in math_dapo

### DIFF
--- a/verl/utils/reward_score/math_dapo.py
+++ b/verl/utils/reward_score/math_dapo.py
@@ -190,9 +190,7 @@ def is_correct_minerva(
     return (pred == gt), pred
 
 
-def is_correct_strict_box(
-    pred: str, gt: str, pause_tokens_index: Optional[list[int]] = None
-) -> tuple[bool, str]:
+def is_correct_strict_box(pred: str, gt: str, pause_tokens_index: Optional[list[int]] = None) -> tuple[bool, str]:
     """Check if the prediction is correct using strict boxed answer criteria.
 
     Args:

--- a/verl/utils/reward_score/math_dapo.py
+++ b/verl/utils/reward_score/math_dapo.py
@@ -219,7 +219,7 @@ def is_correct_strict_box(
 
 def verify(
     solution_str: str, answer: str, strict_box_verify: bool = False, pause_tokens_index: Optional[list[int]] = None
-) -> bool:
+) -> tuple[bool, str]:
     """Verify if the solution is correct.
 
     Args:
@@ -229,7 +229,7 @@ def verify(
         pause_tokens_index: Indices of pause tokens
 
     Returns:
-        True if the solution is correct, False otherwise
+        Tuple of (is_correct, extracted_prediction)
     """
     if strict_box_verify:
         correct, pred = is_correct_strict_box(solution_str, answer, pause_tokens_index)
@@ -244,7 +244,7 @@ def compute_score(
     ground_truth: str,
     strict_box_verify: bool = False,
     pause_tokens_index: Optional[list[int]] = None,
-) -> float:
+) -> dict:
     """Compute the reward score for a solution.
 
     Args:
@@ -254,7 +254,7 @@ def compute_score(
         pause_tokens_index: Indices of pause tokens
 
     Returns:
-        Reward score (1.0 for correct, -1.0 for incorrect)
+        Dictionary containing score (1.0 for correct, -1.0 for incorrect), accuracy, and prediction
     """
     # Limit solution length for efficiency
     solution_str = solution_str[-300:]  # The longest answer in MATH-500 has 159 characters

--- a/verl/utils/reward_score/math_dapo.py
+++ b/verl/utils/reward_score/math_dapo.py
@@ -192,7 +192,7 @@ def is_correct_minerva(
 
 def is_correct_strict_box(
     pred: str, gt: str, pause_tokens_index: Optional[list[int]] = None
-) -> tuple[int, Optional[str]]:
+) -> tuple[bool, str]:
     """Check if the prediction is correct using strict boxed answer criteria.
 
     Args:
@@ -201,7 +201,7 @@ def is_correct_strict_box(
         pause_tokens_index: Indices of pause tokens
 
     Returns:
-        Tuple of (score, extracted_prediction)
+        Tuple of (is_correct, extracted_prediction)
     """
     # Extract the relevant part of the prediction
     if pause_tokens_index is not None:
@@ -212,9 +212,9 @@ def is_correct_strict_box(
 
     # Extract and check the boxed answer
     boxed_pred = last_boxed_only_string(pred)
-    extracted_pred = remove_boxed(boxed_pred) if boxed_pred is not None else None
+    extracted_pred = remove_boxed(boxed_pred) if boxed_pred is not None else "[INVALID]"
 
-    return 1 if (extracted_pred == gt) else -1, extracted_pred
+    return (extracted_pred == gt), extracted_pred
 
 
 def verify(
@@ -233,9 +233,9 @@ def verify(
     """
     if strict_box_verify:
         correct, pred = is_correct_strict_box(solution_str, answer, pause_tokens_index)
-        return correct == 1, pred
+    else:
+        correct, pred = is_correct_minerva(solution_str, answer)
 
-    correct, pred = is_correct_minerva(solution_str, answer)
     return correct, pred
 
 


### PR DESCRIPTION
### What does this PR do?

This PR improves null safety and fixes type annotation inconsistencies in the `math_dapo` reward scoring module.

Current implementation could return null, which leads to training failures as reported in #2704.
The default scorer `is_correct_minerva` already replaces null with `"[INVALID]"` to avoid this problem.
This PR aligns `is_correct_strict_box` with that behavior by substituting null with `"[INVALID]"`, ensuring consistent handling across scorers and preventing unexpected crashes during training.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

For test, replaced the [code](https://github.com/volcengine/verl/blob/2deda718f03cb5b905dd30096ee55cb622905417/verl/utils/reward_score/__init__.py#L62),

`res = math_dapo.compute_score(solution_str, ground_truth)`
with
`res = math_dapo.compute_score(solution_str, ground_truth, strict_box_verify=True)`

* tested with `recipe/dapo/test_dapo_7b_math.sh` and `Qwen/Qwen3-4B` model.


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

- Changed null prediction handling from returning `None` to `"[INVALID]"`, eliminating `Optional[str]` types
- Fixed return type annotations to match actual return values:
   - `is_correct_strict_box`: `tuple[int, Optional[str]]` → `tuple[bool, str]`
   - `verify`: `bool` → `tuple[bool, str]`
   - `compute_score`: `float` → `dict`
- Made `verify` function logic more explicit with clear if-else branching
- Aligned documentation with actual return types

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
