### PR TITLE
[data] feat: shuffle data before parallel filtering to avoid bottleneck

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -245,11 +245,27 @@ class RLHFDataset(Dataset):
                         traceback.print_exc()
                         return self.max_prompt_length + 1
 
+            orig_idx_col = "__orig_idx__"
+            if self.num_workers > 1:
+                # dataset.map internally splits data into chunks and assigns them to processes.
+                # When slow samples cluster together, they form a bottleneck,
+                # so the rows are shuffled before filtering and then restored to their original order.
+                num = 0
+                while orig_idx_col in dataframe.column_names:
+                    orig_idx_col = f"__orig_idx_{num}__"
+                    num += 1
+                dataframe = dataframe.add_column(orig_idx_col, list(range(len(dataframe))))
+                dataframe = dataframe.shuffle(seed=42)
+
             dataframe = dataframe.filter(
                 lambda doc: doc2len(doc) <= self.max_prompt_length,
                 num_proc=self.num_workers,
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
             )
+
+            if self.num_workers > 1:
+                dataframe = dataframe.sort(orig_idx_col)
+                dataframe = dataframe.remove_columns(orig_idx_col)
 
             print(f"filter dataset len: {len(dataframe)}")
         return dataframe


### PR DESCRIPTION
### What does this PR do?

### Problem
When using `dataset.filter()` with `num_proc > 1`, the data is split into chunks and assigned to each worker process. Since the dataset preserves the order of the original Parquet files, slow-to-process samples are likely to be clustered together in the same chunk. For example, if a specific Parquet file contains only long-context samples with images and videos, all those computationally expensive samples will be assigned to the same worker, creating a bottleneck that degrades overall filtering performance.

### Solution
- When using multiple workers (`num_workers > 1`), shuffle the dataset before filtering to distribute slow samples across multiple chunks.
- Add a temporary index column (`__orig_idx__`) to preserve the original order.
- After filtering, sort by the index column to restore the original order and remove the temporary column.
- In case the mine with 64 num_proc, this speeds up filtering from 53 minutes to 19 minutes 

### Changes
- Added shuffle/restore logic to `maybe_filter_out_long_prompts()` method
- Included dynamic column naming to avoid conflicts with existing columns

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
