### PR TITLE
[training_utils] feat: use TMA to load Tiles in linear_cross_entropy kernels

### DIFF
--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -104,3 +104,11 @@ def auto_set_ascend_device_name(config):
                 )
 
             config.trainer.device = "npu"
+
+
+def get_device_capability(device_id: int = 0) -> tuple[int, int]:
+    major, minor = None, None
+    if is_cuda_available:
+        major, minor = torch.cuda.get_device_capability(device_id)
+
+    return major, minor


### PR DESCRIPTION
### What does this PR do?

The triton kernels of linear_cross_entropy iteratively load `hidden` and `weight` block tile by calculating data address explicitly at present, which shows poor performance on Hopper GPU. This PR improve that with the TMA of Hopper to avoid heavy address calculation.

### Test

```
python3 tests/utils/test_linear_cross_entropy.py
```
Latency(ms) improvement of test cases in`test_linear_cross_entropy.py`  on H20 
|case |linear_cross_entropy Forward| linear_cross_entropy Forward with TMA|linear_cross_entropy Backward| linear_cross_entropy Backward with TMA|
|---|---|----|---|----|
|0|129.64|18.83|157.85|56.14|
|1|35.35|6.02|49.91|22.10|
|2|12.28|2.05|16.41|6.63|
|3|71.36|10.29|89.49|31.32|
|4|405.92|56.49|477.97|173.43|

### Design & Code Changes
add `USE_TMA` parameter and use `tl.make_tensor_descriptor` to create desc of TMA in triton kernels if it is enabled


