### PR TITLE
[megatron] fix: correct weight passing in fused forward

### DIFF
--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -200,7 +200,9 @@ def _fused_GPTModel_forward(
         hidden_states = gather_from_sequence_parallel_region(hidden_states)
     logprobs, entropy = linear_cross_entropy(
         hidden_states,
-        model.output_layer.weight,
+        model.output_layer.weight
+        if not model.share_embeddings_and_output_weights
+        else model.shared_embedding_or_output_weight(),
         labels,
         temperature,
         "none",

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -200,9 +200,11 @@ def _fused_GPTModel_forward(
         hidden_states = gather_from_sequence_parallel_region(hidden_states)
     logprobs, entropy = linear_cross_entropy(
         hidden_states,
-        model.output_layer.weight
-        if not model.share_embeddings_and_output_weights
-        else model.shared_embedding_or_output_weight(),
+        (
+            model.shared_embedding_or_output_weight()
+            if model.share_embeddings_and_output_weights
+            else model.output_layer.weight
+        ),
         labels,
         temperature,
         "none",


### PR DESCRIPTION
### What does this PR do?

This PR addresses the issue encountered when setting `use fuse kernel` to `true` during `qwen3-0.6` training in `megatron`. The specific error is as follows:
```code
  File "model_forward_fused.py", line 201, in _fused_GPTModel_forward
    logprobs, entropy = linear_cross_entropy(
                         ^^^^^^^^^^^^^^^^^^^^^
  File "function.py", line 576, in apply
    return super().apply(*args, **kwargs)  # type: ignore[misc]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "linear_cross_entropy.py", line 77, in forward
    logprobs, entropy, _maximum, _accumulate, _entropy_b = kernels.efficient_entropy_forward(
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "kernels.py", line 518, in efficient_entropy_forward
    assert hidden.is_cuda and weight.is_cuda and labels.is_cuda
                              ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_cuda'

```

Upon investigation, the issue arises when the `weight` passed to `linear_cross_entropy` is `None` during the call to the `_fused_GPTModel_forward` function of the `GPTmodel`. This is because when `share_embeddings_and_output_weights` is set to `true`, the `weight` from `embeddings_layer` should be passed instead of the `output_layer`.

### Test

It has been experimentally verified that when `share_embeddings_and_output_weights` is set to `true`, the `forward` function correctly passes the `weight` from `embeddings_layer`, resolving the error.

### API and Usage Example

This PR does not involve any API changes; usage remains unchanged.

### Design & Code Changes

The `_fused_GPTModel_forward` function in `verl/models/mcore/model_forward_fused.py` has been modified to ensure the correct `weight` is passed to `linear_cross_entropy`.
