### PR TITLE
[merger] fix: support vision_model keys in Megatron merger for VL models

### DIFF
--- a/scripts/legacy_model_merger.py
+++ b/scripts/legacy_model_merger.py
@@ -586,15 +586,15 @@ class MegatronModelMerger(BaseModelMerger):
         """
         Checks if the key is a valid Megatron state key.
 
-        Now the model merger only supports keys that start with "decoder/embedding/output_layer" in TransformerLayer.
+        Now the model merger only supports keys that start with "decoder/embedding/output_layer/vision_model" in TransformerLayer.
         Shall not use key starts with "model."
         """
         if key.startswith("model."):
             raise ValueError(
-                f"Invalid key {key} in Megatron state_dict. Expected keys to start with 'decoder/embedding/output_layer' in TransformerLayer."
+                f"Invalid key {key} in Megatron state_dict. Expected keys to start with 'decoder/embedding/output_layer/vision_model' in TransformerLayer."
             )
 
-        skip_checking_keys = ["embedding.word_embeddings", "output_layer"]
+        skip_checking_keys = ["embedding.word_embeddings", "output_layer", "vision_model"]
         for skip_key in skip_checking_keys:
             if skip_key in key:
                 print(f"skip checking key {key}")

--- a/verl/model_merger/megatron_model_merger.py
+++ b/verl/model_merger/megatron_model_merger.py
@@ -289,16 +289,16 @@ class MegatronModelMerger(BaseModelMerger):
         """
         Checks if the key is a valid Megatron state key.
 
-        Now the model merger only supports keys that start with "decoder/embedding/output_layer" in TransformerLayer.
+        Now the model merger only supports keys that start with "decoder/embedding/output_layer/vision_model" in TransformerLayer.
         Shall not use key starts with "model."
         """
         if key.startswith("model."):
             raise ValueError(
                 f"Invalid key {key} in Megatron state_dict. Expected keys to start with "
-                f"'decoder/embedding/output_layer' in TransformerLayer."
+                f"'decoder/embedding/output_layer/vision_model' in TransformerLayer."
             )
 
-        skip_checking_keys = ["embedding.word_embeddings", "output_layer"]
+        skip_checking_keys = ["embedding.word_embeddings", "output_layer", "vision_model"]
         for skip_key in skip_checking_keys:
             if skip_key in key:
                 print(f"skip checking key {key}")


### PR DESCRIPTION
## Summary

- Add `vision_model` to the `skip_checking_keys` list in `_check_megatron_state_key()` method
- Update docstrings and error messages to reflect the new supported key prefix
- Apply same fix to both `megatron_model_merger.py` and `legacy_model_merger.py`

This allows merging Vision-Language model checkpoints (like Qwen2.5-VL-7B) back to HuggingFace format. Previously, keys like `vision_model.patch_embed.proj.weight` would fail validation because the merger expected all keys to start with 'decoder'.

Fixes #4498

## Test plan

- [ ] Test merging a VL model checkpoint (e.g., Qwen2.5-VL-7B trained with Megatron) back to HuggingFace format

🤖 Generated with [Claude Code](https://claude.com/claude-code)