### PR TITLE
[recipe] fix: tighten async rollouter task handling

### DIFF
--- a/recipe/fully_async_policy/fully_async_rollouter.py
+++ b/recipe/fully_async_policy/fully_async_rollouter.py
@@ -572,7 +572,6 @@ class FullyAsyncRollouter(FullyAsyncRayPPOTrainer):
             if self.feed_task not in done:
                 raise RuntimeError("Processor or consumer task exited prematurely")
 
-            # If we get here, feed_task is done successfully
             print("[FullyAsyncRollouter] Sample feed completed")
 
             # Wait for streaming to complete


### PR DESCRIPTION
### What does this PR do?

1. Initialize asyncio condition/lock via _init_async_objects during worker init to avoid loop-mismatch errors in Ray.
2. Monitor feed/processor/consumer tasks with asyncio.wait so premature worker exits surface early instead of hanging on a full queue.
3. Fix #4205 


### Test

pre-commit run --files recipe/fully_async_policy/fully_async_rollouter.py

sh recipe/fully_async_policy/shell/dapo_7b_math_fsdp2_1_1.sh

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
