### PR TITLE
[fsdp] feat: FSDP2 Only Load Rank0

### DIFF
--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -222,7 +222,9 @@ class FSDPSFTTrainer:
         torch_dtype = self.config.model.fsdp_config.get("model_dtype", "fp32")
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
         # load config first
-        config = AutoConfig.from_pretrained(local_model_path, trust_remote_code=trust_remote_code)
+        config = AutoConfig.from_pretrained(
+            local_model_path, trust_remote_code=trust_remote_code, attn_implementation="flash_attention_2"
+        )
         self.model_config = config
         if hasattr(self.model_config, "max_position_embeddings"):
             self.model_config.max_position_embeddings = max(
@@ -247,7 +249,6 @@ class FSDPSFTTrainer:
                     local_model_path,
                     config=config,
                     torch_dtype=torch_dtype,
-                    attn_implementation="flash_attention_2",
                     trust_remote_code=trust_remote_code,
                 )
 

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -233,17 +233,23 @@ class FSDPSFTTrainer:
 
         # This may be very large
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not config.tie_word_embeddings,
+            mesh=None if self.config.model.strategy == "fsdp2" else self.device_mesh,
         )
 
         with init_context():
-            self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
-                local_model_path,
-                config=config,
-                torch_dtype=torch_dtype,
-                attn_implementation="flash_attention_2",
-                trust_remote_code=trust_remote_code,
-            )
+            if self.config.model.strategy == "fsdp2" and torch.distributed.get_rank() > 0:
+                self.model: PreTrainedModel = AutoModelForCausalLM.from_config(
+                    config, trust_remote_code=trust_remote_code
+                )
+            else:
+                self.model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
+                    local_model_path,
+                    config=config,
+                    torch_dtype=torch_dtype,
+                    attn_implementation="flash_attention_2",
+                    trust_remote_code=trust_remote_code,
+                )
 
             if self.use_remove_padding or self.config.ulysses_sequence_parallel_size > 1:
                 from verl.models.transformers.monkey_patch import apply_monkey_patch
@@ -255,6 +261,8 @@ class FSDPSFTTrainer:
                 from liger_kernel.transformers.monkey_patch import _apply_liger_kernel_to_instance
 
                 _apply_liger_kernel_to_instance(model=self.model)
+
+            self.model = self.model.to(torch_dtype)
 
             if self.lora:
                 self.model.enable_input_require_grads()
@@ -334,7 +342,7 @@ class FSDPSFTTrainer:
                 "offload_policy": cpu_offload,
                 "reshard_after_forward": True,
             }
-            full_state = self.model.state_dict()
+            full_state = self.model.state_dict() if torch.distributed.get_rank() == 0 else {}
             apply_fsdp2(self.model, fsdp_kwargs, self.config.model.fsdp_config)
             fsdp2_load_full_state_dict(self.model, full_state, self.device_mesh, cpu_offload)
             self.fsdp_model = self.model

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -207,7 +207,8 @@ class FSDPEngine(BaseEngine):
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings,
+            mesh=None if self.engine_config.strategy == "fsdp2" else self.device_mesh,
         )
 
         with init_context(), warnings.catch_warnings():
@@ -215,12 +216,17 @@ class FSDPEngine(BaseEngine):
 
             auto_class = get_hf_auto_model_class(hf_config=self.model_config.hf_config)
 
-            module = auto_class.from_pretrained(
-                pretrained_model_name_or_path=self.model_config.local_path,
-                torch_dtype=torch_dtype,
-                config=self.model_config.hf_config,
-                trust_remote_code=self.model_config.trust_remote_code,
-            )
+            if self.engine_config.strategy == "fsdp2" and self.rank > 0:
+                module = auto_class.from_config(
+                    self.model_config.hf_config, trust_remote_code=self.model_config.trust_remote_code
+                )
+            else:
+                module = auto_class.from_pretrained(
+                    pretrained_model_name_or_path=self.model_config.local_path,
+                    torch_dtype=torch_dtype,
+                    config=self.model_config.hf_config,
+                    trust_remote_code=self.model_config.trust_remote_code,
+                )
 
             use_liger = self.model_config.use_liger
             # Apply Liger kernel to the model if use_liger is set to True
@@ -357,7 +363,7 @@ class FSDPEngine(BaseEngine):
                 "offload_policy": offload_policy,
                 "reshard_after_forward": self.engine_config.reshard_after_forward,
             }
-            full_state = module.state_dict()
+            full_state = module.state_dict() if self.rank == 0 else {}
             apply_fsdp2(module, fsdp_kwargs, self.engine_config)
             fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
         else:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -343,7 +343,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # NOTE(fix me): tie_word_embedding causes meta_tensor init to hang
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not actor_model_config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not actor_model_config.tie_word_embeddings,
+            mesh=None if self.config.actor.strategy == "fsdp2" else self.device_mesh,
         )
 
         with init_context(), warnings.catch_warnings():
@@ -374,13 +375,16 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 else:
                     actor_module_class = AutoModel
 
-            actor_module = actor_module_class.from_pretrained(
-                pretrained_model_name_or_path=local_path,
-                torch_dtype=torch_dtype,
-                config=actor_model_config,
-                trust_remote_code=trust_remote_code,
-                attn_implementation=attn_implementation,
-            )
+            if self.rank > 0 and self.config.actor.strategy == "fsdp2":
+                actor_module = actor_module_class.from_config(actor_model_config, trust_remote_code=trust_remote_code)
+            else:
+                actor_module = actor_module_class.from_pretrained(
+                    pretrained_model_name_or_path=local_path,
+                    torch_dtype=torch_dtype,
+                    config=actor_model_config,
+                    trust_remote_code=trust_remote_code,
+                    attn_implementation=attn_implementation,
+                )
 
             # Apply Liger kernel to the model if use_liger is set to True
             if use_liger:
@@ -525,7 +529,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 "reshard_after_forward": fsdp_config.reshard_after_forward,
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
-            full_state = actor_module.state_dict()
+            full_state = actor_module.state_dict() if self.rank == 0 else {}
             apply_fsdp2(actor_module, fsdp_kwargs, fsdp_config)
             fsdp2_load_full_state_dict(actor_module, full_state, fsdp_mesh, cpu_offload)
             actor_module_fsdp = actor_module
@@ -1273,7 +1277,8 @@ class CriticWorker(Worker, DistProfilerExtension):
             critic_model_config.text_config.topk_method = "greedy"
 
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not critic_model_config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not critic_model_config.tie_word_embeddings,
+            mesh=None if config.strategy == "fsdp2" else self.device_mesh,
         )
 
         with init_context(), warnings.catch_warnings():
@@ -1287,6 +1292,7 @@ class CriticWorker(Worker, DistProfilerExtension):
                 torch_dtype,
                 critic_model_config,
                 config.model.get("trust_remote_code", False),
+                load_from_pretrained=not (config.strategy == "fsdp2" and self.rank > 0),
             )
 
             use_remove_padding = config.model.get("use_remove_padding", False)
@@ -1408,7 +1414,7 @@ class CriticWorker(Worker, DistProfilerExtension):
                 "reshard_after_forward": fsdp_config.reshard_after_forward,
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
-            full_state = critic_module.state_dict()
+            full_state = critic_module.state_dict() if self.rank == 0 else {}
             apply_fsdp2(critic_module, fsdp_kwargs, fsdp_config)
             fsdp2_load_full_state_dict(critic_module, full_state, fsdp_mesh, offload_policy)
         else:
@@ -1667,18 +1673,24 @@ class RewardModelWorker(Worker, DistProfilerExtension):
 
         # note that we have to create model in fp32. Otherwise, the optimizer is in bf16, which is incorrect
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not model_config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not model_config.tie_word_embeddings,
+            mesh=None if config.strategy == "fsdp2" else self.device_mesh,
         )
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")
             model_config.classifier_dropout = 0.0
-            reward_module = AutoModelForTokenClassification.from_pretrained(
-                pretrained_model_name_or_path=local_path,
-                config=model_config,
-                torch_dtype=torch.bfloat16,
-                trust_remote_code=trust_remote_code,
-            )
+            if config.strategy == "fsdp2" and self.rank > 0:
+                reward_module = AutoModelForTokenClassification.from_config(
+                    model_config, trust_remote_code=trust_remote_code
+                )
+            else:
+                reward_module = AutoModelForTokenClassification.from_pretrained(
+                    pretrained_model_name_or_path=local_path,
+                    config=model_config,
+                    torch_dtype=torch.bfloat16,
+                    trust_remote_code=trust_remote_code,
+                )
 
             apply_monkey_patch(
                 model=reward_module,
@@ -1715,7 +1727,7 @@ class RewardModelWorker(Worker, DistProfilerExtension):
                 "reshard_after_forward": config.model.fsdp_config.reshard_after_forward,
                 "shard_placement_fn": get_shard_placement_fn(fsdp_size=self.device_mesh.shape[-1]),
             }
-            full_state = reward_module.state_dict()
+            full_state = reward_module.state_dict() if self.rank == 0 else {}
             apply_fsdp2(reward_module, fsdp_kwargs, config.model.fsdp_config)
             fsdp2_load_full_state_dict(reward_module, full_state, fsdp_mesh, cpu_offload)
         else:


### PR DESCRIPTION
Supersedes https://github.com/volcengine/verl/pull/3493, only load model on rank0 which is broadcasted later `fsdp2_load_full_state_dict`

Note: Not implemented for PEFT