### PR TITLE
[algo] fix: Add seq mean mask denominator option

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -781,6 +781,9 @@ def agg_loss(
     """
     Aggregate the loss across global batch to ensure the loss is invariant to fsdp/megatron parallelism.
 
+    NOTE: ``dp_size``, ``batch_num_tokens``, and ``global_batch_size`` are only compatible with the new model engine
+        for now, while the legacy model engines conduct the aggregation outside ``agg_loss``.
+
     NOTE: The returned loss has different behaviors for different backend:
     - FSDP: the loss is directly used for backward.
     - Megatron: the loss should be scaled by `num_microbatches` and `cp_size` for pp schedule.

--- a/verl/workers/actor/megatron_actor.py
+++ b/verl/workers/actor/megatron_actor.py
@@ -479,11 +479,6 @@ class MegatronPPOActor(BasePPOActor):
 
                 entropy_coeff = self.config.entropy_coeff
                 loss_agg_mode = self.config.loss_agg_mode
-
-                # Populate global_batch_info for loss aggregation
-                self.config.global_batch_info["dp_size"] = data.get("dp_size", 1)
-                self.config.global_batch_info["global_batch_size"] = data.get("global_batch_size", None)
-
                 loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
 
                 policy_loss_fn = get_policy_loss_fn(loss_mode)
@@ -522,12 +517,7 @@ class MegatronPPOActor(BasePPOActor):
             if calculate_entropy:
                 entropy = output["entropy"][:, -response_length - 1 : -1].contiguous()
                 if not forward_only:
-                    entropy_loss = agg_loss(
-                        loss_mat=entropy,
-                        loss_mask=response_mask,
-                        loss_agg_mode=loss_agg_mode,
-                        **self.config.global_batch_info,
-                    )
+                    entropy_loss = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
                     entropy_coeff = meta_info["entropy_coeff"]
                     policy_loss = pg_loss - entropy_coeff * entropy_loss
                 else:
@@ -540,12 +530,7 @@ class MegatronPPOActor(BasePPOActor):
                     ref_log_prob = data["ref_log_prob"]
                     # compute kl loss
                     kld = kl_penalty(logprob=log_prob, ref_logprob=ref_log_prob, kl_penalty=self.config.kl_loss_type)
-                    kl_loss = agg_loss(
-                        loss_mat=kld,
-                        loss_mask=response_mask,
-                        loss_agg_mode=self.config.loss_agg_mode,
-                        **self.config.global_batch_info,
-                    )
+                    kl_loss = agg_loss(loss_mat=kld, loss_mask=response_mask, loss_agg_mode=self.config.loss_agg_mode)
 
                     policy_loss = policy_loss + kl_loss * self.config.kl_loss_coef
                     metrics["actor/kl_loss"] = kl_loss.detach().item()


### PR DESCRIPTION
## Summary

Refactor `agg_loss` function and fix entropy/KL loss scaling in distributed training.

**Changes:**
- **Refactor**: Unify `seq-mean-*` modes with shared denominator logic using `masked_sum`
- **Behavior change**: `seq-mean-token-sum-norm` now applies seq-mean division (denominator = `global_batch_size * dp_size` or `local_bsz`), matching the mode name
- **Simplification**: Remove fully-masked sequence exclusion from denominator; use total batch size consistently

NOTE: Since the global loss aggregation logic is not compatible with the legacy model engine that conduct the aggregation outside `agg_loss` and is going to be deprecated, we keep this PR from modifying the the legacy model engine.

⚠️ **Breaking**: `seq-mean-token-sum-norm` now divides by both `loss_scale_factor` AND `seq_denominator`. Previously only divided by `loss_scale_factor`.

## Test plan

- [ ] Verify PPO training with `seq-mean-token-sum` mode
- [ ] Verify PPO training with `seq-mean-token-mean` mode  
- [ ] Verify PPO training with `seq-mean-token-sum-norm` mode (note: behavior changed)
- [ ] Confirm entropy/KL loss values are correctly scaled in multi-GPU training
