### PR TITLE
[vllm] fix: correctly pass params to `from_lora_tensors` in vLLM 0.12.0

### DIFF
--- a/verl/utils/vllm/utils.py
+++ b/verl/utils/vllm/utils.py
@@ -82,10 +82,11 @@ class VLLMHijack:
                     "dtype": self.lora_config.lora_dtype,
                     "weights_mapper": hf_to_vllm_mapper,
                 }
-                if hasattr(self, "embedding_modules"):
-                    lora_request_kwargs["embedding_modules"] = self.embedding_modules
                 if hasattr(self, "embedding_padding_modules"):
+                    lora_request_kwargs["embedding_modules"] = self.embedding_modules
                     lora_request_kwargs["embedding_padding_modules"] = self.embedding_padding_modules
+                else:
+                    lora_request_kwargs["model_vocab_size"] = self.vocab_size
                 if hasattr(self.lora_config, "lora_extra_vocab_size"):
                     lora_request_kwargs["target_embedding_padding"] = (
                         self.vocab_size + self.lora_config.lora_extra_vocab_size


### PR DESCRIPTION
### What does this PR do?

https://github.com/vllm-project/vllm/commit/39e63dec7c751a28d5a577caf16439e08a878c92

https://github.com/volcengine/verl/pull/4606 still has some issues in supporting vLLM 0.12.0. Since `embedding_modules` attribute still exists in vLLM 0.12.0, it's not reliable to decide whether we should pass `embedding_modules` args based on that, while `embedding_padding_modules` is a reliable attribute, since the attribute has been completely removed in the commit and the arg is removed together with `embedding_modules`. Also, `model_vocab_size` was added as a param in addition.

<img width="1022" height="314" alt="image" src="https://github.com/user-attachments/assets/fef9ed41-14f2-445a-b5f1-9c69a55ebc01" />


### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>