### PR TITLE
[ckpt] fix: Megatron save ckpt after validation

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -1229,27 +1229,20 @@ def mapping_string_to_attn_backend(args: dict) -> dict:
         args["attention_backend"] = AttnBackend[args["attention_backend"]]
     return args
 
+
 def get_megatron_module_device(models: list[Any]) -> str:
     if not models:
-        return 'cpu' 
+        return "cpu"
 
     model_chunk = models[0]
-    if isinstance(model_chunk, DDP):
-        if not model_chunk.buffers:
-            try:
-                return next(model_chunk.module.parameters()).device.type
-            except StopIteration:
-                return 'cpu'
-
-        buffer = model_chunk.buffers[0]
-        if buffer.param_data.storage().size() == 0:
-            return 'cpu'
-        else:
-            return get_device_name()
-    else:
-        # for ref module
+    if not model_chunk.buffers:
         try:
-            param = next(model_chunk.parameters())
-            return param.data.device.type
+            return next(model_chunk.module.parameters()).device.type
         except StopIteration:
-            return 'cpu'
+            return "cpu"
+
+    buffer = model_chunk.buffers[0]
+    if buffer.param_data.storage().size() == 0:
+        return "cpu"
+    else:
+        return get_device_name()

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -38,12 +38,12 @@ from verl.utils.megatron.tensor_parallel import (
     vocab_parallel_log_probs_from_logits,
 )
 from verl.utils.megatron_utils import (
+    get_megatron_module_device,
     load_megatron_model_to_gpu,
     load_megatron_optimizer,
     offload_megatron_model_to_cpu,
     offload_megatron_optimizer,
     register_megatron_training_hooks,
-    get_megatron_module_device,
 )
 from verl.utils.model import (
     extract_multi_modal_inputs,


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the `save_checkpoint` function for MegatronEngine. https://github.com/volcengine/verl/pull/4799 is a similar PR, which modifies FSDPEngine.

In the original logic, if the model engine is used (`use_legacy_worker_impl=disable`), the `wake_up` function in `verl/workers/engine_workers.py` will be invoked during the rollout phase of each step, which will offload the model to CPU.

Under normal circumstances, the `compute_log_prob` function called during the training phase can load the model back to  GPU. However, the training process is not executed during the validation phase, leaving the model on the CPU. If a checkpoint is saved immediately after validation, it will trigger the following error: `AssertionError: Expects tensor to be on the compute device cuda:0, was on cpu.`

To fix this bug, this PR checks whether the model is located on the CPU before saving the checkpoint and loads it onto the GPU if that is the case.