### PR TITLE
[single_controller] fix: pass max_colocate_count and detached params when merging RayResourcePool

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -246,7 +246,9 @@ def merge_resource_pool(rp1: RayResourcePool, rp2: RayResourcePool) -> RayResour
 
     new_store = rp1.store + rp2.store
 
-    merged = type(rp1)(new_store, rp1.use_gpu, f"{rp1.name_prefix}_{rp2.name_prefix}")
+    merged = type(rp1)(
+        new_store, rp1.use_gpu, f"{rp1.name_prefix}_{rp2.name_prefix}", rp1.max_colocate_count, rp1.detached
+    )
     merged.pgs = rp1.get_placement_groups(device_name=get_device_name()) + rp2.get_placement_groups(
         device_name=get_device_name()
     )


### PR DESCRIPTION
### What does this PR do?

Fix the parameter missing issue in the `merge_resource_pool` function, which failed to pass max_colocate_count and detached arguments when instantiating the merged RayResourcePool object. If the max_colocate_count parameter is not passed, the default value of 10 will be used.
