### PR TITLE
fix: correct infer_tp size calculation in rollout device mesh

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -477,7 +477,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             rollout_config: RolloutConfig = omega_conf_to_dataclass(self.config.rollout)
 
             # 3.1 build rollout device mesh (sglang need only)
-            infer_tp = rollout_config.tensor_model_parallel_size * rollout_config.data_parallel_size
+            # Note: infer_tp should only be tensor_model_parallel_size, not multiplied by data_parallel_size
+            # data_parallel_size controls rollout DP sharding, not the infer_tp dimension
+            infer_tp = rollout_config.tensor_model_parallel_size
             infer_pp = rollout_config.pipeline_model_parallel_size
             infer_world_size = infer_tp * infer_pp
             dp = self.world_size // infer_world_size

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -594,7 +594,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self.model_config = model_config
 
         # 2. build rollout device mesh
-        infer_tp = self.config.rollout.tensor_model_parallel_size * self.config.rollout.data_parallel_size
+        # Note: infer_tp should only be tensor_model_parallel_size, not multiplied by data_parallel_size
+        # data_parallel_size controls rollout DP sharding, not the infer_tp dimension
+        infer_tp = self.config.rollout.tensor_model_parallel_size
         infer_pp = self.config.rollout.pipeline_model_parallel_size
         infer_world_size = infer_tp * infer_pp
         dp = self.world_size // infer_world_size

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -498,7 +498,9 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
         )
 
         # 2. build rollout device mesh
-        infer_tp = self.config.rollout.tensor_model_parallel_size * self.config.rollout.data_parallel_size
+        # Note: infer_tp should only be tensor_model_parallel_size, not multiplied by data_parallel_size
+        # data_parallel_size controls rollout DP sharding, not the infer_tp dimension
+        infer_tp = self.config.rollout.tensor_model_parallel_size
         infer_pp = self.config.rollout.pipeline_model_parallel_size
         infer_world_size = infer_tp * infer_pp
         dp = self.world_size // infer_world_size


### PR DESCRIPTION
## Summary

Fixes #4569 - The `infer_tp` size was incorrectly calculated by multiplying `tensor_model_parallel_size` by `data_parallel_size`.

### The Bug

```python
# WRONG:
infer_tp = tensor_model_parallel_size * data_parallel_size

# CORRECT:
infer_tp = tensor_model_parallel_size
```

### Why This is Wrong

- `tensor_model_parallel_size` defines how the model is split across GPUs (tensor parallelism)
- `data_parallel_size` controls rollout DP sharding (a separate dimension)
- Multiplying them together incorrectly inflates `infer_world_size`
- This causes `dp` (data parallel groups) to be smaller than intended
- Result: prompts don't distribute properly across DP workers

### Impact

According to the issue, this bug caused:
- ~1,880 throughput with the bug vs ~3,177 with the fix (**69% improvement**)
- Only certain ranks received prompts
- Uneven workload distribution

### Changes

Fixed the calculation in three files:
- `verl/workers/fsdp_workers.py`
- `verl/workers/megatron_workers.py`
- `verl/workers/engine_workers.py`

## Test plan

- [x] Syntax check passes
- [ ] The issue reporter's benchmark should show improved throughput

🤖 Generated with [Claude Code](https://claude.com/claude-code)