### PR TITLE
[rollout] fix: resolve agent loop config path in multi-node Ray training

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -80,11 +80,16 @@ def resolve_config_path(config_path: str) -> str:
     try:
         import verl
         verl_package_dir = os.path.dirname(verl.__file__)
-        # verl package is at <project_root>/verl, so project root is parent dir
-        project_root = os.path.dirname(verl_package_dir)
-        project_path = os.path.join(project_root, config_path)
-        if os.path.exists(project_path):
-            return project_path
+        # Strategy 1: For development/editable installs.
+        # Assumes a layout like: <project_root>/verl and <project_root>/recipe
+        dev_path = os.path.join(os.path.dirname(verl_package_dir), config_path)
+        if os.path.exists(dev_path):
+            return dev_path
+        # Strategy 2: For standard package installations.
+        # Assumes `recipe` is a data folder inside the `verl` package.
+        install_path = os.path.join(verl_package_dir, config_path)
+        if os.path.exists(install_path):
+            return install_path
     except (ImportError, AttributeError):
         pass  # verl not installed or __file__ not available
     
@@ -93,7 +98,6 @@ def resolve_config_path(config_path: str) -> str:
         f"Agent loop configuration file not found: {config_path}. "
         f"Tried current directory and verl project root."
     )
-
 
 
 class AsyncLLMServerManager:


### PR DESCRIPTION
### What does this PR do?

Fixes agent loop configuration file path resolution in multi-node Ray training environments. 

**Problem:** When running multi-node training, relative paths to agent loop config files fail on remote worker nodes with `FileNotFoundError` because the working directory differs across nodes.

**Solution:** Updated `resolve_config_path()` to dynamically resolve relative paths using the verl package installation location, making it work universally regardless of execution directory.

Related issue: Agent loop config files cannot be loaded in multi-node setups.


### Test

**Testing approach:**
- Tested with 2-node Ray cluster (4 GPUs total)
- Configuration: `recipe/langgraph_agent/example/agent.yaml`
- Results: Config file successfully resolved on all remote nodes

**Before fix:**
```shell
FileNotFoundError: [Errno 2] No such file or directory:
'/dfs/data/recipe/langgraph_agent/example/agent.yaml'
```
**After fix:**
```shell
[DEBUG] Found file at verl base path: /dfs/data/work/verl/recipe/langgraph_agent/example/agent.yaml
Training proceeds successfully
```

### API and Usage Example

**No API changes.** The fix is internal to the `resolve_config_path()` helper function.

Users continue to use relative paths in config as before:
```yaml
rollout:
  agent:
    agent_loop_config_path: "recipe/langgraph_agent/example/agent.yaml"
```
The path resolution now works correctly across all nodes.

### Design & Code Changes

__File Changed:__ `verl/experimental/agent_loop/agent_loop.py`

__Function Modified:__ `resolve_config_path()` 

__Key Changes:__

1. Removed hardcoded path fallbacks
2. Added dynamic path resolution using `verl.__file__` to locate project root
3. Improved error messages with `FileNotFoundError`

__Resolution Strategy:__

1. If absolute path → return as-is
2. Try current working directory
3. Try relative to verl package installation (e.g., `/path/to/verl/recipe/...`)
4. Raise clear error if not found

__Code Diff:__
```python
def resolve_config_path(config_path: str) -> str:
    """Resolve agent loop configuration file path.
    
    In multi-node Ray training, relative paths may not resolve correctly
    because the working directory on remote nodes can differ from the driver node.
    """
    # Return absolute paths unchanged
    if os.path.isabs(config_path):
        return config_path
    
    # Try current working directory first
    cwd_path = os.path.abspath(config_path)
    if os.path.exists(cwd_path):
        return cwd_path
    
    # Try relative to verl project root (where verl package is installed)
    try:
        import verl
        verl_package_dir = os.path.dirname(verl.__file__)
        project_root = os.path.dirname(verl_package_dir)
        project_path = os.path.join(project_root, config_path)
        if os.path.exists(project_path):
            return project_path
    except (ImportError, AttributeError):
        pass
    
    # File not found - raise clear error
    raise FileNotFoundError(
        f"Agent loop configuration file not found: {config_path}. "
        f"Tried current directory and verl project root."
    )

```
### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`

