### PR TITLE
feat(actor): add loss_scale_factor for seq-mean-token-sum-norm mode

### DIFF
--- a/docs/algo/grpo.md
+++ b/docs/algo/grpo.md
@@ -57,6 +57,7 @@ Instead of adding KL penalty in the reward, GRPO regularizes by directly adding 
 Configure the following to enable DrGRPO, with all other parameters the same as GRPO's:
 
 - `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which turns off seq-dim averaging
+- `actor_rollout_ref.actor.loss_scale_factor`: (Optional) Set to a constant integer (e.g., max response length) to ensure consistent normalization throughout training. If not set, uses the current batch's response length.
 - `actor_rollout_ref.actor.use_kl_loss`: Please set it to False for DrGRPO
 - `algorithm.norm_adv_by_std_in_grpo`: False, which turns off standard deviation norm
 

--- a/examples/grpo_trainer/README.md
+++ b/examples/grpo_trainer/README.md
@@ -55,6 +55,7 @@ The work [Understanding R1-Zero-Like Training: A Critical Perspective](https://a
 Configure the following to enable DrGRPO, with all other parameters the same as GRPO's:
 
 - `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which turns off seq-dim averaging
+- `actor_rollout_ref.actor.loss_scale_factor`: (Optional) Set to a constant integer (e.g., max response length) to ensure consistent normalization throughout training. If not set, uses the current batch's response length.
 - `actor_rollout_ref.actor.use_kl_loss`: Please set it to False for DrGRPO
 - `algorithm.norm_adv_by_std_in_grpo`: False, which turns off standard deviation norm
 

--- a/recipe/fully_async_policy/ray_trainer.py
+++ b/recipe/fully_async_policy/ray_trainer.py
@@ -353,8 +353,13 @@ class FullyAsyncRayPPOTrainer(RayPPOTrainer):
                 old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                 entropys = old_log_prob.batch["entropys"]
                 response_masks = batch.batch["response_mask"]
-                loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                actor_config = self.config.actor_rollout_ref.actor
+                entropy_agg = agg_loss(
+                    loss_mat=entropys,
+                    loss_mask=response_masks,
+                    loss_agg_mode=actor_config.loss_agg_mode,
+                    loss_scale_factor=actor_config.loss_scale_factor,
+                )
                 old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                 metrics.update(old_log_prob_metrics)
                 old_log_prob.batch.pop("entropys")

--- a/recipe/one_step_off_policy/ray_trainer.py
+++ b/recipe/one_step_off_policy/ray_trainer.py
@@ -514,8 +514,13 @@ class OneStepOffRayTrainer(RayPPOTrainer):
                     old_log_prob = self.actor_wg.compute_log_prob(batch)
                     entropys = old_log_prob.batch["entropys"]
                     response_masks = batch.batch["response_mask"]
-                    loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                    entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                    actor_config = self.config.actor_rollout_ref.actor
+                    entropy_agg = agg_loss(
+                        loss_mat=entropys,
+                        loss_mask=response_masks,
+                        loss_agg_mode=actor_config.loss_agg_mode,
+                        loss_scale_factor=actor_config.loss_scale_factor,
+                    )
                     old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                     metrics.update(old_log_prob_metrics)
                     old_log_prob.batch.pop("entropys")

--- a/recipe/prime/prime_ray_trainer.py
+++ b/recipe/prime/prime_ray_trainer.py
@@ -485,8 +485,13 @@ class RayPRIMETrainer(RayPPOTrainer):
                         old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = compute_response_mask(batch)
-                        loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                        entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                        actor_config = self.config.actor_rollout_ref.actor
+                        entropy_agg = agg_loss(
+                            loss_mat=entropys,
+                            loss_mask=response_masks,
+                            loss_agg_mode=actor_config.loss_agg_mode,
+                            loss_scale_factor=actor_config.loss_scale_factor,
+                        )
                         old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                         metrics.update(old_log_prob_metrics)
                         old_log_prob.batch.pop("entropys")

--- a/recipe/sppo/dp_actor.py
+++ b/recipe/sppo/dp_actor.py
@@ -145,7 +145,12 @@ class DataParallelSPPOActor(DataParallelPPOActor):
                     )
 
                     if entropy_coeff != 0:
-                        entropy_loss = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                        entropy_loss = agg_loss(
+                            loss_mat=entropy,
+                            loss_mask=response_mask,
+                            loss_agg_mode=loss_agg_mode,
+                            loss_scale_factor=self.config.loss_scale_factor,
+                        )
 
                         # compute policy loss
                         policy_loss = pg_loss - entropy_loss * entropy_coeff
@@ -159,7 +164,10 @@ class DataParallelSPPOActor(DataParallelPPOActor):
                             logprob=log_prob, ref_logprob=ref_log_prob, kl_penalty=self.config.kl_loss_type
                         )
                         kl_loss = agg_loss(
-                            loss_mat=kld, loss_mask=response_mask, loss_agg_mode=self.config.loss_agg_mode
+                            loss_mat=kld,
+                            loss_mask=response_mask,
+                            loss_agg_mode=self.config.loss_agg_mode,
+                            loss_scale_factor=self.config.loss_scale_factor,
                         )
 
                         policy_loss = policy_loss + kl_loss * self.config.kl_loss_coef

--- a/recipe/sppo/sppo_ray_trainer.py
+++ b/recipe/sppo/sppo_ray_trainer.py
@@ -257,8 +257,13 @@ class RaySPPOTrainer(RayPPOTrainer):
                     old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                     entropys = old_log_prob.batch["entropys"]
                     response_masks = batch.batch["response_mask"]
-                    loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                    entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                    actor_config = self.config.actor_rollout_ref.actor
+                    entropy_agg = agg_loss(
+                        loss_mat=entropys,
+                        loss_mask=response_masks,
+                        loss_agg_mode=actor_config.loss_agg_mode,
+                        loss_scale_factor=actor_config.loss_scale_factor,
+                    )
                     old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                     metrics.update(old_log_prob_metrics)
                     old_log_prob.batch.pop("entropys")

--- a/recipe/transfer_queue/ray_trainer.py
+++ b/recipe/transfer_queue/ray_trainer.py
@@ -1460,8 +1460,13 @@ class RayPPOTrainer:
                         data = asyncio.run(self.tq_client.async_get_data(old_log_prob_output_meta))
                         entropys = data["entropys"]
                         response_masks = data["response_mask"]
-                        loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                        entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                        actor_config = self.config.actor_rollout_ref.actor
+                        entropy_agg = agg_loss(
+                            loss_mat=entropys,
+                            loss_mask=response_masks,
+                            loss_agg_mode=actor_config.loss_agg_mode,
+                            loss_scale_factor=actor_config.loss_scale_factor,
+                        )
                         old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                         metrics.update(old_log_prob_metrics)
 

--- a/recipe/vla/rob_ray_trainer.py
+++ b/recipe/vla/rob_ray_trainer.py
@@ -297,8 +297,13 @@ class RobRayPPOTrainer(RayPPOTrainer):
                         old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                         entropys = old_log_prob.batch["entropys"]
                         response_masks = batch.batch["response_mask"]
-                        loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
-                        entropy_agg = agg_loss(loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode)
+                        actor_config = self.config.actor_rollout_ref.actor
+                        entropy_agg = agg_loss(
+                            loss_mat=entropys,
+                            loss_mask=response_masks,
+                            loss_agg_mode=actor_config.loss_agg_mode,
+                            loss_scale_factor=actor_config.loss_scale_factor,
+                        )
                         old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                         metrics.update(old_log_prob_metrics)
                         old_log_prob.batch.pop("entropys")

--- a/tests/trainer/config/legacy_ppo_megatron_trainer.yaml
+++ b/tests/trainer/config/legacy_ppo_megatron_trainer.yaml
@@ -62,8 +62,9 @@ actor_rollout_ref:
     clip_ratio_low: 0.2
     clip_ratio_high: 0.2
     clip_ratio_c: 3.0 # lower bound of the value for Dual-clip PPO from https://arxiv.org/pdf/1912.09729
-    loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean"
+    loss_agg_mode: "token-mean" # / "seq-mean-token-sum" / "seq-mean-token-mean" / "seq-mean-token-sum-norm"
     # NOTE: "token-mean" is the default behavior
+    loss_scale_factor: null  # Scale factor for "seq-mean-token-sum-norm" mode. If null, uses response_length.
     entropy_coeff: 0
     use_kl_loss: False # True for GRPO
     kl_loss_coef: 0.001 # for grpo

--- a/tests/trainer/config/legacy_ppo_trainer.yaml
+++ b/tests/trainer/config/legacy_ppo_trainer.yaml
@@ -254,8 +254,12 @@ actor_rollout_ref:
     # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
     clip_ratio_c: 3.0
 
-    # Loss aggregation mode: "token-mean", "seq-mean-token-sum", or "seq-mean-token-mean"
+    # Loss aggregation mode: "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", or "seq-mean-token-sum-norm"
     loss_agg_mode: token-mean
+
+    # Scale factor for "seq-mean-token-sum-norm" loss aggregation mode.
+    # If null, uses response_length. Set to a constant to ensure consistent normalization.
+    loss_scale_factor: null
 
     # Entropy regularization coefficient in PPO loss
     entropy_coeff: 0

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -78,6 +78,7 @@ actor_rollout_ref:
       ppo_kl_coef: 0.1
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
+    loss_scale_factor: null
     entropy_coeff: 0
     calculate_entropy: false
     use_kl_loss: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -64,6 +64,7 @@ actor_rollout_ref:
       ppo_kl_coef: 0.1
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
+    loss_scale_factor: null
     entropy_coeff: 0
     calculate_entropy: false
     use_kl_loss: false

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -71,8 +71,12 @@ policy_loss:
 # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
 clip_ratio_c: 3.0
 
-# Loss aggregation mode: "token-mean", "seq-mean-token-sum", or "seq-mean-token-mean"
+# Loss aggregation mode: "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", or "seq-mean-token-sum-norm"
 loss_agg_mode: token-mean
+
+# Scale factor for "seq-mean-token-sum-norm" loss aggregation mode.
+# If null, uses response_length. Set to a constant to ensure consistent normalization.
+loss_scale_factor: null
 
 # Entropy regularization coefficient in PPO loss
 entropy_coeff: 0

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1135,9 +1135,12 @@ class RayPPOTrainer:
                             old_log_prob = self.actor_rollout_wg.compute_log_prob(batch)
                             entropys = old_log_prob.batch["entropys"]
                             response_masks = batch.batch["response_mask"]
-                            loss_agg_mode = self.config.actor_rollout_ref.actor.loss_agg_mode
+                            actor_config = self.config.actor_rollout_ref.actor
                             entropy_agg = agg_loss(
-                                loss_mat=entropys, loss_mask=response_masks, loss_agg_mode=loss_agg_mode
+                                loss_mat=entropys,
+                                loss_mask=response_masks,
+                                loss_agg_mode=actor_config.loss_agg_mode,
+                                loss_scale_factor=actor_config.loss_scale_factor,
                             )
                             old_log_prob_metrics = {"actor/entropy": entropy_agg.detach().item()}
                             metrics.update(old_log_prob_metrics)

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -71,6 +71,8 @@ class ActorConfig(BaseConfig):
         policy_loss (PolicyLossConfig): Configuration for policy loss computation.
         clip_ratio_c (float): Clipping ratio for critic loss.
         loss_agg_mode (str): Loss aggregation mode. Options: 'token-mean', 'sample-mean'.
+        loss_scale_factor (Optional[int]): Scale factor for 'seq-mean-token-sum-norm' loss aggregation mode.
+            If None, uses response_length. Set to a constant to ensure consistent normalization.
         entropy_coeff (float): Entropy coefficient for regularization.
         use_kl_loss (bool): Whether to use KL divergence loss.
         use_torch_compile (bool): Whether to use torch.compile for optimization.
@@ -108,6 +110,7 @@ class ActorConfig(BaseConfig):
     policy_loss: PolicyLossConfig = field(default_factory=PolicyLossConfig)
     clip_ratio_c: float = 3.0
     loss_agg_mode: str = "token-mean"
+    loss_scale_factor: Optional[int] = None
     entropy_coeff: float = 0
     calculate_entropy: bool = False
     use_kl_loss: bool = False

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -102,6 +102,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     config.global_batch_info["dp_size"] = data["dp_size"]
     config.global_batch_info["batch_num_tokens"] = data["batch_num_tokens"]
     config.global_batch_info["global_batch_size"] = data["global_batch_size"]
+    config.global_batch_info["loss_scale_factor"] = config.loss_scale_factor
 
     metrics = {}
 


### PR DESCRIPTION
Add configurable loss_scale_factor to replace hardcoded divisor in seq-mean-token-sum-norm loss aggregation. Users can set a constant value to ensure consistent normalization throughout training.

- Add loss_scale_factor param to agg_loss() in core_algos.py
- Add loss_scale_factor field to ActorConfig
- Propagate via global_batch_info to policy loss functions
- Update all direct agg_loss calls in trainers and recipes
- Update YAML configs and DrGRPO documentation
