### PR TITLE
fix(registry): make reward manager registration idempotent

### DIFF
--- a/tests/workers/reward_manager/test_registry_on_cpu.py
+++ b/tests/workers/reward_manager/test_registry_on_cpu.py
@@ -92,3 +92,21 @@ def test_decorator_returns_original_class(setup):
 
     assert OriginalClass().method() == 42
     assert REWARD_MANAGER_REGISTRY["return_test"] == OriginalClass
+
+
+def test_idempotent_registration_same_class(setup):
+    """Test that registering the same class twice is idempotent (no error).
+
+    This is important for distributed environments like Ray where modules
+    may be imported multiple times across workers.
+    """
+
+    @register("idempotent_test")
+    class IdempotentManager:
+        pass
+
+    # Register the same class again - should not raise
+    decorated = register("idempotent_test")(IdempotentManager)
+
+    assert decorated == IdempotentManager
+    assert REWARD_MANAGER_REGISTRY["idempotent_test"] == IdempotentManager


### PR DESCRIPTION
## Summary

In distributed environments like Ray, modules may be imported multiple times across workers. This caused `ValueError` when the same reward manager class was registered more than once, even though the classes were functionally identical.

## Changes

- Added `_get_class_identifier()` helper function that creates a unique identifier based on `module + qualname`
- Updated `register()` decorator to compare class identifiers instead of class objects
- Re-registering the same class (by qualified name) is now silently accepted
- Registering different classes with the same name still raises an error
- Added test for idempotent registration behavior

## Root Cause

The original code compared class objects directly:
```python
if name in REWARD_MANAGER_REGISTRY and REWARD_MANAGER_REGISTRY[name] != cls:
    raise ValueError(...)
```

In Ray's distributed environment, the same class imported in different workers has different object ids, causing this comparison to fail even for identical classes.

## Test Plan

- [x] Added `test_idempotent_registration_same_class` test
- [x] Existing tests continue to pass (registering different classes with same name still raises error)

Fixes #4718

🤖 Generated with [Claude Code](https://claude.com/claude-code)