### PR TITLE
[metric] calculate rollout actor probs kl divergence

### DIFF
--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -59,6 +59,13 @@ def calculate_log_prob_diff(log_probs1: torch.Tensor, log_probs2: torch.Tensor, 
     full_diff = torch.abs(log_probs1 - log_probs2)
     return torch.masked_select(full_diff, mask)
 
+def calculate_rollout_actor_probs_kl_divergence(rollout_probs: torch.Tensor, rollout_old_log_probs: torch.Tensor, actor_old_log_probs: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    # implemention of https://arxiv.org/pdf/2512.01374
+    rollout_probs = torch.masked_select(rollout_probs, mask)
+    rollout_old_log_probs = torch.masked_select(rollout_old_log_probs, mask)
+    actor_old_log_probs = torch.masked_select(actor_old_log_probs, mask)
+    result = rollout_probs * (rollout_old_log_probs - actor_old_log_probs)
+    return result.mean().detach().item()
 
 def calculate_debug_metrics(data: DataProto) -> dict:
     """
@@ -78,6 +85,7 @@ def calculate_debug_metrics(data: DataProto) -> dict:
             "training/rollout_probs_diff_mean": mean value of logprob diff of rollout vs. actor
             "training/rollout_probs_diff_std": std value of logprob diff of rollout vs. actor
             "training/rollout_actor_probs_pearson_corr": logprob's pearson corrcoef of rollout vs. actor, reference to https://arxiv.org/pdf/2506.13585
+             "training/rollout_actor_probs_kl_divergence": kl divergence of rollout vs. actor, reference to https://arxiv.org/pdf/2512.01374
     """
 
     rollout_old_log_probs = data.batch["rollout_log_probs"]
@@ -100,10 +108,12 @@ def calculate_debug_metrics(data: DataProto) -> dict:
     response_mask_bool = response_mask.bool()
     pearson_corrcoef = pearson_correlation_coefficient(actor_probs, rollout_probs, response_mask_bool)
     rollout_probs_diff = calculate_log_prob_diff(actor_probs, rollout_probs, response_mask_bool)
+    kl_divergence = calculate_rollout_actor_probs_kl_divergence(rollout_probs, rollout_old_log_probs, actor_old_log_probs, response_mask_bool)
     return {
         "training/rollout_probs_diff_valid": 1,
         "training/rollout_probs_diff_max": torch.max(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_mean": torch.mean(rollout_probs_diff).detach().item(),
         "training/rollout_probs_diff_std": torch.std(rollout_probs_diff).detach().item(),
         "training/rollout_actor_probs_pearson_corr": pearson_corrcoef,
+        "training/rollout_actor_probs_kl_divergence": kl_divergence,
     }

--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -59,7 +59,7 @@ def calculate_log_prob_diff(log_probs1: torch.Tensor, log_probs2: torch.Tensor, 
     full_diff = torch.abs(log_probs1 - log_probs2)
     return torch.masked_select(full_diff, mask)
 
-def calculate_rollout_actor_probs_kl_divergence(rollout_probs: torch.Tensor, rollout_old_log_probs: torch.Tensor, actor_old_log_probs: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+def calculate_rollout_actor_probs_kl_divergence(rollout_probs: torch.Tensor, rollout_old_log_probs: torch.Tensor, actor_old_log_probs: torch.Tensor, mask: torch.Tensor) -> float:
     # implemention of https://arxiv.org/pdf/2512.01374
     rollout_probs = torch.masked_select(rollout_probs, mask)
     rollout_old_log_probs = torch.masked_select(rollout_old_log_probs, mask)

--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -61,11 +61,11 @@ def calculate_log_prob_diff(log_probs1: torch.Tensor, log_probs2: torch.Tensor, 
 
 def calculate_rollout_actor_probs_kl_divergence(rollout_probs: torch.Tensor, rollout_old_log_probs: torch.Tensor, actor_old_log_probs: torch.Tensor, mask: torch.Tensor) -> float:
     # implemention of https://arxiv.org/pdf/2512.01374
-    rollout_probs = torch.masked_select(rollout_probs, mask)
-    rollout_old_log_probs = torch.masked_select(rollout_old_log_probs, mask)
-    actor_old_log_probs = torch.masked_select(actor_old_log_probs, mask)
-    result = rollout_probs * (rollout_old_log_probs - actor_old_log_probs)
-    return result.mean().detach().item()
+    kl_terms = rollout_probs * (rollout_old_log_probs - actor_old_log_probs)
+    masked_kl_terms = torch.masked_select(kl_terms, mask)
+    if masked_kl_terms.numel() == 0:
+        return 0.0
+    return masked_kl_terms.mean().detach().item()
 
 def calculate_debug_metrics(data: DataProto) -> dict:
     """


### PR DESCRIPTION
### What does this PR do?
> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.
<img width="403" height="269" alt="image" src="https://github.com/user-attachments/assets/c390c34f-dfe7-402c-8a43-67e9a986f010" />

add kl divergence metric of rollout vs. actor, reference to https://arxiv.org/pdf/2512.01374
### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
