### PR TITLE
[misc] feat: Add `actor_rollout_ref.actor.calculate_entropy` for entropy fwd

### DIFF
--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -77,6 +77,7 @@ actor_rollout_ref:
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     entropy_coeff: 0
+    calculate_entropy: false
     use_kl_loss: false
     use_torch_compile: true
     kl_loss_coef: 0.001

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -64,6 +64,7 @@ actor_rollout_ref:
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     entropy_coeff: 0
+    calculate_entropy: false
     use_kl_loss: false
     use_torch_compile: true
     kl_loss_coef: 0.001

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -74,6 +74,9 @@ loss_agg_mode: token-mean
 # Entropy regularization coefficient in PPO loss
 entropy_coeff: 0
 
+# When true, the actor forward will request entropy from the model
+calculate_entropy: false
+
 # Whether to use KL loss instead of KL reward penalty. True for GRPO
 use_kl_loss: false
 

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -106,6 +106,7 @@ class ActorConfig(BaseConfig):
     clip_ratio_c: float = 3.0
     loss_agg_mode: str = "token-mean"
     entropy_coeff: float = 0
+    calculate_entropy: bool = False
     use_kl_loss: bool = False
     use_torch_compile: bool = True
     kl_loss_coef: float = 0.001


### PR DESCRIPTION
Currently, `entropys` is only calculated in non-bypass when calculating `old_log_prob`