### PR TITLE
fix: correct enable_activation_offload config parameter name

### DIFF
--- a/examples/sglang_multiturn/run_qwen2.5-0.5b_gsm8k_multiturn_w_interaction.sh
+++ b/examples/sglang_multiturn/run_qwen2.5-0.5b_gsm8k_multiturn_w_interaction.sh
@@ -24,7 +24,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
     actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
-    +actor_rollout_ref.model.enable_activation_offloading=True \
+    +actor_rollout_ref.model.enable_activation_offload=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=$TRAIN_BATCH_SIZE \
     actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$MICRO_BATCH_SIZE \

--- a/tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh
+++ b/tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh
@@ -31,7 +31,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.model.use_remove_padding=True \
     actor_rollout_ref.model.use_liger=False \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
-    +actor_rollout_ref.model.enable_activation_offloading=True \
+    +actor_rollout_ref.model.enable_activation_offload=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=128 \
     actor_rollout_ref.actor.ulysses_sequence_parallel_size=1 \


### PR DESCRIPTION
## Summary

Fixes #4672 - The shell scripts were using `enable_activation_offloading` but the `HFModelConfig` field is named `enable_activation_offload` (without the "ing" suffix).

This mismatch caused OmegaConf to fail with:
```
omegaconf.errors.ConfigKeyError: Key 'enable_activation_offloading' not in 'HFModelConfig'
```

### Changes

Fixed the parameter name in two shell scripts:
- `examples/sglang_multiturn/run_qwen2.5-0.5b_gsm8k_multiturn_w_interaction.sh`
- `tests/special_e2e/run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh`

### Note

The function that implements the feature is correctly named `enable_activation_offloading()` (with "ing"), but the config field that controls it is `enable_activation_offload` (without "ing"). The worker code correctly uses the config field name.