### PR TITLE
fix(fully_async): use rollout.total_epochs for total_rollout_steps calculation

### DIFF
--- a/recipe/fully_async_policy/fully_async_rollouter.py
+++ b/recipe/fully_async_policy/fully_async_rollouter.py
@@ -108,7 +108,7 @@ class FullyAsyncRollouter(FullyAsyncRayPPOTrainer):
 
         # ==================== fully async config ====================
 
-        self.total_rollout_steps = len(self.train_dataloader) * self.config.trainer.total_epochs
+        self.total_rollout_steps = len(self.train_dataloader) * self.config.rollout.total_epochs
         if self.config.rollout.total_rollout_steps is not None:
             self.total_rollout_steps = min(self.config.rollout.total_rollout_steps, self.total_rollout_steps)
         print(f"[FullyAsyncRollouter] Total rollout steps: {self.total_rollout_steps}")


### PR DESCRIPTION
  ## Summary
  - Fix inconsistent `total_epochs` usage in `fully_async_rollouter.py`

  ## Problem
  The `total_rollout_steps` calculation (line 111) uses `trainer.total_epochs`, but the epoch loop (line 365) uses `rollout.total_epochs`. This causes experiments to
  terminate early when users configure `rollout.total_epochs` without explicitly setting `trainer.total_epochs`.

  ## Changes
  Changed `total_rollout_steps` calculation to use `rollout.total_epochs` for consistency.

  ## Test plan
  - [x] Verified fix resolves early termination issue
  - [x] Confirmed epoch loop and rollout steps now use the same config value