### PR TITLE
Enable attention sink support under ulysses sequence-parallel training

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -31,6 +31,7 @@ from verl.utils.ulysses import (
     get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
     slice_input_tensor,
+    get_ulysses_sequence_parallel_rank
 )
 
 
@@ -102,6 +103,17 @@ def _ulysses_flash_attention_forward(
         position_ids_list = [torch.empty_like(position_ids) for _ in range(ulysses_sp_size)]
         torch.distributed.all_gather(position_ids_list, position_ids, group=get_ulysses_sequence_parallel_group())
         position_ids = torch.concat(position_ids_list, dim=-1)
+
+        # ============ Slice per-head parameters, for example attention sink used in gpt-oss ============
+        sp_rank = get_ulysses_sequence_parallel_rank()
+        num_heads_per_gpu = query_states.size(2)  # num_heads // sp_size
+        head_start = sp_rank * num_heads_per_gpu
+        head_end = (sp_rank + 1) * num_heads_per_gpu
+        
+        # Slice s_aux (attention sink per-head parameter)
+        if 's_aux' in kwargs and kwargs['s_aux'] is not None:
+            s_aux = kwargs['s_aux']  # Shape: [n_head]
+            kwargs['s_aux'] = s_aux[head_start:head_end]  # Shape: [n_head/n]
 
     # (bsz, seq_len, n_head/n, head_dim)
     query_length = query_states.size(1)


### PR DESCRIPTION
### What does this PR do?

This PR updates sequence parallelism to be compatible with attention sink mechanisms used in GPT-OSS and other models that rely on attention sinks within the attention layer.

In the current implementation, Ulysses sequence parallelism evenly splits query heads across sequence-parallel ranks, but does not correctly partition the attention sink or assign the corresponding sink parameters to the owning GPUs. This leads to shape inconsistencies during attention computation.

This change ensures that attention sink tensors are split and placed consistently with the associated query heads on each sequence-parallel rank, resolving the shape mismatch and enabling correct attention execution under sequence parallelism.

```
2025-11-24T15:40:09.031Z [36m(TaskRunner pid=16027)[0m out, softmax_lse, *rest = flash_attn_3_cuda.fwd(
2025-11-24T15:40:09.031Z [36m(TaskRunner pid=16027)[0m File "/home/jobuser/.local/lib/python3.10/site-packages/torch/_ops.py", line 1243, in __call__
2025-11-24T15:40:09.031Z [36m(TaskRunner pid=16027)[0m return self._op(*args, **kwargs)
2025-11-24T15:40:09.031Z [36m(TaskRunner pid=16027)[0m RuntimeError: s_aux must have shape (num_heads)
```

A illustration of what this PR does is shown in the diagram here:

<img width="487" height="374" alt="Screenshot 2025-12-16 at 3 27 00 PM" src="https://github.com/user-attachments/assets/690345d0-1c0a-4522-8bdc-66f7ca23683b" />

where we split the attention sink weights also and assign the corresponding sink to the belongings sequence parallel ranks. 

This is one of the steps to support agentic RL training with gpt-oss: https://github.com/volcengine/verl/issues/3794 

Attention sink in FA3 is under review and will be released once being tested.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

On gsm8k, memory is reduced by 2x while the reward converges to the same point as the run without sequence parallel.

Yellow: sp_size = 4
Blue: sp_size = 1

Other hyper parameters:

* 1 node with 8 h200 gpus 
* actor_rollout_ref/actor/ppo_mini_batch_size = 256
* actor_rollout_ref/actor/ppo_micro_batch_size_per_gpu = 32
* data/train_batch_size = 256
* actor_rollout_ref/rollout/prompt_length = 512

<img width="686" height="348" alt="Screenshot 2025-12-16 at 3 41 41 PM" src="https://github.com/user-attachments/assets/2f2f2ff9-c9ed-4bcd-99eb-4c4a5141303c" />

<img width="1380" height="352" alt="Screenshot 2025-12-16 at 3 41 58 PM" src="https://github.com/user-attachments/assets/514a6d3d-c190-40b9-b8fe-1731fa532128" />


Unite test:

```

=============================== warnings summary ============================================================== warnings summary ===============================

tests/models/test_transformers_ulysses.py::test_configstests/models/test_transformers_ulysses.py::test_configs

  /home/jobuser/.local/lib/python3.10/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but tests/models/test_transformers_ulysses.py::test_configs returned [SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 4,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=4, is_valid=True), SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 8,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=2, is_valid=True)], which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(  /home/jobuser/.local/lib/python3.10/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but tests/models/test_transformers_ulysses.py::test_configs returned [SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 4,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=4, is_valid=True), SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 8,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=2, is_valid=True)], which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(



-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

======================== 3 passed, 1 warning in 18.60s ================================================= 3 passed, 1 warning in 18.60s =========================

PASSED

=============================== warnings summary ===============================
tests/models/test_transformers_ulysses.py::test_configs
  /home/jobuser/.local/lib/python3.10/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but tests/models/test_transformers_ulysses.py::test_configs returned [SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 4,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=4, is_valid=True), SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 8,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=2, is_valid=True)], which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 3 passed, 1 warning in 18.91s =========================
PASSED

=============================== warnings summary ===============================
tests/models/test_transformers_ulysses.py::test_configs
  /home/jobuser/.local/lib/python3.10/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but tests/models/test_transformers_ulysses.py::test_configs returned [SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 4,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=4, is_valid=True), SequenceParallelConfig(config=GptOssConfig {
    "attention_bias": true,
    "attention_dropout": 0.0,
    "head_dim": 64,
    "hidden_act": "silu",
    "hidden_size": 3584,
    "initializer_range": 0.02,
    "intermediate_size": 2880,
    "layer_types": [
      "sliding_attention",
      "full_attention"
    ],
    "max_position_embeddings": 131072,
    "model_type": "gpt_oss",
    "num_attention_heads": 32,
    "num_experts_per_tok": 4,
    "num_hidden_layers": 2,
    "num_key_value_heads": 8,
    "num_local_experts": 128,
    "output_router_logits": false,
    "rms_norm_eps": 1e-05,
    "rope_scaling": {
      "beta_fast": 32.0,
      "beta_slow": 1.0,
      "factor": 32.0,
      "original_max_position_embeddings": 4096,
      "rope_type": "yarn",
      "truncate": false
    },
    "rope_theta": 150000.0,
    "router_aux_loss_coef": 0.9,
    "sliding_window": 128,
    "tie_word_embeddings": false,
    "transformers_version": "4.56.0",
    "use_cache": true,
    "vocab_size": 201088
  }
  , sp_size=2, is_valid=True)], which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 3 passed, 1 warning in 18.94s =========================
[rank2]:[W1216 23:08:55.839707775 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank3]:[W1216 23:08:55.841265167 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank0]:[W1216 23:08:55.938162627 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
[rank1]:[W1216 23:08:55.938387584 ProcessGroupNCCL.cpp:1538] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())


```

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
