### PR TITLE
[RFC][BREAKING][misc] refactor: Abstract and unify attention utils

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -109,7 +109,6 @@ Actor/Rollout/Reference Policy
       path: ~/models/deepseek-llm-7b-chat
       external_lib: null
       override_config:
-        attn_implementation: flash_attention_2  # or eager, sdpa - attention implementation override
         model_config: {}
         moe_config:  # Megatron only, can adjust moe configuration
           freeze_moe_router: False  # Megatron only, can freeze moe router (no grad)
@@ -118,6 +117,7 @@ Actor/Rollout/Reference Policy
       trust_remote_code: False
       use_remove_padding: False
     actor:
+      attn_implementation: auto
       strategy: fsdp  # This is for backward-compatibility
       ppo_mini_batch_size: 256
       ppo_micro_batch_size: null # will be deprecated, use ppo_micro_batch_size_per_gpu
@@ -165,6 +165,7 @@ Actor/Rollout/Reference Policy
         # For more flexibility, you can specify the contents to load from the checkpoint.
         load_contents: ${actor_rollout_ref.actor.checkpoint.save_contents}
     ref:
+      attn_implementation: ${actor_rollout_ref.actor.attn_implementation}
       fsdp_config:
         param_offload: False
         wrap_policy:
@@ -177,6 +178,7 @@ Actor/Rollout/Reference Policy
       ulysses_sequence_parallel_size: ${actor_rollout_ref.actor.ulysses_sequence_parallel_size} # sp size
     rollout:
       name: vllm
+      attn_implementation: ${actor_rollout_ref.actor.attn_implementation}
       temperature: 1.0
       top_k: -1 # 0 for hf rollout, -1 for vllm rollout
       top_p: 1
@@ -228,11 +230,7 @@ Actor/Rollout/Reference Policy
   that need to be imported. Used to register models or tokenizers into
   the Huggingface system.
 - ``actor_rollout_ref.model.override_config``: Used to override some of
-  the model's original configurations. Common overrides include:
-  
-  - ``attn_implementation``: Override the attention implementation. Default is ``flash_attention_2``.
-    Supported values: ``flash_attention_2``, ``eager``, ``sdpa``. Use ``eager`` for debugging or
-    compatibility issues. See :ref:`attention-implementation-override` for detailed usage.
+  the model's original configurations
 
 - ``actor_rollout_ref.model.enable_gradient_checkpointing``: FSDP only, decide
   Whether to enable gradient checkpointing for the actor,
@@ -461,6 +459,7 @@ Reward Model
 
    reward_model:
      enable: False
+     attn_implementation: ${actor_rollout_ref.actor.attn_implementation}
      model:
        input_tokenizer: ${actor_rollout_ref.model.path}  # set this to null if the chat template is identical
        path: ~/models/Anomy-RM-v0.1

--- a/recipe/one_step_off_policy/fsdp_workers.py
+++ b/recipe/one_step_off_policy/fsdp_workers.py
@@ -187,6 +187,8 @@ class RolloutWorker(ActorRolloutRefWorker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
+        from verl.utils.attention_utils import configure_attention
+
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
         override_model_config = OmegaConf.to_container(OmegaConf.create(self.config.model.get("override_config", {})))
@@ -205,8 +207,9 @@ class RolloutWorker(ActorRolloutRefWorker):
                 self.tokenizer.chat_template = self.config.model.custom_chat_template
 
         # override model kwargs
+        attn_impl = configure_attention(self.config.model.get("attn_implementation", None))["hf"]
         actor_model_config = AutoConfig.from_pretrained(
-            local_path, trust_remote_code=trust_remote_code, attn_implementation="flash_attention_2"
+            local_path, trust_remote_code=trust_remote_code, attn_implementation=attn_impl
         )
 
         # patch for kimi-vl

--- a/recipe/prime/prime_dp_rm.py
+++ b/recipe/prime/prime_dp_rm.py
@@ -19,12 +19,12 @@ import itertools
 
 import torch
 import torch.distributed
-from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
 from torch import nn, optim
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
+from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.device import get_device_name
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import get_reverse_idx, rearrange_micro_batches

--- a/recipe/spin/fsdp_workers.py
+++ b/recipe/spin/fsdp_workers.py
@@ -337,6 +337,8 @@ class RewardModelWorker(Worker):
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
         from transformers import AutoConfig, AutoModelForTokenClassification
 
+        from verl.utils.attention_utils import configure_attention
+
         # download the checkpoint from hdfs
         local_path = copy_to_local(config.model.path)
 
@@ -362,11 +364,13 @@ class RewardModelWorker(Worker):
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
             model_config.classifier_dropout = 0.0
+
+            attn_impl = configure_attention(self.config.model.get("attn_implementation", None))["hf"]
             reward_module = AutoModelForTokenClassification.from_pretrained(
                 pretrained_model_name_or_path=local_path,
                 config=model_config,
                 torch_dtype=torch.bfloat16,
-                attn_implementation="flash_attention_2",
+                attn_implementation=attn_impl,
                 trust_remote_code=trust_remote_code,
             )
 
@@ -404,8 +408,7 @@ class RewardModelWorker(Worker):
         self.reward_module = self._build_model(config=self.config)
 
     def _forward_micro_batch(self, micro_batch):
-        from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-
+        from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
         from verl.utils.ulysses import gather_outputs_and_unpad, ulysses_pad_and_slice_inputs
 
         with torch.no_grad(), torch.autocast(device_type=get_device_name(), dtype=torch.bfloat16):

--- a/tests/models/test_transformer.py
+++ b/tests/models/test_transformer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import torch
-from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
 from transformers import (
     ApertusConfig,
     AutoModelForCausalLM,
@@ -24,6 +23,7 @@ from transformers import (
     Qwen2Config,
 )
 
+from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
 from verl.utils.torch_functional import log_probs_from_logits_all_rmpad, masked_mean
 

--- a/tests/models/test_transformers_ulysses.py
+++ b/tests/models/test_transformers_ulysses.py
@@ -19,13 +19,13 @@ import pytest
 import torch
 import torch.distributed
 import transformers
-from flash_attn.bert_padding import index_first_axis, rearrange, unpad_input
 from packaging import version
 from torch.distributed import init_device_mesh
 from transformers import AutoModelForCausalLM, LlamaConfig, PretrainedConfig, Qwen2Config
 
 from verl.models.transformers.monkey_patch import apply_monkey_patch
 from verl.protocol import DataProto
+from verl.utils.attention_utils import index_first_axis, rearrange, unpad_input
 from verl.utils.distributed import initialize_global_process_group
 from verl.utils.model import compute_position_id_with_mask, create_random_mask
 from verl.utils.ulysses import (

--- a/tests/special_distributed/test_fsdp_ckpt.py
+++ b/tests/special_distributed/test_fsdp_ckpt.py
@@ -28,8 +28,7 @@ from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2
 
 
 def create_random_input_ids(batch_size, seq_len, vocab_size):
-    from flash_attn.bert_padding import unpad_input
-
+    from verl.utils.attention_utils import unpad_input
     from verl.utils.model import compute_position_id_with_mask, create_random_mask
 
     input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")

--- a/tests/utils/test_activation_offload.py
+++ b/tests/utils/test_activation_offload.py
@@ -30,8 +30,7 @@ from verl.utils.fsdp_utils import MixedPrecisionPolicy, apply_fsdp2, get_fsdp_wr
 
 
 def create_random_input_ids(batch_size, seq_len, vocab_size):
-    from flash_attn.bert_padding import unpad_input
-
+    from verl.utils.attention_utils import unpad_input
     from verl.utils.model import compute_position_id_with_mask, create_random_mask
 
     input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), device="cuda")

--- a/verl/models/llama/megatron/modeling_llama_megatron.py
+++ b/verl/models/llama/megatron/modeling_llama_megatron.py
@@ -217,7 +217,7 @@ class ParallelLlamaForCausalLM(nn.Module):
         )
 
 
-from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input  # noqa: F401, E402
+from verl.utils.attention_utils import index_first_axis, pad_input, unpad_input  # noqa: F401, E402
 
 
 class ParallelLlamaModelRmPad(nn.Module):

--- a/verl/models/qwen2/megatron/layers/parallel_attention.py
+++ b/verl/models/qwen2/megatron/layers/parallel_attention.py
@@ -21,15 +21,8 @@
 import math
 from typing import Optional
 
-import torch.nn.functional as F
-from einops import rearrange
-from transformers.utils import is_flash_attn_2_available
-
-if is_flash_attn_2_available():
-    from flash_attn import flash_attn_varlen_func
-    from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input  # noqa: F401
-
 import torch
+import torch.nn.functional as F
 from flash_attn.layers.rotary import apply_rotary_emb
 from megatron.core import ModelParallelConfig, tensor_parallel
 from megatron.core import parallel_state as mpu
@@ -37,6 +30,7 @@ from torch import nn
 from transformers import Qwen2Config
 
 from verl.models.qwen2.megatron.layers.parallel_linear import QKVParallelLinear
+from verl.utils.attention_utils import flash_attn_varlen_func, index_first_axis, pad_input, unpad_input  # noqa: F401
 from verl.utils.megatron import tensor_parallel as tp_utils
 
 
@@ -300,8 +294,8 @@ def apply_rotary_pos_emb_rmpad(q, k, cos, sin, position_ids, indices, sequence_l
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
 
-    q_embed = index_first_axis(rearrange(q_embed, "b s ... -> (b s) ..."), indices)
-    k_embed = index_first_axis(rearrange(k_embed, "b s ... -> (b s) ..."), indices)
+    q_embed = index_first_axis(q_embed, indices)
+    k_embed = index_first_axis(k_embed, indices)
 
     return q_embed, k_embed
 

--- a/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
+++ b/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
@@ -218,7 +218,7 @@ class ParallelQwen2ForCausalLM(nn.Module):
         )
 
 
-from flash_attn.bert_padding import index_first_axis, pad_input, unpad_input  # noqa: F401, E402
+from verl.utils.attention_utils import index_first_axis, pad_input, unpad_input  # noqa: F401, E402
 
 
 class ParallelQwen2ModelRmPad(nn.Module):

--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import itertools
 import logging
 import os
@@ -21,15 +20,18 @@ from typing import Optional
 
 import torch
 import torch.distributed as dist
-from transformers.modeling_flash_attention_utils import _flash_attention_forward, fa_peft_integration_check
 from transformers.models.glm4v.modeling_glm4v import (
     Glm4vCausalLMOutputWithPast,
     Glm4vForConditionalGeneration,
     Glm4vTextAttention,
 )
-from transformers.utils import is_flash_attn_2_available, is_flash_attn_greater_or_equal_2_10
 
-from verl.utils.device import is_npu_available
+from verl.utils.attention_utils import (
+    _flash_attention_forward,
+    fa_peft_integration_check,
+    flash_attn_supports,
+    flash_attn_varlen_func,
+)
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -42,21 +44,8 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
-if is_flash_attn_2_available():
-    from flash_attn import flash_attn_func, flash_attn_varlen_func
-
-    _flash_supports_window_size = "window_size" in inspect.signature(flash_attn_func).parameters
-    _flash_supports_deterministic = "deterministic" in inspect.signature(flash_attn_func).parameters
-    _flash_use_top_left_mask = not is_flash_attn_greater_or_equal_2_10()
-
-if is_npu_available:
-    from transformers.integrations.npu_flash_attention import npu_flash_attn_func as flash_attn_func
-    from transformers.integrations.npu_flash_attention import npu_flash_attn_varlen_func as flash_attn_varlen_func
-    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
-
-    _flash_supports_window_size = "window_size" in inspect.signature(flash_attn_func).parameters
-    _flash_supports_deterministic = "deterministic" in inspect.signature(flash_attn_func).parameters
-    _flash_use_top_left_mask = flash_attn_supports_top_left_mask()
+_flash_use_top_left_mask = flash_attn_supports("top_left_mask")
+_flash_supports_deterministic = flash_attn_supports("deterministic")
 
 _flash_deterministic_enabled = os.getenv("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
 

--- a/verl/models/transformers/kimi_vl.py
+++ b/verl/models/transformers/kimi_vl.py
@@ -17,12 +17,9 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward
 
 from verl.models.transformers.monkey_patch import is_transformers_version_in_range
-
-# Import compatibility wrapper for flash_attn_supports_top_left_mask
-from verl.utils.transformers_compat import flash_attn_supports_top_left_mask
+from verl.utils.attention_utils import _flash_attention_forward, flash_attn_supports
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -172,7 +169,7 @@ def _ulysses_flash_attn_forward(
         dropout=dropout_rate,
         sliding_window=None,
         is_causal=self.is_causal,
-        use_top_left_mask=flash_attn_supports_top_left_mask(),
+        use_top_left_mask=flash_attn_supports("top_left_mask"),
         position_ids=position_ids,  # important: pass position ids
         softmax_scale=self.softmax_scale,
     )

--- a/verl/models/transformers/llama.py
+++ b/verl/models/transformers/llama.py
@@ -23,12 +23,10 @@ else:
     pass
 
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from transformers.utils import logging
 
-# Import compatibility wrapper for flash_attn_supports_top_left_mask
-from verl.utils.transformers_compat import flash_attn_supports_top_left_mask
+from verl.utils.attention_utils import _flash_attention_forward, flash_attn_supports
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -149,7 +147,7 @@ def llama_flash_attn_forward(
         position_ids=position_ids,
         dropout=dropout_rate,
         sliding_window=getattr(self, "sliding_window", None),
-        use_top_left_mask=flash_attn_supports_top_left_mask(),
+        use_top_left_mask=flash_attn_supports("top_left_mask"),
         is_causal=self.is_causal,
         **kwargs,
     )

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -20,9 +20,9 @@ from types import SimpleNamespace
 from typing import Optional
 
 import torch
-from transformers.modeling_flash_attention_utils import _flash_attention_forward
 from transformers.modeling_utils import PreTrainedModel
 
+from verl.utils.attention_utils import _flash_attention_forward
 from verl.utils.import_utils import is_trl_available
 from verl.utils.transformers_compat import is_transformers_version_in_range
 from verl.utils.ulysses import (

--- a/verl/models/transformers/qwen2.py
+++ b/verl/models/transformers/qwen2.py
@@ -16,12 +16,10 @@ from typing import Callable, Optional
 
 import torch
 from transformers.cache_utils import Cache
-from transformers.modeling_flash_attention_utils import _flash_attention_forward
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 from transformers.utils import logging
 
-# Import compatibility wrapper for flash_attn_supports_top_left_mask
-from verl.utils.transformers_compat import flash_attn_supports_top_left_mask
+from verl.utils.attention_utils import _flash_attention_forward, flash_attn_supports
 from verl.utils.ulysses import (
     gather_heads_scatter_seq,
     gather_seq_scatter_heads,
@@ -139,7 +137,7 @@ def qwen2_flash_attn_forward(
         dropout=dropout_rate,
         sliding_window=sliding_window,
         is_causal=self.is_causal,
-        use_top_left_mask=flash_attn_supports_top_left_mask(),
+        use_top_left_mask=flash_attn_supports("top_left_mask"),
     )
 
     # use full_q_len to reshape

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -77,6 +77,7 @@ actor_rollout_ref:
     entropy_coeff: 0
     use_kl_loss: false
     use_torch_compile: true
+    attn_implementation: auto
     kl_loss_coef: 0.001
     kl_loss_type: low_var_kl
     ppo_epochs: 1
@@ -120,6 +121,7 @@ actor_rollout_ref:
   ref:
     strategy: megatron
     use_torch_compile: ${oc.select:actor_rollout_ref.actor.use_torch_compile,true}
+    attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
     log_prob_micro_batch_size: null
     log_prob_micro_batch_size_per_gpu: null
     log_prob_use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
@@ -174,6 +176,7 @@ actor_rollout_ref:
   rollout:
     _target_: verl.workers.config.RolloutConfig
     name: ???
+    attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
     mode: sync
     temperature: 1.0
     top_k: -1
@@ -363,6 +366,7 @@ critic:
   _target_: verl.workers.config.McoreCriticConfig
   rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
   strategy: megatron
+  attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
   enable: null
   model:
     path: ~/models/deepseek-llm-7b-chat
@@ -426,6 +430,7 @@ reward_model:
   n_gpus_per_node: 0
   nnodes: 0
   strategy: megatron
+  attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
   model:
     input_tokenizer: ${actor_rollout_ref.model.path}
     path: ~/models/FsfairX-LLaMA3-RM-v0.1

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -65,6 +65,7 @@ actor_rollout_ref:
     entropy_coeff: 0
     use_kl_loss: false
     use_torch_compile: true
+    attn_implementation: auto
     kl_loss_coef: 0.001
     kl_loss_type: low_var_kl
     ppo_epochs: 1
@@ -111,6 +112,7 @@ actor_rollout_ref:
   ref:
     strategy: ${actor_rollout_ref.actor.strategy}
     use_torch_compile: ${oc.select:actor_rollout_ref.actor.use_torch_compile,true}
+    attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
     log_prob_micro_batch_size: null
     log_prob_micro_batch_size_per_gpu: null
     log_prob_use_dynamic_bsz: ${oc.select:actor_rollout_ref.actor.use_dynamic_bsz,false}
@@ -165,6 +167,7 @@ actor_rollout_ref:
   rollout:
     _target_: verl.workers.config.RolloutConfig
     name: ???
+    attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
     mode: sync
     temperature: 1.0
     top_k: -1
@@ -365,6 +368,7 @@ critic:
   _target_: verl.workers.config.FSDPCriticConfig
   rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
   strategy: fsdp
+  attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
   enable: null
   ppo_mini_batch_size: ${oc.select:actor_rollout_ref.actor.ppo_mini_batch_size,256}
   ppo_micro_batch_size: null
@@ -419,6 +423,7 @@ reward_model:
   n_gpus_per_node: 0
   nnodes: 0
   strategy: fsdp
+  attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
   model:
     input_tokenizer: ${actor_rollout_ref.model.path}
     path: ~/models/FsfairX-LLaMA3-RM-v0.1

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -81,6 +81,9 @@ use_kl_loss: false
 # oc.select: the default val for ref.use_torch_compile
 use_torch_compile: true
 
+# Attention backend for the actor. Defaults to auto; can be overridden per-role.
+attn_implementation: auto
+
 # KL loss coefficient when use_kl_loss is enabled. For GRPO
 kl_loss_coef: 0.001
 

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -7,6 +7,9 @@ rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
 # fsdp or fsdp2 strategy used for critic model training
 strategy: ???
 
+# Attention backend for critic. Defaults to actor's value, otherwise auto.
+attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
+
 # whether to enable the critic worker.
 # by default it is only enabled if advantage estimator is gae
 # set it to True manually if you always want to enable critic worker

--- a/verl/trainer/config/ref/ref.yaml
+++ b/verl/trainer/config/ref/ref.yaml
@@ -5,6 +5,9 @@ strategy: ${actor_rollout_ref.actor.strategy}
 # same as actor_rollout_ref.actor.use_torch_compile if it exists, otherwise 1
 use_torch_compile: ${oc.select:actor_rollout_ref.actor.use_torch_compile,true}
 
+# Attention backend for the reference model. Defaults to actor's value, otherwise auto.
+attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
+
 # [Will be deprecated, use log_prob_micro_batch_size_per_gpu]
 # The batch size for one forward pass in the computation of log_prob. Global batch size.
 log_prob_micro_batch_size: null

--- a/verl/trainer/config/reward_model/reward_model.yaml
+++ b/verl/trainer/config/reward_model/reward_model.yaml
@@ -15,6 +15,9 @@ nnodes: 0
 # FSDP strategy: "fsdp" or "fsdp2"
 strategy: ???
 
+# Attention backend for reward model. Defaults to actor's value, otherwise auto.
+attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
+
 # model config for reward scoring
 model:
 

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -4,6 +4,9 @@ _target_: verl.workers.config.RolloutConfig
 # actor_rollout_ref.rollout.name: hf/vllm/sglang. The default value will be removed in the future
 name: ???
 
+# Attention backend for rollout engine (SGLang/vLLM/HF). Defaults to actor's value, otherwise auto.
+attn_implementation: ${oc.select:actor_rollout_ref.actor.attn_implementation,auto}
+
 # sync: LLM, async: AsyncLLM
 mode: sync
 

--- a/verl/utils/attention_utils.py
+++ b/verl/utils/attention_utils.py
@@ -12,89 +12,302 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable
+import importlib
+import os
+from functools import cache
+from typing import Callable, Optional
 
-_index_first_axis, _pad_input, _rearrange, _unpad_input = None, None, None, None
+from transformers.utils import (
+    is_flash_attn_2_available,
+    is_flash_attn_3_available,
+    is_torch_flex_attn_available,
+    logging,
+)
+
+_logger = logging.get_logger(__name__)
+
+_ATTN_FUNCS_MAP: Optional[dict[str, Callable]] = None
+
+_HF_VALID_IMPLS = {
+    "flash_attention_3",
+    "flash_attention_2",
+    "flex_attention",
+    "sdpa",
+    "eager",
+}
+
+ENV_ATTN_IMPLEMENTATION = os.getenv("VERL_ATTN_IMPLEMENTATION")
+
+_FA_REQUIRED = (
+    "_index_first_axis",
+    "lazy_import_flash_attention",
+)
+
+_FA_OPTIONAL = (
+    "_flash_attention_forward",
+    "fa_peft_integration_check",
+    "flash_attn_supports_top_left_mask",
+)
 
 
-def _get_attention_functions() -> tuple[Callable, Callable, Callable, Callable]:
-    """Dynamically import attention functions based on available hardware."""
+def _normalize(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if v in {"fa", "fa2", "flash2"}:
+        return "flash_attention_2"
+    if v in {"fa3", "flash3"}:
+        return "flash_attention_3"
+    if v in {"fi", "flashinfer", "flash_infer"}:
+        return "flashinfer"
+    if v in {"flex", "flex_attn"}:
+        return "flex_attention"
+    return v
 
-    from verl.utils.device import is_cuda_available, is_npu_available
 
-    global _index_first_axis, _pad_input, _rearrange, _unpad_input
+@cache
+def resolve_attn_implementation(preferred: Optional[str] = None, *, for_vision: bool = False) -> str:
+    if preferred not in {"auto", *_HF_VALID_IMPLS}:
+        _logger.warning_once(f"Unknown attention implementation '{preferred}'. Using auto detection instead.")
+        preferred = "auto"
+    elif preferred in {*_HF_VALID_IMPLS}:
+        if preferred == "flash_attention_3" and not is_flash_attn_3_available():
+            _logger.warning_once("Requested flash_attention_3 but it's not available. Using auto detection instead.")
+            preferred = "auto"
+        elif preferred == "flash_attention_2" and not is_flash_attn_2_available():
+            _logger.warning_once("Requested flash_attention_2 but it's not available. Using auto detection instead.")
+            preferred = "auto"
+        elif preferred == "flex_attention" and not is_torch_flex_attn_available():
+            _logger.warning_once("Requested flex_attention but it's not available. Using auto detection instead.")
+            preferred = "auto"
+        else:
+            return preferred
+    if preferred == "auto":
+        if is_flash_attn_3_available():
+            return "flash_attention_3"
+        if is_flash_attn_2_available():
+            return "flash_attention_2"
+        if is_torch_flex_attn_available():
+            return "flex_attention"
+    return "sdpa"
 
-    if is_cuda_available:
-        from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
-    elif is_npu_available:
-        from verl.utils.npu_utils import index_first_axis, pad_input, rearrange, unpad_input
 
-    _index_first_axis, _pad_input, _rearrange, _unpad_input = index_first_axis, pad_input, rearrange, unpad_input
+@cache
+def resolve_sglang_attention_backend(preferred: Optional[str] = None) -> str:
+    if preferred in ("flash_attention_3", "flash_attention_2", "auto"):
+        return "fa3"
+    if preferred == "flashinfer":
+        return "flashinfer"
+    if preferred == "flex_attention":
+        return "flex_attention"
+    if preferred in ("sdpa", "eager"):
+        return "torch_native"
+    return "fa3"
 
-    return _index_first_axis, _pad_input, _rearrange, _unpad_input
+
+@cache
+def resolve_vllm_attention_backend(preferred: Optional[str] = None) -> Optional[str]:
+    if preferred in ("flash_attention_3", "flash_attention_2"):
+        return "FLASH_ATTN"
+    if preferred == "flex_attention":
+        return "FLEX_ATTENTION"
+    if preferred in ("sdpa", "eager"):
+        return "TORCH_SDPA"
+    if preferred == "flashinfer":
+        return "FLASHINFER"
+    return None
+
+
+def configure_attention(
+    preferred: Optional[str] = None,
+    *,
+    sglang_engine_kwargs: Optional[dict] = None,
+    set_vllm_env: bool = False,
+    for_vision: bool = False,
+) -> dict[str, Optional[str]]:
+    """
+    Configure attention backend across HF, SGLang and vLLM
+
+    - Where to set:
+      - Pass `preferred` here, or set env `VERL_ATTN_IMPLEMENTATION`.
+      - Prefer per-role config: `actor.attn_implementation`, `rollout.attn_implementation`,
+        `ref.attn_implementation`, `critic.attn_implementation`, `reward_model.attn_implementation`
+    - Legal values (case-insensitive):
+      - 'flash_attention_3', 'flash_attention_2', 'flex_attention', 'sdpa', 'eager', 'auto'.
+      - 'flashinfer' is supported for SGLang/vLLM only.
+    - Returns dict with keys: 'hf', 'sglang', 'vllm'.
+      If requested, also fills `sglang_engine_kwargs['attention_backend']` and sets `VLLM_ATTENTION_BACKEND`
+    """
+    # preferred (minus auto) > ENV_ATTN_IMPLEMENTATION > auto
+    if (not (preferred_norm := _normalize(preferred))) or preferred_norm == "auto":
+        preferred_norm = _normalize(ENV_ATTN_IMPLEMENTATION) or "auto"
+
+    hf_impl = (
+        preferred_norm
+        if ((not _has_assigned_gpu()) and preferred_norm in _HF_VALID_IMPLS and preferred_norm != "auto")
+        else resolve_attn_implementation(preferred_norm, for_vision=for_vision)
+    )
+    sglang_backend = resolve_sglang_attention_backend(preferred_norm)
+    vllm_backend = resolve_vllm_attention_backend(preferred_norm)
+
+    if (
+        preferred_norm is not None
+        and sglang_engine_kwargs is not None
+        and "attention_backend" not in sglang_engine_kwargs
+    ):
+        sglang_engine_kwargs["attention_backend"] = sglang_backend
+
+    if set_vllm_env and vllm_backend is not None and not os.getenv("VLLM_ATTENTION_BACKEND"):
+        os.environ["VLLM_ATTENTION_BACKEND"] = vllm_backend
+
+    return {"hf": hf_impl, "sglang": (sglang_backend if preferred_norm is not None else None), "vllm": vllm_backend}
+
+
+def _get_attention_functions() -> dict[str, Callable]:
+    """Resolve attention helpers via Transformers + einops and return a cached mapping.
+
+    - "index_first_axis", "pad_input", "rearrange", "unpad_input":
+      backend-agnostic helpers resolved via Transformers (FA3/FA2/NPU or PyTorch fallbacks)
+      and einops for tensor rearrangements.
+    - `_FA_OPTIONAL` (e.g. "_flash_attention_forward", "fa_peft_integration_check",
+      "flash_attn_supports_top_left_mask"):
+      HF shims that raise ImportError at call time if unavailable, preserving lazy semantics.
+
+    - required symbols listed in `_FA_REQUIRED` are resolved eagerly and must be present
+    - optional symbols listed in `_FA_OPTIONAL` resolve to call-time raising stubs if missing
+
+    The result is cached on first call.
+    """
+    global _ATTN_FUNCS_MAP
+
+    if _ATTN_FUNCS_MAP is not None:
+        return _ATTN_FUNCS_MAP
+
+    try:
+        fa_utils = importlib.import_module("transformers.modeling_flash_attention_utils")
+    except Exception as e:
+        raise ImportError("transformers is required for attention utilities. Please install `transformers`.") from e
+    try:
+        from einops import rearrange as _einops_rearrange
+    except Exception as e:
+        raise ImportError("einops is required for tensor rearrangements. Please `pip install einops`.") from e
+
+    def _get_symbol(name: str, *, required: bool) -> Callable:
+        sym = getattr(fa_utils, name, None)
+        if sym is None:
+            if required:
+                raise ImportError(f"Required symbol '{name}' not found in transformers.modeling_flash_attention_utils")
+
+            def _raise(*_a, **_k):
+                raise ImportError(f"Symbol '{name}' not found in transformers.modeling_flash_attention_utils")
+
+            return _raise
+        return sym
+
+    resolved_required = {name: _get_symbol(name, required=True) for name in _FA_REQUIRED}
+    resolved_optional = {name: _get_symbol(name, required=False) for name in _FA_OPTIONAL}
+
+    # Select appropriate pad/unpad pair and kwargs processor based on available backends (FA3/FA2/NPU)
+    (flash_fn, _flash_varlen_fn, pad_input, unpad_input), process_flash_kwargs_fn = resolved_required[
+        "lazy_import_flash_attention"
+    ](implementation=None)
+    index_first_axis_fn = resolved_required["_index_first_axis"]
+
+    _ATTN_FUNCS_MAP = {
+        "index_first_axis": index_first_axis_fn,
+        "pad_input": pad_input,
+        "rearrange": _einops_rearrange,
+        "unpad_input": unpad_input,
+        "flash_attn_varlen_func": _flash_varlen_fn,
+        "process_flash_kwargs_fn": process_flash_kwargs_fn,
+    }
+    for _name in _FA_OPTIONAL:
+        _ATTN_FUNCS_MAP[_name] = resolved_optional[_name]
+
+    return _ATTN_FUNCS_MAP
+
+
+def _flash_attention_forward(*args, **kwargs):
+    return _get_attention_functions()["_flash_attention_forward"](*args, **kwargs)
+
+
+def flash_attn_varlen_func(*args, **kwargs):
+    return _get_attention_functions()["flash_attn_varlen_func"](*args, **kwargs)
+
+
+def fa_peft_integration_check(*args, **kwargs):
+    return _get_attention_functions()["fa_peft_integration_check"](*args, **kwargs)
 
 
 def index_first_axis(*args, **kwargs):
-    """
-    Unified entry point for `index_first_axis` across CUDA and NPU backends.
-
-    Dynamically dispatches to the appropriate device-specific implementation:
-      - On CUDA: `flash_attn.bert_padding.index_first_axis`
-      - On NPU: `transformers.integrations.npu_flash_attention.index_first_axis`
-        (falls back to `transformers.modeling_flash_attention_utils._index_first_axis`
-        in newer versions of transformers).
-
-    Users can call this function directly without worrying about the underlying device.
-    """
-    func, *_ = _get_attention_functions()
-    return func(*args, **kwargs)
+    return _get_attention_functions()["index_first_axis"](*args, **kwargs)
 
 
 def pad_input(*args, **kwargs):
-    """
-    Unified entry point for `pad_input` across CUDA and NPU backends.
-
-    Dynamically dispatches to the appropriate device-specific implementation:
-      - On CUDA: `flash_attn.bert_padding.pad_input`
-      - On NPU: `transformers.integrations.npu_flash_attention.pad_input`
-        (falls back to `transformers.modeling_flash_attention_utils._pad_input`
-        in newer versions of transformers).
-
-    Users can call this function directly without worrying about the underlying device.
-    """
-    _, func, *_ = _get_attention_functions()
-    return func(*args, **kwargs)
+    return _get_attention_functions()["pad_input"](*args, **kwargs)
 
 
 def rearrange(*args, **kwargs):
-    """
-    Unified entry point for `rearrange` across CUDA and NPU backends.
-
-    Dynamically dispatches to the appropriate device-specific implementation:
-      - On CUDA: `flash_attn.bert_padding.rearrange`
-      - On NPU: `transformers.integrations.npu_flash_attention.rearrange`
-        (falls back to `einops.rearrange` if no dedicated NPU implementation exists).
-
-    Users can call this function directly without worrying about the underlying device.
-    """
-    *_, func, _ = _get_attention_functions()
-    return func(*args, **kwargs)
+    return _get_attention_functions()["rearrange"](*args, **kwargs)
 
 
 def unpad_input(*args, **kwargs):
-    """
-    Unified entry point for `unpad_input` across CUDA and NPU backends.
-
-    Dynamically dispatches to the appropriate device-specific implementation:
-      - On CUDA: `flash_attn.bert_padding.unpad_input`
-      - On NPU: `transformers.integrations.npu_flash_attention.unpad_input`
-        (falls back to `transformers.modeling_flash_attention_utils._unpad_input`
-        in newer versions of transformers).
-
-    Users can call this function directly without worrying about the underlying device.
-    """
-    *_, func = _get_attention_functions()
-    return func(*args, **kwargs)
+    return _get_attention_functions()["unpad_input"](*args, **kwargs)
 
 
-__all__ = ["index_first_axis", "pad_input", "rearrange", "unpad_input"]
+def flash_attn_supports(feature: str) -> bool:
+    feature_norm = (feature or "").strip().lower()
+    if feature_norm in {"top_left_mask", "top-left-mask", "top_left"}:
+        return _get_attention_functions()["flash_attn_supports_top_left_mask"]()
+
+    process_fn = _get_attention_functions().get("process_flash_kwargs_fn")
+    if process_fn is None:
+        return False
+
+    try:
+        base = dict(query_length=1, key_length=1, is_causal=True, dropout=0.0)
+        probe = {}
+        if feature_norm in {"window_size", "sliding_window", "sliding-window"}:
+            probe["sliding_window"] = 16
+        elif feature_norm == "deterministic":
+            probe["deterministic"] = True
+        elif feature_norm == "softcap":
+            probe["softcap"] = 1.0
+        else:
+            return False
+
+        flash_kwargs = process_fn(**base, **probe)
+        if feature_norm in {"window_size", "sliding_window", "sliding-window"}:
+            return "window_size" in flash_kwargs
+        return feature_norm in flash_kwargs
+    except Exception:
+        return False
+
+
+def _has_assigned_gpu() -> bool:
+    try:
+        import ray
+
+        gpu_ids = ray.get_gpu_ids()
+        if isinstance(gpu_ids, list | tuple) and len(gpu_ids) > 0:
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+__all__ = [
+    "index_first_axis",
+    "pad_input",
+    "rearrange",
+    "unpad_input",
+    "_flash_attention_forward",
+    "flash_attn_varlen_func",
+    "flash_attn_supports",
+    "fa_peft_integration_check",
+    "resolve_attn_implementation",
+    "resolve_sglang_attention_backend",
+    "resolve_vllm_attention_backend",
+    "configure_attention",
+]

--- a/verl/utils/megatron/pipeline_parallel.py
+++ b/verl/utils/megatron/pipeline_parallel.py
@@ -20,7 +20,7 @@ from .sequence_parallel import pad_to_sequence_parallel
 
 
 def compute_transformers_input_shapes(batches, meta_info):
-    from flash_attn.bert_padding import unpad_input  # flash 2 is a must for Megatron
+    from verl.utils.attention_utils import unpad_input
 
     # pre-compute input shapes for each micro-batch at each pp stage
     input_shapes = []

--- a/verl/utils/megatron/tensor_parallel.py
+++ b/verl/utils/megatron/tensor_parallel.py
@@ -170,7 +170,7 @@ def vocab_parallel_log_probs_from_logits_response_rmpad(input_ids, attention_mas
         response_length: int
 
     """
-    from flash_attn.bert_padding import pad_input, unpad_input
+    from verl.utils.attention_utils import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -619,12 +619,15 @@ def patch_valuehead_model(model) -> None:
 def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code):
     from transformers import AutoModelForCausalLM, AutoModelForTokenClassification, AutoModelForVision2Seq
 
+    from verl.utils.attention_utils import configure_attention
+
     try:
+        attn_impl = configure_attention(getattr(model_config, "attn_implementation", None))["hf"]
         model = AutoModelForTokenClassification.from_pretrained(
             pretrained_model_name_or_path=local_path,
             torch_dtype=torch_dtype,
             config=model_config,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_impl,
             trust_remote_code=trust_remote_code,
         )
         return model
@@ -642,11 +645,13 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
         module_class = AutoModelForVision2Seq
     else:
         module_class = AutoModelForCausalLM
+
+    attn_impl = configure_attention(getattr(model_config, "attn_implementation", None))["hf"]
     ori_model = module_class.from_pretrained(
         pretrained_model_name_or_path=local_path,
         torch_dtype=torch_dtype,
         config=model_config,
-        attn_implementation="flash_attention_2",
+        attn_implementation=attn_impl,
         trust_remote_code=trust_remote_code,
     )
     model = AutoModelForCausalLMWithValueHead.from_pretrained(ori_model)

--- a/verl/utils/npu_utils.py
+++ b/verl/utils/npu_utils.py
@@ -121,7 +121,7 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
     # index with integer indices. Moreover, torch's index is a bit slower than it needs to be,
     # so we write custom forward and backward to make it a bit faster.
     return (
-        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
+        index_first_axis(hidden_states, indices),
         indices,
         cu_seqlens,
         max_seqlen_in_batch,

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -448,7 +448,7 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
         logits_rmpad: [total_nnz, vocab_size]
         response_length: int
     """
-    from flash_attn.bert_padding import pad_input, unpad_input
+    from verl.utils.attention_utils import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
     input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
@@ -477,7 +477,7 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
         seqlen: int
         response_length: int
     """
-    from flash_attn.bert_padding import pad_input
+    from verl.utils.attention_utils import pad_input
 
     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # transpose back to [total_nnz, 1]
     input_ids_rmpad = input_ids_rmpad.squeeze(-1)

--- a/verl/utils/transformers_compat.py
+++ b/verl/utils/transformers_compat.py
@@ -22,19 +22,6 @@ from typing import Optional
 
 from packaging import version
 
-# Handle version compatibility for flash_attn_supports_top_left_mask
-# This function was added in newer versions of transformers
-try:
-    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
-except ImportError:
-    # For older versions of transformers that don't have this function
-    # Default to False as a safe fallback for older versions
-    def flash_attn_supports_top_left_mask():
-        """Fallback implementation for older transformers versions.
-        Returns False to disable features that require this function.
-        """
-        return False
-
 
 @lru_cache
 def is_transformers_version_in_range(min_version: Optional[str] = None, max_version: Optional[str] = None) -> bool:

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -116,14 +116,12 @@ class DataParallelPPOActor(BasePPOActor):
                 # unpad the position_ids to align the rotary
                 if position_ids.dim() == 3:
                     position_ids_rmpad = (
-                        index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices)
+                        index_first_axis(rearrange(position_ids, "c b s ... -> b s c ..."), indices)
                         .transpose(0, 1)
                         .unsqueeze(1)
                     )  # (4, bsz, seqlen) -> (4, 1, bsz * seqlen)
                 else:
-                    position_ids_rmpad = index_first_axis(
-                        rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices
-                    ).transpose(0, 1)
+                    position_ids_rmpad = index_first_axis(position_ids.unsqueeze(-1), indices).transpose(0, 1)
 
                 if "image_bound" in multi_modal_inputs:
                     from verl.utils.dataset.vision_utils import process_multi_modal_inputs_for_minicpmo

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -108,6 +108,7 @@ class ActorConfig(BaseConfig):
     entropy_coeff: float = 0
     use_kl_loss: bool = False
     use_torch_compile: bool = True
+    attn_implementation: str = "auto"
     kl_loss_coef: float = 0.001
     kl_loss_type: str = "low_var_kl"
     ppo_epochs: int = 1

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -86,6 +86,7 @@ class CriticConfig(BaseConfig):
     model_config: HFModelConfig = None
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
     profiler: ProfilerConfig = field(default_factory=ProfilerConfig)
+    attn_implementation: str = "auto"
 
     def __post_init__(self):
         """Validate critic configuration parameters."""

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -113,6 +113,7 @@ class RolloutConfig(BaseConfig):
     response_length: int = 512
 
     dtype: str = "bfloat16"
+    attn_implementation: str = "auto"
     gpu_memory_utilization: float = 0.5
     ignore_eos: bool = False
     enforce_eager: bool = True

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -75,14 +75,12 @@ class DataParallelPPOCritic(BasePPOCritic):
                 # unpad the position_ids to align the rotary
                 if position_ids.dim() == 3:
                     position_ids_rmpad = (
-                        index_first_axis(rearrange(position_ids, "c b s ... -> (b s) c ..."), indices)
+                        index_first_axis(rearrange(position_ids, "c b s ... -> b s c ..."), indices)
                         .transpose(0, 1)
                         .unsqueeze(1)
                     )  # (4, bsz, seqlen) -> (4, 1, bsz * seqlen)
                 else:
-                    position_ids_rmpad = index_first_axis(
-                        rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices
-                    ).transpose(0, 1)
+                    position_ids_rmpad = index_first_axis(position_ids.unsqueeze(-1), indices).transpose(0, 1)
 
                 # pad and slice the inputs if sp > 1
                 if self.ulysses_sequence_parallel_size > 1:

--- a/verl/workers/roles/utils/padding.py
+++ b/verl/workers/roles/utils/padding.py
@@ -16,15 +16,7 @@ import torch
 from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
-from verl.utils.device import (
-    is_cuda_available,
-    is_npu_available,
-)
-
-if is_cuda_available:
-    from flash_attn.bert_padding import pad_input, unpad_input
-elif is_npu_available:
-    from transformers.integrations.npu_flash_attention import pad_input, unpad_input
+from verl.utils.attention_utils import pad_input, unpad_input
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -398,6 +398,8 @@ class SGLangRollout(BaseRollout):
             self.config.multi_turn.max_user_turns = self.config.max_model_len // 3
 
     def _init_inference_engine(self, trust_remote_code, actor_module, port):
+        from verl.utils.attention_utils import configure_attention
+
         # initialize the inference engine
         nnodes = -(-self._tp_size // len(self.visible_devices_set))
         if nnodes > 1:
@@ -421,8 +423,9 @@ class SGLangRollout(BaseRollout):
         engine_kwargs = self.config.get("engine_kwargs", {}).get("sglang", {}) or {}
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
 
-        # attention backend will be changed to fa3 if not specified
-        attention_backend = engine_kwargs.pop("attention_backend", None)
+        preferred_attn = self.config.get("attn_implementation", None)
+        configure_attention(preferred=preferred_attn, sglang_engine_kwargs=engine_kwargs)
+        backend = engine_kwargs.get("attention_backend") or "fa3"
         max_running_requests = self.config.get("max_num_seqs", None)
 
         try:
@@ -433,7 +436,6 @@ class SGLangRollout(BaseRollout):
 
         if self.config.mode == "async" and not self.config.skip_tokenizer_init:
             raise ValueError("async mode requires skip_tokenizer_init to be True")
-        backend = attention_backend if attention_backend is not None else "fa3"
         sglang_port = int(os.getenv("SGLANG_PORT", "30000")) + (dist.get_rank() * 2)
         if effective_first:
             os.environ["SGLANG_BLOCK_NONZERO_RANK_CHILDREN"] = "0"

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -192,6 +192,8 @@ class vLLMHttpServerBase:
         return self._server_address, self._server_port
 
     async def launch_server(self, master_address: str = None, master_port: int = None):
+        from verl.utils.attention_utils import configure_attention
+
         if self.node_rank != 0:
             assert master_address and master_port, "non-master node should provide master address and port"
             self._master_address = master_address
@@ -278,6 +280,9 @@ class vLLMHttpServerBase:
 
         if self.replica_rank == 0:
             pprint(server_args)
+
+        preferred_attn = self.config.get("attn_implementation", None)
+        configure_attention(preferred=preferred_attn, set_vllm_env=True)
 
         CMD_MODULES = [vllm.entrypoints.cli.serve]
         parser = FlexibleArgumentParser(description="vLLM CLI")

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -130,6 +130,7 @@ class vLLMRollout(BaseRollout):
         device_mesh: DeviceMesh,
     ):
         super().__init__(config, model_config, device_mesh)
+        from verl.utils.attention_utils import configure_attention
 
         if config.layered_summon:
             self.sleep_level = 1
@@ -212,6 +213,9 @@ class vLLMRollout(BaseRollout):
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         if config.get("limit_images", None):  # support for multi-image data
             engine_kwargs["limit_mm_per_prompt"] = {"image": config.get("limit_images")}
+
+        preferred_attn = config.get("attn_implementation", None)
+        configure_attention(preferred=preferred_attn, set_vllm_env=True)
 
         compilation_config = {}
 


### PR DESCRIPTION
Abstract and unify attention utilities and backend for Transformers, Megatron, vLLM, and SGLang

```yaml
# Example (per-role)
actor:
  attn_implementation: auto   # auto|flash_attention_3|flash_attention_2|flex_attention|sdpa|eager
rollout:
  attn_implementation: ${actor.attn_implementation} # auto|flash_attention_3|flash_attention_2|flashinfer|flex_attention|sdpa|eager
ref:
  attn_implementation: ${actor.attn_implementation}
critic:
  attn_implementation: auto
reward_model:
  attn_implementation: auto
# Global override, optional
# VERL_ATTN_IMPLEMENTATION=flash_attention_3
```
- Priority: per-role (minus auto) > env `VERL_ATTN_IMPLEMENTATION`> auto
- Default `auto` (`flash_attention_3` > `flash_attention_2` > `flex_attention` > `sdpa` > `eager`)
- **Deprecated**: `actor_rollout_ref.model.override_config.attn_implementation`, use per-role