### PR TITLE
[rollout, vllm, sglang] fix: forward max_tokens/max_new_tokens from rollout config to vllm/sglang backends

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -433,6 +433,12 @@ class AgentLoopWorker:
             logprobs=config.calculate_log_probs,
         )
 
+        # configure max generation tokens for vllm/sglang
+        for param_name in ["max_tokens", "max_new_tokens"]:
+            param_value = getattr(config, param_name, None)
+            if param_value is not None:
+                sampling_params[param_name] = param_value
+
         # override sampling params for validation
         if batch.meta_info.get("validate", False):
             sampling_params["top_p"] = config.val_kwargs.top_p

--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -101,13 +101,21 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
         sampling_params = dict(
             temperature=config.temperature,
             top_p=config.top_p,
+            top_k=config.top_k,
             repetition_penalty=1.0,
             logprobs=config.calculate_log_probs,
         )
 
+        # configure max generation tokens for vllm/sglang
+        for param_name in ["max_tokens", "max_new_tokens"]:
+            param_value = getattr(config, param_name, None)
+            if param_value is not None:
+                sampling_params[param_name] = param_value
+
         # override sampling params for validation
         if batch.meta_info.get("validate", False):
             sampling_params["top_p"] = config.val_kwargs.top_p
+            sampling_params["top_k"] = config.val_kwargs.top_k
             sampling_params["temperature"] = config.val_kwargs.temperature
 
         if "agent_name" not in batch.non_tensor_batch:

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -204,6 +204,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    max_tokens: null
+    max_new_tokens: null
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -195,6 +195,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    max_tokens: null
+    max_new_tokens: null
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -16,6 +16,12 @@ top_k: -1
 # Top-p sampling parameter. Default 1.0.
 top_p: 1
 
+# max number of tokens to generate for vllm.
+max_tokens: null
+
+# max number of tokens to generate for sglang.
+max_new_tokens: null
+
 # typically the same as data max prompt length
 # same as data.max_prompt_length if it exists
 prompt_length: ${oc.select:data.max_prompt_length,512}

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -130,6 +130,8 @@ class RolloutConfig(BaseConfig):
     do_sample: bool = True
     n: int = 1
     repetition_penalty: float = 1.0
+    max_tokens: Optional[int] = None
+    max_new_tokens: Optional[int] = None
 
     # Early termination threshold for multi-turn rollout in sglang.
     # Abort remaining requests when (1 - over_sample_rate) * total_requests are completed.

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -327,6 +327,7 @@ class SGLangHttpServer:
                 f"({self.config.max_model_len})."
             )
 
+        # Determine max_new_tokens from sampling_params or use configured response_length as default
         if "max_new_tokens" in sampling_params:
             max_new_tokens = sampling_params.pop("max_new_tokens")
         elif "max_tokens" in sampling_params:


### PR DESCRIPTION
### What does this PR do?

In the current codebase, when max_tokens is not specified in sampling_params, its default value is dynamically calculated based on prompt_ids . This approach can lead to the generation of text exceeding the intended length, resulting in unnecessary computation, resource waste, and reduced inference performance. By configuring max_tokens in the configuration file, a fixed upper bound can be set to prevent uncontrolled text generation, ensuring predictable resource utilization and inference efficiency.

>verl/workers/rollout/vllm_rollout/vllm_async_server.py +505
```python
# Determine max_tokens from sampling_params or use configured response_length as default
if "max_tokens" in sampling_params:
    max_tokens = sampling_params.pop("max_tokens")
elif "max_new_tokens" in sampling_params:
    # support sglang-style 'max_new_tokens' param
    max_tokens = sampling_params.pop("max_new_tokens")
else:
    # Default to a calculation that considers configured lengths
    max_tokens = self.config.response_length + self.config.prompt_length - len(prompt_ids)
```

However, the max_tokens/max_new_tokens parameter is not passed into sampling_params in agent_loop.py. This leads to max_tokens in vllm_async_server.py only taking the default dynamically calculated value, which does not meet expectations in certain scenarios.
>verl/experimental/agent_loop/agent_loop.py +428
```python
config = self.config.actor_rollout_ref.rollout
sampling_params = dict(
    temperature=config.temperature,
    top_p=config.top_p,
    top_k=config.top_k,
    repetition_penalty=1.0,
    logprobs=config.calculate_log_probs,
)
```

Therefore, we have added the two parameters max_tokens/max_new_tokens to the rollout configuration, setting their default value as null. When these parameters are configured in the runtime script file, the corresponding values in vllm_async_server.py/sglang_async_server.py will be updated accordingly. If the parameters are not configured in the runtime script file, the original default logic will be followed, thereby avoiding any impact on existing functionality.
>verl/experimental/agent_loop/agent_loop.py
```python
for param_name in ["max_tokens", "max_new_tokens"]:
    param_value = getattr(config, param_name, None)
    if param_value is not None:
        sampling_params[param_name] = param_value
)
```

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: [[feat: ensure max_new_tokens is set correctly in sampling_params](https://github.com/volcengine/verl/pull/4634)

### API and Usage Example

```shell
 actor_rollout_ref.rollout.max_tokens=${max_response_length}
```