### PR TITLE
[megatron] fix: Pass optimizer config betas to Megatron optimizer config

### DIFF
--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -49,6 +49,10 @@ def init_megatron_optim_config(optim_config: dict, fp16: bool = False) -> Optimi
                 "params_dtype": torch.bfloat16,
             }
         )
+    if optim_config.optimizer == "adam":
+        optim_args["adam_beta1"] = optim_config.betas[0]
+        optim_args["adam_beta2"] = optim_config.betas[1]
+        
     override_config = optim_config.get("override_optimizer_config", {})
     if override_config:
         for k, v in override_config.items():

--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -19,9 +19,10 @@ from megatron.core.optimizer import get_megatron_optimizer as get_megatron_optim
 from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 
 from verl.utils.logger import print_rank_0
+from verl.workers.config.optimizer import McoreOptimizerConfig
 
 
-def init_megatron_optim_config(optim_config: dict, fp16: bool = False) -> OptimizerConfig:
+def init_megatron_optim_config(optim_config: McoreOptimizerConfig, fp16: bool = False) -> OptimizerConfig:
     optim_args = {
         "optimizer": optim_config.optimizer,
         "lr": optim_config.lr,

--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -52,7 +52,7 @@ def init_megatron_optim_config(optim_config: dict, fp16: bool = False) -> Optimi
     if optim_config.optimizer == "adam":
         optim_args["adam_beta1"] = optim_config.betas[0]
         optim_args["adam_beta2"] = optim_config.betas[1]
-        
+
     override_config = optim_config.get("override_optimizer_config", {})
     if override_config:
         for k, v in override_config.items():


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug where the value of the beta parameters for the Adam optimizer `actor_rollout_ref.(actor|critic).optim.betas` are ignored when using the Megatron backend.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: beta; optimizer
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

No changes

### API and Usage Example

No changes

### Design & Code Changes

No design choices or changes

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
