### PR TITLE
[Fix][DAPO] Fix strict_box_verify not being forwarded to DAPO compute_score.

### DIFF
--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -30,10 +30,10 @@ class DAPORewardManager(RewardManagerBase):
         self.is_async_reward_score = inspect.iscoroutinefunction(self.compute_score)
 
         # DAPO Reward Config
-        overlong_buffer_cfg = config.reward_model.get("reward_kwargs", {}).get("overlong_buffer_cfg", None)
-        self.overlong_buffer_cfg = overlong_buffer_cfg
-        self.max_resp_len = config.reward_model.get("reward_kwargs", {}).get("max_resp_len", None)
-        self.strict_box_verify = config.reward_model.get("reward_kwargs", {}).get("strict_box_verify", False)
+        reward_kwargs = config.reward_model.get("reward_kwargs", {})
+        self.overlong_buffer_cfg = reward_kwargs.get("overlong_buffer_cfg")
+        self.max_resp_len = reward_kwargs.get("max_resp_len")
+        self.strict_box_verify = reward_kwargs.get("strict_box_verify", False)
         self.reward_router_address = reward_router_address
         self.reward_model_tokenizer = reward_model_tokenizer
 

--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -39,7 +39,7 @@ class DAPORewardManager(RewardManagerBase):
 
         if self.overlong_buffer_cfg is not None:
             assert self.max_resp_len is not None, (
-                f"max_resp_len must be provided if {overlong_buffer_cfg=}, but got None"
+                f"max_resp_len must be provided if {self.overlong_buffer_cfg}, but got None"
             )
             assert self.max_resp_len >= self.overlong_buffer_cfg.len, (
                 "max_resp_len must be larger than overlong_buffer.len"

--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -33,6 +33,7 @@ class DAPORewardManager(RewardManagerBase):
         overlong_buffer_cfg = config.reward_model.get("reward_kwargs", {}).get("overlong_buffer_cfg", None)
         self.overlong_buffer_cfg = overlong_buffer_cfg
         self.max_resp_len = config.reward_model.get("reward_kwargs", {}).get("max_resp_len", None)
+        self.strict_box_verify = config.reward_model.get("reward_kwargs", {}).get("strict_box_verify", False)
         self.reward_router_address = reward_router_address
         self.reward_model_tokenizer = reward_model_tokenizer
 
@@ -73,6 +74,7 @@ class DAPORewardManager(RewardManagerBase):
                 solution_str=response_str,
                 ground_truth=ground_truth,
                 extra_info=extra_info,
+                strict_box_verify=self.strict_box_verify,
                 **extra_reward_kwargs,
             )
         else:
@@ -83,6 +85,7 @@ class DAPORewardManager(RewardManagerBase):
                     solution_str=response_str,
                     ground_truth=ground_truth,
                     extra_info=extra_info,
+                    strict_box_verify=self.strict_box_verify,
                     **extra_reward_kwargs,
                 ),
             )

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -59,7 +59,12 @@ def default_compute_score(
     elif data_source in ["math_dapo", "math", "math_dapo_reasoning"] or data_source.startswith("aime"):
         from . import math_dapo
 
-        res = math_dapo.compute_score(solution_str, ground_truth)
+        res = math_dapo.compute_score(
+            solution_str,
+            ground_truth,
+            strict_box_verify=kwargs.get("strict_box_verify", False),
+            pause_tokens_index=kwargs.get("pause_tokens_index"),
+        )
     elif data_source in [
         "numina_aops_forum",
         "numina_synthetic_math",

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -63,7 +63,6 @@ def default_compute_score(
             solution_str,
             ground_truth,
             strict_box_verify=kwargs.get("strict_box_verify", False),
-            pause_tokens_index=kwargs.get("pause_tokens_index"),
         )
     elif data_source in [
         "numina_aops_forum",

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -34,6 +34,7 @@ class DAPORewardManager(AbstractRewardManager):
         reward_fn_key="data_source",
         max_resp_len=None,
         overlong_buffer_cfg=None,
+        strict_box_verify: bool = False,
     ) -> None:
         self.tokenizer = tokenizer
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
@@ -41,6 +42,7 @@ class DAPORewardManager(AbstractRewardManager):
         self.reward_fn_key = reward_fn_key
         self.overlong_buffer_cfg = overlong_buffer_cfg
         self.max_resp_len = max_resp_len
+        self.strict_box_verify = strict_box_verify
 
         if self.overlong_buffer_cfg is not None:
             assert self.max_resp_len is not None, (
@@ -99,6 +101,7 @@ class DAPORewardManager(AbstractRewardManager):
                 solution_str=response_str,
                 ground_truth=ground_truth,
                 extra_info=extra_info,
+                strict_box_verify=self.strict_box_verify,
             )
 
             score: float


### PR DESCRIPTION
### What does this PR do?
Fix a bug where strict_box_verify existed and used in DAPO reward but was never propagated to compute_score. The DAPO reward managers now read this flag and pass it through, enabling boxed-answer verification as intended.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
