### PR TITLE
fix(lora): use TOKEN_CLS task type for Critic model

### DIFF
--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -1329,13 +1329,15 @@ class CriticWorker(Worker, DistProfilerExtension):
                 critic_module = PeftModel.from_pretrained(critic_module, local_adapter_path, is_trainable=True)
                 peft_config = critic_module.peft_config["default"]
                 # Ensure task_type is TaskType enum, not string
+                # Use TOKEN_CLS for Critic since it's loaded as AutoModelForTokenClassification
                 if isinstance(peft_config.task_type, str):
-                    peft_config.task_type = TaskType.CAUSAL_LM
+                    peft_config.task_type = TaskType.TOKEN_CLS
 
             else:
                 # Convert config to regular Python types before creating PEFT model
+                # Use TOKEN_CLS for Critic since it's loaded as AutoModelForTokenClassification
                 lora_config = {
-                    "task_type": TaskType.CAUSAL_LM,
+                    "task_type": TaskType.TOKEN_CLS,
                     "r": self.config.model.lora_rank,
                     "lora_alpha": self.config.model.lora_alpha,
                     "target_modules": convert_to_regular_types(self.config.model.target_modules),


### PR DESCRIPTION
## Summary
- Fix AttributeError when using LoRA with Critic model in PPO training
- The Critic is loaded via `AutoModelForTokenClassification` which doesn't have generation methods like `prepare_inputs_for_generation`
- Using `TaskType.CAUSAL_LM` caused PEFT to expect these methods, resulting in the error

## Root Cause
The `load_valuehead_model` function (model.py:625) loads the Critic as `AutoModelForTokenClassification`, but the LoRA configuration was using `TaskType.CAUSAL_LM`. This mismatch causes PEFT to expect causal LM methods that don't exist in token classification models.

## Changes
- Changed `TaskType.CAUSAL_LM` to `TaskType.TOKEN_CLS` for the Critic model's LoRA configuration in `fsdp_workers.py`
- This aligns the LoRA task type with the actual model architecture

## Before
```python
peft_config.task_type = TaskType.CAUSAL_LM
# ...
lora_config = {"task_type": TaskType.CAUSAL_LM, ...}
```

## After
```python
peft_config.task_type = TaskType.TOKEN_CLS
# ...
lora_config = {"task_type": TaskType.TOKEN_CLS, ...}
```

Fixes #4620 