### PR TITLE
[data] fix: build_messages for multi-modal data

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -317,7 +317,7 @@ class RLHFDataset(Dataset):
                     assert image_offset < len(images), f"image_offset {image_offset} >= len(images) {len(images)}"
                     image = images[image_offset]
                     if isinstance(image, Image.Image):
-                        image= image.convert("RGB")
+                        image = image.convert("RGB")
                         content_list.append({"type": "image", "image": image})
                     elif isinstance(image, dict):
                         if "bytes" in image:


### PR DESCRIPTION
### What does this PR do?

fix https://github.com/volcengine/verl/pull/4759


1. When concatenating image and video datasets, pop will return None for image or video sample, this will raise Traceback
 
Original Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/torchdata/stateful_dataloader/worker.py", line 242, in _worker_loop
    data = fetcher.fetch(index)  # type: ignore[union-attr]
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
            ~~~~~~~~~~~~^^^^^                                                                                                                                                                                                                 File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_e77e513345569ff8/verl/utils/dataset/rl_dataset.py", line 339, in __getitem__
    row_dict["raw_prompt"] = self._build_messages(row_dict)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_e77e513345569ff8/verl/utils/dataset/rl_dataset.py", line 332, in _build_messages
    assert image_offset == len(images), f"image_offset {image_offset} != len(images) {len(images)}"
                           ^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()

2. messages format is like this, so we need unpacking instead of insert image or video, this will raise Traceback
```
[
      {
          "role": "user",
          "content": [
              {
                  "type": "video",
                  "video": os.path.expanduser("~/models/hf_data/test-videos/space_woaudio.mp4"),
                  "min_pixels": 4 * 32 * 32,
                  "max_pixels": 256 * 32 * 32,
                  "total_pixels": 4096 * 32 * 32,
              },
              {
                  "type": "text",
                  "text": "Describe this video. Then you must call the "
                  "image generator tool to generate a green image for me.",
              },
          ],
      },
]
```       

 File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_a858101d9415992f/verl/experimental/agent_loop/agent_loop.py", line 515, in _run_agent_loop
   output: AgentLoopOutput = await agent_loop.run(sampling_params, **kwargs)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_a858101d9415992f/verl/experimental/agent_loop/single_turn_agent_loop.py", line 44, in run
   multi_modal_data = await self.process_vision_info(messages)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_a858101d9415992f/verl/experimental/agent_loop/agent_loop.py", line 236, in process_vision_info
   images, videos = await self.dataset_cls.process_vision_info(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/tmp/ray/session_2026-01-09_06-01-53_053078_153/runtime_resources/working_dir_files/_ray_pkg_a858101d9415992f/verl/utils/dataset/rl_dataset.py", line 390, in process_vision_info
   images, videos = process_vision_info(messages, image_patch_size=image_patch_size, return_video_metadata=True)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.12/dist-packages/qwen_vl_utils/vision_process.py", line 515, in process_vision_info
   image_inputs.append(fetch_image(vision_info, image_patch_size=image_patch_size))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/usr/local/lib/python3.12/dist-packages/qwen_vl_utils/vision_process.py", line 103, in fetch_image
   elif image.startswith("http://") or image.startswith("https://"):
        ^^^^^^^^^^^^^^^^
ttributeError: 'dict' object has no attribute 'startswith'



> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
