### PR TITLE
[ci] fix: Correct version relationship between torch and torchvision in ascend dockerfile

### DIFF
--- a/docker/ascend/Dockerfile.ascend_8.2.rc1_a2
+++ b/docker/ascend/Dockerfile.ascend_8.2.rc1_a2
@@ -33,6 +33,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    # Install torch & torch_npu & torchvision
+    pip install torch==2.5.1 torch_npu==2.5.1 torchvision==0.20.1 && \
     # Install vllm
     cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
     # Install vllm-ascend
@@ -40,8 +42,6 @@ RUN ARCH=$(uname -m) && \
     # Install MindSpeed & Megatron
     pip install -e MindSpeed && \
     echo "export PYTHONPATH=\$PYTHONPATH:/Megatron-LM" >> ~/.bashrc && \
-    # Install torch & torch_npu
-    pip install torch==2.5.1 torch_npu==2.5.1 && \
     # Clear extra files
     rm -rf /tmp/* /var/tmp/* && \
     pip cache purge

--- a/docker/ascend/Dockerfile.ascend_8.2.rc1_a3
+++ b/docker/ascend/Dockerfile.ascend_8.2.rc1_a3
@@ -33,6 +33,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    # Install torch & torch_npu & torchvision
+    pip install torch==2.5.1 torch_npu==2.5.1 torchvision==0.20.1 && \
     # Install vllm
     cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
     # Install vllm-ascend
@@ -40,8 +42,6 @@ RUN ARCH=$(uname -m) && \
     # Install MindSpeed & Megatron
     pip install -e MindSpeed && \
     echo "export PYTHONPATH=\$PYTHONPATH:/Megatron-LM" >> ~/.bashrc && \
-    # Install torch & torch_npu
-    pip install torch==2.5.1 torch_npu==2.5.1 && \
     # Clear extra files
     rm -rf /tmp/* /var/tmp/* && \
     pip cache purge

--- a/docker/ascend/Dockerfile.ascend_8.3.rc1_a2
+++ b/docker/ascend/Dockerfile.ascend_8.3.rc1_a2
@@ -33,6 +33,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    # Install torch & torch_npu & torchvision
+    pip install torch==2.7.1 torch_npu==2.7.1 torchvision==0.22.1 && \
     # Install vllm
     cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
     # Install vllm-ascend
@@ -40,8 +42,6 @@ RUN ARCH=$(uname -m) && \
     # Install MindSpeed & Megatron
     pip install -e MindSpeed && \
     echo "export PYTHONPATH=\$PYTHONPATH:/Megatron-LM" >> ~/.bashrc && \
-    # Install torch & torch_npu
-    pip install torch==2.7.1 torch_npu==2.7.1 && \
     # Clear extra files
     rm -rf /tmp/* /var/tmp/* && \
     pip cache purge

--- a/docker/ascend/Dockerfile.ascend_8.3.rc1_a3
+++ b/docker/ascend/Dockerfile.ascend_8.3.rc1_a3
@@ -33,6 +33,8 @@ RUN ARCH=$(uname -m) && \
     fi && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    # Install torch & torch_npu & torchvision
+    pip install torch==2.7.1 torch_npu==2.7.1 torchvision==0.22.1 && \
     # Install vllm
     cd vllm && VLLM_TARGET_DEVICE=empty pip install -v -e . && cd .. && \
     # Install vllm-ascend
@@ -40,8 +42,6 @@ RUN ARCH=$(uname -m) && \
     # Install MindSpeed & Megatron
     pip install -e MindSpeed && \
     echo "export PYTHONPATH=\$PYTHONPATH:/Megatron-LM" >> ~/.bashrc && \
-    # Install torch & torch_npu
-    pip install torch==2.7.1 torch_npu==2.7.1 && \
     # Clear extra files
     rm -rf /tmp/* /var/tmp/* && \
     pip cache purge

--- a/requirements-npu.txt
+++ b/requirements-npu.txt
@@ -17,4 +17,3 @@ mathruler
 torchdata
 einops
 qwen_vl_utils
-torchvision==0.20.1


### PR DESCRIPTION
### What does this PR do?

When the torch version is upgraded from `2.5.1` to `2.7.1`, the hardcoded `torchvision==0.20.1` in the `requirement-npu.txt` file is ignored. This causes the torch version to be forcibly downgraded by torchvision during the installation process in the Dockerfile build of version 8.3.RC1, resulting in inconsistency with the `torch_npu` version.

This PR is committed to solve this conflict, by moving torchvision version setting from `requirement-npu.txt` to corresponding dockerfile, torch and torch_npu can be the same version (2.5.1 or 2.7.1).

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Not related.

### API and Usage Example

Not related.

### Design & Code Changes

Not related.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
