### PR TITLE
[recipe] feat: add fully async comm between rollout and sim node in disagg mode

### DIFF
--- a/recipe/vla/run_simpleVLA_isaac_disagg.sh
+++ b/recipe/vla/run_simpleVLA_isaac_disagg.sh
@@ -99,7 +99,7 @@ $PYTHON -m recipe.vla.main_ppo \
     +trainer.n_rollout_gpus_per_node=$NUM_ROLLOUT_GPUS \
     trainer.nnodes=$NUM_NODES \
     trainer.save_freq=30 \
-    trainer.test_freq=30 \
+    trainer.test_freq=-1 \
     trainer.total_epochs=20 \
     trainer.val_only=False \
     trainer.total_training_steps=10000 \

--- a/recipe/vla/workers/env/env_worker.py
+++ b/recipe/vla/workers/env/env_worker.py
@@ -163,7 +163,7 @@ class EnvWorker(Worker):
         state_ids = self.simulator_list[0].get_all_state_ids()
         return state_ids
 
-    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="env"))
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="env"), blocking=False)
     def reset_envs_to_state_ids(self, data: DataProto):
         """Reset environments to specified state IDs.
 


### PR DESCRIPTION

### What does this PR do?

This PR provides a new feature on VLA recipe, fully async communication between rollout and simulation nodes in disaggregate mode. This PR allows two overlap optimization:

1. Overlapping between simulation tool **reset** and rollout weights **update**. Now we can reset the simulation status and update actor_rollout weights simultaneously, without sync wait.
  *This feature saves costs close to 8-step execution time.*

2. Overlapping **communication** between simulation steps and rollout steps, aka eliminating the transfer overhead among nodes. Now in each step, different pipeline stages (see PR #3918 ) will be executed independently, thus there will be no sync waits among stages, so that the relatively longer steps (simulation steps currently) can be executed continuously.
  *This feature saves about 12% costs in each VLA RL step, depending on actual execution time of simulation steps.*

**Details about communication overlapping**
- At first our disaggregate mode on VLA show workflows as follow:
![img_v3_02sm_7be54524-8d37-4380-a4d2-fb871837d64g](https://github.com/user-attachments/assets/f21244b1-1d4e-4bac-82d3-4a40008c6ca2)
  - As in disaggregate mode, rollout steps are executed on local nodes and simulation steps are executed on remote nodes.
  - Low GPU utilization, lots of resources are wasted.

- So we implement the pipeline execute mode in PR #3918 , then the workflow (2 stages for instance) shows as follows:
![img_v3_02sm_d398e0bb-ed08-4eaf-ae4d-53d6b9f1343g](https://github.com/user-attachments/assets/084e21d1-6224-4cce-8e0c-026e4f8e733c)
  - We can see that the rollout steps (R) and simulation steps (S) are executed partially overlapped (pipeline stage 0 and 1), and simulation steps take much longer time than rollout ones.
  - There are still parts of wasted time (unnecessary data transfer delays) because of the sequential workflow. The reason is shown as follows: 
  ![img_v3_02sm_abd3887d-1220-43b6-af16-fcf357d20c3g](https://github.com/user-attachments/assets/c9493870-0934-4478-a8cf-7b9928f580f1)
  - The sync waits among pipeline stages cannot be eliminated due to sequential workflow: although steps are executed in various nodes, they need to be synchronized after each step, which causes communication cost and is unnecessary.
 
- Then we implemented async communication pipelines to overlap the communication time by different execution time between rollout and simulation steps. The workflows and execution results are shown as follows:
![img_v3_02sm_60b64952-ed9c-40c5-8665-2187e21112fg](https://github.com/user-attachments/assets/074caaeb-8cfe-4b75-8de3-9e73f8c7d02e)

---
### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

```shell
# you can use `ray.timeline` tool for profiling in recipe/vla/main_ppo.py
bash recipe/vla/run_simpleVLA_isaac_disagg.sh
```

Profile results of reset overlapping
<img width="1420" height="232" alt="image" src="https://github.com/user-attachments/assets/dd98ea70-fa3f-4938-a02e-a44f64a0d1e9" />


Profile results of communication overlapping
<img width="1058" height="228" alt="image" src="https://github.com/user-attachments/assets/a9274864-ccd4-42f9-b5c4-1277bc0c1317" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
