### PR TITLE
test on avoiding unnecessary object deserialization

### DIFF
--- a/examples/data_preprocess/gsm8k.py
+++ b/examples/data_preprocess/gsm8k.py
@@ -20,6 +20,7 @@ import os
 import re
 
 import datasets
+import ray
 
 from verl.utils.hdfs_io import copy, makedirs
 
@@ -32,19 +33,13 @@ def extract_solution(solution_str):
     return final_solution
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--local_dir", default=None, help="The save directory for the preprocessed dataset.")
-    parser.add_argument("--hdfs_dir", default=None)
-    parser.add_argument("--local_dataset_path", default=None, help="The local path to the raw dataset, if it exists.")
-    parser.add_argument(
-        "--local_save_dir", default="~/data/gsm8k", help="The save directory for the preprocessed dataset."
-    )
+@ray.remote(num_cpus=0)
+def download_and_preprocess_on_node(data_source, local_dataset_path, local_save_dir, hdfs_dir):
+    """Download and preprocess the GSM8k dataset on a specific node."""
+    import socket
 
-    args = parser.parse_args()
-    local_dataset_path = args.local_dataset_path
-
-    data_source = "openai/gsm8k"
+    hostname = socket.gethostname()
+    print(f"Downloading and preprocessing GSM8k dataset on node: {hostname}")
 
     if local_dataset_path is not None:
         dataset = datasets.load_dataset(local_dataset_path, "main")
@@ -89,6 +84,40 @@ if __name__ == "__main__":
     train_dataset = train_dataset.map(function=make_map_fn("train"), with_indices=True)
     test_dataset = test_dataset.map(function=make_map_fn("test"), with_indices=True)
 
+    # Expand ~ in the path
+    local_save_dir_expanded = os.path.expanduser(local_save_dir)
+    os.makedirs(local_save_dir_expanded, exist_ok=True)
+
+    train_dataset.to_parquet(os.path.join(local_save_dir_expanded, "train.parquet"))
+    test_dataset.to_parquet(os.path.join(local_save_dir_expanded, "test.parquet"))
+
+    print(f"Dataset saved to {local_save_dir_expanded} on node: {hostname}")
+
+    if hdfs_dir is not None:
+        makedirs(hdfs_dir)
+        copy(src=local_save_dir_expanded, dst=hdfs_dir)
+        print(f"Dataset copied to HDFS: {hdfs_dir} from node: {hostname}")
+
+    return hostname
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_dir", default=None, help="The save directory for the preprocessed dataset.")
+    parser.add_argument("--hdfs_dir", default=None)
+    parser.add_argument("--local_dataset_path", default=None, help="The local path to the raw dataset, if it exists.")
+    parser.add_argument(
+        "--local_save_dir", default="~/data/gsm8k", help="The save directory for the preprocessed dataset."
+    )
+    parser.add_argument(
+        "--distributed", action="store_true", help="Download to all nodes in the Ray cluster instead of just head node."
+    )
+
+    args = parser.parse_args()
+    local_dataset_path = args.local_dataset_path
+
+    data_source = "openai/gsm8k"
+
     hdfs_dir = args.hdfs_dir
     local_save_dir = args.local_dir
     if local_save_dir is not None:
@@ -96,10 +125,86 @@ if __name__ == "__main__":
     else:
         local_save_dir = args.local_save_dir
 
-    train_dataset.to_parquet(os.path.join(local_save_dir, "train.parquet"))
-    test_dataset.to_parquet(os.path.join(local_save_dir, "test.parquet"))
+    if args.distributed:
+        # Initialize Ray if not already initialized
+        if not ray.is_initialized():
+            ray.init()
 
-    if hdfs_dir is not None:
-        makedirs(hdfs_dir)
+        # Get all available nodes and schedule tasks on each node
+        nodes = ray.nodes()
+        alive_nodes = [node for node in nodes if node["Alive"]]
 
-        copy(src=local_save_dir, dst=hdfs_dir)
+        print(f"Found {len(alive_nodes)} alive nodes in the Ray cluster:")
+        for node in alive_nodes:
+            node_ip = node["NodeManagerAddress"]
+            print(f"  - {node_ip}")
+
+        # Download and preprocess on all nodes
+        download_tasks = []
+        for node in alive_nodes:
+            node_ip = node["NodeManagerAddress"]
+            task = download_and_preprocess_on_node.options(
+                resources={"node:" + node_ip: 0.001}  # Schedule to specific node
+            ).remote(data_source, local_dataset_path, local_save_dir, hdfs_dir)
+            download_tasks.append(task)
+
+        # Wait for all tasks to complete
+        completed_nodes = ray.get(download_tasks)
+        print(f"\nDataset successfully downloaded and preprocessed on {len(completed_nodes)} nodes:")
+        for hostname in completed_nodes:
+            print(f"  - {hostname}")
+    else:
+        # Original single-node behavior
+        if local_dataset_path is not None:
+            dataset = datasets.load_dataset(local_dataset_path, "main")
+        else:
+            dataset = datasets.load_dataset(data_source, "main")
+
+        train_dataset = dataset["train"]
+        test_dataset = dataset["test"]
+
+        instruction_following = 'Let\'s think step by step and output the final answer after "####".'
+
+        # add a row to each data item that represents a unique id
+        def make_map_fn(split):
+            def process_fn(example, idx):
+                question_raw = example.pop("question")
+
+                question = question_raw + " " + instruction_following
+
+                answer_raw = example.pop("answer")
+                solution = extract_solution(answer_raw)
+                data = {
+                    "data_source": data_source,
+                    "prompt": [
+                        {
+                            "role": "user",
+                            "content": question,
+                        }
+                    ],
+                    "ability": "math",
+                    "reward_model": {"style": "rule", "ground_truth": solution},
+                    "extra_info": {
+                        "split": split,
+                        "index": idx,
+                        "answer": answer_raw,
+                        "question": question_raw,
+                    },
+                }
+                return data
+
+            return process_fn
+
+        train_dataset = train_dataset.map(function=make_map_fn("train"), with_indices=True)
+        test_dataset = test_dataset.map(function=make_map_fn("test"), with_indices=True)
+
+        local_save_dir_expanded = os.path.expanduser(local_save_dir)
+        os.makedirs(local_save_dir_expanded, exist_ok=True)
+
+        train_dataset.to_parquet(os.path.join(local_save_dir_expanded, "train.parquet"))
+        test_dataset.to_parquet(os.path.join(local_save_dir_expanded, "test.parquet"))
+
+        if hdfs_dir is not None:
+            makedirs(hdfs_dir)
+
+            copy(src=local_save_dir_expanded, dst=hdfs_dir)

--- a/examples/data_preprocess/run_on_all_nodes.py
+++ b/examples/data_preprocess/run_on_all_nodes.py
@@ -1,0 +1,178 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Run a command on all nodes of a Ray cluster.
+
+Usage:
+    python run_on_all_nodes.py "echo hello"
+    python run_on_all_nodes.py "pip install numpy" --timeout 300
+    python run_on_all_nodes.py "ls -la /data" --ray-address auto
+"""
+
+import argparse
+import subprocess
+import socket
+
+import ray
+
+
+@ray.remote(num_cpus=0)
+def run_command_on_node(command: str, timeout: int = 60) -> dict:
+    """Run a shell command on a specific node and return the result."""
+    hostname = socket.gethostname()
+    ip_address = socket.gethostbyname(hostname)
+
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "hostname": hostname,
+            "ip": ip_address,
+            "success": result.returncode == 0,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "hostname": hostname,
+            "ip": ip_address,
+            "success": False,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": f"Command timed out after {timeout} seconds",
+        }
+    except Exception as e:
+        return {
+            "hostname": hostname,
+            "ip": ip_address,
+            "success": False,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": str(e),
+        }
+
+
+def run_on_all_nodes(command: str, timeout: int = 60, verbose: bool = True) -> list[dict]:
+    """
+    Run a command on all nodes of a Ray cluster.
+
+    Args:
+        command: The shell command to run on each node.
+        timeout: Timeout in seconds for each command execution.
+        verbose: Whether to print progress and results.
+
+    Returns:
+        List of result dictionaries from each node.
+    """
+    # Get all available nodes and schedule tasks on each node
+    nodes = ray.nodes()
+    alive_nodes = [node for node in nodes if node["Alive"]]
+
+    if verbose:
+        print(f"Found {len(alive_nodes)} alive nodes in the Ray cluster:")
+        for node in alive_nodes:
+            node_ip = node["NodeManagerAddress"]
+            print(f"  - {node_ip}")
+        print(f"\nRunning command: {command}\n")
+
+    # Run command on all nodes
+    tasks = []
+    for node in alive_nodes:
+        node_ip = node["NodeManagerAddress"]
+        task = run_command_on_node.options(
+            resources={"node:" + node_ip: 0.001}  # Schedule to specific node
+        ).remote(command, timeout)
+        tasks.append(task)
+
+    # Wait for all tasks to complete
+    results = ray.get(tasks)
+
+    if verbose:
+        print("=" * 60)
+        print("Results:")
+        print("=" * 60)
+
+        success_count = 0
+        for result in results:
+            status = "✓" if result["success"] else "✗"
+            print(f"\n[{status}] {result['hostname']} ({result['ip']}) - exit code: {result['returncode']}")
+
+            if result["stdout"].strip():
+                print("  stdout:")
+                for line in result["stdout"].strip().split("\n"):
+                    print(f"    {line}")
+
+            if result["stderr"].strip():
+                print("  stderr:")
+                for line in result["stderr"].strip().split("\n"):
+                    print(f"    {line}")
+
+            if result["success"]:
+                success_count += 1
+
+        print("\n" + "=" * 60)
+        print(f"Summary: {success_count}/{len(results)} nodes succeeded")
+        print("=" * 60)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run a command on all nodes of a Ray cluster.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    python run_on_all_nodes.py "echo hello"
+    python run_on_all_nodes.py "pip install numpy" --timeout 300
+    python run_on_all_nodes.py "ls -la /data" --ray-address auto
+    python run_on_all_nodes.py "nvidia-smi" --quiet
+        """,
+    )
+    parser.add_argument("command", type=str, help="The shell command to run on all nodes")
+    parser.add_argument(
+        "--timeout", type=int, default=60, help="Timeout in seconds for each command execution (default: 60)"
+    )
+    parser.add_argument(
+        "--ray-address",
+        type=str,
+        default=None,
+        help="Ray cluster address to connect to (default: auto-detect or start local)",
+    )
+    parser.add_argument("--quiet", "-q", action="store_true", help="Only print summary, not detailed output")
+
+    args = parser.parse_args()
+
+    # Initialize Ray
+    if not ray.is_initialized():
+        if args.ray_address:
+            ray.init(address=args.ray_address)
+        else:
+            ray.init()
+
+    results = run_on_all_nodes(args.command, timeout=args.timeout, verbose=not args.quiet)
+
+    # Exit with non-zero if any node failed
+    if not all(r["success"] for r in results):
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## How to test

```
python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k --distributed

python run_on_all_nodes.py "python3 -c \"import transformers; transformers.pipeline('text-generation', model='Qwen/Qwen2.5-0.5B-Instruct')\"" --timeout 600

PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
 data.train_files=$HOME/data/gsm8k/train.parquet \
 data.val_files=$HOME/data/gsm8k/test.parquet \
 data.train_batch_size=256 \
 data.max_prompt_length=512 \
 data.max_response_length=512 \
 actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
 actor_rollout_ref.actor.optim.lr=1e-6 \
 actor_rollout_ref.actor.ppo_mini_batch_size=64 \
 actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4 \
 actor_rollout_ref.rollout.name=vllm \
 actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
 actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
 actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
 actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
 critic.optim.lr=1e-5 \
 critic.model.path=Qwen/Qwen2.5-0.5B-Instruct \
 critic.ppo_micro_batch_size_per_gpu=4 \
 algorithm.kl_ctrl.kl_coef=0.001 \
 trainer.logger=console \
 trainer.val_before_train=False \
 trainer.n_gpus_per_node=1 \
 trainer.nnodes=1 \
 trainer.save_freq=10 \
 trainer.test_freq=10 \
 trainer.total_epochs=15 2>&1 | tee verl_demo.log
```

thinking: can we move most parts and do some fusion as the current worker components, so the need for the deserialized data on driver is less?