### PR TITLE
add system_prompt support to SFTDataset

### DIFF
--- a/verl/trainer/config/sft_trainer.yaml
+++ b/verl/trainer/config/sft_trainer.yaml
@@ -13,8 +13,10 @@ data:
   # Single-turn settings
   prompt_key: question
   response_key: answer
+  system_prompt_key: null
   prompt_dict_keys: null
   response_dict_keys: null
+  system_prompt_dict_keys: null
   # Multi-turn settings
   multiturn:
     enable: false  # Set to true to use multi-turn dataset


### PR DESCRIPTION


### What does this PR do?

   Add system_prompt_key and system_prompt_dict_keys configuration options to enable system prompts in SFT training. The dataset now extracts system prompts from parquet files and includes them in the chat template with the "system" role.

   Changes:
   - Add system_prompt_key and system_prompt_dict_keys to sft_trainer.yaml config
   - Extract system prompts in _read_files_and_tokenize method
   - Include system prompts in chat template when applying tokenization
