### PR TITLE
Fix: use prime reward manager for GSPO script

### DIFF
--- a/examples/gspo_trainer/run_qwen30b_gspo.sh
+++ b/examples/gspo_trainer/run_qwen30b_gspo.sh
@@ -38,9 +38,6 @@ critic_model_path=$actor_model_path
 
 max_prompt_length=$((1024 * 2))
 max_response_length=$((1024 * 8))
-enable_overlong_buffer=True
-overlong_buffer_len=$((1024 * 4))
-overlong_penalty_factor=1.0
 
 train_batch_size=256
 ppo_mini_batch_size=32
@@ -151,15 +148,6 @@ ROLLOUT_CONFIG="
     actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
     actor_rollout_ref.rollout.val_kwargs.n=$n_resp_per_prompt_val"
 
-# ===================================== Reward =====================================
-REWARD_CONFIG="
-    reward_model.reward_manager=dapo \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
-    +reward_model.reward_kwargs.max_resp_len=${max_response_length}"
-
 python3 -m verl.trainer.main_ppo \
     --config-path=./config \
     --config-name=$CONFIG_NAME \
@@ -177,6 +165,7 @@ python3 -m verl.trainer.main_ppo \
     data.filter_overlong_prompts=True \
     data.filter_overlong_prompts_workers=64 \
     data.truncation='error' \
+    reward_model.reward_manager=prime \
     trainer.use_legacy_worker_impl=disable \
     trainer.critic_warmup=$critic_warmup \
     trainer.logger=['console','wandb'] \
@@ -193,5 +182,4 @@ python3 -m verl.trainer.main_ppo \
     trainer.total_training_steps=500 \
     $ACTOR_CONFIG \
     $CIRITC_CONFIG \
-    $ROLLOUT_CONFIG \
-    $REWARD_CONFIG
+    $ROLLOUT_CONFIG

--- a/examples/gspo_trainer/test_gspo_3b_math.sh
+++ b/examples/gspo_trainer/test_gspo_3b_math.sh
@@ -53,7 +53,6 @@ if [ "$rollout_engine" = "vllm" ]; then
     export VLLM_USE_V1=1
 fi
 gpu_memory_utilization=0.8
-reward_manager=dapo
 adv_estimator=grpo
 shuffle_dataset=true
 first_time_dataset_prep=true # prepare dataset
@@ -78,10 +77,6 @@ n_resp_per_prompt=16
 
 max_prompt_length=$((1024 * 2))
 max_response_length=$((1024 * 8))
-# dapo reward manager params
-enable_overlong_buffer=false # true
-overlong_buffer_len=$((1024 * 4))
-overlong_penalty_factor=1.0
 
 # Paths and namings
 SFT_MODEL=$(basename $MODEL_PATH)
@@ -173,12 +168,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.fsdp_config.param_offload=${offload} \
     actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
     actor_rollout_ref.actor.entropy_checkpointing=${entropy_checkpointing} \
-    reward_model.reward_manager=${reward_manager} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.log=false \
-    +reward_model.reward_kwargs.max_resp_len=${max_response_length} \
+    reward_model.reward_manager=prime \
     trainer.logger='["console","wandb"]' \
     trainer.project_name="${project_name}" \
     trainer.experiment_name="${exp_name}" \

--- a/examples/gspo_trainer/test_gspo_3b_math_slurm.sh
+++ b/examples/gspo_trainer/test_gspo_3b_math_slurm.sh
@@ -57,7 +57,6 @@ if [ "$rollout_engine" = "vllm" ]; then
     export VLLM_USE_V1=1
 fi
 gpu_memory_utilization=0.8
-reward_manager=dapo
 adv_estimator=grpo
 shuffle_dataset=true
 first_time_dataset_prep=true # prepare dataset
@@ -82,10 +81,7 @@ n_resp_per_prompt=16
 
 max_prompt_length=$((1024 * 2))
 max_response_length=$((1024 * 8))
-# dapo reward manager params
-enable_overlong_buffer=false # true
-overlong_buffer_len=$((1024 * 4))
-overlong_penalty_factor=1.0
+
 
 # Paths and namings
 SFT_MODEL=$(basename $MODEL_PATH)
@@ -177,12 +173,7 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.ref.fsdp_config.param_offload=${offload} \
     actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
     actor_rollout_ref.actor.entropy_checkpointing=${entropy_checkpointing} \
-    reward_model.reward_manager=${reward_manager} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.log=false \
-    +reward_model.reward_kwargs.max_resp_len=${max_response_length} \
+    reward_model.reward_manager=prime \
     trainer.logger='["console","wandb"]' \
     trainer.project_name="${project_name}" \
     trainer.experiment_name="${exp_name}" \

--- a/examples/gspo_trainer/test_gspo_qwen30b_a3b_ep.sh
+++ b/examples/gspo_trainer/test_gspo_qwen30b_a3b_ep.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 export NCCL_DEBUG=WARN
 # export VERL_LOGGING_LEVEL=DEBUG
 
-project_name='DAPO'
+project_name='GSPO'
 exp_name='GSPO-Qwen3-30B-A3B-Base-MATH'
 
 adv_estimator=grpo
@@ -19,9 +19,6 @@ clip_ratio_high=4e-4
 
 max_prompt_length=$((1024 * 2))
 max_response_length=$((1024 * 8))
-enable_overlong_buffer=True
-overlong_buffer_len=$((1024 * 4))
-overlong_penalty_factor=1.0
 
 loss_agg_mode="token-mean"
 loss_mode=gspo
@@ -149,12 +146,7 @@ python3 -m verl.trainer.main_ppo \
     +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1 \
     +actor_rollout_ref.actor.megatron.override_transformer_config.gradient_accumulation_fusion=True \
     +actor_rollout_ref.actor.megatron.override_transformer_config.moe_permute_fusion=True \
-    reward_model.reward_manager=dapo \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
-    +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
-    +reward_model.reward_kwargs.max_resp_len=${max_response_length} \
+    reward_model.reward_manager=prime \
     trainer.logger='["console","wandb"]' \
     trainer.project_name="${project_name}" \
     trainer.experiment_name="${exp_name}-tp${gen_tp}-ep${gen_ep}" \


### PR DESCRIPTION
## Description

This PR fixes the configuration in the GSPO example script. Previously, it used `reward_manager=dapo` with overlong penalties, which seems to be a leftover from DAPO experiments.

I have updated it to use `reward_manager=prime` (standard for Math tasks) and removed the DAPO-specific `overlong_buffer` configurations to ensure the script runs standard GSPO logic correctly.

## Changes
- Changed `reward_manager` from `dapo` to the default setting.
- Removed `overlong_buffer_cfg` parameters.