### PR TITLE
[fsdp] fix: shard LoRA modules separately to prevent dtype mismatch errors with FSDP2

### DIFF
--- a/recipe/flowrl/flowrl_fsdp_worker.py
+++ b/recipe/flowrl/flowrl_fsdp_worker.py
@@ -325,7 +325,7 @@ class FlowRLActorRolloutRefWorker(ActorRolloutRefWorker):
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
             full_state = actor_module.state_dict()
-            apply_fsdp2(actor_module, fsdp_kwargs, fsdp_config)
+            apply_fsdp2(actor_module, fsdp_kwargs, fsdp_config, is_lora=self._is_lora)
             fsdp2_load_full_state_dict(actor_module, full_state, fsdp_mesh, cpu_offload)
             actor_module_fsdp = actor_module
         else:

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -328,7 +328,7 @@ class FSDPSFTTrainer:
                 "reshard_after_forward": True,
             }
             full_state = self.model.state_dict()
-            apply_fsdp2(self.model, fsdp_kwargs, self.config.model.fsdp_config)
+            apply_fsdp2(self.model, fsdp_kwargs, self.config.model.fsdp_config, is_lora=self.lora)
             fsdp2_load_full_state_dict(self.model, full_state, self.device_mesh, cpu_offload)
             self.fsdp_model = self.model
         else:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -346,7 +346,7 @@ class FSDPEngine(BaseEngine):
                 "reshard_after_forward": self.engine_config.reshard_after_forward,
             }
             full_state = module.state_dict()
-            apply_fsdp2(module, fsdp_kwargs, self.engine_config)
+            apply_fsdp2(module, fsdp_kwargs, self.engine_config, is_lora=self._is_lora)
             fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
         else:
             raise NotImplementedError(f"Unknown strategy {self.engine_config.strategy}")

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -525,7 +525,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
             full_state = actor_module.state_dict()
-            apply_fsdp2(actor_module, fsdp_kwargs, fsdp_config)
+            apply_fsdp2(actor_module, fsdp_kwargs, fsdp_config, is_lora=self._is_lora)
             fsdp2_load_full_state_dict(actor_module, full_state, fsdp_mesh, cpu_offload)
             actor_module_fsdp = actor_module
         else:
@@ -1406,7 +1406,7 @@ class CriticWorker(Worker, DistProfilerExtension):
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
             full_state = critic_module.state_dict()
-            apply_fsdp2(critic_module, fsdp_kwargs, fsdp_config)
+            apply_fsdp2(critic_module, fsdp_kwargs, fsdp_config, is_lora=self._is_lora)
             fsdp2_load_full_state_dict(critic_module, full_state, fsdp_mesh, offload_policy)
         else:
             raise NotImplementedError(f"Unknown strategy {config.strategy}")


### PR DESCRIPTION
### What does this PR do?

Fixes #3470

Currently, when the base model is loaded in a dtype other than fp32, its parameters end up in a different dtype than the LoRA adapters (since we do not set `autocast_adapter_dtype=False` and the adapter parameters are cast to fp32 by default). With FSDP1, the wrapping policies for base model modules and LoRA modules are handled separately, so this mismatch does not cause issues. For FSDP2, however, there is no equivalent handling, and base model parameters and LoRA parameters can end up under the same FSDP wrapper, leading to dtype mismatch errors. This PR fixes this issue.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+is%3Aopen+FSDP2
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Running `python -m verl.trainer.main_ppo` with `actor_rollout_ref.actor.strategy=fsdp2` and `actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16` in the current main branch gives the error:
```
AssertionError: FSDP expects uniform original parameter dtype but got {torch.float32, torch.bfloat16}
```
but it runs well in this branch.

### API and Usage Example

No API changes.

### Design & Code Changes

This change updates the FSDP2 wrapping logic to explicitly identify LoRA modules and shard them separately from the base model modules.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
