### PR TITLE
[megatron, training_utils] fix: router replay R3 align router replay data with global layer indices

### DIFF
--- a/examples/router_replay/README.md
+++ b/examples/router_replay/README.md
@@ -68,4 +68,4 @@ actor_rollout_ref.actor.router_replay.mode="R3"
 actor_rollout_ref.rollout.enable_rollout_routing_replay=True
 ```
 
-R3 mode requires the rollout backend to support returning router selection results. Currently, this functionality is being tested based on the vllm implementation at https://github.com/vllm-project/vllm/pull/28284 and SGLang implementation at https://github.com/sgl-project/sglang/commit/bed301a5acaa9577c9aa706468bdf242f6a43051.
+R3 mode requires the rollout backend to support returning router selection results. Currently, this functionality is being tested based on the vllm implementation at https://github.com/vllm-project/vllm/pull/28284 as well as bug fix at https://github.com/vllm-project/vllm/pull/33013 and SGLang implementation at https://github.com/sgl-project/sglang/commit/bed301a5acaa9577c9aa706468bdf242f6a43051.

--- a/examples/router_replay/run_qwen30_a3b_megatron_vllm.sh
+++ b/examples/router_replay/run_qwen30_a3b_megatron_vllm.sh
@@ -6,7 +6,9 @@ NODES=1
 # R2: enable routing replay
 # R3: enable rollout routing replay
 # If enabling R3, please set actor_rollout_ref.rollout.enable_rollout_routing_replay=True
-# R3 example is based on vllm related pr https://github.com/vllm-project/vllm/pull/5322
+# R3 example is based on vllm related pr:
+#   - https://github.com/vllm-project/vllm/pull/28284
+#   - https://github.com/vllm-project/vllm/pull/33013
 
 ROUTING_REPLAY_MODE="R2" 
 

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -242,11 +242,24 @@ def set_router_replay_data(layers_topk_idx, attention_mask, tf_config, vp_rank=N
         layers_topk_idx_reshape = layers_topk_idx_rmpad_split.permute(0, 2, 1, 3).squeeze(
             dim=0
         )  # layer_num, dynamic_bs_all, topk
+        num_layers_in_data = layers_topk_idx_reshape.shape[0]
+        use_global_layer_index = getattr(tf_config, "num_layers", None) == num_layers_in_data
         local_rank_info = get_current_rank_layer_info(tf_config, vp_rank)
         offset, _ = local_rank_info["start"], local_rank_info["end"]
         router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
         for i, router in enumerate(router_instances_list):
-            router.set_target_indices(layers_topk_idx_reshape[i + offset].to(torch.int64))
+            layer_idx = None
+            if use_global_layer_index:
+                layer_number = getattr(router, "layer_number", None)
+                if layer_number is not None:
+                    layer_idx = layer_number - 1
+            if layer_idx is None:
+                layer_idx = i + offset
+            if layer_idx < 0 or layer_idx >= num_layers_in_data:
+                raise ValueError(
+                    f"router replay layer index {layer_idx} out of range for data with {num_layers_in_data} layers"
+                )
+            router.set_target_indices(layers_topk_idx_reshape[layer_idx].to(torch.int64))
 
 
 def reorder_and_merge_vpp_layers(


### PR DESCRIPTION
### What does this PR do?

DeepSeek-V3-style MoE employs a hybrid architecture with the first three layers as dense FFN blocks before switching to MoE layers, which means not every layer has a router.

This PR fixes DeepSeek V3 architecture for router replay R3, as vLLM reports routed_experts across all transformer layers (including dense). Megatron only has routers for MoE layers. Mapping with i + offset silently shifts every MoE layer after a dense layer. So, when routed‑experts tensors include dense layers (full `num_layers`), we should map replay data by each router’s global layer_number; Otherwise, we should fall back to local offset indexing and validate bounds to catch mismatches. We also patch TopKRouter.set_layer_number to store the global layer number in each RouterReplay instance so global alignment is reliable with VPP/PP.

Dependent on https://github.com/vllm-project/vllm/pull/33013

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

Without this fix:
<img width="3646" height="1132" alt="image" src="https://github.com/user-attachments/assets/d2400f03-4e25-4f52-8717-a23b58cc23ce" />

With this fix, it looks good now:
<img width="3668" height="1210" alt="image" src="https://github.com/user-attachments/assets/7a9b4818-861f-4a52-8c13-90e6ed6f9530" />

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>
