### PR TITLE
[trainer] feat: enable ray-based sft trainer on ascend npu

### DIFF
--- a/.github/workflows/e2e_ascend.yml
+++ b/.github/workflows/e2e_ascend.yml
@@ -68,7 +68,7 @@ jobs:
   non_rl_job:
     if: github.repository_owner == 'volcengine'
     name: E2E Ascend testing for non-RL algorithm scenarios
-    runs-on: linux-aarch64-a2-2
+    runs-on: linux-aarch64-a2-4
     timeout-minutes: 60
     container:
       image: swr.ap-southeast-1.myhuaweicloud.com/base_image/ascend-ci/verl/verl:verl-8.3.rc1-910b-ubuntu22.04-py3.11-latest
@@ -109,7 +109,10 @@ jobs:
         run: |
           ray stop --force
           bash tests/special_npu/run_qwen2_5_05b_sft_peft_sp2.sh
-          rm -rf $HOME/ckpts
+      - name: Running gsm8k e2e training tests with peft sft on ASCEND NPU (ray mode)
+        run: |
+          ray stop --force
+          mode=ray bash tests/special_npu/run_qwen2_5_05b_sft_peft_sp2.sh
       - name: Running NPU profiling unit tests
         run: |
           ray stop --force

--- a/recipe/dapo/main_dapo.py
+++ b/recipe/dapo/main_dapo.py
@@ -24,7 +24,7 @@ from omegaconf import OmegaConf
 
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.ppo.reward import load_reward_manager
-from verl.utils.device import auto_set_ascend_device_name, is_cuda_available
+from verl.utils.device import auto_set_device, is_cuda_available
 
 from .dapo_ray_trainer import RayDAPOTrainer
 
@@ -32,7 +32,7 @@ from .dapo_ray_trainer import RayDAPOTrainer
 @hydra.main(config_path="config", config_name="dapo_trainer", version_base=None)
 def main(config):
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_ppo(config)
 

--- a/recipe/one_step_off_policy/main_ppo.py
+++ b/recipe/one_step_off_policy/main_ppo.py
@@ -30,7 +30,7 @@ from verl.trainer.ppo.ray_trainer import ResourcePoolManager
 from verl.trainer.ppo.reward import load_reward_manager
 from verl.trainer.ppo.utils import Role, need_reference_policy
 from verl.utils.config import validate_config
-from verl.utils.device import auto_set_ascend_device_name
+from verl.utils.device import auto_set_device
 
 
 def create_resource_pool_manager(config, roles: list) -> ResourcePoolManager:
@@ -225,7 +225,7 @@ def main(config):
     start_time = time()
 
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_ppo(config, task_runner_class=OneStepTaskRunner)
     print(f"total time: {time() - start_time:.2f} seconds")

--- a/recipe/r1_ascend/main_ppo.py
+++ b/recipe/r1_ascend/main_ppo.py
@@ -27,7 +27,7 @@ from omegaconf import OmegaConf
 
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
 from verl.trainer.main_ppo import TaskRunner as TaskRunnerBase
-from verl.utils.device import auto_set_ascend_device_name, is_cuda_available
+from verl.utils.device import auto_set_device, is_cuda_available
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -41,7 +41,7 @@ def main(config):
         config_dict: Hydra configuration dictionary containing training parameters.
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_ppo(config)
 

--- a/recipe/transfer_queue/main_ppo.py
+++ b/recipe/transfer_queue/main_ppo.py
@@ -33,7 +33,7 @@ from verl.trainer.main_ppo import (
 from verl.trainer.ppo.reward import load_reward_manager
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
-from verl.utils.device import auto_set_ascend_device_name, is_cuda_available
+from verl.utils.device import auto_set_device, is_cuda_available
 
 from .ray_trainer import RayPPOTrainer
 
@@ -46,7 +46,7 @@ def main(config):
         config_dict: Hydra configuration dictionary containing training parameters.
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_ppo(config)
 

--- a/verl/trainer/fsdp_sft_trainer.py
+++ b/verl/trainer/fsdp_sft_trainer.py
@@ -50,7 +50,7 @@ from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.dataset import SFTDataset
 from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset
 from verl.utils.device import (
-    auto_set_ascend_device_name,
+    auto_set_device,
     get_device_id,
     get_device_name,
     is_cuda_available,
@@ -843,7 +843,7 @@ def run_sft(config):
 @hydra.main(config_path="config", config_name="sft_trainer", version_base=None)
 def main(config):
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_sft(config)
 

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -28,7 +28,7 @@ from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 from verl.trainer.ppo.reward import load_reward_manager
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
-from verl.utils.device import auto_set_ascend_device_name, is_cuda_available
+from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import load_extern_object
 
 
@@ -40,7 +40,7 @@ def main(config):
         config_dict: Hydra configuration dictionary containing training parameters.
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
-    auto_set_ascend_device_name(config)
+    auto_set_device(config)
 
     run_ppo(config)
 

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -127,25 +127,25 @@ def set_expandable_segments(enable: bool) -> None:
         torch.cuda.memory._set_allocator_settings(f"expandable_segments:{enable}")
 
 
-def auto_set_ascend_device_name(config) -> None:
-    """Automatically configure device name for Ascend NPU environments.
+def auto_set_device(config) -> None:
+    """Automatically configure device name for different accelerators.
 
-    If running on an Ascend NPU system, this function ensures the trainer
-    device configuration is set to 'npu'. Logs a warning if the config
-    was set to a different device type.
+    For example, on Ascend NPU, this function defaults the trainer device to "npu"
+    unless explicitly set to "cpu".
 
     Args:
         config: Configuration object with trainer.device attribute.
     """
-    if config and config.trainer and config.trainer.device:
+    if config and hasattr(config, "trainer") and hasattr(config.trainer, "device"):
         if is_torch_npu_available():
-            if config.trainer.device != "npu":
+            if config.trainer.device not in ["cpu", "npu"]:
                 logger.warning(
                     f"Detect setting config.trainer.device to {config.trainer.device} for Ascend NPU, maybe"
                     f"from default value in config file, automatically set to `npu` instead."
                 )
 
             config.trainer.device = "npu"
+        # Other cases: set device to "cuda" via config file, no need to change.
 
 
 def get_device_capability(device_id: int = 0) -> tuple[int | None, int | None]:


### PR DESCRIPTION
### What does this PR do?

This PR implements Ray-based SFT support for the Ascend NPU platform and includes a minor interface adjustment: the function `auto_set_ascend_device_name` is renamed to `auto_set_device`. The revised interface is designed to be generic and can be seamlessly integrated with other hardware accelerators.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
