### PR TITLE
[megatron] feat: optimize the mbridge checkpoint saving speed

### DIFF
--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -499,7 +499,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 log_with_rank(f"Saving HF model checkpoint to {local_path} with bridge", rank=self.rank, logger=logger)
                 hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
                 if self.vanilla_bridge:
-                    self.bridge.save_weights(self.model, hf_ckpt_path)
+                    self.bridge.save_weights(
+                        self.model, hf_ckpt_path, distributed_filesystem=True, memory_efficient=True
+                    )
                 else:
                     self.bridge.save_hf_weights(self.model, hf_ckpt_path)
 
@@ -569,7 +571,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             if self.bridge is not None:
                 hf_model_ckpt_path = get_hf_model_checkpoint_path(local_path)
                 if self.vanilla_bridge:
-                    self.bridge.save_weights(self.model, hf_model_ckpt_path)
+                    self.bridge.save_weights(
+                        self.model, hf_model_ckpt_path, distributed_filesystem=True, memory_efficient=True
+                    )
                 else:
                     self.bridge.save_hf_weights(self.model, hf_model_ckpt_path)
             else:


### PR DESCRIPTION
adopt mbridge's fast saving API https://github.com/ISEEKYAN/mbridge/blob/main/mbridge/core/bridge.py#L302-L303, which will reduce the saving time of large models a lot.

In my test, the deepseek 671B saving time is under 2 minutes