### PR TITLE
[reward] fix:  fix reward computation in _validate when use_reward_loop=True and reward_model.enable=True

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -684,6 +684,15 @@ class RayPPOTrainer:
             sample_inputs.extend(input_texts)
             sample_uids.extend(test_batch.non_tensor_batch["uid"])
 
+            # compute reward model score if needed (similar to training loop)
+            if self.use_rm and "rm_scores" not in test_batch.batch.keys():
+                if not self.use_reward_loop:
+                    reward_tensor = self.rm_wg.compute_rm_score(test_batch)
+                else:
+                    assert self.reward_loop_manager is not None, "RewardLoopManager is None"
+                    reward_tensor = self.reward_loop_manager.compute_rm_score(test_batch)
+                test_batch = test_batch.union(reward_tensor)
+
             # evaluate using reward_function
             reward_tensor, reward_extra_info = self._compute_or_extract_reward(
                 test_batch, reward_fn=self.val_reward_fn, reward_for_val=True


### PR DESCRIPTION
### What does this PR do?

###  Problem
When `reward_model.enable=True` and `reward_model.use_reward_loop=True`, the `_validate` method was not computing reward model scores using `self.reward_loop_manager` before calling `_compute_or_extract_reward`, which caused errors during validation.

<img width="1427" height="554" alt="WeChatWorkScreenshot_b66d2afc-9105-4243-968e-d133f3dfaa81" src="https://github.com/user-attachments/assets/a5c5dbb4-73f1-47eb-9c46-f835e2aa9225" />


###  Solution
Added reward model score computation logic in `_validate` method to match the training loop behavior:
- Check if `use_rm=True` and `rm_scores` is not already in the batch
- If `use_reward_loop=True`, use `self.reward_loop_manager.compute_rm_score()` to compute scores
- Otherwise, use `self.rm_wg.compute_rm_score()` for legacy reward model
- Merge the computed scores into the batch before calling `_compute_or_extract_reward`

This ensures validation uses the same reward computation path as training when reward loop is enabled.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
