### PR TITLE
fix(sft_trainer): Fix global_tokens and total_tokens metrics always showing 0.0

### DIFF
--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -313,9 +313,9 @@ class SFTTrainer:
                 data = tu.get_tensordict(tensor_dict=data, non_tensor_dict=meta_info)
                 batch_seqlens = self._get_batch_seqlens(data=data)
                 # this is necessary. Otherwise, it is interpreted as NonTensorStack
-                batch_seqlens = NonTensorData(batch_seqlens)
+                batch_seqlens_ntd = NonTensorData(batch_seqlens)
 
-                tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens)
+                tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens_ntd)
 
                 # start profile in SPMD mode
                 if global_step == self.start_profile_step:
@@ -335,7 +335,7 @@ class SFTTrainer:
                     metrics["train/lr"] = metrics.pop("lr")
                     metrics["train/mfu"] = metrics.pop("mfu")
                     metrics["train/global_tokens"] = torch.sum(
-                        torch.tensor(batch_seqlens.data, device=self.device_name)
+                        torch.tensor(batch_seqlens, device=self.device_name)
                     ).item()
                     total_tokens += metrics["train/global_tokens"]
                     metrics["train/total_tokens(B)"] = total_tokens / 1e9

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -291,11 +291,11 @@ class SFTTrainer:
                 global_step += 1
                 # construct tensordict
                 data = tu.get_tensordict(tensor_dict=data, non_tensor_dict=meta_info)
-                batch_seqlens = self._get_batch_seqlens(data=data)
+                batch_seqlens = self._get_batch_seqlens(data=data).tolist()
                 # this is necessary. Otherwise, it is interpreted as NonTensorStack
-                batch_seqlens = NonTensorData(batch_seqlens.tolist())
+                batch_seqlens_ntd = NonTensorData(batch_seqlens)
 
-                tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens)
+                tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens_ntd)
 
                 # start profile in SPMD mode
                 if global_step == self.start_profile_step:
@@ -314,7 +314,7 @@ class SFTTrainer:
                 metrics["train/grad_norm"] = metrics.pop("grad_norm")
                 metrics["train/lr"] = metrics.pop("lr")
                 metrics["train/mfu"] = metrics.pop("mfu")
-                metrics["train/global_tokens"] = torch.sum(torch.tensor(batch_seqlens.data, device=self.device_name)).item()
+                metrics["train/global_tokens"] = torch.sum(torch.tensor(batch_seqlens, device=self.device_name)).item()
                 total_tokens += metrics["train/global_tokens"]
                 metrics["train/total_tokens(B)"] = total_tokens / 1e9
                 tracking.log(data=metrics, step=global_step)


### PR DESCRIPTION
## Summary

Fix a bug in `sft_trainer.py` where `train/global_tokens` and `train/total_tokens(B)` metrics always show `0.0`.

**Root Cause:**
The `batch_seqlens` variable is wrapped in `NonTensorData` at line 316, but when calculating metrics at line 337-339, the code passes the `NonTensorData` object directly to `torch.tensor()`, which cannot correctly convert it, resulting in zero values.

**Fix:**
Extract the raw list data using `.data` attribute: `batch_seqlens.data`

## Evidence

Training logs showing the bug (metrics are always 0.0):

```
step:2463 - train/loss:0.6040167808532715 - train/grad_norm:0.6981590168109557 - train/lr:4.59405088739498e-06 - train/mfu:0.3199340489915991 - train/global_tokens:0.0 - train/total_tokens(B):0.0
step:2464 - train/loss:0.6058582663536072 - train/grad_norm:0.49556096821458145 - train/lr:4.593644936938091e-06 - train/mfu:0.2912232439316744 - train/global_tokens:0.0 - train/total_tokens(B):0.0
```

## Changes

```diff
-                    metrics["train/global_tokens"] = torch.sum(
-                        torch.tensor(batch_seqlens, device=self.device_name)
-                    ).item()
+                    metrics["train/global_tokens"] = torch.sum(
+                        torch.tensor(batch_seqlens.data, device=self.device_name)
+                    ).item()
```

## Test Plan

- [x] Verified that `batch_seqlens` is a `NonTensorData` object at the metrics calculation point
- [ ] Run SFT training and verify `global_tokens` and `total_tokens(B)` now show correct values