### PR TITLE
[rollout] partial rollout

### DIFF
--- a/recipe/partial_rollout/config/partial_rollout_trainer.yaml
+++ b/recipe/partial_rollout/config/partial_rollout_trainer.yaml
@@ -1,0 +1,44 @@
+hydra:
+  searchpath:
+   - file://verl/trainer/config
+   # - file://recipe/dapo/config
+
+defaults:
+  - ppo_trainer
+  #- dapo_trainer
+  - _self_
+
+
+
+data:
+  gen_batch_size: ${data.train_batch_size}
+
+reward_model:
+  reward_manager: dapo
+  overlong_buffer: 
+    enable: False # We try to avoid forgetting to set enable
+    len: 0
+    penalty_factor: 0.0
+    log: False
+
+algorithm:
+  filter_groups:
+    _target_: verl.trainer.config.FilterGroupsConfig
+    enable: False # We try to avoid forgetting to set enable
+    metric: null # acc / score / seq_reward / seq_final_reward / ...
+    max_num_gen_batches: 0 # Non-positive values mean no upper limit
+
+trainer:
+  project_name: verl-dapo
+
+
+
+actor_rollout_ref:
+  # config for the rollout (only for resource isolation)
+  rollout:
+      # max rounds of rollout before the prompt is forced finished, 1 means no partial rollout
+      partial_rollout_max_split: -1
+
+      partial_rollout_mode: async 
+
+      rollout_threshold_rate: 0.8

--- a/recipe/partial_rollout/dapo_ray_trainer.py
+++ b/recipe/partial_rollout/dapo_ray_trainer.py
@@ -1,0 +1,486 @@
+
+
+
+import os
+import uuid
+from collections import defaultdict
+from copy import deepcopy
+from pprint import pprint
+from typing import Optional
+
+import numpy as np
+import torch
+from tqdm import tqdm
+
+from verl import DataProto
+from verl.trainer.ppo.core_algos import agg_loss
+from verl.trainer.ppo.metric_utils import compute_data_metrics, compute_throughout_metrics, compute_timing_metrics
+from verl.trainer.ppo.ray_trainer import (
+    AdvantageEstimator,
+    RayPPOTrainer,
+    apply_kl_penalty,
+    compute_advantage,
+    compute_response_mask,
+)
+from verl.trainer.ppo.reward import compute_reward
+from verl.utils.metric import reduce_metrics
+from verl.utils.profiler import marked_timer
+from verl.utils.rollout_skip import RolloutSkip
+
+
+def dapo_ray_trainer_fit(self):
+    """
+    The training loop of PPO.
+    The driver process only need to call the compute functions of the worker group through RPC
+    to construct the PPO dataflow.
+    The light-weight advantage computation is done on the driver process.
+    """
+    from omegaconf import OmegaConf
+
+    from verl.utils.tracking import Tracking
+
+    logger = Tracking(
+        project_name=self.config.trainer.project_name,
+        experiment_name=self.config.trainer.experiment_name,
+        default_backend=self.config.trainer.logger,
+        config=OmegaConf.to_container(self.config, resolve=True),
+    )
+
+    self.global_steps = 0
+    self.gen_steps = 0
+
+    # load checkpoint before doing anything
+    self._load_checkpoint()
+
+    # perform validation before training
+    # currently, we only support validation using the reward_function.
+    if self.val_reward_fn is not None and self.config.trainer.get("val_before_train", True):
+        val_metrics = self._validate()
+        assert val_metrics, f"{val_metrics=}"
+        pprint(f"Initial validation metrics: {val_metrics}")
+        logger.log(data=val_metrics, step=self.global_steps)
+        if self.config.trainer.get("val_only", False):
+            return
+
+    if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
+        rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
+        rollout_skip.wrap_generate_sequences()
+
+    # add tqdm
+    progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
+
+    # we start from step 1
+    self.global_steps += 1
+    self.gen_steps += 1
+    last_val_metrics = None
+
+    partial_batch: Optional[DataProto] = None  # samples whose rollout is not finished yet
+    staged_batch: Optional[DataProto] = None  # samples whose rollout has been finished but not yet trained on
+
+    prev_step_profile = False
+    curr_step_profile = (
+        self.global_steps in self.config.global_profiler.steps
+        if self.config.global_profiler.steps is not None
+        else False
+    )
+    next_step_profile = False
+
+    timing_raw = defaultdict(float)
+    batch = None
+    num_prompt_in_batch = 0
+    num_gen_batches = 0
+    for epoch in range(self.config.trainer.total_epochs):
+        for batch_dict in self.train_dataloader:
+            metrics = {}
+
+            with marked_timer("start_profile", timing_raw):
+                self._start_profiling(
+                    not prev_step_profile and curr_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else curr_step_profile
+                )
+
+            new_batch: DataProto = DataProto.from_single_dict(batch_dict)
+            new_batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(new_batch.batch))],
+                                                         dtype=object)
+            # repeat to align with repeated responses in rollout
+            new_batch = new_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n,
+                                         interleave=True)  # gen_prompt_bsz * n
+            new_batch.non_tensor_batch["age"] = np.ones(len(new_batch.batch), dtype=int)
+            new_batch.non_tensor_batch["raw_response_ids"] = np.fromiter(([] for _ in range(len(new_batch.batch))),
+                                                                         dtype=object)
+            new_batch = DataProto.concat([partial_batch, new_batch]) if partial_batch is not None else new_batch
+
+            num_gen_batches += 1
+            # pop those keys for generation
+
+            if "multi_modal_data" in new_batch.non_tensor_batch.keys():
+                gen_batch = new_batch.pop(
+                    batch_keys=["input_ids", "attention_mask", "position_ids"],
+                    non_tensor_batch_keys=["raw_prompt_ids", "multi_modal_data", "raw_response_ids"],
+                )
+            else:
+                gen_batch = new_batch.pop(
+                    batch_keys=["input_ids", "attention_mask", "position_ids"],
+                    non_tensor_batch_keys=["raw_prompt_ids", "raw_response_ids"],
+                )
+
+            gen_batch.non_tensor_batch["age"] = new_batch.non_tensor_batch["age"]
+
+            is_last_step = self.global_steps >= self.total_training_steps
+
+            with marked_timer("step", timing_raw):
+                # generate a batch
+                with marked_timer("gen", timing_raw, "red"):
+                    if self.aggregator:
+                        self.aggregator.set_sample_num.remote(len(gen_batch))
+                        self.aggregator.clear.remote()
+                    if not self.async_rollout_mode:
+                        gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch)
+                    else:
+                        gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch)
+                    timing_raw.update(gen_batch_output.meta_info["timing"])
+                    gen_batch_output.meta_info.pop("timing", None)
+                with marked_timer("filter", timing_raw):
+
+                    new_batch = new_batch.union(gen_batch_output)
+
+                    finished_mask = new_batch.non_tensor_batch.pop("finished")
+
+                    if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
+                        finished_mask = (new_batch.non_tensor_batch[
+                                             "age"] == self.config.algorithm.partial_rollout_max_split) | finished_mask
+                    if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
+                        finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
+                                          for response in
+                                          gen_batch_output.non_tensor_batch['raw_response_ids']]) | finished_mask
+
+                    staged_out, partial_batch = DataProto.split_data(new_batch,
+                                                                     finished_mask)
+
+                    raw_prompt_ids = staged_out.non_tensor_batch['raw_prompt_ids']
+                    raw_response_ids = staged_out.non_tensor_batch['raw_response_ids']
+                    print(
+                        f"staged_out raw_prompt_ids :{len(raw_prompt_ids)} -- {[len(i) for i in raw_prompt_ids]} ")
+                    print(
+                        f"staged_out raw_response_ids :{len(raw_response_ids)} -- {[len(i) for i in raw_response_ids]}")
+
+                    staged_out.non_tensor_batch.pop("raw_prompt_ids")  # TODO ?
+                    staged_out.non_tensor_batch.pop("raw_response_ids")
+
+                    if len(partial_batch.batch) > 0:
+
+                        raw_prompt_ids = partial_batch.non_tensor_batch['raw_prompt_ids']
+                        raw_response_ids = partial_batch.non_tensor_batch['raw_response_ids']
+                        # device = torch.distributed.get_rank()
+                        print(
+                            f"partial_batch :raw_prompt_ids :{len(raw_prompt_ids)} -- {[len(i) for i in raw_prompt_ids]} ")
+                        print(
+                            f"partial_batch :raw_response_ids :{len(raw_response_ids)} -- {[len(i) for i in raw_response_ids]}")
+
+                        # breakpoint()
+                        for key in ("input_ids", "attention_mask", "position_ids"):
+                            tmp = partial_batch.batch.pop(key, None)
+                            partial_batch.batch[key] = tmp[:,
+                                                       : self.config.data.max_prompt_length]  # TODO ?
+
+                        for key in ("prompts", "responses", "rollout_log_probs"):
+                            # we don't support rollout_log_probs in this feature branch yet
+                            if key in partial_batch.batch:
+                                partial_batch.batch.pop(key)
+                    else:
+                        partial_batch = None
+
+                    # note that we no longer ensure the order of samples in staged_batch
+
+                    staged_batch = DataProto.concat(
+                        [staged_batch, staged_out]) if staged_batch is not None else staged_out
+
+                    # prompts whose number of finished rollout is enough can be trained on
+                    # while filtering, we ensure sample number is divisible by n_gpus_per_node and as large as possible
+                    can_train_mask = np.zeros(len(staged_batch.batch), dtype=bool)
+                    id2count = defaultdict(int)
+                    required_rollouts = self.config.actor_rollout_ref.rollout.n
+                    divisor = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * required_rollouts
+
+                    for uid in staged_batch.non_tensor_batch["uid"]:
+                        id2count[uid] += 1
+                    assert not id2count or max(
+                        id2count.values()) <= required_rollouts, "max number of responses exceeds rollout n"
+
+                    complete_uids = [uid for uid, count in id2count.items() if
+                                     count == required_rollouts]
+
+                    total_complete_samples = len(complete_uids) * required_rollouts
+                    max_usable_groups = (total_complete_samples // divisor) * divisor // required_rollouts
+                    can_train_count = max_usable_groups * required_rollouts
+
+                    if can_train_count == 0:
+                        print(f"{total_complete_samples=}, no complete uid groups available. Keep generating...")
+                        continue
+
+                    selected_uids = set(complete_uids[:max_usable_groups])
+
+                    for i, uid in enumerate(staged_batch.non_tensor_batch["uid"]):
+                        if uid in selected_uids:
+                            can_train_mask[i] = True
+
+                    new_batch, staged_batch = DataProto.split_data(staged_batch,
+                                                                   can_train_mask)
+
+                if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                    with marked_timer("gen_max", timing_raw, "red"):
+                        gen_baseline_batch = deepcopy(gen_batch)
+                        gen_baseline_batch.meta_info["do_sample"] = False
+                        gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
+
+                        new_batch = new_batch.union(gen_baseline_output)
+                        # compute reward model score on new_batch
+                        rm_scores = None
+                        if self.use_rm and "rm_scores" not in new_batch.batch.keys():
+                            rm_scores = self.rm_wg.compute_rm_score(new_batch)
+                            new_batch = new_batch.union(rm_scores)
+                        reward_baseline_tensor, _ = compute_reward(new_batch, self.reward_fn)
+                        reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                        keys_to_pop = set(gen_baseline_output.batch.keys())
+                        if rm_scores is not None:
+                            keys_to_pop.update(rm_scores.batch.keys())
+                        new_batch.pop(batch_keys=list(keys_to_pop))
+
+                        new_batch.batch["reward_baselines"] = reward_baseline_tensor
+
+                        del rm_scores, gen_baseline_batch, gen_baseline_output
+
+                if self.config.algorithm.use_kl_in_reward:
+                    # We need these metrics for apply_kl_penalty if using kl in reward
+                    new_batch = self.compute_kl_related_metrics(new_batch, metrics, timing_raw)
+                    # otherwise, we will compute those after dynamic sampling
+
+                with marked_timer("reward", timing_raw, "yellow"):
+                    # compute scores. Support both model and function-based.
+                    # We first compute the scores using reward model. Then, we call reward_fn to combine
+                    # the results from reward model and rule-based results.
+                    if self.use_rm and "rm_scores" not in new_batch.batch.keys():
+                        # we first compute reward model score
+                        reward_tensor = self.rm_wg.compute_rm_score(new_batch)
+                        new_batch = new_batch.union(reward_tensor)
+
+                    # we combine with rule-based rm
+                    reward_tensor, reward_extra_infos_dict = compute_reward(new_batch, self.reward_fn)
+
+                    new_batch.batch["token_level_scores"] = reward_tensor
+
+                    if reward_extra_infos_dict:
+                        new_batch.non_tensor_batch.update(
+                            {k: np.array(v) for k, v in reward_extra_infos_dict.items()}
+                        )
+
+                    # compute rewards. apply_kl_penalty if available
+                    if self.config.algorithm.use_kl_in_reward:
+                        new_batch, kl_metrics = apply_kl_penalty(
+                            new_batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
+                        )
+                        metrics.update(
+                            kl_metrics
+                        )  # TODO: This will be cleared if we use multiple genenration batches
+                    else:
+                        new_batch.batch["token_level_rewards"] = new_batch.batch["token_level_scores"]
+
+                if not self.config.algorithm.filter_groups.enable:
+                    batch = new_batch
+                else:  # NOTE: When prompts after filtering is less than train batch size,
+                    # we skip to the next generation batch
+                    metric_name = self.config.algorithm.filter_groups.metric
+                    if metric_name == "seq_final_reward":
+                        # Turn to numpy for easier filtering
+                        new_batch.non_tensor_batch["seq_final_reward"] = (
+                            new_batch.batch["token_level_rewards"].sum(dim=-1).numpy()
+                        )
+                    elif metric_name == "seq_reward":
+                        new_batch.non_tensor_batch["seq_reward"] = (
+                            new_batch.batch["token_level_scores"].sum(dim=-1).numpy()
+                        )
+
+                    # Collect the sequence reward for each trajectory
+                    prompt_uid2metric_vals = defaultdict(list)
+                    for uid, metric_val in zip(
+                            new_batch.non_tensor_batch["uid"], new_batch.non_tensor_batch[metric_name], strict=True
+                    ):
+                        prompt_uid2metric_vals[uid].append(metric_val)
+
+                    prompt_uid2metric_std = {}
+                    for prompt_uid, metric_vals in prompt_uid2metric_vals.items():
+                        prompt_uid2metric_std[prompt_uid] = np.std(metric_vals)
+
+                    kept_prompt_uids = [
+                        uid
+                        for uid, std in prompt_uid2metric_std.items()
+                        if std > 0 or len(prompt_uid2metric_vals[uid]) == 1
+                    ]
+                    num_prompt_in_batch += len(kept_prompt_uids)
+
+                    kept_traj_idxs = []
+                    for idx, traj_from_prompt_uid in enumerate(new_batch.non_tensor_batch["uid"]):
+                        if traj_from_prompt_uid in kept_prompt_uids:
+                            kept_traj_idxs.append(idx)
+
+                    new_batch = new_batch[kept_traj_idxs]
+                    batch = new_batch if batch is None else DataProto.concat([batch, new_batch])
+
+                    prompt_bsz = self.config.data.train_batch_size
+                    if num_prompt_in_batch < prompt_bsz:
+                        print(f"{num_prompt_in_batch=} < {prompt_bsz=}")
+                        max_num_gen_batches = self.config.algorithm.filter_groups.max_num_gen_batches
+                        if max_num_gen_batches <= 0 or num_gen_batches < max_num_gen_batches:
+                            print(f"{num_gen_batches=}. Keep generating...")
+                            self.gen_steps += 1
+                            is_last_step = self.global_steps >= self.total_training_steps
+                            continue
+                        else:
+                            raise ValueError(
+                                f"{num_gen_batches=} >= {max_num_gen_batches=}."
+                                + " Generated too many. Please check if your data are too difficult."
+                                + " You could also try set max_num_gen_batches=0 to enable endless trials."
+                            )
+                    else:
+                        # Align the batch
+                        traj_bsz = self.config.data.train_batch_size * self.config.actor_rollout_ref.rollout.n
+                        batch = batch[:traj_bsz]
+                        if partial_batch:
+                            partial_batch.non_tensor_batch["age"] += 1
+
+                # === Updating ===
+                # Balance the number of valid tokens across DP ranks.
+                # NOTE: This usually changes the order of data in the `batch`,
+                # which won't affect the advantage calculation (since it's based on uid),
+                # but might affect the loss calculation (due to the change of mini-batching).
+                # TODO: Decouple the DP balancing and mini-batching.
+                if self.config.trainer.balance_batch:
+                    self._balance_batch(batch, metrics=metrics)
+
+                # compute global_valid tokens
+                batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+
+                if not self.config.algorithm.use_kl_in_reward:
+                    batch = self.compute_kl_related_metrics(batch, metrics, timing_raw)
+
+                # compute values
+                if self.use_critic:
+                    with marked_timer("values", timing_raw, "cyan"):
+                        values = self.critic_wg.compute_values(batch)
+                        batch = batch.union(values)
+
+                # Compute rollout correction weights and off-policy metrics (inherited from RayPPOTrainer)
+                from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
+
+                rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+                if rollout_corr_config is not None and "rollout_log_probs" in batch.batch:
+                    batch, is_metrics = compute_rollout_correction_and_add_to_batch(batch, rollout_corr_config)
+                    # IS and off-policy metrics already have rollout_corr/ prefix
+                    metrics.update(is_metrics)
+
+                with marked_timer("adv", timing_raw, "brown"):
+                    # compute advantages, executed on the driver process
+                    norm_adv_by_std_in_grpo = self.config.algorithm.get("norm_adv_by_std_in_grpo", True)
+                    batch = compute_advantage(
+                        batch,
+                        adv_estimator=self.config.algorithm.adv_estimator,
+                        gamma=self.config.algorithm.gamma,
+                        lam=self.config.algorithm.lam,
+                        num_repeat=self.config.actor_rollout_ref.rollout.n,
+                        norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                    )
+
+                # update critic
+                if self.use_critic:
+                    with marked_timer("update_critic", timing_raw, "pink"):
+                        critic_output = self.critic_wg.update_critic(batch)
+                    critic_output_metrics = reduce_metrics(critic_output.meta_info["metrics"])
+                    metrics.update(critic_output_metrics)
+
+                # implement critic warmup
+                if self.config.trainer.critic_warmup <= self.global_steps:
+                    # update actor
+                    with marked_timer("update_actor", timing_raw, "red"):
+                        actor_output = self.actor_rollout_wg.update_actor(batch)
+                    actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                    metrics.update(actor_output_metrics)
+
+                # Log rollout generations if enabled
+                rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
+                if rollout_data_dir:
+                    self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
+
+            # validate
+            if (
+                    self.val_reward_fn is not None
+                    and self.config.trainer.test_freq > 0
+                    and (is_last_step or self.global_steps % self.config.trainer.test_freq == 0)
+            ):
+                with marked_timer("testing", timing_raw, "green"):
+                    val_metrics: dict = self._validate()
+                    if is_last_step:
+                        last_val_metrics = val_metrics
+                metrics.update(val_metrics)
+
+            if self.config.trainer.save_freq > 0 and (
+                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+            ):
+                with marked_timer("save_checkpoint", timing_raw, "green"):
+                    self._save_checkpoint()
+
+            with marked_timer("stop_profile", timing_raw):
+                next_step_profile = (
+                    self.global_steps + 1 in self.config.global_profiler.steps
+                    if self.config.global_profiler.steps is not None
+                    else False
+                )
+                self._stop_profiling(
+                    curr_step_profile and not next_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else curr_step_profile
+                )
+                prev_step_profile = curr_step_profile
+                curr_step_profile = next_step_profile
+            if self.enable_partial_rollout:
+                metrics.update(
+                    {
+                        "training/can_train_count": can_train_count,
+                        "training/total_complete_samples": total_complete_samples,
+                    }
+                )
+
+            # collect metrics
+            metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
+            metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+            # TODO: implement actual tflpo and theoretical tflpo
+            n_gpus = self.resource_pool_manager.get_n_gpus()
+            metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+            timing_raw = defaultdict(float)  # clear timing
+
+            metrics["train/num_gen_batches"] = num_gen_batches
+            batch = None
+            num_prompt_in_batch = 0
+            num_gen_batches = 0
+
+            # TODO: make a canonical logger that supports various backend
+            logger.log(data=metrics, step=self.global_steps)
+
+            if is_last_step:
+                pprint(f"Final validation metrics: {last_val_metrics}")
+                progress_bar.close()
+                return
+
+            progress_bar.update(1)
+            self.global_steps += 1
+            self.gen_steps += 1
+    # check if last step checkpint exists
+    checkpoint_dir = os.path.join(self.config.trainer.default_local_dir, f"global_step_{self.global_steps}")
+    if not os.path.exists(checkpoint_dir):
+        # save last step checkpoint
+        timing_raw = defaultdict(float)
+        with marked_timer("save_checkpoint", timing_raw, "green"):
+            self._save_checkpoint()
+        metrics = {f"timing/{k}": v for k, v in timing_raw.items()}
+        logger.log(data=metrics, step=self.global_steps)

--- a/recipe/partial_rollout/dapo_ray_trainer.py
+++ b/recipe/partial_rollout/dapo_ray_trainer.py
@@ -176,10 +176,8 @@ def dapo_ray_trainer_fit(self):
 
                     staged_out, partial_batch = DataProto.split_data(new_batch, finished_mask)
 
-                    raw_prompt_ids = staged_out.non_tensor_batch["raw_prompt_ids"]
-                    raw_response_ids = staged_out.non_tensor_batch["raw_response_ids"]
 
-                    staged_out.non_tensor_batch.pop("raw_prompt_ids")  # TODO ?
+                    staged_out.non_tensor_batch.pop("raw_prompt_ids")
                     staged_out.non_tensor_batch.pop("raw_response_ids")
 
                     if len(partial_batch.batch) > 0:

--- a/recipe/partial_rollout/dapo_ray_trainer.py
+++ b/recipe/partial_rollout/dapo_ray_trainer.py
@@ -196,8 +196,10 @@ def dapo_ray_trainer_fit(self):
                     else:
                         partial_batch = None
 
+                    if staged_batch is not None and len(staged_batch.batch) > 0:
+                        staged_batch.meta_info.pop("global_token_num",None)
+                        staged_out.meta_info.pop("global_token_num",None)
                     # note that we no longer ensure the order of samples in staged_batch
-
                     staged_batch = (
                         DataProto.concat([staged_batch, staged_out]) if staged_batch is not None else staged_out
                     )

--- a/recipe/partial_rollout/dapo_ray_trainer.py
+++ b/recipe/partial_rollout/dapo_ray_trainer.py
@@ -178,10 +178,6 @@ def dapo_ray_trainer_fit(self):
 
                     raw_prompt_ids = staged_out.non_tensor_batch["raw_prompt_ids"]
                     raw_response_ids = staged_out.non_tensor_batch["raw_response_ids"]
-                    print(f"staged_out raw_prompt_ids :{len(raw_prompt_ids)} -- {[len(i) for i in raw_prompt_ids]} ")
-                    print(
-                        f"staged_out raw_response_ids :{len(raw_response_ids)} -- {[len(i) for i in raw_response_ids]}"
-                    )
 
                     staged_out.non_tensor_batch.pop("raw_prompt_ids")  # TODO ?
                     staged_out.non_tensor_batch.pop("raw_response_ids")
@@ -189,13 +185,6 @@ def dapo_ray_trainer_fit(self):
                     if len(partial_batch.batch) > 0:
                         raw_prompt_ids = partial_batch.non_tensor_batch["raw_prompt_ids"]
                         raw_response_ids = partial_batch.non_tensor_batch["raw_response_ids"]
-                        # TODO  Remove print
-                        print(
-                            f"partial_batch :raw_prompt_ids :{len(raw_prompt_ids)} -- {[len(i) for i in raw_prompt_ids]} "
-                        )
-                        print(
-                            f"partial_batch :raw_response_ids :{len(raw_response_ids)} -- {[len(i) for i in raw_response_ids]}"
-                        )
 
                         # breakpoint()
                         for key in ("input_ids", "attention_mask", "position_ids"):

--- a/recipe/partial_rollout/main_dapo.py
+++ b/recipe/partial_rollout/main_dapo.py
@@ -1,0 +1,189 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Note that we don't combine the main with ray_trainer as ray_trainer is used by other main.
+"""
+
+import os
+import socket
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo.reward import load_reward_manager
+from verl.utils.device import is_cuda_available
+
+from recipe.dapo.dapo_ray_trainer import RayDAPOTrainer
+
+from .patch_manager import apply_partialrollout_patch
+
+
+
+
+@hydra.main(config_path="config", config_name="partial_rollout_trainer", version_base=None)
+def main(config):
+    run_ppo(config)
+    
+
+def run_ppo(config) -> None:
+    if not ray.is_initialized():
+        # this is for local ray cluster
+        default_runtime_env = {
+            "env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_LOGGING_LEVEL": "WARN","RAY_DEBUG": "1"}
+        }
+        ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+        runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
+        runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
+        ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
+        print(f"ray init kwargs: {ray_init_kwargs}")
+        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+
+    try:
+        if (
+            is_cuda_available
+            and config.global_profiler.tool == "nsys"
+            and OmegaConf.select(config.global_profiler, "steps") is not None
+            and len(OmegaConf.select(config.global_profiler, "steps")) > 0
+        ):
+            nsight_options = OmegaConf.to_container(
+                config.global_profiler.global_tool_config.nsys.controller_nsight_options
+            )
+            runner = TaskRunner.options(runtime_env={"nsight": nsight_options}).remote()
+        else:
+            runner = TaskRunner.remote()
+        ray.get(runner.run.remote(config))
+    finally:
+        if ray.is_initialized():
+            ray.shutdown()
+
+
+@ray.remote(num_cpus=1)  # please make sure main_task is not scheduled on head
+class TaskRunner:
+    def run(self, config):
+        # print initial config
+        from pprint import pprint
+        apply_partialrollout_patch()
+        from omegaconf import OmegaConf
+
+        from verl.utils.fs import copy_to_local
+
+        print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+
+        pprint(OmegaConf.to_container(config, resolve=True))  # resolve=True will eval symbol values
+        OmegaConf.resolve(config)
+
+        # download the checkpoint from hdfs
+        local_path = copy_to_local(config.actor_rollout_ref.model.path)
+
+        # instantiate tokenizer
+        from verl.utils import hf_processor, hf_tokenizer
+
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        # used for multimodal LLM, could be none
+        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        from verl.single_controller.ray import RayWorkerGroup
+
+        # define worker classes
+        if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
+            assert config.critic.strategy in {"fsdp", "fsdp2"}
+
+            from verl.workers.fsdp_workers import ActorRolloutRefWorker, CriticWorker
+
+            ray_worker_group_cls = RayWorkerGroup
+
+        elif config.actor_rollout_ref.actor.strategy == "megatron":
+            assert config.actor_rollout_ref.actor.strategy == config.critic.strategy
+            from verl.workers.megatron_workers import ActorRolloutRefWorker, CriticWorker
+
+            ray_worker_group_cls = RayWorkerGroup
+
+        else:
+            raise NotImplementedError
+
+        from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
+
+        role_worker_mapping = {
+            Role.ActorRollout: ray.remote(ActorRolloutRefWorker),
+            Role.Critic: ray.remote(CriticWorker),
+        }
+
+        global_pool_id = "global_pool"
+        resource_pool_spec = {
+            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+        }
+        mapping = {
+            Role.ActorRollout: global_pool_id,
+            Role.Critic: global_pool_id,
+        }
+
+        # we should adopt a multi-source reward function here
+        # - for rule-based rm, we directly call a reward score
+        # - for model-based rm, we call a model
+        # - for code related prompt, we send to a sandbox if there are test cases
+        # - finally, we combine all the rewards together
+        # - The reward type depends on the tag of the data
+        if config.reward_model.enable:
+            if config.reward_model.strategy in {"fsdp", "fsdp2"}:
+                from verl.workers.fsdp_workers import RewardModelWorker
+            elif config.reward_model.strategy == "megatron":
+                from verl.workers.megatron_workers import RewardModelWorker
+            else:
+                raise NotImplementedError
+            role_worker_mapping[Role.RewardModel] = ray.remote(RewardModelWorker)
+            mapping[Role.RewardModel] = global_pool_id
+
+        # reference model
+        if config.algorithm.use_kl_in_reward or config.actor_rollout_ref.actor.use_kl_loss:
+            role_worker_mapping[Role.RefPolicy] = ray.remote(ActorRolloutRefWorker)
+            mapping[Role.RefPolicy] = global_pool_id
+
+        reward_fn = load_reward_manager(
+            config,
+            tokenizer,
+            0,
+            max_resp_len=config.data.max_response_length,
+            overlong_buffer_cfg=config.reward_model.overlong_buffer,
+        )
+        if getattr(config.actor_rollout_ref.rollout, "partial_rollout_mode", None) == "async" and getattr(
+                config.actor_rollout_ref.rollout, "partial_rollout_max_split", -1) > 0:
+            from recipe.partial_rollout.ray_trainer import AggregatorActor
+            role_worker_mapping[Role.Aggregator] = ray.remote(AggregatorActor)
+        # Note that we always use function-based RM for validation
+        val_reward_fn = load_reward_manager(
+            config,
+            tokenizer,
+            1,
+            max_resp_len=config.data.max_response_length,
+            overlong_buffer_cfg=config.reward_model.overlong_buffer,
+        )
+        resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
+        trainer = RayDAPOTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            reward_fn=reward_fn,
+            val_reward_fn=val_reward_fn,
+        )
+        trainer.init_workers()
+        trainer.fit()
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/partial_rollout/main_ppo.py
+++ b/recipe/partial_rollout/main_ppo.py
@@ -1,0 +1,463 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Note that we don't combine the main with ray_trainer as ray_trainer is used by other mpain.
+"""
+
+import os
+import socket
+import warnings
+
+import hydra
+import ray
+from omegaconf import OmegaConf
+
+from verl.experimental.dataset.sampler import AbstractSampler
+from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.trainer.ppo.reward import load_reward_manager
+from verl.trainer.ppo.utils import need_critic, need_reference_policy
+from verl.utils.config import validate_config
+from verl.utils.device import is_cuda_available
+from verl.utils.import_utils import load_extern_type
+
+
+
+from .patch_manager import apply_partialrollout_patch
+
+
+
+
+@hydra.main(config_path="config", config_name="partial_rollout_trainer", version_base=None)
+def main(config):
+    """Main entry point for PPO training with Hydra configuration management.
+
+    Args:
+        config_dict: Hydra configuration dictionary containing training parameters.
+    """
+    
+    run_ppo(config)
+    
+
+
+# Define a function to run the PPO-like training process
+def run_ppo(config, task_runner_class=None) -> None:
+    """Initialize Ray cluster and run distributed PPO training process.
+
+    Args:
+        config: Training configuration object containing all necessary parameters
+                for distributed PPO training including Ray initialization settings,
+                model paths, and training hyperparameters.
+        task_runner_class: For recipe to change TaskRunner.
+    """
+    # Check if Ray is not initialized
+    if not ray.is_initialized():
+        # Initialize Ray with a local cluster configuration
+        # Set environment variables in the runtime environment to control tokenizer parallelism,
+        # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
+        # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
+        default_runtime_env = get_ppo_ray_runtime_env()
+        ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
+        runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
+
+        if config.transfer_queue.enable:
+            # Add runtime environment variables for transfer queue
+            runtime_env_vars = runtime_env_kwargs.get("env_vars", {})
+            runtime_env_vars["TRANSFER_QUEUE_ENABLE"] = "1"
+            runtime_env_kwargs["env_vars"] = runtime_env_vars
+
+        runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
+        ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
+        print(f"ray init kwargs: {ray_init_kwargs}")
+        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+
+    if task_runner_class is None:
+        task_runner_class = ray.remote(num_cpus=1)(TaskRunner)  # please make sure main_task is not scheduled on head
+
+    # Create a remote instance of the TaskRunner class, and
+    # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
+    if (
+            is_cuda_available
+            and config.global_profiler.tool == "nsys"
+            and config.global_profiler.get("steps") is not None
+            and len(config.global_profiler.get("steps", [])) > 0
+    ):
+        from verl.utils.import_utils import is_nvtx_available
+
+        assert is_nvtx_available(), "nvtx is not available in CUDA platform. Please 'pip3 install nvtx'"
+        nsight_options = OmegaConf.to_container(
+            config.global_profiler.global_tool_config.nsys.controller_nsight_options
+        )
+        runner = task_runner_class.options(runtime_env={"nsight": nsight_options}).remote()
+    else:
+        runner = task_runner_class.remote()
+    ray.get(runner.run.remote(config))
+
+    # [Optional] get the path of the timeline trace file from the configuration, default to None
+    # This file is used for performance analysis
+    timeline_json_file = config.ray_kwargs.get("timeline_json_file", None)
+    if timeline_json_file:
+        ray.timeline(filename=timeline_json_file)
+
+
+class TaskRunner:
+    """Ray remote class for executing distributed PPO training tasks.
+
+    This class encapsulates the main training logic and runs as a Ray remote actor
+    to enable distributed execution across multiple nodes and GPUs.
+
+    Attributes:
+        role_worker_mapping: Dictionary mapping Role enums to Ray remote worker classes
+        mapping: Dictionary mapping Role enums to resource pool IDs for GPU allocation
+    """
+
+    def __init__(self):
+        self.role_worker_mapping = {}
+        self.mapping = {}
+
+    def add_actor_rollout_worker(self, config):
+        """Add actor rollout worker based on the actor strategy."""
+        from verl.single_controller.ray import RayWorkerGroup
+
+        if config.actor_rollout_ref.rollout.mode == "sync":
+            warnings.warn("spmd rollout mode is deprecated and will be removed in v0.6.2", stacklevel=2)
+
+        if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
+            from verl.workers.fsdp_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker
+
+            actor_rollout_cls = (
+                AsyncActorRolloutRefWorker
+                if config.actor_rollout_ref.rollout.mode == "async"
+                else ActorRolloutRefWorker
+            )
+            ray_worker_group_cls = RayWorkerGroup
+
+        elif config.actor_rollout_ref.actor.strategy == "megatron":
+            from verl.workers.megatron_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker
+
+            actor_rollout_cls = (
+                AsyncActorRolloutRefWorker
+                if config.actor_rollout_ref.rollout.mode == "async"
+                else ActorRolloutRefWorker
+            )
+            ray_worker_group_cls = RayWorkerGroup
+
+        else:
+            raise NotImplementedError
+
+        from verl.trainer.ppo.ray_trainer import Role
+
+        self.role_worker_mapping[Role.ActorRollout] = ray.remote(actor_rollout_cls)
+
+        return actor_rollout_cls, ray_worker_group_cls
+
+    def add_critic_worker(self, config):
+        """Add critic worker to role mapping."""
+        if config.critic.strategy in {"fsdp", "fsdp2"}:
+            use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+            if use_legacy_worker_impl in ["auto", "enable"]:
+                from verl.workers.fsdp_workers import CriticWorker
+            elif use_legacy_worker_impl == "disable":
+                from verl.workers.roles import CriticWorker
+
+                print("Using new worker implementation")
+            else:
+                raise ValueError(f"Invalid use_legacy_worker_impl: {use_legacy_worker_impl}")
+
+        elif config.critic.strategy == "megatron":
+            from verl.workers.megatron_workers import CriticWorker
+
+        else:
+            raise NotImplementedError
+
+        from verl.trainer.ppo.ray_trainer import Role
+
+        self.role_worker_mapping[Role.Critic] = ray.remote(CriticWorker)
+
+    def init_resource_pool_mgr(self, config):
+        """Initialize resource pool manager."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        global_pool_id = "global_pool"
+        resource_pool_spec = {
+            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+        }
+        # TODO Here you can use the new registration method to support dynamic registration of roles
+        if config.reward_model.enable_resource_pool:
+            if config.reward_model.n_gpus_per_node <= 0:
+                raise ValueError("config.reward_model.n_gpus_per_node must be greater than 0")
+            if config.reward_model.nnodes <= 0:
+                raise ValueError("config.reward_model.nnodes must be greater than 0")
+
+            reward_pool = [config.reward_model.n_gpus_per_node] * config.reward_model.nnodes
+            resource_pool_spec["reward_pool"] = reward_pool
+
+        self.mapping[Role.ActorRollout] = global_pool_id
+        self.mapping[Role.Critic] = global_pool_id
+        from verl.trainer.ppo.ray_trainer import ResourcePoolManager
+
+        resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+        return resource_pool_manager
+
+    def add_reward_model_worker(self, config):
+        """Add reward model worker if enabled."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        if config.reward_model.enable:
+            use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+            if use_legacy_worker_impl in ["auto", "enable"]:
+                if config.reward_model.strategy in {"fsdp", "fsdp2"}:
+                    from verl.workers.fsdp_workers import RewardModelWorker
+                elif config.reward_model.strategy == "megatron":
+                    from verl.workers.megatron_workers import RewardModelWorker
+                else:
+                    raise NotImplementedError
+            elif use_legacy_worker_impl == "disable":
+                from verl.workers.roles import RewardModelWorker
+
+                print("Using new worker implementation")
+            else:
+                raise ValueError(f"Invalid use_legacy_worker_impl: {use_legacy_worker_impl}")
+
+            self.role_worker_mapping[Role.RewardModel] = ray.remote(RewardModelWorker)
+            if config.reward_model.enable_resource_pool:
+                self.mapping[Role.RewardModel] = "reward_pool"
+            else:
+                self.mapping[Role.RewardModel] = "global_pool"
+
+    def add_ref_policy_worker(self, config, ref_policy_cls):
+        """Add reference policy worker if KL loss or KL reward is used."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        if config.algorithm.use_kl_in_reward or config.actor_rollout_ref.actor.use_kl_loss:
+            self.role_worker_mapping[Role.RefPolicy] = ray.remote(ref_policy_cls)
+            self.mapping[Role.RefPolicy] = "global_pool"
+
+    def add_aggregator_worker(self, config):
+        """Add aggregator worker for partial rollout."""
+        from verl.trainer.ppo.ray_trainer import Role
+        if config.actor_rollout_ref.rollout.partial_rollout_mode == "async" and config.actor_rollout_ref.rollout.partial_rollout_max_split > 0:
+            from verl.trainer.ppo.ray_trainer import AggregatorActor
+            self.role_worker_mapping[Role.Aggregator] = ray.remote(AggregatorActor)
+
+    def run(self, config):
+        """Execute the main PPO training workflow.
+
+        This method sets up the distributed training environment, initializes
+        workers, datasets, and reward functions, then starts the training process.
+
+        Args:
+            config: Training configuration object containing all parameters needed
+                   for setting up and running the PPO training process.
+        """
+        # Print the initial configuration. `resolve=True` will evaluate symbolic values.
+        from pprint import pprint
+        apply_partialrollout_patch()
+        from omegaconf import OmegaConf
+
+        from verl.utils.fs import copy_to_local
+
+        print(f"TaskRunner hostname: {socket.gethostname()}, PID: {os.getpid()}")
+        pprint(OmegaConf.to_container(config, resolve=True))
+        OmegaConf.resolve(config)
+
+        actor_rollout_cls, ray_worker_group_cls = self.add_actor_rollout_worker(config)
+        self.add_critic_worker(config)
+
+        # We should adopt a multi-source reward function here:
+        # - for rule-based rm, we directly call a reward score
+        # - for model-based rm, we call a model
+        # - for code related prompt, we send to a sandbox if there are test cases
+        # finally, we combine all the rewards together
+        # The reward type depends on the tag of the data
+        self.add_reward_model_worker(config)
+
+        # Add a reference policy worker if KL loss or KL reward is used.
+        self.add_ref_policy_worker(config, actor_rollout_cls)
+
+        self.add_aggregator_worker(config)
+
+        # validate config
+        validate_config(
+            config=config,
+            use_reference_policy=need_reference_policy(self.role_worker_mapping),
+            use_critic=need_critic(config),
+        )
+
+        # Download the checkpoint from HDFS to the local machine.
+        # `use_shm` determines whether to use shared memory, which could lead to faster model loading if turned on
+        local_path = copy_to_local(
+            config.actor_rollout_ref.model.path, use_shm=config.actor_rollout_ref.model.get("use_shm", False)
+        )
+
+        # Instantiate the tokenizer and processor.
+        from verl.utils import hf_processor, hf_tokenizer
+
+        trust_remote_code = config.data.get("trust_remote_code", False)
+        tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        # Used for multimodal LLM, could be None
+        processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
+
+        # Load the reward manager for training and validation.
+        reward_fn = load_reward_manager(
+            config, tokenizer, num_examine=0, **config.reward_model.get("reward_kwargs", {})
+        )
+        val_reward_fn = load_reward_manager(
+            config, tokenizer, num_examine=1, **config.reward_model.get("reward_kwargs", {})
+        )
+
+        resource_pool_manager = self.init_resource_pool_mgr(config)
+
+        from verl.utils.dataset.rl_dataset import collate_fn
+
+        # Create training and validation datasets.
+        train_dataset = create_rl_dataset(
+            config.data.train_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=True,
+            max_samples=config.data.get("train_max_samples", -1),
+        )
+        val_dataset = create_rl_dataset(
+            config.data.val_files,
+            config.data,
+            tokenizer,
+            processor,
+            is_train=False,
+            max_samples=config.data.get("val_max_samples", -1),
+        )
+        train_sampler = create_rl_sampler(config.data, train_dataset)
+
+        # Initialize the PPO trainer.
+        trainer = RayPPOTrainer(
+            config=config,
+            tokenizer=tokenizer,
+            processor=processor,
+            role_worker_mapping=self.role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+            ray_worker_group_cls=ray_worker_group_cls,
+            reward_fn=reward_fn,
+            val_reward_fn=val_reward_fn,
+            train_dataset=train_dataset,
+            val_dataset=val_dataset,
+            collate_fn=collate_fn,
+            train_sampler=train_sampler,
+        )
+        # Initialize the workers of the trainer.
+        trainer.init_workers()
+
+        # Start the training process.
+        trainer.fit()
+
+
+def create_rl_dataset(data_paths, data_config, tokenizer, processor, is_train=True, max_samples: int = -1):
+    """Create a dataset.
+
+    Arguments:
+        data_paths: List of paths to data files.
+        data_config: The data config.
+        tokenizer (Tokenizer): The tokenizer.
+        processor (Processor): The processor.
+
+    Returns:
+        dataset (Dataset): The dataset.
+    """
+    from torch.utils.data import Dataset
+
+    from verl.utils.dataset.rl_dataset import RLHFDataset
+
+    # Check if a custom dataset class is specified in the data configuration
+    # and if the path to the custom class is provided
+    if "custom_cls" in data_config and data_config.custom_cls.get("path", None) is not None:
+        # Dynamically load the custom dataset class
+        dataset_cls = load_extern_type(data_config.custom_cls.path, data_config.custom_cls.name)
+        # Verify that the custom dataset class inherits from torch.utils.data.Dataset
+        if not issubclass(dataset_cls, Dataset):
+            raise TypeError(
+                f"The custom dataset class '{data_config.custom_cls.name}' from "
+                f"'{data_config.custom_cls.path}' must inherit from torch.utils.data.Dataset"
+            )
+    elif "datagen" in data_config and data_config.datagen.get("path", None) is not None and is_train:
+        # If a data generation strategy is specified, use the DynamicGenDataset class
+        from verl.utils.dataset.dynamicgen_dataset import DynamicGenDataset
+
+        dataset_cls = DynamicGenDataset
+        print("Using DynamicGenDataset for data generation.")
+    else:
+        # Use the default RLHFDataset class if no custom class is specified
+        dataset_cls = RLHFDataset
+    print(f"Using dataset class: {dataset_cls.__name__}")
+
+    # Instantiate the dataset using the determined dataset class
+    dataset = dataset_cls(
+        data_files=data_paths,
+        tokenizer=tokenizer,
+        processor=processor,
+        config=data_config,
+        max_samples=max_samples,
+    )
+
+    return dataset
+
+
+def create_rl_sampler(data_config, dataset):
+    """Create a sampler for the dataset.
+
+    Arguments:
+        data_config: The data config.
+        dataset (Dataset): The dataset.
+
+    Returns:
+        sampler (Sampler): The sampler.
+    """
+    import torch
+    from torch.utils.data import SequentialSampler
+
+    # torch.utils.data.RandomSampler could not recover properly
+    from torchdata.stateful_dataloader.sampler import RandomSampler
+
+    if data_config.sampler is not None and data_config.sampler.get("class_path", None) is not None:
+        curriculum_class = load_extern_type(
+            data_config.sampler.class_path,
+            data_config.sampler.class_name,
+        )
+        sampler = curriculum_class(
+            data_source=dataset,
+            data_config=data_config,
+        )
+        assert isinstance(sampler, AbstractSampler)
+        assert data_config.get("dataloader_num_workers", 8) == 0, (
+            "If using curriculum, num_workers must be 0 to prevent data caching. "
+            "If the dataloader caches data before the batch is done the "
+            "curriculum sampler won't have the opportunity to reorder it. "
+        )
+
+    # Use a sampler to facilitate checkpoint resumption.
+    # If shuffling is enabled in the data configuration, create a random sampler.
+    elif data_config.shuffle:
+        train_dataloader_generator = torch.Generator()
+        seed = data_config.get("seed")
+        if seed is not None:
+            train_dataloader_generator.manual_seed(seed)
+        sampler = RandomSampler(data_source=dataset, generator=train_dataloader_generator)
+    else:
+        # If shuffling is disabled, use a sequential sampler to iterate through the dataset in order.
+        sampler = SequentialSampler(data_source=dataset)
+
+    return sampler
+
+
+if __name__ == "__main__":
+    main()

--- a/recipe/partial_rollout/main_ppo.py
+++ b/recipe/partial_rollout/main_ppo.py
@@ -248,7 +248,7 @@ class TaskRunner:
         """Add aggregator worker for partial rollout."""
         from verl.trainer.ppo.ray_trainer import Role
         if config.actor_rollout_ref.rollout.partial_rollout_mode == "async" and config.actor_rollout_ref.rollout.partial_rollout_max_split > 0:
-            from verl.trainer.ppo.ray_trainer import AggregatorActor
+            from recipe.partial_rollout.ray_trainer import AggregatorActor
             self.role_worker_mapping[Role.Aggregator] = ray.remote(AggregatorActor)
 
     def run(self, config):

--- a/recipe/partial_rollout/main_ppo.py
+++ b/recipe/partial_rollout/main_ppo.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
 # Copyright 2024 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,11 +33,7 @@ from verl.utils.config import validate_config
 from verl.utils.device import is_cuda_available
 from verl.utils.import_utils import load_extern_type
 
-
-
 from .patch_manager import apply_partialrollout_patch
-
-
 
 
 @hydra.main(config_path="config", config_name="partial_rollout_trainer", version_base=None)
@@ -46,9 +43,8 @@ def main(config):
     Args:
         config_dict: Hydra configuration dictionary containing training parameters.
     """
-    
+
     run_ppo(config)
-    
 
 
 # Define a function to run the PPO-like training process
@@ -88,10 +84,10 @@ def run_ppo(config, task_runner_class=None) -> None:
     # Create a remote instance of the TaskRunner class, and
     # Execute the `run` method of the TaskRunner instance remotely and wait for it to complete
     if (
-            is_cuda_available
-            and config.global_profiler.tool == "nsys"
-            and config.global_profiler.get("steps") is not None
-            and len(config.global_profiler.get("steps", [])) > 0
+        is_cuda_available
+        and config.global_profiler.tool == "nsys"
+        and config.global_profiler.get("steps") is not None
+        and len(config.global_profiler.get("steps", [])) > 0
     ):
         from verl.utils.import_utils import is_nvtx_available
 
@@ -247,8 +243,13 @@ class TaskRunner:
     def add_aggregator_worker(self, config):
         """Add aggregator worker for partial rollout."""
         from verl.trainer.ppo.ray_trainer import Role
-        if config.actor_rollout_ref.rollout.partial_rollout_mode == "async" and config.actor_rollout_ref.rollout.partial_rollout_max_split > 0:
+
+        if (
+            config.actor_rollout_ref.rollout.partial_rollout_mode == "async"
+            and config.actor_rollout_ref.rollout.partial_rollout_max_split > 0
+        ):
             from recipe.partial_rollout.ray_trainer import AggregatorActor
+
             self.role_worker_mapping[Role.Aggregator] = ray.remote(AggregatorActor)
 
     def run(self, config):
@@ -263,6 +264,7 @@ class TaskRunner:
         """
         # Print the initial configuration. `resolve=True` will evaluate symbolic values.
         from pprint import pprint
+
         apply_partialrollout_patch()
         from omegaconf import OmegaConf
 

--- a/recipe/partial_rollout/patch_manager.py
+++ b/recipe/partial_rollout/patch_manager.py
@@ -3,9 +3,10 @@
 
 def apply_partialrollout_patch():
     from recipe.dapo.dapo_ray_trainer import RayDAPOTrainer
-    from verl.trainer.ppo.ray_trainer import RayPPOTrainer
     from recipe.partial_rollout.dapo_ray_trainer import dapo_ray_trainer_fit
-    from recipe.partial_rollout.ray_trainer import ray_trainer__init__, ray_trainer_init_workers, ray_trainer_fit
+    from recipe.partial_rollout.ray_trainer import ray_trainer__init__, ray_trainer_fit, ray_trainer_init_workers
+    from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+
     RayPPOTrainer.__init__ = ray_trainer__init__
     RayPPOTrainer.init_workers = ray_trainer_init_workers
     RayPPOTrainer.fit = ray_trainer_fit

--- a/recipe/partial_rollout/patch_manager.py
+++ b/recipe/partial_rollout/patch_manager.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+
+def apply_partialrollout_patch():
+    from recipe.dapo.dapo_ray_trainer import RayDAPOTrainer
+    from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+    from recipe.partial_rollout.dapo_ray_trainer import dapo_ray_trainer_fit
+    from recipe.partial_rollout.ray_trainer import ray_trainer__init__, ray_trainer_init_workers, ray_trainer_fit
+    RayPPOTrainer.__init__ = ray_trainer__init__
+    RayPPOTrainer.init_workers = ray_trainer_init_workers
+    RayPPOTrainer.fit = ray_trainer_fit
+    RayDAPOTrainer.fit = dapo_ray_trainer_fit

--- a/recipe/partial_rollout/ray_trainer.py
+++ b/recipe/partial_rollout/ray_trainer.py
@@ -403,7 +403,7 @@ def ray_trainer_fit(self):
                     finished_mask = batch.non_tensor_batch.pop("finished")
                     if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
                         finished_mask = (batch.non_tensor_batch[
-                                             "age"] == self.config.algorithm.partial_rollout_max_split) | finished_mask
+                                             "age"] == self.config.actor_rollout_ref.rollout.partial_rollout_max_split) | finished_mask
                     if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
                         finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
                                           for response in

--- a/recipe/partial_rollout/ray_trainer.py
+++ b/recipe/partial_rollout/ray_trainer.py
@@ -419,6 +419,9 @@ def ray_trainer_fit(self):
                     else:
                         partial_batch = None
 
+                    if staged_batch is not None and len(staged_batch.batch) > 0:
+                        staged_batch.meta_info.pop("global_token_num",None)
+                        staged_out.meta_info.pop("global_token_num",None)
                     # note that we no longer ensure the order of samples in staged_batch
                     staged_batch = (
                         DataProto.concat([staged_batch, staged_out]) if staged_batch is not None else staged_out

--- a/recipe/partial_rollout/ray_trainer.py
+++ b/recipe/partial_rollout/ray_trainer.py
@@ -1,0 +1,1893 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+PPO Trainer with Ray-based single controller.
+This trainer supports model-agonistic model initialization with huggingface
+"""
+
+import json
+import os
+import uuid
+from collections import defaultdict
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pprint import pprint
+from typing import Optional
+import threading
+
+import numpy as np
+import ray
+import torch
+from omegaconf import OmegaConf, open_dict
+from torch.utils.data import Dataset, Sampler
+from torchdata.stateful_dataloader import StatefulDataLoader
+from tqdm import tqdm
+
+from verl import DataProto
+from verl.experimental.dataset.sampler import AbstractCurriculumSampler
+from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
+from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+from verl.single_controller.ray.base import create_colocated_worker_cls
+from verl.trainer.config import AlgoConfig
+from verl.trainer.ppo import core_algos
+from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
+from verl.trainer.ppo.metric_utils import (
+    compute_data_metrics,
+    compute_throughout_metrics,
+    compute_timing_metrics,
+    process_validation_metrics,
+)
+from verl.trainer.ppo.reward import compute_reward, compute_reward_async
+from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_reward_model
+from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage, compute_response_mask, ResourcePoolManager
+from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
+from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.debug import marked_timer
+from verl.utils.metric import reduce_metrics
+from verl.utils.rollout_skip import RolloutSkip
+from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
+from verl.utils.torch_functional import masked_mean
+from verl.utils.tracking import ValidationGenerationsLogger
+
+
+class AggregatorActor:
+    def __init__(self, threshold_rate):
+        self.total = 0
+        self.stopped = False
+        self.sample_num = 0
+        self.threshold_rate = threshold_rate
+        self.threshold = 0
+        self.prefetch_request_index_lock = threading.Lock()
+
+    def set_sample_num(self, value):
+        self.sample_num = value
+        self.threshold = int(self.threshold_rate * self.sample_num)
+
+    def clear(self):
+        self.total = 0
+        self.stopped = False
+
+    def add(self, value):
+        with self.prefetch_request_index_lock:
+            self.total += value
+        if self.total >= self.threshold and not self.stopped:
+            self.stopped = True
+        return self.stopped
+
+    def is_stopped(self):
+        return self.stopped
+
+    def get_total(self):
+        return self.total
+
+    def get_threshold(self):
+        return self.threshold
+
+
+def ray_trainer__init__(
+        self,
+        config,
+        tokenizer,
+        role_worker_mapping: dict[Role, WorkerType],
+        resource_pool_manager: ResourcePoolManager,
+        ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
+        processor=None,
+        reward_fn=None,
+        val_reward_fn=None,
+        train_dataset: Optional[Dataset] = None,
+        val_dataset: Optional[Dataset] = None,
+        collate_fn=None,
+        train_sampler: Optional[Sampler] = None,
+        device_name=None,
+):
+    """
+    Initialize distributed PPO trainer with Ray backend.
+    Note that this trainer runs on the driver process on a single CPU/GPU node.
+
+    Args:
+        config: Configuration object containing training parameters.
+        tokenizer: Tokenizer used for encoding and decoding text.
+        role_worker_mapping (dict[Role, WorkerType]): Mapping from roles to worker classes.
+        resource_pool_manager (ResourcePoolManager): Manager for Ray resource pools.
+        ray_worker_group_cls (RayWorkerGroup, optional): Class for Ray worker groups. Defaults to RayWorkerGroup.
+        processor: Optional data processor, used for multimodal data
+        reward_fn: Function for computing rewards during training.
+        val_reward_fn: Function for computing rewards during validation.
+        train_dataset (Optional[Dataset], optional): Training dataset. Defaults to None.
+        val_dataset (Optional[Dataset], optional): Validation dataset. Defaults to None.
+        collate_fn: Function to collate data samples into batches.
+        train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
+        device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
+    """
+
+    # Store the tokenizer for text processing
+    self.tokenizer = tokenizer
+    self.processor = processor
+    self.config = config
+    self.reward_fn = reward_fn
+    self.val_reward_fn = val_reward_fn
+
+    self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
+    assert self.hybrid_engine, "Currently, only support hybrid engine"
+
+    if self.hybrid_engine:
+        assert Role.ActorRollout in role_worker_mapping, f"{role_worker_mapping.keys()=}"
+
+    self.role_worker_mapping = role_worker_mapping
+    self.resource_pool_manager = resource_pool_manager
+    self.use_reference_policy = need_reference_policy(self.role_worker_mapping)
+    self.use_rm = need_reward_model(self.role_worker_mapping)
+    self.use_critic = need_critic(self.config)
+    self.ray_worker_group_cls = ray_worker_group_cls
+    self.device_name = device_name if device_name else self.config.trainer.device
+    self.validation_generations_logger = ValidationGenerationsLogger(
+        project_name=self.config.trainer.project_name,
+        experiment_name=self.config.trainer.experiment_name,
+    )
+
+    # if ref_in_actor is True, the reference policy will be actor without lora applied
+    self.ref_in_actor = (
+            config.actor_rollout_ref.model.get("lora_rank", 0) > 0
+            or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+    )
+
+    # define in-reward KL control
+    # kl loss control currently not suppoorted
+    if self.config.algorithm.use_kl_in_reward:
+        self.kl_ctrl_in_reward = core_algos.get_kl_controller(self.config.algorithm.kl_ctrl)
+
+    self.aggregator = None
+    self.enable_partial_rollout: bool = self.config.actor_rollout_ref.rollout.partial_rollout_max_split > 1
+    # check partial rollout config
+    assert (config.data.max_response_length %
+            config.actor_rollout_ref.rollout.partial_rollout_max_split == 0), \
+        "max_response_length must be divisible by partial_rollout_max_split"
+
+    self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
+
+
+def ray_trainer_init_workers(self):
+    """Initialize distributed training workers using Ray backend.
+
+    Creates:
+    1. Ray resource pools from configuration
+    2. Worker groups for each role (actor, critic, etc.)
+    """
+    self.resource_pool_manager.create_resource_pool()
+
+    self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
+
+    if Role.Aggregator in self.role_worker_mapping:
+        self.aggregator = self.role_worker_mapping[Role.Aggregator].options(name="aggregator_actor").remote(
+            threshold_rate=self.config.actor_rollout_ref.rollout.rollout_threshold_rate)
+
+    # create actor and rollout
+    if self.hybrid_engine:
+        resource_pool = self.resource_pool_manager.get_resource_pool(Role.ActorRollout)
+        actor_rollout_cls = RayClassWithInitArgs(
+            cls=self.role_worker_mapping[Role.ActorRollout],
+            config=self.config.actor_rollout_ref,
+            role=str(Role.ActorRollout),
+        )
+        self.resource_pool_to_cls[resource_pool][str(Role.ActorRollout)] = actor_rollout_cls
+    else:
+        raise NotImplementedError
+
+    # create critic
+    if self.use_critic:
+        resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
+        critic_cfg = omega_conf_to_dataclass(self.config.critic)
+        critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
+        self.resource_pool_to_cls[resource_pool][str(Role.Critic)] = critic_cls
+
+    # create reference policy if needed
+    if self.use_reference_policy:
+        resource_pool = self.resource_pool_manager.get_resource_pool(Role.RefPolicy)
+        ref_policy_cls = RayClassWithInitArgs(
+            self.role_worker_mapping[Role.RefPolicy],
+            config=self.config.actor_rollout_ref,
+            role=str(Role.RefPolicy),
+        )
+        self.resource_pool_to_cls[resource_pool][str(Role.RefPolicy)] = ref_policy_cls
+
+    # create a reward model if reward_fn is None
+    if self.use_rm:
+        # we create a RM here
+        resource_pool = self.resource_pool_manager.get_resource_pool(Role.RewardModel)
+        rm_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.RewardModel], config=self.config.reward_model)
+        self.resource_pool_to_cls[resource_pool][str(Role.RewardModel)] = rm_cls
+
+    # initialize WorkerGroup
+    # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
+    # you should not use `create_colocated_worker_cls`.
+    # Instead, directly pass different resource pool to different worker groups.
+    # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
+    all_wg = {}
+    wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
+    if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
+        wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+    if OmegaConf.select(self.config.global_profiler, "steps") is not None:
+        wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
+        # Only require nsight worker options when tool is nsys
+        if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
+            assert (
+                OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                is not None
+            ), "worker_nsight_options must be set when using nsys with profile_steps"
+            wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
+                OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+            )
+    wg_kwargs["device_name"] = self.device_name
+
+    for resource_pool, class_dict in self.resource_pool_to_cls.items():
+        worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
+        wg_dict = self.ray_worker_group_cls(
+            resource_pool=resource_pool,
+            ray_cls_with_init=worker_dict_cls,
+            **wg_kwargs,
+        )
+        spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
+        all_wg.update(spawn_wg)
+
+    if self.use_critic:
+        self.critic_wg = all_wg[str(Role.Critic)]
+        self.critic_wg.init_model()
+
+    if self.use_reference_policy and not self.ref_in_actor:
+        self.ref_policy_wg = all_wg[str(Role.RefPolicy)]
+        self.ref_policy_wg.init_model()
+
+    self.rm_wg = None
+    # initalization of rm_wg will be deprecated in the future
+    if self.use_rm:
+        self.rm_wg = all_wg[str(Role.RewardModel)]
+        self.rm_wg.init_model()
+
+    # we should create rollout at the end so that vllm can have a better estimation of kv cache memory
+    self.actor_rollout_wg = all_wg[str(Role.ActorRollout)]
+    self.actor_rollout_wg.init_model()
+
+    # create async rollout manager and request scheduler
+    self.async_rollout_mode = False
+    if self.config.actor_rollout_ref.rollout.mode == "async":
+        from verl.experimental.agent_loop import AgentLoopManager
+
+        self.async_rollout_mode = True
+        self.async_rollout_manager = AgentLoopManager(
+            config=self.config, worker_group=self.actor_rollout_wg, rm_wg=self.rm_wg
+        )
+
+
+def ray_trainer_fit(self):
+    """
+    The training loop of PPO.
+    The driver process only need to call the compute functions of the worker group through RPC
+    to construct the PPO dataflow.
+    The light-weight advantage computation is done on the driver process.
+    """
+    from omegaconf import OmegaConf
+
+    from verl.utils.tracking import Tracking
+
+    logger = Tracking(
+        project_name=self.config.trainer.project_name,
+        experiment_name=self.config.trainer.experiment_name,
+        default_backend=self.config.trainer.logger,
+        config=OmegaConf.to_container(self.config, resolve=True),
+    )
+
+    self.global_steps = 0
+
+    # load checkpoint before doing anything
+    self._load_checkpoint()
+
+    current_epoch = self.global_steps // len(self.train_dataloader)
+
+    # perform validation before training
+    # currently, we only support validation using the reward_function.
+    if self.val_reward_fn is not None and self.config.trainer.get("val_before_train", True):
+        val_metrics = self._validate()
+        assert val_metrics, f"{val_metrics=}"
+        pprint(f"Initial validation metrics: {val_metrics}")
+        logger.log(data=val_metrics, step=self.global_steps)
+        if self.config.trainer.get("val_only", False):
+            return
+
+    if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
+        rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
+        rollout_skip.wrap_generate_sequences()
+
+    # add tqdm
+    progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
+
+    # we start from step 1
+    self.global_steps += 1
+    last_val_metrics = None
+    self.max_steps_duration = 0
+    partial_batch: Optional[DataProto] = None  # samples whose rollout is not finished yet
+    staged_batch: Optional[DataProto] = None  # samples whose rollout has been finished but not yet trained on
+    prev_step_profile = False
+    curr_step_profile = (
+        self.global_steps in self.config.global_profiler.steps
+        if self.config.global_profiler.steps is not None
+        else False
+    )
+    next_step_profile = False
+
+    for epoch in range(current_epoch, self.config.trainer.total_epochs):
+        for batch_dict in self.train_dataloader:
+            metrics = {}
+            timing_raw = {}
+
+            with marked_timer("start_profile", timing_raw):
+                self._start_profiling(
+                    not prev_step_profile and curr_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else curr_step_profile
+                )
+            batch: DataProto = DataProto.from_single_dict(batch_dict)
+            batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
+                                                     dtype=object)
+            # repeat to align with repeated responses in rollout
+            batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+            batch.non_tensor_batch["age"] = np.ones(len(batch.batch), dtype=int)
+            batch.non_tensor_batch["raw_response_ids"] = np.fromiter(([] for _ in range(len(batch.batch))),
+                                                                     dtype=object)
+
+            batch = DataProto.concat([partial_batch, batch]) if partial_batch is not None else batch
+            # add uid to batch
+            batch.non_tensor_batch["uid"] = np.array(
+                [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
+            )
+
+            gen_batch = self._get_gen_batch(batch)
+
+            # pass global_steps to trace
+            gen_batch.meta_info["global_steps"] = self.global_steps
+            gen_batch_output = gen_batch.repeat(
+                repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
+            )
+
+            is_last_step = self.global_steps >= self.total_training_steps
+            with marked_timer("step", timing_raw):
+                # generate a batch
+                with marked_timer("gen", timing_raw, color="red"):
+                    if self.aggregator:
+                        self.aggregator.set_sample_num.remote(len(gen_batch))
+                        self.aggregator.clear.remote()
+
+                    if not self.async_rollout_mode:
+                        gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch_output)
+                    else:
+                        gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
+
+                    timing_raw.update(gen_batch_output.meta_info["timing"])
+                    gen_batch_output.meta_info.pop("timing", None)
+                with marked_timer("filter", timing_raw):
+                    batch = batch.union(gen_batch_output)
+
+                    finished_mask = batch.non_tensor_batch.pop("finished")
+                    if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
+                        finished_mask = (batch.non_tensor_batch[
+                                             "age"] == self.config.algorithm.partial_rollout_max_split) | finished_mask
+                    if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
+                        finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
+                                          for response in
+                                          gen_batch_output.non_tensor_batch['raw_response_ids']]) | finished_mask
+                    staged_out, partial_batch = DataProto.split_data(batch, finished_mask)
+                    staged_out.non_tensor_batch.pop("raw_prompt_ids")
+                    staged_out.non_tensor_batch.pop("raw_response_ids")
+
+                    if len(partial_batch.batch) > 0:
+                        for key in ("input_ids", "attention_mask", "position_ids"):
+                            tmp = partial_batch.batch.pop(key, None)
+                            partial_batch.batch[key] = tmp[:, : self.config.data.max_prompt_length]
+
+                        for key in ("prompts", "responses", "rollout_log_probs"):
+                            # we don't support rollout_log_probs in this feature branch yet
+                            if key in partial_batch.batch:
+                                partial_batch.batch.pop(key)
+                    else:
+                        partial_batch = None
+
+                    # note that we no longer ensure the order of samples in staged_batch
+                    staged_batch = DataProto.concat(
+                        [staged_batch, staged_out]) if staged_batch is not None else staged_out
+
+                    # prompts whose number of finished rollout is enough can be trained on
+                    # while filtering, we ensure sample number is divisible by n_gpus_per_node and as large as possible
+                    can_train_mask = np.zeros(len(staged_batch.batch), dtype=bool)
+                    id2count = defaultdict(int)
+                    required_rollouts = self.config.actor_rollout_ref.rollout.n
+                    divisor = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * required_rollouts
+
+                    for uid in staged_batch.non_tensor_batch["uid"]:
+                        id2count[uid] += 1
+                    assert not id2count or max(
+                        id2count.values()) <= required_rollouts, "max number of responses exceeds rollout n"
+
+                    complete_uids = [uid for uid, count in id2count.items() if count == required_rollouts]
+
+                    total_complete_samples = len(complete_uids) * required_rollouts
+                    max_usable_groups = (total_complete_samples // divisor) * divisor // required_rollouts
+                    can_train_count = max_usable_groups * required_rollouts
+
+                    if can_train_count == 0:
+                        print(f"{total_complete_samples=}, no complete uid groups available. Keep generating...")
+                        continue
+
+                    selected_uids = set(complete_uids[:max_usable_groups])
+
+                    for i, uid in enumerate(staged_batch.non_tensor_batch["uid"]):
+                        if uid in selected_uids:
+                            can_train_mask[i] = True
+
+                    batch, staged_batch = DataProto.split_data(staged_batch, can_train_mask)
+                    if partial_batch:
+                        partial_batch.non_tensor_batch["age"] += 1
+                if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                    if self.reward_fn is None:
+                        raise ValueError("A reward_fn is required for REMAX advantage estimation.")
+
+                    with marked_timer("gen_max", timing_raw, color="purple"):
+                        gen_baseline_batch = deepcopy(gen_batch)
+                        gen_baseline_batch.meta_info["do_sample"] = False
+                        if not self.async_rollout_mode:
+                            gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+                        else:
+                            gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
+                        batch = batch.union(gen_baseline_output)
+                        # compute reward model score on batch
+                        rm_scores = None
+                        if self.use_rm and "rm_scores" not in batch.batch.keys():
+                            rm_scores = self.rm_wg.compute_rm_score(batch)
+                            batch = batch.union(rm_scores)
+                        reward_baseline_tensor, _ = compute_reward(batch, self.reward_fn)
+                        reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                        keys_to_pop = set(gen_baseline_output.batch.keys())
+                        if rm_scores is not None:
+                            keys_to_pop.update(rm_scores.batch.keys())
+                        batch.pop(batch_keys=list(keys_to_pop))
+
+                        batch.batch["reward_baselines"] = reward_baseline_tensor
+
+                        del rm_scores, gen_baseline_batch, gen_baseline_output
+
+
+                if "response_mask" not in batch.batch.keys():
+                    batch.batch["response_mask"] = compute_response_mask(batch)
+                # Balance the number of valid tokens across DP ranks.
+                # NOTE: This usually changes the order of data in the `batch`,
+                # which won't affect the advantage calculation (since it's based on uid),
+                # but might affect the loss calculation (due to the change of mini-batching).
+                if self.config.trainer.balance_batch:
+                    self._balance_batch(batch, metrics=metrics)
+
+                # compute global_valid tokens
+                batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+
+                with marked_timer("reward", timing_raw, color="yellow"):
+                    # compute reward model score
+                    if self.use_rm and "rm_scores" not in batch.batch.keys():
+                        reward_tensor = self.rm_wg.compute_rm_score(batch)
+                        batch = batch.union(reward_tensor)
+
+                    if self.config.reward_model.launch_reward_fn_async:
+                        future_reward = compute_reward_async.remote(
+                            data=batch, config=self.config, tokenizer=self.tokenizer
+                        )
+                    else:
+                        reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
+
+                # Operating Mode Selection:
+                # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)
+                # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
+                #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
+                rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+                bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+                if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
+                    from verl.trainer.ppo.rollout_corr_helper import apply_rollout_correction
+
+                    apply_rollout_correction(
+                        batch=batch,
+                        rollout_corr_config=rollout_corr_config,
+                        policy_loss_config=self.config.actor_rollout_ref.actor.policy_loss,
+                    )
+                else:  # Recompute old_log_probs
+                    with marked_timer("old_log_prob", timing_raw, color="blue"):
+                        old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
+                        entropys = old_log_prob.batch["entropys"]
+                        response_masks = batch.batch["response_mask"]
+                        loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
+                        entropy_agg = agg_loss(
+                            loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode
+                        )
+                        old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
+                        metrics.update(old_log_prob_metrics)
+                        old_log_prob.batch.pop("entropys")
+                        batch = batch.union(old_log_prob)
+                        if "rollout_log_probs" in batch.batch.keys():
+                            # TODO: we may want to add diff of probs too.
+                            from verl.utils.debug.metrics import calculate_debug_metrics
+
+                            metrics.update(calculate_debug_metrics(batch))
+
+                assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
+
+                if self.use_reference_policy:
+                    # compute reference log_prob
+                    with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
+                        if not self.ref_in_actor:
+                            ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                        else:
+                            ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
+                        batch = batch.union(ref_log_prob)
+
+                # compute values
+                if self.use_critic:
+                    with marked_timer("values", timing_raw, color="cyan"):
+                        values = self.critic_wg.compute_values(batch)
+                        batch = batch.union(values)
+
+                with marked_timer("adv", timing_raw, color="brown"):
+                    # we combine with rule-based rm
+                    reward_extra_infos_dict: dict[str, list]
+                    if self.config.reward_model.launch_reward_fn_async:
+                        reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                    batch.batch["token_level_scores"] = reward_tensor
+
+                    if reward_extra_infos_dict:
+                        batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
+
+                    # compute rewards. apply_kl_penalty if available
+                    if self.config.algorithm.use_kl_in_reward:
+                        batch, kl_metrics = apply_kl_penalty(
+                            batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
+                        )
+                        metrics.update(kl_metrics)
+                    else:
+                        batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
+
+                    # Compute rollout correction: IS weights, rejection sampling, and metrics
+                    # Only runs in decoupled mode (computes once per batch using stable π_old)
+                    # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
+                    if (
+                        rollout_corr_config is not None
+                        and "rollout_log_probs" in batch.batch
+                        and not bypass_recomputing_logprobs  # Only in decoupled mode
+                    ):
+                        from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
+
+                        # Compute IS weights, apply rejection sampling, compute metrics
+                        batch, is_metrics = compute_rollout_correction_and_add_to_batch(batch, rollout_corr_config)
+                        # IS and off-policy metrics already have rollout_corr/ prefix
+                        metrics.update(is_metrics)
+
+                    # compute advantages, executed on the driver process
+                    norm_adv_by_std_in_grpo = self.config.algorithm.get(
+                        "norm_adv_by_std_in_grpo", True
+                    )  # GRPO adv normalization factor
+
+                    batch = compute_advantage(
+                        batch,
+                        adv_estimator=self.config.algorithm.adv_estimator,
+                        gamma=self.config.algorithm.gamma,
+                        lam=self.config.algorithm.lam,
+                        num_repeat=self.config.actor_rollout_ref.rollout.n,
+                        norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                        config=self.config.algorithm,
+                    )
+
+                # update critic
+                if self.use_critic:
+                    with marked_timer("update_critic", timing_raw, color="pink"):
+                        critic_output = self.critic_wg.update_critic(batch)
+                    critic_output_metrics = reduce_metrics(critic_output.meta_info["metrics"])
+                    metrics.update(critic_output_metrics)
+
+                # implement critic warmup
+                if self.config.trainer.critic_warmup <= self.global_steps:
+                    # update actor
+                    with marked_timer("update_actor", timing_raw, color="red"):
+                        rollout_config = self.config.actor_rollout_ref.rollout
+                        batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
+                        # TODO: Make "temperature" single source of truth from generation.
+                        batch.meta_info["temperature"] = rollout_config.temperature
+                        actor_output = self.actor_rollout_wg.update_actor(batch)
+                    actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                    metrics.update(actor_output_metrics)
+
+                # Log rollout generations if enabled
+                rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
+                if rollout_data_dir:
+                    self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
+
+            # validate
+            if (
+                self.val_reward_fn is not None
+                and self.config.trainer.test_freq > 0
+                and (is_last_step or self.global_steps % self.config.trainer.test_freq == 0)
+            ):
+                with marked_timer("testing", timing_raw, color="green"):
+                    val_metrics: dict = self._validate()
+                    if is_last_step:
+                        last_val_metrics = val_metrics
+                metrics.update(val_metrics)
+
+            # Check if the ESI (Elastic Server Instance)/training plan is close to expiration.
+            esi_close_to_expiration = should_save_ckpt_esi(
+                max_steps_duration=self.max_steps_duration,
+                redundant_time=self.config.trainer.esi_redundant_time,
+            )
+            # Check if the conditions for saving a checkpoint are met.
+            # The conditions include a mandatory condition (1) and
+            # one of the following optional conditions (2/3/4):
+            # 1. The save frequency is set to a positive value.
+            # 2. It's the last training step.
+            # 3. The current step number is a multiple of the save frequency.
+            # 4. The ESI(Elastic Server Instance)/training plan is close to expiration.
+            if self.config.trainer.save_freq > 0 and (
+                is_last_step or self.global_steps % self.config.trainer.save_freq == 0 or esi_close_to_expiration
+            ):
+                if esi_close_to_expiration:
+                    print("Force saving checkpoint: ESI instance expiration approaching.")
+                with marked_timer("save_checkpoint", timing_raw, color="green"):
+                    self._save_checkpoint()
+
+            with marked_timer("stop_profile", timing_raw):
+                next_step_profile = (
+                    self.global_steps + 1 in self.config.global_profiler.steps
+                    if self.config.global_profiler.steps is not None
+                    else False
+                )
+                self._stop_profiling(
+                    curr_step_profile and not next_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else curr_step_profile
+                )
+                prev_step_profile = curr_step_profile
+                curr_step_profile = next_step_profile
+
+            steps_duration = timing_raw["step"]
+            self.max_steps_duration = max(self.max_steps_duration, steps_duration)
+
+            # training metrics
+            metrics.update(
+                {
+                    "training/global_step": self.global_steps,
+                    "training/epoch": epoch,
+                }
+            )
+            if self.enable_partial_rollout:
+                metrics.update(
+                    {
+                        "training/can_train_count": can_train_count,
+                        "training/total_complete_samples": total_complete_samples,
+                    }
+                )
+            # collect metrics
+            metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
+            metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+            # TODO: implement actual tflpo and theoretical tflpo
+            n_gpus = self.resource_pool_manager.get_n_gpus()
+            metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+            # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
+
+            # this is experimental and may be changed/removed in the future in favor of a general-purpose one
+            if isinstance(self.train_dataloader.sampler, AbstractCurriculumSampler):
+                self.train_dataloader.sampler.update(batch=batch)
+
+            # TODO: make a canonical logger that supports various backend
+            logger.log(data=metrics, step=self.global_steps)
+
+            progress_bar.update(1)
+            self.global_steps += 1
+
+            if (
+                hasattr(self.config.actor_rollout_ref.actor, "profiler")
+                and self.config.actor_rollout_ref.actor.profiler.tool == "torch_memory"
+            ):
+                self.actor_rollout_wg.dump_memory_snapshot(
+                    tag=f"post_update_step{self.global_steps}", sub_dir=f"step{self.global_steps}"
+                )
+
+            if is_last_step:
+                pprint(f"Final validation metrics: {last_val_metrics}")
+                progress_bar.close()
+                return
+
+            # this is experimental and may be changed/removed in the future
+            # in favor of a general-purpose data buffer pool
+            if hasattr(self.train_dataset, "on_batch_end"):
+                # The dataset may be changed after each training batch
+                self.train_dataset.on_batch_end(batch=batch)
+
+
+
+
+
+
+class RayPPOTrainer111:
+    """Distributed PPO trainer using Ray for scalable reinforcement learning.
+
+    This trainer orchestrates distributed PPO training across multiple nodes and GPUs,
+    managing actor rollouts, critic training, and reward computation with Ray backend.
+    Supports various model architectures including FSDP, Megatron, vLLM, and SGLang integration.
+    """
+
+    # TODO: support each role have individual ray_worker_group_cls,
+    # i.e., support different backend of different role
+    def __init__(
+        self,
+        config,
+        tokenizer,
+        role_worker_mapping: dict[Role, WorkerType],
+        resource_pool_manager: ResourcePoolManager,
+        ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
+        processor=None,
+        reward_fn=None,
+        val_reward_fn=None,
+        train_dataset: Optional[Dataset] = None,
+        val_dataset: Optional[Dataset] = None,
+        collate_fn=None,
+        train_sampler: Optional[Sampler] = None,
+        device_name=None,
+    ):
+        """
+        Initialize distributed PPO trainer with Ray backend.
+        Note that this trainer runs on the driver process on a single CPU/GPU node.
+
+        Args:
+            config: Configuration object containing training parameters.
+            tokenizer: Tokenizer used for encoding and decoding text.
+            role_worker_mapping (dict[Role, WorkerType]): Mapping from roles to worker classes.
+            resource_pool_manager (ResourcePoolManager): Manager for Ray resource pools.
+            ray_worker_group_cls (RayWorkerGroup, optional): Class for Ray worker groups. Defaults to RayWorkerGroup.
+            processor: Optional data processor, used for multimodal data
+            reward_fn: Function for computing rewards during training.
+            val_reward_fn: Function for computing rewards during validation.
+            train_dataset (Optional[Dataset], optional): Training dataset. Defaults to None.
+            val_dataset (Optional[Dataset], optional): Validation dataset. Defaults to None.
+            collate_fn: Function to collate data samples into batches.
+            train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
+            device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
+        """
+
+        # Store the tokenizer for text processing
+        self.tokenizer = tokenizer
+        self.processor = processor
+        self.config = config
+        self.reward_fn = reward_fn
+        self.val_reward_fn = val_reward_fn
+
+        self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
+        assert self.hybrid_engine, "Currently, only support hybrid engine"
+
+        if self.hybrid_engine:
+            assert Role.ActorRollout in role_worker_mapping, f"{role_worker_mapping.keys()=}"
+
+        self.role_worker_mapping = role_worker_mapping
+        self.resource_pool_manager = resource_pool_manager
+        self.use_reference_policy = need_reference_policy(self.role_worker_mapping)
+        self.use_rm = need_reward_model(self.role_worker_mapping)
+        self.use_critic = need_critic(self.config)
+        self.ray_worker_group_cls = ray_worker_group_cls
+        self.device_name = device_name if device_name else self.config.trainer.device
+        self.validation_generations_logger = ValidationGenerationsLogger(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+        )
+
+        # if ref_in_actor is True, the reference policy will be actor without lora applied
+        self.ref_in_actor = (
+            config.actor_rollout_ref.model.get("lora_rank", 0) > 0
+            or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        )
+
+        # define in-reward KL control
+        # kl loss control currently not suppoorted
+        if self.config.algorithm.use_kl_in_reward:
+            self.kl_ctrl_in_reward = core_algos.get_kl_controller(self.config.algorithm.kl_ctrl)
+
+        self.aggregator = None
+        self.enable_partial_rollout: bool = self.config.actor_rollout_ref.rollout.partial_rollout_max_split > 1
+        # check partial rollout config
+        assert (config.data.max_response_length %
+                config.actor_rollout_ref.rollout.partial_rollout_max_split == 0), \
+            "max_response_length must be divisible by partial_rollout_max_split"
+
+        self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
+
+    def _create_dataloader(self, train_dataset, val_dataset, collate_fn, train_sampler: Optional[Sampler]):
+        """
+        Creates the train and validation dataloaders.
+        """
+        # TODO: we have to make sure the batch size is divisible by the dp size
+        from verl.trainer.main_ppo import create_rl_dataset, create_rl_sampler
+
+        if train_dataset is None:
+            train_dataset = create_rl_dataset(
+                self.config.data.train_files,
+                self.config.data,
+                self.tokenizer,
+                self.processor,
+                max_samples=self.config.data.get("train_max_samples", -1),
+            )
+        if val_dataset is None:
+            val_dataset = create_rl_dataset(
+                self.config.data.val_files,
+                self.config.data,
+                self.tokenizer,
+                self.processor,
+                max_samples=self.config.data.get("val_max_samples", -1),
+            )
+        self.train_dataset, self.val_dataset = train_dataset, val_dataset
+
+        if train_sampler is None:
+            train_sampler = create_rl_sampler(self.config.data, self.train_dataset)
+        if collate_fn is None:
+            from verl.utils.dataset.rl_dataset import collate_fn as default_collate_fn
+
+            collate_fn = default_collate_fn
+
+        num_workers = self.config.data["dataloader_num_workers"]
+
+        self.train_dataloader = StatefulDataLoader(
+            dataset=self.train_dataset,
+            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
+            num_workers=num_workers,
+            drop_last=True,
+            collate_fn=collate_fn,
+            sampler=train_sampler,
+        )
+
+        val_batch_size = self.config.data.val_batch_size  # Prefer config value if set
+        if val_batch_size is None:
+            val_batch_size = len(self.val_dataset)
+
+        self.val_dataloader = StatefulDataLoader(
+            dataset=self.val_dataset,
+            batch_size=val_batch_size,
+            num_workers=num_workers,
+            shuffle=self.config.data.get("validation_shuffle", True),
+            drop_last=False,
+            collate_fn=collate_fn,
+        )
+
+        assert len(self.train_dataloader) >= 1, "Train dataloader is empty!"
+        assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
+
+        print(
+            f"Size of train dataloader: {len(self.train_dataloader)}, Size of val dataloader: "
+            f"{len(self.val_dataloader)}"
+        )
+
+        total_training_steps = len(self.train_dataloader) * self.config.trainer.total_epochs
+
+        if self.config.trainer.total_training_steps is not None:
+            total_training_steps = self.config.trainer.total_training_steps
+
+        self.total_training_steps = total_training_steps
+        print(f"Total training steps: {self.total_training_steps}")
+
+        try:
+            OmegaConf.set_struct(self.config, True)
+            with open_dict(self.config):
+                if OmegaConf.select(self.config, "actor_rollout_ref.actor.optim"):
+                    self.config.actor_rollout_ref.actor.optim.total_training_steps = total_training_steps
+                if OmegaConf.select(self.config, "critic.optim"):
+                    self.config.critic.optim.total_training_steps = total_training_steps
+        except Exception as e:
+            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
+
+    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
+        """Dump rollout/validation samples as JSONL."""
+        os.makedirs(dump_path, exist_ok=True)
+        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
+
+        n = len(inputs)
+        base_data = {
+            "input": inputs,
+            "output": outputs,
+            "gts": gts,
+            "score": scores,
+            "step": [self.global_steps] * n,
+        }
+
+        for k, v in reward_extra_infos_dict.items():
+            if len(v) == n:
+                base_data[k] = v
+
+        lines = []
+        for i in range(n):
+            entry = {k: v[i] for k, v in base_data.items()}
+            lines.append(json.dumps(entry, ensure_ascii=False))
+
+        with open(filename, "w") as f:
+            f.write("\n".join(lines) + "\n")
+
+        print(f"Dumped generations to {filename}")
+
+    def _log_rollout_data(
+        self, batch: DataProto, reward_extra_infos_dict: dict, timing_raw: dict, rollout_data_dir: str
+    ):
+        """Log rollout data to disk.
+        Args:
+            batch (DataProto): The batch containing rollout data
+            reward_extra_infos_dict (dict): Additional reward information to log
+            timing_raw (dict): Timing information for profiling
+            rollout_data_dir (str): Directory path to save the rollout data
+        """
+        with marked_timer("dump_rollout_generations", timing_raw, color="green"):
+            inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
+            outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
+            scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
+            sample_gts = [item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch]
+
+            reward_extra_infos_to_dump = reward_extra_infos_dict.copy()
+            if "request_id" in batch.non_tensor_batch:
+                reward_extra_infos_dict.setdefault(
+                    "request_id",
+                    batch.non_tensor_batch["request_id"].tolist(),
+                )
+
+            self._dump_generations(
+                inputs=inputs,
+                outputs=outputs,
+                gts=sample_gts,
+                scores=scores,
+                reward_extra_infos_dict=reward_extra_infos_to_dump,
+                dump_path=rollout_data_dir,
+            )
+
+    def _maybe_log_val_generations(self, inputs, outputs, scores):
+        """Log a table of validation samples to the configured logger (wandb or swanlab)"""
+
+        generations_to_log = self.config.trainer.log_val_generations
+
+        if generations_to_log == 0:
+            return
+
+        import numpy as np
+
+        # Create tuples of (input, output, score) and sort by input text
+        samples = list(zip(inputs, outputs, scores, strict=True))
+        samples.sort(key=lambda x: x[0])  # Sort by input text
+
+        # Use fixed random seed for deterministic shuffling
+        rng = np.random.RandomState(42)
+        rng.shuffle(samples)
+
+        # Take first N samples after shuffling
+        samples = samples[:generations_to_log]
+
+        # Log to each configured logger
+        self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
+
+    def _get_gen_batch(self, batch: DataProto) -> DataProto:
+        reward_model_keys = set({"data_source", "reward_model", "extra_info", "uid"}) & batch.non_tensor_batch.keys()
+
+        # pop those keys for generation
+        batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
+        non_tensor_batch_keys_to_pop = set(batch.non_tensor_batch.keys()) - reward_model_keys
+        gen_batch = batch.pop(
+            batch_keys=batch_keys_to_pop,
+            non_tensor_batch_keys=list(non_tensor_batch_keys_to_pop),
+        )
+
+        # For agent loop, we need reward model keys to compute score.
+        if self.async_rollout_mode:
+            gen_batch.non_tensor_batch.update(batch.non_tensor_batch)
+
+        return gen_batch
+
+    def _validate(self):
+        data_source_lst = []
+        reward_extra_infos_dict: dict[str, list] = defaultdict(list)
+
+        # Lists to collect samples for the table
+        sample_inputs = []
+        sample_outputs = []
+        sample_gts = []
+        sample_scores = []
+        sample_turns = []
+        sample_uids = []
+
+        for test_data in self.val_dataloader:
+            test_batch = DataProto.from_single_dict(test_data)
+
+            if "uid" not in test_batch.non_tensor_batch:
+                test_batch.non_tensor_batch["uid"] = np.array(
+                    [str(uuid.uuid4()) for _ in range(len(test_batch.batch))], dtype=object
+                )
+
+            # repeat test batch
+            test_batch = test_batch.repeat(
+                repeat_times=self.config.actor_rollout_ref.rollout.val_kwargs.n, interleave=True
+            )
+
+            # we only do validation on rule-based rm
+            if self.config.reward_model.enable and test_batch[0].non_tensor_batch["reward_model"]["style"] == "model":
+                return {}
+
+            # Store original inputs
+            input_ids = test_batch.batch["input_ids"]
+            # TODO: Can we keep special tokens except for padding tokens?
+            input_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in input_ids]
+            sample_inputs.extend(input_texts)
+            sample_uids.extend(test_batch.non_tensor_batch["uid"])
+
+            ground_truths = [
+                item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in test_batch
+            ]
+            sample_gts.extend(ground_truths)
+
+            test_gen_batch = self._get_gen_batch(test_batch)
+            test_gen_batch.meta_info = {
+                "eos_token_id": self.tokenizer.eos_token_id,
+                "pad_token_id": self.tokenizer.pad_token_id,
+                "recompute_log_prob": False,
+                "do_sample": self.config.actor_rollout_ref.rollout.val_kwargs.do_sample,
+                "validate": True,
+                "global_steps": self.global_steps,
+            }
+            print(f"test_gen_batch meta info: {test_gen_batch.meta_info}")
+
+            # pad to be divisible by dp_size
+            size_divisor = (
+                self.actor_rollout_wg.world_size
+                if not self.async_rollout_mode
+                else self.config.actor_rollout_ref.rollout.agent.num_workers
+            )
+            test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, size_divisor)
+            if not self.async_rollout_mode:
+                test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
+            else:
+                test_output_gen_batch_padded = self.async_rollout_manager.generate_sequences(test_gen_batch_padded)
+
+            # unpad
+            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size)
+
+            print("validation generation end")
+
+            # Store generated outputs
+            output_ids = test_output_gen_batch.batch["responses"]
+            output_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in output_ids]
+            sample_outputs.extend(output_texts)
+
+            test_batch = test_batch.union(test_output_gen_batch)
+            test_batch.meta_info["validate"] = True
+
+            # evaluate using reward_function
+            if self.val_reward_fn is None:
+                raise ValueError("val_reward_fn must be provided for validation.")
+            result = self.val_reward_fn(test_batch, return_dict=True)
+            reward_tensor = result["reward_tensor"]
+            scores = reward_tensor.sum(-1).cpu().tolist()
+            sample_scores.extend(scores)
+
+            reward_extra_infos_dict["reward"].extend(scores)
+            if "reward_extra_info" in result:
+                for key, lst in result["reward_extra_info"].items():
+                    reward_extra_infos_dict[key].extend(lst)
+
+            # collect num_turns of each prompt
+            if "__num_turns__" in test_batch.non_tensor_batch:
+                sample_turns.append(test_batch.non_tensor_batch["__num_turns__"])
+
+            data_source_lst.append(test_batch.non_tensor_batch.get("data_source", ["unknown"] * reward_tensor.shape[0]))
+
+        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
+
+        # dump generations
+        val_data_dir = self.config.trainer.get("validation_data_dir", None)
+        if val_data_dir:
+            self._dump_generations(
+                inputs=sample_inputs,
+                outputs=sample_outputs,
+                gts=sample_gts,
+                scores=sample_scores,
+                reward_extra_infos_dict=reward_extra_infos_dict,
+                dump_path=val_data_dir,
+            )
+
+        for key_info, lst in reward_extra_infos_dict.items():
+            assert len(lst) == 0 or len(lst) == len(sample_scores), f"{key_info}: {len(lst)=}, {len(sample_scores)=}"
+
+        data_sources = np.concatenate(data_source_lst, axis=0)
+
+        data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+        metric_dict = {}
+        for data_source, var2metric2val in data_src2var2metric2val.items():
+            core_var = "acc" if "acc" in var2metric2val else "reward"
+            for var_name, metric2val in var2metric2val.items():
+                n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
+                for metric_name, metric_val in metric2val.items():
+                    if (
+                        (var_name == core_var)
+                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])
+                        and (f"@{n_max}" in metric_name)
+                    ):
+                        metric_sec = "val-core"
+                    else:
+                        metric_sec = "val-aux"
+                    pfx = f"{metric_sec}/{data_source}/{var_name}/{metric_name}"
+                    metric_dict[pfx] = metric_val
+
+        if len(sample_turns) > 0:
+            sample_turns = np.concatenate(sample_turns)
+            metric_dict["val-aux/num_turns/min"] = sample_turns.min()
+            metric_dict["val-aux/num_turns/max"] = sample_turns.max()
+            metric_dict["val-aux/num_turns/mean"] = sample_turns.mean()
+
+        return metric_dict
+
+    def init_workers(self):
+        """Initialize distributed training workers using Ray backend.
+
+        Creates:
+        1. Ray resource pools from configuration
+        2. Worker groups for each role (actor, critic, etc.)
+        """
+        self.resource_pool_manager.create_resource_pool()
+
+        self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
+
+        if Role.Aggregator in self.role_worker_mapping:
+            self.aggregator = self.role_worker_mapping[Role.Aggregator].options(name="aggregator_actor").remote(
+                threshold_rate=self.config.actor_rollout_ref.rollout.rollout_threshold_rate)
+
+        # create actor and rollout
+        if self.hybrid_engine:
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.ActorRollout)
+            actor_rollout_cls = RayClassWithInitArgs(
+                cls=self.role_worker_mapping[Role.ActorRollout],
+                config=self.config.actor_rollout_ref,
+                role=str(Role.ActorRollout),
+            )
+            self.resource_pool_to_cls[resource_pool][str(Role.ActorRollout)] = actor_rollout_cls
+        else:
+            raise NotImplementedError
+
+        # create critic
+        if self.use_critic:
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
+            critic_cfg = omega_conf_to_dataclass(self.config.critic)
+            critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
+            self.resource_pool_to_cls[resource_pool][str(Role.Critic)] = critic_cls
+
+        # create reference policy if needed
+        if self.use_reference_policy:
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.RefPolicy)
+            ref_policy_cls = RayClassWithInitArgs(
+                self.role_worker_mapping[Role.RefPolicy],
+                config=self.config.actor_rollout_ref,
+                role=str(Role.RefPolicy),
+            )
+            self.resource_pool_to_cls[resource_pool][str(Role.RefPolicy)] = ref_policy_cls
+
+        # create a reward model if reward_fn is None
+        if self.use_rm:
+            # we create a RM here
+            resource_pool = self.resource_pool_manager.get_resource_pool(Role.RewardModel)
+            rm_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.RewardModel], config=self.config.reward_model)
+            self.resource_pool_to_cls[resource_pool][str(Role.RewardModel)] = rm_cls
+
+        # initialize WorkerGroup
+        # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
+        # you should not use `create_colocated_worker_cls`.
+        # Instead, directly pass different resource pool to different worker groups.
+        # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
+        all_wg = {}
+        wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
+        if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
+            wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
+        if OmegaConf.select(self.config.global_profiler, "steps") is not None:
+            wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
+            # Only require nsight worker options when tool is nsys
+            if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
+                assert (
+                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                    is not None
+                ), "worker_nsight_options must be set when using nsys with profile_steps"
+                wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
+                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                )
+        wg_kwargs["device_name"] = self.device_name
+
+        for resource_pool, class_dict in self.resource_pool_to_cls.items():
+            worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
+            wg_dict = self.ray_worker_group_cls(
+                resource_pool=resource_pool,
+                ray_cls_with_init=worker_dict_cls,
+                **wg_kwargs,
+            )
+            spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
+            all_wg.update(spawn_wg)
+
+        if self.use_critic:
+            self.critic_wg = all_wg[str(Role.Critic)]
+            self.critic_wg.init_model()
+
+        if self.use_reference_policy and not self.ref_in_actor:
+            self.ref_policy_wg = all_wg[str(Role.RefPolicy)]
+            self.ref_policy_wg.init_model()
+
+        self.rm_wg = None
+        # initalization of rm_wg will be deprecated in the future
+        if self.use_rm:
+            self.rm_wg = all_wg[str(Role.RewardModel)]
+            self.rm_wg.init_model()
+
+        # we should create rollout at the end so that vllm can have a better estimation of kv cache memory
+        self.actor_rollout_wg = all_wg[str(Role.ActorRollout)]
+        self.actor_rollout_wg.init_model()
+
+        # create async rollout manager and request scheduler
+        self.async_rollout_mode = False
+        if self.config.actor_rollout_ref.rollout.mode == "async":
+            from verl.experimental.agent_loop import AgentLoopManager
+
+            self.async_rollout_mode = True
+            self.async_rollout_manager = AgentLoopManager(
+                config=self.config, worker_group=self.actor_rollout_wg, rm_wg=self.rm_wg
+            )
+
+    def _save_checkpoint(self):
+        from verl.utils.fs import local_mkdir_safe
+
+        # path: given_path + `/global_step_{global_steps}` + `/actor`
+        local_global_step_folder = os.path.join(
+            self.config.trainer.default_local_dir, f"global_step_{self.global_steps}"
+        )
+
+        print(f"local_global_step_folder: {local_global_step_folder}")
+        actor_local_path = os.path.join(local_global_step_folder, "actor")
+
+        actor_remote_path = (
+            None
+            if self.config.trainer.default_hdfs_dir is None
+            else os.path.join(self.config.trainer.default_hdfs_dir, f"global_step_{self.global_steps}", "actor")
+        )
+
+        remove_previous_ckpt_in_save = self.config.trainer.get("remove_previous_ckpt_in_save", False)
+        if remove_previous_ckpt_in_save:
+            print(
+                "Warning: remove_previous_ckpt_in_save is deprecated,"
+                + " set max_actor_ckpt_to_keep=1 and max_critic_ckpt_to_keep=1 instead"
+            )
+        max_actor_ckpt_to_keep = (
+            self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+        )
+        max_critic_ckpt_to_keep = (
+            self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
+        )
+
+        self.actor_rollout_wg.save_checkpoint(
+            actor_local_path, actor_remote_path, self.global_steps, max_ckpt_to_keep=max_actor_ckpt_to_keep
+        )
+
+        if self.use_critic:
+            critic_local_path = os.path.join(local_global_step_folder, str(Role.Critic))
+            critic_remote_path = (
+                None
+                if self.config.trainer.default_hdfs_dir is None
+                else os.path.join(
+                    self.config.trainer.default_hdfs_dir, f"global_step_{self.global_steps}", str(Role.Critic)
+                )
+            )
+            self.critic_wg.save_checkpoint(
+                critic_local_path, critic_remote_path, self.global_steps, max_ckpt_to_keep=max_critic_ckpt_to_keep
+            )
+
+        # save dataloader
+        local_mkdir_safe(local_global_step_folder)
+        dataloader_local_path = os.path.join(local_global_step_folder, "data.pt")
+        dataloader_state_dict = self.train_dataloader.state_dict()
+        torch.save(dataloader_state_dict, dataloader_local_path)
+
+        # latest checkpointed iteration tracker (for atomic usage)
+        local_latest_checkpointed_iteration = os.path.join(
+            self.config.trainer.default_local_dir, "latest_checkpointed_iteration.txt"
+        )
+        with open(local_latest_checkpointed_iteration, "w") as f:
+            f.write(str(self.global_steps))
+
+    def _load_checkpoint(self):
+        if self.config.trainer.resume_mode == "disable":
+            # NOTE: while there is no checkpoint to load, we still need to offload the model and optimizer to CPU
+            self.actor_rollout_wg.load_checkpoint(None)
+            return 0
+
+        # load from hdfs
+        if self.config.trainer.default_hdfs_dir is not None:
+            raise NotImplementedError("load from hdfs is not implemented yet")
+        else:
+            checkpoint_folder = self.config.trainer.default_local_dir  # TODO: check path
+            if not os.path.isabs(checkpoint_folder):
+                working_dir = os.getcwd()
+                checkpoint_folder = os.path.join(working_dir, checkpoint_folder)
+            global_step_folder = find_latest_ckpt_path(checkpoint_folder)  # None if no latest
+
+        # find global_step_folder
+        if self.config.trainer.resume_mode == "auto":
+            if global_step_folder is None:
+                print("Training from scratch")
+                self.actor_rollout_wg.load_checkpoint(None)
+                return 0
+        else:
+            if self.config.trainer.resume_mode == "resume_path":
+                assert isinstance(self.config.trainer.resume_from_path, str), "resume ckpt must be str type"
+                assert "global_step_" in self.config.trainer.resume_from_path, (
+                    "resume ckpt must specify the global_steps"
+                )
+                global_step_folder = self.config.trainer.resume_from_path
+                if not os.path.isabs(global_step_folder):
+                    working_dir = os.getcwd()
+                    global_step_folder = os.path.join(working_dir, global_step_folder)
+        print(f"Load from checkpoint folder: {global_step_folder}")
+        # set global step
+        self.global_steps = int(global_step_folder.split("global_step_")[-1])
+
+        print(f"Setting global step to {self.global_steps}")
+        print(f"Resuming from {global_step_folder}")
+
+        actor_path = os.path.join(global_step_folder, "actor")
+        critic_path = os.path.join(global_step_folder, str(Role.Critic))
+        # load actor
+        self.actor_rollout_wg.load_checkpoint(
+            actor_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load
+        )
+        # load critic
+        if self.use_critic:
+            self.critic_wg.load_checkpoint(
+                critic_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load
+            )
+
+        # load dataloader,
+        # TODO: from remote not implemented yet
+        dataloader_local_path = os.path.join(global_step_folder, "data.pt")
+        if os.path.exists(dataloader_local_path):
+            dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
+            self.train_dataloader.load_state_dict(dataloader_state_dict)
+        else:
+            print(f"Warning: No dataloader state found at {dataloader_local_path}, will start from scratch")
+
+    def _start_profiling(self, do_profile: bool) -> None:
+        """Start profiling for all worker groups if profiling is enabled."""
+        if do_profile:
+            self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
+            if self.use_reference_policy:
+                self.ref_policy_wg.start_profile(profile_step=self.global_steps)
+            if self.use_critic:
+                self.critic_wg.start_profile(profile_step=self.global_steps)
+            if self.use_rm:
+                self.rm_wg.start_profile(profile_step=self.global_steps)
+
+    def _stop_profiling(self, do_profile: bool) -> None:
+        """Stop profiling for all worker groups if profiling is enabled."""
+        if do_profile:
+            self.actor_rollout_wg.stop_profile()
+            if self.use_reference_policy:
+                self.ref_policy_wg.stop_profile()
+            if self.use_critic:
+                self.critic_wg.stop_profile()
+            if self.use_rm:
+                self.rm_wg.stop_profile()
+
+    def _balance_batch(self, batch: DataProto, metrics, logging_prefix="global_seqlen", keep_minibatch=False):
+        """Reorder the data on single controller such that each dp rank gets similar total tokens"""
+        attention_mask = batch.batch["attention_mask"]
+        batch_size = attention_mask.shape[0]
+        global_seqlen_lst = batch.batch["attention_mask"].view(batch_size, -1).sum(-1)  # (train_batch_size,)
+        workload_lst = calculate_workload(global_seqlen_lst)
+        world_size = self.actor_rollout_wg.world_size
+        if keep_minibatch:
+            # Decouple the DP balancing and mini-batching.
+            minibatch_size = self.config.actor_rollout_ref.actor.get("ppo_mini_batch_size")
+            minibatch_num = len(workload_lst) // minibatch_size
+            global_partition_lst = [[] for _ in range(world_size)]
+            for i in range(minibatch_num):
+                rearrange_minibatch_lst = get_seqlen_balanced_partitions(
+                    workload_lst[i * minibatch_size : (i + 1) * minibatch_size],
+                    k_partitions=world_size,
+                    equal_size=True,
+                )
+                for j, part in enumerate(rearrange_minibatch_lst):
+                    global_partition_lst[j].extend([x + minibatch_size * i for x in part])
+        else:
+            global_partition_lst = get_seqlen_balanced_partitions(
+                workload_lst, k_partitions=world_size, equal_size=True
+            )
+        # Place smaller micro-batches at both ends to reduce the bubbles in pipeline parallel.
+        for idx, partition in enumerate(global_partition_lst):
+            partition.sort(key=lambda x: (workload_lst[x], x))
+            ordered_partition = partition[::2] + partition[1::2][::-1]
+            global_partition_lst[idx] = ordered_partition
+        # reorder based on index. The data will be automatically equally partitioned by dispatch function
+        global_idx = torch.tensor([j for partition in global_partition_lst for j in partition])
+        batch.reorder(global_idx)
+        global_balance_stats = log_seqlen_unbalance(
+            seqlen_list=global_seqlen_lst, partitions=global_partition_lst, prefix=logging_prefix
+        )
+        metrics.update(global_balance_stats)
+
+    def fit(self):
+        """
+        The training loop of PPO.
+        The driver process only need to call the compute functions of the worker group through RPC
+        to construct the PPO dataflow.
+        The light-weight advantage computation is done on the driver process.
+        """
+        from omegaconf import OmegaConf
+
+        from verl.utils.tracking import Tracking
+
+        logger = Tracking(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+            default_backend=self.config.trainer.logger,
+            config=OmegaConf.to_container(self.config, resolve=True),
+        )
+
+        self.global_steps = 0
+
+        # load checkpoint before doing anything
+        self._load_checkpoint()
+
+        current_epoch = self.global_steps // len(self.train_dataloader)
+
+        # perform validation before training
+        # currently, we only support validation using the reward_function.
+        if self.val_reward_fn is not None and self.config.trainer.get("val_before_train", True):
+            val_metrics = self._validate()
+            assert val_metrics, f"{val_metrics=}"
+            pprint(f"Initial validation metrics: {val_metrics}")
+            logger.log(data=val_metrics, step=self.global_steps)
+            if self.config.trainer.get("val_only", False):
+                return
+
+        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
+            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
+            rollout_skip.wrap_generate_sequences()
+
+        # add tqdm
+        progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
+
+        # we start from step 1
+        self.global_steps += 1
+        last_val_metrics = None
+        self.max_steps_duration = 0
+        partial_batch: Optional[DataProto] = None  # samples whose rollout is not finished yet
+        staged_batch: Optional[DataProto] = None  # samples whose rollout has been finished but not yet trained on
+        prev_step_profile = False
+        curr_step_profile = (
+            self.global_steps in self.config.global_profiler.steps
+            if self.config.global_profiler.steps is not None
+            else False
+        )
+        next_step_profile = False
+
+        for epoch in range(current_epoch, self.config.trainer.total_epochs):
+            for batch_dict in self.train_dataloader:
+                metrics = {}
+                timing_raw = {}
+
+                with marked_timer("start_profile", timing_raw):
+                    self._start_profiling(
+                        not prev_step_profile and curr_step_profile
+                        if self.config.global_profiler.profile_continuous_steps
+                        else curr_step_profile
+                    )
+                batch: DataProto = DataProto.from_single_dict(batch_dict)
+                batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
+                                                         dtype=object)
+                # repeat to align with repeated responses in rollout
+                batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+                batch.non_tensor_batch["age"] = np.ones(len(batch.batch), dtype=int)
+                batch.non_tensor_batch["raw_response_ids"] = np.fromiter(([] for _ in range(len(batch.batch))),
+                                                                         dtype=object)
+
+                batch = DataProto.concat([partial_batch, batch]) if partial_batch is not None else batch
+                # add uid to batch
+                batch.non_tensor_batch["uid"] = np.array(
+                    [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
+                )
+
+                gen_batch = self._get_gen_batch(batch)
+
+                # pass global_steps to trace
+                gen_batch.meta_info["global_steps"] = self.global_steps
+                gen_batch_output = gen_batch.repeat(
+                    repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
+                )
+
+                is_last_step = self.global_steps >= self.total_training_steps
+                with marked_timer("step", timing_raw):
+                    # generate a batch
+                    with marked_timer("gen", timing_raw, color="red"):
+                        if self.aggregator:
+                            self.aggregator.set_sample_num.remote(len(gen_batch))
+                            self.aggregator.clear.remote()
+
+                        if not self.async_rollout_mode:
+                            gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch_output)
+                        else:
+                            gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
+
+                        timing_raw.update(gen_batch_output.meta_info["timing"])
+                        gen_batch_output.meta_info.pop("timing", None)
+                    with marked_timer("filter", timing_raw):
+                        batch = batch.union(gen_batch_output)
+
+                        finished_mask = batch.non_tensor_batch.pop("finished")
+                        if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
+                            finished_mask = (batch.non_tensor_batch[
+                                                 "age"] == self.config.algorithm.partial_rollout_max_split) | finished_mask
+                        if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
+                            finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
+                                              for response in
+                                              gen_batch_output.non_tensor_batch['raw_response_ids']]) | finished_mask
+                        staged_out, partial_batch = DataProto.split_data(batch, finished_mask)
+                        staged_out.non_tensor_batch.pop("raw_prompt_ids")
+                        staged_out.non_tensor_batch.pop("raw_response_ids")
+
+                        if len(partial_batch.batch) > 0:
+                            for key in ("input_ids", "attention_mask", "position_ids"):
+                                tmp = partial_batch.batch.pop(key, None)
+                                partial_batch.batch[key] = tmp[:, : self.config.data.max_prompt_length]
+
+                            for key in ("prompts", "responses", "rollout_log_probs"):
+                                # we don't support rollout_log_probs in this feature branch yet
+                                if key in partial_batch.batch:
+                                    partial_batch.batch.pop(key)
+                        else:
+                            partial_batch = None
+
+                        # note that we no longer ensure the order of samples in staged_batch
+                        staged_batch = DataProto.concat(
+                            [staged_batch, staged_out]) if staged_batch is not None else staged_out
+
+                        # prompts whose number of finished rollout is enough can be trained on
+                        # while filtering, we ensure sample number is divisible by n_gpus_per_node and as large as possible
+                        can_train_mask = np.zeros(len(staged_batch.batch), dtype=bool)
+                        id2count = defaultdict(int)
+                        required_rollouts = self.config.actor_rollout_ref.rollout.n
+                        divisor = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * required_rollouts
+
+                        for uid in staged_batch.non_tensor_batch["uid"]:
+                            id2count[uid] += 1
+                        assert not id2count or max(
+                            id2count.values()) <= required_rollouts, "max number of responses exceeds rollout n"
+
+                        complete_uids = [uid for uid, count in id2count.items() if count == required_rollouts]
+
+                        total_complete_samples = len(complete_uids) * required_rollouts
+                        max_usable_groups = (total_complete_samples // divisor) * divisor // required_rollouts
+                        can_train_count = max_usable_groups * required_rollouts
+
+                        if can_train_count == 0:
+                            print(f"{total_complete_samples=}, no complete uid groups available. Keep generating...")
+                            continue
+
+                        selected_uids = set(complete_uids[:max_usable_groups])
+
+                        for i, uid in enumerate(staged_batch.non_tensor_batch["uid"]):
+                            if uid in selected_uids:
+                                can_train_mask[i] = True
+
+                        batch, staged_batch = DataProto.split_data(staged_batch, can_train_mask)
+                        if partial_batch:
+                            partial_batch.non_tensor_batch["age"] += 1
+                    if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                        if self.reward_fn is None:
+                            raise ValueError("A reward_fn is required for REMAX advantage estimation.")
+
+                        with marked_timer("gen_max", timing_raw, color="purple"):
+                            gen_baseline_batch = deepcopy(gen_batch)
+                            gen_baseline_batch.meta_info["do_sample"] = False
+                            if not self.async_rollout_mode:
+                                gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
+                            else:
+                                gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
+                            batch = batch.union(gen_baseline_output)
+                            # compute reward model score on batch
+                            rm_scores = None
+                            if self.use_rm and "rm_scores" not in batch.batch.keys():
+                                rm_scores = self.rm_wg.compute_rm_score(batch)
+                                batch = batch.union(rm_scores)
+                            reward_baseline_tensor, _ = compute_reward(batch, self.reward_fn)
+                            reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
+
+                            keys_to_pop = set(gen_baseline_output.batch.keys())
+                            if rm_scores is not None:
+                                keys_to_pop.update(rm_scores.batch.keys())
+                            batch.pop(batch_keys=list(keys_to_pop))
+
+                            batch.batch["reward_baselines"] = reward_baseline_tensor
+
+                            del rm_scores, gen_baseline_batch, gen_baseline_output
+
+
+                    if "response_mask" not in batch.batch.keys():
+                        batch.batch["response_mask"] = compute_response_mask(batch)
+                    # Balance the number of valid tokens across DP ranks.
+                    # NOTE: This usually changes the order of data in the `batch`,
+                    # which won't affect the advantage calculation (since it's based on uid),
+                    # but might affect the loss calculation (due to the change of mini-batching).
+                    if self.config.trainer.balance_batch:
+                        self._balance_batch(batch, metrics=metrics)
+
+                    # compute global_valid tokens
+                    batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+
+                    with marked_timer("reward", timing_raw, color="yellow"):
+                        # compute reward model score
+                        if self.use_rm and "rm_scores" not in batch.batch.keys():
+                            reward_tensor = self.rm_wg.compute_rm_score(batch)
+                            batch = batch.union(reward_tensor)
+
+                        if self.config.reward_model.launch_reward_fn_async:
+                            future_reward = compute_reward_async.remote(
+                                data=batch, config=self.config, tokenizer=self.tokenizer
+                            )
+                        else:
+                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
+
+                    # Operating Mode Selection:
+                    # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)
+                    # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
+                    #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
+                    rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
+                    bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+                    if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
+                        from verl.trainer.ppo.rollout_corr_helper import apply_rollout_correction
+
+                        apply_rollout_correction(
+                            batch=batch,
+                            rollout_corr_config=rollout_corr_config,
+                            policy_loss_config=self.config.actor_rollout_ref.actor.policy_loss,
+                        )
+                    else:  # Recompute old_log_probs
+                        with marked_timer("old_log_prob", timing_raw, color="blue"):
+                            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
+                            entropys = old_log_prob.batch["entropys"]
+                            response_masks = batch.batch["response_mask"]
+                            loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
+                            entropy_agg = agg_loss(
+                                loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode
+                            )
+                            old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
+                            metrics.update(old_log_prob_metrics)
+                            old_log_prob.batch.pop("entropys")
+                            batch = batch.union(old_log_prob)
+                            if "rollout_log_probs" in batch.batch.keys():
+                                # TODO: we may want to add diff of probs too.
+                                from verl.utils.debug.metrics import calculate_debug_metrics
+
+                                metrics.update(calculate_debug_metrics(batch))
+
+                    assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
+
+                    if self.use_reference_policy:
+                        # compute reference log_prob
+                        with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
+                            if not self.ref_in_actor:
+                                ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
+                            else:
+                                ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
+                            batch = batch.union(ref_log_prob)
+
+                    # compute values
+                    if self.use_critic:
+                        with marked_timer("values", timing_raw, color="cyan"):
+                            values = self.critic_wg.compute_values(batch)
+                            batch = batch.union(values)
+
+                    with marked_timer("adv", timing_raw, color="brown"):
+                        # we combine with rule-based rm
+                        reward_extra_infos_dict: dict[str, list]
+                        if self.config.reward_model.launch_reward_fn_async:
+                            reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
+                        batch.batch["token_level_scores"] = reward_tensor
+
+                        if reward_extra_infos_dict:
+                            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
+
+                        # compute rewards. apply_kl_penalty if available
+                        if self.config.algorithm.use_kl_in_reward:
+                            batch, kl_metrics = apply_kl_penalty(
+                                batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
+                            )
+                            metrics.update(kl_metrics)
+                        else:
+                            batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
+
+                        # Compute rollout correction: IS weights, rejection sampling, and metrics
+                        # Only runs in decoupled mode (computes once per batch using stable π_old)
+                        # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
+                        if (
+                            rollout_corr_config is not None
+                            and "rollout_log_probs" in batch.batch
+                            and not bypass_recomputing_logprobs  # Only in decoupled mode
+                        ):
+                            from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
+
+                            # Compute IS weights, apply rejection sampling, compute metrics
+                            batch, is_metrics = compute_rollout_correction_and_add_to_batch(batch, rollout_corr_config)
+                            # IS and off-policy metrics already have rollout_corr/ prefix
+                            metrics.update(is_metrics)
+
+                        # compute advantages, executed on the driver process
+                        norm_adv_by_std_in_grpo = self.config.algorithm.get(
+                            "norm_adv_by_std_in_grpo", True
+                        )  # GRPO adv normalization factor
+
+                        batch = compute_advantage(
+                            batch,
+                            adv_estimator=self.config.algorithm.adv_estimator,
+                            gamma=self.config.algorithm.gamma,
+                            lam=self.config.algorithm.lam,
+                            num_repeat=self.config.actor_rollout_ref.rollout.n,
+                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
+                            config=self.config.algorithm,
+                        )
+
+                    # update critic
+                    if self.use_critic:
+                        with marked_timer("update_critic", timing_raw, color="pink"):
+                            critic_output = self.critic_wg.update_critic(batch)
+                        critic_output_metrics = reduce_metrics(critic_output.meta_info["metrics"])
+                        metrics.update(critic_output_metrics)
+
+                    # implement critic warmup
+                    if self.config.trainer.critic_warmup <= self.global_steps:
+                        # update actor
+                        with marked_timer("update_actor", timing_raw, color="red"):
+                            rollout_config = self.config.actor_rollout_ref.rollout
+                            batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
+                            # TODO: Make "temperature" single source of truth from generation.
+                            batch.meta_info["temperature"] = rollout_config.temperature
+                            actor_output = self.actor_rollout_wg.update_actor(batch)
+                        actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                        metrics.update(actor_output_metrics)
+
+                    # Log rollout generations if enabled
+                    rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
+                    if rollout_data_dir:
+                        self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
+
+                # validate
+                if (
+                    self.val_reward_fn is not None
+                    and self.config.trainer.test_freq > 0
+                    and (is_last_step or self.global_steps % self.config.trainer.test_freq == 0)
+                ):
+                    with marked_timer("testing", timing_raw, color="green"):
+                        val_metrics: dict = self._validate()
+                        if is_last_step:
+                            last_val_metrics = val_metrics
+                    metrics.update(val_metrics)
+
+                # Check if the ESI (Elastic Server Instance)/training plan is close to expiration.
+                esi_close_to_expiration = should_save_ckpt_esi(
+                    max_steps_duration=self.max_steps_duration,
+                    redundant_time=self.config.trainer.esi_redundant_time,
+                )
+                # Check if the conditions for saving a checkpoint are met.
+                # The conditions include a mandatory condition (1) and
+                # one of the following optional conditions (2/3/4):
+                # 1. The save frequency is set to a positive value.
+                # 2. It's the last training step.
+                # 3. The current step number is a multiple of the save frequency.
+                # 4. The ESI(Elastic Server Instance)/training plan is close to expiration.
+                if self.config.trainer.save_freq > 0 and (
+                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0 or esi_close_to_expiration
+                ):
+                    if esi_close_to_expiration:
+                        print("Force saving checkpoint: ESI instance expiration approaching.")
+                    with marked_timer("save_checkpoint", timing_raw, color="green"):
+                        self._save_checkpoint()
+
+                with marked_timer("stop_profile", timing_raw):
+                    next_step_profile = (
+                        self.global_steps + 1 in self.config.global_profiler.steps
+                        if self.config.global_profiler.steps is not None
+                        else False
+                    )
+                    self._stop_profiling(
+                        curr_step_profile and not next_step_profile
+                        if self.config.global_profiler.profile_continuous_steps
+                        else curr_step_profile
+                    )
+                    prev_step_profile = curr_step_profile
+                    curr_step_profile = next_step_profile
+
+                steps_duration = timing_raw["step"]
+                self.max_steps_duration = max(self.max_steps_duration, steps_duration)
+
+                # training metrics
+                metrics.update(
+                    {
+                        "training/global_step": self.global_steps,
+                        "training/epoch": epoch,
+                    }
+                )
+                if self.enable_partial_rollout:
+                    metrics.update(
+                        {
+                            "training/can_train_count": can_train_count,
+                            "training/total_complete_samples": total_complete_samples,
+                        }
+                    )
+                # collect metrics
+                metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
+                metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
+                # TODO: implement actual tflpo and theoretical tflpo
+                n_gpus = self.resource_pool_manager.get_n_gpus()
+                metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
+                # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
+
+                # this is experimental and may be changed/removed in the future in favor of a general-purpose one
+                if isinstance(self.train_dataloader.sampler, AbstractCurriculumSampler):
+                    self.train_dataloader.sampler.update(batch=batch)
+
+                # TODO: make a canonical logger that supports various backend
+                logger.log(data=metrics, step=self.global_steps)
+
+                progress_bar.update(1)
+                self.global_steps += 1
+
+                if (
+                    hasattr(self.config.actor_rollout_ref.actor, "profiler")
+                    and self.config.actor_rollout_ref.actor.profiler.tool == "torch_memory"
+                ):
+                    self.actor_rollout_wg.dump_memory_snapshot(
+                        tag=f"post_update_step{self.global_steps}", sub_dir=f"step{self.global_steps}"
+                    )
+
+                if is_last_step:
+                    pprint(f"Final validation metrics: {last_val_metrics}")
+                    progress_bar.close()
+                    return
+
+                # this is experimental and may be changed/removed in the future
+                # in favor of a general-purpose data buffer pool
+                if hasattr(self.train_dataset, "on_batch_end"):
+                    # The dataset may be changed after each training batch
+                    self.train_dataset.on_batch_end(batch=batch)

--- a/recipe/partial_rollout/ray_trainer.py
+++ b/recipe/partial_rollout/ray_trainer.py
@@ -19,48 +19,39 @@ PPO Trainer with Ray-based single controller.
 This trainer supports model-agonistic model initialization with huggingface
 """
 
-import json
-import os
+import threading
 import uuid
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import dataclass, field
 from pprint import pprint
 from typing import Optional
-import threading
 
 import numpy as np
 import ray
 import torch
-from omegaconf import OmegaConf, open_dict
+from omegaconf import OmegaConf
 from torch.utils.data import Dataset, Sampler
-from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
 
 from verl import DataProto
 from verl.experimental.dataset.sampler import AbstractCurriculumSampler
-from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
-from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
 from verl.single_controller.ray.base import create_colocated_worker_cls
-from verl.trainer.config import AlgoConfig
 from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
 from verl.trainer.ppo.metric_utils import (
     compute_data_metrics,
     compute_throughout_metrics,
     compute_timing_metrics,
-    process_validation_metrics,
 )
+from verl.trainer.ppo.ray_trainer import ResourcePoolManager, apply_kl_penalty, compute_advantage, compute_response_mask
 from verl.trainer.ppo.reward import compute_reward, compute_reward_async
 from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_reward_model
-from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage, compute_response_mask, ResourcePoolManager
-from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
+from verl.utils.checkpoint.checkpoint_manager import should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.metric import reduce_metrics
 from verl.utils.rollout_skip import RolloutSkip
-from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
-from verl.utils.torch_functional import masked_mean
 from verl.utils.tracking import ValidationGenerationsLogger
 
 
@@ -99,20 +90,20 @@ class AggregatorActor:
 
 
 def ray_trainer__init__(
-        self,
-        config,
-        tokenizer,
-        role_worker_mapping: dict[Role, WorkerType],
-        resource_pool_manager: ResourcePoolManager,
-        ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
-        processor=None,
-        reward_fn=None,
-        val_reward_fn=None,
-        train_dataset: Optional[Dataset] = None,
-        val_dataset: Optional[Dataset] = None,
-        collate_fn=None,
-        train_sampler: Optional[Sampler] = None,
-        device_name=None,
+    self,
+    config,
+    tokenizer,
+    role_worker_mapping: dict[Role, WorkerType],
+    resource_pool_manager: ResourcePoolManager,
+    ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
+    processor=None,
+    reward_fn=None,
+    val_reward_fn=None,
+    train_dataset: Optional[Dataset] = None,
+    val_dataset: Optional[Dataset] = None,
+    collate_fn=None,
+    train_sampler: Optional[Sampler] = None,
+    device_name=None,
 ):
     """
     Initialize distributed PPO trainer with Ray backend.
@@ -161,8 +152,8 @@ def ray_trainer__init__(
 
     # if ref_in_actor is True, the reference policy will be actor without lora applied
     self.ref_in_actor = (
-            config.actor_rollout_ref.model.get("lora_rank", 0) > 0
-            or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+        config.actor_rollout_ref.model.get("lora_rank", 0) > 0
+        or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
     )
 
     # define in-reward KL control
@@ -173,9 +164,9 @@ def ray_trainer__init__(
     self.aggregator = None
     self.enable_partial_rollout: bool = self.config.actor_rollout_ref.rollout.partial_rollout_max_split > 1
     # check partial rollout config
-    assert (config.data.max_response_length %
-            config.actor_rollout_ref.rollout.partial_rollout_max_split == 0), \
+    assert config.data.max_response_length % config.actor_rollout_ref.rollout.partial_rollout_max_split == 0, (
         "max_response_length must be divisible by partial_rollout_max_split"
+    )
 
     self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
@@ -192,8 +183,11 @@ def ray_trainer_init_workers(self):
     self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
 
     if Role.Aggregator in self.role_worker_mapping:
-        self.aggregator = self.role_worker_mapping[Role.Aggregator].options(name="aggregator_actor").remote(
-            threshold_rate=self.config.actor_rollout_ref.rollout.rollout_threshold_rate)
+        self.aggregator = (
+            self.role_worker_mapping[Role.Aggregator]
+            .options(name="aggregator_actor")
+            .remote(threshold_rate=self.config.actor_rollout_ref.rollout.rollout_threshold_rate)
+        )
 
     # create actor and rollout
     if self.hybrid_engine:
@@ -360,27 +354,23 @@ def ray_trainer_fit(self):
                     else curr_step_profile
                 )
             batch: DataProto = DataProto.from_single_dict(batch_dict)
-            batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                     dtype=object)
+            batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
             # repeat to align with repeated responses in rollout
             batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
             batch.non_tensor_batch["age"] = np.ones(len(batch.batch), dtype=int)
-            batch.non_tensor_batch["raw_response_ids"] = np.fromiter(([] for _ in range(len(batch.batch))),
-                                                                     dtype=object)
+            batch.non_tensor_batch["raw_response_ids"] = np.fromiter(
+                ([] for _ in range(len(batch.batch))), dtype=object
+            )
 
             batch = DataProto.concat([partial_batch, batch]) if partial_batch is not None else batch
             # add uid to batch
-            batch.non_tensor_batch["uid"] = np.array(
-                [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
-            )
+            batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
 
             gen_batch = self._get_gen_batch(batch)
 
             # pass global_steps to trace
             gen_batch.meta_info["global_steps"] = self.global_steps
-            gen_batch_output = gen_batch.repeat(
-                repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
-            )
+            gen_batch_output = gen_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
 
             is_last_step = self.global_steps >= self.total_training_steps
             with marked_timer("step", timing_raw):
@@ -402,12 +392,17 @@ def ray_trainer_fit(self):
 
                     finished_mask = batch.non_tensor_batch.pop("finished")
                     if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
-                        finished_mask = (batch.non_tensor_batch[
-                                             "age"] == self.config.actor_rollout_ref.rollout.partial_rollout_max_split) | finished_mask
+                        finished_mask = (
+                            batch.non_tensor_batch["age"]
+                            == self.config.actor_rollout_ref.rollout.partial_rollout_max_split
+                        ) | finished_mask
                     if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
-                        finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
-                                          for response in
-                                          gen_batch_output.non_tensor_batch['raw_response_ids']]) | finished_mask
+                        finished_mask = (
+                            [
+                                len(response) >= self.config.actor_rollout_ref.rollout.response_length
+                                for response in gen_batch_output.non_tensor_batch["raw_response_ids"]
+                            ]
+                        ) | finished_mask
                     staged_out, partial_batch = DataProto.split_data(batch, finished_mask)
                     staged_out.non_tensor_batch.pop("raw_prompt_ids")
                     staged_out.non_tensor_batch.pop("raw_response_ids")
@@ -425,8 +420,9 @@ def ray_trainer_fit(self):
                         partial_batch = None
 
                     # note that we no longer ensure the order of samples in staged_batch
-                    staged_batch = DataProto.concat(
-                        [staged_batch, staged_out]) if staged_batch is not None else staged_out
+                    staged_batch = (
+                        DataProto.concat([staged_batch, staged_out]) if staged_batch is not None else staged_out
+                    )
 
                     # prompts whose number of finished rollout is enough can be trained on
                     # while filtering, we ensure sample number is divisible by n_gpus_per_node and as large as possible
@@ -437,8 +433,9 @@ def ray_trainer_fit(self):
 
                     for uid in staged_batch.non_tensor_batch["uid"]:
                         id2count[uid] += 1
-                    assert not id2count or max(
-                        id2count.values()) <= required_rollouts, "max number of responses exceeds rollout n"
+                    assert not id2count or max(id2count.values()) <= required_rollouts, (
+                        "max number of responses exceeds rollout n"
+                    )
 
                     complete_uids = [uid for uid, count in id2count.items() if count == required_rollouts]
 
@@ -488,7 +485,6 @@ def ray_trainer_fit(self):
 
                         del rm_scores, gen_baseline_batch, gen_baseline_output
 
-
                 if "response_mask" not in batch.batch.keys():
                     batch.batch["response_mask"] = compute_response_mask(batch)
                 # Balance the number of valid tokens across DP ranks.
@@ -534,9 +530,7 @@ def ray_trainer_fit(self):
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
                         loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                        entropy_agg = agg_loss(
-                            loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode
-                        )
+                        entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
                         old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                         metrics.update(old_log_prob_metrics)
                         old_log_prob.batch.pop("entropys")
@@ -736,1158 +730,3 @@ def ray_trainer_fit(self):
             if hasattr(self.train_dataset, "on_batch_end"):
                 # The dataset may be changed after each training batch
                 self.train_dataset.on_batch_end(batch=batch)
-
-
-
-
-
-
-class RayPPOTrainer111:
-    """Distributed PPO trainer using Ray for scalable reinforcement learning.
-
-    This trainer orchestrates distributed PPO training across multiple nodes and GPUs,
-    managing actor rollouts, critic training, and reward computation with Ray backend.
-    Supports various model architectures including FSDP, Megatron, vLLM, and SGLang integration.
-    """
-
-    # TODO: support each role have individual ray_worker_group_cls,
-    # i.e., support different backend of different role
-    def __init__(
-        self,
-        config,
-        tokenizer,
-        role_worker_mapping: dict[Role, WorkerType],
-        resource_pool_manager: ResourcePoolManager,
-        ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
-        processor=None,
-        reward_fn=None,
-        val_reward_fn=None,
-        train_dataset: Optional[Dataset] = None,
-        val_dataset: Optional[Dataset] = None,
-        collate_fn=None,
-        train_sampler: Optional[Sampler] = None,
-        device_name=None,
-    ):
-        """
-        Initialize distributed PPO trainer with Ray backend.
-        Note that this trainer runs on the driver process on a single CPU/GPU node.
-
-        Args:
-            config: Configuration object containing training parameters.
-            tokenizer: Tokenizer used for encoding and decoding text.
-            role_worker_mapping (dict[Role, WorkerType]): Mapping from roles to worker classes.
-            resource_pool_manager (ResourcePoolManager): Manager for Ray resource pools.
-            ray_worker_group_cls (RayWorkerGroup, optional): Class for Ray worker groups. Defaults to RayWorkerGroup.
-            processor: Optional data processor, used for multimodal data
-            reward_fn: Function for computing rewards during training.
-            val_reward_fn: Function for computing rewards during validation.
-            train_dataset (Optional[Dataset], optional): Training dataset. Defaults to None.
-            val_dataset (Optional[Dataset], optional): Validation dataset. Defaults to None.
-            collate_fn: Function to collate data samples into batches.
-            train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
-            device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
-        """
-
-        # Store the tokenizer for text processing
-        self.tokenizer = tokenizer
-        self.processor = processor
-        self.config = config
-        self.reward_fn = reward_fn
-        self.val_reward_fn = val_reward_fn
-
-        self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
-        assert self.hybrid_engine, "Currently, only support hybrid engine"
-
-        if self.hybrid_engine:
-            assert Role.ActorRollout in role_worker_mapping, f"{role_worker_mapping.keys()=}"
-
-        self.role_worker_mapping = role_worker_mapping
-        self.resource_pool_manager = resource_pool_manager
-        self.use_reference_policy = need_reference_policy(self.role_worker_mapping)
-        self.use_rm = need_reward_model(self.role_worker_mapping)
-        self.use_critic = need_critic(self.config)
-        self.ray_worker_group_cls = ray_worker_group_cls
-        self.device_name = device_name if device_name else self.config.trainer.device
-        self.validation_generations_logger = ValidationGenerationsLogger(
-            project_name=self.config.trainer.project_name,
-            experiment_name=self.config.trainer.experiment_name,
-        )
-
-        # if ref_in_actor is True, the reference policy will be actor without lora applied
-        self.ref_in_actor = (
-            config.actor_rollout_ref.model.get("lora_rank", 0) > 0
-            or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
-        )
-
-        # define in-reward KL control
-        # kl loss control currently not suppoorted
-        if self.config.algorithm.use_kl_in_reward:
-            self.kl_ctrl_in_reward = core_algos.get_kl_controller(self.config.algorithm.kl_ctrl)
-
-        self.aggregator = None
-        self.enable_partial_rollout: bool = self.config.actor_rollout_ref.rollout.partial_rollout_max_split > 1
-        # check partial rollout config
-        assert (config.data.max_response_length %
-                config.actor_rollout_ref.rollout.partial_rollout_max_split == 0), \
-            "max_response_length must be divisible by partial_rollout_max_split"
-
-        self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
-
-    def _create_dataloader(self, train_dataset, val_dataset, collate_fn, train_sampler: Optional[Sampler]):
-        """
-        Creates the train and validation dataloaders.
-        """
-        # TODO: we have to make sure the batch size is divisible by the dp size
-        from verl.trainer.main_ppo import create_rl_dataset, create_rl_sampler
-
-        if train_dataset is None:
-            train_dataset = create_rl_dataset(
-                self.config.data.train_files,
-                self.config.data,
-                self.tokenizer,
-                self.processor,
-                max_samples=self.config.data.get("train_max_samples", -1),
-            )
-        if val_dataset is None:
-            val_dataset = create_rl_dataset(
-                self.config.data.val_files,
-                self.config.data,
-                self.tokenizer,
-                self.processor,
-                max_samples=self.config.data.get("val_max_samples", -1),
-            )
-        self.train_dataset, self.val_dataset = train_dataset, val_dataset
-
-        if train_sampler is None:
-            train_sampler = create_rl_sampler(self.config.data, self.train_dataset)
-        if collate_fn is None:
-            from verl.utils.dataset.rl_dataset import collate_fn as default_collate_fn
-
-            collate_fn = default_collate_fn
-
-        num_workers = self.config.data["dataloader_num_workers"]
-
-        self.train_dataloader = StatefulDataLoader(
-            dataset=self.train_dataset,
-            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
-            num_workers=num_workers,
-            drop_last=True,
-            collate_fn=collate_fn,
-            sampler=train_sampler,
-        )
-
-        val_batch_size = self.config.data.val_batch_size  # Prefer config value if set
-        if val_batch_size is None:
-            val_batch_size = len(self.val_dataset)
-
-        self.val_dataloader = StatefulDataLoader(
-            dataset=self.val_dataset,
-            batch_size=val_batch_size,
-            num_workers=num_workers,
-            shuffle=self.config.data.get("validation_shuffle", True),
-            drop_last=False,
-            collate_fn=collate_fn,
-        )
-
-        assert len(self.train_dataloader) >= 1, "Train dataloader is empty!"
-        assert len(self.val_dataloader) >= 1, "Validation dataloader is empty!"
-
-        print(
-            f"Size of train dataloader: {len(self.train_dataloader)}, Size of val dataloader: "
-            f"{len(self.val_dataloader)}"
-        )
-
-        total_training_steps = len(self.train_dataloader) * self.config.trainer.total_epochs
-
-        if self.config.trainer.total_training_steps is not None:
-            total_training_steps = self.config.trainer.total_training_steps
-
-        self.total_training_steps = total_training_steps
-        print(f"Total training steps: {self.total_training_steps}")
-
-        try:
-            OmegaConf.set_struct(self.config, True)
-            with open_dict(self.config):
-                if OmegaConf.select(self.config, "actor_rollout_ref.actor.optim"):
-                    self.config.actor_rollout_ref.actor.optim.total_training_steps = total_training_steps
-                if OmegaConf.select(self.config, "critic.optim"):
-                    self.config.critic.optim.total_training_steps = total_training_steps
-        except Exception as e:
-            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
-
-    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
-        """Dump rollout/validation samples as JSONL."""
-        os.makedirs(dump_path, exist_ok=True)
-        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
-
-        n = len(inputs)
-        base_data = {
-            "input": inputs,
-            "output": outputs,
-            "gts": gts,
-            "score": scores,
-            "step": [self.global_steps] * n,
-        }
-
-        for k, v in reward_extra_infos_dict.items():
-            if len(v) == n:
-                base_data[k] = v
-
-        lines = []
-        for i in range(n):
-            entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
-
-        with open(filename, "w") as f:
-            f.write("\n".join(lines) + "\n")
-
-        print(f"Dumped generations to {filename}")
-
-    def _log_rollout_data(
-        self, batch: DataProto, reward_extra_infos_dict: dict, timing_raw: dict, rollout_data_dir: str
-    ):
-        """Log rollout data to disk.
-        Args:
-            batch (DataProto): The batch containing rollout data
-            reward_extra_infos_dict (dict): Additional reward information to log
-            timing_raw (dict): Timing information for profiling
-            rollout_data_dir (str): Directory path to save the rollout data
-        """
-        with marked_timer("dump_rollout_generations", timing_raw, color="green"):
-            inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
-            outputs = self.tokenizer.batch_decode(batch.batch["responses"], skip_special_tokens=True)
-            scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
-            sample_gts = [item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch]
-
-            reward_extra_infos_to_dump = reward_extra_infos_dict.copy()
-            if "request_id" in batch.non_tensor_batch:
-                reward_extra_infos_dict.setdefault(
-                    "request_id",
-                    batch.non_tensor_batch["request_id"].tolist(),
-                )
-
-            self._dump_generations(
-                inputs=inputs,
-                outputs=outputs,
-                gts=sample_gts,
-                scores=scores,
-                reward_extra_infos_dict=reward_extra_infos_to_dump,
-                dump_path=rollout_data_dir,
-            )
-
-    def _maybe_log_val_generations(self, inputs, outputs, scores):
-        """Log a table of validation samples to the configured logger (wandb or swanlab)"""
-
-        generations_to_log = self.config.trainer.log_val_generations
-
-        if generations_to_log == 0:
-            return
-
-        import numpy as np
-
-        # Create tuples of (input, output, score) and sort by input text
-        samples = list(zip(inputs, outputs, scores, strict=True))
-        samples.sort(key=lambda x: x[0])  # Sort by input text
-
-        # Use fixed random seed for deterministic shuffling
-        rng = np.random.RandomState(42)
-        rng.shuffle(samples)
-
-        # Take first N samples after shuffling
-        samples = samples[:generations_to_log]
-
-        # Log to each configured logger
-        self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
-
-    def _get_gen_batch(self, batch: DataProto) -> DataProto:
-        reward_model_keys = set({"data_source", "reward_model", "extra_info", "uid"}) & batch.non_tensor_batch.keys()
-
-        # pop those keys for generation
-        batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
-        non_tensor_batch_keys_to_pop = set(batch.non_tensor_batch.keys()) - reward_model_keys
-        gen_batch = batch.pop(
-            batch_keys=batch_keys_to_pop,
-            non_tensor_batch_keys=list(non_tensor_batch_keys_to_pop),
-        )
-
-        # For agent loop, we need reward model keys to compute score.
-        if self.async_rollout_mode:
-            gen_batch.non_tensor_batch.update(batch.non_tensor_batch)
-
-        return gen_batch
-
-    def _validate(self):
-        data_source_lst = []
-        reward_extra_infos_dict: dict[str, list] = defaultdict(list)
-
-        # Lists to collect samples for the table
-        sample_inputs = []
-        sample_outputs = []
-        sample_gts = []
-        sample_scores = []
-        sample_turns = []
-        sample_uids = []
-
-        for test_data in self.val_dataloader:
-            test_batch = DataProto.from_single_dict(test_data)
-
-            if "uid" not in test_batch.non_tensor_batch:
-                test_batch.non_tensor_batch["uid"] = np.array(
-                    [str(uuid.uuid4()) for _ in range(len(test_batch.batch))], dtype=object
-                )
-
-            # repeat test batch
-            test_batch = test_batch.repeat(
-                repeat_times=self.config.actor_rollout_ref.rollout.val_kwargs.n, interleave=True
-            )
-
-            # we only do validation on rule-based rm
-            if self.config.reward_model.enable and test_batch[0].non_tensor_batch["reward_model"]["style"] == "model":
-                return {}
-
-            # Store original inputs
-            input_ids = test_batch.batch["input_ids"]
-            # TODO: Can we keep special tokens except for padding tokens?
-            input_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in input_ids]
-            sample_inputs.extend(input_texts)
-            sample_uids.extend(test_batch.non_tensor_batch["uid"])
-
-            ground_truths = [
-                item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in test_batch
-            ]
-            sample_gts.extend(ground_truths)
-
-            test_gen_batch = self._get_gen_batch(test_batch)
-            test_gen_batch.meta_info = {
-                "eos_token_id": self.tokenizer.eos_token_id,
-                "pad_token_id": self.tokenizer.pad_token_id,
-                "recompute_log_prob": False,
-                "do_sample": self.config.actor_rollout_ref.rollout.val_kwargs.do_sample,
-                "validate": True,
-                "global_steps": self.global_steps,
-            }
-            print(f"test_gen_batch meta info: {test_gen_batch.meta_info}")
-
-            # pad to be divisible by dp_size
-            size_divisor = (
-                self.actor_rollout_wg.world_size
-                if not self.async_rollout_mode
-                else self.config.actor_rollout_ref.rollout.agent.num_workers
-            )
-            test_gen_batch_padded, pad_size = pad_dataproto_to_divisor(test_gen_batch, size_divisor)
-            if not self.async_rollout_mode:
-                test_output_gen_batch_padded = self.actor_rollout_wg.generate_sequences(test_gen_batch_padded)
-            else:
-                test_output_gen_batch_padded = self.async_rollout_manager.generate_sequences(test_gen_batch_padded)
-
-            # unpad
-            test_output_gen_batch = unpad_dataproto(test_output_gen_batch_padded, pad_size=pad_size)
-
-            print("validation generation end")
-
-            # Store generated outputs
-            output_ids = test_output_gen_batch.batch["responses"]
-            output_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in output_ids]
-            sample_outputs.extend(output_texts)
-
-            test_batch = test_batch.union(test_output_gen_batch)
-            test_batch.meta_info["validate"] = True
-
-            # evaluate using reward_function
-            if self.val_reward_fn is None:
-                raise ValueError("val_reward_fn must be provided for validation.")
-            result = self.val_reward_fn(test_batch, return_dict=True)
-            reward_tensor = result["reward_tensor"]
-            scores = reward_tensor.sum(-1).cpu().tolist()
-            sample_scores.extend(scores)
-
-            reward_extra_infos_dict["reward"].extend(scores)
-            if "reward_extra_info" in result:
-                for key, lst in result["reward_extra_info"].items():
-                    reward_extra_infos_dict[key].extend(lst)
-
-            # collect num_turns of each prompt
-            if "__num_turns__" in test_batch.non_tensor_batch:
-                sample_turns.append(test_batch.non_tensor_batch["__num_turns__"])
-
-            data_source_lst.append(test_batch.non_tensor_batch.get("data_source", ["unknown"] * reward_tensor.shape[0]))
-
-        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
-
-        # dump generations
-        val_data_dir = self.config.trainer.get("validation_data_dir", None)
-        if val_data_dir:
-            self._dump_generations(
-                inputs=sample_inputs,
-                outputs=sample_outputs,
-                gts=sample_gts,
-                scores=sample_scores,
-                reward_extra_infos_dict=reward_extra_infos_dict,
-                dump_path=val_data_dir,
-            )
-
-        for key_info, lst in reward_extra_infos_dict.items():
-            assert len(lst) == 0 or len(lst) == len(sample_scores), f"{key_info}: {len(lst)=}, {len(sample_scores)=}"
-
-        data_sources = np.concatenate(data_source_lst, axis=0)
-
-        data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
-        metric_dict = {}
-        for data_source, var2metric2val in data_src2var2metric2val.items():
-            core_var = "acc" if "acc" in var2metric2val else "reward"
-            for var_name, metric2val in var2metric2val.items():
-                n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
-                for metric_name, metric_val in metric2val.items():
-                    if (
-                        (var_name == core_var)
-                        and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])
-                        and (f"@{n_max}" in metric_name)
-                    ):
-                        metric_sec = "val-core"
-                    else:
-                        metric_sec = "val-aux"
-                    pfx = f"{metric_sec}/{data_source}/{var_name}/{metric_name}"
-                    metric_dict[pfx] = metric_val
-
-        if len(sample_turns) > 0:
-            sample_turns = np.concatenate(sample_turns)
-            metric_dict["val-aux/num_turns/min"] = sample_turns.min()
-            metric_dict["val-aux/num_turns/max"] = sample_turns.max()
-            metric_dict["val-aux/num_turns/mean"] = sample_turns.mean()
-
-        return metric_dict
-
-    def init_workers(self):
-        """Initialize distributed training workers using Ray backend.
-
-        Creates:
-        1. Ray resource pools from configuration
-        2. Worker groups for each role (actor, critic, etc.)
-        """
-        self.resource_pool_manager.create_resource_pool()
-
-        self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
-
-        if Role.Aggregator in self.role_worker_mapping:
-            self.aggregator = self.role_worker_mapping[Role.Aggregator].options(name="aggregator_actor").remote(
-                threshold_rate=self.config.actor_rollout_ref.rollout.rollout_threshold_rate)
-
-        # create actor and rollout
-        if self.hybrid_engine:
-            resource_pool = self.resource_pool_manager.get_resource_pool(Role.ActorRollout)
-            actor_rollout_cls = RayClassWithInitArgs(
-                cls=self.role_worker_mapping[Role.ActorRollout],
-                config=self.config.actor_rollout_ref,
-                role=str(Role.ActorRollout),
-            )
-            self.resource_pool_to_cls[resource_pool][str(Role.ActorRollout)] = actor_rollout_cls
-        else:
-            raise NotImplementedError
-
-        # create critic
-        if self.use_critic:
-            resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
-            critic_cfg = omega_conf_to_dataclass(self.config.critic)
-            critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
-            self.resource_pool_to_cls[resource_pool][str(Role.Critic)] = critic_cls
-
-        # create reference policy if needed
-        if self.use_reference_policy:
-            resource_pool = self.resource_pool_manager.get_resource_pool(Role.RefPolicy)
-            ref_policy_cls = RayClassWithInitArgs(
-                self.role_worker_mapping[Role.RefPolicy],
-                config=self.config.actor_rollout_ref,
-                role=str(Role.RefPolicy),
-            )
-            self.resource_pool_to_cls[resource_pool][str(Role.RefPolicy)] = ref_policy_cls
-
-        # create a reward model if reward_fn is None
-        if self.use_rm:
-            # we create a RM here
-            resource_pool = self.resource_pool_manager.get_resource_pool(Role.RewardModel)
-            rm_cls = RayClassWithInitArgs(self.role_worker_mapping[Role.RewardModel], config=self.config.reward_model)
-            self.resource_pool_to_cls[resource_pool][str(Role.RewardModel)] = rm_cls
-
-        # initialize WorkerGroup
-        # NOTE: if you want to use a different resource pool for each role, which can support different parallel size,
-        # you should not use `create_colocated_worker_cls`.
-        # Instead, directly pass different resource pool to different worker groups.
-        # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
-        all_wg = {}
-        wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
-        if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
-            wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
-        if OmegaConf.select(self.config.global_profiler, "steps") is not None:
-            wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
-            # Only require nsight worker options when tool is nsys
-            if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
-                assert (
-                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
-                    is not None
-                ), "worker_nsight_options must be set when using nsys with profile_steps"
-                wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
-                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
-                )
-        wg_kwargs["device_name"] = self.device_name
-
-        for resource_pool, class_dict in self.resource_pool_to_cls.items():
-            worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
-            wg_dict = self.ray_worker_group_cls(
-                resource_pool=resource_pool,
-                ray_cls_with_init=worker_dict_cls,
-                **wg_kwargs,
-            )
-            spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
-            all_wg.update(spawn_wg)
-
-        if self.use_critic:
-            self.critic_wg = all_wg[str(Role.Critic)]
-            self.critic_wg.init_model()
-
-        if self.use_reference_policy and not self.ref_in_actor:
-            self.ref_policy_wg = all_wg[str(Role.RefPolicy)]
-            self.ref_policy_wg.init_model()
-
-        self.rm_wg = None
-        # initalization of rm_wg will be deprecated in the future
-        if self.use_rm:
-            self.rm_wg = all_wg[str(Role.RewardModel)]
-            self.rm_wg.init_model()
-
-        # we should create rollout at the end so that vllm can have a better estimation of kv cache memory
-        self.actor_rollout_wg = all_wg[str(Role.ActorRollout)]
-        self.actor_rollout_wg.init_model()
-
-        # create async rollout manager and request scheduler
-        self.async_rollout_mode = False
-        if self.config.actor_rollout_ref.rollout.mode == "async":
-            from verl.experimental.agent_loop import AgentLoopManager
-
-            self.async_rollout_mode = True
-            self.async_rollout_manager = AgentLoopManager(
-                config=self.config, worker_group=self.actor_rollout_wg, rm_wg=self.rm_wg
-            )
-
-    def _save_checkpoint(self):
-        from verl.utils.fs import local_mkdir_safe
-
-        # path: given_path + `/global_step_{global_steps}` + `/actor`
-        local_global_step_folder = os.path.join(
-            self.config.trainer.default_local_dir, f"global_step_{self.global_steps}"
-        )
-
-        print(f"local_global_step_folder: {local_global_step_folder}")
-        actor_local_path = os.path.join(local_global_step_folder, "actor")
-
-        actor_remote_path = (
-            None
-            if self.config.trainer.default_hdfs_dir is None
-            else os.path.join(self.config.trainer.default_hdfs_dir, f"global_step_{self.global_steps}", "actor")
-        )
-
-        remove_previous_ckpt_in_save = self.config.trainer.get("remove_previous_ckpt_in_save", False)
-        if remove_previous_ckpt_in_save:
-            print(
-                "Warning: remove_previous_ckpt_in_save is deprecated,"
-                + " set max_actor_ckpt_to_keep=1 and max_critic_ckpt_to_keep=1 instead"
-            )
-        max_actor_ckpt_to_keep = (
-            self.config.trainer.get("max_actor_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
-        )
-        max_critic_ckpt_to_keep = (
-            self.config.trainer.get("max_critic_ckpt_to_keep", None) if not remove_previous_ckpt_in_save else 1
-        )
-
-        self.actor_rollout_wg.save_checkpoint(
-            actor_local_path, actor_remote_path, self.global_steps, max_ckpt_to_keep=max_actor_ckpt_to_keep
-        )
-
-        if self.use_critic:
-            critic_local_path = os.path.join(local_global_step_folder, str(Role.Critic))
-            critic_remote_path = (
-                None
-                if self.config.trainer.default_hdfs_dir is None
-                else os.path.join(
-                    self.config.trainer.default_hdfs_dir, f"global_step_{self.global_steps}", str(Role.Critic)
-                )
-            )
-            self.critic_wg.save_checkpoint(
-                critic_local_path, critic_remote_path, self.global_steps, max_ckpt_to_keep=max_critic_ckpt_to_keep
-            )
-
-        # save dataloader
-        local_mkdir_safe(local_global_step_folder)
-        dataloader_local_path = os.path.join(local_global_step_folder, "data.pt")
-        dataloader_state_dict = self.train_dataloader.state_dict()
-        torch.save(dataloader_state_dict, dataloader_local_path)
-
-        # latest checkpointed iteration tracker (for atomic usage)
-        local_latest_checkpointed_iteration = os.path.join(
-            self.config.trainer.default_local_dir, "latest_checkpointed_iteration.txt"
-        )
-        with open(local_latest_checkpointed_iteration, "w") as f:
-            f.write(str(self.global_steps))
-
-    def _load_checkpoint(self):
-        if self.config.trainer.resume_mode == "disable":
-            # NOTE: while there is no checkpoint to load, we still need to offload the model and optimizer to CPU
-            self.actor_rollout_wg.load_checkpoint(None)
-            return 0
-
-        # load from hdfs
-        if self.config.trainer.default_hdfs_dir is not None:
-            raise NotImplementedError("load from hdfs is not implemented yet")
-        else:
-            checkpoint_folder = self.config.trainer.default_local_dir  # TODO: check path
-            if not os.path.isabs(checkpoint_folder):
-                working_dir = os.getcwd()
-                checkpoint_folder = os.path.join(working_dir, checkpoint_folder)
-            global_step_folder = find_latest_ckpt_path(checkpoint_folder)  # None if no latest
-
-        # find global_step_folder
-        if self.config.trainer.resume_mode == "auto":
-            if global_step_folder is None:
-                print("Training from scratch")
-                self.actor_rollout_wg.load_checkpoint(None)
-                return 0
-        else:
-            if self.config.trainer.resume_mode == "resume_path":
-                assert isinstance(self.config.trainer.resume_from_path, str), "resume ckpt must be str type"
-                assert "global_step_" in self.config.trainer.resume_from_path, (
-                    "resume ckpt must specify the global_steps"
-                )
-                global_step_folder = self.config.trainer.resume_from_path
-                if not os.path.isabs(global_step_folder):
-                    working_dir = os.getcwd()
-                    global_step_folder = os.path.join(working_dir, global_step_folder)
-        print(f"Load from checkpoint folder: {global_step_folder}")
-        # set global step
-        self.global_steps = int(global_step_folder.split("global_step_")[-1])
-
-        print(f"Setting global step to {self.global_steps}")
-        print(f"Resuming from {global_step_folder}")
-
-        actor_path = os.path.join(global_step_folder, "actor")
-        critic_path = os.path.join(global_step_folder, str(Role.Critic))
-        # load actor
-        self.actor_rollout_wg.load_checkpoint(
-            actor_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load
-        )
-        # load critic
-        if self.use_critic:
-            self.critic_wg.load_checkpoint(
-                critic_path, del_local_after_load=self.config.trainer.del_local_ckpt_after_load
-            )
-
-        # load dataloader,
-        # TODO: from remote not implemented yet
-        dataloader_local_path = os.path.join(global_step_folder, "data.pt")
-        if os.path.exists(dataloader_local_path):
-            dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
-            self.train_dataloader.load_state_dict(dataloader_state_dict)
-        else:
-            print(f"Warning: No dataloader state found at {dataloader_local_path}, will start from scratch")
-
-    def _start_profiling(self, do_profile: bool) -> None:
-        """Start profiling for all worker groups if profiling is enabled."""
-        if do_profile:
-            self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
-            if self.use_reference_policy:
-                self.ref_policy_wg.start_profile(profile_step=self.global_steps)
-            if self.use_critic:
-                self.critic_wg.start_profile(profile_step=self.global_steps)
-            if self.use_rm:
-                self.rm_wg.start_profile(profile_step=self.global_steps)
-
-    def _stop_profiling(self, do_profile: bool) -> None:
-        """Stop profiling for all worker groups if profiling is enabled."""
-        if do_profile:
-            self.actor_rollout_wg.stop_profile()
-            if self.use_reference_policy:
-                self.ref_policy_wg.stop_profile()
-            if self.use_critic:
-                self.critic_wg.stop_profile()
-            if self.use_rm:
-                self.rm_wg.stop_profile()
-
-    def _balance_batch(self, batch: DataProto, metrics, logging_prefix="global_seqlen", keep_minibatch=False):
-        """Reorder the data on single controller such that each dp rank gets similar total tokens"""
-        attention_mask = batch.batch["attention_mask"]
-        batch_size = attention_mask.shape[0]
-        global_seqlen_lst = batch.batch["attention_mask"].view(batch_size, -1).sum(-1)  # (train_batch_size,)
-        workload_lst = calculate_workload(global_seqlen_lst)
-        world_size = self.actor_rollout_wg.world_size
-        if keep_minibatch:
-            # Decouple the DP balancing and mini-batching.
-            minibatch_size = self.config.actor_rollout_ref.actor.get("ppo_mini_batch_size")
-            minibatch_num = len(workload_lst) // minibatch_size
-            global_partition_lst = [[] for _ in range(world_size)]
-            for i in range(minibatch_num):
-                rearrange_minibatch_lst = get_seqlen_balanced_partitions(
-                    workload_lst[i * minibatch_size : (i + 1) * minibatch_size],
-                    k_partitions=world_size,
-                    equal_size=True,
-                )
-                for j, part in enumerate(rearrange_minibatch_lst):
-                    global_partition_lst[j].extend([x + minibatch_size * i for x in part])
-        else:
-            global_partition_lst = get_seqlen_balanced_partitions(
-                workload_lst, k_partitions=world_size, equal_size=True
-            )
-        # Place smaller micro-batches at both ends to reduce the bubbles in pipeline parallel.
-        for idx, partition in enumerate(global_partition_lst):
-            partition.sort(key=lambda x: (workload_lst[x], x))
-            ordered_partition = partition[::2] + partition[1::2][::-1]
-            global_partition_lst[idx] = ordered_partition
-        # reorder based on index. The data will be automatically equally partitioned by dispatch function
-        global_idx = torch.tensor([j for partition in global_partition_lst for j in partition])
-        batch.reorder(global_idx)
-        global_balance_stats = log_seqlen_unbalance(
-            seqlen_list=global_seqlen_lst, partitions=global_partition_lst, prefix=logging_prefix
-        )
-        metrics.update(global_balance_stats)
-
-    def fit(self):
-        """
-        The training loop of PPO.
-        The driver process only need to call the compute functions of the worker group through RPC
-        to construct the PPO dataflow.
-        The light-weight advantage computation is done on the driver process.
-        """
-        from omegaconf import OmegaConf
-
-        from verl.utils.tracking import Tracking
-
-        logger = Tracking(
-            project_name=self.config.trainer.project_name,
-            experiment_name=self.config.trainer.experiment_name,
-            default_backend=self.config.trainer.logger,
-            config=OmegaConf.to_container(self.config, resolve=True),
-        )
-
-        self.global_steps = 0
-
-        # load checkpoint before doing anything
-        self._load_checkpoint()
-
-        current_epoch = self.global_steps // len(self.train_dataloader)
-
-        # perform validation before training
-        # currently, we only support validation using the reward_function.
-        if self.val_reward_fn is not None and self.config.trainer.get("val_before_train", True):
-            val_metrics = self._validate()
-            assert val_metrics, f"{val_metrics=}"
-            pprint(f"Initial validation metrics: {val_metrics}")
-            logger.log(data=val_metrics, step=self.global_steps)
-            if self.config.trainer.get("val_only", False):
-                return
-
-        if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
-            rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
-            rollout_skip.wrap_generate_sequences()
-
-        # add tqdm
-        progress_bar = tqdm(total=self.total_training_steps, initial=self.global_steps, desc="Training Progress")
-
-        # we start from step 1
-        self.global_steps += 1
-        last_val_metrics = None
-        self.max_steps_duration = 0
-        partial_batch: Optional[DataProto] = None  # samples whose rollout is not finished yet
-        staged_batch: Optional[DataProto] = None  # samples whose rollout has been finished but not yet trained on
-        prev_step_profile = False
-        curr_step_profile = (
-            self.global_steps in self.config.global_profiler.steps
-            if self.config.global_profiler.steps is not None
-            else False
-        )
-        next_step_profile = False
-
-        for epoch in range(current_epoch, self.config.trainer.total_epochs):
-            for batch_dict in self.train_dataloader:
-                metrics = {}
-                timing_raw = {}
-
-                with marked_timer("start_profile", timing_raw):
-                    self._start_profiling(
-                        not prev_step_profile and curr_step_profile
-                        if self.config.global_profiler.profile_continuous_steps
-                        else curr_step_profile
-                    )
-                batch: DataProto = DataProto.from_single_dict(batch_dict)
-                batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))],
-                                                         dtype=object)
-                # repeat to align with repeated responses in rollout
-                batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
-                batch.non_tensor_batch["age"] = np.ones(len(batch.batch), dtype=int)
-                batch.non_tensor_batch["raw_response_ids"] = np.fromiter(([] for _ in range(len(batch.batch))),
-                                                                         dtype=object)
-
-                batch = DataProto.concat([partial_batch, batch]) if partial_batch is not None else batch
-                # add uid to batch
-                batch.non_tensor_batch["uid"] = np.array(
-                    [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
-                )
-
-                gen_batch = self._get_gen_batch(batch)
-
-                # pass global_steps to trace
-                gen_batch.meta_info["global_steps"] = self.global_steps
-                gen_batch_output = gen_batch.repeat(
-                    repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
-                )
-
-                is_last_step = self.global_steps >= self.total_training_steps
-                with marked_timer("step", timing_raw):
-                    # generate a batch
-                    with marked_timer("gen", timing_raw, color="red"):
-                        if self.aggregator:
-                            self.aggregator.set_sample_num.remote(len(gen_batch))
-                            self.aggregator.clear.remote()
-
-                        if not self.async_rollout_mode:
-                            gen_batch_output = self.actor_rollout_wg.generate_sequences(gen_batch_output)
-                        else:
-                            gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
-
-                        timing_raw.update(gen_batch_output.meta_info["timing"])
-                        gen_batch_output.meta_info.pop("timing", None)
-                    with marked_timer("filter", timing_raw):
-                        batch = batch.union(gen_batch_output)
-
-                        finished_mask = batch.non_tensor_batch.pop("finished")
-                        if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "sync":
-                            finished_mask = (batch.non_tensor_batch[
-                                                 "age"] == self.config.algorithm.partial_rollout_max_split) | finished_mask
-                        if self.config.actor_rollout_ref.rollout.partial_rollout_mode == "async":
-                            finished_mask = ([len(response) >= self.config.actor_rollout_ref.rollout.response_length
-                                              for response in
-                                              gen_batch_output.non_tensor_batch['raw_response_ids']]) | finished_mask
-                        staged_out, partial_batch = DataProto.split_data(batch, finished_mask)
-                        staged_out.non_tensor_batch.pop("raw_prompt_ids")
-                        staged_out.non_tensor_batch.pop("raw_response_ids")
-
-                        if len(partial_batch.batch) > 0:
-                            for key in ("input_ids", "attention_mask", "position_ids"):
-                                tmp = partial_batch.batch.pop(key, None)
-                                partial_batch.batch[key] = tmp[:, : self.config.data.max_prompt_length]
-
-                            for key in ("prompts", "responses", "rollout_log_probs"):
-                                # we don't support rollout_log_probs in this feature branch yet
-                                if key in partial_batch.batch:
-                                    partial_batch.batch.pop(key)
-                        else:
-                            partial_batch = None
-
-                        # note that we no longer ensure the order of samples in staged_batch
-                        staged_batch = DataProto.concat(
-                            [staged_batch, staged_out]) if staged_batch is not None else staged_out
-
-                        # prompts whose number of finished rollout is enough can be trained on
-                        # while filtering, we ensure sample number is divisible by n_gpus_per_node and as large as possible
-                        can_train_mask = np.zeros(len(staged_batch.batch), dtype=bool)
-                        id2count = defaultdict(int)
-                        required_rollouts = self.config.actor_rollout_ref.rollout.n
-                        divisor = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * required_rollouts
-
-                        for uid in staged_batch.non_tensor_batch["uid"]:
-                            id2count[uid] += 1
-                        assert not id2count or max(
-                            id2count.values()) <= required_rollouts, "max number of responses exceeds rollout n"
-
-                        complete_uids = [uid for uid, count in id2count.items() if count == required_rollouts]
-
-                        total_complete_samples = len(complete_uids) * required_rollouts
-                        max_usable_groups = (total_complete_samples // divisor) * divisor // required_rollouts
-                        can_train_count = max_usable_groups * required_rollouts
-
-                        if can_train_count == 0:
-                            print(f"{total_complete_samples=}, no complete uid groups available. Keep generating...")
-                            continue
-
-                        selected_uids = set(complete_uids[:max_usable_groups])
-
-                        for i, uid in enumerate(staged_batch.non_tensor_batch["uid"]):
-                            if uid in selected_uids:
-                                can_train_mask[i] = True
-
-                        batch, staged_batch = DataProto.split_data(staged_batch, can_train_mask)
-                        if partial_batch:
-                            partial_batch.non_tensor_batch["age"] += 1
-                    if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-                        if self.reward_fn is None:
-                            raise ValueError("A reward_fn is required for REMAX advantage estimation.")
-
-                        with marked_timer("gen_max", timing_raw, color="purple"):
-                            gen_baseline_batch = deepcopy(gen_batch)
-                            gen_baseline_batch.meta_info["do_sample"] = False
-                            if not self.async_rollout_mode:
-                                gen_baseline_output = self.actor_rollout_wg.generate_sequences(gen_baseline_batch)
-                            else:
-                                gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
-                            batch = batch.union(gen_baseline_output)
-                            # compute reward model score on batch
-                            rm_scores = None
-                            if self.use_rm and "rm_scores" not in batch.batch.keys():
-                                rm_scores = self.rm_wg.compute_rm_score(batch)
-                                batch = batch.union(rm_scores)
-                            reward_baseline_tensor, _ = compute_reward(batch, self.reward_fn)
-                            reward_baseline_tensor = reward_baseline_tensor.sum(dim=-1)
-
-                            keys_to_pop = set(gen_baseline_output.batch.keys())
-                            if rm_scores is not None:
-                                keys_to_pop.update(rm_scores.batch.keys())
-                            batch.pop(batch_keys=list(keys_to_pop))
-
-                            batch.batch["reward_baselines"] = reward_baseline_tensor
-
-                            del rm_scores, gen_baseline_batch, gen_baseline_output
-
-
-                    if "response_mask" not in batch.batch.keys():
-                        batch.batch["response_mask"] = compute_response_mask(batch)
-                    # Balance the number of valid tokens across DP ranks.
-                    # NOTE: This usually changes the order of data in the `batch`,
-                    # which won't affect the advantage calculation (since it's based on uid),
-                    # but might affect the loss calculation (due to the change of mini-batching).
-                    if self.config.trainer.balance_batch:
-                        self._balance_batch(batch, metrics=metrics)
-
-                    # compute global_valid tokens
-                    batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
-
-                    with marked_timer("reward", timing_raw, color="yellow"):
-                        # compute reward model score
-                        if self.use_rm and "rm_scores" not in batch.batch.keys():
-                            reward_tensor = self.rm_wg.compute_rm_score(batch)
-                            batch = batch.union(reward_tensor)
-
-                        if self.config.reward_model.launch_reward_fn_async:
-                            future_reward = compute_reward_async.remote(
-                                data=batch, config=self.config, tokenizer=self.tokenizer
-                            )
-                        else:
-                            reward_tensor, reward_extra_infos_dict = compute_reward(batch, self.reward_fn)
-
-                    # Operating Mode Selection:
-                    # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)
-                    # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
-                    #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
-                    rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-                    bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
-                    if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
-                        from verl.trainer.ppo.rollout_corr_helper import apply_rollout_correction
-
-                        apply_rollout_correction(
-                            batch=batch,
-                            rollout_corr_config=rollout_corr_config,
-                            policy_loss_config=self.config.actor_rollout_ref.actor.policy_loss,
-                        )
-                    else:  # Recompute old_log_probs
-                        with marked_timer("old_log_prob", timing_raw, color="blue"):
-                            old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
-                            entropys = old_log_prob.batch["entropys"]
-                            response_masks = batch.batch["response_mask"]
-                            loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                            entropy_agg = agg_loss(
-                                loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode
-                            )
-                            old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
-                            metrics.update(old_log_prob_metrics)
-                            old_log_prob.batch.pop("entropys")
-                            batch = batch.union(old_log_prob)
-                            if "rollout_log_probs" in batch.batch.keys():
-                                # TODO: we may want to add diff of probs too.
-                                from verl.utils.debug.metrics import calculate_debug_metrics
-
-                                metrics.update(calculate_debug_metrics(batch))
-
-                    assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
-
-                    if self.use_reference_policy:
-                        # compute reference log_prob
-                        with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
-                            if not self.ref_in_actor:
-                                ref_log_prob = self.ref_policy_wg.compute_ref_log_prob(batch)
-                            else:
-                                ref_log_prob = self.actor_rollout_wg.compute_ref_log_prob(batch)
-                            batch = batch.union(ref_log_prob)
-
-                    # compute values
-                    if self.use_critic:
-                        with marked_timer("values", timing_raw, color="cyan"):
-                            values = self.critic_wg.compute_values(batch)
-                            batch = batch.union(values)
-
-                    with marked_timer("adv", timing_raw, color="brown"):
-                        # we combine with rule-based rm
-                        reward_extra_infos_dict: dict[str, list]
-                        if self.config.reward_model.launch_reward_fn_async:
-                            reward_tensor, reward_extra_infos_dict = ray.get(future_reward)
-                        batch.batch["token_level_scores"] = reward_tensor
-
-                        if reward_extra_infos_dict:
-                            batch.non_tensor_batch.update({k: np.array(v) for k, v in reward_extra_infos_dict.items()})
-
-                        # compute rewards. apply_kl_penalty if available
-                        if self.config.algorithm.use_kl_in_reward:
-                            batch, kl_metrics = apply_kl_penalty(
-                                batch, kl_ctrl=self.kl_ctrl_in_reward, kl_penalty=self.config.algorithm.kl_penalty
-                            )
-                            metrics.update(kl_metrics)
-                        else:
-                            batch.batch["token_level_rewards"] = batch.batch["token_level_scores"]
-
-                        # Compute rollout correction: IS weights, rejection sampling, and metrics
-                        # Only runs in decoupled mode (computes once per batch using stable π_old)
-                        # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
-                        if (
-                            rollout_corr_config is not None
-                            and "rollout_log_probs" in batch.batch
-                            and not bypass_recomputing_logprobs  # Only in decoupled mode
-                        ):
-                            from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
-
-                            # Compute IS weights, apply rejection sampling, compute metrics
-                            batch, is_metrics = compute_rollout_correction_and_add_to_batch(batch, rollout_corr_config)
-                            # IS and off-policy metrics already have rollout_corr/ prefix
-                            metrics.update(is_metrics)
-
-                        # compute advantages, executed on the driver process
-                        norm_adv_by_std_in_grpo = self.config.algorithm.get(
-                            "norm_adv_by_std_in_grpo", True
-                        )  # GRPO adv normalization factor
-
-                        batch = compute_advantage(
-                            batch,
-                            adv_estimator=self.config.algorithm.adv_estimator,
-                            gamma=self.config.algorithm.gamma,
-                            lam=self.config.algorithm.lam,
-                            num_repeat=self.config.actor_rollout_ref.rollout.n,
-                            norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
-                            config=self.config.algorithm,
-                        )
-
-                    # update critic
-                    if self.use_critic:
-                        with marked_timer("update_critic", timing_raw, color="pink"):
-                            critic_output = self.critic_wg.update_critic(batch)
-                        critic_output_metrics = reduce_metrics(critic_output.meta_info["metrics"])
-                        metrics.update(critic_output_metrics)
-
-                    # implement critic warmup
-                    if self.config.trainer.critic_warmup <= self.global_steps:
-                        # update actor
-                        with marked_timer("update_actor", timing_raw, color="red"):
-                            rollout_config = self.config.actor_rollout_ref.rollout
-                            batch.meta_info["multi_turn"] = rollout_config.multi_turn.enable
-                            # TODO: Make "temperature" single source of truth from generation.
-                            batch.meta_info["temperature"] = rollout_config.temperature
-                            actor_output = self.actor_rollout_wg.update_actor(batch)
-                        actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
-                        metrics.update(actor_output_metrics)
-
-                    # Log rollout generations if enabled
-                    rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
-                    if rollout_data_dir:
-                        self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
-
-                # validate
-                if (
-                    self.val_reward_fn is not None
-                    and self.config.trainer.test_freq > 0
-                    and (is_last_step or self.global_steps % self.config.trainer.test_freq == 0)
-                ):
-                    with marked_timer("testing", timing_raw, color="green"):
-                        val_metrics: dict = self._validate()
-                        if is_last_step:
-                            last_val_metrics = val_metrics
-                    metrics.update(val_metrics)
-
-                # Check if the ESI (Elastic Server Instance)/training plan is close to expiration.
-                esi_close_to_expiration = should_save_ckpt_esi(
-                    max_steps_duration=self.max_steps_duration,
-                    redundant_time=self.config.trainer.esi_redundant_time,
-                )
-                # Check if the conditions for saving a checkpoint are met.
-                # The conditions include a mandatory condition (1) and
-                # one of the following optional conditions (2/3/4):
-                # 1. The save frequency is set to a positive value.
-                # 2. It's the last training step.
-                # 3. The current step number is a multiple of the save frequency.
-                # 4. The ESI(Elastic Server Instance)/training plan is close to expiration.
-                if self.config.trainer.save_freq > 0 and (
-                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0 or esi_close_to_expiration
-                ):
-                    if esi_close_to_expiration:
-                        print("Force saving checkpoint: ESI instance expiration approaching.")
-                    with marked_timer("save_checkpoint", timing_raw, color="green"):
-                        self._save_checkpoint()
-
-                with marked_timer("stop_profile", timing_raw):
-                    next_step_profile = (
-                        self.global_steps + 1 in self.config.global_profiler.steps
-                        if self.config.global_profiler.steps is not None
-                        else False
-                    )
-                    self._stop_profiling(
-                        curr_step_profile and not next_step_profile
-                        if self.config.global_profiler.profile_continuous_steps
-                        else curr_step_profile
-                    )
-                    prev_step_profile = curr_step_profile
-                    curr_step_profile = next_step_profile
-
-                steps_duration = timing_raw["step"]
-                self.max_steps_duration = max(self.max_steps_duration, steps_duration)
-
-                # training metrics
-                metrics.update(
-                    {
-                        "training/global_step": self.global_steps,
-                        "training/epoch": epoch,
-                    }
-                )
-                if self.enable_partial_rollout:
-                    metrics.update(
-                        {
-                            "training/can_train_count": can_train_count,
-                            "training/total_complete_samples": total_complete_samples,
-                        }
-                    )
-                # collect metrics
-                metrics.update(compute_data_metrics(batch=batch, use_critic=self.use_critic))
-                metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
-                # TODO: implement actual tflpo and theoretical tflpo
-                n_gpus = self.resource_pool_manager.get_n_gpus()
-                metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
-                # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
-
-                # this is experimental and may be changed/removed in the future in favor of a general-purpose one
-                if isinstance(self.train_dataloader.sampler, AbstractCurriculumSampler):
-                    self.train_dataloader.sampler.update(batch=batch)
-
-                # TODO: make a canonical logger that supports various backend
-                logger.log(data=metrics, step=self.global_steps)
-
-                progress_bar.update(1)
-                self.global_steps += 1
-
-                if (
-                    hasattr(self.config.actor_rollout_ref.actor, "profiler")
-                    and self.config.actor_rollout_ref.actor.profiler.tool == "torch_memory"
-                ):
-                    self.actor_rollout_wg.dump_memory_snapshot(
-                        tag=f"post_update_step{self.global_steps}", sub_dir=f"step{self.global_steps}"
-                    )
-
-                if is_last_step:
-                    pprint(f"Final validation metrics: {last_val_metrics}")
-                    progress_bar.close()
-                    return
-
-                # this is experimental and may be changed/removed in the future
-                # in favor of a general-purpose data buffer pool
-                if hasattr(self.train_dataset, "on_batch_end"):
-                    # The dataset may be changed after each training batch
-                    self.train_dataset.on_batch_end(batch=batch)

--- a/recipe/partial_rollout/vllm_rollout_spmd.py
+++ b/recipe/partial_rollout/vllm_rollout_spmd.py
@@ -1,0 +1,489 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The vllm_rollout that can be applied in different backend
+When working with FSDP:
+- Use DTensor weight loader (recommended) or HF weight loader
+- Utilize state_dict from the FSDP to synchronize the weights among tp ranks in vLLM
+When working with Megatron:
+- Use Megatron weight loader
+- During training, only the current pp stage holds the parameters
+- Before inference, broadcast the parameters of the current pp rank
+  to all other pp ranks (all pp ranks holds all the parameters)
+- Bind the parameters to the inference engine
+- Do inference in tp. pp is treated as additional dp
+- After inference, all the parameters that doesn't belong to this pp rank is freed.
+"""
+
+import logging
+import os
+import uuid
+import copy
+
+
+
+import numpy as np
+import ray
+import torch
+import torch.distributed
+from omegaconf import ListConfig
+from tensordict import TensorDict
+from torch.distributed.device_mesh import DeviceMesh
+from vllm import LLM, SamplingParams
+from vllm.config import CompilationConfig, LoRAConfig
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.model_loader.utils import process_weights_after_loading
+from vllm.distributed import parallel_state as vpu
+
+try:
+    # https://github.com/vllm-project/vllm/commit/96b9aa5aa076e64c68765232aec343e4d0006e2a
+    from vllm.config import CompilationMode
+
+    _use_compilation_mode = True
+except ImportError:
+    from vllm.config import CompilationLevel
+
+    _use_compilation_mode = False
+
+try:
+    from vllm.worker.worker_base import WorkerWrapperBase
+except ModuleNotFoundError:
+    # https://github.com/vllm-project/vllm/commit/6a113d9aed8221a9c234535958e70e34ab6cac5b
+    from vllm.v1.worker.worker_base import WorkerWrapperBase
+
+
+
+from verl import DataProto
+from verl.third_party.vllm import VLLM_SLEEP_LEVEL
+from verl.utils.model import get_lora_rank_from_adapter
+from verl.utils.profiler import GPUMemoryLogger
+from verl.utils.torch_functional import get_response_mask, pad_2d_list_to_length
+from verl.workers.config import HFModelConfig, RolloutConfig
+
+from verl.workers.rollout.vllm_rollout.vllm_rollout_spmd import _pre_process_inputs
+from verl.workers.rollout.vllm_rollout.utils import (
+    get_vllm_max_lora_rank,
+)
+from verl.workers.rollout.vllm_rollout.vllm_rollout_spmd import vLLMRollout
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+
+
+class vLLMRolloutPatch(vLLMRollout):
+    
+    def __init__(
+        self,
+        config: RolloutConfig,
+        model_config: HFModelConfig,
+        device_mesh: DeviceMesh,
+):
+        super(vLLMRollout,self).__init__(self,config, model_config, device_mesh)
+        if config.layered_summon:
+            self.sleep_level = 1
+        else:
+            self.sleep_level = VLLM_SLEEP_LEVEL
+
+        model_path = model_config.local_path
+        tokenizer = model_config.tokenizer
+        model_hf_config = model_config.hf_config
+        trust_remote_code = model_config.trust_remote_code
+
+        lora_adapter_path = getattr(model_config, "lora_adapter_path", None)
+        if lora_adapter_path is not None:
+            lora_rank = get_lora_rank_from_adapter(lora_adapter_path)
+        else:
+            lora_rank = model_config.lora_rank
+
+        self.lora_kwargs = (
+            {"enable_lora": True, "max_loras": 1, "max_lora_rank": get_vllm_max_lora_rank(lora_rank)}
+            if model_config.lora_rank > 0
+            else {}
+        )
+
+        tensor_parallel_size = self.config.get("tensor_model_parallel_size", 1)
+        assert tensor_parallel_size <= torch.distributed.get_world_size(), (
+            "tensor parallel size should be less than or equal to the world size"
+        )
+        max_num_batched_tokens = self.config.get("max_num_batched_tokens", 8192)
+        if self.config.partial_rollout_mode == "async" and self.config.partial_rollout_max_split > 0:
+            self.aggregator = ray.get_actor("aggregator_actor")
+        else:
+            self.aggregator = None
+
+        rope_scaling_config = getattr(model_hf_config, "rope_scaling", None)
+        if not rope_scaling_config:
+            max_position_embeddings = None
+            if hasattr(model_hf_config, "max_position_embeddings"):
+                max_position_embeddings = model_hf_config.max_position_embeddings
+            elif hasattr(model_hf_config, "llm_config") and hasattr(
+                    model_hf_config.llm_config, "max_position_embeddings"
+            ):
+                max_position_embeddings = model_hf_config.llm_config.max_position_embeddings
+            elif hasattr(model_hf_config, "text_config") and hasattr(
+                    model_hf_config.text_config, "max_position_embeddings"
+            ):
+                max_position_embeddings = model_hf_config.text_config.max_position_embeddings
+            if max_position_embeddings is None:
+                raise ValueError("max_position_embeddings not found in model_hf_config")
+            assert max_position_embeddings >= config.prompt_length + config.response_length, (
+                "model context length should be greater than total sequence length"
+            )
+        else:
+            # handle type where there's a length extend factor
+            # see https://qwen.readthedocs.io/en/latest/deployment/vllm.html#extended-context-support
+            # for using yarn as an example
+            rope_scaling_factor = rope_scaling_config.get("factor", 1.0)
+
+            assert (
+                    model_hf_config.max_position_embeddings * rope_scaling_factor
+                    >= config.prompt_length + config.response_length
+            ), (
+                    "model context length should be greater than total sequence length, "
+                    + f"got rope_scaling_factor={rope_scaling_factor} and "
+                    + f"max_position_embeddings={model_hf_config.max_position_embeddings}"
+            )
+
+        max_model_len = int(config.max_model_len or config.prompt_length + config.response_length)
+
+        # This parameter verification is borrowed from vllm:
+        # https://github.com/vllm-project/vllm/blob/561253b37faadaafe68168ea32d8d8157621a6b4/vllm/config/scheduler.py#L249
+        if max_num_batched_tokens < max_model_len and not self.config.enable_chunked_prefill:
+            raise ValueError(
+                f"max_num_batched_tokens ({max_num_batched_tokens}) is smaller than max_model_len ({max_model_len}). "
+                "Please increase max_num_batched_tokens or enable chunked prefill."
+            )
+
+        load_format = "dummy" if config.load_format.startswith("dummy") else config.load_format
+
+        # copy it to avoid secretly modifying the engine config
+        engine_kwargs = config.get("engine_kwargs", {}).get("vllm", {}) or {}
+
+        # For each vLLM engine parameter,
+        # - `None` means not setting it, so we pop it, and leave it to vLLM default value
+        #    (which can vary across different vLLM versions);
+        # - Otherwise it's the desired value we want to explicitly set.
+        engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
+        if config.get("limit_images", None):  # support for multi-image data
+            engine_kwargs["limit_mm_per_prompt"] = {"image": config.get("limit_images")}
+
+        compilation_config = {}
+
+        cudagraph_capture_sizes = config.get("cudagraph_capture_sizes")
+        # enforce_eager must be False to use cudagraph
+        if not config.enforce_eager and cudagraph_capture_sizes:
+            if isinstance(cudagraph_capture_sizes, ListConfig):
+                compilation_args = {"cudagraph_capture_sizes": cudagraph_capture_sizes}
+                if _use_compilation_mode:
+                    compilation_args["mode"] = CompilationMode.VLLM_COMPILE
+                else:
+                    compilation_args["level"] = CompilationLevel.PIECEWISE
+                compilation_config["compilation_config"] = CompilationConfig(**compilation_args)
+            else:
+                logger.warning(f"cudagraph_capture_sizes must be a list, but got {cudagraph_capture_sizes}")
+
+        self.inference_engine = LLM(
+            model=model_path,
+            enable_sleep_mode=config.free_cache_engine,
+            tensor_parallel_size=tensor_parallel_size,
+            distributed_executor_backend="external_launcher",
+            dtype=config.dtype,
+            enforce_eager=config.enforce_eager,
+            gpu_memory_utilization=config.gpu_memory_utilization,
+            disable_custom_all_reduce=True,
+            skip_tokenizer_init=False,
+            max_model_len=max_model_len,
+            max_num_seqs=config.max_num_seqs,
+            load_format=load_format,
+            disable_log_stats=config.disable_log_stats,
+            max_num_batched_tokens=max_num_batched_tokens,
+            enable_chunked_prefill=config.enable_chunked_prefill,
+            enable_prefix_caching=config.enable_prefix_caching,
+            trust_remote_code=trust_remote_code,
+            seed=config.get("seed", 0),
+            **compilation_config,
+            **self.lora_kwargs,
+            **engine_kwargs,
+        )
+
+        kwargs = dict(
+            n=1,
+            logprobs=0,  # can be set to 0 and let actor to recompute
+            max_tokens=config.response_length,
+            repetition_penalty=config.get("repetition_penalty", 1.0),
+        )
+
+        kwargs["detokenize"] = False
+
+        # supporting adding any sampling params from the config file
+        for k in config.keys():
+            if hasattr(SamplingParams(), str(k)) and k != "seed":
+                kwargs[k] = config.get(k)
+        kwargs["n"] = 1  # already repeat in ray_trainer
+        print(f"kwargs: {kwargs}")
+        self.sampling_params = SamplingParams(**kwargs)
+
+        self.pad_token_id = tokenizer.pad_token_id
+
+    @GPUMemoryLogger(role="vllm rollout spmd", logger=logger)
+    @torch.no_grad()
+    def vllmrollout_generate_sequences(self, prompts: DataProto, **kwargs) -> DataProto:
+        """Generate sequences for a batch of prompts.
+
+        Args:
+            batch (DataProto): Input batch.
+
+        Returns:
+            DataProto: Output batch.
+            - prompts: [bsz, prompt_length], prompt token ids from dataset.
+            - responses: [bsz, response_length], output token ids include response tokens
+            from LLM generation and observation tokens from tool_calls.
+            - response_mask: [bsz, response_length], 1 for LLM generated tokens, 0 for observation/padding tokens.
+            - input_ids: [bsz, prompt_length + response_length], whole sequence token ids, including prompt tokens
+            and response tokens.
+            - attention_mask: [bsz, prompt_length + response_length], 0 for padding tokens, 1 for other tokens.
+            - position_ids: [bsz, prompt_length + response_length], incremental position ids.
+
+            For multi-turn conversations:
+            responses:     |<- LLM generation ->|<- tool_calls ->|<- LLM generation ->|<- padding ->|
+            response_mask: | 1, 1, 1, ..., 1, 1 | 0, 0, .., 0, 0 | 1, 1, 1, ..., 1, 1 | 0, 0, ..., 0|
+        """
+        idx = prompts.batch["input_ids"]  # (bs, prompt_length)
+        # left-padded attention_mask
+        attention_mask = prompts.batch["attention_mask"]
+        position_ids = prompts.batch["position_ids"]
+
+        # used to construct attention_mask
+        eos_token_id = prompts.meta_info["eos_token_id"]
+
+        batch_size = idx.size(0)
+
+        non_tensor_batch = prompts.non_tensor_batch
+        age_list = non_tensor_batch["age"] if "age" in non_tensor_batch else None
+        index_list = [i for i, val in sorted(enumerate(age_list), key=lambda x: (-x[1], x[0]))]
+
+        if "raw_prompt_ids" not in non_tensor_batch:
+            non_tensor_batch["raw_prompt_ids"] = np.array(
+                [_pre_process_inputs(self.pad_token_id, idx[i]) for i in range(batch_size)], dtype=object
+            )
+
+        if batch_size != len(non_tensor_batch["raw_prompt_ids"]):
+            raise RuntimeError("vllm sharding manager is not work properly.")
+
+        raw_prompt_ids = non_tensor_batch.pop("raw_prompt_ids")
+        if "raw_response_ids" in non_tensor_batch and self.config.partial_rollout_max_split > 0:
+            raw_response_ids = non_tensor_batch.pop("raw_response_ids")
+        else:
+            raw_response_ids = np.fromiter(([] for _ in range(batch_size)), dtype=object)
+
+        if "multi_modal_data" in non_tensor_batch:
+            vllm_inputs = []
+            for raw_prompt_ids, multi_modal_data in zip(
+                non_tensor_batch.pop("raw_prompt_ids"), non_tensor_batch.pop("multi_modal_data"), strict=True
+            ):
+                vllm_inputs.append({"prompt_token_ids": raw_prompt_ids, "multi_modal_data": multi_modal_data})
+        else:
+            vllm_inputs = [{"prompt_token_ids": raw_prompt_ids_ + raw_response_ids_} for
+                        raw_prompt_ids_, raw_response_ids_ in zip(raw_prompt_ids, raw_response_ids)]
+
+        need_response_length = [self.config.response_length - len(response) for response in raw_response_ids]
+
+        for input_data in vllm_inputs:
+            # Ensure token IDs are lists or numpy arrays
+            if not isinstance(input_data["prompt_token_ids"], list | np.ndarray):
+                raise TypeError(
+                    f"prompt_token_ids must be a list or numpy array, got {type(input_data['prompt_token_ids'])}"
+                )
+
+            input_data["prompt_token_ids"] = list(input_data["prompt_token_ids"])
+
+        do_sample = prompts.meta_info.get("do_sample", True)
+        is_validate = prompts.meta_info.get("validate", False)
+        if not do_sample:
+            kwargs = {
+                "best_of": 1,
+                "top_p": 1.0,
+                "top_k": -1,
+                "min_p": 0.0,
+                "temperature": 0,
+                "n": 1,  # if greedy, only 1 response
+            }
+        elif is_validate:
+            # TODO: try **
+            kwargs = {
+                "top_k": self.config.val_kwargs.top_k,
+                "top_p": self.config.val_kwargs.top_p,
+                "temperature": self.config.val_kwargs.temperature,
+                "n": 1,  # if validate, already repeat in ray_trainer
+            }
+        elif self.config.partial_rollout_mode == "sync" and self.config.partial_rollout_max_split > 0:
+            kwargs = {
+                "n": 1,  # also repeated in ray_trainer
+                "max_tokens": self.config.response_length // self.config.partial_rollout_max_split,
+            }
+
+        lora_requests = None
+        if self.lora_kwargs:
+            lora_int_ids = list(self.inference_engine.llm_engine.list_loras())
+            if len(lora_int_ids) > 0:
+                lora_int_id = lora_int_ids[0]
+                lora_requests = [
+                    LoRARequest(lora_name=f"{lora_int_id}", lora_int_id=lora_int_id, lora_path="/simon-stub-path")
+                ] * batch_size
+
+        # users can customize different sampling_params at different run
+        with self.update_sampling_params(self,**kwargs):
+
+            if self.config.partial_rollout_mode == "sync" or self.config.partial_rollout_max_split == -1:
+                outputs = self.inference_engine.generate(
+                    prompts=vllm_inputs,  # because we have already convert it to prompt token id
+                    sampling_params=self.sampling_params,
+                    lora_request=lora_requests,
+                    use_tqdm=False,
+                )
+            else:
+                new_vllm_inputs = [vllm_inputs[i] for i in index_list]
+                outputs_sorted = self.async_generate_sequences(
+                    prompts=new_vllm_inputs,  # because we have already convert it to prompt token id
+                    sampling_params=self.sampling_params,
+                    need_response_length=need_response_length,
+                    age_list=age_list)
+                reverse_index = {j: k for k, j in enumerate(index_list)}
+                outputs = [outputs_sorted[reverse_index[j]] for j in range(len(index_list))]
+
+            # TODO(sgm): disable logprob when recompute_log_prob is enable
+            # if n = 1: (bs, response_length) ; if n > 1: (bs * n, response_length)
+
+            response = []
+            finished = []
+            rollout_log_probs = []
+            for output in outputs:
+                for sample_id in range(len(output.outputs)):
+                    response_ids = output.outputs[sample_id].token_ids
+                    response.append(response_ids)
+                    if self.config.partial_rollout_mode == "sync":
+                        finished.append(output.outputs[sample_id].finish_reason != "length")
+                    else:
+                        finished.append(output.finished == True)
+                    if self.config.calculate_log_probs:
+                        curr_log_prob = []
+                        for i, logprob in enumerate(output.outputs[sample_id].logprobs):
+                            curr_log_prob.append(logprob[response_ids[i]].logprob)
+                        rollout_log_probs.append(curr_log_prob)
+                        non_tensor_batch["finished"] = np.array(finished)
+
+            non_tensor_batch["finished"] = np.array(finished)
+            response = raw_response_ids + np.fromiter(response, dtype=object)
+            non_tensor_batch["raw_response_ids"] = response
+            non_tensor_batch["raw_prompt_ids"] = raw_prompt_ids
+            response = pad_2d_list_to_length(response, self.pad_token_id, max_length=self.config.response_length).to(
+                idx.device
+            )
+            if self.config.calculate_log_probs:
+                rollout_log_probs = pad_2d_list_to_length(
+                    rollout_log_probs, -1, max_length=self.config.response_length
+                ).to(idx.device)
+                rollout_log_probs = rollout_log_probs.to(torch.float32)
+
+            seq = torch.cat([idx, response], dim=-1)
+
+        response_length = response.size(1)
+        delta_position_id = torch.arange(1, response_length + 1, device=position_ids.device)
+        delta_position_id = delta_position_id.unsqueeze(0).expand(batch_size, -1)
+        if position_ids.dim() == 3:  # qwen2vl mrope (batch size, 4, seq len)
+            delta_position_id = delta_position_id.view(batch_size, 1, -1).expand(batch_size, position_ids.size(1), -1)
+
+        # TODO(sgm): fix position_ids on right_pad
+        # prompt: left pad + response: right pad
+        # attention_mask: [0,0,0,0,1,1,1,1, | 1,1,1,0,0,0,0,0]
+        # position_ids:   [0,0,0,0,0,1,2,3, | 4,5,6,7,8,9,10,11]
+        response_position_ids = position_ids[..., -1:] + delta_position_id
+        position_ids = torch.cat([position_ids, response_position_ids], dim=-1)
+        response_attention_mask = get_response_mask(
+            response_id=response, eos_token=eos_token_id, dtype=attention_mask.dtype
+        )
+        attention_mask = torch.cat((attention_mask, response_attention_mask), dim=-1)
+
+        # all the tp ranks should contain the same data here. data in all ranks are valid
+        batch = TensorDict(
+            {
+                "prompts": idx,
+                "responses": response,
+                "input_ids": seq,  # here input_ids become the whole sentences
+                "attention_mask": attention_mask,
+                "position_ids": position_ids,
+            },
+            batch_size=batch_size,
+        )
+        if self.config.calculate_log_probs:
+            # we will recompute old log prob with actor
+            batch["rollout_log_probs"] = rollout_log_probs
+
+        return DataProto(batch=batch, non_tensor_batch=non_tensor_batch)
+
+
+    
+    def async_generate_sequences(self, prompts: list, **kwargs):
+        engine = self.inference_engine.llm_engine
+        is_pipeline_last_stage = vpu.get_pipeline_model_parallel_group().is_last_rank
+        need_response_length = kwargs.pop("need_response_length")
+        age_list = kwargs.pop("age_list")
+        if self.aggregator:
+            aged_sample_num = sum(age_list == self.config.partial_rollout_max_split)
+        else:
+            aged_sample_num = 0
+            samples_num = len(prompts)
+        stop_signal = None
+        output_list = []
+        for i, prompt_token_ids in enumerate(prompts):
+            request_id = f"req_{i}_{uuid.uuid4().hex[:6]}"
+
+            sampling_params = copy.deepcopy(self.sampling_params)
+            sampling_params.max_tokens = need_response_length[i]
+            engine.add_request(
+                request_id=request_id,
+                prompt=prompt_token_ids,
+                params=sampling_params
+            )
+        count = 0
+        t = 0
+        while engine.has_unfinished_requests():
+            t = t + 1
+            step_outputs = engine.step()
+            if self.aggregator:
+                if ray.get(self.aggregator.is_stopped.remote()) and count >= aged_sample_num and t % 20 == 0:
+                    stop_signal = True
+            else:
+                if len(output_list) >= samples_num and count >= aged_sample_num and t % 20 == 0:
+                    stop_signal = True
+            for output in step_outputs:
+                if output.finished or stop_signal:
+                    if age_list is not None:
+                        aged_prompt = age_list[
+                                        int(output.request_id.split("_")[1])] == self.config.partial_rollout_max_split
+                        if aged_prompt:
+                            count += 1
+                    output_list.append(output)
+                    request_id = output.request_id
+
+                    if self.aggregator:
+                        if is_pipeline_last_stage and vpu.get_tensor_model_parallel_rank() == 0:
+                            self.aggregator.add.remote(1)
+                if stop_signal:
+                    engine.abort_request([request_id])
+        output_list.sort(key=lambda x: int(x.request_id.split("_")[1]))
+        print(f"output_list : {len(output_list)}")
+        return output_list

--- a/recipe/partial_rollout/vllm_rollout_spmd.py
+++ b/recipe/partial_rollout/vllm_rollout_spmd.py
@@ -474,5 +474,4 @@ class vLLMRolloutPatch(vLLMRollout):
                 if stop_signal:
                     engine.abort_request([request_id])
         output_list.sort(key=lambda x: int(x.request_id.split("_")[1]))
-        print(f"output_list : {len(output_list)}")
         return output_list

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -499,6 +499,32 @@ class DataProto:
 
         return cls.from_dict(tensors=tensors, non_tensors=non_tensors, meta_info=meta_info, auto_padding=auto_padding)
 
+    @staticmethod
+    def split_data(data_proto: "DataProto", filter_mask) -> tuple["DataProto", "DataProto"]:
+        """
+        Split a DataProto into two based on a boolean mask.
+        Args:
+            data_proto: The DataProto to split
+            filter_mask: Boolean tensor/array where True values go to the first DataProto
+        Returns:
+            Tuple[DataProto, DataProto]: First DataProto with items where mask is True,
+                                        Second DataProto with items where mask is False
+        """
+        # Convert to tensor if it's a list or numpy array
+        if isinstance(filter_mask, list):
+            filter_mask = torch.tensor(filter_mask, dtype=torch.bool)
+        elif isinstance(filter_mask, np.ndarray):
+            filter_mask = torch.from_numpy(filter_mask)
+
+        # Create inverse mask
+        inverse_mask = ~filter_mask
+
+        # Split into two DataProtos
+        first_proto = data_proto.select_idxs(filter_mask)
+        second_proto = data_proto.select_idxs(inverse_mask)
+        return first_proto, second_proto 
+    
+    
     @classmethod
     def from_dict(
         cls,

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -522,9 +522,8 @@ class DataProto:
         # Split into two DataProtos
         first_proto = data_proto.select_idxs(filter_mask)
         second_proto = data_proto.select_idxs(inverse_mask)
-        return first_proto, second_proto 
-    
-    
+        return first_proto, second_proto
+
     @classmethod
     def from_dict(
         cls,

--- a/verl/trainer/ppo/utils.py
+++ b/verl/trainer/ppo/utils.py
@@ -36,6 +36,7 @@ class Role(Enum):
     RewardModel = 5
     ActorRolloutRef = 6
     Env = 7
+    Aggregator = 8
 
     def __str__(self):
         return self._get_role_string()
@@ -49,6 +50,7 @@ class Role(Enum):
             Role.RefPolicy: "ref",
             Role.RewardModel: "rm",
             Role.ActorRolloutRef: "actor_rollout_ref",
+            Role.Aggregator: "aggregator",
         }
         return role_mapping.get(self, self.name.lower())
 
@@ -62,6 +64,7 @@ class Role(Enum):
             "ref": cls.RefPolicy,
             "rm": cls.RewardModel,
             "actor_rollout_ref": cls.ActorRolloutRef,
+            "aggregator": cls.Aggregator,
         }
         role = string_mapping.get(name.lower())
         if role is None:

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -204,6 +204,12 @@ class RolloutConfig(BaseConfig):
     skip_tokenizer_init: bool = False
 
     quantization: Optional[str] = None
+    
+    partial_rollout_mode: str = "async"
+
+    rollout_threshold_rate: float = 0.8
+
+    partial_rollout_max_split: int = -1
 
     def __post_init__(self):
         """Validate the rollout config"""

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -204,7 +204,7 @@ class RolloutConfig(BaseConfig):
     skip_tokenizer_init: bool = False
 
     quantization: Optional[str] = None
-    
+
     partial_rollout_mode: str = "async"
 
     rollout_threshold_rate: float = 0.8

--- a/verl/workers/rollout/base.py
+++ b/verl/workers/rollout/base.py
@@ -105,11 +105,9 @@ def get_rollout_class(rollout_name: str, mode: str) -> type[BaseRollout]:
         module_name, class_name = fqdn.rsplit(".", 1)
         rollout_module = importlib.import_module(module_name)
         from recipe.partial_rollout.vllm_rollout_spmd import vLLMRolloutPatch
-        #from verl.workers.rollout.vllm_rollout.vllm_rollout_spmd import vLLMRollout
         rollout_module_class = getattr(rollout_module, class_name)
         for name, attr in rollout_module_class.__dict__.items():
             if name =="__init__":
-                print("name1 :",name)
                 attr = MethodType(vLLMRolloutPatch.__init__,rollout_module_class)
                 setattr(rollout_module_class,name,attr)
             if name == "generate_sequences":

--- a/verl/workers/rollout/base.py
+++ b/verl/workers/rollout/base.py
@@ -15,6 +15,7 @@
 import importlib
 from abc import ABC, abstractmethod
 from typing import Generator
+from types import MethodType
 
 import torch
 from torch.distributed.device_mesh import DeviceMesh
@@ -96,8 +97,30 @@ def get_rollout_class(rollout_name: str, mode: str) -> type[BaseRollout]:
     Returns:
         The rollout class.
     """
-    assert (rollout_name, mode) in _ROLLOUT_REGISTRY, f"Rollout {rollout_name} with mode {mode} not found"
-    fqdn = _ROLLOUT_REGISTRY[(rollout_name, mode)]
-    module_name, class_name = fqdn.rsplit(".", 1)
-    rollout_module = importlib.import_module(module_name)
-    return getattr(rollout_module, class_name)
+
+    
+    if rollout_name=="vllm" and mode=="partial_rollout":
+        
+        fqdn = _ROLLOUT_REGISTRY[("vllm", "sync")]
+        module_name, class_name = fqdn.rsplit(".", 1)
+        rollout_module = importlib.import_module(module_name)
+        from recipe.partial_rollout.vllm_rollout_spmd import vLLMRolloutPatch
+        #from verl.workers.rollout.vllm_rollout.vllm_rollout_spmd import vLLMRollout
+        rollout_module_class = getattr(rollout_module, class_name)
+        for name, attr in rollout_module_class.__dict__.items():
+            if name =="__init__":
+                print("name1 :",name)
+                attr = MethodType(vLLMRolloutPatch.__init__,rollout_module_class)
+                setattr(rollout_module_class,name,attr)
+            if name == "generate_sequences":
+                attr = MethodType(vLLMRolloutPatch.vllmrollout_generate_sequences,rollout_module_class)
+                setattr(rollout_module_class,name,attr)
+        attr = MethodType(vLLMRolloutPatch.async_generate_sequences,rollout_module_class)
+        setattr(rollout_module_class,"async_generate_sequences",attr)
+        return rollout_module_class
+    else:
+        assert (rollout_name, mode) in _ROLLOUT_REGISTRY, f"Rollout {rollout_name} with mode {mode} not found"
+        fqdn = _ROLLOUT_REGISTRY[(rollout_name, mode)]
+        module_name, class_name = fqdn.rsplit(".", 1)
+        rollout_module = importlib.import_module(module_name)
+        return getattr(rollout_module, class_name)


### PR DESCRIPTION
### What does this PR do?

We conducted tests on the partial rollout feature using the DAPO algorithm with the qwen3-0.6B and qwen2.5-7B models. The blue curve represents the scenario where the partial rollout feature is enabled, while the red curve represents it being disabled. As shown in the results, there is a significant improvement in throughput and a reduction in inference latency. Meanwhile, the trend of the rewards curve remains consistent with that of the scenario where partial rollout is disabled.


<img width="1404" height="1219" alt="6BE712FC-FF90-4F1F-FF4B-91D1B725A5A9" src="https://github.com/user-attachments/assets/2cc4e751-35c7-47e1-80b1-59efe6f581f2" />

In aime2024

|                    | base  | 20steps | 60steps | 100steps | 180steps | 220steps | 260steps |
| ------------------ | ----- | ------- | ------- | -------- | -------- | -------- | -------- |
| with partial rollout | 5.78  | 7.91    | 9.58    | 11.3    | 13.28   | 13.07    | 12.13    | 
| without partial rollout | 5.78  | 7.55    | 10.67   | 11.3     | 12.23    | 10.98    | 9.63     |


#### qwen2.5-7B
<img width="1362" height="1193" alt="img" src="https://github.com/user-attachments/assets/8b326bb7-90db-40e5-a90b-c86c5f89346f" />


#### qwen3-0.6B
<img width="1375" height="1186" alt="img_1" src="https://github.com/user-attachments/assets/a04098f1-a1b6-4da4-afa7-a84d6a534542" />


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

rfc link：https://github.com/volcengine/verl/issues/4348

partial rollout  parameter：
    actor_rollout_ref.rollout.partial_rollout_max_split=2 
    actor_rollout_ref.rollout.partial_rollout_mode="async" 
    actor_rollout_ref.rollout.rollout_threshold_rate=0.8 
    actor_rollout_ref.rollout.mode="partial_rollout"  