### PR TITLE
docs: fix typos in code comments and messages

### DIFF
--- a/recipe/collabllm/collabllm_interation.py
+++ b/recipe/collabllm/collabllm_interation.py
@@ -172,7 +172,7 @@ class CollabLLMInteraction(BaseInteraction):
                         break
                     else:
                         logger.warning(
-                            f"[CollabLLMInteraction] got an invaild response {response} full_response {full_response}. \
+                            f"[CollabLLMInteraction] got an invalid response {response} full_response {full_response}. \
                                 Retrying..."
                         )
                         continue

--- a/recipe/fully_async_policy/checkpoint_engine.py
+++ b/recipe/fully_async_policy/checkpoint_engine.py
@@ -311,7 +311,7 @@ class CheckpointEngine:
         )
         print(
             f"set checkpoint_engine device buffer size: {self.device_buffer_size_M}M, "
-            f"and finally set it to {bucket_size >> 20}M considering the largest paramter tensor size"
+            f"and finally set it to {bucket_size >> 20}M considering the largest parameter tensor size"
         )
         self.bucket_size = bucket_size
 

--- a/recipe/vla/envs/isaac_env/isaac_env.py
+++ b/recipe/vla/envs/isaac_env/isaac_env.py
@@ -107,7 +107,7 @@ class IsaacEnv(gym.Env):
         if self.task_suite_name.startswith("libero"):
             self.task_descriptions = self.env.cfg.libero_config.task_info["language_instruction"]
             assert self.env_cfg.osc_type == "pose_rel", (
-                f"Only pose_rel osc type is supported for libero. Recieved: {self.env_cfg.osc_type}"
+                f"Only pose_rel osc type is supported for libero. Received: {self.env_cfg.osc_type}"
             )
         else:
             raise ValueError(f"Task suite {self.task_suite_name} is not supported.")

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -46,7 +46,7 @@ def get_rope_index(
     video_token_id = processor.video_token_id
     vision_start_token_id = processor.vision_start_token_id
 
-    # Since we use timestamps to seperate videos,
+    # Since we use timestamps to separate videos,
     # like <t1> <vision_start> <frame1> <vision_end> <t2> <vision_start> <frame2> <vision_end>,
     # the video_grid_thw should also be split
     if video_grid_thw is not None:


### PR DESCRIPTION
## Summary

Fixed several typos in code comments and error messages:

- `verl/models/transformers/qwen3_vl.py`: seperate → separate
- `recipe/fully_async_policy/checkpoint_engine.py`: paramter → parameter
- `recipe/collabllm/collabllm_interation.py`: invaild → invalid
- `recipe/vla/envs/isaac_env/isaac_env.py`: Recieved → Received