### PR TITLE
[docker] fix: Add omegaconf to Python package installation

### DIFF
--- a/docker/Dockerfile.stable.vllm
+++ b/docker/Dockerfile.stable.vllm
@@ -15,7 +15,7 @@ RUN export NVTE_FRAMEWORK=pytorch && MAX_JOBS=128 NVTE_BUILD_THREADS_PER_JOB=4 p
 
 RUN pip install --upgrade --no-cache-dir transformers tokenizers
 
-RUN pip install codetiming tensordict mathruler pylatexenc qwen_vl_utils
+RUN pip install codetiming tensordict mathruler pylatexenc qwen_vl_utils omegaconf
 
 RUN pip install flash_attn==2.8.1
 


### PR DESCRIPTION
### What does this PR do?

Fixes the [vLLM Docker image](https://github.com/volcengine/verl/blob/main/docker/Dockerfile.stable.vllm) to include a missing import (No module named 'omegaconf'). Found by building the Docker image locally and then running a test to import the PPO trainer via

```py
from verl.trainer.ppo.ray_trainer import RayPPOTrainer
```

Slurm script used for testing:

```sh
#!/bin/bash
#SBATCH --job-name=rl-bench-test
#SBATCH --partition=hopper-prod
#SBATCH --qos=high
#SBATCH --nodes=1
#SBATCH --ntasks=1
#SBATCH --cpus-per-task=8
#SBATCH --gpus-per-node=1
#SBATCH --mem=32G
#SBATCH --time=01:00:00
#SBATCH --output=logs/verl_test_%j.out
#SBATCH --error=logs/verl_test_%j.out

# VERL Container Test Script (Compute Node - Enroot Only)
# This script imports the pre-built Docker image using enroot and runs verification tests
#
# Prerequisites:
#   1. Docker image must be built and pushed to the registry first
#   2. Run build_container.sh on the login node before submitting this job
#
# Based on: https://github.com/volcengine/verl

set -e

# Parse command line arguments
SQSH_FILE=""
while [[ $# -gt 0 ]]; do
    case $1 in
        --sqsh)
            SQSH_FILE="$2"
            shift 2
            ;;
        *)
            echo "ERROR: Unknown argument: $1"
            echo ""
            echo "Usage: sbatch test_container.slurm [--sqsh <path>]"
            echo ""
            echo "Options:"
            echo "  --sqsh <path>  Use specific .sqsh file instead of importing from registry"
            echo ""
            echo "Examples:"
            echo "  sbatch test_container.slurm"
            echo "  sbatch test_container.slurm --sqsh /fsx/nouamane/docker_images/verl.sqsh"
            exit 1
            ;;
    esac
done

# Set enroot environment variables to use writable locations
export ENROOT_RUNTIME_PATH="${ENROOT_RUNTIME_PATH:-$HOME/.enroot/runtime}"
export ENROOT_DATA_PATH="${ENROOT_DATA_PATH:-$HOME/.enroot/data}"
export ENROOT_CACHE_PATH="${ENROOT_CACHE_PATH:-$HOME/.enroot/cache}"

# Create directories if they don't exist
mkdir -p "$ENROOT_RUNTIME_PATH" "$ENROOT_DATA_PATH" "$ENROOT_CACHE_PATH"

echo "========================================="
echo "VERL Container Test"
echo "========================================="
echo "Job ID: $SLURM_JOB_ID"
echo "Node: $SLURM_NODELIST"
echo "Started at: $(date)"
echo "========================================="

# Configuration
FRAMEWORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
IMAGE_NAME="verl"
IMAGE_TAG="${IMAGE_TAG:-latest}"
CONTAINER_IMAGES_DIR="${CONTAINER_IMAGES_DIR:-/fsx/nouamane/docker_images}"

# Determine if we need to import or use existing .sqsh
if [[ -n "$SQSH_FILE" ]]; then
    # Use provided .sqsh file
    if [[ ! -f "$SQSH_FILE" ]]; then
        echo "ERROR: .sqsh file not found: $SQSH_FILE"
        exit 1
    fi
    ENROOT_IMAGE="$SQSH_FILE"
    echo "Configuration:"
    echo "  Using .sqsh file: $ENROOT_IMAGE"
    echo "========================================="
else
    # Import from registry
    REGISTRY="${REGISTRY}"

    # Validate required environment variables
    if [[ -z "$REGISTRY" ]]; then
        echo "ERROR: REGISTRY environment variable not set"
        echo ""
        echo "Please set it before submitting this job:"
        echo "  export REGISTRY=registry.hpc-cluster-hopper.hpc.internal.huggingface.tech"
        echo "  sbatch test_container.slurm"
        echo ""
        echo "Or use --sqsh to specify a .sqsh file directly:"
        echo "  sbatch test_container.slurm --sqsh /path/to/verl.sqsh"
        exit 1
    fi

    REGISTRY_IMAGE="${REGISTRY}/library/${IMAGE_NAME}:${IMAGE_TAG}"
    ENROOT_FILENAME="library+${IMAGE_NAME}+${IMAGE_TAG}.sqsh"
    ENROOT_IMAGE="${CONTAINER_IMAGES_DIR}/${ENROOT_FILENAME}"

    echo "Configuration:"
    echo "  Registry: $REGISTRY"
    echo "  Registry image: $REGISTRY_IMAGE"
    echo "  Container images directory: $CONTAINER_IMAGES_DIR"
    echo "  Target enroot image: $ENROOT_IMAGE"
    echo "========================================="

    # Check if enroot is available
    if ! command -v enroot &> /dev/null; then
        echo "ERROR: enroot command not found"
        echo ""
        echo "This script requires enroot for container management on compute nodes."
        echo "Please ensure enroot is installed and available on compute nodes."
        exit 1
    fi

    echo "✓ Enroot is available"
    echo ""

    # Create container images directory if it doesn't exist
    mkdir -p "$CONTAINER_IMAGES_DIR"

    # Check if image already exists
    if [[ -f "$ENROOT_IMAGE" ]]; then
        echo "WARNING: Enroot image already exists: $ENROOT_IMAGE"
        echo "Removing old image..."
        rm -f "$ENROOT_IMAGE"
    fi

    # Import image using enroot
    echo "========================================="
    echo "Importing image from registry..."
    echo "This may take several minutes..."
    echo "========================================="

    enroot import "docker://${REGISTRY_IMAGE}"

    if [[ $? -eq 0 ]]; then
        echo "✓ Image imported successfully"
    else
        echo "ERROR: Enroot import failed"
        echo ""
        echo "Please check:"
        echo "  1. Did you run build_container.sh on the login node first?"
        echo "  2. Is the registry URL correct? ($REGISTRY)"
        echo "  3. Is the image available in the registry?"
        echo "  4. Can this compute node access the registry?"
        echo ""
        echo "Try manually checking:"
        echo "  docker pull $REGISTRY_IMAGE"
        exit 1
    fi

    # Move to shared storage location
    if [[ -f "$ENROOT_FILENAME" ]]; then
        echo "Moving image to shared storage..."
        mv "$ENROOT_FILENAME" "$ENROOT_IMAGE"
        echo "✓ Image moved to: $ENROOT_IMAGE"
    else
        echo "ERROR: Enroot image file not found after import: $ENROOT_FILENAME"
        exit 1
    fi

    # Verify image file
    echo ""
    echo "========================================="
    echo "Verifying enroot image..."
    echo "========================================="

    if [[ -f "$ENROOT_IMAGE" ]]; then
        IMAGE_SIZE=$(du -h "$ENROOT_IMAGE" | cut -f1)
        echo "✓ Enroot image exists: $ENROOT_IMAGE"
        echo "  Size: $IMAGE_SIZE"
    else
        echo "ERROR: Enroot image not found at expected location"
        exit 1
    fi
fi

# Run verification tests using srun with Pyxis
echo ""
echo "========================================="
echo "Running verification tests..."
echo "========================================="

srun --container-image="$ENROOT_IMAGE" \
     --container-mounts="/fsx:/fsx" \
     --no-container-mount-home \
     python3 <<'EOF'
import importlib
import shutil
import sys

tests = []


def register(name):
    def decorator(fn):
        tests.append((name, fn))
        return fn

    return decorator


def import_group(modules):
    failures = []
    for spec in modules:
        label = spec["label"]
        module_name = spec["module"]
        attr = spec.get("version_attr", "__version__")
        try:
            module = importlib.import_module(module_name)
            version = getattr(module, attr, None) if attr else None
            if version:
                print(f"  ✓ {label} ({module_name}) - version {version}")
            else:
                print(f"  ✓ {label} ({module_name}) - import ok")
        except Exception as exc:
            failures.append((label, exc))
            print(f"  ✗ {label} ({module_name}) - {exc}")
    if failures:
        raise RuntimeError(
            f"{len(failures)} import(s) failed: {', '.join(label for label, _ in failures)}"
        )


@register("Python runtime")
def _():
    print(f"✓ Python version: {sys.version.split()[0]}")


@register("PyTorch and CUDA")
def _():
    import torch

    print(f"✓ PyTorch version: {torch.__version__}")
    print(f"  CUDA available: {torch.cuda.is_available()}")
    if torch.cuda.is_available():
        print(f"  CUDA devices: {torch.cuda.device_count()}")
        print(f"  Current device: {torch.cuda.get_device_name(0)}")
    print(f"  CUDA version: {torch.version.cuda}")


@register("vLLM")
def _():
    import vllm

    print(f"✓ vLLM version: {getattr(vllm, '__version__', 'unknown')}")


@register("VERL trainer import")
def _():
    from verl.trainer.ppo.ray_trainer import RayPPOTrainer  # noqa: F401

    print("✓ RayPPOTrainer import succeeded")


@register("Core training libraries")
def _():
    import_group(
        [
            {"label": "TRL", "module": "trl"},
            {"label": "Transformers", "module": "transformers"},
            {"label": "Tokenizers", "module": "tokenizers"},
        ]
    )


@register("NVIDIA/accelerator extensions")
def _():
    import_group(
        [
            {"label": "PyBind11", "module": "pybind11"},
            {"label": "NVIDIA MathDx", "module": "nvidia.mathdx"},
            {"label": "Apex", "module": "apex", "version_attr": None},
            {"label": "TransformerEngine", "module": "transformer_engine"},
            {"label": "FlashAttention", "module": "flash_attn"},
            {"label": "NVTX", "module": "nvtx", "version_attr": None},
            {"label": "Liger Kernel", "module": "liger_kernel", "version_attr": None},
            {"label": "Megatron-LM", "module": "megatron", "version_attr": None},
        ]
    )


@register("Training utilities")
def _():
    import_group(
        [
            {"label": "codetiming", "module": "codetiming"},
            {"label": "tensordict", "module": "tensordict"},
            {"label": "mathruler", "module": "mathruler", "version_attr": None},
            {"label": "pylatexenc", "module": "pylatexenc", "version_attr": None},
            {"label": "qwen_vl_utils", "module": "qwen_vl_utils", "version_attr": None},
            {"label": "mbridge", "module": "mbridge", "version_attr": None},
            {"label": "matplotlib", "module": "matplotlib"},
        ]
    )


@register("System binaries")
def _():
    missing = []
    for cmd in ("numactl", "nsys"):
        path = shutil.which(cmd)
        if path:
            print(f"✓ {cmd} available at {path}")
        else:
            print(f"✗ {cmd} not found in PATH")
            missing.append(cmd)
    if missing:
        raise RuntimeError(f"Missing system binaries: {', '.join(missing)}")


tests_passed = 0
tests_failed = 0

for idx, (name, fn) in enumerate(tests, start=1):
    print(f"\nTest {idx}: {name}")
    print("----------------------------------------")
    try:
        fn()
        tests_passed += 1
    except Exception as exc:
        print(f"✗ {name} failed: {exc}")
        tests_failed += 1

print("\n========================================")
print(f"Tests passed: {tests_passed}/{len(tests)}")
print(f"Tests failed: {tests_failed}/{len(tests)}")
print("========================================")

if tests_failed:
    sys.exit(1)
EOF

if [[ $? -ne 0 ]]; then
    echo ""
    echo "✗ Some tests failed"
    echo ""
    echo "Please check the test output above for details"
    exit 1
fi

echo ""
echo "========================================="
echo "VERL Container Test Completed Successfully!"
echo "Finished at: $(date)"
echo "========================================="
echo ""
echo "Enroot image: $ENROOT_IMAGE"
echo ""
echo "Next steps:"
echo ""
echo "1. Set environment variables (if needed):"
echo "   export HF_HOME=/fsx/hf_cache"
echo "   export WANDB_API_KEY=your_key_here"
echo "   huggingface-cli login  # For gated models"
echo ""
echo "2. Try a single-node GRPO smoke test (see README for configs):"
echo ""
echo "   srun --gres=gpu:8 \\"
echo "     --container-image=\"$ENROOT_IMAGE\" \\"
echo "     --container-mounts=\"/fsx:/fsx,/scratch:/scratch\" \\"
echo "     --no-container-mount-home \\"
echo "     bash -lc 'cd /opt/verl && python grpo.py --help'"
echo ""
echo "3. For multi-node training:"
echo "   See run_multinode.slurm or ../../shared/slurm_templates/"
echo ""
```

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: No module named 'omegaconf'
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
