### PR TITLE
[recipe] fix: Generate wrong token after update weights of SGLang

### DIFF
--- a/recipe/gkd/megatron_workers.py
+++ b/recipe/gkd/megatron_workers.py
@@ -60,10 +60,11 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 class TensorBuffer:
     def __init__(self, memory_alloc, dtype):
-        device = get_device_id()
+        self.device = get_device_id()
         dtype_size = torch.tensor([], dtype=dtype).element_size()
         self.capacity = memory_alloc // dtype_size
-        self.tensor = torch.empty(self.capacity, dtype=dtype, device=device)
+        self.dtype = dtype
+        self.tensor = torch.empty(self.capacity, dtype=self.dtype, device=self.device)
         self.keys = []
         self.shapes = []
 
@@ -74,6 +75,7 @@ class TensorBuffer:
     def clear(self):
         self.keys.clear()
         self.shapes.clear()
+        self.tensor = torch.empty(self.capacity, dtype=self.dtype, device=self.device)
 
     def append(self, key, shape, weight=None):
         if weight is not None:


### PR DESCRIPTION
### What does this PR do?

> fix the garbled rollout after update weights of SGLang. Don't know why it works but it works. Should use with https://github.com/sgl-project/sglang/pull/14486 

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
