### PR TITLE
[training_utils] fix: add file locking to prevent race conditions during copy_to_shm

### DIFF
--- a/verl/utils/fs.py
+++ b/verl/utils/fs.py
@@ -159,8 +159,13 @@ def copy_to_shm(src: str):
                 f"restart the task."
             )
         else:
+            if os.path.lexists(dest):
+                if os.path.isdir(dest) and not os.path.islink(dest):
+                    shutil.rmtree(dest)
+                else:
+                    os.remove(dest)
             if os.path.isdir(src):
-                shutil.copytree(src, dest, symlinks=False, dirs_exist_ok=True)
+                shutil.copytree(src, dest, symlinks=False)
             else:
                 shutil.copy2(src, dest)
     return dest

--- a/verl/utils/fs.py
+++ b/verl/utils/fs.py
@@ -142,22 +142,27 @@ def copy_to_shm(src: str):
     """
     Load the model into   /dev/shm   to make the process of loading the model multiple times more efficient.
     """
+
+    from filelock import FileLock
+
     shm_model_root = "/dev/shm/verl-cache/"
     src_abs = os.path.abspath(os.path.normpath(src))
     dest = os.path.join(shm_model_root, hashlib.md5(src_abs.encode("utf-8")).hexdigest())
     os.makedirs(dest, exist_ok=True)
     dest = os.path.join(dest, os.path.basename(src_abs))
-    if os.path.exists(dest) and verify_copy(src, dest):
-        # inform user and depends on him
-        print(
-            f"[WARNING]: The memory model path {dest} already exists. If it is not you want, please clear it and "
-            f"restart the task."
-        )
-    else:
-        if os.path.isdir(src):
-            shutil.copytree(src, dest, symlinks=False, dirs_exist_ok=True)
+    lock_file = dest + ".file.lock"
+    with FileLock(lock_file=lock_file):
+        if os.path.exists(dest) and verify_copy(src, dest):
+            # inform user and depends on him
+            print(
+                f"[WARNING]: The memory model path {dest} already exists. If it is not you want, please clear it and "
+                f"restart the task."
+            )
         else:
-            shutil.copy2(src, dest)
+            if os.path.isdir(src):
+                shutil.copytree(src, dest, symlinks=False, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dest)
     return dest
 
 


### PR DESCRIPTION
### What does this PR do?
When copying small models, some processes may finish earlier and start reading the file while other processes are still rewriting the same file, which can lead to errors or potential model corruption.

Adds a file lock to the copy logic to prevent race conditions when multiple processes write to the same file. This ensures files are fully written before being read in multi-process environments.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
