### PR TITLE
[vllm] fix: Update get_encoding import for vllm versions 0.13.0 and above

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -76,6 +76,7 @@ if _VLLM_VERSION > version.parse("0.11.0"):
         get_encoding()
     elif _VLLM_VERSION >= version.parse("0.13.0"):
         from vllm.entrypoints.openai.parser.harmony_utils import get_encoding
+        
         get_encoding()
 else:
     from vllm.utils import FlexibleArgumentParser, get_tcp_uri


### PR DESCRIPTION
as title