### PR TITLE
[rollout] fix: configurable agent loop + multimodal data for fully-async

### DIFF
--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -111,9 +111,9 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
             sampling_params["top_p"] = config.val_kwargs.top_p
             sampling_params["temperature"] = config.val_kwargs.temperature
 
-        # by default, we assume it's a single turn agent
         if "agent_name" not in batch.non_tensor_batch:
-            batch.non_tensor_batch["agent_name"] = np.array(["single_turn_agent"] * len(batch), dtype=object)
+            default_agent_loop = config.agent.default_agent_loop
+            batch.non_tensor_batch["agent_name"] = np.array([default_agent_loop] * len(batch), dtype=object)
 
         if "index" in batch.non_tensor_batch:
             index = batch.non_tensor_batch["index"]
@@ -186,6 +186,8 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
                     server_manager=self.server_manager,
                     tokenizer=self.tokenizer,
                     processor=self.processor,
+                    dataset_cls=self.dataset_cls,
+                    dataset_config=self.config.data,
                 )
                 output: AgentLoopOutput = await agent_loop.run(
                     sampling_params, cancellation_event=self.cancellation_event, **kwargs

--- a/verl/experimental/fully_async_policy/agent_loop/partial_tool_agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/partial_tool_agent_loop.py
@@ -84,6 +84,7 @@ class AsyncPartialToolAgentLoop(ToolAgentLoop):
     async def _init_agent_data(self, kwargs: dict, param_version: int) -> AgentData:
         messages = list(kwargs["raw_prompt"])
         image_data = copy.deepcopy(kwargs.get("multi_modal_data", {}).get("image", None))
+        video_data = copy.deepcopy(kwargs.get("multi_modal_data", {}).get("video", None))
         metrics = {}
         request_id = uuid4().hex
         tools_kwargs = kwargs.get("tools_kwargs", {})
@@ -107,6 +108,7 @@ class AsyncPartialToolAgentLoop(ToolAgentLoop):
         agent_data = AgentData(
             messages=messages,
             image_data=image_data,
+            video_data=video_data,
             metrics=metrics,
             request_id=request_id,
             tools_kwargs=tools_kwargs,

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -68,8 +68,8 @@ def prepare_single_generation_data(batch_dict, config) -> DataProto:
 
     full_batch = DataProto.from_single_dict(batch_dict)
 
-    batch_keys_to_pop = ["input_ids", "attention_mask", "position_ids"]
-    non_tensor_batch_keys_to_pop = ["raw_prompt_ids"]
+    batch_keys_to_pop = []
+    non_tensor_batch_keys_to_pop = []
 
     full_batch.pop(
         batch_keys=batch_keys_to_pop,


### PR DESCRIPTION
## Description

* **`verl/experimental/fully_async_policy/agent_loop/agent_loop.py`**

  * Use `config.agent.default_agent_loop` as the default `agent_name` when `agent_name` is not present in `batch.non_tensor_batch`.
  * Pass `dataset_cls=self.dataset_cls` and `dataset_config=self.config.data` into `hydra.utils.instantiate(...)` when creating an agent loop instance.

* **`verl/experimental/fully_async_policy/agent_loop/partial_tool_agent_loop.py`**

  * Extract `video_data` from `multi_modal_data` and include `video_data` in the created `AgentData` instance (in addition to existing `image_data`).

* **`verl/experimental/fully_async_policy/detach_utils.py`**

  * Stop popping original batch fields in `prepare_single_generation_data`.
  * Set `agent_name` to `async_partial_tool_agent` or `partial_single_turn_agent` depending on `config.actor_rollout_ref.rollout.multi_turn.enable`.

## Testing

*  Verified the fully async training entry can run successfully on 4 GPU server setup (multi-turn enabled, partial rollout enabled, vLLM async mode).


## Related

* Fixes and extends the scope of: [4834](https://github.com/volcengine/verl/issues/4834)
