### PR TITLE
[tool] fix: attach to existing MLflow run when MLFLOW_RUN_ID is set

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -86,10 +86,17 @@ class Tracking:
             MLFLOW_TRACKING_URI = os.environ.get("MLFLOW_TRACKING_URI", "sqlite:////tmp/mlruns.db")
             mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
-            # Project_name is actually experiment_name in MLFlow
-            # If experiment does not exist, will create a new experiment
-            experiment = mlflow.set_experiment(project_name)
-            mlflow.start_run(experiment_id=experiment.experiment_id, run_name=experiment_name)
+            # Some cloud providers like Azure ML or Databricks automatically set MLFLOW_RUN_ID
+            # If set, attach to the existing run instead of creating a new one
+            run_id = os.environ.get("MLFLOW_RUN_ID")
+            if run_id:
+                mlflow.start_run(run_id=run_id)
+            else:
+                # Project_name is actually experiment_name in MLFlow
+                # If experiment does not exist, will create a new experiment
+                experiment = mlflow.set_experiment(project_name)
+                mlflow.start_run(experiment_id=experiment.experiment_id, run_name=experiment_name)
+
             mlflow.log_params(_compute_mlflow_params_from_objects(config))
             self.logger["mlflow"] = _MlflowLoggingAdapter()
 


### PR DESCRIPTION
Some cloud providers (e.g. Azure ML, Databricks) automatically set the `MLFLOW_RUN_ID` environment variable.  
Previously, `verl` always called `mlflow.set_experiment(...); mlflow.start_run(experiment_id=..., run_name=...)`, which can conflict with the provider-managed run context and cause MLflow to throw an exception.

This change detects `MLFLOW_RUN_ID` and **attaches to the existing run** instead of creating a new one, preventing duplicate runs and enabling seamless integration with managed MLflow environments.

### What does this PR do?

- Detect `MLFLOW_RUN_ID` during `Tracking(..., default_backend="mlflow")` initialization.
- If `MLFLOW_RUN_ID` is present, call `mlflow.start_run(run_id=...)` to attach to the provider-managed run.
- Otherwise, keep the previous behavior: `mlflow.set_experiment(project_name)` and start a new run under that experiment.

### Why is this needed?

On Azure ML, MLflow run context is automatically created and `MLFLOW_RUN_ID` is injected.  
Starting a new run under a different experiment ID triggers a mismatch error like:

```
MlflowException: Cannot start run with ID <...> experiment ID does not match environment run ID.
Make sure --experiment-name or --experiment-id matches experiment set with set_experiment()...
```

Because the cloud provider-generated `MLFLOW_RUN_ID` is not predictable and is set outside the user config, this cannot be reliably worked around via configuration alone.

### Test

- ✅ Local smoke test (manual): verified the MLflow backend initializes correctly when:
  - `MLFLOW_RUN_ID` is **set** → attaches to existing run
  - `MLFLOW_RUN_ID` is **not set** → creates/uses experiment and starts a new run
- CI: (existing unit tests)

*(If you have an Azure ML job run link/log snippet, you can paste it here as additional evidence.)*

### API and Usage Example

No API changes. Behavior is automatically enabled when `MLFLOW_RUN_ID` is set by the environment.

### Design & Code Changes

- `verl/utils/tracking.py`
  - Add a conditional path to honor `MLFLOW_RUN_ID` and attach to an existing MLflow run.
  - Preserve the previous experiment-based run creation when `MLFLOW_RUN_ID` is absent.