### PR TITLE
Fix SPIN worker to inherit AsyncActorRolloutRefWorker

### DIFF
--- a/recipe/spin/fsdp_workers.py
+++ b/recipe/spin/fsdp_workers.py
@@ -47,7 +47,7 @@ from verl.utils.fsdp_utils import (
 from verl.utils.import_utils import import_external_libs
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import log_gpu_memory_usage
-from verl.workers.fsdp_workers import ActorRolloutRefWorker
+from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
 from verl.workers.sharding_manager.fsdp_ulysses import FSDPUlyssesShardingManager
 
 logger = logging.getLogger(__file__)
@@ -76,7 +76,7 @@ def get_sharding_strategy(device_mesh):
     return sharding_strategy
 
 
-class SPINRolloutRefWorker(ActorRolloutRefWorker):
+class SPINRolloutRefWorker(AsyncActorRolloutRefWorker):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
         from recipe.spin.dp_actor import SPINDataParallelPPOActor as DataParallelPPOActor


### PR DESCRIPTION
Fixes #4220

This PR addresses the RuntimeError: no running event loop issue in SPIN recipe by changing `SPINRolloutRefWorker` to inherit from `AsyncActorRolloutRefWorker` instead of `ActorRolloutRefWorker`.

## Problem

As noted by @wuxibin89 in #4246, the SPIN recipe has a break because `SPINRolloutRefWorker` should inherit from `AsyncActorRolloutRefWorker`, which is an asyncio Ray actor that always has an event loop.

## Solution

Changed the inheritance from `ActorRolloutRefWorker` to `AsyncActorRolloutRefWorker`:
- Updated import statement (line 50)
- Updated class declaration (line 79)

## Why This Fix Works

`AsyncActorRolloutRefWorker` is an asyncio Ray actor that maintains a running event loop throughout its lifecycle. This event loop is required for:
- vLLM's async rollout methods (`generate`, `chat_completion`, etc.)
- Worker mode switching (`wake_up`, `sleep`)
- All other async operations in the rollout pipeline

By inheriting from `AsyncActorRolloutRefWorker`, the SPIN worker gets:
✅ A persistent event loop (maintained by Ray)
✅ Support for async methods
✅ Compatibility with vLLMAsyncRollout

## Files Changed

- `recipe/spin/fsdp_workers.py`: 2 lines changed (import + class inheritance)

## Testing

This fix aligns SPIN recipe with other async recipes like `fully_async_policy` which also inherit from `AsyncActorRolloutRefWorker`.