### PR TITLE
multiturn_eval

### DIFF
--- a/docs/multiturn_eval.md
+++ b/docs/multiturn_eval.md
@@ -1,0 +1,65 @@
+Lightweight Multi-Turn Tool Evaluation
+======================================
+
+This guide explains how to run multi-turn tool-call evaluation with ``main_multiturn_eval``. It reuses the training AgentLoop rollout without running PPO optimization, so you can validate tool-use flows with minimal overhead.
+
+Goals
+~~~~~
+
+- Add a missing “single-run multi-turn tool eval” path by reusing the training rollout/AgentLoop pipeline.
+- Decouple evaluation from training scripts—only keep the rollout stage instead of bundling eval with PPO runs.
+- Prioritize vLLM support. sglang currently fails when ``tp=1`` (and has not been adapted for multi-TP); vLLM coverage is sufficient for the current use case.
+
+Key Files
+~~~~~~~~~
+
+- ``verl/trainer/main_multiturn_eval.py``: Entry point. Extracts AgentLoop from ``main_ppo`` to do Ray init, dataset/sampler creation, checkpoint loading, generation, and reward collection.
+- ``verl/trainer/config/multiturn_eval.yaml``: Hydra config mirroring the training actor/rollout/reward layout, plus ``evaluation`` and ``output`` sections.
+- ``examples/sglang_multiturn/run_qwen3-4b_gsm8k_multiturn_eval.sh``: Example script for vLLM async multi-turn tool evaluation; use directly or as a template.
+
+How to Run
+~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Run from the project root
+   bash examples/sglang_multiturn/run_qwen3-4b_gsm8k_multiturn_eval.sh \
+     actor_rollout_ref.model.path=/path/to/model \
+     checkpoint_dir=/path/to/fsdp_or_fsdp2_checkpoint_parent_dir \
+     data.eval_files=/path/to/eval.parquet \
+     output.path=./eval_results \
+     output.scores_path=evaluation_scores.json
+
+Notes:
+
+- ``checkpoint_dir`` can point to a specific ``global_step_*`` or its parent; the script will pick the latest checkpoint automatically.
+- Defaults: ``rollout.mode=async``, ``rollout.name=vllm``, ``multi_turn.enable=true``. Add ``multi_turn.tool_config_path`` and ``multi_turn.interaction_config_path`` if tools/interaction are needed.
+- Outputs go to ``output.path`` (``evaluation_scores.*`` and ``evaluation_summary.json``).
+
+FSDP Checkpoint Loading
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Verified loading weights from FSDP/FSDP2 training checkpoints.
+- ``main_multiturn_eval.py`` includes a ``DeviceMesh`` compatibility patch and process-group registration to avoid Torch 2.8+ FSDP sharded-load errors.
+- To skip checkpoint restore and just use the base model, set ``checkpoint_dir=null``.
+
+Validated Scenarios
+~~~~~~~~~~~~~~~~~~~
+
+All succeeded when loading checkpoints saved from FSDP training:
+
+- GSM8K multi-turn tool use: ``async + vllm + tp1 -> agentloop``; ``async + vllm + tp2 -> agentloop``.
+- Geo3K multi-turn tool use: ``async + vllm + tp1 -> agentloop``; ``async + vllm + tp2 -> agentloop``.
+- Multimodal multi-turn tool use: ``async + vllm + multimodal + tp1 -> agentloop (multimodal)``; ``async + vllm + multimodal + tp2 -> agentloop (multimodal)``.
+
+Lightweight Flow & Custom Metrics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Evaluation keeps only the AgentLoop rollout from ``main_ppo`` and removes optimization, making startup and resource usage much lighter than training.
+- Default summaries live in ``aggregate_summary``; per-sample records are built in ``collect_sample_records``. To add new metrics or formats, extend these functions or emit custom metrics from AgentLoop (they will be stored under ``agent_metrics``).
+
+Limitations & Next Steps
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Currently validated only with vLLM; sglang still breaks when ``tp=1`` (and multi-TP is untested). Next step: fix sglang TP compatibility.
+- For other tasks or tool configs, reuse the provided script template and swap ``data.*`` and tool config paths.

--- a/examples/sglang_multiturn/run_qwen3-4b_gsm8k_multiturn_eval.sh
+++ b/examples/sglang_multiturn/run_qwen3-4b_gsm8k_multiturn_eval.sh
@@ -1,0 +1,43 @@
+# Multi-turn tool evaluation script for GSM8K
+# run on 8xH100
+# make sure your current working directory is the root of the project
+
+set -x
+
+ulimit -n 65535
+
+PROJECT_DIR="$(pwd)"
+CONFIG_PATH="$PROJECT_DIR/verl/trainer/config"
+
+python3 -m verl.trainer.main_multiturn_eval \
+    --config-path="$CONFIG_PATH" \
+    --config-name='multiturn_eval' \
+    data.eval_files=PATH_TO_EVAL_DATA \
+    data.eval_batch_size=64 \
+    data.max_prompt_length=1024 \
+    data.max_response_length=1024 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    data.return_raw_chat=True \
+    data.need_tools_kwargs=True \
+    actor_rollout_ref.model.path=PATH_TO_MODEL \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.multi_turn.enable=True \
+    actor_rollout_ref.rollout.multi_turn.tool_config_path="$PROJECT_DIR/examples/sglang_multiturn/config/tool_config/gsm8k_tool_config.yaml" \
+    actor_rollout_ref.rollout.multi_turn.interaction_config_path=null \
+    actor_rollout_ref.rollout.agent.num_workers=8 \
+    trainer.n_gpus_per_node=2 \
+    trainer.nnodes=1 \
+    reward_model.enable=False \
+    reward_model.enable_resource_pool=False \
+    checkpoint_dir=PATH_TO_CHECKPOINT \
+    evaluation.max_batches=null \
+    evaluation.max_samples=null \
+    output.path=./eval_results \
+    output.scores_path=evaluation_scores.json \
+    $@
+

--- a/verl/trainer/config/multiturn_eval.yaml
+++ b/verl/trainer/config/multiturn_eval.yaml
@@ -1,0 +1,93 @@
+# Default component overrides to mirror the PPO trainer structure.
+defaults:
+  - actor@actor_rollout_ref.actor: dp_actor
+  - data@data: legacy_data
+  - rollout@actor_rollout_ref.rollout: rollout
+  - model@actor_rollout_ref.model: hf_model
+  - reward_model@reward_model: dp_reward_model
+  - _self_
+
+# Entry point used by Hydra (matches verl.trainer.main_multiturn_eval:run_multiturn_evaluation).
+_target_: verl.trainer.main_multiturn_eval.run_multiturn_evaluation
+
+# Actor/rollout configuration tweaks for evaluation.
+actor_rollout_ref:
+  hybrid_engine: true
+  actor:
+    ppo_mini_batch_size: 256
+    # This parameter is required for validation but not used during evaluation.
+    ppo_micro_batch_size_per_gpu: 32
+    # This parameter is required for validation but not used during evaluation.
+    ppo_infer_micro_batch_size_per_gpu: 32
+    # This parameter is required for validation but not used during evaluation.
+    ppo_max_token_len_per_gpu: 16384
+    # This parameter is required for validation but not used during evaluation.
+    ppo_infer_max_token_len_per_gpu: 16384
+    # This parameter is required for validation but not used during evaluation.
+
+  rollout:
+    mode: async
+    name: vllm
+
+    multi_turn:
+      enable: true
+      tool_config_path: null
+      interaction_config_path: null
+
+    agent:
+      default_agent_loop: tool_agent
+      num_workers: 8
+
+# Checkpoint configuration for loading trained models.
+# If checkpoint_dir is provided, it will load the model from checkpoint instead of model_path.
+# checkpoint_dir should point to the directory containing global_step_* subdirectories.
+# You can specify a specific checkpoint by setting checkpoint_dir to the full path of a global_step_* folder,
+# or set it to the parent directory to automatically load the latest checkpoint.
+checkpoint_dir: null
+
+# Dataset overrides for offline evaluation.
+data:
+  eval_files: ${data.val_files}
+  shuffle: false
+  return_raw_chat: true
+  need_tools_kwargs: true
+  eval_batch_size: 64
+  dataloader_num_workers: 0
+
+# Reward model configuration (kept for parity with PPO).
+reward_model:
+  enable: false
+  enable_resource_pool: false
+  use_dynamic_bsz: true
+  forward_max_token_len_per_gpu: 16384
+
+# Evaluation-specific runtime knobs.
+evaluation:
+  max_batches: null
+  max_samples: null
+
+# Output file paths for evaluation artifacts.
+output:
+  path: ./eval_results
+  scores_path: evaluation_scores.json
+
+# Minimal trainer section supplying tracing metadata and cluster topology.
+trainer:
+  project_name: verl_multiturn_eval
+  experiment_name: gsm8k_multiturn_eval
+  nnodes: 1
+  n_gpus_per_node: 8
+  use_legacy_worker_impl: auto
+
+# Optional custom reward hook (same schema as PPO trainer).
+custom_reward_function:
+  path: null
+  name: compute_score
+
+# Ray initialization arguments (merged with PPO defaults at runtime).
+ray_kwargs:
+  ray_init:
+    num_cpus: 8
+    num_gpus: ${trainer.n_gpus_per_node}
+    runtime_env: {}
+  timeline_json_file: null

--- a/verl/trainer/main_multiturn_eval.py
+++ b/verl/trainer/main_multiturn_eval.py
@@ -1,0 +1,876 @@
+"""
+Multi-turn tool call evaluation module for batch processing of tool-use conversations.
+Independent from PPO training, supports batch reading, tool calling, and reward recording.
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import hydra
+import numpy as np
+import pandas as pd
+import ray
+from omegaconf import DictConfig, OmegaConf
+from torchdata.stateful_dataloader import StatefulDataLoader
+from tqdm import tqdm
+
+os.environ["NCCL_DEBUG"] = "WARN"
+os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+from verl import DataProto
+from verl.experimental.agent_loop import AgentLoopManager
+from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
+from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
+from verl.single_controller.ray.base import create_colocated_worker_cls
+from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
+from verl.trainer.main_ppo import create_rl_dataset, create_rl_sampler
+from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
+from verl.trainer.ppo.reward import load_reward_manager
+from verl.utils import hf_processor, hf_tokenizer
+from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
+from verl.utils.dataset.rl_dataset import collate_fn
+from verl.utils.fs import copy_to_local
+from verl.workers.fsdp_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker, RewardModelWorker
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+@hydra.main(config_path="config", config_name="multiturn_eval", version_base=None)
+def main(config: DictConfig):
+    """Main entry point for multi-turn evaluation with Hydra configuration."""
+    run_multiturn_evaluation(config)
+
+
+def initialize_ray_cluster(config: DictConfig):
+    """Initialize Ray with the same runtime env defaults used during training."""
+    if ray.is_initialized():
+        logger.info("Ray is already initialized, skipping initialization")
+        return
+
+    ray_kwargs = config.get("ray_kwargs", {}) or {}
+    ray_init_kwargs = ray_kwargs.get("ray_init", {})
+    runtime_env_cfg = ray_init_kwargs.get("runtime_env", {})
+    default_runtime_env = get_ppo_ray_runtime_env()
+    runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_cfg)
+    ray_init_with_env = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
+    ray_init_dict = OmegaConf.to_container(ray_init_with_env, resolve=True)
+    print(f"ray init dict: {ray_init_dict}")
+
+    # Check if we're connecting to an existing cluster and remove resource specifications
+    # to avoid conflicts when connecting to existing Ray clusters
+    try:
+        ray.init(**ray_init_dict)
+    except:
+        _remove_num_resources(ray_init_dict)
+        logger.info(
+            "Connecting to existing Ray cluster detected, removing num_cpus/num_gpus from init parameters"
+        )
+        print(f"ray init dict: {ray_init_dict}")
+        ray.init(**ray_init_dict)
+
+    logger.info("Initialized Ray cluster with config: %s", ray_init_dict)
+
+
+def _remove_num_resources(ray_init_dict: Dict[str, Any]) -> None:
+    """Remove num_cpus and num_gpus from the init dict when connecting to another Ray cluster."""
+    for key in ("num_cpus", "num_gpus"):
+        ray_init_dict.pop(key, None)
+
+
+def load_tokenizer_and_processor(config: DictConfig):
+    """Load tokenizer/processor based on actor rollout model configuration."""
+    model_cfg = config.actor_rollout_ref.model
+    local_model_path = copy_to_local(model_cfg.path, use_shm=model_cfg.get("use_shm", False))
+    tokenizer_path = model_cfg.get("tokenizer_path") or local_model_path
+    trust_remote_code = model_cfg.get("trust_remote_code", False)
+
+    tokenizer = hf_tokenizer(tokenizer_path, trust_remote_code=trust_remote_code)
+    processor = None
+    # For multi-modal models, try to auto-enable processor when not explicitly requested.
+    # Text-only models may not ship a processor; we ignore failures unless the user forced it on.
+    use_processor_cfg = model_cfg.get("use_processor", None)
+    if use_processor_cfg is not False:
+        try:
+            processor = hf_processor(tokenizer_path, trust_remote_code=trust_remote_code, use_fast=True)
+            if use_processor_cfg is None:
+                # Make downstream components aware that processor is available.
+                model_cfg.use_processor = True
+        except Exception as e:
+            if use_processor_cfg:
+                # Explicitly requested but failed to load -> surface the error.
+                raise
+            logger.info("Processor not found for model %s, running in text-only mode. (%s)", tokenizer_path, e)
+
+    chat_template = model_cfg.get("custom_chat_template") or model_cfg.get("chat_template")
+    if chat_template:
+        tokenizer.chat_template = chat_template
+        if processor:
+            processor.chat_template = chat_template
+
+    return tokenizer, processor
+
+
+def _resolve_eval_files(data_cfg: DictConfig):
+    eval_files = data_cfg.get("eval_files")
+    if eval_files is None:
+        eval_files = data_cfg.get("val_files")
+    if eval_files is None:
+        eval_files = data_cfg.get("train_files")
+    if eval_files is None:
+        raise ValueError("Please provide data.eval_files (or val/train files) for evaluation.")
+    return eval_files
+
+
+def create_eval_dataloader(config: DictConfig, tokenizer, processor):
+    """Create RL dataset/dataloader that matches the PPO training pipeline."""
+    data_cfg = config.data
+    eval_files = _resolve_eval_files(data_cfg)
+    dataset = create_rl_dataset(eval_files, data_cfg, tokenizer, processor, is_train=False)
+    sampler = create_rl_sampler(data_cfg, dataset)
+
+    batch_size = (
+        data_cfg.get("eval_batch_size")
+        or data_cfg.get("val_batch_size")
+        or data_cfg.get("train_batch_size")
+    )
+    if batch_size is None:
+        raise ValueError("Set data.eval_batch_size (or val/train batch size) for evaluation.")
+
+    dataloader = StatefulDataLoader(
+        dataset=dataset,
+        batch_size=batch_size,
+        num_workers=data_cfg.get("dataloader_num_workers", 0),
+        drop_last=False,
+        shuffle=False,
+        sampler=sampler,
+        collate_fn=collate_fn,
+    )
+    return dataset, dataloader
+
+
+def ensure_batch_uids(batch: DataProto):
+    """Attach unique ids to each sample if they are missing."""
+    if "uid" not in batch.non_tensor_batch:
+        batch.non_tensor_batch["uid"] = np.array(
+            [str(uuid.uuid4()) for _ in range(len(batch.batch))],
+            dtype=object,
+        )
+
+
+def _maybe_patch_device_mesh() -> str:
+    """
+    Torch 2.8.0 DeviceMesh does not expose `_dim_group_names`, but
+    FSDP2 sharded load path in torch.distributed assumes it exists.
+    Add a lightweight compatibility property so checkpoint loading
+    does not crash on AttributeError. Some backends (e.g., sglang)
+    also assign to this field when creating sub-meshes, so we expose
+    a setter backed by a private attribute.
+    """
+    try:
+        from torch.distributed.device_mesh import DeviceMesh
+    except Exception as e:  # pragma: no cover - defensive
+        return f"skip:torch_import_failed:{e}"
+
+    if hasattr(DeviceMesh, "_dim_group_names"):
+        return "skip:already_patched"
+
+    _BACKING_ATTR = "_dim_group_names_backing"
+
+    def _dim_group_names_getter(self):
+        if hasattr(self, _BACKING_ATTR):
+            return getattr(self, _BACKING_ATTR)
+        infos = getattr(self, "_dim_group_infos", None)
+        if infos is not None:
+            names = []
+            for idx, info in enumerate(infos):
+                name = getattr(info, "name", None)
+                if name is None:
+                    mesh_dims = getattr(self, "mesh_dim_names", None)
+                    name = mesh_dims[idx] if mesh_dims and idx < len(mesh_dims) else None
+                names.append(name)
+            return names
+
+        mesh_dims = getattr(self, "mesh_dim_names", None)
+        return list(mesh_dims) if mesh_dims is not None else []
+
+    def _dim_group_names_setter(self, value):
+        setattr(self, _BACKING_ATTR, value)
+
+    DeviceMesh._dim_group_names = property(_dim_group_names_getter, _dim_group_names_setter)
+    return "patched"
+
+
+def _patch_device_mesh_on_workers(actor_rollout_wg: RayWorkerGroup, extra_group_names: Optional[List[str]] = None):
+    """Apply the DeviceMesh compatibility patch inside all rollout workers."""
+    try:
+        import ray
+    except Exception:  # pragma: no cover - defensive
+        return
+
+    extra_group_names = extra_group_names or []
+
+    def _register_device_mesh_process_groups(worker_container):
+        """Register simple named process groups (fsdp/ddp/sp etc.) to default WORLD group."""
+        try:
+            import torch.distributed as dist
+            from torch.distributed.distributed_c10d import _get_group_size_by_name, _register_process_group
+        except Exception as e:  # pragma: no cover - defensive
+            return [f"skip:dist_import_failed:{e}"]
+
+        if not dist.is_initialized():
+            return ["skip:dist_not_initialized"]
+
+        def _register_for_worker(worker):
+            results = []
+            meshes = []
+            if hasattr(worker, "device_mesh"):
+                meshes.append(getattr(worker, "device_mesh"))
+            ulysses_mesh = getattr(worker, "ulysses_device_mesh", None)
+            if ulysses_mesh is not None:
+                meshes.append(ulysses_mesh)
+
+            for mesh in meshes:
+                if mesh is None:
+                    continue
+                names = getattr(mesh, "mesh_dim_names", None) or getattr(mesh, "_dim_group_names", None) or []
+                names = list(names) if names else []
+                # Merge extra group names (e.g., infer_tp for sglang) to ensure registration.
+                for extra_name in extra_group_names:
+                    if extra_name and extra_name not in names:
+                        names.append(extra_name)
+                if not names:
+                    names = ["fsdp"]
+                for name in names:
+                    if not name:
+                        continue
+                    try:
+                        _get_group_size_by_name(name)
+                        results.append(f"skip:exists:{name}")
+                        continue
+                    except Exception:
+                        pass
+                    try:
+                        _register_process_group(name, dist.group.WORLD)
+                        results.append(f"registered:{name}")
+                    except Exception as e:  # pragma: no cover - defensive
+                        results.append(f"error:register:{name}:{e}")
+            return results
+
+        if hasattr(worker_container, "worker_dict"):
+            all_results = []
+            for sub_worker in worker_container.worker_dict.values():
+                all_results.extend(_register_for_worker(sub_worker))
+            return all_results
+        return _register_for_worker(worker_container)
+
+    def _patch_and_register(worker_container):
+        patch_status = _maybe_patch_device_mesh()
+        register_result = _register_device_mesh_process_groups(worker_container)
+        return {"patch": patch_status, "register": register_result}
+
+    patch_results = ray.get(
+        [
+            worker.__ray_call__.remote(lambda self: _patch_and_register(self))  # type: ignore[misc]
+            for worker in actor_rollout_wg.workers
+        ]
+    )
+    logger.warning("DeviceMesh patch/register results: %s", patch_results)
+
+
+def _apply_rollout_backend_patches(config: DictConfig, actor_rollout_wg: RayWorkerGroup):
+    """
+    Apply backend-specific distributed patches based on rollout engine.
+    vllm: only local compatibility patch (no worker registration).
+    sglang: apply worker-side patch + registration since sub-mesh names
+            (e.g., infer_tp) must be registered.
+    default: safe local patch only.
+    """
+    rollout_name = str(config.actor_rollout_ref.rollout.get("name", "")).lower()
+    if rollout_name == "sglang":
+        _patch_device_mesh_on_workers(actor_rollout_wg, extra_group_names=["infer_tp", "tp"])
+        _maybe_patch_device_mesh()
+    elif rollout_name == "vllm":
+        # vllm uses FSDP checkpoint loading on workers; ensure worker classes see the patch too.
+        _patch_device_mesh_on_workers(actor_rollout_wg)
+        _maybe_patch_device_mesh()
+    else:
+        _maybe_patch_device_mesh()
+
+
+def prepare_generation_batch(batch: DataProto, async_mode: bool) -> DataProto:
+    """Subset the batch to the tensors required by rollout workers."""
+    reward_model_keys = {"data_source", "reward_model", "extra_info", "uid"}
+    batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
+    non_tensor_keys_to_pop = [k for k in batch.non_tensor_batch.keys() if k not in reward_model_keys]
+    gen_batch = batch.pop(batch_keys=batch_keys_to_pop, non_tensor_batch_keys=non_tensor_keys_to_pop)
+    if async_mode:
+        # AgentLoop needs access to metadata (tool specs, etc.) on each request.
+        gen_batch.non_tensor_batch.update(batch.non_tensor_batch)
+    return gen_batch
+
+
+def load_checkpoint_if_needed(config: DictConfig, actor_rollout_wg: RayWorkerGroup):
+    """Load checkpoint if checkpoint_dir is specified in config.
+    
+    This function loads model weights from a checkpoint directory, similar to how
+    ray_trainer.py loads checkpoints during training resume.
+    
+    Note on checkpoint_dir vs model.path:
+    - model.path is ALWAYS required for loading tokenizer and processor
+    - checkpoint_dir is OPTIONAL: if provided, model weights will be loaded from checkpoint
+      (overriding the initial weights loaded from model.path during init_model)
+    - If checkpoint_dir is None, model weights will come from model.path (original model evaluation)
+    
+    Args:
+        config: Configuration object containing checkpoint_dir
+        actor_rollout_wg: Actor rollout worker group to load checkpoint into
+        
+    Raises:
+        ValueError: If checkpoint_dir is invalid or checkpoint not found
+    """
+    checkpoint_dir = config.get("checkpoint_dir")
+    if checkpoint_dir is None:
+        logger.info("No checkpoint_dir specified, using model weights from model.path (original model)")
+        return
+    
+    # Resolve checkpoint directory path
+    if not os.path.isabs(checkpoint_dir):
+        working_dir = os.getcwd()
+        checkpoint_dir = os.path.join(working_dir, checkpoint_dir)
+    
+    # Check if checkpoint_dir points to a specific global_step_* folder or parent directory
+    if "global_step_" in checkpoint_dir:
+        # Direct path to a specific checkpoint
+        global_step_folder = checkpoint_dir
+        if not os.path.isabs(global_step_folder):
+            working_dir = os.getcwd()
+            global_step_folder = os.path.join(working_dir, global_step_folder)
+    else:
+        # Parent directory, find latest checkpoint
+        global_step_folder = find_latest_ckpt_path(checkpoint_dir)
+        if global_step_folder is None:
+            raise ValueError(
+                f"No checkpoint found in {checkpoint_dir}. "
+                f"Please ensure the directory contains global_step_* subdirectories "
+                f"or specify the full path to a specific checkpoint."
+            )
+    
+    logger.info(f"Loading checkpoint from: {global_step_folder}")
+    
+    # Extract global step number for logging
+    if "global_step_" in global_step_folder:
+        try:
+            global_step = int(global_step_folder.split("global_step_")[-1])
+            logger.info(f"Checkpoint global step: {global_step}")
+        except ValueError:
+            logger.warning(f"Could not parse global step from path: {global_step_folder}")
+    
+    # Construct actor checkpoint path (same structure as ray_trainer.py)
+    actor_path = os.path.join(global_step_folder, "actor")
+    if not os.path.exists(actor_path):
+        raise ValueError(
+            f"Actor checkpoint not found at {actor_path}. "
+            f"Expected checkpoint structure: {global_step_folder}/actor/"
+        )
+    
+    # Load checkpoint (del_local_after_load=False for evaluation)
+    logger.info(f"Loading actor checkpoint from: {actor_path}")
+    try:
+        actor_rollout_wg.load_checkpoint(actor_path, del_local_after_load=False)
+    except RuntimeError as e:
+        # Torch 2.8 FSDP may fail if named process groups were not registered.
+        if "process group" in str(e) and "fsdp" in str(e).lower():
+            logger.warning("Checkpoint load hit process group error, retrying after registering device mesh groups.")
+            _patch_device_mesh_on_workers(actor_rollout_wg)
+            actor_rollout_wg.load_checkpoint(actor_path, del_local_after_load=False)
+        else:
+            raise
+    logger.info("Checkpoint loaded successfully")
+
+
+def initialize_worker_groups(
+    config: DictConfig,
+) -> tuple[AgentLoopManager | RayWorkerGroup, RayWorkerGroup, Optional[RayWorkerGroup]]:
+    """Create rollout (and optional reward) workers using the same logic as PPO training."""
+
+    rollout_cfg = config.actor_rollout_ref.rollout
+    actor_strategy = config.actor_rollout_ref.actor.strategy
+    if actor_strategy in {"fsdp", "fsdp2"}:
+        actor_worker_cls = AsyncActorRolloutRefWorker if rollout_cfg.mode == "async" else ActorRolloutRefWorker
+    elif actor_strategy == "megatron":
+        from verl.workers.megatron_workers import ActorRolloutRefWorker as MegaActorWorker
+        from verl.workers.megatron_workers import AsyncActorRolloutRefWorker as MegaAsyncActorWorker
+
+        actor_worker_cls = MegaAsyncActorWorker if rollout_cfg.mode == "async" else MegaActorWorker
+    else:
+        raise NotImplementedError(f"Unsupported actor strategy: {actor_strategy}")
+
+    role_worker_mapping = {Role.ActorRollout: ray.remote(actor_worker_cls)}
+
+    reward_wg_cls = None
+    if config.reward_model.enable:
+        use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+        if use_legacy_worker_impl in ["auto", "enable"]:
+            if config.reward_model.strategy in {"fsdp", "fsdp2"}:
+                reward_worker_impl = RewardModelWorker
+            elif config.reward_model.strategy == "megatron":
+                from verl.workers.megatron_workers import RewardModelWorker as MegatronRewardWorker
+
+                reward_worker_impl = MegatronRewardWorker
+            else:
+                raise NotImplementedError(f"Unsupported reward strategy: {config.reward_model.strategy}")
+        elif use_legacy_worker_impl == "disable":
+            from verl.workers.roles import RewardModelWorker as NewRewardWorker
+
+            reward_worker_impl = NewRewardWorker
+            logger.info("Using new reward worker implementation")
+        else:
+            raise ValueError(f"Invalid use_legacy_worker_impl: {use_legacy_worker_impl}")
+
+        reward_wg_cls = ray.remote(reward_worker_impl)
+        role_worker_mapping[Role.RewardModel] = reward_wg_cls
+
+    trainer_cfg = config.get("trainer", {})
+    n_gpus_per_node = trainer_cfg.get("n_gpus_per_node", 1)
+    nnodes = trainer_cfg.get("nnodes", 1)
+    global_pool_id = "global_pool"
+    resource_pool_spec = {global_pool_id: [n_gpus_per_node] * nnodes}
+    mapping = {Role.ActorRollout: global_pool_id}
+
+    if config.reward_model.enable:
+        if config.reward_model.enable_resource_pool:
+            if config.reward_model.n_gpus_per_node <= 0 or config.reward_model.nnodes <= 0:
+                raise ValueError("reward_model resource pool sizes must be positive.")
+            reward_pool_id = "reward_pool"
+            resource_pool_spec[reward_pool_id] = [config.reward_model.n_gpus_per_node] * config.reward_model.nnodes
+            mapping[Role.RewardModel] = reward_pool_id
+        else:
+            mapping[Role.RewardModel] = global_pool_id
+
+    resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
+    resource_pool_manager.create_resource_pool()
+    resource_pool_to_cls = {pool: {} for pool in resource_pool_manager.resource_pool_dict.values()}
+
+    actor_pool = resource_pool_manager.get_resource_pool(Role.ActorRollout)
+    actor_cls = RayClassWithInitArgs(
+        cls=role_worker_mapping[Role.ActorRollout],
+        config=config.actor_rollout_ref,
+        role="actor_rollout",
+    )
+    resource_pool_to_cls[actor_pool]["actor_rollout"] = actor_cls
+
+    if config.reward_model.enable:
+        rm_pool = resource_pool_manager.get_resource_pool(Role.RewardModel)
+        rm_cls = RayClassWithInitArgs(role_worker_mapping[Role.RewardModel], config=config.reward_model)
+        resource_pool_to_cls[rm_pool]["rm"] = rm_cls
+
+    all_wg = {}
+    for resource_pool, class_dict in resource_pool_to_cls.items():
+        worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
+        wg_dict = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=worker_dict_cls)
+        spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
+        all_wg.update(spawn_wg)
+
+    actor_rollout_wg = all_wg["actor_rollout"]
+    actor_rollout_wg.init_model()
+
+    reward_wg = None
+    if config.reward_model.enable:
+        reward_wg = all_wg["rm"]
+        reward_wg.init_model()
+
+    if rollout_cfg.mode == "async":
+        agent_loop_handle = AgentLoopManager(config=config, worker_group=actor_rollout_wg, rm_wg=reward_wg)
+    else:
+        agent_loop_handle = actor_rollout_wg
+
+    return agent_loop_handle, actor_rollout_wg, reward_wg
+
+
+def _determine_size_divisor(actor_rollout_wg: RayWorkerGroup, config: DictConfig, async_mode: bool) -> int:
+    if not async_mode:
+        return actor_rollout_wg.world_size
+    agent_cfg = config.actor_rollout_ref.rollout.agent
+    return max(1, agent_cfg.get("num_workers", 1))
+
+
+def run_generation_step(
+    agent_handle: AgentLoopManager | RayWorkerGroup,
+    actor_rollout_wg: RayWorkerGroup,
+    batch: DataProto,
+    tokenizer,
+    config: DictConfig,
+) -> tuple[DataProto, float]:
+    async_mode = isinstance(agent_handle, AgentLoopManager)
+    gen_batch = prepare_generation_batch(batch, async_mode)
+    gen_batch.meta_info["eos_token_id"] = tokenizer.eos_token_id
+    gen_batch.meta_info["pad_token_id"] = tokenizer.pad_token_id
+    gen_batch.meta_info["recompute_log_prob"] = False
+    gen_batch.meta_info["validate"] = True
+    val_kwargs = config.actor_rollout_ref.rollout.get("val_kwargs", None)
+    if val_kwargs and val_kwargs.get("do_sample") is not None:
+        gen_batch.meta_info["do_sample"] = val_kwargs.do_sample
+
+    size_divisor = _determine_size_divisor(actor_rollout_wg, config, async_mode)
+    gen_batch_padded, pad_size = pad_dataproto_to_divisor(gen_batch, size_divisor)
+    start = time.time()
+    if async_mode:
+        output_padded = agent_handle.generate_sequences(prompts=gen_batch_padded)
+    else:
+        # sglang sync path uses a decorator that expects the batch as the first positional arg.
+        output_padded = agent_handle.generate_sequences(gen_batch_padded)
+    generation_time = time.time() - start
+    timing = output_padded.meta_info.pop("timing", None)
+    if timing:
+        logger.debug("Generation timing stats: %s", timing)
+    output_batch = unpad_dataproto(output_padded, pad_size=pad_size)
+    return output_batch, generation_time
+
+
+def compute_reward_outputs(batch: DataProto, reward_wg: Optional[RayWorkerGroup], reward_fn):
+    """Compute reward outputs for evaluation batch.
+    
+    Args:
+        batch: DataProto containing prompts and responses
+        reward_wg: Optional reward model worker group
+        reward_fn: Reward manager function
+        
+    Returns:
+        Tuple of (scores list, reward_result dict)
+    """
+    if reward_wg is not None:
+        reward_tensor = reward_wg.compute_rm_score(batch)
+        batch = batch.union(reward_tensor)
+    
+    if reward_fn is None:
+        batch_size = batch.batch["attention_mask"].shape[0]
+        scores = [0.0] * batch_size
+        return scores, {"reward_tensor": None, "reward_extra_info": {}}
+    
+    try:
+        reward_result = reward_fn(batch, return_dict=True)
+        reward_tensor = reward_result.get("reward_tensor")
+        if reward_tensor is None:
+            batch_size = batch.batch["attention_mask"].shape[0]
+            scores = [0.0] * batch_size
+        else:
+            scores = reward_tensor.sum(-1).detach().cpu().tolist()
+    except Exception as e:
+        logger.warning(f"Error in reward_fn: {e}, using zero rewards")
+        batch_size = batch.batch["attention_mask"].shape[0]
+        scores = [0.0] * batch_size
+        try:
+            # Fallback to non-dict return
+            reward_tensor = reward_fn(batch)
+            if reward_tensor is not None:
+                scores = reward_tensor.sum(-1).detach().cpu().tolist()
+            reward_result = {"reward_tensor": reward_tensor, "reward_extra_info": {}}
+        except Exception as e2:
+            logger.error(f"Error in reward_fn fallback: {e2}")
+            reward_result = {"reward_tensor": None, "reward_extra_info": {}}
+    
+    return scores, reward_result
+
+def collect_sample_records(
+    combined_batch: DataProto,
+    generation_time: float,
+    reward_scores: List[float],
+    reward_result: Dict[str, Any],
+    rollout_metrics: Optional[List[Dict[str, Any]]],
+    tokenizer,
+):
+    prompts = tokenizer.batch_decode(combined_batch.batch["prompts"], skip_special_tokens=True)
+    responses = tokenizer.batch_decode(combined_batch.batch["responses"], skip_special_tokens=True)
+    sample_ids = combined_batch.non_tensor_batch["uid"].tolist()
+    num_turns = combined_batch.non_tensor_batch.get("__num_turns__", np.ones(len(responses), dtype=np.int32))
+    reward_extra = reward_result.get("reward_extra_info", {})
+
+    # Extract tool_rewards and interaction_rewards from non_tensor_batch
+    # For agent loop: extra_fields contains "tool_rewards" (list) and "turn_scores" (list)
+    # For sglang rollout: reward_scores contains tool_reward_scores (dict) and user_turn_rewards (list)
+    tool_rewards_list = combined_batch.non_tensor_batch.get("tool_rewards", None)
+    turn_scores_list = combined_batch.non_tensor_batch.get("turn_scores", None)
+    reward_scores_dict = combined_batch.non_tensor_batch.get("reward_scores", None)
+
+    records = []
+    for idx, sample_id in enumerate(sample_ids):
+        record = {
+            "sample_id": sample_id,
+            "prompt": prompts[idx],
+            "response": responses[idx],
+            "sample_score": reward_scores[idx],
+            "num_turns": int(num_turns[idx]) if len(num_turns) else 0,
+            "generation_time": generation_time,
+        }
+        
+        # Extract tool_rewards (from agent loop extra_fields)
+        if tool_rewards_list is not None and idx < len(tool_rewards_list):
+            tool_rewards = tool_rewards_list[idx]
+            if isinstance(tool_rewards, (list, np.ndarray)):
+                record["tool_rewards"] = list(tool_rewards) if isinstance(tool_rewards, np.ndarray) else tool_rewards
+            else:
+                record["tool_rewards"] = tool_rewards
+        
+        # Extract interaction_rewards/turn_scores (from agent loop extra_fields)
+        if turn_scores_list is not None and idx < len(turn_scores_list):
+            turn_scores = turn_scores_list[idx]
+            if isinstance(turn_scores, (list, np.ndarray)):
+                record["interaction_rewards"] = list(turn_scores) if isinstance(turn_scores, np.ndarray) else turn_scores
+            else:
+                record["interaction_rewards"] = turn_scores
+        
+        # Extract tool_rewards and user_turn_rewards (from sglang rollout reward_scores)
+        if reward_scores_dict is not None and idx < len(reward_scores_dict):
+            reward_scores_item = reward_scores_dict[idx]
+            if isinstance(reward_scores_item, dict):
+                # Extract tool_reward_scores (dict with tool names as keys)
+                tool_reward_scores = {k: v for k, v in reward_scores_item.items() if k != "user_turn_rewards"}
+                if tool_reward_scores:
+                    record["tool_rewards"] = tool_reward_scores
+                # Extract user_turn_rewards (list)
+                if "user_turn_rewards" in reward_scores_item:
+                    user_turn_rewards = reward_scores_item["user_turn_rewards"]
+                    if isinstance(user_turn_rewards, (list, np.ndarray)):
+                        record["interaction_rewards"] = list(user_turn_rewards) if isinstance(user_turn_rewards, np.ndarray) else user_turn_rewards
+                    else:
+                        record["interaction_rewards"] = user_turn_rewards
+        
+        if rollout_metrics and idx < len(rollout_metrics):
+            record["agent_metrics"] = rollout_metrics[idx]
+        for key, values in reward_extra.items():
+            if len(values) > idx:
+                record[f"reward_extra.{key}"] = values[idx]
+        records.append(record)
+    return records
+
+
+def compute_response_lengths(responses, pad_token_id: Optional[int], eos_token_id: Optional[int]) -> List[int]:
+    """Compute per-response lengths using EOS/pad cutoffs when available."""
+    if responses is None:
+        return []
+    responses_np = responses.cpu().numpy() if hasattr(responses, "cpu") else np.array(responses)
+    lengths: List[int] = []
+    for row in responses_np:
+        row_list = row.tolist()
+        cutoffs = []
+        if pad_token_id is not None:
+            try:
+                cutoffs.append(int(row_list.index(pad_token_id)))
+            except ValueError:
+                pass
+        if eos_token_id is not None:
+            try:
+                cutoffs.append(int(row_list.index(eos_token_id) + 1))
+            except ValueError:
+                pass
+        length = min(cutoffs) if cutoffs else len(row_list)
+        lengths.append(max(length, 0))
+    return lengths
+
+
+def aggregate_summary(
+    sample_scores: List[float],
+    generation_times: List[float],
+    reward_times: List[float],
+    response_lengths: List[int],
+) -> Dict[str, Any]:
+    """You can add more metrics here."""
+    total_samples = len(sample_scores)
+    return {
+        "total_samples": total_samples,
+        "mean_sample_score": float(np.mean(sample_scores)) if sample_scores else 0.0,
+        "std_sample_score": float(np.std(sample_scores)) if sample_scores else 0.0,
+        "total_generation_time": float(sum(generation_times)),
+        "total_reward_time": float(sum(reward_times)),
+        "avg_generation_time_per_sample": float(np.mean(generation_times)) if generation_times else 0.0,
+        "avg_reward_time_per_sample": float(np.mean(reward_times)) if reward_times else 0.0,
+        "mean_response_length": float(np.mean(response_lengths)) if response_lengths else 0.0,
+        "std_response_length": float(np.std(response_lengths)) if response_lengths else 0.0,
+        "max_response_length": int(np.max(response_lengths)) if response_lengths else 0,
+        "min_response_length": int(np.min(response_lengths)) if response_lengths else 0,
+    }
+
+
+def append_results_to_file(records: List[Dict[str, Any]], scores_path: Path, is_first_batch: bool):
+    """Append records to output file incrementally to avoid memory overflow.
+    
+    Args:
+        records: List of record dictionaries to append
+        scores_path: Path to the output file
+        is_first_batch: Whether this is the first batch (determines write mode)
+    """
+    if not records:
+        return
+    
+    if scores_path.suffix == ".parquet":
+        # For parquet, use pandas append mode
+        df = pd.DataFrame(records)
+        if is_first_batch:
+            df.to_parquet(scores_path, index=False, engine='pyarrow')
+        else:
+            # Append to existing parquet file
+            existing_df = pd.read_parquet(scores_path)
+            combined_df = pd.concat([existing_df, df], ignore_index=True)
+            combined_df.to_parquet(scores_path, index=False, engine='pyarrow')
+    elif scores_path.suffix == ".jsonl":
+        # JSONL format: append line by line (recommended for large datasets)
+        mode = 'w' if is_first_batch else 'a'
+        with open(scores_path, mode, encoding='utf-8') as f:
+            for record in records:
+                f.write(json.dumps(record, ensure_ascii=False) + '\n')
+    else:
+        # JSON format: append to array (less efficient for large files)
+        if is_first_batch:
+            with open(scores_path, 'w', encoding='utf-8') as f:
+                json.dump(records, f, indent=2, ensure_ascii=False)
+        else:
+            # Read existing, append, and write back
+            with open(scores_path, 'r', encoding='utf-8') as f:
+                existing_records = json.load(f)
+            existing_records.extend(records)
+            with open(scores_path, 'w', encoding='utf-8') as f:
+                json.dump(existing_records, f, indent=2, ensure_ascii=False)
+
+
+def save_summary(metrics: Dict[str, Any], config: DictConfig):
+    """Save evaluation summary at the end of evaluation.
+    
+    Args:
+        metrics: Summary metrics dictionary
+        config: Configuration object
+    """
+    output_dir = Path(config.output.path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary_path = output_dir / "evaluation_summary.json"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(metrics, f, indent=2)
+    logger.info("Saved evaluation summary to %s", summary_path)
+
+
+def run_multiturn_evaluation(config: DictConfig):
+    """Main entry that mirrors PPO rollout but skips optimization."""
+    logger.info("Starting multi-turn evaluation...")
+    logger.info("Configuration:\n%s", OmegaConf.to_yaml(config))
+
+    initialize_ray_cluster(config)
+    tokenizer, processor = load_tokenizer_and_processor(config)
+    _, dataloader = create_eval_dataloader(config, tokenizer, processor)
+    agent_handle, actor_rollout_wg, reward_wg = initialize_worker_groups(config)
+
+    # Backend-specific distributed patches (e.g., sglang needs DeviceMesh group registration)
+    _apply_rollout_backend_patches(config, actor_rollout_wg)
+
+    # Load checkpoint if checkpoint_dir is specified
+    # Note: checkpoint_dir and model.path are NOT mutually exclusive:
+    # - model.path is still needed for tokenizer/processor loading
+    # - checkpoint_dir is used to load model weights (overrides initial weights from model.path)
+    load_checkpoint_if_needed(config, actor_rollout_wg)
+    # Patch again after checkpoint load in case distributed state was initialized lazily.
+    _apply_rollout_backend_patches(config, actor_rollout_wg)
+
+    reward_kwargs = config.reward_model.get("reward_kwargs", {})
+    reward_fn = load_reward_manager(config, tokenizer, num_examine=1, **reward_kwargs)
+
+    eval_cfg = config.get("evaluation", {})
+    max_batches = eval_cfg.get("max_batches")
+    max_samples = eval_cfg.get("max_samples")
+
+    # Prepare output paths
+    output_dir = Path(config.output.path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    scores_path = None
+    if config.output.get("scores_path"):
+        scores_path = output_dir / config.output.scores_path
+        # Remove existing file if present
+        if scores_path.exists():
+            scores_path.unlink()
+            logger.info("Removed existing scores file: %s", scores_path)
+
+    # Keep only metrics in memory, not full records
+    sample_scores: List[float] = []
+    generation_times: List[float] = []
+    reward_times: List[float] = []
+    response_lengths: List[int] = []
+    
+    consumed_samples = 0
+    progress = tqdm(total=len(dataloader), desc="Batches", disable=len(dataloader) == 0)
+
+    try:
+        for batch_idx, batch_dict in enumerate(dataloader):
+            if max_batches is not None and batch_idx >= max_batches:
+                break
+
+            batch = DataProto.from_single_dict(batch_dict)
+            ensure_batch_uids(batch)
+            
+            generation_output, generation_time = run_generation_step(
+                agent_handle=agent_handle,
+                actor_rollout_wg=actor_rollout_wg,
+                batch=batch,
+                tokenizer=tokenizer,
+                config=config,
+            )
+            combined_batch = batch.union(generation_output)
+            combined_batch.meta_info["validate"] = True
+
+            scores, reward_result = compute_reward_outputs(combined_batch, reward_wg, reward_fn)
+            per_sample_gen_time = (generation_time / len(scores)) if scores else 0.0
+            reward_time = reward_result.get("reward_time", 0.0)
+            per_sample_reward_time = (reward_time / len(scores)) if scores else 0.0
+
+            sample_records = collect_sample_records(
+                combined_batch=combined_batch,
+                generation_time=per_sample_gen_time,
+                reward_scores=scores,
+                reward_result=reward_result,
+                rollout_metrics=generation_output.meta_info.get("metrics"),
+                tokenizer=tokenizer,
+            )
+            
+            # Write results incrementally to avoid memory overflow
+            if scores_path:
+                is_first_batch = (batch_idx == 0)
+                append_results_to_file(sample_records, scores_path, is_first_batch)
+                if is_first_batch:
+                    logger.info("Started writing results to %s", scores_path)
+            
+            # Only keep metrics in memory
+            sample_scores.extend(scores)
+            generation_times.extend([per_sample_gen_time] * len(scores))
+            reward_times.extend([per_sample_reward_time] * len(scores))
+            lengths = compute_response_lengths(
+                responses=combined_batch.batch.get("responses"),
+                pad_token_id=tokenizer.pad_token_id,
+                eos_token_id=tokenizer.eos_token_id,
+            )
+            if lengths:
+                response_lengths.extend(lengths)
+
+            consumed_samples += len(scores)
+            if max_samples is not None and consumed_samples >= max_samples:
+                break
+            progress.update(1)
+    finally:
+        progress.close()
+
+    if scores_path:
+        logger.info("Finished writing all results to %s", scores_path)
+
+    summary_metrics = aggregate_summary(sample_scores, generation_times, reward_times, response_lengths)
+    save_summary(summary_metrics, config)
+    logger.info("Multi-turn evaluation completed!")
+    logger.info("Summary metrics: %s", json.dumps(summary_metrics, indent=2))
+
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

  - Purpose: reuse the training AgentLoop rollout for single-run multi-turn eval without
    PPO, decoupling eval from training.
  - How to run: vLLM async GSM8K example script with key Hydra knobs, outputs, and
    checkpoint handling.
  - Checkpoints: supports loading FSDP/FSDP2 training checkpoints via built-in
    DeviceMesh/process-group compatibility patches.
  - Validated scenarios: GSM8K, Geo3K, and multimodal; async + vLLM with TP1/TP2 all
    pass on FSDP checkpoints.
  - Extensibility: add custom metrics via aggregate_summary / collect_sample_records or
    AgentLoop agent_metrics.
  - Note: sglang TP compatibility is still missing (tp=1 fails, multi-TP untested); to
    be fixed later.
  - No source code changes—documentation-only addition.
  
  
  ## Reviewer Notes

  - Please skim the new doc for correctness of run instructions and limitations.