### PR TITLE
[fsdp] test: add backward determinism test

### DIFF
--- a/tests/special_e2e/sft/test_sp_loss_match.py
+++ b/tests/special_e2e/sft/test_sp_loss_match.py
@@ -88,7 +88,8 @@ def test_trainer_forward_consistency(trainer: FSDPSFTTrainer, total_steps: int =
 
     if trainer.device_mesh.get_rank() == 0:
         print("\nDebug comparison completed successfully.")
-        
+
+
 def _check_backward_determinism(trainer: FSDPSFTTrainer, micro_batch: TensorDict, mode_label: str):
     if trainer.device_mesh.get_rank() == 0:
         print(f"\nChecking backward determinism ({mode_label})...")

--- a/tests/special_e2e/sft/test_sp_loss_match.py
+++ b/tests/special_e2e/sft/test_sp_loss_match.py
@@ -18,6 +18,7 @@ from tensordict import TensorDict
 from torch.distributed.device_mesh import init_device_mesh
 
 from verl.trainer.fsdp_sft_trainer import FSDPSFTTrainer
+from verl.utils.device import is_torch_npu_available
 from verl.utils.distributed import initialize_global_process_group
 from verl.workers.engine.utils import enable_full_determinism
 
@@ -200,6 +201,9 @@ def main(config):
     """
     trainer = create_trainer(config)
     test_trainer_forward_consistency(trainer)
+    if is_torch_npu_available(check_device=False):
+        print("Skip backward determinism test when torch_npu is available.")
+        return
     test_trainer_backward_determinism(trainer)
 
 

--- a/tests/special_e2e/sft/test_sp_loss_match.py
+++ b/tests/special_e2e/sft/test_sp_loss_match.py
@@ -120,6 +120,9 @@ def _check_backward_determinism(trainer: FSDPSFTTrainer, micro_batch: TensorDict
 
 
 def test_trainer_backward_determinism(trainer: FSDPSFTTrainer):
+    seed = 42
+    enable_full_determinism(seed=seed)
+
     """Test backward determinism for both ref and SP+rmpad modes on one micro-batch."""
     if trainer.device_mesh.get_rank() == 0:
         print("\nStarting backward determinism check...")
@@ -157,9 +160,6 @@ def create_trainer(config):
         FSDPSFTTrainer: Initialized trainer instance
     """
     local_rank, rank, world_size = initialize_global_process_group()
-
-    seed = 42
-    enable_full_determinism(seed=seed)
 
     device_mesh = init_device_mesh(device_type="cuda", mesh_shape=(world_size,), mesh_dim_names=("fsdp",))
 


### PR DESCRIPTION
### What does this PR do?

Add backward determinism test to verify the effectiveness of `enable_full_determinism`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
  - [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
