### PR TITLE
[fsdp] feat: Support zero2 optional feature for FSDP1

### DIFF
--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -19,7 +19,7 @@ optimizer_offload: false
 offload_policy: false
 
 # Reshard after forward pass to reduce memory footprint
-# On FSDP1, the corresponding configuration is sharding_strategy=ShardingStrategy.SHARD_GRAD_OP
+# For FSDP1, `false` enables `ShardingStrategy.SHARD_GRAD_OP`
 reshard_after_forward: true
 
 # Number of GPUs in each FSDP shard group; -1 means auto

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -106,7 +106,7 @@ def create_device_mesh(world_size, fsdp_size):
     return device_mesh
 
 
-def get_sharding_strategy(device_mesh, zero3_enable):
+def get_sharding_strategy(device_mesh, zero3_enable=True):
     from torch.distributed.fsdp import ShardingStrategy
 
     if zero3_enable:
@@ -492,7 +492,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             print(f"wrap_policy: {auto_wrap_policy}")
 
         fsdp_mesh = self.device_mesh
-        fsdp_enable_zero3 = fsdp_config.get("reshard_after_forward")
+        fsdp_enable_zero3 = fsdp_config.reshard_after_forward
         sharding_strategy = get_sharding_strategy(fsdp_mesh, fsdp_enable_zero3)
 
         # TODO: add transformer policy


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Currently in verl, FSDP2 enables zero2 by setting `reshard_after_forward=false`, this PR reuses the `reshard_after_forward `parameter to enable zero2 for FSDP1, achieved a 3% performance improvement on the Qwen2.5-7B-Instruct model.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

We conducted tests based on the Qwen2.5-7B-Instruct model on Ascend A2, collected profiling data for analysis, eliminated the all-gather operation during backward when memory was sufficient, and achieved performance gains equivalent to `backward_allgather_time * num_layers * batch_size`.
<img width="1280" height="594" alt="image" src="https://github.com/user-attachments/assets/fddd30bc-706d-4648-b099-144151a7bc6f" />
<img width="1280" height="578" alt="image" src="https://github.com/user-attachments/assets/cf7db448-25b9-4b23-b901-f810b0b6b831" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

use `actor_rollout_ref.actor.fsdp_config.reshard_after_forward=False` in script to enable FSDP1 zero2.

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
