### PR TITLE
[worker] feat: support pass addition func in worker_init

### DIFF
--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -184,7 +184,7 @@ class Worker(WorkerHelper):
             get_visible_devices_keyword().upper(),
         ]
 
-    def __init__(self, cuda_visible_devices=None) -> None:
+    def __init__(self, cuda_visible_devices=None, **kwargs) -> None:
         """Initialize the worker with environment settings and device configuration.
 
         Args:
@@ -224,6 +224,11 @@ class Worker(WorkerHelper):
         self.fused_worker_dict = {}
         self.__dispatch_dp_rank = {}
         self.__collect_dp_rank = {}
+
+        if kwargs.get("addition_funcs", None) is not None:
+            for func in kwargs["addition_funcs"]:
+                func(config=kwargs.get("config", None))
+                print(f"Addition func {func} applied.")
 
     def get_fused_worker_by_name(self, worker_name: str):
         """Get a fused worker by its name.

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -57,8 +57,8 @@ class TrainingWorker(Worker):
     and do not provide exact APIs as Tinker does. But this can be added in the future.
     """
 
-    def __init__(self, config: TrainingWorkerConfig):
-        Worker.__init__(self)
+    def __init__(self, config: TrainingWorkerConfig, **kwargs):
+        Worker.__init__(self, **kwargs)
 
         from verl.workers.engine import BaseEngine, EngineRegistry
 
@@ -220,9 +220,9 @@ class ActorWorker(Worker, DistProfilerExtension):
     or a hybrid engine based on the config.rollout
     """
 
-    def __init__(self, config: ActorConfig):
+    def __init__(self, config: ActorConfig, **kwargs):
         self.config = config
-        Worker.__init__(self)
+        Worker.__init__(self, **kwargs)
         self.profiler_config = self.config.profiler
         tool_config = self.profiler_config.tool_config
         DistProfilerExtension.__init__(
@@ -375,9 +375,9 @@ class CriticWorker(Worker, DistProfilerExtension):
     or a hybrid engine based on the config.rollout
     """
 
-    def __init__(self, config: CriticConfig):
+    def __init__(self, config: CriticConfig, **kwargs):
         self.config = config
-        Worker.__init__(self)
+        Worker.__init__(self, **kwargs)
         self.profiler_config = self.config.profiler
         tool_config = self.profiler_config.tool_config
         DistProfilerExtension.__init__(
@@ -546,7 +546,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     """
 
     def __init__(self, config: DictConfig, role: str, **kwargs):
-        Worker.__init__(self)
+        Worker.__init__(self, **kwargs)
         self.config = config
         self.role = role
         self.actor: ActorWorker = None

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -138,7 +138,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     """
 
     def __init__(self, config: DictConfig, role: str, **kwargs):
-        Worker.__init__(self)
+        Worker.__init__(self, **kwargs)
 
         self.config = config
         import torch.distributed
@@ -1137,8 +1137,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
 
 class CriticWorker(Worker, DistProfilerExtension):
-    def __init__(self, config: FSDPCriticConfig):
-        Worker.__init__(self)
+    def __init__(self, config: FSDPCriticConfig, **kwargs):
+        Worker.__init__(self, **kwargs)
         omega_profiler_config = config.get("profiler", {})
         profiler_config = omega_conf_to_dataclass(omega_profiler_config, dataclass_type=ProfilerConfig)
         if omega_profiler_config.get("tool", None) in ["npu", "nsys", "torch", "torch_memory"]:
@@ -1578,8 +1578,8 @@ class RewardModelWorker(Worker, DistProfilerExtension):
     Note that we only implement the reward model that is subclass of AutoModelForTokenClassification.
     """
 
-    def __init__(self, config):
-        Worker.__init__(self)
+    def __init__(self, config, **kwargs):
+        Worker.__init__(self, **kwargs)
 
         omega_profiler_config = config.get("profiler", {})
         profiler_config = omega_conf_to_dataclass(omega_profiler_config, dataclass_type=ProfilerConfig)

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -235,7 +235,7 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
     """
 
     def __init__(self, config: DictConfig, role: str, **kwargs):
-        Worker.__init__(self)
+        Worker.__init__(self, **kwargs)
         self.config = config
         if repatch is not None:
             # NPU MindSpeed patch, will be refactored with MindSpeedEngine.
@@ -983,8 +983,8 @@ class AsyncActorRolloutRefWorker(ActorRolloutRefWorker):
 
 
 class CriticWorker(MegatronWorker, DistProfilerExtension):
-    def __init__(self, config: McoreCriticConfig):
-        Worker.__init__(self)
+     def __init__(self, config: McoreCriticConfig, **kwargs):
+        Worker.__init__(self, **kwargs)
 
         omega_profiler_config = config.get("profiler", {})
         profiler_config = omega_conf_to_dataclass(omega_profiler_config, dataclass_type=ProfilerConfig)
@@ -1283,8 +1283,8 @@ class RewardModelWorker(MegatronWorker, DistProfilerExtension):
     Note that we only implement the reward model that is subclass of AutoModelForSequenceClassification.
     """
 
-    def __init__(self, config):
-        Worker.__init__(self)
+    def __init__(self, config, **kwargs):
+        Worker.__init__(self, **kwargs)
 
         profiler_config = omega_conf_to_dataclass(config.get("profiler", {}), dataclass_type=ProfilerConfig)
         omega_profiler_config = config.get("profiler", {})


### PR DESCRIPTION
### What does this PR do?

This PR implements support for passing additional functions during worker initialization. The main goal is to enhance the extensibility of the worker system by allowing execution of user-defined functions during worker initialization.

### Checklist Before Starting

pass

### Test

pass

### API and Usage Example

pass

### Design & Code Changes

To support new model architectures and model conversions, we need to add interfaces at the worker level to runtime register new fields for some dict in verl.

for example, we can use like this:
```python
from xxx import register_new_model_func
trainer.addition_funcs = [register_new_model_func]
...
actor_rollout_cls = RayClassWithInitArgs(
    cls=self.role_worker_mapping[actor_role],
    config=self.config.actor_rollout_ref,
    role=str(actor_role),
    addition_funcs=getattr(self, "addition_funcs", None)
)
```

### Checklist Before Submitting

pass
