### PR TITLE
[ci] fix: Remove extra pip config in Ascend dockerfile

### DIFF
--- a/docker/ascend/Dockerfile.ascend_8.2.rc1_a2
+++ b/docker/ascend/Dockerfile.ascend_8.2.rc1_a2
@@ -14,12 +14,6 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 # 4. Install vllm
 RUN ARCH=$(uname -m) && \
     echo "[LOG INFO] Detected architecture: $ARCH" && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        echo "[LOG INFO] Entering x86_64 branch: Setting pip extra index url"; \
-        pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/ https://mirrors.huaweicloud.com/ascend/repos/pypi"; \
-    else \
-        echo "[LOG INFO] Entering aarch64 branch: No extra pip index url set"; \
-    fi && \
     git clone --depth 1 --branch v0.9.1 https://github.com/vllm-project/vllm && \
     cd vllm && \
     VLLM_TARGET_DEVICE=empty pip install -v -e . && \

--- a/docker/ascend/Dockerfile.ascend_8.2.rc1_a3
+++ b/docker/ascend/Dockerfile.ascend_8.2.rc1_a3
@@ -14,12 +14,6 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 # 4. Install vllm
 RUN ARCH=$(uname -m) && \
     echo "[LOG INFO] Detected architecture: $ARCH" && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        echo "[LOG INFO] Entering x86_64 branch: Setting pip extra index url"; \
-        pip config set global.extra-index-url "https://download.pytorch.org/whl/cpu/ https://mirrors.huaweicloud.com/ascend/repos/pypi"; \
-    else \
-        echo "[LOG INFO] Entering aarch64 branch: No extra pip index url set"; \
-    fi && \
     git clone --depth 1 --branch v0.9.1 https://github.com/vllm-project/vllm && \
     cd vllm && \
     VLLM_TARGET_DEVICE=empty pip install -v -e . && \


### PR DESCRIPTION
### What does this PR do?

Scheduled workflow `docker-build-ascend-a2` and `docker-build-ascend-a3` have been cancelled due to timeout for 3+ days, log shows that so many time cost in installing pip packages. Specific pip config maybe the reason. This PR is committed for removing it.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Not related.

### API and Usage Example

Not related.

### Design & Code Changes

Not related.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
