### PR TITLE
[doc] feat: render LaTeX in md docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,7 @@ If possible, please add CI test(s) for your new feature:
 pip install -e .[test]
 
 # Install documentation dependencies
+cd docs
 pip install -r requirements-docs.txt
 
 # Generate HTML docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,13 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
 ]
+
+# MyST-Parser settings
+myst_enable_extensions = [
+    "dollarmath",  # Enables $...$ and $$...$$ syntax
+    "amsmath",  # Enables amsmath environments
+]
+
 # Use Google style docstrings instead of NumPy docstrings.
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False


### PR DESCRIPTION
### What does this PR do?

Add MyST extentions to render LaTeX in md doc.

### Test

<img width="1444" height="917" alt="image" src="https://github.com/user-attachments/assets/8276e523-c81c-4640-9d42-556f1640238f" />
