### PR TITLE
[ray, single_controller, trainer, utils] feat: Add distributed backend selection support (Ray/openYuanrong)

### DIFF
--- a/tests/single_controller/test_auto_padding_on_cpu.py
+++ b/tests/single_controller/test_auto_padding_on_cpu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import ray
 import torch
 
 from verl import DataProto
@@ -21,6 +20,8 @@ from verl.protocol import DataProtoConfig
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+
+import ray  # noqa: E402 isort: skip
 
 # or set env var VERL_AUTO_PADDING = "1" / "true"
 DataProtoConfig.auto_padding = True

--- a/tests/single_controller/test_colocated_workers.py
+++ b/tests/single_controller/test_colocated_workers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ray
 
 from verl import DataProto
 from verl.single_controller.base import Worker
@@ -24,6 +23,8 @@ from verl.single_controller.ray.base import (
     create_colocated_worker_cls,
 )
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_colocated_workers_fused.py
+++ b/tests/single_controller/test_colocated_workers_fused.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ray
 
 from verl import DataProto
 from verl.single_controller.base import Worker
@@ -24,6 +23,8 @@ from verl.single_controller.ray.base import (
     create_colocated_worker_cls_fused,
 )
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_data_transfer.py
+++ b/tests/single_controller/test_data_transfer.py
@@ -15,7 +15,6 @@
 In this test, we instantiate a data parallel worker with 8 GPUs
 """
 
-import ray
 import tensordict
 import torch
 from codetiming import Timer
@@ -28,6 +27,8 @@ from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils.device import get_device_name
 from verl.utils.ray_utils import parallel_put
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_decorator_on_cpu.py
+++ b/tests/single_controller/test_decorator_on_cpu.py
@@ -16,7 +16,6 @@ import asyncio
 import time
 
 import pytest
-import ray
 import torch
 from tensordict import TensorDict
 
@@ -25,6 +24,8 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils import tensordict_utils as tu
+
+import ray  # noqa: E402 isort: skip
 
 
 # Pytest fixture for Ray setup/teardown

--- a/tests/single_controller/test_driverfunc_to_worker.py
+++ b/tests/single_controller/test_driverfunc_to_worker.py
@@ -14,7 +14,6 @@
 
 import os
 
-import ray
 import torch
 from tensordict import TensorDict
 
@@ -23,6 +22,8 @@ from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray import RayWorkerGroup
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 os.environ["RAY_DEDUP_LOGS"] = "0"
 os.environ["NCCL_DEBUG"] = "WARN"

--- a/tests/single_controller/test_fused_workers_on_cpu.py
+++ b/tests/single_controller/test_fused_workers_on_cpu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ray
 
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
@@ -22,6 +21,8 @@ from verl.single_controller.ray.base import (
     RayWorkerGroup,
     create_colocated_worker_raw_cls,
 )
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_high_level_scheduling_api.py
+++ b/tests/single_controller/test_high_level_scheduling_api.py
@@ -14,11 +14,11 @@
 import gc
 import time
 
-import ray
-
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, merge_resource_pool
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_nested_worker.py
+++ b/tests/single_controller/test_nested_worker.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 
-import ray
-
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 class TestActor(Worker):

--- a/tests/single_controller/test_ray_collectives.py
+++ b/tests/single_controller/test_ray_collectives.py
@@ -20,13 +20,14 @@ Rollout rank 2, 3 - Rollout rank 1
 Then, we initiate 4 p2p comms from actor to rollout
 """
 
-import ray
 import ray.util.collective as collective
 import torch
 
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_ray_local_envs_on_cpu.py
+++ b/tests/single_controller/test_ray_local_envs_on_cpu.py
@@ -17,10 +17,10 @@ e2e test verl.single_controller.ray
 
 import os
 
-import ray
-
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_ray_utils_on_cpu.py
+++ b/tests/single_controller/test_ray_utils_on_cpu.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import pytest
-import ray
 
 from verl.utils.ray_utils import parallel_put
+
+import ray  # noqa: E402 isort: skip
 
 
 # Initialize Ray for testing if not already done globally

--- a/tests/single_controller/test_rvdz.py
+++ b/tests/single_controller/test_rvdz.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ray
+import verl.utils.distributed_backend  # noqa: F401
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_split_resource_pool.py
+++ b/tests/single_controller/test_split_resource_pool.py
@@ -14,7 +14,6 @@
 
 import os
 
-import ray
 import torch
 
 from verl import DataProto
@@ -27,6 +26,8 @@ from verl.single_controller.ray.base import (
     split_resource_pool,
 )
 from verl.utils.device import get_device_name, get_nccl_backend
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/tests/single_controller/test_worker_group_basics.py
+++ b/tests/single_controller/test_worker_group_basics.py
@@ -15,13 +15,14 @@
 e2e test verl.single_controller.ray
 """
 
-import ray
 import torch
 
 from verl.single_controller.base.decorator import Dispatch, Execute, collect_all_to_all, register
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 def two_to_all_dispatch_fn(worker_group, *args, **kwargs):

--- a/tests/single_controller/test_worker_group_torch.py
+++ b/tests/single_controller/test_worker_group_torch.py
@@ -17,13 +17,14 @@ import os
 os.environ["RAY_DEDUP_LOGS"] = "0"
 os.environ["NCCL_DEBUG"] = "WARN"
 
-import ray
 import torch
 import torch.distributed
 
 from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 from verl.utils.device import get_device_name
+
+import ray  # noqa: E402 isort: skip
 
 
 @ray.remote

--- a/verl/__init__.py
+++ b/verl/__init__.py
@@ -18,6 +18,8 @@ import os
 
 from packaging.version import parse as parse_version
 
+import verl.utils.distributed_backend  # noqa: F401
+
 from .protocol import DataProto
 from .utils.device import is_npu_available
 from .utils.import_utils import import_external_libs

--- a/verl/utils/distributed_backend.py
+++ b/verl/utils/distributed_backend.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Distributed backend selection module.
+
+This module allows users to choose between Ray and YuanRong (ray_adapter) backends
+via the DISTRIBUTED_BACKEND environment variable.
+
+Usage:
+    Set DISTRIBUTED_BACKEND=yr or DISTRIBUTED_BACKEND=yuanrong to use ray_adapter
+    Set DISTRIBUTED_BACKEND=ray or leave unset to use ray (default)
+
+    Import this module at the very beginning of entry points:
+        import verl.utils.distributed_backend  # Must be before any other import ray
+"""
+
+import os
+import sys
+
+_BACKEND = os.getenv("DISTRIBUTED_BACKEND", "ray").lower()
+
+if _BACKEND in ("yr", "yuanrong"):
+    try:
+        import ray_adapter as _ray_module
+    except ImportError:
+        raise ImportError(
+            f"DISTRIBUTED_BACKEND is set to '{_BACKEND}' but ray_adapter is not installed. "
+            "Please install ray_adapter or set DISTRIBUTED_BACKEND=ray to use the default Ray backend."
+        ) from None
+    # Inject the selected module into sys.modules so that all subsequent
+    # 'import ray' statements will use the selected backend
+    sys.modules["ray"] = _ray_module
+else:
+    pass


### PR DESCRIPTION
### What does this PR do?

This PR adds support for selecting between Ray and openYuanrong (ray_adapter) as the distributed backend via the `DISTRIBUTED_BACKEND` environment variable.

### Checklist Before Starting

- [x] Search for similar PRs. Query: `distributed backend selection ray adapter`
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Test commands:
```bash
# Test with default Ray backend
pytest tests/single_controller/test_ray_utils_on_cpu.py -v

# Test with openYuanrong backend
DISTRIBUTED_BACKEND=yr pytest tests/single_controller/test_ray_utils_on_cpu.py -v
```

### API and Usage Example

Set the `DISTRIBUTED_BACKEND` environment variable to choose the backend:
- `DISTRIBUTED_BACKEND=ray` or unset: Use default Ray backend (default)
- `DISTRIBUTED_BACKEND=yr` or `DISTRIBUTED_BACKEND=yuanrong`: Use openYuanrong backend

```bash
# Use default Ray backend
bash examples/grpo_trainer/run_qwen2_5_7b_grpo_npu.sh

# Use openYuanrong backend (both 'yr' and 'yuanrong' are supported)
DISTRIBUTED_BACKEND=yr bash examples/grpo_trainer/run_qwen2_5_7b_grpo_npu.sh
# or
DISTRIBUTED_BACKEND=yuanrong bash examples/grpo_trainer/run_qwen2_5_7b_grpo_npu.sh
```

### Design & Code Changes
Design Overview: To support the YuanRong distributed computing platform alongside Ray, we implemented a non-intrusive backend injection mechanism. By utilizing Python's sys.modules interception, we can dynamically redirect import ray to the YuanRong adapter ( ray_adapter ) at runtime based on an environment variable. This approach allows the existing codebase to remain largely unchanged, as it continues to import and use the ray namespace, while the underlying implementation is transparently switched to YuanRong when configured.

**Specific Changes:**

1. **New file** : verl/utils/distributed_backend.py - Core backend selection module. It checks the DISTRIBUTED_BACKEND environment variable and injects either ray_adapter or the standard ray module into sys.modules['ray'] .
2. **Modified files** :
   - verl/__init__.py : Added import verl.utils.distributed_backend to ensure the backend injection logic is executed immediately upon package initialization.
   - Test files : Updated import order in 17 test files to ensure import ray occurs after verl imports. This guarantees that the injection logic in verl/__init__.py runs before ray is loaded.
 
### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.