### PR TITLE
[misc] feat: `.git-blame-ignore-revs` for large but non-informative commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,33 +1,13 @@
 # Local uasge: git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 # [dev] feat: immigrate from yapf & pylint to ruff based on pre-commit
-# This commit changed 268 files and modified ~20k lines for formatting.
+# Changed 268 files, +10k/-9k lines. This is the biggest formatter change.
 b00f77d8
 
 # [ci] refactor: reduce ruff line-length from 300 to 120
-# Massive formatting change affecting 238 files and ~8k lines.
+# Changed 238 files, +6k/-1k lines. Global formatting change.
 00a10a8e
 
-# CI: limit ruff checks and enable push tests
-# Large cleanup involving 99 files and ~7k deletions.
-568239fb
-
 # [Lint] fix: linting errors in all files
-# Global linting fix affecting 179 files.
+# Changed 179 files, +1k/-3k lines. Global lint fix.
 8e5ad468
-
-# [env] feat: safely bump py version to 3.10
-# Bulk update affecting 142 files.
-eac4863a
-
-# [doc] fix: quickstart example can't work on zsh
-# Bulk documentation find-and-replace affecting 138 files.
-a31a8f25
-
-# [ci] feat: pre-commit check all the files by default
-# Formatting enforcement affecting 52 files.
-c3ffce26
-
-# [misc] fix: add compileall pre-commit hook checks and improve code quality
-# Formatting/Linting update affecting 23 files.
-d73e600f


### PR DESCRIPTION
### What does this PR do?

This PR adds `.git-blame-ignore-revs` for ignoring large but non-informative commits.