### PR TITLE
[recipe] fix: dynamic recursion_limit and error handling in ReactAgentLoop

### DIFF
--- a/recipe/langgraph_agent/react_agent_loop.py
+++ b/recipe/langgraph_agent/react_agent_loop.py
@@ -167,8 +167,6 @@ class ReactAgentLoop(AgentLoopBase):
         try:
             state = await self.graph.ainvoke(input={"messages": messages}, config=config)
         except Exception as e:
-            # Gracefully handle any graph execution errors (e.g., GraphRecursionError)
-            # This ensures training can continue even when individual agent loops fail
             logger.error(f"Agent loop execution failed: {type(e).__name__}: {e}")
             logger.error("Attempting to recover by extracting last valid trajectory.")
 
@@ -186,12 +184,9 @@ class ReactAgentLoop(AgentLoopBase):
                     break
 
             if last_valid_ai_message:
-                # Best case: We have a valid trajectory from existing messages
                 logger.info("Recovered valid trajectory from existing messages.")
                 state = {"messages": messages}
             else:
-                # Worst case: No valid trajectory, create minimal valid fallback
-                # This ensures convert_to_agent_output() doesn't fail
                 logger.warning("No valid trajectory found. Creating minimal fallback.")
                 fallback_message = AIMessage(
                     content="[Agent execution failed - no valid trajectory]",


### PR DESCRIPTION
### What does this PR do?

This PR fixes training crashes in ReactAgentLoop caused by `GraphRecursionError` and `AssertionError`. The fix implements dynamic `recursion_limit` calculation based on `max_assistant_turns` configuration and robust error recovery mechanism.

**Issues:** Training crashes with:
1. `AssertionError: Last message must have prompt_ids in response_metadata`

### Test

**Test Environment:**
- Multi-node training with Qwen2.5-3B
- `max_assistant_turns=25`

**Test Results:**
- GraphRecursionError eliminated
- AssertionError eliminated  
- Dynamic recursion_limit correctly calculated (75 for max_assistant_turns=25)
- Training continues successfully even when agent loop fails
- Valid trajectories recovered and used for training

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
