### PR TITLE
[recipe, VLA] feat: support isaac server mode for multitask libero config

### DIFF
--- a/tests/experimental/vla/test_isaac_server_mode.py
+++ b/tests/experimental/vla/test_isaac_server_mode.py
@@ -1,0 +1,344 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests for Isaac Server Mode.
+
+Tests the server-based simulation approach where Ray Actors manage
+Isaac Lab simulations across multiple GPUs.
+"""
+
+import unittest
+
+import numpy as np
+import pytest
+import ray
+from omegaconf import OmegaConf
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_ray():
+    """Initialize Ray for all tests in this module."""
+    if not ray.is_initialized():
+        # Try to connect to existing Ray cluster
+        try:
+            ray.init(address="auto")
+            print("Connected to existing Ray cluster")
+        except Exception:
+            # Fall back to local mode for testing
+            ray.init(local_mode=True)
+            print("Started Ray in local mode")
+
+    yield
+
+    # Cleanup after all tests
+    # Note: Don't shutdown Ray if it was already running
+    # ray.shutdown()
+
+
+def test_task_balanced_sampler():
+    """
+    Test TaskBalancedSampler for balanced task distribution.
+
+    Verifies that:
+    1. Sampler correctly validates batch_size divisibility
+    2. All tasks are represented in samples
+    3. Proper error handling for invalid configurations
+    """
+    from verl.experimental.vla.workers.env.utils import TaskBalancedSampler
+
+    # Create a mock dataset with task_ids
+    class MockDataset:
+        def __init__(self, num_samples, num_tasks):
+            self.task_ids = [i % num_tasks for i in range(num_samples)]
+            self.data = list(range(num_samples))
+
+        def __len__(self):
+            return len(self.data)
+
+        def __getitem__(self, idx):
+            return {"task_id": self.task_ids[idx], "data": self.data[idx]}
+
+    num_tasks = 10
+    num_samples = 100
+    batch_size = 16
+    max_per_task = 4
+    stage_num = 2
+
+    dataset = MockDataset(num_samples, num_tasks)
+
+    # Test 1: Valid configuration
+    sampler = TaskBalancedSampler(
+        dataset=dataset, batch_size=batch_size, max_per_task=max_per_task, stage_num=stage_num
+    )
+
+    # Verify samples_per_stage
+    assert sampler.samples_per_stage == batch_size // stage_num
+
+    # Get samples
+    sample_indices = list(sampler)
+    assert len(sample_indices) > 0
+
+    # Verify batch size
+    first_batch = sample_indices[:batch_size]
+    assert len(first_batch) == batch_size
+
+    # Test 2: Invalid configuration - batch_size not divisible by stage_num
+    with pytest.raises(AssertionError, match="batch_size .* must be divisible by stage_num"):
+        TaskBalancedSampler(
+            dataset=dataset,
+            batch_size=15,
+            max_per_task=max_per_task,
+            stage_num=2,  # 15 not divisible by 2
+        )
+
+    print("✓ TaskBalancedSampler test passed")
+
+
+def test_isaac_server_manager_creation():
+    """
+    Test IsaacServerManager creation and initialization.
+
+    Note: This test requires Isaac Sim environment to be properly configured.
+    """
+    # pytest.skip("Requires Isaac Sim environment - run manually in Isaac container")
+
+    from verl.experimental.vla.isaac_server import IsaacServerManager
+
+    num_stages = 2
+    num_servers_per_stage = 2
+    num_tasks = 4
+    group_size = 8
+
+    manager = IsaacServerManager(
+        num_stages=num_stages,
+        num_servers_per_stage=num_servers_per_stage,
+        num_tasks=num_tasks,
+        group_size=group_size,
+        env_id="Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0",
+        render_last_only=True,
+        camera_height=256,
+        camera_width=256,
+        accelerator_type="sim",
+    )
+
+    # Initialize servers
+    success = manager.initialize()
+    assert success, "Failed to initialize IsaacServerManager"
+
+    # Verify server count
+    assert len(manager.servers) == num_stages
+    for stage_servers in manager.servers:
+        assert len(stage_servers) == num_servers_per_stage
+
+    print(f"✓ IsaacServerManager created with {num_stages} stages, {num_servers_per_stage} servers per stage")
+
+
+def test_isaac_server_rollout_loop():
+    """
+    Test complete generation-simulation loop with Isaac Server Mode.
+
+    This is a full integration test that verifies:
+    1. EnvLoop initialization with isaac_server_mode
+    2. Environment worker and server creation
+    3. Environment reset
+    4. Action generation (mocked)
+    5. Environment step execution
+    6. Observation/reward/termination handling
+    7. Proper cleanup
+
+    Requires:
+    - Ray cluster with 'sim' resources available
+    - Isaac Sim environment properly configured
+    """
+    from verl import DataProto
+    from verl.experimental.vla.env_loop import EnvLoop
+    from verl.experimental.vla.workers.env import EnvWorkerServer
+    from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+
+    # Test configuration - small scale for fast testing
+    num_stages = 2
+    num_servers = 4  # Total Isaac servers across all stages
+    num_tasks = 4
+    group_size = 8  # Envs per task
+    num_envs = 8  # Envs per worker (in server mode, this is per-stage batch size)
+    total_trajs = num_stages * num_envs
+    num_action_chunks = 8
+    action_dim = 7
+
+    config = OmegaConf.create(
+        {
+            "env": {
+                "rollout": {"pipeline_stage_num": num_stages},
+                "train": {
+                    "isaac_server_mode": True,
+                    "num_isaac_servers": num_servers,
+                    "num_tasks": num_tasks,
+                    "group_size": group_size,
+                    "env_id": "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0",
+                    "num_envs": num_envs,
+                    "total_trajs": total_trajs,
+                    "simulator_type": "isaac",
+                    "max_episode_steps": 64,
+                    "only_eval": False,
+                    "reward_coef": 1.0,
+                    "init_params": {
+                        "camera_heights": 256,
+                        "camera_widths": 256,
+                        "camera_names": ["agentview"],
+                    },
+                    "video_cfg": {
+                        "save_video": False,
+                    },
+                    "seed": 42,
+                },
+                "actor": {"model": {"num_action_chunks": num_action_chunks, "action_dim": action_dim}},
+                "enable_offload": False,
+            }
+        }
+    )
+
+    print(f"\n{'=' * 60}")
+    print("Isaac Server Mode Gen-Sim Loop Integration Test")
+    print(f"{'=' * 60}")
+    print("Configuration:")
+    print(f"  - Stages: {num_stages}")
+    print(f"  - Total trajectories: {total_trajs}")
+    print(f"  - Envs per stage: {num_envs}")
+    print(f"  - Isaac servers: {num_servers}")
+    print(f"  - Tasks: {num_tasks}, Group size: {group_size}")
+    print(f"  - Action chunks: {num_action_chunks}, Action dim: {action_dim}")
+
+    # Step 1: Create environment worker group
+    print("\n[Step 1] Creating environment worker group...")
+    env_resource_pool = RayResourcePool([1], use_gpu=False)  # 1 EnvWorkerServer, no GPU needed
+    env_cls = RayClassWithInitArgs(cls=ray.remote(EnvWorkerServer), config=config.env)
+    env_wg = RayWorkerGroup(
+        resource_pool=env_resource_pool,
+        ray_cls_with_init=env_cls,
+        name_prefix="env",
+    )
+    print(f"✓ Environment worker group created (world_size={env_wg.world_size})")
+
+    # Step 2: Create a minimal rollout worker group (dummy, just for EnvLoop interface)
+    # In real training, this would be the model inference workers
+    print("\n[Step 2] Creating rollout worker group...")
+
+    # Create a simple mock worker class that EnvLoop won't actually call
+    @ray.remote
+    class DummyRolloutWorker:
+        def __init__(self):
+            pass
+
+    rollout_resource_pool = RayResourcePool([1], use_gpu=False)
+    rollout_cls = RayClassWithInitArgs(cls=DummyRolloutWorker)
+    rollout_wg = RayWorkerGroup(
+        resource_pool=rollout_resource_pool,
+        ray_cls_with_init=rollout_cls,
+        name_prefix="rollout",
+    )
+    print("✓ Rollout worker group created (dummy for testing)")
+
+    # Step 3: Create EnvLoop
+    print("\n[Step 3] Creating EnvLoop...")
+    env_loop = EnvLoop(
+        env_wg=env_wg,
+        rollout_wg=rollout_wg,
+        config=config,
+    )
+    print("✓ EnvLoop created")
+    print(f"  - isaac_server_mode: {env_loop.isaac_server_mode}")
+    print(f"  - total_trajs: {env_loop.total_trajs}")
+    print(f"  - num_envs_per_worker: {env_loop.num_envs_per_worker}")
+    print(f"  - stage_num: {env_loop.stage_num}")
+
+    # Step 4: Initialize workers and simulators
+    print("\n[Step 4] Initializing workers and simulators...")
+    env_loop.env_wg.init_worker()
+    print("✓ Workers initialized")
+
+    env_loop.env_wg.init_simulator()
+    print(f"✓ Simulators initialized (IsaacServerManager + {num_servers} IsaacServers created)")
+
+    # Step 5: Reset environment
+    print("\n[Step 5] Resetting environment...")
+    reset_data = DataProto.from_dict(
+        non_tensors={
+            "state_ids": list(range(total_trajs)),
+            "task_ids": [i % num_tasks for i in range(total_trajs)],
+        }
+    )
+    obs_data = env_loop.env_wg.reset_envs_to_state_ids(reset_data)
+    assert obs_data is not None, "Reset should return observations"
+    print("✓ Environment reset successful")
+    print(f"  - Received observations for {len(reset_data.non_tensor_batch['state_ids'])} trajectories")
+
+    # Step 6: Execute one generation-simulation step
+    print("\n[Step 6] Executing generation-simulation loop (1 step)...")
+
+    # Generate mock actions (in real scenario, this would come from model)
+    print("  [Gen] Generating actions (mocked with random values)...")
+    mock_actions = np.random.randn(total_trajs, num_action_chunks, action_dim).astype(np.float32)
+    print(f"  ✓ Actions generated: shape {mock_actions.shape}")
+
+    # Execute actions in environment (stage by stage)
+    print("  [Sim] Executing actions in environment...")
+    for stage_id in range(num_stages):
+        print(f"    - Stage {stage_id}: Processing {num_envs} trajectories...")
+
+        # Create action batch for this stage
+        action_batch = DataProto.from_dict(
+            non_tensors={
+                "actions": mock_actions,
+                "prompts": ["test"] * total_trajs,  # Dummy prompts
+            }
+        )
+
+        # Execute step
+        step_result = env_loop.env_wg.env_interact_step(action_batch)
+        assert step_result is not None, f"Stage {stage_id} should return step result"
+
+        print(f"    ✓ Stage {stage_id} completed")
+
+        # Verify we got observations and rewards
+        if hasattr(step_result, "batch"):
+            batch = step_result.batch
+            if "rews" in batch:
+                print(f"      Rewards received: shape {batch['rews'].shape}")
+            if "obs" in batch or "full_image" in batch:
+                print("      Observations received")
+
+    print("  ✓ Simulation step completed")
+
+    # Step 7: Finish rollout and cleanup
+    print("\n[Step 7] Cleanup...")
+    env_loop.env_wg.finish_rollout()
+    print("✓ Finish rollout called")
+
+    print(f"\n{'=' * 60}")
+    print("✓✓✓ Isaac Server Mode Gen-Sim Loop Test PASSED ✓✓✓")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    # Initialize Ray if not already initialized
+    if not ray.is_initialized():
+        try:
+            ray.init(address="auto")
+            print("Connected to existing Ray cluster")
+        except Exception:
+            ray.init(local_mode=True)
+            print("Started Ray in local mode")
+
+    unittest.main()

--- a/verl/experimental/vla/README.md
+++ b/verl/experimental/vla/README.md
@@ -62,6 +62,22 @@ python -c "import ray; ray.init(address=\"<main_node_ip>:6379\"); print(ray._pri
 *If you see output pattern like "'train_rollout': 0.9992" and "'sim': 0.9992", the sim workers are scheduled up successfully*
 *The actual value depends on your GPUs per node, usually <1 - 1e-4 * num_gpus>*
 
+## Isaac Server Mode
+
+Isaac Server Mode runs Isaac Lab simulations as Ray Actors, enabling unified resource management and multi-task support. See `run_simpleVLA_isaac_disagg_server.sh` for example.
+
+Key configuration:
+```bash
+env.train.isaac_server_mode=True
+env.train.num_isaac_servers=$NUM_ISAAC_SERVERS    # Number of Isaac servers (one per GPU)
+env.train.num_tasks=$NUM_TASKS                    # Number of tasks in benchmark
+env.train.group_size=$GROUP_SIZE                  # Environments per task
+```
+
+Important constraints:
+- `BATCH_SIZE` must be divisible by `STAGE_NUM`
+- `NUM_TASKS × GROUP_SIZE = NUM_ROLLOUT_GPUS_PER_NODE × STAGE_NUM × ROLLOUT_N`
+
 **References:**
 *   [https://github.com/PRIME-RL/SimpleVLA-RL](https://github.com/PRIME-RL/SimpleVLA-RL)
 *   [https://github.com/RLinf/RLinf](https://github.com/RLinf/RLinf)

--- a/verl/experimental/vla/README.md
+++ b/verl/experimental/vla/README.md
@@ -78,6 +78,8 @@ Important constraints:
 - `BATCH_SIZE` must be divisible by `STAGE_NUM`
 - `NUM_TASKS × GROUP_SIZE = NUM_ROLLOUT_GPUS_PER_NODE × STAGE_NUM × ROLLOUT_N`
 
+*Note: If you see noisy renders, set `ISAAC_FLUSH_SHADER_CACHE=1` to flush NVIDIA shader cache (see script for details).*
+
 **References:**
 *   [https://github.com/PRIME-RL/SimpleVLA-RL](https://github.com/PRIME-RL/SimpleVLA-RL)
 *   [https://github.com/RLinf/RLinf](https://github.com/RLinf/RLinf)

--- a/verl/experimental/vla/config/rob_ppo_trainer.yaml
+++ b/verl/experimental/vla/config/rob_ppo_trainer.yaml
@@ -70,10 +70,6 @@ env:
     
     # Environment ID for Isaac Lab
     env_id: "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0"
-    
-    # Camera settings
-    camera_height: 256
-    camera_width: 256
 
     init_params:
       camera_depths: False

--- a/verl/experimental/vla/config/rob_ppo_trainer.yaml
+++ b/verl/experimental/vla/config/rob_ppo_trainer.yaml
@@ -26,6 +26,55 @@ env:
     num_envs: 16
     seed: 42
     task_suite_name: libero_10
+
+    # ============================================================
+    # Isaac Simulation Mode Configuration
+    # ============================================================
+    # Two modes available:
+    # 1. Standard mode (isaac_server_mode=false):
+    #    - Each EnvWorker runs local Isaac instances
+    #    - Simple but limited scalability
+    #
+    # 2. Isaac Server mode (isaac_server_mode=true):
+    #    - Isaac Sim runs as Ray-managed IsaacServers
+    #    - Ray manages all resources uniformly
+    #    - Better scalability and resource management
+    # ============================================================
+    
+    # Enable Isaac server mode (recommended for production)
+    isaac_server_mode: False
+    
+    # Number of EnvWorker instances per node in Isaac server mode
+    # These are lightweight clients, so typically only need 1
+    server_mode_env_workers: 1
+    
+    # Number of Isaac servers per stage (only for isaac_server_mode=true)
+    # Typically equals the number of simulation GPUs
+    num_isaac_servers: 8
+    
+    # Number of tasks in the multi-task environment
+    num_tasks: 10
+    
+    # Envs per task (only for Ray actor mode)
+    # sim_envs_per_stage = num_tasks × group_size
+    group_size: 16
+    
+    # Original env worker count (how many workers would exist in standard mode)
+    # This tells the coordinator how many stages to handle
+    # total_stages = original_env_worker_count × pipeline_stage_num
+    original_env_worker_count: 8
+    
+    # Total trajectories for training (for EnvWorkerServer coordination)
+    # This is the number of trajectories participating in training, NOT sim envs
+    total_trajs: 128
+    
+    # Environment ID for Isaac Lab
+    env_id: "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0"
+    
+    # Camera settings
+    camera_height: 256
+    camera_width: 256
+
     init_params:
       camera_depths: False
       camera_heights: 256

--- a/verl/experimental/vla/dp_rob.py
+++ b/verl/experimental/vla/dp_rob.py
@@ -226,7 +226,11 @@ class RobDataParallelPPOActor(BasePPOActor):
             if calculate_entropy:
                 entropys = restore_dynamic_batch(entropys, batch_idx_list)
 
-        return log_probs, entropys
+        # Return dict format to match upstream interface (since #4678)
+        result = {"log_probs": log_probs}
+        if calculate_entropy:
+            result["entropys"] = entropys
+        return result
 
     def update_policy(self, data: DataProto):
         self.actor_module.train()

--- a/verl/experimental/vla/env_loop.py
+++ b/verl/experimental/vla/env_loop.py
@@ -50,10 +50,14 @@ class EnvLoop:
         self.action_dim = config.env.actor.model.action_dim
         self.num_action_chunks = config.env.actor.model.num_action_chunks
         # Derived properties
-        self.total_envs = self.env_wg.world_size * self.num_envs_per_worker
-        if self.total_envs % self.stage_num != 0:
-            raise ValueError(f"Total envs ({self.total_envs}) must be divisible by stage_num ({self.stage_num})")
-        self.envs_per_stage = self.total_envs // self.stage_num
+        # In server/ray mode, total_trajs is configured explicitly
+        # In local mode, it's computed from world_size * num_envs_per_worker
+        # Backward compatible: support both total_trajs (new) and total_envs (legacy)
+        default_total = self.env_wg.world_size * self.num_envs_per_worker
+        self.total_trajs = config.env.train.get("total_trajs", config.env.train.get("total_envs", default_total))
+        if self.total_trajs % self.stage_num != 0:
+            raise ValueError(f"total_trajs ({self.total_trajs}) must be divisible by stage_num ({self.stage_num})")
+        self.trajs_per_stage = self.total_trajs // self.stage_num
 
         self.env_wg.init_worker()
         self.env_wg.init_simulator()
@@ -97,7 +101,17 @@ class EnvLoop:
         # --- Pipeline state ---
         trajectories = {i: [] for i in range(self.stage_num)}  # To store (obs, action, rew, done) tuples
         rollout_futures = {}
-        # is_complete = torch.zeros((self.total_envs,), dtype=torch.bool)
+        # is_complete = torch.zeros((self.total_trajs,), dtype=torch.bool)
+
+        # Extract traj_keys for each stage (important for action-env mapping)
+        # Each traj_key maps a rollout traj to exactly one sim env
+        staged_traj_keys = {}
+        for stage_id in range(self.stage_num):
+            stage_data = staged_obs[stage_id]
+            if "traj_keys" in stage_data.non_tensor_batch:
+                staged_traj_keys[stage_id] = stage_data.non_tensor_batch["traj_keys"]
+            else:
+                staged_traj_keys[stage_id] = None
 
         for stage_id in range(self.stage_num):
             # trajectories[stage_id].append({'obs': staged_obs[stage_id]})
@@ -111,9 +125,19 @@ class EnvLoop:
                 action_result: DataProto = await asyncio.to_thread(rollout_futures[stage_id].get)
 
                 trajectories[stage_id][-1]["action"] = action_result
+
+                # Include traj_keys to ensure action-env mapping (1:1 traj-env correspondence)
+                non_tensors = {"actions": action_result.batch["action"].cpu().numpy()}
+                if staged_traj_keys[stage_id] is not None:
+                    non_tensors["traj_keys"] = staged_traj_keys[stage_id]
+
                 action_data = DataProto.from_dict(
-                    non_tensors={"actions": action_result.batch["action"].cpu().numpy()},
-                    meta_info={"stage_id": stage_id},
+                    non_tensors=non_tensors,
+                    meta_info={
+                        "stage_id": stage_id,
+                        "step_idx": step_idx,
+                        "max_steps": self.max_interactions,
+                    },
                 )
 
                 env_ref = self.env_wg.env_interact_step(action_data)
@@ -139,21 +163,27 @@ class EnvLoop:
         return self._collate_trajectories(trajectories, initial_state_ids, meta_info=prompts.meta_info)
 
     def _restructure_obs_data(self, data_proto: DataProto) -> list[DataProto]:
-        """Reshapes flat observation data from env_wg into a list of per-stage DataProto objects."""
-        # env_wg returns a flat batch ordered by [worker0_stage0, worker0_stage1, ...,
-        # worker1_stage0, worker1_stage1, ...]
-        # First, un-flatten by worker, then by stage
+        """Reshapes flat observation data from env_wg into a list of per-stage DataProto objects.
 
-        num_workers = self.env_wg.world_size
+        Reset returns data in interleaved format:
+            traj_0 (stage_0), traj_1 (stage_1), traj_2 (stage_0), traj_3 (stage_1), ...
 
+        Each trajectory has num_envs_per_worker (e.g., 8) environments.
+        We need to de-interleave by stage.
+        """
+        # Total trajectories = total_trajs / num_envs_per_worker
+        num_trajectories = self.total_trajs // self.num_envs_per_worker
+
+        # Chunk data by trajectory (each trajectory = num_envs_per_worker envs)
+        trajectory_chunks = data_proto.chunk(num_trajectories)
+
+        # Group by stage (trajectories are assigned round-robin to stages)
         staged_data = [[] for _ in range(self.stage_num)]
-        chunks = data_proto.chunk(num_workers)
-        for worker_chunk in chunks:
-            stage_chunks = worker_chunk.chunk(self.stage_num)
-            for stage_id, data in enumerate(stage_chunks):
-                staged_data[stage_id].append(data)
+        for traj_idx, traj_data in enumerate(trajectory_chunks):
+            stage_id = traj_idx % self.stage_num
+            staged_data[stage_id].append(traj_data)
 
-        # Concatenate data from all workers for each stage
+        # Concatenate trajectories for each stage
         return [DataProto.concat(data_list) for data_list in staged_data]
 
     def _collate_trajectories(self, trajectories: dict, initial_state_ids: np.ndarray, meta_info) -> DataProto:

--- a/verl/experimental/vla/env_loop.py
+++ b/verl/experimental/vla/env_loop.py
@@ -177,6 +177,10 @@ class EnvLoop:
             trajectory_chunks = data_proto.chunk(self.total_trajs)
         else:
             # Local mode: each trajectory has num_envs_per_worker envs
+            assert self.total_trajs % self.num_envs_per_worker == 0, (
+                f"total_trajs ({self.total_trajs}) must be divisible by "
+                f"num_envs_per_worker ({self.num_envs_per_worker})"
+            )
             num_trajectories = self.total_trajs // self.num_envs_per_worker
             trajectory_chunks = data_proto.chunk(num_trajectories)
 

--- a/verl/experimental/vla/isaac_server/__init__.py
+++ b/verl/experimental/vla/isaac_server/__init__.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Isaac Lab Server Module
+
+This module provides the Isaac Lab multi-task server components for
+distributed reinforcement learning with Isaac Lab environments.
+
+Components:
+    - isaac_server.py: IsaacServer - Ray Actor running Isaac Lab simulation
+    - isaac_server_manager.py: IsaacServerManager - manages multiple servers across stages/GPUs
+"""
+
+from .isaac_server import IsaacServer
+from .isaac_server_manager import IsaacServerManager
+
+__all__ = [
+    "IsaacServer",
+    "IsaacServerManager",
+]

--- a/verl/experimental/vla/isaac_server/isaac_server.py
+++ b/verl/experimental/vla/isaac_server/isaac_server.py
@@ -256,6 +256,21 @@ class IsaacServer:
 
         # Use simple kwargs initialization (same as IsaacEnv)
         launch_args = {"headless": True, "enable_cameras": True}
+
+        # Optional: Flush NVIDIA driver shader cache to fix rendering noise caused by cache overflow
+        # Set ISAAC_FLUSH_SHADER_CACHE=1 if you see:
+        #   - Noisy/corrupted rendered images
+        #   - Warning: "ShaderCache: 95 percent of the driver's shadercache size limit has been reached"
+        # Note: This makes startup slower (cache rebuild) but fixes render quality
+        # After one flush, you can remove the env var as cache will be clean
+        if os.environ.get("ISAAC_FLUSH_SHADER_CACHE", "0") == "1":
+            logger.info(
+                f"[Stage {self.stage_id} Actor {self.actor_rank}] "
+                "Flushing shader cache (startup will be slower but fixes render quality)"
+            )
+            extra_args = ["--/renderer/shadercache/driverDiskCache/flush=true"]
+            launch_args["extra_args"] = extra_args
+
         app_launcher = AppLauncher(**launch_args)
         self.simulation_app = app_launcher.app
 

--- a/verl/experimental/vla/isaac_server/isaac_server.py
+++ b/verl/experimental/vla/isaac_server/isaac_server.py
@@ -1,0 +1,587 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Isaac Lab Simulation Server (Ray-based)
+
+A Ray Actor that runs Isaac Lab multi-task simulation on a single GPU.
+Benefits of using Ray servers:
+- Unified resource management by Ray
+- Simplified deployment (no manual server startup)
+- Efficient data transfer via Ray's object store
+
+Architecture:
+    - One IsaacServer per GPU
+    - Each Server handles a subset of tasks
+    - Multiple Servers managed by IsaacServerManager (one manager per stage)
+
+Usage:
+    # Create server (Ray will schedule to available GPU)
+    server = IsaacServer.options(num_gpus=1).remote(
+        env_id="Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0",
+        num_tasks=5,
+        group_size=8,  # Envs per task
+        actor_rank=0,
+        task_offset=0,
+    )
+
+    # Initialize (must call before step/reset)
+    ray.get(server.init_env.remote())
+
+    # Use step/reset
+    result = ray.get(server.step.remote(actions, env_indices))
+"""
+
+import logging
+import os
+from typing import Any, Optional
+
+import numpy as np
+import ray
+
+logger = logging.getLogger("IsaacServer")
+
+
+def setup_per_process_caches(server_rank: int, stage_id: int = 0, clear_cache: bool = False):
+    """Setup per-process cache directories to avoid locking conflicts.
+
+    Prevents OptiX/shader cache conflicts.
+    Must be called BEFORE importing any Isaac/Omniverse modules.
+
+    Important: Each (stage_id, server_rank) pair needs unique cache directories
+    to avoid conflicts between different stage servers.
+
+    Args:
+        server_rank: The rank of this server within a stage.
+        stage_id: The stage ID (for multi-stage training).
+        clear_cache: If True, clear existing cache directories before setup.
+                     This ensures clean state but increases startup time.
+    """
+    import shutil
+
+    # Use stage_id/server_rank to create unique cache paths
+    cache_suffix = f"stage_{stage_id}/rank_{server_rank}"
+
+    def _setup_cache_dir(base_path: str, clear: bool) -> str:
+        """Create cache directory, optionally clearing existing content."""
+        cache_dir = os.path.join(base_path, cache_suffix)
+        if clear and os.path.exists(cache_dir):
+            shutil.rmtree(cache_dir)
+        os.makedirs(cache_dir, exist_ok=True)
+        return cache_dir
+
+    # === OptiX Cache ===
+    optix_base = "/tmp/optix_cache"  # Don't inherit from env - always use fresh
+    optix_rank_cache = _setup_cache_dir(optix_base, clear_cache)
+    os.environ["OPTIX_CACHE_PATH"] = optix_rank_cache
+    os.environ["OPTIX7_CACHE_PATH"] = optix_rank_cache
+
+    # === NVIDIA Driver Shader Cache ===
+    shader_base = "/tmp/nv_shader_cache"  # Don't inherit from env
+    shader_rank_cache = _setup_cache_dir(shader_base, clear_cache)
+    os.environ["__GL_SHADER_DISK_CACHE"] = "1"
+    os.environ["__GL_SHADER_DISK_CACHE_PATH"] = shader_rank_cache
+    os.environ["__GL_SHADER_DISK_CACHE_SKIP_CLEANUP"] = "1"
+
+    # === Omniverse Kit Cache (includes shader cache) ===
+    ov_base = "/tmp/ov_cache"  # Don't inherit from env
+    ov_rank_cache = _setup_cache_dir(ov_base, clear_cache)
+    os.environ["OMNI_KIT_CACHE_DIR"] = ov_rank_cache
+    os.environ["OMNI_USER_CACHE_DIR"] = ov_rank_cache  # Also set user cache
+    os.environ["CARB_DATA_PATH"] = os.path.join(ov_rank_cache, "carb")  # Carbonite data
+
+    # === XDG Base Directories ===
+    # Note: Kit in Isaac Sim container uses hardcoded paths (/isaac-sim/kit/data/)
+    # which ignore XDG variables. The kvdb conflict warning is benign - Kit
+    # gracefully disables kvdb when another process holds the lock.
+    # This doesn't affect training or rendering, only settings persistence.
+    xdg_base = "/tmp/xdg_home"
+    xdg_rank_home = _setup_cache_dir(xdg_base, clear_cache)
+    os.environ["XDG_DATA_HOME"] = os.path.join(xdg_rank_home, "data")
+    os.environ["XDG_CONFIG_HOME"] = os.path.join(xdg_rank_home, "config")
+    os.environ["XDG_CACHE_HOME"] = os.path.join(xdg_rank_home, "cache")
+    os.makedirs(os.environ["XDG_DATA_HOME"], exist_ok=True)
+    os.makedirs(os.environ["XDG_CONFIG_HOME"], exist_ok=True)
+    os.makedirs(os.environ["XDG_CACHE_HOME"], exist_ok=True)
+
+    # Use print to ensure visibility in Ray logs
+    cleared_msg = " (cleared)" if clear_cache else ""
+    print(f"[Stage {stage_id} Rank {server_rank}] Cache directories configured{cleared_msg}:", flush=True)
+    print(f"  OptiX:  {optix_rank_cache}", flush=True)
+    print(f"  Shader: {shader_rank_cache}", flush=True)
+    print(f"  OV Kit: {ov_rank_cache}", flush=True)
+    print(f"  XDG:    {xdg_rank_home}", flush=True)
+
+
+@ray.remote(num_gpus=1)
+class IsaacServer:
+    """
+    Ray Actor for Isaac Lab multi-task simulation.
+
+    Managed by Ray for unified resource management.
+
+    Key features:
+    1. Uses Ray's server methods directly
+    2. GPU allocated by Ray scheduler (num_gpus=1)
+    3. Data transferred via Ray's object store (automatic serialization)
+    4. Lifecycle managed by Ray (no manual start/stop)
+
+    Thread Safety:
+        Ray servers are single-threaded by default, so all method calls
+        are serialized.
+    """
+
+    def __init__(
+        self,
+        env_id: str = "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0",
+        num_tasks: int = 5,
+        group_size: int = 8,  # Fixed envs per task
+        actor_rank: int = 0,
+        task_offset: int = 0,
+        render_last_only: bool = True,
+        camera_height: int = 256,
+        camera_width: int = 256,
+        stage_id: int = 0,
+    ):
+        """
+        Initialize the Isaac Sim Server.
+
+        Args:
+            env_id: Gymnasium environment ID for multi-task Isaac env
+            num_tasks: Number of tasks this server handles
+            group_size: Number of parallel envs per task (fixed for all tasks)
+            actor_rank: Rank of this server (0 to num_servers-1)
+            task_offset: Global task ID offset for this server
+            render_last_only: If True, only render on the last step of action chunks
+            camera_height: Camera image height
+            camera_width: Camera image width
+            stage_id: Pipeline stage ID (for logging and identification)
+        """
+        self.env_id = env_id
+        self.num_tasks = num_tasks
+        self.group_size = group_size
+        self.actor_rank = actor_rank
+        self.task_offset = task_offset
+        self.render_last_only = render_last_only
+        self.camera_height = camera_height
+        self.camera_width = camera_width
+        self.stage_id = stage_id
+
+        # Total envs = num_tasks * group_size
+        self.total_envs = num_tasks * group_size
+
+        # Task ID to env indices mapping (local to this server)
+        # task_id here is LOCAL (0 to num_tasks-1)
+        self.task_to_env_indices = {
+            task_id: list(range(task_id * group_size, (task_id + 1) * group_size)) for task_id in range(num_tasks)
+        }
+
+        # Will be initialized in init_env()
+        self.env = None
+        self.simulation_app = None
+        self.device = None
+        self.action_dim = None
+        self._initialized = False
+
+        logger.info(
+            f"[Stage {stage_id} Server {actor_rank}] Created: "
+            f"{num_tasks} tasks (offset={task_offset}), "
+            f"group_size={group_size}, {self.total_envs} envs"
+        )
+
+    def init_env(self) -> dict:
+        """
+        Initialize the Isaac Lab environment.
+
+        This is separated from __init__ because Isaac Lab initialization
+        requires GPU context which may not be ready during server creation.
+
+        Returns:
+            dict with status and environment info
+        """
+        if self._initialized:
+            return {
+                "status": "ok",
+                "message": "Already initialized",
+                "num_tasks": self.num_tasks,
+                "group_size": self.group_size,
+                "total_envs": self.total_envs,
+            }
+
+        import torch
+
+        # Setup per-process caches (unique per stage + actor to avoid conflicts)
+        # Set ISAAC_CLEAR_CACHE=1 env var to clear caches on startup (slower but cleaner)
+        clear_cache = os.environ.get("ISAAC_CLEAR_CACHE", "0") == "1"
+        setup_per_process_caches(self.actor_rank, self.stage_id, clear_cache=clear_cache)
+
+        # Set environment variables for Isaac Lab config
+        # GROUP_SIZE = envs per task (not total envs!)
+        os.environ["GROUP_SIZE"] = str(self.group_size)
+        os.environ["TASK_OFFSET"] = str(self.task_offset)
+        os.environ["NUM_TASKS"] = str(self.num_tasks)
+
+        logger.info(f"[Stage {self.stage_id} Actor {self.actor_rank}] Initializing Isaac environment: {self.env_id}")
+
+        # Detect GPU
+        num_gpus = torch.cuda.device_count()
+        # Ray assigns GPU via CUDA_VISIBLE_DEVICES, so device is always "cuda:0" from actor's view
+        self.device = "cuda:0"
+
+        logger.info(f"[Stage {self.stage_id} Actor {self.actor_rank}] Visible GPUs: {num_gpus}, using {self.device}")
+
+        # Import Isaac Lab components - follow IsaacEnv pattern exactly
+        import gymnasium as gym
+        from isaaclab.app import AppLauncher
+
+        # Use simple kwargs initialization (same as IsaacEnv)
+        launch_args = {"headless": True, "enable_cameras": True}
+        app_launcher = AppLauncher(**launch_args)
+        self.simulation_app = app_launcher.app
+
+        # Force franka registration (same as IsaacEnv)
+        import isaaclab_playground.tasks.manipulation.libero.config.franka  # noqa
+
+        # Now import Isaac Lab task utilities
+        from isaaclab_tasks.utils import parse_env_cfg
+
+        # Parse environment config (same as IsaacEnv._init_env)
+        env_cfg = parse_env_cfg(self.env_id, num_envs=self.total_envs)
+
+        # Configure environment (following IsaacEnv pattern exactly)
+        env_cfg.env_name = f"stage{self.stage_id}_actor{self.actor_rank}"
+        env_cfg.sim.device = self.device
+        env_cfg.sim.physx.enable_ccd = True
+        env_cfg.terminations.time_out = None
+        env_cfg.observations.policy.concatenate_terms = False
+
+        # Override camera dimensions if supported
+        if hasattr(env_cfg, "camera_height"):
+            env_cfg.camera_height = self.camera_height
+            env_cfg.camera_width = self.camera_width
+            if hasattr(env_cfg, "recreate_cameras"):
+                env_cfg.recreate_cameras()
+            logger.info(
+                f"[Stage {self.stage_id} Actor {self.actor_rank}] Set camera: {self.camera_width}x{self.camera_height}"
+            )
+
+        # Set task offset if supported
+        if hasattr(env_cfg, "task_offset"):
+            env_cfg.task_offset = self.task_offset
+
+        # Ensure correct num_envs
+        if hasattr(env_cfg, "scene") and hasattr(env_cfg.scene, "num_envs"):
+            env_cfg.scene.num_envs = self.total_envs
+
+        # Create environment (same as IsaacEnv)
+        self.env = gym.make(self.env_id, cfg=env_cfg).unwrapped
+        self.action_dim = self.env.action_space.shape[-1]
+
+        # Verify envs created
+        actual_num_envs = self.env.num_envs
+        if actual_num_envs != self.total_envs:
+            logger.warning(
+                f"[Stage {self.stage_id} Actor {self.actor_rank}] "
+                f"Env count mismatch: requested {self.total_envs}, got {actual_num_envs}"
+            )
+            self.total_envs = actual_num_envs
+            # Rebuild task mapping
+            self.group_size = actual_num_envs // self.num_tasks if self.num_tasks > 0 else actual_num_envs
+            self.task_to_env_indices = {
+                task_id: list(range(task_id * self.group_size, (task_id + 1) * self.group_size))
+                for task_id in range(self.num_tasks)
+            }
+
+        # Initial reset
+        self.env.reset()
+        self._initialized = True
+
+        logger.info(
+            f"[Stage {self.stage_id} Actor {self.actor_rank}] "
+            f"Initialized: {self.total_envs} envs, action_dim={self.action_dim}"
+        )
+
+        return {
+            "status": "ok",
+            "num_tasks": self.num_tasks,
+            "group_size": self.group_size,
+            "total_envs": self.total_envs,
+            "action_dim": self.action_dim,
+            "task_offset": self.task_offset,
+            "actor_rank": self.actor_rank,
+            "stage_id": self.stage_id,
+        }
+
+    def get_task_mapping(self) -> dict:
+        """Return the task ID to env indices mapping."""
+        return {
+            "status": "ok",
+            "task_to_env_indices": self.task_to_env_indices,
+            "num_tasks": self.num_tasks,
+            "group_size": self.group_size,
+            "total_envs": self.total_envs,
+            "task_offset": self.task_offset,
+            "actor_rank": self.actor_rank,
+            "stage_id": self.stage_id,
+        }
+
+    def step(self, actions: np.ndarray, env_indices: list) -> dict:
+        """
+        Execute step on specified environments.
+
+        Args:
+            actions: Actions array, shape (len(env_indices), action_dim) or
+                     (len(env_indices), num_chunks, action_dim) for chunked actions
+            env_indices: List of env indices to step
+
+        Returns:
+            dict with obs, rewards, terminations, truncations, infos
+        """
+        if not self._initialized:
+            raise RuntimeError("Actor not initialized. Call init_env() first.")
+
+        import torch
+
+        actions = np.array(actions)
+
+        logger.debug(
+            f"[Stage {self.stage_id} Actor {self.actor_rank}] "
+            f"Step: {len(env_indices)} envs, indices={env_indices[:5]}..."
+        )
+
+        # Check if actions have chunk dimension: [num_envs, num_chunks, action_dim]
+        if len(actions.shape) == 3:
+            return self._handle_chunk_step(actions, env_indices)
+
+        # Single step: [num_envs, action_dim]
+        full_actions = torch.zeros(self.total_envs, self.action_dim, device=self.device)
+        full_actions[env_indices] = torch.tensor(actions, device=self.device, dtype=torch.float32)
+
+        # Step all envs
+        obs, rewards, terminations, truncations, infos = self.env.step(full_actions)
+
+        # Extract results for requested env indices
+        response = {
+            "status": "ok",
+            "obs": self._extract_obs(obs, env_indices),
+            "rewards": rewards[env_indices].cpu().numpy(),
+            "terminations": terminations[env_indices].cpu().numpy(),
+            "truncations": truncations[env_indices].cpu().numpy(),
+            "infos": self._extract_infos(infos, env_indices),
+        }
+
+        return response
+
+    def _handle_chunk_step(self, chunk_actions: np.ndarray, env_indices: list) -> dict:
+        """
+        Handle action chunks: execute each chunk sequentially.
+
+        Args:
+            chunk_actions: [num_envs, num_chunks, action_dim]
+            env_indices: list of env indices to step
+
+        Returns:
+            dict with accumulated rewards and final obs
+        """
+        import torch
+
+        num_chunks = chunk_actions.shape[1]
+
+        chunk_rewards = []
+        chunk_terminations = []
+        chunk_truncations = []
+
+        # Save original render_interval to restore later
+        original_render_interval = None
+        if self.render_last_only and hasattr(self.env.unwrapped, "cfg"):
+            original_render_interval = self.env.unwrapped.cfg.sim.render_interval
+
+        for chunk_idx in range(num_chunks):
+            is_last_chunk = chunk_idx == num_chunks - 1
+
+            # Control rendering for efficiency
+            if self.render_last_only and original_render_interval is not None:
+                if is_last_chunk:
+                    self.env.unwrapped.cfg.sim.render_interval = original_render_interval
+                else:
+                    self.env.unwrapped.cfg.sim.render_interval = 999999
+
+            # Get actions for this chunk
+            actions = chunk_actions[:, chunk_idx, :]
+
+            # Build full action tensor
+            full_actions = torch.zeros(self.total_envs, self.action_dim, device=self.device)
+            full_actions[env_indices] = torch.tensor(actions, device=self.device, dtype=torch.float32)
+
+            # Step all envs
+            obs, rewards, terminations, truncations, infos = self.env.step(full_actions)
+
+            # Collect results for this chunk
+            chunk_rewards.append(rewards[env_indices].cpu().numpy())
+            chunk_terminations.append(terminations[env_indices].cpu().numpy())
+            chunk_truncations.append(truncations[env_indices].cpu().numpy())
+
+        # Restore original render_interval
+        if self.render_last_only and original_render_interval is not None:
+            self.env.unwrapped.cfg.sim.render_interval = original_render_interval
+
+        # Stack chunk results: [num_envs, num_chunks]
+        stacked_rewards = np.stack(chunk_rewards, axis=1)
+        stacked_terminations = np.stack(chunk_terminations, axis=1)
+        stacked_truncations = np.stack(chunk_truncations, axis=1)
+
+        return {
+            "status": "ok",
+            "obs": self._extract_obs(obs, env_indices),
+            "rewards": stacked_rewards,
+            "terminations": stacked_terminations,
+            "truncations": stacked_truncations,
+            "infos": self._extract_infos(infos, env_indices),
+        }
+
+    def reset(self, env_indices: Optional[list] = None, stabilize: bool = True) -> dict:
+        """
+        Reset specified environments.
+
+        Args:
+            env_indices: List of env indices to reset (None for all)
+            stabilize: Whether to run stabilization steps (10 zero-action steps)
+
+        Returns:
+            dict with obs
+        """
+        if not self._initialized:
+            raise RuntimeError("Actor not initialized. Call init_env() first.")
+
+        import torch
+
+        if env_indices is None:
+            env_indices = list(range(self.total_envs))
+
+        logger.debug(f"[Stage {self.stage_id} Actor {self.actor_rank}] Reset: {len(env_indices)} envs")
+
+        # Validate env_indices
+        actual_num_envs = self.env.unwrapped.num_envs
+        max_idx = max(env_indices) if env_indices else 0
+        if max_idx >= actual_num_envs:
+            raise RuntimeError(f"env_indices out of bounds: max={max_idx}, but env only has {actual_num_envs} envs")
+
+        # Use Isaac Lab's internal _reset_idx for partial reset
+        reset_env_ids = torch.tensor(env_indices, device=self.device, dtype=torch.long)
+        self.env.unwrapped._reset_idx(reset_env_ids)
+
+        # Stabilize: run zero-action steps to let physics settle
+        if stabilize:
+            zero_actions = torch.zeros(self.total_envs, self.action_dim, device=self.device)
+            for _ in range(10):
+                obs, _, _, _, infos = self.env.step(zero_actions)
+        else:
+            obs = self.env.unwrapped.observation_manager.compute()
+
+        return {
+            "status": "ok",
+            "obs": self._extract_obs(obs, env_indices),
+        }
+
+    def ping(self) -> dict:
+        """Health check."""
+        return {
+            "status": "ok",
+            "message": "pong",
+            "initialized": self._initialized,
+            "stage_id": self.stage_id,
+            "actor_rank": self.actor_rank,
+        }
+
+    def close(self) -> dict:
+        """Clean up resources."""
+        logger.info(f"[Stage {self.stage_id} Actor {self.actor_rank}] Closing...")
+
+        if self.env:
+            self.env.close()
+            self.env = None
+
+        if self.simulation_app:
+            self.simulation_app.close()
+            self.simulation_app = None
+
+        self._initialized = False
+
+        return {"status": "ok", "message": "Actor closed"}
+
+    def _to_cpu_numpy(self, value: Any) -> Any:
+        """Recursively convert any CUDA tensors to CPU numpy arrays."""
+        import torch
+
+        if isinstance(value, torch.Tensor):
+            return value.cpu().numpy()
+        elif isinstance(value, dict):
+            return {k: self._to_cpu_numpy(v) for k, v in value.items()}
+        elif isinstance(value, list | tuple):
+            return type(value)(self._to_cpu_numpy(v) for v in value)
+        elif isinstance(value, np.ndarray):
+            return value
+        else:
+            if hasattr(value, "cpu") and callable(value.cpu):
+                try:
+                    return value.cpu().numpy()
+                except Exception:
+                    pass
+            return value
+
+    def _extract_obs(self, obs: Any, env_indices: list) -> dict:
+        """Extract observations for specified env indices."""
+        import torch
+
+        if isinstance(obs, dict):
+            result = {}
+            for key, value in obs.items():
+                if isinstance(value, torch.Tensor):
+                    result[key] = value[env_indices].cpu().numpy()
+                elif isinstance(value, dict):
+                    result[key] = self._extract_obs(value, env_indices)
+                elif isinstance(value, np.ndarray):
+                    result[key] = value[env_indices]
+                else:
+                    result[key] = self._to_cpu_numpy(value)
+            return result
+        elif isinstance(obs, torch.Tensor):
+            return obs[env_indices].cpu().numpy()
+        elif isinstance(obs, np.ndarray):
+            return obs[env_indices]
+        else:
+            return self._to_cpu_numpy(obs)
+
+    def _extract_infos(self, infos: dict, env_indices: list) -> dict:
+        """Extract infos for specified env indices."""
+        import torch
+
+        result = {}
+        if infos:
+            for key, value in infos.items():
+                if isinstance(value, torch.Tensor):
+                    if value.dim() > 0 and value.shape[0] >= max(env_indices) + 1:
+                        result[key] = value[env_indices].cpu().numpy()
+                    else:
+                        result[key] = value.cpu().numpy()
+                elif isinstance(value, np.ndarray):
+                    if value.ndim > 0 and value.shape[0] >= max(env_indices) + 1:
+                        result[key] = value[env_indices]
+                    else:
+                        result[key] = value
+                elif isinstance(value, dict):
+                    result[key] = self._extract_infos(value, env_indices)
+                else:
+                    result[key] = self._to_cpu_numpy(value)
+        return result

--- a/verl/experimental/vla/isaac_server/isaac_server_manager.py
+++ b/verl/experimental/vla/isaac_server/isaac_server_manager.py
@@ -1,0 +1,572 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Isaac Sim Server Manager
+
+Manages multiple IsaacServers across GPUs and pipeline stages.
+
+Architecture:
+    ┌────────────────────────────────────────────────────────────────────┐
+    │                 IsaacServerManager                                 │
+    │                                                                    │
+    │  Stage 0 (actors[0]):          Stage 1 (actors[1]):               │
+    │  ┌──────────────────────┐      ┌──────────────────────┐           │
+    │  │ Actor 0 (GPU 0)      │      │ Actor 0 (GPU 0)      │           │
+    │  │ Tasks: 0-4           │      │ Tasks: 0-4           │           │
+    │  ├──────────────────────┤      ├──────────────────────┤           │
+    │  │ Actor 1 (GPU 1)      │      │ Actor 1 (GPU 1)      │           │
+    │  │ Tasks: 5-9           │      │ Tasks: 5-9           │           │
+    │  ├──────────────────────┤      ├──────────────────────┤           │
+    │  │ ...                  │      │ ...                  │           │
+    │  └──────────────────────┘      └──────────────────────┘           │
+    └────────────────────────────────────────────────────────────────────┘
+
+Key Concepts:
+    - Each stage has its own set of servers (physical isolation between stages)
+    - Each server handles a subset of tasks
+    - All servers in a stage share the same task → server mapping
+    - Batched operations are parallelized via ray.get() on multiple servers
+
+Usage:
+    manager = IsaacServerManager(
+        num_stages=2,
+        num_actors_per_stage=8,
+        num_tasks=40,
+        group_size=8,
+    )
+    manager.initialize()  # Creates and initializes all actors
+
+    # Step on specific stage
+    result = manager.step_batched(server_requests, stage_id=0)
+
+    # Reset all stages
+    results = manager.reset_batched(server_requests, stage_id=0)
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+import numpy as np
+import ray
+
+from .isaac_server import IsaacServer
+
+logger = logging.getLogger(__name__)
+
+
+class IsaacServerManager:
+    """
+    Manager for multiple IsaacServers across stages and GPUs.
+
+    Design:
+    - Creates num_stages × num_servers_per_stage servers
+    - Each stage is physically isolated (separate server instances)
+    - Provides batched step/reset operations for efficiency
+
+    Thread Safety:
+    - Manager methods are thread-safe for concurrent calls from different stages
+    - Uses ThreadPoolExecutor for parallel ray.get() calls
+    """
+
+    def __init__(
+        self,
+        num_stages: int = 2,
+        num_servers_per_stage: int = 8,
+        num_tasks: int = 40,
+        group_size: int = 8,
+        env_id: str = "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0",
+        render_last_only: bool = True,
+        camera_height: int = 256,
+        camera_width: int = 256,
+        placement_group=None,
+        accelerator_type: Optional[str] = None,
+        runtime_env: Optional[dict] = None,
+    ):
+        """
+        Initialize the actor manager.
+
+        Args:
+            num_stages: Number of pipeline stages (each gets its own server set)
+            num_servers_per_stage: Number of servers per stage (typically = num GPUs)
+            num_tasks: Total number of tasks (split across actors)
+            group_size: Number of envs per task (fixed for all tasks)
+            env_id: Isaac Lab environment ID
+            render_last_only: Only render last step of action chunks
+            camera_height: Camera image height
+            camera_width: Camera image width
+            placement_group: Optional Ray placement group for scheduling
+            accelerator_type: Optional accelerator type label (e.g., "sim")
+            runtime_env: Optional Ray runtime environment for servers
+        """
+        self.num_stages = num_stages
+        self.num_servers_per_stage = num_servers_per_stage
+        self.num_tasks = num_tasks
+        self.group_size = group_size
+        self.env_id = env_id
+        self.render_last_only = render_last_only
+        self.camera_height = camera_height
+        self.camera_width = camera_width
+        self.placement_group = placement_group
+        self.accelerator_type = accelerator_type
+        self.runtime_env = runtime_env
+
+        # Total envs = num_tasks * group_size
+        self._total_envs = num_tasks * group_size
+
+        # Calculate task distribution across servers
+        # Tasks are distributed evenly; some servers get +1 task if remainder > 0
+        self.tasks_per_server = num_tasks // num_servers_per_stage
+        self.remainder_tasks = num_tasks % num_servers_per_stage
+
+        # servers[stage_id][server_rank] = IsaacServer handle
+        self.servers: list[list[ray.ObjectRef]] = []
+
+        # Global task mapping (same for all stages)
+        # task_id → server_rank
+        self._task_to_server: dict[int, int] = {}
+        # task_id → local env indices on that server
+        self._task_to_env_indices: dict[int, list[int]] = {}
+        # server_rank → task_offset
+        self._server_task_offsets: list[int] = []
+
+        self._initialized = False
+
+        # Thread pool for parallel operations
+        self._executor = ThreadPoolExecutor(max_workers=num_servers_per_stage)
+
+        # Calculate GPU requirements
+        # Each GPU is shared by num_stages servers (time-sharing across pipeline stages)
+        # e.g., 2 stages → 2 servers per GPU → 0.5 GPU/server
+        servers_per_gpu = num_stages
+        self.gpu_per_server = 1.0 / servers_per_gpu
+        total_gpus_needed = num_servers_per_stage  # One GPU per server rank, shared by stages
+
+        logger.info(
+            f"IsaacServerManager created: "
+            f"{num_stages} stages × {num_servers_per_stage} servers = "
+            f"{num_stages * num_servers_per_stage} total servers, "
+            f"{num_tasks} tasks × {group_size} group_size = {self._total_envs} total_envs"
+        )
+        if self.remainder_tasks > 0:
+            logger.info(
+                f"Task distribution: servers 0-{self.remainder_tasks - 1} handle {self.tasks_per_server + 1} tasks, "
+                f"servers {self.remainder_tasks}-{num_servers_per_stage - 1} handle {self.tasks_per_server} tasks"
+            )
+        logger.info(
+            f"GPU allocation: {servers_per_gpu} servers/GPU, "
+            f"{self.gpu_per_server:.2f} GPU/server, "
+            f"total GPUs needed: {total_gpus_needed}"
+        )
+
+    def initialize(self) -> bool:
+        """
+        Create and initialize all servers.
+
+        This creates num_stages × num_servers_per_stage servers,
+        each running on its own GPU (managed by Ray).
+
+        Returns:
+            True if all servers initialized successfully
+        """
+        if self._initialized:
+            logger.warning("Manager already initialized")
+            return True
+
+        logger.info("Creating IsaacServers...")
+
+        # Build task distribution
+        self._build_task_mapping()
+
+        # Create servers for each stage
+        for stage_id in range(self.num_stages):
+            stage_servers = []
+            for server_rank in range(self.num_servers_per_stage):
+                # Calculate tasks for this server
+                if server_rank < self.remainder_tasks:
+                    server_num_tasks = self.tasks_per_server + 1
+                    task_offset = server_rank * (self.tasks_per_server + 1)
+                else:
+                    server_num_tasks = self.tasks_per_server
+                    task_offset = (
+                        self.remainder_tasks * (self.tasks_per_server + 1)
+                        + (server_rank - self.remainder_tasks) * self.tasks_per_server
+                    )
+
+                # Build server options
+                # Each server gets 1/num_stages GPU so that all stages can time-share the same GPUs
+                # Example: 2 stages × 8 servers/stage = 16 servers, each with 0.5 GPU = 8 GPUs total
+                server_options = {"num_gpus": self.gpu_per_server}
+
+                # Add runtime_env if provided (same as EnvWorker uses)
+                if self.runtime_env is not None:
+                    server_options["runtime_env"] = self.runtime_env
+
+                # Add placement group if provided
+                if self.placement_group is not None:
+                    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+                    bundle_idx = server_rank % len(self.placement_group.bundle_specs)
+                    server_options["scheduling_strategy"] = PlacementGroupSchedulingStrategy(
+                        placement_group=self.placement_group,
+                        placement_group_bundle_index=bundle_idx,
+                    )
+
+                # Add accelerator type if specified
+                if self.accelerator_type is not None:
+                    server_options["resources"] = {self.accelerator_type: 1e-4}
+
+                # Server's total envs = num_tasks * group_size
+                server_total_envs = server_num_tasks * self.group_size
+
+                # Create server
+                server = IsaacServer.options(**server_options).remote(
+                    env_id=self.env_id,
+                    num_tasks=server_num_tasks,
+                    group_size=self.group_size,  # Fixed envs per task
+                    actor_rank=server_rank,
+                    task_offset=task_offset,
+                    render_last_only=self.render_last_only,
+                    camera_height=self.camera_height,
+                    camera_width=self.camera_width,
+                    stage_id=stage_id,
+                )
+                stage_servers.append(server)
+
+                logger.info(
+                    f"Created server: stage={stage_id}, rank={server_rank}, "
+                    f"tasks={task_offset}-{task_offset + server_num_tasks - 1}, "
+                    f"envs={server_total_envs}, gpu={self.gpu_per_server:.2f}"
+                )
+
+            self.servers.append(stage_servers)
+
+        # Initialize all servers in parallel
+        logger.info("Initializing all servers...")
+        init_futures = []
+        for stage_id, stage_servers in enumerate(self.servers):
+            for server in stage_servers:
+                init_futures.append(server.init_env.remote())
+
+        # Wait for all initializations
+        try:
+            results = ray.get(init_futures)
+            for result in results:
+                if result.get("status") != "ok":
+                    logger.error(f"Server initialization failed: {result}")
+                    return False
+        except Exception as e:
+            logger.error(f"Server initialization error: {e}")
+            return False
+
+        # Verify servers are ready
+        _ = ray.get(self.servers[0][0].get_task_mapping.remote())
+
+        self._initialized = True
+        logger.info(
+            f"All servers initialized: "
+            f"{self.num_stages * self.num_servers_per_stage} servers, "
+            f"{self._total_envs} envs per stage"
+        )
+
+        return True
+
+    def _build_task_mapping(self):
+        """Build global task → server mapping."""
+        self._task_to_server.clear()
+        self._task_to_env_indices.clear()
+        self._server_task_offsets.clear()
+
+        for server_rank in range(self.num_servers_per_stage):
+            # Calculate tasks for this server
+            if server_rank < self.remainder_tasks:
+                server_num_tasks = self.tasks_per_server + 1
+                task_offset = server_rank * (self.tasks_per_server + 1)
+            else:
+                server_num_tasks = self.tasks_per_server
+                task_offset = (
+                    self.remainder_tasks * (self.tasks_per_server + 1)
+                    + (server_rank - self.remainder_tasks) * self.tasks_per_server
+                )
+
+            self._server_task_offsets.append(task_offset)
+
+            # Map global task_ids to this server
+            # local_task_id is 0-based within the server
+            for local_task_id in range(server_num_tasks):
+                global_task_id = task_offset + local_task_id
+                self._task_to_server[global_task_id] = server_rank
+
+                # Local env indices for this task on the server
+                # Each task has group_size envs, indexed locally within the server
+                self._task_to_env_indices[global_task_id] = list(
+                    range(local_task_id * self.group_size, (local_task_id + 1) * self.group_size)
+                )
+
+        logger.debug(f"Task mapping built: {self.num_tasks} tasks across {self.num_servers_per_stage} servers")
+
+    def get_server_for_task(self, global_task_id: int) -> int:
+        """Get the server rank that handles a given global task ID."""
+        return self._task_to_server.get(global_task_id, 0)
+
+    def get_env_indices_for_task(self, global_task_id: int) -> list:
+        """
+        Get LOCAL env indices for a given global task ID.
+
+        These are indices local to the server that handles this task.
+        """
+        return self._task_to_env_indices.get(global_task_id, [])
+
+    def step(
+        self,
+        actions: np.ndarray,
+        env_indices: list,
+        server_rank: int,
+        stage_id: int,
+        render_last_only: bool = True,
+    ) -> dict:
+        """
+        Send step command to a specific server.
+
+        Args:
+            actions: Actions array
+            env_indices: LOCAL env indices on that server
+            server_rank: Which server
+            stage_id: Which pipeline stage
+            render_last_only: Only render last step of action chunks
+
+        Returns:
+            Response dict
+        """
+        if not self._initialized:
+            raise RuntimeError("Manager not initialized. Call initialize() first.")
+
+        if stage_id >= len(self.servers) or server_rank >= len(self.servers[stage_id]):
+            raise ValueError(f"Invalid stage_id={stage_id} or server_rank={server_rank}")
+
+        return ray.get(self.servers[stage_id][server_rank].step.remote(actions, env_indices))
+
+    def reset(
+        self,
+        env_indices: list,
+        server_rank: int,
+        stage_id: int,
+        stabilize: bool = True,
+    ) -> dict:
+        """
+        Send reset command to a specific server.
+
+        Args:
+            env_indices: LOCAL env indices on that server
+            server_rank: Which server
+            stage_id: Which pipeline stage
+            stabilize: Whether to run stabilization steps
+
+        Returns:
+            Response dict
+        """
+        if not self._initialized:
+            raise RuntimeError("Manager not initialized. Call initialize() first.")
+
+        if stage_id >= len(self.servers) or server_rank >= len(self.servers[stage_id]):
+            raise ValueError(f"Invalid stage_id={stage_id} or server_rank={server_rank}")
+
+        return ray.get(self.servers[stage_id][server_rank].reset.remote(env_indices, stabilize))
+
+    def step_batched(
+        self,
+        server_requests: dict[int, tuple[np.ndarray, list]],
+        stage_id: int,
+        render_last_only: bool = True,
+    ) -> dict[int, dict]:
+        """
+        Send step commands to multiple servers CONCURRENTLY.
+
+        Uses ray.get() for parallel execution across servers.
+
+        Args:
+            server_requests: Dict mapping server_rank -> (actions, env_indices)
+                e.g., {0: (actions_0, [0,1,2]), 2: (actions_2, [8,9,10])}
+            stage_id: Which pipeline stage
+            render_last_only: Only render last step of action chunks
+
+        Returns:
+            Dict mapping server_rank -> response dict
+        """
+        if not self._initialized:
+            raise RuntimeError("Manager not initialized. Call initialize() first.")
+
+        # Submit all step calls
+        futures = {}
+        for server_rank, (actions, indices) in server_requests.items():
+            if server_rank >= len(self.servers[stage_id]):
+                logger.error(f"Invalid server_rank={server_rank}")
+                continue
+            future = self.servers[stage_id][server_rank].step.remote(actions, indices)
+            futures[server_rank] = future
+
+        # Wait for all results
+        results = {}
+        for server_rank, future in futures.items():
+            try:
+                results[server_rank] = ray.get(future)
+            except Exception as e:
+                logger.error(f"Step failed on server {server_rank}: {e}")
+                results[server_rank] = {"status": "error", "message": str(e)}
+
+        return results
+
+    def reset_batched(
+        self,
+        server_requests: dict[int, list],
+        stage_id: int,
+        stabilize: bool = True,
+    ) -> dict[int, dict]:
+        """
+        Send reset commands to multiple servers CONCURRENTLY.
+
+        Args:
+            server_requests: Dict mapping server_rank -> env_indices
+                e.g., {0: [0,1,2,3], 2: [8,9,10,11]}
+            stage_id: Which pipeline stage
+            stabilize: Whether to run stabilization steps
+
+        Returns:
+            Dict mapping server_rank -> response dict
+        """
+        if not self._initialized:
+            raise RuntimeError("Manager not initialized. Call initialize() first.")
+
+        # Submit all reset calls
+        futures = {}
+        for server_rank, indices in server_requests.items():
+            if server_rank >= len(self.servers[stage_id]):
+                logger.error(f"Invalid server_rank={server_rank}")
+                continue
+            future = self.servers[stage_id][server_rank].reset.remote(indices, stabilize)
+            futures[server_rank] = future
+
+        # Wait for all results
+        results = {}
+        for server_rank, future in futures.items():
+            try:
+                results[server_rank] = ray.get(future)
+            except Exception as e:
+                logger.error(f"Reset failed on server {server_rank}: {e}")
+                results[server_rank] = {"status": "error", "message": str(e)}
+
+        return results
+
+    def reset_all_stages_batched(
+        self,
+        server_requests: dict[int, list],
+        stabilize: bool = True,
+    ) -> dict[int, dict[int, dict]]:
+        """
+        Send reset commands to all stages with the same server_requests.
+
+        This is useful for initial reset where all stages need the same env states.
+
+        Args:
+            server_requests: Dict mapping server_rank -> env_indices
+            stabilize: Whether to run stabilization steps
+
+        Returns:
+            Dict mapping stage_id -> (server_rank -> response dict)
+        """
+        if not self._initialized:
+            raise RuntimeError("Manager not initialized. Call initialize() first.")
+
+        # Submit all reset calls for all stages
+        futures_by_stage = {}
+        for stage_id in range(self.num_stages):
+            futures = {}
+            for server_rank, indices in server_requests.items():
+                if server_rank >= len(self.servers[stage_id]):
+                    continue
+                future = self.servers[stage_id][server_rank].reset.remote(indices, stabilize)
+                futures[server_rank] = future
+            futures_by_stage[stage_id] = futures
+
+        # Wait for all results
+        results = {}
+        for stage_id, futures in futures_by_stage.items():
+            stage_results = {}
+            for server_rank, future in futures.items():
+                try:
+                    stage_results[server_rank] = ray.get(future)
+                except Exception as e:
+                    logger.error(f"Reset failed on stage {stage_id} server {server_rank}: {e}")
+                    stage_results[server_rank] = {"status": "error", "message": str(e)}
+            results[stage_id] = stage_results
+
+        return results
+
+    @property
+    def num_tasks(self) -> int:
+        """Get total number of tasks."""
+        return self._num_tasks
+
+    @num_tasks.setter
+    def num_tasks(self, value: int):
+        self._num_tasks = value
+
+    @property
+    def total_envs(self) -> int:
+        """Get total number of envs per stage."""
+        return self._total_envs
+
+    @property
+    def initialized(self) -> bool:
+        """Check if manager is initialized."""
+        return self._initialized
+
+    def close(self):
+        """Close all servers and clean up resources."""
+        logger.info("Closing all servers...")
+
+        # Close thread pool
+        self._executor.shutdown(wait=True)
+
+        # Close all servers
+        close_futures = []
+        for stage_servers in self.servers:
+            for server in stage_servers:
+                close_futures.append(server.close.remote())
+
+        # Wait for all closes
+        if close_futures:
+            try:
+                ray.get(close_futures)
+            except Exception as e:
+                logger.warning(f"Error closing servers: {e}")
+
+        # Kill servers
+        for stage_servers in self.servers:
+            for server in stage_servers:
+                try:
+                    ray.kill(server)
+                except Exception:
+                    pass
+
+        self.servers = []
+        self._initialized = False
+
+        logger.info("All servers closed")
+
+    def __del__(self):
+        """Clean up on deletion."""
+        if self._initialized:
+            self.close()

--- a/verl/experimental/vla/rob_ray_trainer.py
+++ b/verl/experimental/vla/rob_ray_trainer.py
@@ -196,10 +196,9 @@ class RobRayPPOTrainer(RayPPOTrainer):
         # create async rollout manager and request scheduler
         self.async_rollout_mode = False
         if self.config.actor_rollout_ref.rollout.mode == "async_envloop":
-            self.async_rollout_mode = True
-
             from verl.experimental.vla.env_loop import EnvLoop
 
+            self.async_rollout_mode = True
             self.async_rollout_manager = EnvLoop(
                 config=self.config, rollout_wg=self.actor_rollout_wg, env_wg=self.env_wg
             )

--- a/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
+++ b/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
@@ -97,7 +97,8 @@ mkdir -p /root/LIBERO/libero/libero/../datasets
 
 SAVE_VIDEO=False
 
-export PYTHONRECURSIONLIMIT=10000
+# TODO: Verify if this is necessary - may be needed for deep config nesting in multi-task setups
+# export PYTHONRECURSIONLIMIT=10000
 # uncomment this to see full error messages
 # export HYDRA_FULL_ERROR=1
 

--- a/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
+++ b/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -x
+
+echo "Ray Actor Mode: Isaac Sim runs as Ray actors (unified resource management)"
+
+WORKSPACE=/workspace/verl_vla/
+
+libero_train_path=$WORKSPACE/data/libero_rl/train.parquet
+libero_test_path=$WORKSPACE/data/libero_rl/test.parquet
+
+train_files=$libero_train_path
+test_files=$libero_test_path
+
+OUTPUT_DIR=${MLP_MODEL_OUTPUT:-"$WORKSPACE/models/vla_libero_grpo_ray"}
+VIDEO_OUTPUT=${MLP_MODEL_OUTPUT:-"$WORKSPACE"}/video/$(date +%Y%m%d_%H%M%S)
+TIMELINE_FILE=${TIMELINE_FILE:-"$WORKSPACE/logs/ray_timeline_$(date +%Y%m%d_%H%M%S).json"}
+SFT_MODEL_PATH=${SFT_MODEL_PATH:-"$WORKSPACE/data/Openvla-oft-SFT-libero10-trajall"}
+
+# for rollout and train
+NUM_NODES=1
+NUM_ROLLOUT_GPUS_PER_NODE=8
+# for simulator
+SIM_NODES=2
+NUM_ENV_GPUS_TOTAL=10
+BATCH_SIZE=32
+# rollout.n should equal to num_envs for isaac env
+# GROUP_SIZE / ROLLOUT_N = max trajectories per task (need >= 2 for uneven data distribution)
+ROLLOUT_N=8
+
+# 512 is required for libero benchmark, but you can reduce it in debugging to run faster
+MAX_EPISODE_STEPS=256
+
+# Number of tasks in the benchmark
+# Must satisfy: NUM_TASKS × GROUP_SIZE =  NUM_ROLLOUT_GPUS_PER_NODE × STAGE_NUM × ROLLOUT_N
+NUM_TASKS=10
+STAGE_NUM=2
+GROUP_SIZE=16
+
+# isaac or libero
+# NOT SUPPORTED: libero means original libero benchmark with mujoco sim
+# isaac means libero benchmark using isaac sim
+SIM_TYPE=${SIM_TYPE:-"isaac"}
+PROJECT_NAME="vla-ray-isaac"
+EXPERIMENT_NAME="${SIM_TYPE}_ray_rl"
+
+# Enable Ray actor mode (recommended)
+USE_RAY_ACTORS=True
+
+# Number of Isaac servers per stage (one per GPU)
+NUM_ISAAC_SERVERS=$NUM_ENV_GPUS_TOTAL
+
+# Isaac environment ID
+ISAAC_ENV_ID="Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0"
+
+# Camera settings
+CAMERA_HEIGHT=256
+CAMERA_WIDTH=256
+
+# TRAJS_PER_BATCH = environments participating in training (from rollout config)
+# ISAAC_ENVS = total environments in Isaac Sim (may be more, extras stay idle)
+TRAJS_PER_BATCH=$((BATCH_SIZE * ROLLOUT_N))
+ISAAC_ENVS=$((NUM_TASKS * GROUP_SIZE * STAGE_NUM))
+
+echo "============================================"
+echo "Environment allocation:"
+echo "  Training envs (TRAJS_PER_BATCH): ${TRAJS_PER_BATCH} = ${NUM_ROLLOUT_GPUS_PER_NODE} gpus × ${NUM_NODES} nodes × ${ROLLOUT_N} rollout_n"
+echo "  Isaac Sim envs: ${ISAAC_ENVS} = ${NUM_TASKS} tasks × ${GROUP_SIZE} group_size × ${STAGE_NUM} stages"
+if [ $ISAAC_ENVS -lt $TRAJS_PER_BATCH ]; then
+    echo "ERROR: Not enough Isaac envs! Need at least ${TRAJS_PER_BATCH}"
+    exit 1
+fi
+echo "  Idle envs: $((ISAAC_ENVS - TRAJS_PER_BATCH))"
+echo "============================================"
+
+echo "============================================"
+echo "Isaac Ray Actor Mode Configuration:"
+echo "  Mode: Ray Actor (unified resource management)"
+echo "  Isaac servers per stage: ${NUM_ISAAC_SERVERS}"
+echo "  Pipeline stages: ${STAGE_NUM}"
+echo "  Total servers: $((NUM_ISAAC_SERVERS * STAGE_NUM))"
+echo "  Tasks: ${NUM_TASKS}"
+echo "  Total envs: ${TRAJS_PER_BATCH} (${NUM_ROLLOUT_GPUS_PER_NODE} gpus × ${STAGE_NUM} stages × ${ROLLOUT_N} envs)"
+echo "  Group size (envs/task): ${GROUP_SIZE}"
+echo "============================================"
+echo ""
+echo "No manual server startup needed - Ray manages everything!"
+echo "============================================"
+
+ISSC_PYTHON="/workspace/isaaclab/_isaac_sim/python.sh"
+PYTHON=python
+if [ -f "$ISSC_PYTHON" ]; then
+    PYTHON=$ISSC_PYTHON
+fi
+
+# avoiding warnings
+mkdir -p /root/LIBERO/libero/libero/../datasets
+
+SAVE_VIDEO=False
+
+export PYTHONRECURSIONLIMIT=10000
+# uncomment this to see full error messages
+# export HYDRA_FULL_ERROR=1
+
+$PYTHON -m verl.experimental.vla.main_ppo \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.train_batch_size=${BATCH_SIZE} \
+    data.val_batch_size=${BATCH_SIZE} \
+    +data.num_tasks=${NUM_TASKS} \
+    actor_rollout_ref.rollout.n=$ROLLOUT_N \
+    env.train.num_envs=$ROLLOUT_N \
+    data.max_prompt_length=256 \
+    data.max_response_length=128 \
+    env.rollout.pipeline_stage_num=$STAGE_NUM \
+    env.train.simulator_type=$SIM_TYPE \
+    env.actor.model.num_action_chunks=8 \
+    env.actor.model.action_dim=7 \
+    env.train.only_eval=False \
+    env.train.max_episode_steps=$MAX_EPISODE_STEPS \
+    env.train.video_cfg.save_video=$SAVE_VIDEO \
+    env.train.video_cfg.video_base_dir=${VIDEO_OUTPUT} \
+    env.train.seed=42 \
+    env.disagg_sim.enable=True \
+    env.disagg_sim.nnodes=$SIM_NODES \
+    env.train.isaac_server_mode=$USE_RAY_ACTORS \
+    env.train.num_isaac_servers=$NUM_ISAAC_SERVERS \
+    env.train.num_tasks=$NUM_TASKS \
+    env.train.group_size=$GROUP_SIZE \
+    env.train.env_id=$ISAAC_ENV_ID \
+    env.train.camera_height=$CAMERA_HEIGHT \
+    env.train.camera_width=$CAMERA_WIDTH \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
+    actor_rollout_ref.model.path=$SFT_MODEL_PATH \
+    actor_rollout_ref.rollout.mode=async_envloop \
+    actor_rollout_ref.actor.optim.lr=5e-6 \
+    actor_rollout_ref.actor.optim.warmup_style=constant \
+    actor_rollout_ref.actor.ppo_mini_batch_size=128 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
+    actor_rollout_ref.actor.use_dynamic_bsz=False \
+    actor_rollout_ref.actor.grad_clip=1 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.num_images_in_input=1 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=False \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.model.trust_remote_code=False \
+    actor_rollout_ref.actor.entropy_coeff=0. \
+    actor_rollout_ref.rollout.temperature=1.6 \
+    actor_rollout_ref.rollout.prompt_length=512 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size=16 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=hf \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.9 \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size=16 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.kl_ctrl.kl_coef=0.00 \
+    trainer.logger=['console'] \
+    trainer.project_name=$PROJECT_NAME \
+    trainer.experiment_name=$EXPERIMENT_NAME \
+    trainer.default_local_dir=$OUTPUT_DIR \
+    trainer.n_gpus_per_node=$NUM_ROLLOUT_GPUS_PER_NODE \
+    +trainer.n_env_gpus_per_node=$NUM_ENV_GPUS_TOTAL \
+    +trainer.n_rollout_gpus_per_node=$NUM_ROLLOUT_GPUS_PER_NODE \
+    trainer.nnodes=$NUM_NODES \
+    env.train.total_trajs=$TRAJS_PER_BATCH \
+    trainer.save_freq=30 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=20 \
+    trainer.val_only=False \
+    trainer.total_training_steps=1000 \
+    algorithm.adv_estimator=reinforce_plus_plus \
+    trainer.val_before_train=False \
+    trainer.resume_mode=disable \
+    +ray_kwargs.timeline_json_file=$TIMELINE_FILE \
+    $@ 2>&1 | tee $WORKSPACE/logs/vla_isaac_ray_$(date +%Y%m%d_%H%M%S).log
+

--- a/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
+++ b/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
@@ -49,6 +49,11 @@ ISAAC_SERVER_MODE=True
 # Number of Isaac servers per stage (one per GPU)
 NUM_ISAAC_SERVERS=$NUM_ENV_GPUS_TOTAL
 
+# Flush NVIDIA shader cache to fix rendering noise (slower startup but fixes quality)
+# Set to 1 if you see noisy renders or cache warnings in logs
+# After one run with flush=1, you can set back to 0
+export ISAAC_FLUSH_SHADER_CACHE=${ISAAC_FLUSH_SHADER_CACHE:-1}
+
 # Isaac environment ID
 ISAAC_ENV_ID="Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0"
 
@@ -95,11 +100,8 @@ fi
 # avoiding warnings
 mkdir -p /root/LIBERO/libero/libero/../datasets
 
-SAVE_VIDEO=False
+SAVE_VIDEO=True
 
-# TODO: Verify if this is necessary - may be needed for deep config nesting in multi-task setups
-# export PYTHONRECURSIONLIMIT=10000
-# uncomment this to see full error messages
 # export HYDRA_FULL_ERROR=1
 
 $PYTHON -m verl.experimental.vla.main_ppo \
@@ -169,7 +171,7 @@ $PYTHON -m verl.experimental.vla.main_ppo \
     trainer.test_freq=-1 \
     trainer.total_epochs=20 \
     trainer.val_only=False \
-    trainer.total_training_steps=1000 \
+    trainer.total_training_steps=30 \
     algorithm.adv_estimator=reinforce_plus_plus \
     trainer.val_before_train=False \
     trainer.resume_mode=disable \

--- a/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
+++ b/verl/experimental/vla/run_simpleVLA_isaac_disagg_server.sh
@@ -28,7 +28,7 @@ BATCH_SIZE=32
 ROLLOUT_N=8
 
 # 512 is required for libero benchmark, but you can reduce it in debugging to run faster
-MAX_EPISODE_STEPS=256
+MAX_EPISODE_STEPS=512
 
 # Number of tasks in the benchmark
 # Must satisfy: NUM_TASKS × GROUP_SIZE =  NUM_ROLLOUT_GPUS_PER_NODE × STAGE_NUM × ROLLOUT_N
@@ -43,8 +43,8 @@ SIM_TYPE=${SIM_TYPE:-"isaac"}
 PROJECT_NAME="vla-ray-isaac"
 EXPERIMENT_NAME="${SIM_TYPE}_ray_rl"
 
-# Enable Ray actor mode (recommended)
-USE_RAY_ACTORS=True
+# Enable Isaac server mode (recommended for multi-task)
+ISAAC_SERVER_MODE=True
 
 # Number of Isaac servers per stage (one per GPU)
 NUM_ISAAC_SERVERS=$NUM_ENV_GPUS_TOTAL
@@ -122,13 +122,13 @@ $PYTHON -m verl.experimental.vla.main_ppo \
     env.train.seed=42 \
     env.disagg_sim.enable=True \
     env.disagg_sim.nnodes=$SIM_NODES \
-    env.train.isaac_server_mode=$USE_RAY_ACTORS \
+    env.train.isaac_server_mode=$ISAAC_SERVER_MODE \
     env.train.num_isaac_servers=$NUM_ISAAC_SERVERS \
     env.train.num_tasks=$NUM_TASKS \
     env.train.group_size=$GROUP_SIZE \
     env.train.env_id=$ISAAC_ENV_ID \
-    env.train.camera_height=$CAMERA_HEIGHT \
-    env.train.camera_width=$CAMERA_WIDTH \
+    env.train.init_params.camera_heights=$CAMERA_HEIGHT \
+    env.train.init_params.camera_widths=$CAMERA_WIDTH \
     actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16 \
     actor_rollout_ref.model.path=$SFT_MODEL_PATH \
     actor_rollout_ref.rollout.mode=async_envloop \

--- a/verl/experimental/vla/workers/env/__init__.py
+++ b/verl/experimental/vla/workers/env/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Environment Workers Module
+
+This module provides environment worker implementations for VLA training:
+    - EnvWorkerServer: Ray-based worker using IsaacServerManager
+"""
+
+from .env_worker_server import EnvWorkerServer
+from .utils import TaskBalancedSampler, create_task_balanced_sampler
+
+__all__ = [
+    "EnvWorkerServer",
+    "TaskBalancedSampler",
+    "create_task_balanced_sampler",
+]

--- a/verl/experimental/vla/workers/env/env_worker_server.py
+++ b/verl/experimental/vla/workers/env/env_worker_server.py
@@ -153,8 +153,9 @@ class EnvWorkerServer(Worker):
         # Isaac configuration
         self.env_id = config.train.get("env_id", "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0")
         self.num_isaac_servers = config.train.get("num_isaac_servers", 8)
-        self.camera_height = config.train.get("camera_height", 256)
-        self.camera_width = config.train.get("camera_width", 256)
+        init_params = config.train.get("init_params", {})
+        self.camera_height = init_params.get("camera_heights", 256)
+        self.camera_width = init_params.get("camera_widths", 256)
 
         # Pre-created manager (from trainer) or None
         self._external_manager = server_manager

--- a/verl/experimental/vla/workers/env/env_worker_server.py
+++ b/verl/experimental/vla/workers/env/env_worker_server.py
@@ -1,0 +1,774 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+EnvWorker Server Mode (Ray-based)
+
+A lightweight EnvWorker that uses IsaacServerManager to manage
+Isaac Lab simulations via Ray servers.
+
+Key features:
+    1. Uses Ray server handles for communication
+    2. Isaac servers managed by IsaacServerManager
+    3. Data transfer via Ray's object store (efficient)
+    4. Servers are co-located in same Ray cluster as training
+
+Architecture:
+    ┌─────────────────────────────────────────────────────────────────┐
+    │                    Ray Cluster                                  │
+    │                                                                 │
+    │  ┌─────────────────────┐      ┌───────────────────────────────┐│
+    │  │  EnvWorkerServer    │ ───▶ │ IsaacServerManager            ││
+    │  │   (Ray Worker)      │      │   ├─ Stage 0: [Server0, ...] ││
+    │  │                     │ ◀─── │   └─ Stage 1: [Server0, ...] ││
+    │  └─────────────────────┘      └───────────────────────────────┘│
+    └─────────────────────────────────────────────────────────────────┘
+
+Usage:
+    # In main_ppo.py:
+    from verl.experimental.vla.workers.env import EnvWorkerServer
+
+    # Or configure in YAML:
+    env:
+        train:
+            isaac_server_mode: true
+"""
+
+import logging
+import os
+import uuid
+from collections import defaultdict
+from typing import Optional
+
+import numpy as np
+import torch
+from omegaconf import DictConfig
+from torch.distributed.device_mesh import init_device_mesh
+
+from verl import DataProto
+from verl.experimental.vla.envs.action_utils import prepare_actions, put_info_on_image, save_rollout_video, tile_images
+from verl.experimental.vla.isaac_server import IsaacServerManager
+from verl.single_controller.base import Worker
+from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
+from verl.utils.device import get_device_name
+
+logger = logging.getLogger(__name__)
+
+
+def extract_images_and_states(obs):
+    """Extract images and states from Isaac Lab MultiTaskObservationsCfg format."""
+    result = {}
+
+    # Extract image from rgb_camera
+    if "rgb_camera" in obs:
+        rgb_camera = obs["rgb_camera"]
+        if isinstance(rgb_camera, dict):
+            if "agentview_cam" in rgb_camera:
+                result["full_image"] = rgb_camera["agentview_cam"]
+                result["camera_name"] = "agentview"
+        elif isinstance(rgb_camera, np.ndarray):
+            if rgb_camera.ndim == 4 and rgb_camera.shape[-1] >= 3:
+                result["full_image"] = rgb_camera[:, :, :, :3]
+                result["camera_name"] = "agentview"
+
+    # Extract state from policy
+    if "policy" in obs:
+        policy = obs["policy"]
+        if isinstance(policy, dict):
+            state_list = []
+            for key in ["eef_pose", "gripper_pos"]:
+                if key in policy:
+                    val = policy[key]
+                    if hasattr(val, "shape"):
+                        if len(val.shape) > 2:
+                            val = val.reshape(val.shape[0], -1)
+                        state_list.append(val)
+            if state_list:
+                result["state"] = np.concatenate(state_list, axis=-1)
+        elif isinstance(policy, np.ndarray):
+            result["state"] = policy
+
+    return result
+
+
+def create_env_batch_dataproto(obs, rews, terminations, truncations, infos, meta=None, task_descriptions=None):
+    """Create DataProto from environment outputs."""
+    ret_dict = {"obs": obs, "rews": rews, "terminations": terminations, "truncations": truncations, "infos": infos}
+    if meta is not None:
+        ret_dict.update(meta=meta)
+
+    images_and_states = extract_images_and_states(ret_dict["obs"])
+
+    tensor_batch = {
+        "full_image": torch.from_numpy(images_and_states["full_image"]).cpu().contiguous(),
+        "state": torch.from_numpy(images_and_states["state"]).cpu().contiguous(),
+        "rews": torch.from_numpy(ret_dict["rews"]).cpu().contiguous(),
+        "terminations": torch.from_numpy(ret_dict["terminations"]).cpu().contiguous(),
+        "truncations": torch.from_numpy(ret_dict["truncations"]).cpu().contiguous(),
+    }
+
+    if task_descriptions is None:
+        task_descriptions = obs.get("task_descriptions", [])
+    non_tensor_batch = {"task_descriptions": task_descriptions}
+    output = DataProto.from_dict(tensors=tensor_batch, non_tensors=non_tensor_batch)
+
+    return output
+
+
+class EnvWorkerServer(Worker):
+    """
+    EnvWorker that uses Ray-based IsaacServerManager.
+
+    Uses Ray-based IsaacServerManager for Isaac Lab simulations.
+
+    Key features:
+    1. Uses IsaacServerManager for managing Ray servers
+    2. Direct Ray server calls for communication
+    3. Can receive manager from trainer (servers created externally)
+    """
+
+    def __init__(self, config: DictConfig, server_manager: Optional[IsaacServerManager] = None):
+        """
+        Initialize EnvWorkerServer.
+
+        Args:
+            config: Configuration dict
+            server_manager: Optional pre-created IsaacServerManager.
+                          If None, will be created in init_worker().
+        """
+        Worker.__init__(self)
+        self.cfg = config
+
+        # Isaac configuration
+        self.env_id = config.train.get("env_id", "Isaac-Libero-Franka-OscPose-Camera-All-Tasks-v0")
+        self.num_isaac_servers = config.train.get("num_isaac_servers", 8)
+        self.camera_height = config.train.get("camera_height", 256)
+        self.camera_width = config.train.get("camera_width", 256)
+
+        # Pre-created manager (from trainer) or None
+        self._external_manager = server_manager
+        self.manager: IsaacServerManager = None
+
+        # Stage configuration
+        self.stage_num = self.cfg.rollout.pipeline_stage_num
+        self.num_envs = self.cfg.train.num_envs
+
+        # group_size = envs per task (from config)
+        self.group_size = config.train.get("group_size", 16)
+
+        # Initialize distributed
+        # EnvWorkerServer is a lightweight coordinator - may not have GPU
+        # Use gloo-only backend if no GPU available
+        import torch.distributed
+
+        if not torch.distributed.is_initialized():
+            # Use rank and world_size from environment (already set by Worker.__init__)
+            rank = self.rank
+            world_size = self.world_size
+
+            # Check if we have GPU
+            has_gpu = torch.cuda.is_available() and torch.cuda.device_count() > 0
+            if has_gpu:
+                # Use both gloo (CPU) and nccl (GPU)
+                backend = "cpu:gloo,cuda:nccl"
+            else:
+                # No GPU - use gloo only
+                backend = "gloo"
+                logger.info(f"[rank={rank}] No GPU available, using gloo backend only")
+
+            torch.distributed.init_process_group(
+                backend=backend,
+                rank=rank,
+                world_size=world_size,
+            )
+
+        # Note: Worker base class already set self._rank and self._world_size from env vars
+        # We don't override them here - they should match torch.distributed values
+
+        # total_trajs from config (backward compatible with total_envs)
+        # In Server mode with single EnvWorkerServer, this is the global total
+        self.total_trajs = self.cfg.train.get("total_trajs", self.cfg.train.get("total_envs", 128))
+
+        logger.info(f"[rank={self.rank}] EnvWorkerServer: total_trajs={self.total_trajs}, world_size={self.world_size}")
+
+        device_name = "cpu" if not torch.cuda.is_available() else get_device_name()
+        env_device_mesh = init_device_mesh(device_name, mesh_shape=(self.world_size, 1), mesh_dim_names=["dp", "tp"])
+        self._register_dispatch_collect_info("env", dp_rank=env_device_mesh["dp"].get_local_rank(), is_collect=True)
+
+        # Hash-key based env mapping
+        self._trajectory_registry: dict[str, dict] = {}
+        self._task_allocation_offset: dict[int, int] = {}
+        self._active_traj_keys: list[str] = []
+
+        # Video saving
+        self.video_cfg = self.cfg.train.get("video_cfg", {})
+        self.save_video = self.video_cfg.get("save_video", False)
+        self.video_base_dir = self.video_cfg.get("video_base_dir", "/tmp/videos")
+        self.render_images: dict[int, dict[int, list[np.ndarray]]] = {}
+        self.video_cnt: dict[int, dict[int, int]] = {}
+        self.camera_view = "agentview"
+
+        logger.info(f"[rank={self.rank}] EnvWorkerServer initialized")
+        logger.info(f"[rank={self.rank}] Using Ray actors")
+        logger.info(f"[rank={self.rank}] Total trajs: {self.total_trajs}, stages: {self.stage_num}")
+
+    def set_server_manager(self, manager: IsaacServerManager):
+        """
+        Set the server manager (created externally by trainer).
+
+        This allows the trainer to create and manage the actors,
+        and pass the manager to this worker.
+        """
+        self.manager = manager
+        logger.info(f"[rank={self.rank}] Actor manager set from trainer")
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_worker(self):
+        """Initialize the Isaac server manager.
+
+        If actor_manager was provided in __init__ or set via set_server_manager(),
+        use that. Otherwise, create a new manager.
+        """
+        if self._external_manager is not None:
+            self.manager = self._external_manager
+            logger.info(f"[rank={self.rank}] Using external server manager")
+        elif self.manager is not None:
+            logger.info(f"[rank={self.rank}] Using pre-set server manager")
+        else:
+            # Create new manager
+            num_tasks = self.cfg.train.get("num_tasks", 10)
+
+            # Use "sim" accelerator_type to schedule actors to sim nodes
+            # Sim nodes are started with python.sh which sets up Isaac environment
+            # So we don't need to pass runtime_env - actors inherit sim node's environment
+            accelerator_type = "sim"
+
+            logger.info(f"[rank={self.rank}] Creating IsaacServerManager...")
+            logger.info(f"[rank={self.rank}] Using accelerator_type='{accelerator_type}' to schedule to sim nodes")
+            logger.info(f"[rank={self.rank}] num_tasks={num_tasks}, group_size={self.group_size}")
+
+            self.manager = IsaacServerManager(
+                num_stages=self.stage_num,
+                num_servers_per_stage=self.num_isaac_servers,
+                num_tasks=num_tasks,
+                group_size=self.group_size,  # Envs per task (fixed)
+                env_id=self.env_id,
+                render_last_only=True,
+                camera_height=self.camera_height,
+                camera_width=self.camera_width,
+                accelerator_type=accelerator_type,
+                # Don't pass runtime_env - let servers inherit sim node's environment
+                # Sim nodes are started with python.sh which sets PYTHONPATH, LD_LIBRARY_PATH, etc.
+            )
+
+            if not self.manager.initialize():
+                raise RuntimeError("Failed to initialize IsaacServerManager")
+
+        logger.info(
+            f"[rank={self.rank}] Connected to Isaac servers: "
+            f"{self.stage_num} stages × {self.num_isaac_servers} servers, "
+            f"{self.manager.num_tasks} tasks, {self.manager._total_envs} sim_envs_per_stage"
+        )
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def init_simulator(self):
+        """No-op for Ray mode - actors are already initialized."""
+        logger.info(f"[rank={self.rank}] init_simulator called (no-op in Ray mode)")
+        return
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="env"), blocking=False)
+    def env_interact_step(self, data: DataProto) -> DataProto:
+        """
+        Interact with the environment through Ray actors.
+
+        Uses Ray actor calls for environment interaction.
+        """
+        chunk_actions = data.non_tensor_batch["actions"]
+        stage_id: int = data.meta_info["stage_id"]
+
+        traj_keys = data.non_tensor_batch.get("traj_keys", None)
+
+        if traj_keys is not None:
+            self._validate_traj_keys(traj_keys)
+        else:
+            logger.warning(f"[rank={self.rank}] traj_keys not provided, using order from reset")
+            # Each stage processes total_trajs / stage_num trajectories
+            trajs_per_stage = self.total_trajs // self.stage_num
+            stage_start = stage_id * trajs_per_stage
+            stage_end = (stage_id + 1) * trajs_per_stage
+            traj_keys = self._active_traj_keys[stage_start:stage_end]
+            self._validate_traj_keys(traj_keys)
+
+        # Prepare actions
+        chunk_actions = prepare_actions(
+            simulator_type=self.cfg.train.simulator_type,
+            raw_chunk_actions=chunk_actions,
+            num_action_chunks=self.cfg.actor.model.num_action_chunks,
+            action_dim=self.cfg.actor.model.action_dim,
+        )
+
+        if isinstance(chunk_actions, torch.Tensor):
+            chunk_actions = chunk_actions.cpu().numpy()
+
+        step_idx = data.meta_info.get("step_idx", 0)
+        max_steps = data.meta_info.get("max_steps", 1)
+
+        # Route to stage-specific actors
+        response = self._server_group_step(chunk_actions, traj_keys, stage_id, step_idx, max_steps)
+
+        if response is None or response.get("status") != "ok":
+            raise RuntimeError(f"[rank={self.rank}] Step request failed: {response}")
+
+        # Build response DataProto
+        env_info_list = {}
+
+        terminations = response["terminations"]
+        truncations = response["truncations"]
+        chunk_dones = np.logical_or(terminations, truncations)
+
+        if chunk_dones.any():
+            infos = response.get("infos", {})
+            if "final_info" in infos:
+                final_info = infos["final_info"]
+                for key in final_info.get("episode", {}):
+                    env_info_list[key] = final_info["episode"][key][chunk_dones[:, -1]]
+
+        # Generate task_descriptions from traj registry
+        task_descriptions = []
+        for key in traj_keys:
+            task_id = self._trajectory_registry[key]["task_id"]
+            task_descriptions.append(f"Task {task_id}")
+
+        env_batch = create_env_batch_dataproto(
+            obs=response["obs"],
+            rews=response["rewards"],
+            terminations=terminations,
+            truncations=truncations,
+            infos=response.get("infos", {}),
+            meta=env_info_list,
+            task_descriptions=task_descriptions,
+        )
+
+        # Video saving
+        if self.save_video:
+            self._collect_video_frames(response, traj_keys, stage_id)
+
+        return env_batch
+
+    def _server_group_step(
+        self,
+        chunk_actions: np.ndarray,
+        traj_keys: list,
+        stage_id: int,
+        step_idx: int = 0,
+        max_steps: int = 1,
+        render_last_only: bool = True,
+    ) -> dict:
+        """
+        Execute step on the stage-specific server group.
+
+        Uses IsaacServerManager.step_batched() for parallel execution.
+        Each traj_key maps to exactly one sim env.
+        """
+        # Group by server_rank for batched execution
+        server_groups = defaultdict(lambda: {"indices": [], "actions": [], "original_positions": []})
+
+        for i, key in enumerate(traj_keys):
+            info = self._trajectory_registry[key]
+            server_rank = info["server_rank"]
+            server_groups[server_rank]["indices"].append(info["env_index"])
+            server_groups[server_rank]["actions"].append(chunk_actions[i])
+            server_groups[server_rank]["original_positions"].append(i)
+
+        # Log step info
+        server_summary = {rank: len(group["indices"]) for rank, group in server_groups.items()}
+        print(
+            f"[EnvWorker Ray] Step {step_idx + 1}/{max_steps} Stage {stage_id}: "
+            f"{len(traj_keys)} trajs -> {len(server_groups)} servers {server_summary}",
+            flush=True,
+        )
+
+        # Build batched requests
+        server_requests = {}
+        position_map = {}
+        for rank, group in server_groups.items():
+            actions = np.array(group["actions"])
+            indices = group["indices"]
+            server_requests[rank] = (actions, indices)
+            position_map[rank] = group["original_positions"]
+
+        # Send requests via manager
+        responses = self.manager.step_batched(server_requests, stage_id=stage_id, render_last_only=render_last_only)
+
+        # Validate responses
+        all_responses = {}
+        for rank, response in responses.items():
+            if response is None or response.get("status") != "ok":
+                raise RuntimeError(
+                    f"[rank={self.rank}] Step request to stage {stage_id} server {rank} failed: {response}"
+                )
+            all_responses[rank] = {
+                "response": response,
+                "original_positions": position_map[rank],
+            }
+
+        # Aggregate responses
+        return self._aggregate_responses(all_responses, len(traj_keys))
+
+    def _aggregate_responses(self, all_responses: dict, num_envs: int) -> dict:
+        """Aggregate responses from multiple actors into a single response."""
+        first_response = next(iter(all_responses.values()))["response"]
+        rewards_shape = first_response["rewards"].shape[1:] if len(first_response["rewards"].shape) > 1 else ()
+        term_shape = first_response["terminations"].shape[1:] if len(first_response["terminations"].shape) > 1 else ()
+
+        aggregated_rewards = np.zeros((num_envs,) + rewards_shape, dtype=first_response["rewards"].dtype)
+        aggregated_terminations = np.zeros((num_envs,) + term_shape, dtype=first_response["terminations"].dtype)
+        aggregated_truncations = np.zeros((num_envs,) + term_shape, dtype=first_response["truncations"].dtype)
+
+        def init_aggregated_obs(obs_dict, num_envs):
+            result = {}
+            for key, value in obs_dict.items():
+                if isinstance(value, dict):
+                    result[key] = init_aggregated_obs(value, num_envs)
+                elif isinstance(value, np.ndarray):
+                    result[key] = np.zeros((num_envs,) + value.shape[1:], dtype=value.dtype)
+                else:
+                    result[key] = [None] * num_envs
+            return result
+
+        aggregated_obs = init_aggregated_obs(first_response["obs"], num_envs)
+
+        def fill_aggregated_obs(agg_obs, response_obs, positions):
+            for key, value in response_obs.items():
+                if isinstance(value, dict):
+                    fill_aggregated_obs(agg_obs[key], value, positions)
+                elif isinstance(value, np.ndarray):
+                    for i, pos in enumerate(positions):
+                        agg_obs[key][pos] = value[i]
+                else:
+                    for i, pos in enumerate(positions):
+                        agg_obs[key][pos] = value[i] if hasattr(value, "__getitem__") else value
+
+        for actor_rank, data in all_responses.items():
+            response = data["response"]
+            positions = data["original_positions"]
+
+            for i, pos in enumerate(positions):
+                aggregated_rewards[pos] = response["rewards"][i]
+                aggregated_terminations[pos] = response["terminations"][i]
+                aggregated_truncations[pos] = response["truncations"][i]
+
+            fill_aggregated_obs(aggregated_obs, response["obs"], positions)
+
+        return {
+            "status": "ok",
+            "obs": aggregated_obs,
+            "rewards": aggregated_rewards,
+            "terminations": aggregated_terminations,
+            "truncations": aggregated_truncations,
+            "infos": {},
+        }
+
+    def _validate_traj_keys(self, traj_keys: list[str]) -> None:
+        """Validate that all traj_keys exist in the registry."""
+        invalid_keys = [key for key in traj_keys if key not in self._trajectory_registry]
+
+        if invalid_keys:
+            suffix = "..." if len(invalid_keys) > 5 else ""
+            raise RuntimeError(
+                f"[rank={self.rank}] Invalid traj_keys: {invalid_keys[:5]}{suffix}. "
+                f"Valid keys: {list(self._trajectory_registry.keys())[:5]}..."
+            )
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def get_all_state_ids(self):
+        """Get all available state IDs."""
+        return list(range(self.manager.num_tasks))
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="env"), blocking=False)
+    def reset_envs_to_state_ids(self, data: DataProto):
+        """
+        Reset environments to specified state IDs (task IDs).
+
+        Each stage is completely isolated and reset independently.
+
+        Key concept: Each traj (rollout) maps to exactly one sim env via a unique traj_key.
+        This 1:1 mapping allows flexible env deployment on sim side.
+
+        Stage assignment: traj_idx % stage_num determines which stage handles each traj.
+
+        IMPORTANT: This stage assignment logic is tightly coupled with TaskBalancedSampler
+        in utils.py, which uses the same round-robin interleaving:
+            - Stage 0: batch[0], batch[2], batch[4], ... (traj_idx % stage_num == 0)
+            - Stage 1: batch[1], batch[3], batch[5], ... (traj_idx % stage_num == 1)
+        If you change the stage assignment here, you MUST update TaskBalancedSampler too.
+        """
+        state_ids_list = list(data.non_tensor_batch["state_ids"])
+        task_ids_list = list(data.non_tensor_batch["task_ids"])
+
+        # Each sample in batch = one traj = one sim env
+        num_trajs = len(state_ids_list)
+        assert num_trajs == len(task_ids_list), "state_ids and task_ids must have same length"
+        assert num_trajs <= self.total_trajs, f"num_trajs={num_trajs} exceeds total_trajs={self.total_trajs}"
+
+        logger.debug(
+            f"[rank={self.rank}] reset_envs_to_state_ids: {num_trajs} trajs, unique_tasks={len(set(task_ids_list))}"
+        )
+
+        # Clear previous mappings
+        self._trajectory_registry.clear()
+        self._task_allocation_offset.clear()
+        self._active_traj_keys.clear()
+
+        # ============================================================
+        # Step 1: Group trajs by stage (each stage is isolated)
+        # ============================================================
+        # Stage assignment uses round-robin: traj_idx % stage_num
+        # This MUST match TaskBalancedSampler's interleaving in utils.py
+        # stage_trajs[stage_id] = list of (traj_idx, task_id) for that stage
+        stage_trajs = {stage_id: [] for stage_id in range(self.stage_num)}
+        for traj_idx in range(num_trajs):
+            stage_id = traj_idx % self.stage_num  # Coupled with TaskBalancedSampler
+            task_id = task_ids_list[traj_idx]
+            stage_trajs[stage_id].append((traj_idx, task_id))
+
+        # ============================================================
+        # Step 2: For each stage, allocate envs and build reset requests
+        # ============================================================
+        # Per-stage data structures
+        stage_traj_keys = {stage_id: [] for stage_id in range(self.stage_num)}
+        stage_server_groups = {
+            stage_id: defaultdict(lambda: {"env_indices": [], "traj_indices": []}) for stage_id in range(self.stage_num)
+        }
+        # Track task allocation offset per stage (each stage has its own pool)
+        stage_task_offsets = {stage_id: {} for stage_id in range(self.stage_num)}
+
+        for stage_id in range(self.stage_num):
+            for traj_idx, task_id in stage_trajs[stage_id]:
+                # Get server that handles this task
+                server_rank = self.manager.get_server_for_task(task_id)
+
+                # Get available env indices for this task on that server
+                task_env_indices = self.manager.get_env_indices_for_task(task_id)
+                pool_size = len(task_env_indices)
+
+                # Sequential allocation within this stage's pool
+                offset = stage_task_offsets[stage_id].get(task_id, 0)
+                if offset >= pool_size:
+                    raise RuntimeError(
+                        f"[rank={self.rank}] Stage {stage_id} Task {task_id} pool exhausted: "
+                        f"pool_size={pool_size}, already allocated={offset}"
+                    )
+
+                env_idx = task_env_indices[offset]
+                stage_task_offsets[stage_id][task_id] = offset + 1
+
+                # Generate unique traj_key for this traj-env pair
+                traj_key = str(uuid.uuid4())[:8]
+                self._trajectory_registry[traj_key] = {
+                    "env_index": env_idx,
+                    "task_id": task_id,
+                    "traj_idx": traj_idx,
+                    "stage_id": stage_id,
+                    "server_rank": server_rank,
+                }
+                stage_traj_keys[stage_id].append((traj_idx, traj_key))
+
+                # Group by server for batched reset
+                stage_server_groups[stage_id][server_rank]["env_indices"].append(env_idx)
+                stage_server_groups[stage_id][server_rank]["traj_indices"].append(traj_idx)
+
+        # ============================================================
+        # Step 3: Reset each stage independently
+        # ============================================================
+        stage_responses = {}
+        for stage_id in range(self.stage_num):
+            server_groups = stage_server_groups[stage_id]
+            server_requests = {rank: group["env_indices"] for rank, group in server_groups.items()}
+
+            trajs_in_stage = len(stage_trajs[stage_id])
+            print(
+                f"[EnvWorker Ray] Stage {stage_id} Reset: {trajs_in_stage} trajs -> {len(server_requests)} server(s)",
+                flush=True,
+            )
+
+            # Reset this stage
+            responses = self.manager.reset_batched(server_requests, stage_id=stage_id, stabilize=True)
+
+            # Validate responses
+            for rank, response in responses.items():
+                if response.get("status") != "ok":
+                    raise RuntimeError(f"[rank={self.rank}] Reset stage {stage_id} server {rank} failed: {response}")
+
+            stage_responses[stage_id] = responses
+
+        # ============================================================
+        # Step 4: Collect observations in traj order
+        # ============================================================
+        # Track position in each server's response for each stage
+        stage_server_positions = {
+            stage_id: {rank: 0 for rank in stage_server_groups[stage_id].keys()} for stage_id in range(self.stage_num)
+        }
+
+        # Build traj_keys list and obs_list in traj order
+        traj_keys = [None] * num_trajs
+        obs_list = [None] * num_trajs
+
+        for stage_id in range(self.stage_num):
+            for traj_idx, traj_key in stage_traj_keys[stage_id]:
+                info = self._trajectory_registry[traj_key]
+                server_rank = info["server_rank"]
+
+                server_obs = stage_responses[stage_id][server_rank]["obs"]
+                pos = stage_server_positions[stage_id][server_rank]
+
+                # Extract single env's observation
+                traj_obs = {}
+                for key, value in server_obs.items():
+                    if isinstance(value, np.ndarray):
+                        traj_obs[key] = value[pos : pos + 1]  # Single env
+                    elif isinstance(value, dict):
+                        traj_obs[key] = {}
+                        for k2, v2 in value.items():
+                            if isinstance(v2, np.ndarray):
+                                traj_obs[key][k2] = v2[pos : pos + 1]
+                            else:
+                                traj_obs[key][k2] = v2
+                    else:
+                        traj_obs[key] = value
+
+                traj_keys[traj_idx] = traj_key
+                obs_list[traj_idx] = traj_obs
+                stage_server_positions[stage_id][server_rank] += 1
+
+        # Store active keys
+        self._active_traj_keys = traj_keys
+
+        logger.info(f"[rank={self.rank}] Reset complete: {len(traj_keys)} traj-env pairs registered")
+
+        # ============================================================
+        # Step 5: Build output DataProto
+        # ============================================================
+        output_tensor_dict = {}
+        output_non_tensor_dict = {}
+
+        images_and_states_list = [extract_images_and_states(obs) for obs in obs_list]
+        if images_and_states_list and images_and_states_list[0]:
+            for k in images_and_states_list[0].keys():
+                if isinstance(images_and_states_list[0][k], np.ndarray):
+                    output_tensor_dict[k] = torch.from_numpy(
+                        np.concatenate([obs[k] for obs in images_and_states_list], axis=0)
+                    )
+
+        # Task descriptions - one per traj
+        task_descriptions = []
+        for traj_idx, obs in enumerate(obs_list):
+            if "task_descriptions" in obs and obs["task_descriptions"]:
+                task_descriptions.append(obs["task_descriptions"][0])
+            else:
+                task_id = self._trajectory_registry[traj_keys[traj_idx]]["task_id"]
+                task_descriptions.append(f"Task {task_id}")
+        output_non_tensor_dict["task_descriptions"] = task_descriptions
+
+        output_non_tensor_dict["traj_keys"] = traj_keys
+
+        output = DataProto.from_dict(tensors=output_tensor_dict, non_tensors=output_non_tensor_dict)
+        return output
+
+    def _collect_video_frames(self, response, traj_keys, stage_id):
+        """Collect images for video saving - organized by stage and task_id."""
+        images_and_states = extract_images_and_states(response["obs"])
+        if "full_image" not in images_and_states:
+            return
+
+        if "camera_name" in images_and_states:
+            self.camera_view = images_and_states["camera_name"]
+
+        full_images = images_and_states["full_image"]
+        rewards = response.get("rewards", np.zeros(len(traj_keys)))
+        terminations = response.get("terminations", np.zeros(len(traj_keys)))
+
+        if stage_id not in self.render_images:
+            self.render_images[stage_id] = {}
+            self.video_cnt[stage_id] = {}
+
+        # Group images by task_id
+        task_id_to_images = {}
+        for i, key in enumerate(traj_keys):
+            task_id = self._trajectory_registry[key]["task_id"]
+            img = full_images[i]
+
+            # Add info overlay
+            if len(rewards.shape) > 1:
+                reward_val = float(rewards[i, -1])
+            else:
+                reward_val = float(rewards[i])
+
+            if len(terminations.shape) > 1:
+                term_val = bool(terminations[i, -1])
+            else:
+                term_val = bool(terminations[i])
+
+            plot_info = {"reward": reward_val, "done": term_val, "task": task_id}
+            img = put_info_on_image(img, plot_info)
+
+            if task_id not in task_id_to_images:
+                task_id_to_images[task_id] = []
+            task_id_to_images[task_id].append(img)
+
+        # Tile and store images for each task_id
+        for task_id, task_images in task_id_to_images.items():
+            if task_id not in self.render_images[stage_id]:
+                self.render_images[stage_id][task_id] = []
+                self.video_cnt[stage_id][task_id] = 0
+
+            nrows = int(np.ceil(np.sqrt(len(task_images))))
+            tiled = tile_images(task_images, nrows=nrows)
+            self.render_images[stage_id][task_id].append(tiled)
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def finish_rollout(self, mode="train"):
+        """Finish rollout - save videos organized by stage and task_id."""
+        if self.save_video and self.render_images:
+            total_videos = 0
+            for stage_id, stage_data in self.render_images.items():
+                for task_id, frames in stage_data.items():
+                    if not frames:
+                        continue
+
+                    output_dir = os.path.join(self.video_base_dir, mode, f"stage_{stage_id}", f"task_{task_id}")
+                    os.makedirs(output_dir, exist_ok=True)
+
+                    cnt = self.video_cnt.get(stage_id, {}).get(task_id, 0)
+                    video_name = f"rollout_{cnt:04d}_{self.camera_view}"
+
+                    save_rollout_video(frames, output_dir, video_name)
+
+                    self.video_cnt[stage_id][task_id] = cnt + 1
+                    total_videos += 1
+
+            self.render_images = {}
+            logger.info(f"[rank={self.rank}] Saved {total_videos} videos to {self.video_base_dir}/{mode}/")
+        return
+
+    def __del__(self):
+        """Clean up - don't close manager if it was provided externally."""
+        # Only close if we created the manager ourselves
+        if (
+            hasattr(self, "manager")
+            and self.manager
+            and hasattr(self, "_external_manager")
+            and self._external_manager is None
+        ):
+            self.manager.close()

--- a/verl/experimental/vla/workers/env/env_worker_server.py
+++ b/verl/experimental/vla/workers/env/env_worker_server.py
@@ -296,7 +296,7 @@ class EnvWorkerServer(Worker):
         Uses Ray actor calls for environment interaction.
         """
         chunk_actions = data.non_tensor_batch["actions"]
-        stage_id: int = data.meta_info["stage_id"]
+        stage_id: int = data.meta_info.get("stage_id", 0)
 
         traj_keys = data.non_tensor_batch.get("traj_keys", None)
 

--- a/verl/experimental/vla/workers/env/env_worker_server.py
+++ b/verl/experimental/vla/workers/env/env_worker_server.py
@@ -394,10 +394,9 @@ class EnvWorkerServer(Worker):
 
         # Log step info
         server_summary = {rank: len(group["indices"]) for rank, group in server_groups.items()}
-        print(
+        logger.debug(
             f"[EnvWorker Ray] Step {step_idx + 1}/{max_steps} Stage {stage_id}: "
-            f"{len(traj_keys)} trajs -> {len(server_groups)} servers {server_summary}",
-            flush=True,
+            f"{len(traj_keys)} trajs -> {len(server_groups)} servers {server_summary}"
         )
 
         # Build batched requests
@@ -599,9 +598,8 @@ class EnvWorkerServer(Worker):
             server_requests = {rank: group["env_indices"] for rank, group in server_groups.items()}
 
             trajs_in_stage = len(stage_trajs[stage_id])
-            print(
-                f"[EnvWorker Ray] Stage {stage_id} Reset: {trajs_in_stage} trajs -> {len(server_requests)} server(s)",
-                flush=True,
+            logger.debug(
+                f"[EnvWorker Ray] Stage {stage_id} Reset: {trajs_in_stage} trajs -> {len(server_requests)} server(s)"
             )
 
             # Reset this stage

--- a/verl/experimental/vla/workers/env/utils.py
+++ b/verl/experimental/vla/workers/env/utils.py
@@ -83,6 +83,9 @@ class TaskBalancedSampler(Sampler):
         self._epoch = 0
         self.stage_num = stage_num
 
+        # Ensure batch_size is evenly divisible by stage_num
+        assert batch_size % stage_num == 0, f"batch_size ({batch_size}) must be divisible by stage_num ({stage_num})"
+
         # When stage_num > 1, each stage gets batch_size/stage_num samples
         # and each stage has its own max_per_task constraint
         self.samples_per_stage = batch_size // stage_num

--- a/verl/experimental/vla/workers/env/utils.py
+++ b/verl/experimental/vla/workers/env/utils.py
@@ -1,0 +1,318 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utility classes and functions for Isaac Server mode.
+
+- TaskBalancedSampler: Ensures each batch has at most max_per_task samples per task/stage
+- create_task_balanced_sampler: Factory function with server config integration
+
+The sampler enforces per-stage task balancing. Each stage has its own server group,
+so we ensure each stage's portion respects the max_per_task constraint independently.
+
+Batch is assigned to stages via round-robin:
+    - Stage 0: batch[0], batch[2], batch[4], ...
+    - Stage 1: batch[1], batch[3], batch[5], ...
+
+When stage_num=1 (default), samples_per_stage = batch_size, and the behavior
+is equivalent to simple per-batch balancing.
+
+Note:
+    num_server_groups must match stage_num (pipeline_stage_num).
+"""
+
+import logging
+import random
+from collections import defaultdict
+from typing import Iterator, Optional
+
+from torch.utils.data import Sampler
+
+logger = logging.getLogger(__name__)
+
+
+class TaskBalancedSampler(Sampler):
+    """
+    A sampler that pre-arranges indices to ensure balanced task distribution per stage.
+
+    Each stage gets samples_per_stage = batch_size // stage_num samples.
+    Within each stage, no task exceeds max_per_task samples.
+    Samples are interleaved across stages: [s0[0], s1[0], s0[1], s1[1], ...]
+
+    When stage_num=1 (default), this reduces to simple per-batch balancing.
+
+    This is critical for Isaac Server mode where each task has limited env capacity:
+        max_envs_per_task = server_group_size / num_envs_per_trajectory
+
+    Args:
+        dataset: The dataset to sample from (must have 'task_ids' field)
+        batch_size: Total number of samples per batch
+        max_per_task: Maximum samples from any single task per stage
+        drop_last: Whether to drop the last incomplete batch
+        shuffle: Whether to shuffle within and across tasks
+        seed: Random seed for reproducibility
+        stage_num: Number of pipeline stages (default 1)
+    """
+
+    def __init__(
+        self,
+        dataset,
+        batch_size: int,
+        max_per_task: int,
+        drop_last: bool = True,
+        shuffle: bool = True,
+        seed: Optional[int] = None,
+        stage_num: int = 1,
+    ):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.max_per_task = max_per_task
+        self.drop_last = drop_last
+        self.shuffle = shuffle
+        self.seed = seed
+        self._epoch = 0
+        self.stage_num = stage_num
+
+        # When stage_num > 1, each stage gets batch_size/stage_num samples
+        # and each stage has its own max_per_task constraint
+        self.samples_per_stage = batch_size // stage_num
+
+        # Build task -> sample indices mapping
+        self._build_task_indices()
+
+        logger.info(
+            f"TaskBalancedSampler initialized: "
+            f"batch_size={batch_size}, max_per_task={max_per_task}, "
+            f"stage_num={stage_num}, samples_per_stage={self.samples_per_stage}, "
+            f"num_tasks={len(self.task_to_indices)}, total_samples={len(dataset)}"
+        )
+
+        # Validate that we can fill batches
+        self._validate_config()
+
+    def _build_task_indices(self):
+        """Build mapping from task_id to sample indices."""
+        self.task_to_indices = defaultdict(list)
+
+        # Try different ways to access task_ids from the dataset
+        if hasattr(self.dataset, "__getitem__"):
+            for idx in range(len(self.dataset)):
+                sample = self.dataset[idx]
+                if isinstance(sample, dict):
+                    task_id = sample.get("task_ids", sample.get("task_id", 0))
+                else:
+                    task_id = 0
+                self.task_to_indices[task_id].append(idx)
+        else:
+            # Fallback: assume all samples are from task 0
+            self.task_to_indices[0] = list(range(len(self.dataset)))
+
+        # Log task distribution
+        task_counts = {t: len(indices) for t, indices in self.task_to_indices.items()}
+        logger.info(f"Task distribution: {task_counts}")
+
+    def _validate_config(self):
+        """Validate that configuration is viable."""
+        num_tasks = len(self.task_to_indices)
+        # Each stage must be fillable independently
+        # When stage_num=1, samples_per_stage = batch_size, so this works for both cases
+        max_possible_per_stage = num_tasks * self.max_per_task
+        if max_possible_per_stage < self.samples_per_stage:
+            logger.warning(
+                f"Cannot fill samples_per_stage={self.samples_per_stage} "
+                f"with max_per_task={self.max_per_task} and only {num_tasks} tasks. "
+                f"Max possible per stage: {max_possible_per_stage}. "
+                f"Consider reducing batch_size, increasing max_per_task, or using more tasks."
+            )
+
+    def set_epoch(self, epoch: int):
+        """Set epoch for shuffling reproducibility."""
+        self._epoch = epoch
+
+    def _generate_balanced_indices(self) -> list[int]:
+        """
+        Generate indices with per-stage task balancing.
+
+        Works for both single-stage (standard) and multi-stage modes:
+        - stage_num=1: Standard mode, samples_per_stage = batch_size
+        - stage_num>1: Multi-stage mode, samples are interleaved across stages
+
+        When stage_num > 1, batch is split into stages via round-robin:
+            - Stage 0: batch[0], batch[2], batch[4], ...
+            - Stage 1: batch[1], batch[3], batch[5], ...
+
+        IMPORTANT: This interleaving is tightly coupled with EnvWorkerServer.reset_envs_to_state_ids()
+        in env_worker_server.py, which uses the same round-robin logic (traj_idx % stage_num).
+        If you change the interleaving here, you MUST update reset_envs_to_state_ids() too.
+
+        Each stage has its own server group, so we need to ensure each stage's
+        portion respects the max_per_task constraint independently.
+
+        Strategy:
+            1. Generate samples for each stage separately (each with max_per_task limit)
+            2. Interleave stage samples to create the batch (no-op when stage_num=1)
+        """
+        rng = random.Random(self.seed + self._epoch if self.seed else None)
+
+        # Create separate copies for each stage
+        # When stage_num=1, this is just one copy (same as standard mode)
+        stage_remaining = []
+        for _ in range(self.stage_num):
+            remaining = {task_id: list(indices) for task_id, indices in self.task_to_indices.items()}
+            if self.shuffle:
+                for indices in remaining.values():
+                    rng.shuffle(indices)
+            stage_remaining.append(remaining)
+
+        all_indices = []
+
+        while True:
+            # Generate samples for each stage
+            stage_batches = []
+            all_stages_done = True
+
+            for stage_id in range(self.stage_num):
+                remaining = stage_remaining[stage_id]
+                active_tasks = {t for t, indices in remaining.items() if indices}
+
+                if not active_tasks:
+                    stage_batches.append([])
+                    continue
+
+                all_stages_done = False
+                stage_batch = []
+                task_counts = defaultdict(int)
+
+                task_list = list(active_tasks)
+                if self.shuffle:
+                    rng.shuffle(task_list)
+
+                # Fill this stage's portion with max_per_task constraint
+                made_progress = True
+                while len(stage_batch) < self.samples_per_stage and made_progress:
+                    made_progress = False
+                    for task_id in task_list:
+                        if task_id not in active_tasks:
+                            continue
+                        if task_counts[task_id] >= self.max_per_task:
+                            continue
+                        if not remaining[task_id]:
+                            active_tasks.discard(task_id)
+                            continue
+
+                        idx = remaining[task_id].pop()
+                        stage_batch.append(idx)
+                        task_counts[task_id] += 1
+                        made_progress = True
+
+                        if len(stage_batch) >= self.samples_per_stage:
+                            break
+
+                stage_batches.append(stage_batch)
+
+            if all_stages_done:
+                break
+
+            # Check if all stages have enough samples
+            stage_sizes = [len(sb) for sb in stage_batches]
+            if all(s == self.samples_per_stage for s in stage_sizes):
+                # Interleave: [s0[0], s1[0], s0[1], s1[1], ...]
+                # When stage_num=1, this just extends with stage_batches[0]
+                batch = []
+                for i in range(self.samples_per_stage):
+                    for stage_id in range(self.stage_num):
+                        batch.append(stage_batches[stage_id][i])
+                all_indices.extend(batch)
+            elif not self.drop_last and any(s > 0 for s in stage_sizes):
+                # Partial batch: interleave what we have
+                max_len = max(stage_sizes)
+                batch = []
+                for i in range(max_len):
+                    for stage_id in range(self.stage_num):
+                        if i < len(stage_batches[stage_id]):
+                            batch.append(stage_batches[stage_id][i])
+                all_indices.extend(batch)
+            else:
+                break
+
+        return all_indices
+
+    def __iter__(self) -> Iterator[int]:
+        """Iterate over pre-arranged indices."""
+        indices = self._generate_balanced_indices()
+        return iter(indices)
+
+    def __len__(self) -> int:
+        """Return total number of samples (after dropping incomplete batches if configured)."""
+        total_samples = sum(len(indices) for indices in self.task_to_indices.values())
+        if self.drop_last:
+            return (total_samples // self.batch_size) * self.batch_size
+        else:
+            return total_samples
+
+
+def create_task_balanced_sampler(data_config, dataset):
+    """
+    Create a task-balanced sampler for Isaac Server mode.
+
+    Args:
+        data_config: Configuration with server_group_size, num_envs, batch_size, stage_num, etc.
+        dataset: The dataset to sample from
+
+    Returns:
+        TaskBalancedSampler instance
+    """
+    # Get config values
+    batch_size = data_config.get("gen_batch_size", data_config.get("train_batch_size", 128))
+    server_group_size = data_config.get("server_group_size", 64)
+    num_envs = data_config.get("num_envs", 8)
+    stage_num = data_config.get("stage_num", 1)
+
+    # Calculate max samples per task
+    # In Isaac Server, each task has server_group_size envs
+    # Each env produces one trajectory, so max_per_task = server_group_size / num_envs
+    max_per_task = server_group_size // num_envs
+    samples_per_stage = batch_size // stage_num
+
+    logger.info(
+        f"Creating TaskBalancedSampler: "
+        f"server_group_size={server_group_size}, num_envs={num_envs}, "
+        f"max_per_task={max_per_task}, stage_num={stage_num}, samples_per_stage={samples_per_stage}"
+    )
+
+    # Validate: each stage's capacity must fit
+    # When stage_num=1, samples_per_stage = batch_size, so this works for both cases
+    # Get num_tasks from config or dataset
+    num_tasks = data_config.get("num_tasks", None)
+    if num_tasks is None and hasattr(dataset, "num_tasks"):
+        num_tasks = dataset.num_tasks
+
+    if num_tasks is not None:
+        max_possible_per_stage = num_tasks * max_per_task
+        if max_possible_per_stage < samples_per_stage:
+            raise ValueError(
+                f"Configuration error: samples_per_stage={samples_per_stage} exceeds capacity. "
+                f"Max possible per stage = {num_tasks} tasks × {max_per_task} max_per_task = {max_possible_per_stage}. "
+                f"Solutions: increase server_group_size, decrease batch_size, or increase stage_num."
+            )
+    # Note: If num_tasks is unknown here, TaskBalancedSampler._validate_config() will check after building task indices
+
+    return TaskBalancedSampler(
+        dataset=dataset,
+        batch_size=batch_size,
+        max_per_task=max_per_task,
+        drop_last=True,
+        shuffle=data_config.get("shuffle", True),
+        seed=data_config.get("seed", None),
+        stage_num=stage_num,
+    )


### PR DESCRIPTION
### What does this PR do?

**Isaac Server Mode for Multi-Task LIBERO**

This PR introduces a decoupled Isaac Lab simulation architecture that separates model inference (Gen) from physics simulation (Env), enabling efficient multi-task reinforcement learning with pipeline parallelism. The simulation is managed via **Ray actors**, supporting **multi-node deployment**.

**Key Features:**

1. **IsaacServer** - Ray actor that wraps Isaac Lab environment, runs on sim GPUs with multi-task support
2. **IsaacServerManager** - Manages multiple IsaacServers across stages and GPUs, handles task-to-server routing
3. **EnvWorkerServer** - Lightweight coordinator that routes actions to correct servers via traj_key mapping
4. **TaskBalancedSampler** - Ensures balanced task distribution in batches, with per-stage interleaving (tightly coupled with EnvWorkerServer stage assignment)
5. **Pipeline-Parallel Rollout** - Each stage has isolated servers, enabling GPU time-multiplexing between simulation and generation
6. **Multi-Node Sim Support** - Sim nodes can be distributed across multiple machines via Ray cluster

<img width="1313" height="739" alt="image" src="https://github.com/user-attachments/assets/58c31483-e7fc-462c-8f36-64fa4b0e0206" />
<img width="1320" height="737" alt="image" src="https://github.com/user-attachments/assets/a3307597-1f90-419c-ba71-ad3242e4453e" />


### Test

Validated on LIBERO-10 benchmark with 10 manipulation tasks across 3 scenes (living room, kitchen, study).

**Test Configuration:**
- 2 SIM Nodes with 10 GPUs total for Isaac Simulation
- 1 TRAIN Node with 8 GPUs for model inference
- 2 Pipeline Stages (matching server groups)
- 10 tasks × 16 envs/task = 160 envs per stage
- 256×256 camera resolution

**Results:**
- Successfully completed multi-task rollouts across all 10 LIBERO tasks
- Pipeline overlap achieved between Gen and Sim
- No environment state corruption between stages (verified via video recordings)
- Ray timeline: 
<img width="1292" height="727" alt="image" src="https://github.com/user-attachments/assets/a6c55d50-1968-4712-97df-7ac61baecf47" />


### API and Usage Example

**1. Start Ray Cluster (Multi-Node Setup):**

```bash
# On head node (TRAIN NODE)
ray start --head --port=6379

# On SIM nodes (join cluster)
ray start --address=<head_node_ip>:6379 --resources='{"sim": 1}'
```

**2. Run Training with Ray-managed Isaac Servers:**

```bash
cd verl/recipe/vla

# Key configuration parameters
export NUM_TASKS=10               # LIBERO-10 tasks
export GROUP_SIZE=16              # Envs per task per stage
export STAGE_NUM=2                # Pipeline stages
export NUM_ISAAC_SERVERS=10       # Total sim GPUs
export SIM_NODES=2                # Number of sim nodes

# Launch training (servers are created automatically by Ray)
./run_simpleVLA_isaac_disagg_server.sh
```

**3. Configuration in YAML:**

```yaml
env:
  train:
    isaac_server_mode: True       # Enable Ray actor mode
    num_isaac_servers: 10         # Servers per stage
    num_tasks: 10
    group_size: 16                # Envs per task
    total_trajs: 128              # Total trajectories for training
  rollout:
    pipeline_stage_num: 2
  disagg_sim:
    enable: True
    nnodes: 2                     # Number of sim nodes
```

**4. Using TaskBalancedSampler in code:**

```python
from recipe.vla.workers.env import create_task_balanced_sampler

sampler = create_task_balanced_sampler(
    dataset=train_dataset,
    batch_size=32,
    max_per_task=16,      # <= GROUP_SIZE
    stage_num=2,          # Match pipeline stages
    seed=42,
)
# Note: Sampler's interleaving is tightly coupled with 
# EnvWorkerServer.reset_envs_to_state_ids() stage assignment
```

### Design & Code Changes

**Architecture Diagram:**

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                           Ray Cluster                                        │
│                                                                              │
│  ┌────────────────────────────────────────────────────────────────────────┐  │
│  │                    TRAIN NODE (Gen - Model Inference)                  │  │
│  │  ┌──────────────┐         ┌─────────────────────────────┐              │  │
│  │  │  VeRL        │         │      EnvWorkerServer        │              │  │
│  │  │  Framework   │────────▶│   (Lightweight Coordinator) │              │  │
│  │  │  + EnvLoop   │         │   traj_key → env mapping    │              │  │
│  │  └──────────────┘         └──────────────┬──────────────┘              │  │
│  └───────────────────────────────────────────┼────────────────────────────┘  │
│                                              │                               │
│                    ┌─────────────────────────┼─────────────────────────┐     │
│                    │  IsaacServerManager     │                         │     │
│                    │  - Task → Server routing                          │     │
│                    │  - Batched step/reset                             │     │
│                    └─────────────────────────┼─────────────────────────┘     │
│                                              │ Ray Actor Calls               │
│  ════════════════════════════════════════════╪═══════════════════════════    │
│  ┌───────────────────────────────────────────┼───────────────────────────┐   │
│  │                 SIM NODES (Multi-Node Support)                        │   │
│  │                                           │                           │   │
│  │   Stage 0 Servers          Stage 1 Servers                            │   │
│  │   ┌─────────────────┐      ┌─────────────────┐                        │   │
│  │   │ IsaacServer 0   │      │ IsaacServer 0   │  (GPU 0, time-shared)  │   │
│  │   │ Tasks: 0-1      │      │ Tasks: 0-1      │                        │   │
│  │   ├─────────────────┤      ├─────────────────┤                        │   │
│  │   │ IsaacServer 1   │      │ IsaacServer 1   │  (GPU 1, time-shared)  │   │
│  │   │ Tasks: 2-3      │      │ Tasks: 2-3      │                        │   │
│  │   ├─────────────────┤      ├─────────────────┤                        │   │
│  │   │ ...             │      │ ...             │                        │   │
│  │   └─────────────────┘      └─────────────────┘                        │   │
│  └───────────────────────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Design & Code Changes

**File Changes:**

| File | Description |
|------|-------------|
| `recipe/vla/isaac_server/isaac_server.py` | IsaacServer - Ray actor wrapping Isaac Lab environment |
| `recipe/vla/isaac_server/isaac_server_manager.py` | IsaacServerManager - manages servers across stages and GPUs |
| `recipe/vla/workers/env/env_worker_server.py` | EnvWorkerServer - lightweight coordinator with traj_key routing |
| `recipe/vla/workers/env/utils.py` | TaskBalancedSampler for per-stage task balancing |
| `recipe/vla/env_loop.py` | EnvLoop with stage-aware traj_key passing |
| `recipe/vla/config/rob_ppo_trainer.yaml` | Configuration for Isaac server mode |
| `recipe/vla/run_simpleVLA_isaac_disagg_server.sh` | Launch script for Ray-based Isaac server mode |

**Key Design Decisions:**

1. **Ray Actor Architecture**: Isaac servers are Ray actors, enabling unified resource management across train and sim nodes. No manual server startup needed.

2. **Multi-Node Sim Support**: Sim nodes join Ray cluster with custom resource label (`sim`), allowing IsaacServers to be scheduled to appropriate nodes.

3. **Traj-Env 1:1 Mapping**: Each trajectory maps to exactly one sim env via `traj_key`, enabling flexible env deployment without group constraints.

4. **Stage Isolation**: Each pipeline stage has its own set of servers, physically isolated. Stages time-share GPUs (e.g., 2 stages → 0.5 GPU/server).

5. **Coupled Stage Assignment**: `traj_idx % stage_num` logic in `reset_envs_to_state_ids()` MUST match `TaskBalancedSampler`'s interleaving.

### Data Flow Example

```
batch_size=64, stage_num=2, num_tasks=10, group_size=16, servers=10

TaskBalancedSampler produces: [t0, t1, t2, t3, ..., t63] (interleaved by stage)
                               ↓    ↓   ↓   ↓
Stage assignment:              S0   S1  S0  S1  ...

Stage 0 gets: trajs [0,2,4,...,62] = 32 trajs → 32 sim envs
Stage 1 gets: trajs [1,3,5,...,63] = 32 trajs → 32 sim envs

Each traj gets a traj_key:
  traj_key="a1b2c3d4" → {env_index=5, task_id=3, stage_id=0, server_rank=0}
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Isaac Lab requires GPU simulation environment which is not available in standard CI.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
