### PR TITLE
[recipe] fix: fully_async_ppo_trainer hydra search path

### DIFF
--- a/recipe/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
+++ b/recipe/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
@@ -1,6 +1,6 @@
 hydra:
   searchpath:
-    - file://verl/trainer/config
+    - pkg://verl.trainer.config
 
 defaults:
   - ppo_megatron_trainer

--- a/recipe/fully_async_policy/config/fully_async_ppo_trainer.yaml
+++ b/recipe/fully_async_policy/config/fully_async_ppo_trainer.yaml
@@ -1,6 +1,6 @@
 hydra:
   searchpath:
-    - file://verl/trainer/config
+    - pkg://verl.trainer.config
 
 defaults:
   - ppo_trainer


### PR DESCRIPTION
### What does this PR do?

Fixes a `In 'fully_async_ppo_trainer': Could not load 'ppo_trainer'.` error currently raised when using `fully_async_ppo_trainer.yaml`, which currently reads:

```yaml
# In recipe/fully_async_policy/config/fully_async_ppo_trainer.yaml
hydra:                          
  searchpath:                   
    - file://verl/trainer/config

defaults:
  - ppo_trainer
  - _self_
[...]
```
IIUC, the error is cause by `ppo_trainer.yaml` being under `verl/trainer/config/ppo_trainer.yaml` which isn't found for the relative path `file://verl/trainer/config`. This PR switches to a path relative to the entire `verl` package, eliminating the error.

Let me know if I'm misunderstanding something here.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: I searched for `fully_async_ppo_trainer`.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

The config error goes away after this change. 

Before:
```
In 'fully_async_ppo_trainer': Could not load 'ppo_trainer'.

Config search path:
        provider=hydra, path=pkg://hydra.conf
        provider=main, path=file:///proj/data-eng/goon/garrett361/experiment-runner/experiments/skywork-rebase-dev/verl/recipe/fully_async_policy/config
        provider=hydra.searchpath in main, path=file://verl/trainer/config
        provider=schema, path=structured://
[...]
```

After:
```
2025-12-03 01:39:29,656 INFO worker.py:1696 -- Using address localhost:6379 set in the environment variable RAY_ADDRESS
2025-12-03 01:39:29,662 INFO worker.py:1837 -- Connecting to existing Ray cluster at address: 9.33.173.188:6379...
2025-12-03 01:39:29,674 INFO worker.py:2014 -- Connected to Ray cluster. View the dashboard at 127.0.0.1:8265
/proj/data-eng/goon/garrett361/experiment-runner/experiments/skywork-rebase-dev/.venv/lib/python3.10/site-packages/ray/_private/worker.py:2062: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
(FullyAsyncTaskRunner pid=2257283) [ASYNC MAIN] Starting fully async PPO training...
[...]
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: A little confused about this, since it seems like this should be covered by
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
