### PR TITLE
[misc] fix: deprecate rollout.mode config option

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -143,30 +143,18 @@ class TaskRunner:
             self.mapping[role] = "global_pool"
             return actor_rollout_cls, ray_worker_group_cls
 
-        if config.actor_rollout_ref.rollout.mode == "sync":
-            raise ValueError(
-                "Rollout mode 'sync' has been removed. Please set "
-                "`actor_rollout_ref.rollout.mode=async` to use the native server rollout."
-            )
-
+        # Note: sync mode validation is now handled in RolloutConfig.__post_init__
+        # Always use async worker since sync mode is deprecated and rejected
         if config.actor_rollout_ref.actor.strategy in {"fsdp", "fsdp2"}:
-            from verl.workers.fsdp_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker
+            from verl.workers.fsdp_workers import AsyncActorRolloutRefWorker
 
-            actor_rollout_cls = (
-                AsyncActorRolloutRefWorker
-                if config.actor_rollout_ref.rollout.mode == "async"
-                else ActorRolloutRefWorker
-            )
+            actor_rollout_cls = AsyncActorRolloutRefWorker
             ray_worker_group_cls = RayWorkerGroup
 
         elif config.actor_rollout_ref.actor.strategy == "megatron":
-            from verl.workers.megatron_workers import ActorRolloutRefWorker, AsyncActorRolloutRefWorker
+            from verl.workers.megatron_workers import AsyncActorRolloutRefWorker
 
-            actor_rollout_cls = (
-                AsyncActorRolloutRefWorker
-                if config.actor_rollout_ref.rollout.mode == "async"
-                else ActorRolloutRefWorker
-            )
+            actor_rollout_cls = AsyncActorRolloutRefWorker
             ray_worker_group_cls = RayWorkerGroup
 
         else:

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -219,6 +220,20 @@ class RolloutConfig(BaseConfig):
 
     def __post_init__(self):
         """Validate the rollout config"""
+        # Deprecation warning for mode field - only async mode is supported
+        if self.mode == "sync":
+            raise ValueError(
+                "Rollout mode 'sync' has been removed. Please set "
+                "`actor_rollout_ref.rollout.mode=async` or remove the mode setting entirely."
+            )
+        if self.mode != "async":
+            warnings.warn(
+                f"Unknown rollout mode '{self.mode}'. Only 'async' mode is supported. "
+                "The 'mode' field is deprecated and will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if self.expert_parallel_size > 1:
             assert self.expert_parallel_size == (self.tensor_model_parallel_size * self.data_parallel_size), (
                 "expert_parallel_size must be equal to tensor_model_parallel_size * data_parallel_size"

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -653,11 +653,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         # 5. switch to trainer mode
         # NOTE: It's critical that hybrid engine in trainer mode initially to load checkpoint.
-        # For sync mode, we directly switch to trainer mode here.
         # For async mode, we can't call run_until_complete here, so we will switch to trainer mode in AgentLoopManager.
-        if rollout_config.mode == "sync" and self._is_actor:
-            loop = get_event_loop()
-            loop.run_until_complete(self.trainer_mode())
+        # Note: sync mode is deprecated and rejected in RolloutConfig.__post_init__
 
     async def rollout_mode(self):
         """Context switch hybridengine to rollout mode."""

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -533,11 +533,8 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
 
         # 5. switch to trainer mode
         # NOTE: It's critical that hybrid engine in trainer mode initially to load checkpoint.
-        # For sync mode, we directly switch to trainer mode here.
         # For async mode, we can't call run_until_complete here, so we will switch to trainer mode in AgentLoopManager.
-        if rollout_config.mode == "sync" and self._is_actor:
-            loop = get_event_loop()
-            loop.run_until_complete(self.trainer_mode())
+        # Note: sync mode is deprecated and rejected in RolloutConfig.__post_init__
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):


### PR DESCRIPTION
## Summary

Addresses #4604 - Deprecates the `actor_rollout_ref.rollout.mode` config option since only `async` mode is now supported.

### Changes:

1. **RolloutConfig validation** (`verl/workers/config/rollout.py`):
   - Added validation in `__post_init__` to raise `ValueError` for "sync" mode
   - Added `DeprecationWarning` for unknown modes

2. **Simplified main_ppo.py**:
   - Removed sync mode check (moved to config validation)
   - Always uses `AsyncActorRolloutRefWorker` instead of conditional selection

3. **Removed dead code paths**:
   - `fsdp_workers.py`: Removed sync mode switch-to-trainer-mode code
   - `megatron_workers.py`: Same cleanup
   - `ray_trainer.py`: Simplified async mode checks since sync is no longer valid

### Backward Compatibility:

The `mode` field is kept in the config for backward compatibility with existing shell scripts that set `actor_rollout_ref.rollout.mode=async`. These scripts will continue to work.

### Follow-up Work:

Shell scripts and documentation that explicitly set `mode=async` can be updated in separate PRs to remove the now-redundant setting.