### PR TITLE
[data] feat: TransferQueue - fix rm_score error of TransferQueue

### DIFF
--- a/verl/experimental/transfer_queue/ray_trainer.py
+++ b/verl/experimental/transfer_queue/ray_trainer.py
@@ -712,7 +712,6 @@ class RayPPOTrainer:
             if self.val_reward_fn is None:
                 raise ValueError("val_reward_fn must be provided for validation.")
 
-            # TODO (TQ): Support PR https://github.com/volcengine/verl/pull/4581
             compute_reward_fields = [
                 "responses",
                 "prompts",
@@ -721,7 +720,7 @@ class RayPPOTrainer:
                 "data_source",
             ]
             if "rm_scores" in batch_meta.field_names:
-                compute_reward_fields = ["rm_scores", "acc"]
+                compute_reward_fields = ["rm_scores", *set(batch_meta.extra_info["reward_extra_keys"])]
 
             val_reward_meta = batch_meta.select_fields(compute_reward_fields)
             result = compute_val_reward_decorated(self.val_reward_fn, val_reward_meta, return_dict=True)
@@ -1325,7 +1324,9 @@ class RayPPOTrainer:
                             "data_source",
                         ]
                         if "rm_scores" in batch_meta.field_names:
-                            compute_reward_fields.extend(["rm_scores", "acc"])
+                            compute_reward_fields.extend(
+                                ["rm_scores", *set(batch_meta.extra_info["reward_extra_keys"])]
+                            )
 
                         compute_reward_meta = batch_meta.select_fields(compute_reward_fields)
 


### PR DESCRIPTION
### What does this PR do?

Previously, there were error logs during the training phase, but errors occurred directly during the val phase.
<img width="999" height="303" alt="image" src="https://github.com/user-attachments/assets/3bec88fe-742a-4f8c-a286-cba6d8f2ac42" />
<img width="1115" height="423" alt="image" src="https://github.com/user-attachments/assets/bdbb484c-7dcf-4013-894b-4d0bb3fa9670" />

The function is normal after the repair.
<img width="1111" height="436" alt="image" src="https://github.com/user-attachments/assets/bc0a7019-69b4-4d8c-9367-4fc634d347a7" />

The reason is that TQ did not retrieve the data with the key "acc".

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
