### PR TITLE
[trainer,vllm] feat: add a recipe to support reorder rollout

### DIFF
--- a/examples/grpo_trainer/run_qwen3-8b_reorder.sh
+++ b/examples/grpo_trainer/run_qwen3-8b_reorder.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+ulimit -n 65536
+
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+export NCCL_DEBUG=WARN
+export VERL_LOGGING_LEVEL=WARN
+
+
+export RAY_num_heartbeats_timeout=10
+export RAY_raylet_heartbeat_period_milliseconds=200
+export RAY_health_check_timeout_ms=6000
+export RAY_health_check_failure_threshold=3
+
+
+project_name='GRPO-qwen8b'
+exp_name='GRPO-Qwen3-8b_bf16'
+
+adv_estimator=grpo
+
+use_kl_in_reward=False
+kl_coef=0.0
+use_kl_loss=False
+kl_loss_coef=0.0
+
+clip_ratio_low=3e-4
+clip_ratio_high=4e-4
+
+max_prompt_length=$((1024 * 4))
+max_response_length=$((1024 * 3))
+enable_overlong_buffer=True
+overlong_buffer_len=$((1024 * 2))
+overlong_penalty_factor=1.0
+
+loss_agg_mode="token-mean"
+loss_mode=gspo
+
+train_prompt_bsz=16
+gen_prompt_bsz=20
+n_resp_per_prompt=4
+train_prompt_mini_bsz=8
+
+
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+HDFS_ROOT=/path/to/HDFS
+DATA_ROOT=/path/to/
+
+MODEL_PATH=Qwen/Qwen3-8B
+
+
+
+CKPTS_DIR=/path/to/checkpoint/
+
+
+# Algorithm
+temperature=1.0
+top_p=1.0
+top_k=-1 # 0 for HF rollout, -1 for vLLM rollout
+val_top_p=0.7
+
+# Performance Related Parameter
+use_dynamic_bsz=True
+actor_ppo_max_token_len=$(((max_prompt_length + max_response_length) * 1))
+infer_ppo_max_token_len=$(((max_prompt_length + max_response_length) * 3))
+offload=True
+
+# gen
+rollout_name=vllm # vllm or sglang
+gen_tp=2
+gen_dp=1
+gen_ep=1
+
+# train
+train_tp=8
+train_pp=1
+EP=1
+ETP=1
+CP=1
+
+TRAIN_FILE=/path/to/train-dataset/
+TEST_FILE=/path/to/test-dataset/
+
+
+
+export MASTER_PORT=$((RANDOM % 10000 + 30000))
+export VLLM_USE_V1=1
+
+
+python3 -m verl.trainer.main_ppo \
+    --config-path=config \
+    --config-name='ppo_megatron_trainer.yaml' \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.prompt_key=prompt \
+    data.return_raw_chat=True \
+    data.truncation='left' \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.optim.clip_grad=1.0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.actor.megatron.param_offload=${offload} \
+    actor_rollout_ref.actor.megatron.optimizer_offload=${offload} \
+    actor_rollout_ref.actor.megatron.grad_offload=${offload} \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${train_pp} \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${train_tp} \
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=$ETP \
+    actor_rollout_ref.actor.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.70 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${val_top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.name=${rollout_name} \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.rollout.data_parallel_size=${gen_dp} \
+    actor_rollout_ref.rollout.expert_parallel_size=${gen_ep} \
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${train_pp} \
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${train_tp} \
+    actor_rollout_ref.ref.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.ref.megatron.expert_tensor_parallel_size=$ETP \
+    actor_rollout_ref.ref.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.ref.megatron.param_offload=${offload} \
+    actor_rollout_ref.actor.megatron.use_mbridge=True \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_router_dtype=fp32 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.gradient_accumulation_fusion=True \
+    reward_model.reward_manager=dapo \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
+    +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
+    +reward_model.reward_kwargs.max_resp_len=${max_response_length} \
+    trainer.logger='["console","wandb"]' \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}-tp${gen_tp}-ep${gen_ep}" \
+    trainer.n_gpus_per_node="${NGPUS_PER_NODE}" \
+    trainer.nnodes="${NNODES}" \
+    trainer.val_before_train=True \
+    trainer.test_freq=10 \
+    trainer.save_freq=100 \
+    trainer.total_epochs=10 \
+    trainer.total_training_steps=500 \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.resume_mode=auto \
+    trainer.log_val_generations=10

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -107,9 +107,7 @@ class AsyncLLMServerManager:
         self.gen_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
         self.train_batch_size = self.config.data.train_batch_size
         self.reorder_rollout = not (self.gen_batch_size == self.train_batch_size)
-
-        if self.reorder_rollout:
-            self.ray_tasks = []
+        self.ray_tasks = []
 
     def cancel_tasks(self):
         """

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -160,8 +160,11 @@ class AsyncLLMServerManager:
             self.ray_tasks.append(task)
             output = await task
             return output
+        except ray.exceptions.TaskCancelledError as e:
+            raise asyncio.CancelledError from e
         except Exception as e:
             logger.error(f"server manager got exception: {e}")
+            raise
 
 
 class AgentLoopMetrics(BaseModel):

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -17,6 +17,7 @@ import logging
 import os
 import random
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -27,17 +28,19 @@ import torch
 from cachetools import LRUCache
 from omegaconf import DictConfig, OmegaConf
 from pydantic import BaseModel, ConfigDict
+from ray.util.queue import Queue
 from tensordict import TensorDict
 from transformers import AutoProcessor, AutoTokenizer
 
 from verl.experimental.agent_loop.prometheus_utils import update_prometheus_config
 from verl.experimental.agent_loop.utils import resolve_config_path
 from verl.experimental.reward import RewardManagerWorker
-from verl.protocol import DataProto
+from verl.protocol import DataProto, DataProtoItem
 from verl.single_controller.ray.base import RayWorkerGroup
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.fs import copy_to_local
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.queue_util import QueueMonitor
 from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
@@ -48,6 +51,31 @@ from verl.workers.rollout.replica import TokenOutput, get_rollout_replica_class
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def chunk_save(batch: DataProto, chunks: int) -> list[DataProto]:
+    """
+    chunk batch without padding
+    Args:
+        batch: the DataProto to chunk
+        chunks: the number of chunks to split on dim=0
+
+    Returns:
+        List[DataProto]: a list of DataProto after splitting
+    """
+    if len(batch) % chunks == 0:
+        return batch.chunk(chunks)
+    else:
+        chunk_size = len(batch) // chunks
+        remainder = len(batch) % chunks
+        result = []
+        start = 0
+
+        for i in range(chunks):
+            end = start + chunk_size + (1 if i < remainder else 0)
+            result.append(batch[start:end])
+            start = end
+        return result
 
 
 class AsyncLLMServerManager:
@@ -75,6 +103,23 @@ class AsyncLLMServerManager:
 
         # LRU cache to map request_id to server
         self.request_id_to_server = LRUCache(maxsize=max_cache_size)
+
+        self.gen_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
+        self.train_batch_size = self.config.data.train_batch_size
+        self.reorder_rollout = not (self.gen_batch_size == self.train_batch_size)
+
+        if self.reorder_rollout:
+            self.ray_tasks = []
+
+    def cancel_tasks(self):
+        """
+        Cancel all ray tasks
+        Returns:
+            no return
+        """
+        for ray_task in self.ray_tasks:
+            ray.cancel(ray_task)
+        self.ray_tasks = []
 
     def _choose_server(self, request_id: str) -> ray.actor.ActorHandle:
         # TODO: implement server pressure awareness load balancing
@@ -106,14 +151,20 @@ class AsyncLLMServerManager:
         Returns:
             TokenOutput: token output
         """
-        server = self._choose_server(request_id)
-        output = await server.generate.remote(
-            request_id=uuid4().hex,  # use new request_id for each turn
-            prompt_ids=prompt_ids,
-            sampling_params=sampling_params,
-            image_data=image_data,
-        )
-        return output
+        try:
+            server = self._choose_server(request_id)
+            task = server.generate.remote(
+                request_id=uuid4().hex,  # use new request_id for each turn
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+            )
+            self.ray_tasks.append(task)
+            output = await task
+            return output
+        except Exception as e:
+            logger.error(f"server manager got exception: {e}")
+
 
 
 class AgentLoopMetrics(BaseModel):
@@ -253,6 +304,73 @@ def register(agent_name: str):
     return decorator
 
 
+def _postprocess(inputs: list[_InternalAgentLoopOutput]) -> DataProto:
+    """Process the padded outputs from _run_agent_loop and combine them into a batch."""
+    # Convert lists back to tensors and stack them to create a batch.
+    prompt_ids = torch.cat([input.prompt_ids for input in inputs], dim=0)
+    response_ids = torch.cat([input.response_ids for input in inputs], dim=0)
+    response_mask = torch.cat([input.response_mask for input in inputs], dim=0)
+    attention_mask = torch.cat([input.attention_mask for input in inputs], dim=0)
+    input_ids = torch.cat([input.input_ids for input in inputs], dim=0)
+    position_ids = torch.cat([input.position_ids for input in inputs], dim=0)
+    optional_outputs = {}
+    if inputs[0].response_logprobs is not None:
+        optional_outputs["rollout_log_probs"] = torch.cat([input.response_logprobs for input in inputs], dim=0)
+
+    batch = TensorDict(
+        {
+            "prompts": prompt_ids,  # [bsz, prompt_length]
+            "responses": response_ids,  # [bsz, response_length]
+            "response_mask": response_mask,  # [bsz, response_length]
+            "input_ids": input_ids,  # [bsz, prompt_length + response_length]
+            "attention_mask": attention_mask,  # [bsz, prompt_length + response_length]
+            # position_ids: [bsz, 3, prompt_length + response_length] or [bsz, prompt_length + response_length]
+            "position_ids": position_ids,
+            **optional_outputs,
+        },
+        batch_size=len(inputs),
+    )
+
+    scores = [input.reward_score for input in inputs]
+    if all(score is not None for score in scores):
+        prompt_length = prompt_ids.size(1)
+        response_length = attention_mask[:, prompt_length:].sum(dim=1) - 1
+        rm_scores = torch.zeros_like(response_mask, dtype=torch.float32)
+        rm_scores[torch.arange(response_mask.size(0)), response_length] = torch.tensor(scores, dtype=torch.float32)
+        batch["rm_scores"] = rm_scores
+
+    non_tensor_batch = {
+        "__num_turns__": np.array([input.num_turns for input in inputs], dtype=np.int32),
+    }
+
+    # add reward_extra_info to non_tensor_batch
+    reward_extra_infos = [input.extra_fields.get("reward_extra_info", {}) for input in inputs]
+    reward_extra_keys = list(reward_extra_infos[0].keys())
+    for key in reward_extra_keys:
+        non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
+
+    # Add multi_modal_inputs to non_tensor_batch if any samples have them
+    multi_modal_inputs_list = [input.multi_modal_inputs for input in inputs]
+    if any(mmi is not None for mmi in multi_modal_inputs_list):
+        non_tensor_batch["multi_modal_inputs"] = np.array(multi_modal_inputs_list, dtype=object)
+
+    metrics = [input.metrics.model_dump() for input in inputs]
+    # Collect extra fields from all inputs and convert them to np.ndarray
+    extra_fields = {}
+    all_keys = set(key for input_item in inputs for key in input_item.extra_fields)
+    for key in all_keys:
+        temp_arr = np.empty(len(inputs), dtype=object)
+        temp_arr[:] = [input.extra_fields.get(key) for input in inputs]
+        extra_fields[key] = temp_arr
+
+    non_tensor_batch.update(extra_fields)
+    return DataProto(
+        batch=batch,
+        non_tensor_batch=non_tensor_batch,
+        meta_info={"metrics": metrics, "reward_extra_keys": reward_extra_keys},
+    )
+
+
 class AgentLoopWorkerBase:
     """Agent loop worker takes a batch of messages and run each message in an agent loop."""
 
@@ -309,8 +427,39 @@ class AgentLoopWorkerBase:
             trace_config.get("max_samples_per_step_per_worker", None),
         )
 
+        self.gen_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
+        self.train_batch_size = self.config.data.train_batch_size
+        self.reorder_rollout = not (self.gen_batch_size == self.train_batch_size)
+
+        if self.reorder_rollout:
+            self.queue = None
+            self.unfinished_queue = None
+            self.tasks = []
+
+    def set_queue(self, queue: QueueMonitor):
+        """
+            Set queue for agent loop worker.
+        Args:
+            queue: output queue for agent loop worker.
+
+        Returns:
+            no return
+        """
+        self.queue = queue
+
+    def set_unfinished_queue(self, unfinished_queue: Queue):
+        """
+            Set unfinished queue for agent loop worker.
+        Args:
+            unfinished_queue: queue for unfinished request in agent loop worker.
+
+        Returns:
+            no return
+        """
+        self.unfinished_queue = unfinished_queue
+
     @tqbridge()
-    async def generate_sequences(self, batch: DataProto) -> DataProto:
+    async def generate_sequences(self, batch: DataProto):
         """Generate sequences from agent loop.
 
         Args:
@@ -338,7 +487,8 @@ class AgentLoopWorkerBase:
             repetition_penalty=1.0,
             logprobs=config.calculate_log_probs,
         )
-
+        if self.reorder_rollout:
+            raw_batch = deepcopy(batch)
         # override sampling params for validation
         if batch.meta_info.get("validate", False):
             sampling_params["top_p"] = config.val_kwargs.top_p
@@ -374,19 +524,68 @@ class AgentLoopWorkerBase:
             batch.meta_info.get("global_steps", -1), index.tolist(), batch.meta_info.get("validate", False)
         )
 
-        tasks = []
+        if self.reorder_rollout:
+            return await self._reorder_create_task(batch, sampling_params, trajectory_info, traced_indices, raw_batch)
+        else:
+            return await self._base_create_task(batch, sampling_params, trajectory_info, traced_indices)
+
+    async def _reorder_create_task(
+        self,
+        batch: DataProto,
+        sampling_params: dict[str, Any],
+        trajectory_info: list[Any],
+        traced_indices: set[int],
+        raw_batch: DataProto,
+    ) -> None:
+        """
+            create reorder ray task for agent loop worker.
+        Args:
+            batch: batch data
+            sampling_params: generate sampling parameters
+            trajectory_info:
+            raw_batch: raw batch without MetaInfo
+
+        Returns:
+            function has no return plz get output in queue
+        """
+        self.tasks = []
         for i in range(len(batch)):
             trace_this_sample = i in traced_indices
             kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
-            tasks.append(
+            self.tasks.append(
+                asyncio.create_task(
+                    self._run_agent_loop(
+                        sampling_params, trajectory_info[i], trace=trace_this_sample, raw_item=raw_batch[i], **kwargs
+                    )
+                )
+            )
+
+        results = await asyncio.gather(*self.tasks, return_exceptions=True)
+
+        for i, result in enumerate(results):
+            if isinstance(result, asyncio.CancelledError):
+                await self.unfinished_queue.put_async(raw_batch[i])
+
+    async def _base_create_task(
+        self,
+        batch: DataProto,
+        sampling_params: dict[str, Any],
+        trajectory_info: list[Any],
+        traced_indices: set[int],
+    ) -> DataProto:
+        self.tasks = []
+
+        for i in range(len(batch)):
+            trace_this_sample = i in traced_indices
+            kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
+            self.tasks.append(
                 asyncio.create_task(
                     self._run_agent_loop(sampling_params, trajectory_info[i], trace=trace_this_sample, **kwargs)
                 )
             )
-        outputs = await asyncio.gather(*tasks)
+        outputs = await asyncio.gather(*self.tasks)
 
-        output = self._postprocess(outputs)
-
+        output = _postprocess(outputs)
         return output
 
     async def _run_agent_loop(
@@ -396,8 +595,9 @@ class AgentLoopWorkerBase:
         *,
         agent_name: str,
         trace: bool = True,
+        raw_item: DataProtoItem = None,
         **kwargs,
-    ) -> _InternalAgentLoopOutput:
+    ):
         with rollout_trace_attr(
             step=trajectory["step"],
             sample_index=trajectory["sample_index"],
@@ -551,7 +751,7 @@ class AgentLoopWorkerBase:
                 output.reward_score = result["reward_score"]
                 output.extra_fields["reward_extra_info"] = result["reward_extra_info"]
 
-            return _InternalAgentLoopOutput(
+            loop_output = _InternalAgentLoopOutput(
                 prompt_ids=prompt_output["input_ids"],
                 response_ids=response_output["input_ids"],
                 input_ids=input_ids,
@@ -566,72 +766,26 @@ class AgentLoopWorkerBase:
                 metrics=output.metrics,
                 extra_fields=output.extra_fields,
             )
+            if self.reorder_rollout:
+                await self.queue.put.remote(
+                    (
+                        raw_item,
+                        loop_output,
+                    )
+                )
+                return
+            else:
+                return loop_output
 
-    def _postprocess(self, inputs: list[_InternalAgentLoopOutput]) -> DataProto:
-        """Process the padded outputs from _run_agent_loop and combine them into a batch."""
-        # Convert lists back to tensors and stack them to create a batch.
-        prompt_ids = torch.cat([input.prompt_ids for input in inputs], dim=0)
-        response_ids = torch.cat([input.response_ids for input in inputs], dim=0)
-        response_mask = torch.cat([input.response_mask for input in inputs], dim=0)
-        attention_mask = torch.cat([input.attention_mask for input in inputs], dim=0)
-        input_ids = torch.cat([input.input_ids for input in inputs], dim=0)
-        position_ids = torch.cat([input.position_ids for input in inputs], dim=0)
-        optional_outputs = {}
-        if inputs[0].response_logprobs is not None:
-            optional_outputs["rollout_log_probs"] = torch.cat([input.response_logprobs for input in inputs], dim=0)
-
-        batch = TensorDict(
-            {
-                "prompts": prompt_ids,  # [bsz, prompt_length]
-                "responses": response_ids,  # [bsz, response_length]
-                "response_mask": response_mask,  # [bsz, response_length]
-                "input_ids": input_ids,  # [bsz, prompt_length + response_length]
-                "attention_mask": attention_mask,  # [bsz, prompt_length + response_length]
-                # position_ids: [bsz, 3, prompt_length + response_length] or [bsz, prompt_length + response_length]
-                "position_ids": position_ids,
-                **optional_outputs,
-            },
-            batch_size=len(inputs),
-        )
-
-        scores = [input.reward_score for input in inputs]
-        if all(score is not None for score in scores):
-            prompt_length = prompt_ids.size(1)
-            response_length = attention_mask[:, prompt_length:].sum(dim=1) - 1
-            rm_scores = torch.zeros_like(response_mask, dtype=torch.float32)
-            rm_scores[torch.arange(response_mask.size(0)), response_length] = torch.tensor(scores, dtype=torch.float32)
-            batch["rm_scores"] = rm_scores
-
-        non_tensor_batch = {
-            "__num_turns__": np.array([input.num_turns for input in inputs], dtype=np.int32),
-        }
-
-        # add reward_extra_info to non_tensor_batch
-        reward_extra_infos = [input.extra_fields.get("reward_extra_info", {}) for input in inputs]
-        reward_extra_keys = list(reward_extra_infos[0].keys())
-        for key in reward_extra_keys:
-            non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
-
-        # Add multi_modal_inputs to non_tensor_batch if any samples have them
-        multi_modal_inputs_list = [input.multi_modal_inputs for input in inputs]
-        if any(mmi is not None for mmi in multi_modal_inputs_list):
-            non_tensor_batch["multi_modal_inputs"] = np.array(multi_modal_inputs_list, dtype=object)
-
-        metrics = [input.metrics.model_dump() for input in inputs]
-        # Collect extra fields from all inputs and convert them to np.ndarray
-        extra_fields = {}
-        all_keys = set(key for input_item in inputs for key in input_item.extra_fields)
-        for key in all_keys:
-            temp_arr = np.empty(len(inputs), dtype=object)
-            temp_arr[:] = [input.extra_fields.get(key) for input in inputs]
-            extra_fields[key] = temp_arr
-
-        non_tensor_batch.update(extra_fields)
-        return DataProto(
-            batch=batch,
-            non_tensor_batch=non_tensor_batch,
-            meta_info={"metrics": metrics, "reward_extra_keys": reward_extra_keys},
-        )
+    async def cancel_tasks(self):
+        """
+            Cancel all asyncIO tasks and cancel manager ray task
+        Returns:
+            no return
+        """
+        for task in self.tasks:
+            task.cancel()
+        self.server_manager.cancel_tasks()
 
     def create_transferqueue_client(self, controller_info, role):
         """Create a client for data system(transfer queue)."""
@@ -713,9 +867,49 @@ class AgentLoopManager:
         self._initialize_llm_servers()
         self._init_agent_loop_workers()
 
+        self.gen_batch_size = self.config.data.get("gen_batch_size", self.config.data.train_batch_size)
+        self.train_batch_size = self.config.data.train_batch_size
+        self.reorder_rollout = not (self.gen_batch_size == self.train_batch_size)
+        if self.reorder_rollout:
+            self.queue = QueueMonitor.remote(self.train_batch_size * self.config.actor_rollout_ref.rollout.n)
+            for worker in self.agent_loop_workers:
+                ray.get(worker.set_queue.remote(self.queue))
+                ray.get(self.queue.append_worker.remote(worker))
+
         # Initially we're in sleep mode.
         if self.config.actor_rollout_ref.rollout.free_cache_engine:
             self.sleep()
+
+    def get_threshold(self) -> int:
+        """
+            get queue threshold.
+        Returns:
+            int: output queue threshold.
+        """
+        return ray.get(self.queue.get_threshold.remote())
+
+    def set_threshold(self, threshold: int):
+        """
+        set queue threshold.
+        Args:
+            threshold: queue threshold
+
+        Returns:
+            no return
+        """
+        ray.get(self.queue.set_threshold.remote(threshold))
+
+    def set_unfinished_queue(self, unfinished_queue):
+        """
+            set unfinished queue for all worker.
+        Args:
+            unfinished_queue: Queue for unfinished worker.
+
+        Returns:
+
+        """
+        for worker in self.agent_loop_workers:
+            ray.get(worker.set_unfinished_queue.remote(unfinished_queue))
 
     def _initialize_llm_servers(self):
         rollout_world_size = (
@@ -773,6 +967,51 @@ class AgentLoopManager:
                 ).remote(self.config, self.server_handles, self.reward_router_address)
             )
 
+    def _run_reorder_worker_generate_sequences(self, prompts: DataProto) -> tuple[DataProto, list[Any]]:
+        chunkes = chunk_save(prompts, len(self.agent_loop_workers))
+        tasks = [
+            worker.generate_sequences.remote(chunk)
+            for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
+        ]
+        try:
+            ray.get(tasks)
+        except ray.exceptions.TaskCancelledError as e:
+            logger.warning(f"Task cancelled: {e}")
+
+        hybird_out = ray.get(self.queue.clear.remote())
+
+        tasks_outputs = []
+        raw_items = []
+        for raw_item, tasks_output in hybird_out:
+            tasks_outputs.append(tasks_output)
+            raw_items.append(raw_item)
+
+        batch_output = _postprocess(tasks_outputs)
+
+        # calculate performance metrics
+        metrics = [batch_output.meta_info.pop("metrics")]  # List[List[Dict[str, str]]]
+        timing = self._performance_metrics(metrics, batch_output)
+
+        batch_output.meta_info = {"timing": timing, **batch_output.meta_info}
+        return batch_output, raw_items
+
+    def _run_worker_generate_sequences(self, prompts: DataProto) -> DataProto:
+        chunkes = prompts.chunk(len(self.agent_loop_workers))
+        outputs = ray.get(
+            [
+                worker.generate_sequences.remote(chunk)
+                for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
+            ]
+        )
+        output = DataProto.concat(outputs)
+
+        # calculate performance metrics
+        metrics = [output.meta_info.pop("metrics") for output in outputs]  # List[List[Dict[str, str]]]
+        timing = self._performance_metrics(metrics, output)
+
+        output.meta_info = {"timing": timing, **outputs[0].meta_info}
+        return output
+
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         """Split input batch and dispatch to agent loop workers.
 
@@ -789,24 +1028,16 @@ class AgentLoopManager:
         if self.reward_model_manager:
             self.reward_model_manager.wake_up()
 
-        chunkes = prompts.chunk(len(self.agent_loop_workers))
-        outputs = ray.get(
-            [
-                worker.generate_sequences.remote(chunk)
-                for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
-            ]
-        )
-        output = DataProto.concat(outputs)
-        # Fix for Issue #4147: Always call sleep() to ensure proper cleanup
+        if self.reorder_rollout:
+            output = self._run_reorder_worker_generate_sequences(prompts)
+        else:
+            output = self._run_worker_generate_sequences(prompts)
+
+
         self.sleep()
         if self.reward_model_manager:
             self.reward_model_manager.sleep()
 
-        # calculate performance metrics
-        metrics = [output.meta_info.pop("metrics") for output in outputs]  # List[List[Dict[str, str]]]
-        timing = self._performance_metrics(metrics, output)
-
-        output.meta_info = {"timing": timing, **outputs[0].meta_info}
         return output
 
     def _performance_metrics(self, metrics: list[list[dict[str, str]]], output: DataProto) -> dict[str, float]:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1030,7 +1030,6 @@ class AgentLoopManager:
         else:
             output = self._run_worker_generate_sequences(prompts)
 
-
         self.sleep()
         if self.reward_model_manager:
             self.reward_model_manager.sleep()

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -166,7 +166,6 @@ class AsyncLLMServerManager:
             logger.error(f"server manager got exception: {e}")
 
 
-
 class AgentLoopMetrics(BaseModel):
     """Agent loop performance metrics."""
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -18,7 +18,6 @@ PPO Trainer with Ray-based single controller.
 This trainer supports model-agonistic model initialization with huggingface
 """
 
-import asyncio
 import json
 import os
 import uuid
@@ -267,18 +266,17 @@ def _get_all_from_queue(queue, max_item=None) -> list[Any]:
     Args:
         queue: queue to get items from.
         max_item: limit the number of items to return.
-
     Returns:
         list[Any]: list of items.
     """
     items = []
-    while not queue.empty():
+    while True:
         try:
+            if max_item and len(items) >= max_item:
+                break
             item = queue.get_nowait()
             items.append(item)
-        except asyncio.QueueEmpty:
-            break
-        if max_item and len(items) >= max_item:
+        except ray.exceptions.QueueEmpty:
             break
     return items
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1067,7 +1067,7 @@ class RayPPOTrainer:
         for epoch in range(current_epoch, self.config.trainer.total_epochs):
             for batch_dict in self.train_dataloader:
                 train_batch_size = self.config.data.train_batch_size * self.config.actor_rollout_ref.rollout.n
-                if self.unfinished_queue.qsize() >= train_batch_size:
+                if self.reorder_rollout and self.unfinished_queue.qsize() >= train_batch_size:
                     # When using reordering, some incomplete long-tail requests are generated,
                     # so these requests need to be grouped into an additional batch for inference.
                     unfinished_batch_list = _get_all_from_queue(self.unfinished_queue, max_item=train_batch_size)
@@ -1122,6 +1122,7 @@ class RayPPOTrainer:
         with marked_timer("step", timing_raw):
             # generate a batch
             with marked_timer("gen", timing_raw, color="red"):
+                raw_item = None
                 if not self.async_rollout_mode:
                     gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch_output)
                 else:

--- a/verl/utils/queue_util.py
+++ b/verl/utils/queue_util.py
@@ -1,0 +1,69 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from asyncio import Queue
+from typing import Any
+
+import ray
+
+
+@ray.remote
+class QueueMonitor:
+    """
+    Queue for early exit. When the queue reaches its threshold, all worker tasks will be canceled.
+    """
+
+    def __init__(self, threshold: int = 10):
+        self.queue = Queue()
+        self.threshold = threshold
+        self.workers = []
+
+    def get_threshold(self):
+        return self.threshold
+
+    def set_threshold(self, threshold: int):
+        self.threshold = threshold
+
+    def check_threshold(self) -> bool:
+        current_size = self.queue.qsize()
+        return current_size >= self.threshold
+
+    def get_current_size(self) -> int:
+        return self.queue.qsize()
+
+    async def put(self, item: Any):
+        if self.check_threshold():
+            await self._cancel_all_workers()
+            return
+
+        await self.queue.put(item)
+
+    def append_worker(self, worker):
+        self.workers.append(worker)
+
+    async def _cancel_all_workers(self):
+        tasks = [worker.cancel_tasks.remote() for worker in self.workers]
+        await asyncio.gather(*tasks)
+
+    def clear(self):
+        items = []
+        while not self.queue.empty():
+            try:
+                item = self.queue.get_nowait()
+                items.append(item)
+                self.queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+        return items


### PR DESCRIPTION
### What does this PR do?
The long-tail effect in the current rollout phase is more pronounced in scenarios with long max response lengths. Therefore, we need a solution to address the long-tail effect in this scenario, thereby reducing the overall training time.

![20251110161447](https://github.com/user-attachments/assets/2cd6cefc-a443-41b4-b695-474ce0d34dcc)

The PR strategy for this project comes from [RollPacker](https://arxiv.org/abs/2509.21009)

Add multiple requests during the data preparation phase. Once the required number of requests for training is met, end all training rollout requests and save them to a list. In a later step, re-add them in a long-tail batch.

experimental data in GRPO-Qwen3-8b_bf16-tp2-ep1 gen_batch_size=18 train_batch_size=16
normal mean ablation experimental group
<img width="1874" height="610" alt="image" src="https://github.com/user-attachments/assets/4b6d14fc-ac6c-4641-ad05-50e29778f42d" />




### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [#2200 PR](https://github.com/volcengine/verl/pull/2200) [#2929 PR](https://github.com/volcengine/verl/pull/2929)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

example: examples/grpo_trainer/run_qwen3-8b_reorder.sh

### API and Usage Example

You can enable this feature by adding a batch size larger than the training batch size.
`data.train_batch_size=8
+data.gen_batch_size=10`


### Design & Code Changes
#### 1. Data preparation stage
Modify the existing data preparation logic, adding a new variable to configure the number of additional data records that need to be prepared. Add additional logic during data preparation to use identified long-tail requests to form batches.
![20251110200626](https://github.com/user-attachments/assets/06514889-4adf-4ad6-a545-d458f222cfd9)

#### 2. rollout post-process
The original `asycio.gather` check logic for the end of a rollout needs to be replaced with a check of the number of completed rollout requests. At the same time, unprocessed requests need to be marked as long-tail requests, added to a new long-tail request list, and the `abort` interface used to abort the request.
![20251110200645](https://github.com/user-attachments/assets/c716abcd-2a76-42ea-8794-9cc5908cce93)

#### 3. reload req
Here we offer two options as solutions: adding in small amounts and multiple times, and adding all at once in multiple batches.

1. The meaning of adding a small number of requests is that long-tail requests from each step will be added to the next round of rollout<sup>1</sup>. After the requests are added, the long-tail request list is cleared<sup>2</sup>. However, due to the limited learning rate, requests that exhibited a long-tail effect in the previous round are likely to exhibit a long-tail effect in this round as well. This may lead to a rollback phenomenon, i.e., a rollback to the original implementation that uses the newly added requests. However, if the one-step-off-policy strategy of using the streaming return results of the previous round as the prompt input<sup>3</sup> can be used, the rollback phenomenon can be largely avoided.
![20251110203121](https://github.com/user-attachments/assets/8174e25d-7089-4cc5-a5cc-78c6dc13b352)


2. Adding multiple requests together means that all long-tail requests are added to the training process to execute a complete training step, provided they form a complete batch. The drawback of this approach is that long-sequence requests that should be distributed across multiple training steps are concentrated into a single step, which may limit the learning rate and prevent effective learning of long-sequence representation capabilities.
normal step:
![20251110193215](https://github.com/user-attachments/assets/a3cc9f8e-6498-4c53-bc03-bfb5531a18da)
unfinished req step:
![20251110193503](https://github.com/user-attachments/assets/34fa01e1-7e0a-458a-b590-6e7b72180a69)


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
