### PR TITLE
feat(trainer): add logging of extra reward metrics

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1534,6 +1534,12 @@ class RayPPOTrainer:
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)
 
+                    # Log extra reward metrics (e.g., format_reward, acc_reward) for training monitoring
+                    if reward_extra_infos_dict:
+                        for key, values in reward_extra_infos_dict.items():
+                            if key != "score" and len(values) > 0:
+                                metrics[f"critic/rewards/{key}"] = np.mean(values)
+
                     # Log rollout generations if enabled
                     rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
                     if rollout_data_dir:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1538,7 +1538,11 @@ class RayPPOTrainer:
                     if reward_extra_infos_dict:
                         for key, values in reward_extra_infos_dict.items():
                             if key != "score" and len(values) > 0:
-                                metrics[f"critic/rewards/{key}"] = np.mean(values)
+                                try:
+                                    metrics[f"training/reward/{key}"] = np.mean(values)
+                                except (TypeError, ValueError):
+                                    # reward_extra_info may carry non-numeric fields; skip those.
+                                    pass
 
                     # Log rollout generations if enabled
                     rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)


### PR DESCRIPTION
## Summary
- Add logging of extra/intermediate rewards to training metrics
- This improves training monitoring by providing visibility into component reward values

## Motivation
As discussed in #2279, logging extra rewards like `format_reward` and `acc_reward` is useful for training monitoring. This enables users to track intermediate reward components in addition to the final combined score.

## Changes
Added logging of extra reward metrics after the actor update (non-numeric extra fields are skipped rather than crashing the step):
```python
# Log extra reward metrics (e.g., format_reward, acc_reward) for training monitoring
if reward_extra_infos_dict:
    for key, values in reward_extra_infos_dict.items():
        if key != "score" and len(values) > 0:
            metrics[f"training/reward/{key}"] = np.mean(values)
```

## Usage
Reward functions can return extra info via the `reward_extra_info` dict:
```python
return {
    'score': final_reward,
    'format_reward': format_score,
    'acc_reward': accuracy_score,
    # ... other intermediate rewards
}
```

These will be logged as:
- `training/reward/format_reward`
- `training/reward/acc_reward`
- etc.

Closes #4545

## Test plan
- [ ] Verify extra rewards appear in wandb/tensorboard when using a reward function with extra info
- [ ] Confirm metrics are logged correctly with multiple extra reward keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)