### PR TITLE
[tool] long for position id

### DIFF
--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -222,7 +222,7 @@ def create_random_mask(
 
 
 def compute_position_id_with_mask(mask):
-    return torch.clip(torch.cumsum(mask, dim=-1) - 1, min=0, max=None)
+    return torch.clip(torch.cumsum(mask.long(), dim=-1) - 1, min=0, max=None)
 
 
 def convert_weight_keys(state_dict: dict[str, torch.Tensor], model: PreTrainedModel):


### PR DESCRIPTION
### What does this PR do?

If user `set_default_dtype` somewhere, the position_id might be wrong in `bfloat16` and `float16`.

