### PR TITLE
[data] fix: use lazy import for qwen_vl_utils in vision_utils.py

### DIFF
--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -17,10 +17,11 @@ from typing import Optional
 
 import torch
 from PIL import Image
-from qwen_vl_utils import fetch_image, fetch_video
 
 
 def process_image(image: dict | Image.Image, image_patch_size: int = 14) -> Image.Image:
+    from qwen_vl_utils import fetch_image
+
     if isinstance(image, Image.Image):
         return image.convert("RGB")
 
@@ -73,6 +74,7 @@ def process_video(
 
     Add video sample FPS in a future MR
     """
+    from qwen_vl_utils import fetch_video
 
     if not isinstance(video, dict) or "video" not in video:
         raise NotImplementedError(VIDEO_FORMAT_HELP)


### PR DESCRIPTION
### What does this PR do?

Fix `ModuleNotFoundError` when importing `verl.trainer.sft_trainer_ray` without `qwen-vl-utils` installed.

**Problem**: Importing `verl.trainer.sft_trainer_ray` fails with `ModuleNotFoundError: No module named 'qwen_vl_utils'` even when not using vision features, because `vision_utils.py` unconditionally imports `qwen_vl_utils` at module level.

**Solution**: Move `qwen_vl_utils` imports from module level to function level (lazy import), following the same pattern already used in `verl/utils/dataset/rl_dataset.py:393`.

Fixes #4958

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+qwen_vl_utils
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
# Before fix (fails)
pip install verl==0.7.0
python -c "import verl.trainer.sft_trainer_ray"
# ModuleNotFoundError: No module named 'qwen_vl_utils'

# After fix (works)
python -c "import verl.trainer.sft_trainer_ray"
# Success - no error
```

### API and Usage Example

No API changes. This is a transparent fix - existing code using vision features will continue to work (with `qwen-vl-utils` installed), while code not using vision features will no longer require the dependency.

### Design & Code Changes

**File changed**: `verl/utils/dataset/vision_utils.py`

```diff
- from qwen_vl_utils import fetch_image, fetch_video

  def process_image(image: dict | Image.Image, image_patch_size: int = 14) -> Image.Image:
+     from qwen_vl_utils import fetch_image
      ...

  def process_video(...) -> torch.Tensor:
+     from qwen_vl_utils import fetch_video
      ...
```

This follows the existing pattern in `verl/utils/dataset/rl_dataset.py:393`:
```python
def _extract_vision_info(...):
    from qwen_vl_utils import process_vision_info  # existing lazy import
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)
- [ ] Apply pre-commit checks
- [ ] Add / Update the documentation (N/A - no user-facing doc changes)
- [ ] Add unit or end-to-end test(s) (N/A - this is a fix for import behavior, tested manually)