### PR TITLE
[reward] fix: conditionally include reward_extra_keys in meta_info based on rm_scores presence

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -789,10 +789,18 @@ class AgentLoopWorker:
             extra_fields[key] = temp_arr
 
         non_tensor_batch.update(extra_fields)
+
+        # Only include reward_extra_keys in meta_info if rm_scores is in batch
+        # This avoids conflicts when reward_tensor is merged later in ray_trainer.py
+        if "rm_scores" in batch.keys():
+            meta_info = {"metrics": metrics, "reward_extra_keys": reward_extra_keys}
+        else:
+            meta_info = {"metrics": metrics}
+
         return DataProto(
             batch=batch,
             non_tensor_batch=non_tensor_batch,
-            meta_info={"metrics": metrics, "reward_extra_keys": reward_extra_keys},
+            meta_info=meta_info,
         )
 
     def create_transferqueue_client(


### PR DESCRIPTION

### What does this PR do?

#### Problem

When `AgentLoopWorker._postprocess()` always includes `reward_extra_keys=[]` in `meta_info` even when `rm_scores` is not in the batch, it causes an assertion error when merging `reward_tensor` later in `ray_trainer.py`.

The error occurs under the following conditions:
- `reward_model.model.path=xxx`
- `reward_model.enable=True`
- `reward_model.use_reward_loop=True`


Error scenario:
1. Agent loop doesn't compute reward (no `rm_scores` in batch)
2. `ray_trainer.py` calls `reward_loop_manager.compute_rm_score(batch)` 
3. The returned `reward_tensor` has `reward_extra_keys` in its `meta_info`
4. `batch.union(reward_tensor)` fails with: `AssertionError: reward_extra_keys in meta_dict1 and meta_dict2 are not the same object`

<img width="1665" height="548" alt="WeChatWorkScreenshot_45c990b8-c4b3-49f4-88fa-1f7a1512c52c" src="https://github.com/user-attachments/assets/532f96d1-6b19-473b-8dee-77f06a095f86" />

#### Solution

Only include `reward_extra_keys` in `meta_info` when `rm_scores` is actually present in the batch. 

####  Changes

- Modified `AgentLoopWorker._postprocess()` to conditionally set `reward_extra_keys` in `meta_info`
- Added check: `if "rm_scores" in batch.keys()` before including `reward_extra_keys`

#### Testing

This fix prevents the assertion error when reward computation is deferred to `reward_loop_manager` in colocate mode.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
