### PR TITLE
[feat] Add multi-turn format checking reward managers

### DIFF
--- a/verl/experimental/reward/reward_loop/__init__.py
+++ b/verl/experimental/reward/reward_loop/__init__.py
@@ -15,10 +15,13 @@
 from .registry import get_reward_loop_manager_cls, register  # noqa: I001
 from .dapo import DAPORewardLoopManager
 from .naive import NaiveRewardLoopManager
-
+from .format_check_dapo import FormatCheckDAPORewardLoopManager
+from .format_check_naive import FormatCheckNaiveRewardLoopManager
 __all__ = [
     "DAPORewardLoopManager",
     "NaiveRewardLoopManager",
+    "FormatCheckDAPORewardLoopManager",
+    "FormatCheckNaiveRewardLoopManager",
     "register",
     "get_reward_loop_manager_cls",
 ]

--- a/verl/experimental/reward/reward_loop/format_check_dapo.py
+++ b/verl/experimental/reward/reward_loop/format_check_dapo.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+from verl import DataProto
+from verl.experimental.reward.reward_loop import register
+from verl.utils.format_reward import compute_format_reward
+from verl.experimental.reward.reward_loop.dapo import DAPORewardLoopManager
+
+
+@register("format_check_dapo")
+class FormatCheckDAPORewardLoopManager(DAPORewardLoopManager):
+    """Reward loop that validates assistant message formatting and adds it to DAPO reward."""
+
+    def __init__(self, config, tokenizer, compute_score=None, reward_router_address=None, reward_model_tokenizer=None):
+        super().__init__(config, tokenizer, compute_score, reward_router_address, reward_model_tokenizer)
+
+    async def run_single(self, data: DataProto) -> dict:
+        base_result = await super().run_single(data)
+        
+        data_item = data[0]
+        messages = data_item.non_tensor_batch["tool_extra_fields"].get("messages")
+
+        format_reward, _ = compute_format_reward(messages)
+
+        reward_score = base_result["reward_score"] + format_reward
+        reward_extra_info = dict(base_result.get("reward_extra_info", {}))
+        reward_extra_info["format_reward"] = format_reward
+
+        return {"reward_score": reward_score, "reward_extra_info": reward_extra_info}

--- a/verl/experimental/reward/reward_loop/format_check_naive.py
+++ b/verl/experimental/reward/reward_loop/format_check_naive.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl import DataProto
+from verl.experimental.reward.reward_loop import register
+from verl.utils.format_reward import compute_format_reward
+from verl.experimental.reward.reward_loop.naive import NaiveRewardLoopManager
+
+
+@register("format_check_naive")
+class FormatCheckNaiveRewardLoopManager(NaiveRewardLoopManager):
+    """Naive reward loop with additional format reward."""
+
+    def __init__(self, config, tokenizer, compute_score=None, reward_router_address=None, reward_model_tokenizer=None):
+        super().__init__(config, tokenizer, compute_score, reward_router_address, reward_model_tokenizer)
+
+    async def run_single(self, data: DataProto) -> dict:
+        base_result = await super().run_single(data)
+        data_item = data[0]
+        messages = data_item.non_tensor_batch["tool_extra_fields"].get("messages")
+
+        format_reward, _ = compute_format_reward(messages)
+
+        reward_score = base_result["reward_score"] + format_reward
+        reward_extra_info = dict(base_result.get("reward_extra_info", {}))
+        reward_extra_info["format_reward"] = format_reward
+
+        return {"reward_score": reward_score, "reward_extra_info": reward_extra_info}

--- a/verl/utils/format_reward.py
+++ b/verl/utils/format_reward.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from typing import Any
+
+import numpy as np
+
+__all__ = ["compute_format_reward"]
+
+# Note:
+# "You can define what the 'assistant' message format should be by modifying the patterns and logic in this file.
+# For example, the current implementation enforces that each assistant message must match a sequence of tags such as
+# <thinking>...</thinking> followed by either <tool_call>...</tool_call> or <answer>...</answer> (see regex patterns below).
+# Adjust or extend these patterns as needed to adapt to different formatting requirements."
+
+def _extract_messages(messages_obj: Any) -> list[dict[str, Any]] | None:
+    """Normalize messages to a list of dicts."""
+    if messages_obj is None:
+        return None
+    if isinstance(messages_obj, np.ndarray):
+        try:
+            messages_obj = messages_obj.item()
+        except ValueError:
+            messages_obj = messages_obj.tolist()
+    if isinstance(messages_obj, list):
+        return messages_obj
+    return None
+
+
+def compute_format_reward(messages_obj: Any) -> tuple[float, dict[str, Any]]:
+    """Compute a format reward (+1.0 / -0.5) without attaching verbose metadata."""
+    messages = _extract_messages(messages_obj)
+    if messages is None:
+        return -0.5, {}
+
+    assistant_contents = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            assistant_contents.append(str(msg.get("content", "")))
+
+    if not assistant_contents:
+        return -0.5, {}
+
+    # Allow 0, 1, or 2 line breaks between </thinking> and the subsequent tag,
+    # to flexibly accept tight, single line, or double line formatting.
+    tool_pattern = re.compile(
+        r"^<thinking>.*?</thinking>\n{0,2}<tool_call>.*?</tool_call>$", re.DOTALL
+    )
+    answer_pattern = re.compile(
+        r"^<thinking>.*?</thinking>\n{0,2}<answer>.*?</answer>$", re.DOTALL
+    )
+
+    for idx, content in enumerate(assistant_contents):
+        is_last = idx == len(assistant_contents) - 1
+        expected_pattern = answer_pattern if is_last else tool_pattern
+        if not expected_pattern.match(content):
+            return -0.5, {}
+
+    return 0.5, {}

--- a/verl/workers/reward_manager/__init__.py
+++ b/verl/workers/reward_manager/__init__.py
@@ -15,6 +15,8 @@
 from .registry import get_reward_manager_cls, register  # noqa: I001
 from .batch import BatchRewardManager
 from .dapo import DAPORewardManager
+from .format_check_dapo import FormatCheckDAPORewardManager
+from .format_check_naive import FormatCheckNaiveRewardManager
 from .naive import NaiveRewardManager
 from .prime import PrimeRewardManager
 
@@ -22,6 +24,8 @@ from .prime import PrimeRewardManager
 __all__ = [
     "BatchRewardManager",
     "DAPORewardManager",
+    "FormatCheckDAPORewardManager",
+    "FormatCheckNaiveRewardManager",
     "NaiveRewardManager",
     "PrimeRewardManager",
     "register",

--- a/verl/workers/reward_manager/format_check_dapo.py
+++ b/verl/workers/reward_manager/format_check_dapo.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+from verl.utils.format_reward import compute_format_reward
+from verl.workers.reward_manager import register
+from verl.workers.reward_manager.dapo import DAPORewardManager
+
+
+@register("format_check_dapo")
+class FormatCheckDAPORewardManager(DAPORewardManager):
+    """DAPO reward manager with an extra formatting bonus/penalty."""
+
+    def __call__(self, data, return_dict=False):
+        if "rm_scores" in data.batch.keys():
+            if return_dict:
+                reward_extra_keys = data.meta_info.get("reward_extra_keys", [])
+                reward_extra_info = {key: data.non_tensor_batch[key] for key in reward_extra_keys}
+                return {"reward_tensor": data.batch["rm_scores"], "reward_extra_info": reward_extra_info}
+            else:
+                return data.batch["rm_scores"]
+
+        base_result = super().__call__(data, return_dict=True)
+        reward_tensor = base_result["reward_tensor"]
+
+        base_extra_info = base_result.get("reward_extra_info", {})
+        reward_extra_info = defaultdict(list)
+        for key, value in base_extra_info.items():
+            reward_extra_info[key] = value
+
+        for i in range(len(data)):
+            data_item = data[i]
+            prompt_ids = data_item.batch["prompts"]
+            prompt_length = prompt_ids.shape[-1]
+            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
+
+            messages = data_item.non_tensor_batch["tool_extra_fields"].get("messages")
+            format_reward, _ = compute_format_reward(messages)
+
+            reward_tensor[i, valid_response_length - 1] += format_reward
+            reward_extra_info["format_reward"].append(format_reward)
+
+        if return_dict:
+            return {"reward_tensor": reward_tensor, "reward_extra_info": reward_extra_info}
+        return reward_tensor

--- a/verl/workers/reward_manager/format_check_naive.py
+++ b/verl/workers/reward_manager/format_check_naive.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+from verl.utils.format_reward import compute_format_reward
+from verl.workers.reward_manager import register
+from verl.workers.reward_manager.naive import NaiveRewardManager
+
+
+@register("format_check_naive")
+class FormatCheckNaiveRewardManager(NaiveRewardManager):
+    """Naive reward manager with an extra formatting bonus/penalty."""
+
+    def __call__(self, data, return_dict=False):
+        if "rm_scores" in data.batch.keys():
+            if return_dict:
+                reward_extra_keys = data.meta_info.get("reward_extra_keys", [])
+                reward_extra_info = {key: data.non_tensor_batch[key] for key in reward_extra_keys}
+                return {"reward_tensor": data.batch["rm_scores"], "reward_extra_info": reward_extra_info}
+            else:
+                return data.batch["rm_scores"]
+        
+        base_result = super().__call__(data, return_dict=True)
+        reward_tensor = base_result["reward_tensor"]
+
+        base_extra_info = base_result.get("reward_extra_info", {})
+        reward_extra_info = defaultdict(list)
+        for key, value in base_extra_info.items():
+            reward_extra_info[key] = value
+
+        for i in range(len(data)):
+            data_item = data[i]
+            prompt_ids = data_item.batch["prompts"]
+            prompt_length = prompt_ids.shape[-1]
+            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
+
+            messages = data_item.non_tensor_batch["tool_extra_fields"].get("messages")
+            format_reward, _ = compute_format_reward(messages)
+
+            reward_tensor[i, valid_response_length - 1] += format_reward
+            reward_extra_info["format_reward"].append(format_reward)
+
+        if return_dict:
+            return {"reward_tensor": reward_tensor, "reward_extra_info": reward_extra_info}
+        return reward_tensor


### PR DESCRIPTION
## Files Modified:
- verl/experimental/agent_loop/tool_agent_loop.py: Enhanced to record full message history for format reward computation
- verl/experimental/reward/reward_loop/__init__.py: Added exports for new format check reward managers
- verl/workers/reward_manager/__init__.py: Added exports for new format check reward managers

## Files Added:
- verl/experimental/reward/reward_loop/format_check_dapo.py: DAPO reward manager with format checking
- verl/experimental/reward/reward_loop/format_check_naive.py: Naive reward manager with format checking
- verl/utils/format_reward.py: Core format reward computation utilities
- verl/workers/reward_manager/format_check_dapo.py: Worker implementation for DAPO format checking
- verl/workers/reward_manager/format_check_naive.py: Worker implementation for naive format checking

## Purpose of Changes:
The format reward check manager was rewritten to address multi-turn conversation scenarios where the previous implementation would concatenate all subsequent assistant/tool messages, causing single-turn format checks to become ineffective.

The new solution extracts all assistant messages from the complete conversation history and performs individual format validation on each turn, ensuring proper format checking regardless of conversation length.

## Key Features:
- Full message history preservation in agent loop for per-turn analysis
- Configurable format checking logic that users can customize
- Support for both DAPO and naive reward manager architectures
- No breaking API changes - fully backward compatible

## Implementation Details:
- tool_agent_loop.py: Modified to always record assistant messages and pass full message context via extra_fields
- format_reward.py: Provides extensible format validation with regex patterns for thinking/tool/answer tags
- New reward managers inherit from existing base classes with format bonus integration

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
