### PR TITLE
[worker] fix: Add profiler initialization for ActorRolloutRefWorker in engine_worker

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -358,7 +358,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
         self._is_rollout = self.role in ["rollout", "actor_rollout", "actor_rollout_ref"]
         self._is_ref = self.role in ["ref", "actor_rollout_ref"]
-        
+
         if self._is_actor:
             omega_profiler_config = config.actor.get("profiler", {})
         elif self._is_rollout:
@@ -367,7 +367,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             omega_profiler_config = config.rollout.get("profiler", {})
         else:
             omega_profiler_config = config.ref.get("profiler", {})
-        
+
         profiler_config = omega_conf_to_dataclass(omega_profiler_config, dataclass_type=ProfilerConfig)
         if omega_profiler_config.get("tool", None) in ["npu", "nsys", "torch", "torch_memory"]:
             tool_config = omega_conf_to_dataclass(
@@ -375,7 +375,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             )
         else:
             tool_config = None
-        
+
         DistProfilerExtension.__init__(
             self, DistProfiler(rank=self.rank, config=profiler_config, tool_config=tool_config)
         )


### PR DESCRIPTION

### What does this PR do?

> In engine worker mode, added ProfilerConfig to the imports and updated the initialization of DistProfilerExtension to include profiler configuration based on the role of the worker. from issue https://github.com/volcengine/verl/issues/4571

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

add profiling config in examples/gspo_trainer/run_qwen30b_gspo.sh 
>  ...
    global_profiler.tool=npu \
    global_profiler.steps=[2] \
    global_profiler.save_path="./profiling/fsdp-dis" \
    actor_rollout_ref.actor.profiler.enable=True \
    actor_rollout_ref.rollout.profiler.enable=False \
    actor_rollout_ref.actor.profiler.ranks=[0] \
    actor_rollout_ref.ref.profiler.enable=False \
    actor_rollout_ref.ref.profiler.ranks=[0] \
    actor_rollout_ref.actor.profiler.tool_config.npu.level="level0" \
    actor_rollout_ref.actor.profiler.tool_config.npu.discrete=True \
    actor_rollout_ref.actor.profiler.tool_config.npu.contents=['npu'] \
    actor_rollout_ref.actor.profiler.tool_config.npu.analysis=True

Successfully collected profiling data：
<img width="1085" height="173" alt="image" src="https://github.com/user-attachments/assets/a2b3931c-e8e1-470c-9e6f-c2fd4ff39e06" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
