### PR TITLE
[recipe] fix: prime compatibility issues

### DIFF
--- a/.github/workflows/e2e_prime.yml
+++ b/.github/workflows/e2e_prime.yml
@@ -1,0 +1,150 @@
+# # Tests layout
+#
+# Each folder under tests/ corresponds to a test category for a sub-namespace in verl. For instance:
+# - `tests/trainer` for testing functionality related to `verl/trainer`
+# - `tests/models` for testing functionality related to `verl/models`
+# - ...
+#
+# There are a few folders with `special_` prefix, created for special purposes:
+# - `special_distributed`: unit tests that must run with multiple GPUs
+# - `special_e2e`: end-to-end tests with training/generation scripts
+# - `special_npu`: tests for NPUs
+# - `special_sanity`: a suite of quick sanity tests
+# - `special_standalone`: a set of test that are designed to run in dedicated environments
+#
+# Accelerators for tests 
+# - By default tests are run with GPU available, except for the ones under `special_npu`, and any test script whose name ends with `on_cpu.py`.
+# - For test scripts with `on_cpu.py` name suffix would be tested on CPU resources in linux environment.
+#
+# # Workflow layout
+#
+# All CI tests are configured by yaml files in `.github/workflows/`. Here's an overview of all test configs:
+# 1. A list of always triggered CPU sanity tests: `check-pr-title.yml`, `secrets_scan.yml`, `check-pr-title,yml`, `pre-commit.yml`, `doc.yml`
+# 2. Some heavy multi-GPU unit tests, such as `model.yml`, `vllm.yml`, `sgl.yml`
+# 3. End-to-end tests: `e2e_*.yml`
+# 4. Unit tests
+#   - `cpu_unit_tests.yml`, run pytest on all scripts with file name pattern `tests/**/test_*_on_cpu.py`
+#   - `gpu_unit_tests.yml`, run pytest on all scripts with file without the `on_cpu.py` suffix.
+#   - Since cpu/gpu unit tests by default runs all tests under `tests`, please make sure tests are manually excluded in them when
+#     - new workflow yaml is added to `.github/workflows`
+#     - new tests are added to workflow mentioned in 2.
+
+
+name: e2e_prime
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  # For push, for now only anti-patterns are specified so it is more conservative
+  # and achieves higher coverage.
+  push:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "verl/*.py"
+      # Other entrypoints
+      - "!examples/*trainer*"
+      - "!tests/**"
+      - "!verl/trainer/main_*.py"
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      # Megatron
+      - "!verl/workers/**/megatron_*.py"
+      - "!recipe/**"
+      - "recipe/prime/**"
+  pull_request:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "**/*.py"
+      # Other entrypoints
+      - "!examples/**"
+      - "!tests/**"
+      - "!verl/trainer/main_*.py"
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      # Other recipes
+      - "!recipe/**"
+      # Megatron
+      - "!verl/workers/**/megatron_*.py"
+      # Home
+      - "recipe/prime/**"
+      # Entrypoints
+      - ".github/workflows/e2e_prime.yml"
+      - "examples/data_preprocess/gsm8k.py"
+      - "tests/special_e2e/run_prime.sh"
+
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare permissions just read content.
+permissions:
+  contents: read
+
+env:
+  IMAGE: "verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm011.dev7"
+  DYNAMIC_RUNNER_ENDPOINT: "https://sd10g3clalm04ug7alq90.apigateway-cn-beijing.volceapi.com/runner"
+
+jobs:
+  setup:
+    if: github.repository_owner == 'volcengine'
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.create-runner.outputs.runner-label }}
+      mlp-task-id: ${{ steps.create-runner.outputs.mlp-task-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: create-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "create"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-image: "${{ env.IMAGE }}"
+
+  e2e_prime:
+    needs: setup
+    runs-on: [ "${{ needs.setup.outputs.runner-label || 'L20x8' }}" ]
+    timeout-minutes: 50 # Increase this timeout value as needed
+    env:
+      HTTP_PROXY: ${{ secrets.PROXY_HTTP }}
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+      SGL_DISABLE_TP_MEMORY_INBALANCE_CHECK: "True"
+      NCCL_SHM_DISABLE: "1"
+      NCCL_P2P_DISABLE: "1"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Install the current repository
+        run: |
+          pip3 install --no-deps -e .[test,gpu]
+      - name: Prepare GSM8K dataset
+        run: |
+          ray stop --force
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+      - name: Running the E2E test with the PRIME algorithm
+        run: |
+          ray stop --force
+          bash tests/special_e2e/run_prime.sh
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        setup,
+        e2e_prime
+      ]
+    if: always()
+    steps:
+      - id: destroy-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "destroy"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-task-id: "${{ needs.setup.outputs.mlp-task-id }}"
+

--- a/recipe/prime/config/prime_trainer.yaml
+++ b/recipe/prime/config/prime_trainer.yaml
@@ -44,6 +44,8 @@ reward_model:
       optimizer_offload: ${actor_rollout_ref.actor.fsdp_config.optimizer_offload}
     update: before # ``before`` for double-forward, ``after`` for single-forward
     optim:
+      optimizer: AdamW
+      optimizer_impl: torch.optim
       lr: 1e-6
       lr_warmup_steps: -1 # Prioritized. Negative values mean delegating to lr_warmup_steps_ratio.
       lr_warmup_steps_ratio: 0.  # the total steps will be injected during runtime

--- a/recipe/prime/config/prime_trainer.yaml
+++ b/recipe/prime/config/prime_trainer.yaml
@@ -23,6 +23,7 @@ actor_rollout_ref:
   rollout:
     # number of responses (i.e. num sample times)
     n: 4
+    mode: sync
   actor:
     entropy_coeff: 0.001
 

--- a/recipe/prime/config/prime_trainer.yaml
+++ b/recipe/prime/config/prime_trainer.yaml
@@ -23,7 +23,6 @@ actor_rollout_ref:
   rollout:
     # number of responses (i.e. num sample times)
     n: 4
-    mode: sync
   actor:
     entropy_coeff: 0.001
 

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -485,6 +485,8 @@ class RayPRIMETrainer(RayPPOTrainer):
                         old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = compute_response_mask(batch)
+                        response_mask_proto = DataProto.from_dict(tensors={"response_mask": response_masks})
+                        batch = batch.union(response_mask_proto)
                         loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
                         entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
                         old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -179,7 +179,7 @@ class RayPRIMETrainer(RayPPOTrainer):
 
     def init_workers(self):
         """Initialize workers for PRIME with async rollout support.
-        
+
         PRIME uses AsyncActorRolloutRefWorker which provides async rollout
         capabilities without requiring AgentLoopManager. The parent class
         tries to create AgentLoopManager when rollout.mode == "async", but
@@ -191,7 +191,7 @@ class RayPRIMETrainer(RayPPOTrainer):
         original_mode = self.config.actor_rollout_ref.rollout.get("mode", "async")
         with open_dict(self.config):
             self.config.actor_rollout_ref.rollout.mode = "sync"
-        
+
         try:
             # Call parent's init_workers which sets up all the worker groups
             super().init_workers()
@@ -199,7 +199,7 @@ class RayPRIMETrainer(RayPPOTrainer):
             # Restore the original async mode
             with open_dict(self.config):
                 self.config.actor_rollout_ref.rollout.mode = original_mode
-        
+
         # PRIME uses AsyncActorRolloutRefWorker which handles async directly
         # The async mode is handled by the worker class, not AgentLoopManager
         self.async_rollout_mode = False

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -177,6 +177,34 @@ class RayPRIMETrainer(RayPPOTrainer):
 
         self.use_critic = False
 
+    def init_workers(self):
+        """Initialize workers for PRIME with async rollout support.
+        
+        PRIME uses AsyncActorRolloutRefWorker which provides async rollout
+        capabilities without requiring AgentLoopManager. The parent class
+        tries to create AgentLoopManager when rollout.mode == "async", but
+        that's only needed for agent-loop-based async,
+        not for PRIME's simple async worker rollout.
+        """
+        # Temporarily disable async mode to prevent AgentLoopManager creation
+        # PRIME's AsyncActorRolloutRefWorker handles async internally
+        original_mode = self.config.actor_rollout_ref.rollout.get("mode", "async")
+        with open_dict(self.config):
+            self.config.actor_rollout_ref.rollout.mode = "sync"
+        
+        try:
+            # Call parent's init_workers which sets up all the worker groups
+            super().init_workers()
+        finally:
+            # Restore the original async mode
+            with open_dict(self.config):
+                self.config.actor_rollout_ref.rollout.mode = original_mode
+        
+        # PRIME uses AsyncActorRolloutRefWorker which handles async directly
+        # The async mode is handled by the worker class, not AgentLoopManager
+        self.async_rollout_mode = False
+        self.async_rollout_manager = None
+
     def _create_dataloader(self, *args, **kwargs):
         from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 


### PR DESCRIPTION
### What does this PR do?

> Fix PRIME compatibility issues, including async rollout, reward model handeling, and batch data format issue.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

1. pass pre-commit run
2. successfully sh run_prime_qwen.sh

### API and Usage Example

> N/A

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

https://github.com/volcengine/verl/issues/2547

* recipe/prime/main_prime.py
Trainer now picks AsyncActorRolloutRefWorker automatically when actor_rollout_ref.rollout.mode=async, keeping sync behavior unchanged but restoring async rollouts.
* recipe/prime/prime_ray_trainer.py
compute_response_mask now returns a DataProto, so batch.union(response_masks) works again.
During training, the response mask DataProto is unioned into the batch before actor updates, preventing KeyErrors when the actor expects response_mask.
* recipe/prime/prime_dp_rm.py
Reward-model forward handling now normalizes outputs that can be either ModelOutput or tuples, so fused/non‑fused kernels both work.
When fused kernels are enabled, the precomputed log_probs are used; otherwise, log probabilities are recomputed from logits. This removes the AttributeError that occurred when the fast path returned tuples.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

