### PR TITLE
[vllm, rollout] fix: Add TP-aware weight loading for async rollout with different parallelism configs

### DIFF
--- a/verl/utils/vllm/patch.py
+++ b/verl/utils/vllm/patch.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from typing import Optional
+import torch
+
+# Environment variable to enable TP resharding fix for async rollout
+# Set VERL_ENABLE_TP_RESHARD=1 to enable automatic weight resharding when
+# training TP size differs from inference TP size
+ENABLE_TP_RESHARD = os.environ.get("VERL_ENABLE_TP_RESHARD", "0") == "1"
+
 # To support different vLLM versions, we add the model into SUPPORTED_MOE_MODELS separately to avoid triggering
 # unsupported issues.
 SUPPORTED_MOE_MODELS = []
@@ -68,27 +77,21 @@ except ImportError:
 
 
 def patch_vllm_moe_model_weight_loader(model):
-    # this is a work around to load the weight of vllm fused moe model
-    # it is from a bug from vllm 0.8.2
-    # all the weights are supposed to have a weight_loader, but the moe weights
-    # do not have a weight_loader, so we need to patch it
-    # (True, 'model.embed_tokens.weight')
-    # (True, 'model.layers.0.self_attn.qkv_proj.weight')
-    # (True, 'model.layers.0.self_attn.qkv_proj.bias')
-    # (True, 'model.layers.0.self_attn.o_proj.weight')
-    # (True, 'model.layers.0.mlp.gate.weight')
-    # (True, 'model.layers.0.mlp.shared_expert.gate_up_proj.weight')
-    # (True, 'model.layers.0.mlp.shared_expert.down_proj.weight')
-    # (False, 'model.layers.0.mlp.shared_expert_gate.weight')   use default
-    # (False, 'model.layers.0.input_layernorm.weight')          use default
-    # (False, 'model.layers.0.post_attention_layernorm.weight') use default
-    # (False, 'model.layers.0.mlp.experts.w13_weight')          use mlp.experts.weight_loader
-    # (False, 'model.layers.0.mlp.experts.w2_weight')          use mlp.experts.weight_loader
+    """
+    Patch vLLM model weight loaders for proper weight synchronization.
 
-    # Early return if no MOE models are supported
-    if not SUPPORTED_MOE_MODELS:
-        return
+    This function does two things:
+    1. Patches MoE expert weights (w13_weight, w2_weight) to use the experts' weight_loader
+       (workaround for vLLM 0.8.2+ bug where MoE weights don't have weight_loaders)
+    2. Patches ALL parameters without weight_loaders to handle TP resharding when training
+       and inference use different tensor parallelism configurations (e.g., Megatron TP=8
+       exports full HF weights, but vLLM uses TP=16)
 
+    Parameters with existing weight_loaders are not modified.
+
+    Args:
+        model: The vLLM model to patch
+    """
     original_model_type = type(model)
     if hasattr(model, "runnable") and "ACLGraphWrapper" in str(original_model_type):
         model = model.runnable
@@ -108,28 +111,133 @@ def patch_vllm_moe_model_weight_loader(model):
     # Get inner model (either model.model or model.language_model)
     inner_model = getattr(model, "model", None) or getattr(model, "language_model", None)
     if inner_model is None:
-        raise ValueError("The provided model does not have a valid 'model' or 'language_model' attribute.")
-
-    if not isinstance(model, tuple(SUPPORTED_MOE_MODELS)) and not isinstance(inner_model, tuple(SUPPORTED_MOE_MODELS)):
+        # Can't patch if we can't find the inner model
         return
 
-    # TODO(@leisuzz): class Qwen3MoeLLMForCausalLM is not available if VLLM version < 0.11.0,
-    # will update the 'if statement' with 'isinstance' when verl commonly use VLLM version >= 0.11.0
+    # For nested models like Qwen3-vl
     if type(inner_model).__name__ == "Qwen3MoeLLMForCausalLM":
-        inner_model = inner_model.model  # Reassign inner_model in Qwen3-vl
+        inner_model = inner_model.model
 
-    for layer_idx, layer in enumerate(inner_model.layers):
-        mlp_attr = MLP_ATTR_MAPPING.get(original_model_type, DEFAULT_MLP_ATTR)
+    # Check if this is a supported MoE model for the expert weight patching
+    is_moe_model = SUPPORTED_MOE_MODELS and (
+        isinstance(model, tuple(SUPPORTED_MOE_MODELS)) or isinstance(inner_model, tuple(SUPPORTED_MOE_MODELS))
+    )
 
-        mlp = getattr(layer, mlp_attr, None)
-        if not mlp:
-            continue
+    # Step 1: Patch MoE expert weights (only for supported MoE models)
+    if is_moe_model and hasattr(inner_model, "layers"):
+        for layer_idx, layer in enumerate(inner_model.layers):
+            mlp_attr = MLP_ATTR_MAPPING.get(original_model_type, DEFAULT_MLP_ATTR)
 
-        experts = getattr(mlp, "experts", None)
-        if not experts or not hasattr(experts, "weight_loader"):
-            continue
+            mlp = getattr(layer, mlp_attr, None)
+            if not mlp:
+                continue
 
-        # Patch the weight loaders
-        for name, param in mlp.named_parameters():
-            if "w13_weight" in name or "w2_weight" in name:
-                param.weight_loader = experts.weight_loader
+            experts = getattr(mlp, "experts", None)
+            if not experts or not hasattr(experts, "weight_loader"):
+                continue
+
+            # Patch MoE expert weight loaders
+            for name, param in mlp.named_parameters():
+                if "w13_weight" in name or "w2_weight" in name:
+                    param.weight_loader = experts.weight_loader
+
+    # Step 2: Patch ALL parameters without weight_loaders for TP resharding
+    # This handles the case where training exports full HF weights but vLLM uses different TP
+    # Only enabled when VERL_ENABLE_TP_RESHARD=1
+    if ENABLE_TP_RESHARD:
+        _, tp_size = _get_tp_rank_and_size()
+        if tp_size > 1:
+            for name, param in inner_model.named_parameters():
+                if not hasattr(param, "weight_loader"):
+                    param.weight_loader = _create_tp_aware_weight_loader(name)
+
+
+def _get_tp_rank_and_size():
+    """Get tensor parallel rank and world size from vLLM's distributed state."""
+    try:
+        from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+
+        return get_tensor_model_parallel_rank(), get_tensor_model_parallel_world_size()
+    except ImportError:
+        # Fallback for older vLLM versions
+        try:
+            from vllm.model_executor.parallel_utils.parallel_state import (
+                get_tensor_model_parallel_rank,
+                get_tensor_model_parallel_world_size,
+            )
+
+            return get_tensor_model_parallel_rank(), get_tensor_model_parallel_world_size()
+        except ImportError:
+            return 0, 1
+
+
+def _create_tp_aware_weight_loader(param_name: str):
+    """
+    Create a weight_loader that can handle full (unsharded) weights from HuggingFace format
+    and shard them according to vLLM's tensor parallelism configuration.
+
+    This is needed when training uses a different TP size than inference (e.g., Megatron TP=8
+    exports full HF weights, but vLLM uses TP=16).
+
+    Args:
+        param_name: The parameter name (used for error messages)
+
+    Returns:
+        A weight_loader function that handles TP resharding
+    """
+
+    def tp_aware_weight_loader(
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        shard_id: Optional[str] = None,
+    ):
+        """
+        Weight loader that handles TP resharding for full HuggingFace weights.
+
+        If loaded_weight matches param size, uses default loading.
+        If loaded_weight is larger, shards it according to TP rank.
+        """
+        tp_rank, tp_size = _get_tp_rank_and_size()
+
+        # If sizes match, no resharding needed
+        if loaded_weight.shape == param.shape:
+            param.data.copy_(loaded_weight)
+            return
+
+        # Determine which dimension to shard
+        # Compare loaded_weight shape with param shape to find the sharded dimension
+        shard_dim = None
+        for dim in range(loaded_weight.dim()):
+            if loaded_weight.shape[dim] != param.shape[dim]:
+                if loaded_weight.shape[dim] == param.shape[dim] * tp_size:
+                    shard_dim = dim
+                    break
+
+        if shard_dim is None:
+            # Can't determine sharding, fall back to assertion (will fail with clear error)
+            assert param.shape == loaded_weight.shape, (
+                f"Cannot determine sharding strategy for {param_name}. "
+                f"Loaded weight shape {loaded_weight.shape} does not match "
+                f"parameter shape {param.shape} and is not a simple TP multiple."
+            )
+            param.data.copy_(loaded_weight)
+            return
+
+        # Calculate shard size and extract the correct shard
+        shard_size = loaded_weight.shape[shard_dim] // tp_size
+
+        # Build slice for extracting this rank's shard
+        slices = [slice(None)] * loaded_weight.dim()
+        slices[shard_dim] = slice(tp_rank * shard_size, (tp_rank + 1) * shard_size)
+
+        shard = loaded_weight[tuple(slices)]
+
+        # Verify shape matches
+        assert shard.shape == param.shape, (
+            f"Sharded weight shape {shard.shape} does not match "
+            f"parameter shape {param.shape} for {param_name}"
+        )
+
+        param.data.copy_(shard)
+
+    return tp_aware_weight_loader


### PR DESCRIPTION
## What does this PR do?

Adds automatic tensor parallel (TP) resharding support when training and inference use different TP configurations. This fixes weight loading failures in fully async workflows where Megatron exports full HuggingFace weights but vLLM expects TP-sharded weights.

Related to #400, #1063,  #4497

## Problem

When using fully async training with:
- **Megatron training**: `tensor_model_parallel_size=8`, `use_mbridge=True`
- **vLLM inference**: `tensor_model_parallel_size=32`

Weight synchronization fails because:
1. mbridge exports full (unsharded) HuggingFace-format weights
2. vLLM parameters expect weights pre-sharded for TP=32
3. Parameters without a `weight_loader` attribute cause assertion errors:
   ```
   AssertionError: param.shape [hidden_size/32, ...] != loaded_weight.shape [hidden_size, ...]
   ```

This affects large MoE models (DeepSeek-V3/R1) where training requires pipeline parallelism but inference benefits from higher TP across nodes.

## Solution

1. Add `VERL_ENABLE_TP_RESHARD` environment variable (opt-in to avoid breaking existing setups)
2. Patch parameters without `weight_loader` to use a TP-aware loader that:
   - Detects which dimension differs by a factor of `tp_size`
   - Automatically shards along that dimension based on `tp_rank`
3. Refactor `patch_vllm_moe_model_weight_loader` to handle both MoE expert patching and general TP resharding

## Test

Validated on DeepSeek-V3-Base with:
- 16 nodes Megatron training (TP=8, PP=16, EP=8)
- 16 nodes vLLM inference (TP=32, EP=32)
- Fully async DAPO training with `use_mbridge=True`

Before fix: Weight loading fails with shape mismatch assertions
After fix: Weights load correctly, training proceeds normally

### Config used

```yaml
parallelism:
  tp: 8
  pp: 16
  ep: 8
  etp: 1
  infer_tp: 32
  infer_ep: 32
  infer_dp: 1
```

### Launch command

```bash
VERL_ENABLE_TP_RESHARD=1 \
VLLM_USE_DEEP_GEMM=1 \
VLLM_ALL2ALL_BACKEND=deepep_high_throughput \
python3 -m ta_verl.recipe.fully_async_dapo.fully_async_main \
  --config-name="deepseek_v3_20251219.yaml" \
  trainer.nnodes="16" \
  rollout.nnodes="16"
```

## API and Usage Example

```bash
# Enable TP resharding for async rollout
VERL_ENABLE_TP_RESHARD=1 python -m verl.trainer.main ...
```

No config changes required. The fix automatically detects and handles TP mismatches.

## Design & Code Changes

**File:** `verl/utils/vllm/patch.py`

1. **`_get_tp_rank_and_size()`**: Helper to get vLLM's tensor parallel configuration
2. **`_create_tp_aware_weight_loader()`**: Creates weight loaders that:
   - Pass through if shapes match
   - Auto-shard if loaded weight is `tp_size` times larger in one dimension
3. **`patch_vllm_moe_model_weight_loader()`**: Extended to patch all parameters without `weight_loader` when `VERL_ENABLE_TP_RESHARD=1`

## Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)
- [x] Apply pre-commit checks
- [ ] Add/Update documentation
- [ ] Add unit tests (manual validation on DeepSeek-V3 scale)

---

## Related Issues

| Issue | Link | Relevance |
|-------|------|-----------|
| #4497 | https://github.com/volcengine/verl/issues/4497 | MoE weight format mismatch (same root cause) |
| #708 | https://github.com/volcengine/verl/issues/708 | DeepSeek R1 infrastructure project |
| #400 | https://github.com/volcengine/verl/issues/400 | TP rollout + FSDP / TP actor feature request |
| #1063 | https://github.com/volcengine/verl/issues/1063 | RFC auto resharding design |