### PR TITLE
refactor(actor_rollout): remove sync mode condition for issue4604

### DIFF
--- a/tests/experimental/agent_loop/agent_utils.py
+++ b/tests/experimental/agent_loop/agent_utils.py
@@ -75,8 +75,6 @@ def init_agent_loop_manager(config: DictConfig) -> AgentLoopManager | RayWorkerG
     actor_rollout_wg = all_wg["actor_rollout"]
     actor_rollout_wg.init_model()
 
-    if config.actor_rollout_ref.rollout.mode == "sync":
-        raise ValueError("Agent loop tests require async rollout mode. Please set rollout.mode=async.")
 
     if config.reward_model.enable_resource_pool and config.reward_model.enable:
         rm_resource_pool = resource_pool_manager.get_resource_pool(Role.RewardModel)


### PR DESCRIPTION
### What does this PR do?
This PR removes the deprecated sync mode validation check in the actor rollout configuration. The actor_rollout_ref.rollout.mode no longer supports "sync" mode, making the validation logic unnecessary. This cleanup improves code maintainability by eliminating obsolete code paths.

Related to issue #4604.

### Checklist Before Starting
Related to issue #4604.

{modules}: rollout

{type}: refactor

No API breaking changes

### Test
This change removes a validation check that prevented the use of sync mode. Since sync mode is no longer supported and the code is being removed (not modified), no specific testing is required beyond verifying that existing async mode functionality continues to work correctly.

### Validation performed:

Confirmed that the codebase no longer contains any sync mode implementations

Verified that existing tests for async rollout mode pass

Ensured no other code references the removed sync mode check

API and Usage Example
This PR does not change any public APIs. It only removes an internal validation check.

python
# Before this change (would raise ValueError if sync mode was set):
config.actor_rollout_ref.rollout.mode = "sync"  # This would raise ValueError

# After this change:
# The sync mode check is removed, but sync mode is not actually implemented.
# Users should continue using "async" mode as before.
config.actor_rollout_ref.rollout.mode = "async"  # This is the only supported mode
Design & Code Changes
High-level design:
The sync mode was deprecated and removed from the codebase, but the validation logic preventing its use was still present. This PR removes that validation check to clean up the code.

Specific changes:

Removed the if-condition that checked for config.actor_rollout_ref.rollout.mode == "sync"

Removed the ValueError that was raised when sync mode was detected

No other changes were made since sync mode is already not implemented elsewhere

Code diff summary:

diff
-    if config.actor_rollout_ref.rollout.mode == "sync":
-        raise ValueError("Agent loop tests require async rollout mode. Please set rollout.mode=async.")
Checklist Before Submitting
[!IMPORTANT]
Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).

Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always

Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).

No documentation changes needed as sync mode was already documented as unsupported

Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This change removes code rather than adding new functionality. Existing tests already cover async mode functionality.

Once your PR is ready for CI, send a message in [the ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).

If your PR is related to the recipe submodule, please also update the reference to the submodule commit via git submodule update --remote or cd recipe && git pull origin main.

Not applicable (this PR is not related to the recipe submodule)