### PR TITLE
[docker] opt: use prebuilt vllm wheel instead of compiling from source   

### DIFF
--- a/docker/Dockerfile.stable.vllm
+++ b/docker/Dockerfile.stable.vllm
@@ -33,7 +33,7 @@ RUN sed -i '/nvidia-cudnn-cu12/d' /usr/local/lib/python3.12/dist-packages/torch-
 RUN pip install --no-deps --force-reinstall nvidia-cudnn-cu12==9.16.0.29
 
 # Use prebuilt wheel instead of compiling from source (saves 30-60 minutes)
-RUN pip install vllm==0.12.0 --only-binary=:all:
+RUN pip install vllm==0.12.0
 
 RUN pip install pybind11
 


### PR DESCRIPTION
## Summary                                                                                                                     
  Replace vllm source compilation with prebuilt wheel package to significantly reduce Docker build time.                         
                                                                                                                                 
  ## Changes                                                                                                                     
                                                                                                                                 
  **Before (compiling from source):**                                                                                            
  ```dockerfile                                                                                                                  
  RUN git clone --depth 1 -b v0.12.0 https://github.com/vllm-project/vllm.git && \                                               
      cd vllm && \                                                                                                               
      find requirements -name "*.txt" -print0 | xargs -0 sed -i '/torch/d' && \                                                  
      pip install -r requirements/build.txt && \                                                                                 
      pip install -e . --no-build-isolation --no-deps && \                                                                       
      pip install -r requirements/cuda.txt                                                                                       

```         

After (using prebuilt wheel):  
  ```dockerfile                                                                                                                                                                                                            
  RUN pip install vllm==0.12.0            
```                                                                                      
                                                                                                                                 
  Benefits                                                                                                                       
                                                                                                                                 
  - Build time: Reduced from ~30-60 minutes to ~2-3 minutes (saves ~50 minutes)                                                  
  - Image size: Smaller final image (no source code or build tools needed)                                                       
  - Reliability: Official prebuilt wheels are tested and stable                                                                  
  - Simplicity: Single line command instead of multi-step build process                                                          
                                                                                                                                 
  Verification                                                                                                                   
                                                                                                                                 
  The prebuilt wheel (466.5 MB) contains all compiled CUDA kernels:                                                              
  - vllm/_C.abi3.so (420 MB)                                                                                                     
  - vllm/_moe_C.abi3.so (134 MB)                                                                                                 
  - vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so (374 MB)                                                                            
  - vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so (195 MB)                                                                            
                                                                                                                                 
  Tested on Linux x86_64 with Python 3.12.                                                                                       
                                                                                                                                 
  Testing                                                                                                                        
                                                                                                                                 
  Build and verify:                                                                                                              
  docker build -f docker/Dockerfile.stable.vllm -t verl-vllm:test .                                                              
  docker run --rm --gpus all verl-vllm:test python3 -c "import vllm; print(vllm.__version__)"    