### PR TITLE
fix(fsdp): handle param offloading in get_actor_weights_info

### DIFF
--- a/recipe/one_step_off_policy/fsdp_workers.py
+++ b/recipe/one_step_off_policy/fsdp_workers.py
@@ -145,6 +145,12 @@ class DetachActorWorker(DetachSync):
         assert self._is_actor
         if hasattr(self, "_weights_info"):
             return self._weights_info
+
+        # When parameter offloading is enabled, we need to load params to GPU
+        # before accessing state_dict, as FSDP requires tensors on GPU
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.actor_module_fsdp)
+
         if fsdp_version(self.actor_module_fsdp) == 1:
             from torch.distributed.fsdp.api import ShardedStateDictConfig, StateDictType
 
@@ -158,6 +164,12 @@ class DetachActorWorker(DetachSync):
         for key, tensor in params.items():
             ret.append((key, tensor.size(), tensor.dtype))
         self._weights_info = ret
+
+        # Note: We don't offload back to CPU here because this function is
+        # typically called at initialization, immediately followed by
+        # sync_rollout_weights which also requires GPU access.
+        # The offload will happen at the end of sync_rollout_weights.
+
         return ret
 
 


### PR DESCRIPTION
## Summary

When parameter offloading is enabled, FSDP requires tensors to be on GPU before accessing `state_dict()`. The `get_actor_weights_info()` function was not handling this case, causing:

```
AssertionError: Expects tensor to be on the compute device cuda:0, was on cpu
```

## Root Cause

The `get_actor_weights_info()` function calls `self._get_actor_params()` which internally accesses `state_dict()`. When parameter offloading is enabled (`self._is_offload_param = True`), the parameters are on CPU, but FSDP's `state_dict()` expects them on GPU.

## Fix

Added a check for `self._is_offload_param` and call `load_fsdp_model_to_gpu()` before accessing parameters. This matches the pattern already used in:
- `sync_rollout_weights()` in the same file
- `get_actor_weights_info()` in the Megatron worker implementation

## Files Changed

- `recipe/fully_async_policy/fsdp_workers.py`
- `recipe/one_step_off_policy/fsdp_workers.py`

## Test Plan

- [x] Pattern matches existing `sync_rollout_weights()` implementation
- [x] Pattern matches Megatron worker implementation
- [ ] Tested with FSDP + parameter offloading enabled

Fixes #4657

🤖 Generated with [Claude Code](https://claude.com/claude-code)