### PR TITLE
Update flops_counter.py

### DIFF
--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -163,7 +163,7 @@ class FlopsCounter:
         # Qwen2/LLama use SwiGelu, gate, having up and down linear layer in mlp
         mlp_N = hidden_size * intermediate_size * 3
         attn_linear_N = hidden_size * (q_size + k_size + v_size + num_attention_heads * head_dim)
-        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        emd_and_lm_head_N = vocab_size * hidden_size  # embedding has 0 MACs
         # non-attn all_layer parm
         dense_N = (mlp_N + attn_linear_N) * num_hidden_layers + emd_and_lm_head_N
         # non-attn all_layer & all_token fwd & bwd flops
@@ -212,7 +212,7 @@ class FlopsCounter:
             * self.config.kv_lora_rank
         )
         attn_linear_N += num_query_heads * self.config.v_head_dim * hidden_size
-        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        emd_and_lm_head_N = vocab_size * hidden_size  # embedding has 0 MACs
         # non-attn all_layer parm
         moe_N = (
             (moe_gata_N + moe_expertmlp_N + attn_linear_N) * (num_hidden_layers - first_k_dense_replace)
@@ -253,7 +253,7 @@ class FlopsCounter:
         # gate + moe export
         moe_mlp_N = hidden_size * moe_topk * moe_intermediate_size * 3 + hidden_size * num_experts
         attn_linear_N = hidden_size * (q_size + k_size + v_size + num_attention_heads * head_dim)
-        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        emd_and_lm_head_N = vocab_size * hidden_size  # embedding has 0 MACs
         # non-attn all_layer parm
         dense_N = (moe_mlp_N + attn_linear_N) * num_hidden_layers + emd_and_lm_head_N
         # non-attn all_layer & all_token fwd & bwd flops
@@ -287,7 +287,7 @@ class FlopsCounter:
         # Gemma3 uses GeGLU (gelu_pytorch_tanh), having 3 matrices in MLP (inherited from Gemma2MLP)
         mlp_N = hidden_size * intermediate_size * 3
         attn_linear_N = hidden_size * (q_size + k_size + v_size + num_attention_heads * head_dim)
-        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        emd_and_lm_head_N = vocab_size * hidden_size  # embedding has 0 MACs
         # non-attn all_layer parm
         dense_N = (mlp_N + attn_linear_N) * num_hidden_layers + emd_and_lm_head_N
         # non-attn all_layer & all_token fwd & bwd flops
@@ -359,7 +359,7 @@ class FlopsCounter:
         # This adds params for q_norm (on H) and k_norm (on num_kv_heads * head_dim)
         qk_norm_params_per_layer = hidden_size + num_key_value_heads * head_dim  # q_norm + k_norm
 
-        emd_and_lm_head_N = vocab_size * hidden_size * 2
+        emd_and_lm_head_N = vocab_size * hidden_size  # embedding has 0 MACs
         # non-attn all_layer params
         dense_N = (mlp_N + attn_linear_N + qk_norm_params_per_layer) * num_hidden_layers + emd_and_lm_head_N
         # non-attn all_layer & all_token fwd & bwd flops


### PR DESCRIPTION
Embedding lookup is 0 MACs, so that `*2` multiplier shouldn't be there (the mac to flop 2x multiplier is already in the `6*` multiplier later.

Alternatively, instead of explaining via a comment, could rename the variable to drop the `emb_and_` prefix, then it's self-documenting.
