### PR TITLE
[megatron] fix: correct typo in modeling_qwen2_megatron.py

### DIFF
--- a/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
+++ b/verl/models/qwen2/megatron/modeling_qwen2_megatron.py
@@ -583,7 +583,7 @@ class ParallelQwen2ForCausalLMRmPadPP(nn.Module):
     def setup_embeddings_and_output_layer(self) -> None:
         """Sets up embedding layer in first stage and output layer in last stage.
 
-        This function initalizes word embeddings in the final stage when we are
+        This function initializes word embeddings in the final stage when we are
         using pipeline parallelism and sharing word embeddings, and sets up param
         attributes on the embedding and output layers.
         """


### PR DESCRIPTION
### What does this PR do?

> This PR corrects a spelling error in the docstring of the `setup_embeddings_and_output_layer` method within `verl/models/qwen2/megatron/modeling_qwen2_megatron.py`. Specifically, it changes `initalizes` to `initializes`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+typo+modeling_qwen2_megatron
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - Title: `[megatron] fix: correct typo in modeling_qwen2_megatron.py`

### Test

> This is a trivial documentation fix (docstring only) and does not affect runtime logic.
> - Visual inspection of the change.

### API and Usage Example

> N/A - This change only affects internal code documentation.

### Design & Code Changes

> **Modifications:**
> - `verl/models/qwen2/megatron/modeling_qwen2_megatron.py`: Fixed typo `initalizes` -> `initializes`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (N/A)
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Trivial docstring fix.
- [] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).