### PR TITLE
[trainer, worker] fix: Pass a dict config to ray to avoid pickling issues with Deepseek V3.1's tokenizer

### DIFF
--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -112,7 +112,7 @@ class SFTTrainer:
 
         config = TrainingWorkerConfig(
             model_type="language_model",
-            model_config=self.model_config,
+            model_config=self.config.model,
             engine_config=self.engine_config,
             optimizer_config=self.optimizer_config,
             checkpoint_config=self.checkpoint_config,

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -16,6 +16,8 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
 
+from omegaconf import DictConfig
+
 from verl.base_config import BaseConfig
 from verl.trainer.config import CheckpointConfig
 
@@ -270,7 +272,7 @@ class VeOmniEngineConfig(EngineConfig):
 @dataclass
 class TrainingWorkerConfig(BaseConfig):
     model_type: str = None  # model type (language_model/value_model)
-    model_config: HFModelConfig = None
+    model_config: HFModelConfig | DictConfig = None
     engine_config: EngineConfig = None
     optimizer_config: OptimizerConfig = None
     checkpoint_config: CheckpointConfig = None

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -62,6 +62,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
 
         self.config = config
         self.model_config = self.config.model_config
+        if isinstance(self.model_config, DictConfig):
+            self.model_config = omega_conf_to_dataclass(self.model_config)
+
         self.engine_config = self.config.engine_config
         self.optimizer_config = self.config.optimizer_config
         self.checkpoint_config = self.config.checkpoint_config


### PR DESCRIPTION


### What does this PR do?

Do not pass the instantiated tokenizer in the config via ray. This commit solves an issue with Deepseek V3.1's tokenizer in the SFT ray trainer.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Deepseek V3.1 successfully instantiates and trains with the SFT Ray trainer.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

No API changes.

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

Avoid instantiating the tokenizer before passing the resulting object to ray remote. 
`TrainingWorkerConfig` now contains a union type which may be debatable.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Deepseek is pretty large and the fix is very small.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
