### PR TITLE
[megatron] fix: fully offload megatron optimizer

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -499,6 +499,7 @@ def offload_megatron_copy_params(optimizers):
                 if isinstance(param_group, list):
                     for param in param_group:
                         offload_tensor_to_cpu(param)
+                        param.grad = None
                 else:
                     offload_tensor_to_cpu(param_group)
         else:


### PR DESCRIPTION
### What does this PR do?

In current RL training, when switching from training to inference and updating weights, the GPU memory usage in the **second step increases significantly** compared to the first step.  

I used torch memory snapshot to analyze this, and found that this is due to the grad attached to the shard_main_param in megatron is not properly offloaded (marked as megatron copy group grads in the picture).

<img width="1764" height="1018" alt="image" src="https://github.com/user-attachments/assets/e26674e1-a45b-4fab-a740-046f21f1495e" />

In megatorn distrib_optimizer, gradient assignment is performed on the model parameter copies in the optimizer, but these copies are not unloaded during subsequent unloading.
```python
# megatron/core/optimizer/distrib_optimizer.py
def copy_group_grads(model_groups, shard_main_groups):
    for model_group, shard_main_group in zip(model_groups, shard_main_groups):
        for model_param, shard_main_param in zip(model_group, shard_main_group):
 
            param_range_map = self._get_model_param_range_map(model_param)
            param_range = param_range_map["param"]
            assert param_range.size == shard_main_param.nelement()
 
            model_grad = model_param.main_grad.clone()
            shard_model_grad = model_grad.view(-1)[param_range.start : param_range.end]
            if self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
                shard_main_param.decoupled_grad = shard_model_grad
            else:
                # Here, gradient assignment is performed on the model parameter copies in the optimizer, 
                # but these copies are not unloaded during subsequent unloading.
                shard_main_param.grad = shard_model_grad.float()
```

I fixed this problem in the offload_group_to_cpu function, and the memory usage becomes right.