### PR TITLE
[algo] feat: add m2po trust region clipping and policy loss functions

### DIFF
--- a/recipe/m2po/test_m2po_qwen3_14b_base.sh
+++ b/recipe/m2po/test_m2po_qwen3_14b_base.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+project_name='DAPO-FullAsync-Qwen3-14B'
+exp_name='Fsdp2-collocate_gpu32_m2po'
+
+
+# Ray
+# RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
+# WORKING_DIR=${WORKING_DIR:-"${PWD}"}
+# RUNTIME_ENV=${RUNTIME_ENV:-"${WORKING_DIR}/verl/trainer/runtime_env.yaml"}
+NNODES=${NNODES:-4}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+# Paths
+BYTENAS=${BYTENAS:-"bandai-lf"}
+# Paths
+DATA_PATH=${DATA_PATH:-"/mnt/bn/${BYTENAS}"}
+# very important! please modify the max_position_embeddings in config.json to 32768 after downloading from huggingface
+MODEL_PATH=${MODEL_PATH:-"${DATA_PATH}/shared/models/Qwen3-14B-Base"}
+MLX_USER=${MLX_USER:-"angel"}
+ARNOLD_TRIAL_ID=${ARNOLD_TRIAL_ID:-"1"}
+CKPTS_DIR=${CKPTS_DIR:-"${DATA_PATH}/users/${MLX_USER}/${project_name}/${exp_name}/trial_${ARNOLD_TRIAL_ID}-$(date +%Y%m%d_%H%M%S)"}
+TRAIN_FILE=${TRAIN_FILE:-"${DATA_PATH}/shared/data/dapo-math/dapo-math-17k.parquet"}
+TEST_FILE=${TEST_FILE:-"${DATA_PATH}/shared/data/dapo-math/aime-2024.parquet"}
+
+# Algorithm parameters
+adv_estimator=grpo
+loss_mode=m2po # vanilla
+# M2PO specific
+m2_budget=0.04
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=0.2
+clip_ratio_high=0.28
+
+# Response length parameters
+max_prompt_length=$((1024 * 2))
+max_response_length=$((1024 * 20))
+enable_overlong_buffer=True
+overlong_buffer_len=$((1024 * 4))
+overlong_penalty_factor=1.0
+
+# Training parameters
+loss_agg_mode="token-mean"
+enable_filter_groups=True
+filter_groups_metric=acc
+max_num_gen_batches=10
+train_prompt_bsz=512
+gen_prompt_bsz=$((train_prompt_bsz * 1))
+n_resp_per_prompt=16
+train_prompt_mini_bsz=32
+
+# Algorithm
+temperature=1.0
+top_p=1.0
+top_k=-1 # 0 for HF rollout, -1 for vLLM rollout
+val_top_p=0.7
+
+# Performance Related Parameter
+use_dynamic_bsz=True
+actor_ppo_max_token_len=$((max_prompt_length + max_response_length))
+infer_ppo_max_token_len=$((max_prompt_length + max_response_length))
+ref_offload=True
+actor_offload=False
+sp_size=4
+gen_tp=4
+fsdp_size=32
+enforce_eager=False
+rollout_name=vllm
+nccl_timeout=3600
+resume_mode='auto' # auto resume_path
+test_freq=20
+save_freq=10
+
+python3 -m recipe.dapo.main_dapo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.prompt_key=prompt \
+    data.truncation='left' \
+    data.gen_batch_size=${gen_prompt_bsz} \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    critic.strategy=fsdp2 \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    +actor_rollout_ref.actor.policy_loss.m2_budget=${m2_budget} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.nccl_timeout=${nccl_timeout} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=${actor_offload} \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${actor_offload} \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.grad_clip=1.0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.80 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.enforce_eager=${enforce_eager} \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k="${top_k}" \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${val_top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=${ref_offload} \
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=${fsdp_size} \
+    actor_rollout_ref.rollout.name=${rollout_name} \
+    reward_model.reward_manager=dapo \
+    reward_model.overlong_buffer.enable=${enable_overlong_buffer} \
+    reward_model.overlong_buffer.len=${overlong_buffer_len} \
+    reward_model.overlong_buffer.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
+    trainer.logger='["console","wandb"]' \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}_gen_tp${gen_tp}sp${sp_size}" \
+    trainer.n_gpus_per_node=$NGPUS_PER_NODE \
+    trainer.nnodes="${NNODES}" \
+    trainer.val_before_train=True \
+    trainer.test_freq=${test_freq} \
+    trainer.save_freq=${save_freq} \
+    trainer.total_epochs=10 \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.resume_mode=${resume_mode}

--- a/recipe/m2po/test_m2po_qwen3_8b_base.sh
+++ b/recipe/m2po/test_m2po_qwen3_8b_base.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+project_name='DAPO-FullAsync-Qwen3-8B'
+exp_name='Fsdp2-collocate_gpu32_m2po'
+
+
+# Ray
+# RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
+# WORKING_DIR=${WORKING_DIR:-"${PWD}"}
+# RUNTIME_ENV=${RUNTIME_ENV:-"${WORKING_DIR}/verl/trainer/runtime_env.yaml"}
+NNODES=${NNODES:-4}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+# Paths
+BYTENAS=${BYTENAS:-"bandai-lf"}
+# Paths
+DATA_PATH=${DATA_PATH:-"/mnt/bn/${BYTENAS}"}
+MODEL_PATH=${MODEL_PATH:-"${DATA_PATH}/shared/models/Qwen3-14B-Base"}
+MLX_USER=${MLX_USER:-"angel"}
+ARNOLD_TRIAL_ID=${ARNOLD_TRIAL_ID:-"1"}
+CKPTS_DIR=${CKPTS_DIR:-"${DATA_PATH}/users/${MLX_USER}/${project_name}/${exp_name}/trial_${ARNOLD_TRIAL_ID}-$(date +%Y%m%d_%H%M%S)"}
+TRAIN_FILE=${TRAIN_FILE:-"${DATA_PATH}/shared/data/dapo-math/dapo-math-17k.parquet"}
+TEST_FILE=${TEST_FILE:-"${DATA_PATH}/shared/data/dapo-math/aime-2024.parquet"}
+
+# Algorithm parameters
+adv_estimator=grpo
+loss_mode=m2po # vanilla
+# M2PO specific
+m2_budget=0.04
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=0.2
+clip_ratio_high=0.28
+
+# Response length parameters
+max_prompt_length=$((1024 * 2))
+max_response_length=$((1024 * 20))
+enable_overlong_buffer=True
+overlong_buffer_len=$((1024 * 4))
+overlong_penalty_factor=1.0
+
+# Training parameters
+loss_agg_mode="token-mean"
+enable_filter_groups=True
+filter_groups_metric=acc
+max_num_gen_batches=10
+train_prompt_bsz=512
+gen_prompt_bsz=$((train_prompt_bsz * 1))
+n_resp_per_prompt=16
+train_prompt_mini_bsz=32
+
+# Algorithm
+temperature=1.0
+top_p=1.0
+top_k=-1 # 0 for HF rollout, -1 for vLLM rollout
+val_top_p=0.7
+
+# Performance Related Parameter
+use_dynamic_bsz=True
+actor_ppo_max_token_len=$((max_prompt_length + max_response_length))
+infer_ppo_max_token_len=$((max_prompt_length + max_response_length))
+ref_offload=True
+actor_offload=False
+sp_size=2
+gen_tp=2
+fsdp_size=32
+enforce_eager=False
+rollout_name=vllm
+nccl_timeout=3600
+resume_mode='auto'
+test_freq=20
+save_freq=10
+
+python3 -m recipe.dapo.main_dapo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.prompt_key=prompt \
+    data.truncation='left' \
+    data.gen_batch_size=${gen_prompt_bsz} \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    critic.strategy=fsdp2 \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    +actor_rollout_ref.actor.policy_loss.m2_budget=${m2_budget} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.nccl_timeout=${nccl_timeout} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=${actor_offload} \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${actor_offload} \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.grad_clip=1.0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.80 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.enforce_eager=${enforce_eager} \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k="${top_k}" \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${val_top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=${ref_offload} \
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=${fsdp_size} \
+    actor_rollout_ref.rollout.name=${rollout_name} \
+    reward_model.reward_manager=dapo \
+    reward_model.overlong_buffer.enable=${enable_overlong_buffer} \
+    reward_model.overlong_buffer.len=${overlong_buffer_len} \
+    reward_model.overlong_buffer.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
+    trainer.logger='["console","wandb"]' \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}_gen_tp${gen_tp}sp${sp_size}" \
+    trainer.n_gpus_per_node=$NGPUS_PER_NODE \
+    trainer.nnodes="${NNODES}" \
+    trainer.val_before_train=True \
+    trainer.test_freq=${test_freq} \
+    trainer.save_freq=${save_freq} \
+    trainer.total_epochs=10 \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.resume_mode=${resume_mode}

--- a/recipe/m2po/test_m2po_qwen3_8b_base.sh
+++ b/recipe/m2po/test_m2po_qwen3_8b_base.sh
@@ -16,7 +16,7 @@ NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 BYTENAS=${BYTENAS:-"bandai-lf"}
 # Paths
 DATA_PATH=${DATA_PATH:-"/mnt/bn/${BYTENAS}"}
-MODEL_PATH=${MODEL_PATH:-"${DATA_PATH}/shared/models/Qwen3-14B-Base"}
+MODEL_PATH=${MODEL_PATH:-"${DATA_PATH}/shared/models/Qwen3-8B-Base"}
 MLX_USER=${MLX_USER:-"angel"}
 ARNOLD_TRIAL_ID=${ARNOLD_TRIAL_ID:-"1"}
 CKPTS_DIR=${CKPTS_DIR:-"${DATA_PATH}/users/${MLX_USER}/${project_name}/${exp_name}/trial_${ARNOLD_TRIAL_ID}-$(date +%Y%m%d_%H%M%S)"}

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1812,14 +1812,15 @@ def _solve_tau_from_sorted_delta2(sorted_delta2: torch.Tensor, target_sum: float
 
             if n - k > 0:
                 tau_sq = (target_sum - csum_k_minus_1) / (n - k)
-            else: # Should not happen if target_sum < total
+            else:
                 tau_sq = sorted_delta2[k].item()
 
             m2_after = target_sum / n
             return tau_sq**0.5, m2_after
 
-    # This part should not be reached if target_sum < total.
-    return 100000.0, total / n if n > 0 else 0.0
+    # This part should not be reached if target_sum < total, as the loop is guaranteed to return.
+    # Raising an error for unexpected cases is safer than returning a potentially incorrect value.
+    raise RuntimeError("Unreachable code in _solve_tau_from_sorted_delta2 was reached. This indicates a logic error.")
 
 def kpo_clip_harmful_tokens(
     old_log_prob: torch.Tensor,
@@ -1988,12 +1989,6 @@ def get_ratio_stats(ratio: torch.Tensor,
         "neg": advantages < 0,
         "nonzero": advantages != 0,
     }
-
-    def _mean_where(x: torch.Tensor, m: torch.Tensor):
-        n = m.sum()
-        if n.item() == 0:
-            return torch.tensor(0.0, device=x.device, dtype=torch.float32)
-        return x[m].sum() / (n + eps)
 
     for name, cmask in conds.items():
         m = base_mask & cmask

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1752,3 +1752,329 @@ def compute_policy_loss_rollout_correction_wrapper(
         rollout_token_veto_threshold=rollout_token_veto_threshold,
         rollout_is_batch_normalize=rollout_is_batch_normalize,
     )
+
+
+def _get_trust_region_tokens_delta_sq(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+):
+    """Calculates delta^2 for harmful tokens based on per-token advantages."""
+    mask = response_mask.bool()
+    delta = old_log_prob - log_prob  # Δ = log p_old - log p_new
+    ratio = torch.exp(-delta)  # r = exp(log_new - log_old)
+
+    # Identify harmful tokens based on per-token advantage and ratio
+    pos_adv_harmful = (advantages > 1e-12) & (ratio > 1.0 + 1e-12)
+    neg_adv_harmful = (advantages < -1e-12) & (ratio < 1.0 - 1e-12)
+
+    harmful_mask = (pos_adv_harmful | neg_adv_harmful) & mask
+
+    delta_sq = delta.pow(2)
+    tr_tokens_delta_sq = delta_sq[harmful_mask]
+
+    return tr_tokens_delta_sq
+
+def _solve_tau_from_sorted_delta2(sorted_delta2: torch.Tensor, target_sum: float) -> tuple[float, float]:
+    """
+    Given sorted ascending values v_i = Δ_i^2 (i=0..n-1) and a target sum S,
+    find τ^2 such that sum_i min(v_i, τ^2) = S.
+    This uses a single pass over breakpoints without binary search.
+
+    Returns:
+        tau (float): sqrt(τ^2). If S >= sum(v_i), returns +inf (no clipping needed).
+                     If S <= 0, returns 0.0 (clip everything to 0).
+        m2_after (float): The new M2 value after clipping.
+    """
+
+    if sorted_delta2.numel() == 0:
+        return 100000.0, 0.0
+
+    n = sorted_delta2.numel()
+    total = float(sorted_delta2.sum().item())
+
+    if target_sum >= total - 1e-12:  # no clipping needed
+        return 100000.0, total / n if n > 0 else 0.0
+    if target_sum <= 1e-12:  # clip everything to 0
+        return 0.0, 0.0
+
+    csum = torch.cumsum(sorted_delta2, dim=0)  # prefix sums
+
+    for k in range(n):
+        # Sum if we clip all subsequent values at the current breakpoint sorted_delta2[k]
+        sum_if_clipped_at_vk = (csum[k - 1].item() if k > 0 else 0.0) + (n - k) * sorted_delta2[k].item()
+
+        if sum_if_clipped_at_vk >= target_sum - 1e-12:
+            # The correct tau^2 is between sorted_delta2[k-1] and sorted_delta2[k].
+            # We need to solve: csum[k-1] + (n-k) * tau^2 = target_sum
+            csum_k_minus_1 = csum[k - 1].item() if k > 0 else 0.0
+
+            if n - k > 0:
+                tau_sq = (target_sum - csum_k_minus_1) / (n - k)
+            else: # Should not happen if target_sum < total
+                tau_sq = sorted_delta2[k].item()
+
+            m2_after = target_sum / n
+            return tau_sq**0.5, m2_after
+
+    # This part should not be reached if target_sum < total.
+    return 100000.0, total / n if n > 0 else 0.0
+
+def kpo_clip_harmful_tokens(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    KL2_budget: float = None
+):
+    """
+    Decide global clip scalars (clip_low, clip_high) under an M2 budget.
+
+    Policy:
+      - Consider only harmful tokens: (A>0 & r>1) or (A<0 & r<1), where r = exp(log_new - log_old).
+      - Sort harmful tokens by delta^2 = (log p_old - log p_new)^2 ascending.
+      - Find a single threshold τ so that capping |delta| at τ across harmful tokens
+        yields overall M2 <= KL2_budget.
+      - Map τ to two global ratio bounds:
+            clip_low  = exp(-τ)  (applies to adv<0 & r<1)
+            clip_high = exp(+τ)  (applies to adv>0 & r>1)
+      - Non-harmful quadrants are not constrained by these bounds.
+
+    Returns:
+      clip_low  (float): lower clamp for tokens with (adv<0 & r<1)
+      clip_high (float): upper clamp for tokens with (adv>0 & r>1)
+    """
+    assert KL2_budget is not None, "KL2_budget must be set."
+
+    tr_tokens_delta_sq = _get_trust_region_tokens_delta_sq(old_log_prob, log_prob, advantages, response_mask)
+    token_num = tr_tokens_delta_sq.numel()
+
+    if token_num == 0: # no clipping needed
+        return 0.0, 100000, 0.0, 0.0
+
+    target_total = KL2_budget * float(token_num)
+    M2_now = float(tr_tokens_delta_sq.sum().detach().item() / token_num)
+
+    if M2_now <= KL2_budget + 1e-12:
+        # No clipping needed -> effectively no constraint
+        return 0.0, 100000, M2_now, M2_now
+
+    # print(f"tr-M2_now: {M2_now}")
+    # print(f"KL2_budget: {KL2_budget}")
+
+    # import pdb; pdb.set_trace()
+
+    sorted_delta2, _ = torch.sort(tr_tokens_delta_sq)  # ascending
+    tau, m2_after = _solve_tau_from_sorted_delta2(sorted_delta2, target_total)
+
+    # Map |Δ|<=τ to ratio bounds per quadrant
+    clip_low = float(torch.exp(torch.tensor(-tau)).item())   # applies to (adv<0, r<1)
+    clip_high = float(torch.exp(torch.tensor(+tau)).item())  # applies to (adv>0, r>1)
+
+    return clip_low, clip_high, M2_now, m2_after
+
+
+@torch.no_grad()
+def get_ratio_stats(ratio: torch.Tensor,
+                    advantages: torch.Tensor,
+                    response_mask: torch.Tensor,
+                    log_prob: torch.Tensor,
+                    old_log_prob: torch.Tensor,
+                    bins=(0.2, 0.5, 0.8, 1.0, 1.2, 1.5, 2.0),
+                    eps: float = 1e-12,
+                    tol: float = 1e-6):
+    """
+    Summarize ratio distribution for three advantage conditions (pos, neg, nonzero).
+    Keeps the (0.8, 1.0) bin AND adds an explicit eq_1.0 bin.
+
+    Final bin order (len=9):
+        (-inf, 0.2], (0.2, 0.5], (0.5, 0.8], (0.8, 1.0), eq_1.0,
+        (1.0, 1.2], (1.2, 1.5], (1.5, 2.0], (2.0, +inf)
+
+    Returns a dict with keys like:
+        ratio_pos/inf_0.2, ..., ratio_pos/gt_2.0  (fractions in [0,1])
+        ratio_pos/avg (mean of ratio over masked & condition tokens)
+    """
+    mask = response_mask.bool()
+    finite = torch.isfinite(ratio)
+    mask = mask & finite
+
+    edges = torch.tensor(bins, device=ratio.device, dtype=ratio.dtype)
+    # bucketize indices for 8 original bins:
+    # 0:(-inf,0.2], 1:(0.2,0.5], 2:(0.5,0.8], 3:(0.8,1.0], 4:(1.0,1.2], 5:(1.2,1.5], 6:(1.5,2.0], 7:(2.0,+inf)
+    bin_idx = torch.bucketize(ratio, edges, right=True)
+
+
+    def compute_for(cond: torch.Tensor):
+        m = mask & cond
+        # 9 bins now (insert eq_1.0 at index 4)
+        counts = torch.zeros(len(bins) + 2, device=ratio.device, dtype=torch.float32)
+
+        if m.any():
+            eq1_mask = (torch.abs(ratio - 1.0) <= tol) & m
+            not_eq1_mask = m & (~eq1_mask)
+
+            if not_eq1_mask.any():
+                idx = bin_idx[not_eq1_mask].reshape(-1).long()
+                # shift indices >= 4 (i.e., > 1.0 side) by +1 to make room for eq_1.0 at index 4
+                shift = (idx >= 4).long()
+                idx = idx + shift
+                counts.scatter_add_(0, idx, torch.ones_like(idx, dtype=torch.float32))
+
+            # put exact-1.0 counts at index 4
+            counts[4] = eq1_mask.sum()
+
+        total = counts.sum()
+        frac = counts / (total + eps)
+
+        # average ratio under this condition (masked)
+        if m.any():
+            avg = ratio[m].sum() / (m.sum() + eps)
+        else:
+            avg = torch.tensor(0.0, device=ratio.device, dtype=torch.float32)
+
+        return frac, avg
+
+    results = {}
+    conditions = {
+        "pos": advantages > 0,
+        "neg": advantages < 0,
+        "nonzero": advantages != 0
+    }
+
+    bin_names = [
+        f"inf_{bins[0]}", f"{bins[0]}_{bins[1]}", f"{bins[1]}_{bins[2]}", f"{bins[2]}_{bins[3]}",
+        "eq_1.0",
+        f"{bins[3]}_{bins[4]}", f"{bins[4]}_{bins[5]}", f"{bins[5]}_{bins[6]}", f"gt_{bins[-1]}"
+    ]
+
+    for cond_name, cond_mask in conditions.items():
+        frac, avg = compute_for(cond_mask)
+        for i, bn in enumerate(bin_names):
+            results[f"ratio_{cond_name}/{bn}"] = frac[i].item()
+        results[f"ratio_{cond_name}/avg"] = float(avg.item())
+
+    # ---- append: conditional KL means ----
+    negative_approx_kl = log_prob - old_log_prob    # = log(ratio)
+    approx_kl = -negative_approx_kl                 # PPO-style approx KL ≥ 0
+
+    base_mask = response_mask.bool() & torch.isfinite(ratio) \
+                & torch.isfinite(log_prob) & torch.isfinite(old_log_prob)
+
+    m_neg_r_lt_1 = base_mask & (advantages < 0) & (ratio < (1.0 - tol))
+    m_pos_r_gt_1 = base_mask & (advantages > 0) & (ratio > (1.0 + tol))
+
+    def _mean_where(x: torch.Tensor, m: torch.Tensor):
+        n = m.sum()
+        if n.item() == 0:
+            return torch.tensor(0.0, device=x.device, dtype=torch.float32)
+        return x[m].sum() / (n + eps)
+
+    results["kl_neg_r_lt_1/mean"] = float(_mean_where(approx_kl, m_neg_r_lt_1).item())
+    results["kl_pos_r_gt_1/mean"] = float(_mean_where(approx_kl, m_pos_r_gt_1).item())
+
+    # optional diagnostics
+    total_tokens = int(mask.sum().item())
+    results["kl_neg_r_lt_1/count"] = int(m_neg_r_lt_1.sum().item())
+    results["kl_pos_r_gt_1/count"] = int(m_pos_r_gt_1.sum().item())
+    results["kl_neg_r_lt_1/frac_tokens"] = float((m_neg_r_lt_1.sum() / (mask.sum() + eps)).item()) if total_tokens > 0 else 0.0
+    results["kl_pos_r_gt_1/frac_tokens"] = float((m_pos_r_gt_1.sum() / (mask.sum() + eps)).item()) if total_tokens > 0 else 0.0
+
+    # ---- append: KL stats (flat with kl_stats/ prefix) ----
+
+    conds = {
+        "pos": advantages > 0,
+        "neg": advantages < 0,
+        "nonzero": advantages != 0,
+    }
+
+    def _mean_where(x: torch.Tensor, m: torch.Tensor):
+        n = m.sum()
+        if n.item() == 0:
+            return torch.tensor(0.0, device=x.device, dtype=torch.float32)
+        return x[m].sum() / (n + eps)
+
+    for name, cmask in conds.items():
+        m = base_mask & cmask
+        results[f"kl_stats/{name}_abs_mean"]    = float(_mean_where(negative_approx_kl.abs(), m).item())
+        results[f"kl_stats/{name}_sq_mean"]     = float(_mean_where(negative_approx_kl.pow(2), m).item())
+        results[f"kl_stats/{name}_signed_mean"] = float(_mean_where(-negative_approx_kl, m).item())
+        # results[f"kl_stats/{name}_approx_mean"] = float(_mean_where(approx_kl, m).item())
+
+    return results
+
+
+@register_policy_loss("m2po")
+def compute_policy_loss_m2po(
+    old_log_prob,
+    log_prob,
+    advantages,
+    response_mask,
+    loss_agg_mode: str = "token-mean",
+    config: Optional[DictConfig | AlgoConfig] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """
+    Compute policy loss under an M2 (KL^2) budget using per-token clipping bounds.
+
+    Adapted from paper https://arxiv.org/abs/2510.01161
+    https://github.com/Infini-AI-Lab/M2PO/blob/main/verl/trainer/ppo/core_algos.py#L812
+
+    Steps:
+      1) Get per-token (clip_low, clip_high) from kpo_clip.
+      2) Compute ratio and apply element-wise clamp.
+      3) Compute surrogate loss -A * ratio_clipped and aggregate.
+
+    Returns:
+      pg_loss:       aggregated policy loss
+      stats:         dict with basic diagnostics (M2 before/after, fractions)
+      clip_low/high: the per-token bounds actually used
+    """
+    assert config is not None
+    assert not isinstance(config, AlgoConfig)
+    m2_budget = config.policy_loss.get("m2_budget", 0.04)
+    miniclip_low = config.policy_loss.get("miniclip_low", None)
+    miniclip_high = config.policy_loss.get("miniclip_high", None)
+
+    clip_low, clip_high, m2_data, m2_after = kpo_clip_harmful_tokens(old_log_prob, log_prob, advantages, response_mask, m2_budget)
+
+    clip_low = 1 - clip_low
+    clip_high = clip_high - 1
+    # print(f"m2po clip_low: {clip_low}, clip_high: {clip_high}")
+    if miniclip_low is not None and clip_low < miniclip_low:
+        clip_low = miniclip_low
+    if miniclip_high is not None and clip_high < miniclip_high:
+        clip_high = miniclip_high
+
+    # ratio = exp(log_new - log_old)
+    ratio = torch.exp(log_prob - old_log_prob)
+    ppo_kl = verl_F.masked_mean(-(log_prob - old_log_prob), response_mask)
+
+    ratio_stats = get_ratio_stats(ratio, advantages, response_mask, log_prob, old_log_prob)
+
+    ##### clip
+    pg_losses1 = -advantages * ratio
+    pg_losses2 = -advantages * torch.clamp(ratio, 1 - clip_low, 1 + clip_high)  # - clip(ratio, 1-cliprange, 1+cliprange) * A
+    clip_pg_losses1 = torch.maximum(pg_losses1, pg_losses2)  # max(-ratio * A, -clip(ratio, 1-cliprange, 1+cliprange) * A)
+    pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses1).float(), response_mask)
+
+    # Apply rollout importance sampling weights if provided
+    if rollout_is_weights is not None:
+        clip_pg_losses1 = clip_pg_losses1 * rollout_is_weights
+
+    pg_loss = agg_loss(loss_mat=clip_pg_losses1, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+
+    pg_clipfrac_lower = torch.tensor(0.0, device=pg_loss.device)
+    pg_metrics = {
+        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
+        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/pg_clipfrac_lower":pg_clipfrac_lower.detach().item(),
+        "m2po/clip_low": clip_low,
+        "m2po/clip_high": clip_high,
+        "m2po/m2": m2_data,
+        "m2po/m2_after": m2_after,
+        "m2po/m2_budget": m2_budget
+
+    }
+    return pg_loss, pg_metrics

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -41,6 +41,7 @@ class PolicyLossConfig(BaseConfig):
         clip_cov_ub (float): Upper bound for clip-cov loss.
         kl_cov_ratio (float): Ratio of tokens to be applied KL penalty for kl-cov loss.
         ppo_kl_coef (float): KL divergence penalty coefficient.
+        m2_budget (float): M2PO budget.
     """
 
     loss_mode: str = "vanilla"
@@ -49,6 +50,7 @@ class PolicyLossConfig(BaseConfig):
     clip_cov_ub: float = 5.0
     kl_cov_ratio: float = 0.0002
     ppo_kl_coef: float = 0.1
+    m2_budget: float = 0.04  # M2PO budget
 
 
 @dataclass


### PR DESCRIPTION
Added functions for trust region token clipping and policy loss computation under an M2 budget. Implemented helper functions to calculate delta squared and solve for clipping thresholds based on advantages and response masks.

### What does this PR do?

This PR implements the m2po loss calculation proposed by paper https://papers.cool/arxiv/2510.01161

### Test
<img width="1590" height="1222" alt="image" src="https://github.com/user-attachments/assets/8c589af9-3478-4448-a804-38402a6bca88" />

Compared DAPO and M2po under the same settings. 

DAPO uses the following script: recipe/m2po/test_m2po_qwen3_8b_base.sh 删除 'actor_rollout_ref.actor.policy_loss.loss_mode="m2po" ' 即可

m2po scripts: recipe/m2po/test_m2po_qwen3_8b_base.sh

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

To use m2po, users only need to set actor_rollout_ref.actor.policy_loss.loss_mode to m2po.

```python
# Add code snippet or script demonstrating how to use this
python3 -m verl.trainer.main_ppo \
  ... \
  actor_rollout_ref.actor.policy_loss.loss_mode="m2po" \
    +actor_rollout_ref.actor.policy_loss.m2_budget=0.04 \
  ...
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
