### PR TITLE
[cfg] chore: remove redundant fields and fix typo

### DIFF
--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -282,7 +282,6 @@ class FSDPActorConfig(ActorConfig):
     entropy_checkpointing: bool = False
     fsdp_config: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     use_remove_padding: bool = False
-    profiler: ProfilerConfig = field(default_factory=ProfilerConfig)
     use_rollout_log_probs: bool = False
 
     def __post_init__(self):

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -88,7 +88,6 @@ class HFModelConfig(BaseConfig):
     # path to pre-trained LoRA adapter to load for continued training
     lora_adapter_path: Optional[str] = None
     use_liger: bool = False
-    lora: dict = field(default_factory=dict)
 
     use_fused_kernels: bool = False
     fused_kernel_options: dict = field(default_factory=dict)
@@ -122,7 +121,7 @@ class HFModelConfig(BaseConfig):
             self.local_hf_config_path, trust_remote_code=self.trust_remote_code
         )
 
-        # constuct hf_config
+        # construct hf_config
         attn_implementation = self.override_config.get("attn_implementation", "flash_attention_2")
         self.hf_config = AutoConfig.from_pretrained(
             self.local_hf_config_path, trust_remote_code=self.trust_remote_code, attn_implementation=attn_implementation


### PR DESCRIPTION
### What does this PR do?

Clean up redundant field definitions in config dataclasses and fix a typo.

- Remove duplicate `profiler` field from `FSDPActorConfig` (already defined in parent class `ActorConfig` at line 160)
- Remove duplicate `lora` field from `HFModelConfig` (already defined at line 86 with proper type annotation `dict[str, Any]`)
- Fix typo in comment: `constuct` -> `construct`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+redundant+config

### Test

This PR only removes redundant code and fixes a typo. No functional changes.

- `profiler` field: Already defined in parent class `ActorConfig` at line 160. `FSDPActorConfig` inherits from `ActorConfig`, so the duplicate at line 285 is unnecessary.
- `lora` field: Two definitions existed in `HFModelConfig`:
  - Line 86: `lora: dict[str, Any] = field(default_factory=dict)` with comment "megatron lora config" (kept)
  - Line 91: `lora: dict = field(default_factory=dict)` without type parameters (removed)
  - Kept the first one because it has proper type annotation and descriptive comment.

### API and Usage Example

No API changes.

### Design & Code Changes

- `verl/workers/config/actor.py`: Remove duplicate `profiler` field from `FSDPActorConfig` (inherited from `ActorConfig:160`)
- `verl/workers/config/model.py`: Remove duplicate `lora` field (keep `line 86` with `dict[str, Any]`, remove `line 91` with `dict`)
- `verl/workers/config/model.py`: Fix typo `constuct` -> `construct`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). N/A, no doc changes needed.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a code cleanup with no functional changes.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)