### PR TITLE
Bug Report: filter_overlong_prompts Fails for Multimodal Data

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -188,9 +188,11 @@ class RLHFDataset(Dataset):
             video_key = self.video_key
 
             if processor is not None:
-                from verl.utils.dataset.vision_utils import process_image, process_video
+                # Use the same vision processing function as Agent Loop for consistency
+                from qwen_vl_utils import process_vision_info
 
-                def doc2len(doc) -> int:
+
+                def doc2len(doc) -> int:                
                     try:
                         messages = self._build_messages(doc)
                         # pass tool schemas if available so the processor can format prompts
@@ -198,38 +200,38 @@ class RLHFDataset(Dataset):
                         if self.tool_schemas is not None:
                             apply_kwargs["tools"] = self.tool_schemas
 
+                        # Use the same vision processing as Agent Loop (process_vision_info)
+                        # Use processor's actual patch_size instead of config default
+                        actual_patch_size = self.processor.image_processor.patch_size if hasattr(self.processor, 'image_processor') else self.image_patch_size
+                        images, videos = process_vision_info(
+                            messages, image_patch_size=actual_patch_size, return_video_metadata=True
+                        )
+
+                        # Extract video metadata (same as Agent Loop)
+                        if videos:
+                            videos, video_metadatas = zip(*videos, strict=True)
+                            videos = list(videos)
+                            video_metadatas = list(video_metadatas)
+                        else:
+                            video_metadatas = None
+
                         raw_prompt = self.processor.apply_chat_template(
                             messages, add_generation_prompt=True, tokenize=False, **apply_kwargs
                         )
-                        if image_key in doc and doc[image_key]:
-                            images = [
-                                process_image(image, image_patch_size=self.image_patch_size) for image in doc[image_key]
-                            ]
-                        else:
-                            images = None
 
-                        if video_key in doc and doc[video_key]:
-                            videos, video_metadata = zip(
-                                *[
-                                    process_video(
-                                        video, image_patch_size=self.image_patch_size, return_video_metadata=True
-                                    )
-                                    for video in doc[video_key]
-                                ],
-                                strict=True,
-                            )
-                            videos = list(videos)
-                            video_metadata = list(video_metadata)
-                            videos_kwargs = {"video_metadata": video_metadata, "do_sample_frames": False}
-                        else:
-                            videos = None
-                            videos_kwargs = {}
-
-                        return len(
-                            processor(text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs)[
-                                "input_ids"
-                            ][0]
+                        # Match Agent Loop's processor call exactly
+                        prompt_len = len(
+                            processor(
+                                text=[raw_prompt],
+                                images=images,
+                                videos=videos,
+                                video_metadatas=video_metadatas, 
+                                return_tensors="pt",               
+                                do_sample_frames=False,            
+                            )["input_ids"][0]
                         )
+
+                        return prompt_len
                     except Exception:
                         print("Error processing one of the samples, skipping...")
                         traceback.print_exc()
@@ -257,7 +259,6 @@ class RLHFDataset(Dataset):
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
             )
 
-            print(f"filter dataset len: {len(dataframe)}")
         return dataframe
 
     def resume_dataset_state(self):


### PR DESCRIPTION
### What does this PR do?

# Bug Report: `filter_overlong_prompts` Fails for Multimodal Data

## Problem Summary

When using `filter_overlong_prompts=True` with multimodal datasets (containing images/videos), the filtering mechanism **completely fails** to correctly calculate prompt lengths, causing:

1. **Training crashes** with `RuntimeError: Sizes of tensors must match except in dimension 0. Expected size 2048 but got size 2597`
2. **Validation failures** due to inconsistent sequence lengths
3. **Silent data corruption** where overlong multimodal samples incorrectly pass filtering

## 🔍 Root Cause Analysis

### Two-Level Bug in `verl/utils/dataset/rl_dataset.py`

#### **Level 1: Logic Error with `pop()` Side Effect**

In `_build_messages()`, the code uses `example.pop()` to extract images/videos:

```python
def _build_messages(self, example: dict):
    messages: list = example[self.prompt_key]
    # ❌ pop() deletes the keys from the example dict
    images = example.pop(self.image_key, None) or []
    videos = example.pop(self.video_key, None) or []
    # ... process and embed images/videos into messages ...
    return messages
```

#### **Level 2: Broken Conditional Check**

In `maybe_filter_out_long_prompts()`, the code checks for images **after** they've been deleted:

```python
def doc2len(doc) -> int:
    # Step 1: Call _build_messages, which pops image_key/video_key
    messages = self._build_messages(doc)
    
    raw_prompt = self.processor.apply_chat_template(messages, ...)
    
    # Step 2: Check if image_key exists in doc
    if image_key in doc and doc[image_key]:  # ❌ Always False!
        images = [process_image(...) for image in doc[image_key]]
    else:
        images = None  # ← Multimodal samples fall here!
    
    # Step 3: Calculate length with images=None
    return len(processor(text=[raw_prompt], images=None, ...)["input_ids"][0])
    #                                        ^^^^^^^^^^^
    #                     Image tokens completely missing!
```

### **Result: Severe Length Underestimation**

| Stage | Calculation | Result |
|-------|-------------|--------|
| **Filtering** | Text only (images=None) | ~2040 tokens ✅ Passes filter |
| **Runtime (Agent Loop)** | Text + Images (correct) | ~2597 tokens ❌ Exceeds limit |

## 📊 Impact Assessment

### **Affected Scenarios**
- ✅ All multimodal RLHF training (Qwen-VL, LLaVA, etc.)
- ✅ Any dataset with `filter_overlong_prompts=True`
- ✅ Both training and validation sets

### **Severity**
- 🔴 **Critical**: Training/validation crashes
- 🔴 **Data Integrity**: Overlong samples contaminate dataset
- 🔴 **Silent Failure**: No warning that filtering is broken

### **Example Numerical Impact**

For a multimodal sample with:
- Text: 100 tokens
- Single high-res image: 1497 tokens

```python
# Original buggy code:
filtered_length = 100 tokens  # ✅ Passes filter (< 2048)
actual_length = 1597 tokens   # ⚠️ Crashes at runtime
```

## 🔧 Fix Implementation

### **Solution: Unified Vision Processing**

Replace `process_image()` from `verl.utils.dataset.vision_utils` with `process_vision_info()` from `qwen_vl_utils` to match Agent Loop's behavior.

### **Key Changes in `maybe_filter_out_long_prompts()`**

```python
def doc2len(doc) -> int:
    try:
        messages = self._build_messages(doc)
        
        # Use the same vision processing as Agent Loop
        from qwen_vl_utils import process_vision_info
        
        #  Use processor's actual patch_size
        actual_patch_size = (
            self.processor.image_processor.patch_size 
            if hasattr(self.processor, 'image_processor') 
            else self.image_patch_size
        )
        
        # Extract images/videos from messages (not from doc!)
        images, videos = process_vision_info(
            messages,  # ← Images are embedded here by _build_messages
            image_patch_size=actual_patch_size,
            return_video_metadata=True
        )
        
        # Split videos and metadatas (same as Agent Loop)
        if videos:
            videos, video_metadatas = zip(*videos, strict=True)
            videos, video_metadatas = list(videos), list(video_metadatas)
        else:
            video_metadatas = None
        
        raw_prompt = self.processor.apply_chat_template(
            messages, add_generation_prompt=True, tokenize=False, **apply_kwargs
        )
        
        # Calculate length with correct images/videos
        return len(
            processor(
                text=[raw_prompt],
                images=images,
                videos=videos,
                video_metadatas=video_metadatas,
                return_tensors="pt",
                do_sample_frames=False,
            )["input_ids"][0]
        )
```

### **Why This Fix Works**

1. **`process_vision_info(messages)`** extracts images/videos from `messages.content`, not from `doc[image_key]`
2. **Bypasses the `pop()` issue** because images are already embedded in messages
3. **Matches Agent Loop** by using identical vision processing logic
4. **Ensures consistent parameters**: `image_patch_size`, `video_metadatas`, `return_tensors`, `do_sample_frames`

## 🧪 Verification

### **Test Setup**
- Dataset: MathVision (multimodal)
- Config: `filter_overlong_prompts=True`, `max_prompt_length=2048`
- Model: Qwen3-VL-4B-Instruct

### **Results**

| Version | Filtering Behavior | Validation Result |
|---------|-------------------|-------------------|
| **Old (Buggy)** | 0 samples filtered | ❌ `RuntimeError: Expected size 2048 but got size 2597` |
| **New (Fixed)** | Correctly filters overlong samples | ✅ No runtime errors |

### **Log Evidence**

**Before Fix:**
```
[OLD VERSION] 📊 Filtering Results:
Original: 1000 samples
Filtered: 1000 samples
Removed:  0 samples (0.00%)
⚠️ Prompt length 2597 exceeds max_prompt_len 2048  # Runtime error
```

**After Fix:**
```
[NEW VERSION] 📊 Filtering Results:
Original: 1000 samples
Filtered: 985 samples
Removed:  15 samples (1.50%)
✅ All prompts within limit, no runtime errors
```

## Benefits of This Fix

1. ✅ **Correctness**: `filter_overlong_prompts` works as intended
2. ✅ **Stability**: Eliminates validation/training crashes
3. ✅ **Consistency**: Unifies vision processing across filtering and runtime
4. ✅ **Maintainability**: Reduces code duplication

## Additional Notes

- **Backward Compatibility**: This fix may filter more samples than before, but this is the **correct** behavior
- **Performance**: No significant performance impact, as filtering is done once during dataset initialization
- **Related Issue**: This also aligns `image_patch_size` calculation with the processor's actual configuration

---

**Related Files:**
- `verl/utils/dataset/rl_dataset.py` (fixed)
- `verl/experimental/agent_loop/agent_loop.py` (reference implementation)