### PR TITLE
[fsdp] fix: optimize model updating in rollout mode in LoRA training with FSDP

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -919,7 +919,7 @@ class RayPPOTrainer:
         """Start profiling for all worker groups if profiling is enabled."""
         if do_profile:
             self.actor_rollout_wg.start_profile(role="e2e", profile_step=self.global_steps)
-            if self.use_reference_policy:
+            if self.use_reference_policy and not self.ref_in_actor:
                 self.ref_policy_wg.start_profile(profile_step=self.global_steps)
             if self.use_critic:
                 self.critic_wg.start_profile(profile_step=self.global_steps)
@@ -930,7 +930,7 @@ class RayPPOTrainer:
         """Stop profiling for all worker groups if profiling is enabled."""
         if do_profile:
             self.actor_rollout_wg.stop_profile()
-            if self.use_reference_policy:
+            if self.use_reference_policy and not self.ref_in_actor:
                 self.ref_policy_wg.stop_profile()
             if self.use_critic:
                 self.critic_wg.stop_profile()

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -628,9 +628,7 @@ def collect_lora_params(module: FSDP, layered_summon: bool, base_sync_done: bool
         else:
             if base_sync_done:
                 lora_params = get_peft_model_state_dict(peft_model)
-                lora_params = {
-                    name: param for name, param in lora_params.items()
-                }
+                lora_params = {name: param for name, param in lora_params.items()}
             else:
                 for name, submodule in module.named_modules():
                     if fsdp_version(submodule) > 0 and name.startswith("_fsdp_wrapped_module.base_model"):
@@ -638,8 +636,10 @@ def collect_lora_params(module: FSDP, layered_summon: bool, base_sync_done: bool
                 for name, param in module.state_dict().items():
                     if any(x in name for x in ["_flat_param", "lora_"]):
                         continue
-                    name = name.replace("_fsdp_wrapped_module.", "").replace(".base_layer", "").replace(
-                        "base_model.model.", ""
+                    name = (
+                        name.replace("_fsdp_wrapped_module.", "")
+                        .replace(".base_layer", "")
+                        .replace("base_model.model.", "")
                     )
                     lora_params[name] = param
             get_torch_device().empty_cache()

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -626,29 +626,22 @@ def collect_lora_params(module: FSDP, layered_summon: bool, base_sync_done: bool
                 )
             lora_params = layered_summon_lora_params(module)
         else:
-            with FSDP.summon_full_params(module, writeback=False):
-                if base_sync_done:
-                    lora_params = get_peft_model_state_dict(peft_model)
-                    lora_params = {
-                        name: param.full_tensor().detach().cpu()
-                        if hasattr(param, "full_tensor")
-                        else param.detach().cpu()
-                        for name, param in lora_params.items()
-                    }
-                else:
-                    model = peft_model.base_model.model
-                    orig_dev = "cpu" if "cpu" in str(next(model.parameters()).device) else get_device_name()
-                    model = model.to("cpu")
-                    for name, param in model.state_dict().items():
-                        if any(x in name for x in ["_flat_param", "lora_"]):
-                            continue
-                        name = name.replace("_fsdp_wrapped_module.", "").replace(".base_layer", "")
-                        lora_params[name] = (
-                            param.full_tensor().detach().cpu()
-                            if hasattr(param, "full_tensor")
-                            else param.detach().cpu()
-                        )
-                    model = model.to(orig_dev)
+            if base_sync_done:
+                lora_params = get_peft_model_state_dict(peft_model)
+                lora_params = {
+                    name: param for name, param in lora_params.items()
+                }
+            else:
+                for name, submodule in module.named_modules():
+                    if fsdp_version(submodule) > 0 and name.startswith("_fsdp_wrapped_module.base_model"):
+                        submodule._is_root = False
+                for name, param in module.state_dict().items():
+                    if any(x in name for x in ["_flat_param", "lora_"]):
+                        continue
+                    name = name.replace("_fsdp_wrapped_module.", "").replace(".base_layer", "").replace(
+                        "base_model.model.", ""
+                    )
+                    lora_params[name] = param
             get_torch_device().empty_cache()
     else:
         if base_sync_done:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -699,15 +699,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         log_gpu_memory_usage("After offload_fsdp_model_to_cpu", logger=logger)
 
         set_expandable_segments(False)
+        device = get_device_id()
 
-        if peft_config is not None and self.base_sync_done:
-            per_tensor_param = params.items() if isinstance(params, dict) else params  # Fixed: handle dict case
-        else:
-            device = get_device_id()  # used when fsdp2 set cpu_offload_policy
-            per_tensor_param = (
-                (name, param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param)
-                for name, param in params.items()
-            )
+        per_tensor_param = (
+            (name, param.to(device, non_blocking=True).full_tensor() if isinstance(param, DTensor) else param)
+            for name, param in params.items()
+        )
 
         if self.config.rollout.free_cache_engine:
             await self.rollout.resume(tags=["weights"])

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -243,7 +243,7 @@ class vLLMAsyncRollout(BaseRollout):
                 lora_tensors=dict(weights),
             )
             self.inference_engine.worker.add_lora(lora_request)
-            logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
+            logger.info("vLLM load lora weights")
         else:
             from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 


### PR DESCRIPTION
### What does this PR do?

Lora training is much slower than full training under the same experiment setup. Just as https://github.com/volcengine/verl/issues/4033, https://github.com/volcengine/verl/issues/4085, https://github.com/volcengine/verl/issues/4055.

From the ray timeline and tensorboard, it seems that the main time discrepancy does not occur during the `generate sequence`, but rather during the switching of `rollout_mode`.

tensorboard:
<img width="1364" height="752" alt="image" src="https://github.com/user-attachments/assets/00f6e054-3e7c-495c-870e-964adc535e38" />
<img width="1246" height="706" alt="image" src="https://github.com/user-attachments/assets/af080faa-0984-4537-83d7-2c1dd0276ac6" />


full:
<img width="1204" height="272" alt="image" src="https://github.com/user-attachments/assets/b6c7b600-4530-4161-a3d9-c971e6279e7e" />

lora:
<img width="1408" height="358" alt="image" src="https://github.com/user-attachments/assets/fbf2f7dd-1b99-4ffb-9942-2c651b4d687e" />

While dived into the code, I found that in version 0.6.1, when the vLLM version is greater than 0.8.5, the default SLEEP_LEVEL is changed to 2, causing the base_model to be reloaded every time rollout_mode is called, which is time-consuming

```Python
elif vs.parse(package_version) >= vs.parse("0.7.0"):
    vllm_version = package_version
    if vs.parse(package_version) >= vs.parse("0.8.5"):
        VLLM_SLEEP_LEVEL = 2
    from vllm import LLM
    from vllm.distributed import parallel_state
```

In `rollout_mode`, when using full training,  `fsdp_module.state_dict()` can be used directly. However, in the LoRA case, the `collect_lora_param` function first summons the parameters and then moves them to the CPU. I think this is time-consuming and unnecessary. 
https://github.com/volcengine/verl/blob/v0.6.1/verl/workers/fsdp_workers.py#L672
https://github.com/volcengine/verl/blob/v0.6.1/verl/utils/fsdp_utils.py#L629

So I modify the lora weight updating schema in this pr.

### Test

Run experiments in both fsdp and fsdp2 with Qwen2.5-7b in gsm8k datasets. The results are as belowed：
- qwen25_7b_lora_fsdp2_async： fsdp2 + lora + fix-code
- qwen25_7b_lora_fsdp_async: fsdp + lora + fix-code
- qwen25_7b_lora_fsdp2_async_old: fsdp2 + lora + current-code
- qwen25_7b_lora_fsdp_async_old: fsdp + lora + current-code
- qwen25_7b_full_fsdp2_async: fsdp2 + full + current-code, for comparsion.

The reward function's curve aligns with expectations, while the training time per step has been significantly reduced.

training_reward:
<img width="1322" height="800" alt="image" src="https://github.com/user-attachments/assets/87dd40cc-b4d7-4e2d-a45c-3a1c3a4331f4" />
val_reward:
<img width="846" height="446" alt="image" src="https://github.com/user-attachments/assets/27f2bdc3-c738-46d9-9f17-356c5d0d0362" />

timing/generate_sequence:
<img width="828" height="834" alt="image" src="https://github.com/user-attachments/assets/5e96866c-75a7-4899-b4aa-f239e4361091" />

timing/gen (with time of rollout mode)
<img width="1156" height="696" alt="image" src="https://github.com/user-attachments/assets/cb85cd17-0eee-422f-a8c5-6eb9791ec125" />

timing/step
<img width="914" height="890" alt="image" src="https://github.com/user-attachments/assets/c4946bbf-338d-41ec-af42-46231a16392b" />



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
