### PR TITLE
[tool] fix: avoid nested ToolResponse in sandbox fusion tool

### DIFF
--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -187,7 +187,7 @@ class SandboxFusionTool(BaseTool):
         run_status = metadata.get("run_status")
         exit_code = metadata.get("exit_code")
 
-        if run_status == "Finished" and exit_code == 0:
+        if run_status == "Finished" and exit_code in (0, None):
             actual_output = stdout + stderr
             logger.debug(f"actual_output from sandbox fusion: {actual_output},{instance_id}")
             return actual_output


### PR DESCRIPTION
### What does this PR do?

Fixes a runtime issue in `SandboxFusionTool` where `execute_code()` returned a `ToolResponse`, but `execute()` wrapped that result in another `ToolResponse(text=...)`. This produced a nested/non-string `text` field and could break downstream tool-response handling.

Additional improvements:
- Make `ExecutionWorker.execute()` robust when `enable_global_rate_limit=False` (no rate limiter actor).
- Return plain-text outputs from sandbox execution and provide clearer failure messages (status + optional exit code) without `KeyError` on missing metadata fields.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- `pytest -q tests/tools/test_sandbox_fusion_tools.py`

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
