### PR TITLE
fix(vllm): Python 3.10+ event loop compatibility for sync mode

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -29,9 +29,6 @@ import asyncio
 import getpass
 import logging
 import os
-
-os.environ["VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE"] = "536870912"
-os.environ["VLLM_ALLREDUCE_USE_SYMM_MEM"] = "0"
 from dataclasses import asdict
 from types import MethodType
 from typing import Any, Generator

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -25,10 +25,13 @@ When working with Megatron:
 - Do inference in tp. pp is treated as additional dp
 - After inference, all the parameters that doesn't belong to this pp rank is freed.
 """
-
+import asyncio
 import getpass
 import logging
 import os
+
+os.environ["VLLM_FLASHINFER_WORKSPACE_BUFFER_SIZE"] = "536870912"
+os.environ["VLLM_ALLREDUCE_USE_SYMM_MEM"] = "0"
 from dataclasses import asdict
 from types import MethodType
 from typing import Any, Generator
@@ -160,7 +163,11 @@ class vLLMAsyncRollout(BaseRollout):
                     address = f"tcp://{ip}:{port}"
             self.socket.bind(address)
 
-        loop = get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
         self.zmq_loop_task = loop.create_task(self._loop_forever())
 
         return address


### PR DESCRIPTION
### What does this PR do?

This PR fixes event loop initialization for Python 3.10+ compatibility when using sync rollout mode (required for PRIME training).

**Problem**: vLLM rollout worker fails on Python 3.10+ with sync mode:
```
RuntimeError: no running event loop
```

**Root Cause**: Current code uses `get_event_loop()` which internally calls deprecated `asyncio.get_event_loop()`. In sync mode (no running event loop), this fails on Python 3.10+.

**Solution**: Replace with `asyncio.get_running_loop()` and fallback:
```python
# Before
loop = get_event_loop()

# After
try:
    loop = asyncio.get_running_loop()
except RuntimeError:
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
```

### Checklist Before Starting

- [x] Search for similar PRs: No existing PR addresses this issue
- [x] Format the PR title as `[modules] {type}: {description}`
  - Module: `vllm`
  - Type: `fix`

### Test

- **Python**: 3.10, 3.11, 3.12
- **Hardware**: NVIDIA B200 GPUs (2 nodes, 8 GPUs each)
- **Model**: Qwen 2.5 32B
- **Sync mode**:  Works (PRIME training)
- **Async mode**:  Works (standard rollout)

Tested and validated by Lynx team.

### API and Usage Example

No API changes. This is a bug fix for Python 3.10+ compatibility.

### Related

- Works with PRIME recipe changes: https://github.com/verl-project/verl-recipe/pull/16