### PR TITLE
[training_utils] fix: add upcasting for `seq_len_effective` to avoid potential overflow in `calculate_workload`

### DIFF
--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -397,6 +397,8 @@ def rearrange_micro_batches(
 
     assert num_micro_batches <= len(seq_len_effective)
 
+    # upcast to int64 to avoid potential overflow im `calculate_workload` computation. 
+    seq_len_effective = seq_len_effective.long()
     # note that seq_len_effective is a GPU tensor. We need to make it a list to avoid D2H!
     workloads = calculate_workload(seq_len_effective).cpu().tolist()
     micro_bsz_idx = get_seqlen_balanced_partitions(workloads, num_micro_batches, equal_size=False)


### PR DESCRIPTION
… avoild potential overflow in `calculate_workload`

### What does this PR do?

> add upcasting for `seq_len_effective` in `rearrange_micro_batches` to avoild potential overflow in `calculate_workload`

### Test

> None. This commit does not affect any computation logic.


### Design & Code Changes

This PR fixes a (potential) bug in `verl/utils/seqlen_balancing.py`:

When `use_dynamic_bsz=True`, `calculate_workload` can overflow if `seq_len_effective` is int32 (which is the default dtype of `input_ids.offsets().diff()` if without upcasting), producing negative workloads and causing partitioning to fail.

Our current run actually relies on two implicit behaviors:

- In `verl/trainer/ppo/ray_trainer.py`, we convert the batch to a NestedTensor; at this point the NestedTensor offsets are still int32.
- During dispatch, DataProto.chunk() implicitly converts NestedTensor offsets to int64, so seq_len_effective becomes int64, avoiding overflow.

This means the job runs only because of the implicit dtype change in the dispatch path.


Blow is the PoC script to prove the correctness of above claim.

<img width="1234" height="273" alt="Clipboard_Screenshot_1769686237" src="https://github.com/user-attachments/assets/8b751940-0ee6-4584-9e4d-6afb261fbb49" />


```
python

#!/usr/bin/env python3
import os
import sys
import torch
from tensordict import TensorDict

from verl.workers.utils.padding import left_right_2_no_padding
from verl.utils.seqlen_balancing import rearrange_micro_batches

def make_mask(length, total_len):
    m = torch.zeros(total_len, dtype=torch.long)
    m[-length:] = 1
    return m

def build_batch():
    total_len = 40960
    lengths = [39232, 15315, 39232, 15315]
    bsz = len(lengths)
    response_len = 16

    input_ids = torch.zeros((bsz, total_len), dtype=torch.long)
    attention_mask = torch.stack([make_mask(l, total_len) for l in lengths], dim=0)
    response_mask = torch.ones((bsz, response_len), dtype=torch.long)
    position_ids = torch.arange(total_len).unsqueeze(0).repeat(bsz, 1)

    batch = TensorDict(
        {
            "input_ids": input_ids,
            "attention_mask": attention_mask,
            "response_mask": response_mask,
            "position_ids": position_ids,
        },
        batch_size=bsz,
    )
    return batch

def run_direct():
    print("\n=== Direct (no ray) ===")
    batch = build_batch()
    batch = left_right_2_no_padding(batch)

    max_token_len = 40000
    try:
        micro_batches, idx = rearrange_micro_batches(
            batch,
            max_token_len=max_token_len,
            dp_group=None,
            num_batches_divided_by=None,
            same_micro_num_in_dp=False,
            min_num_micro_batch=None,
            use_dynamic_bsz_balance=True,
        )
        print("micro batch indices:", idx)
    except AssertionError as e:
        print("AssertionError:", e)

def run_ray_dispatch():
    print("\n=== Ray dispatch simulation ===")
    import ray

    ray.init(ignore_reinit_error=True, include_dashboard=False)

    @ray.remote
    def worker_process(td, open_verl_path):
        import sys
        if open_verl_path not in sys.path:
            sys.path.insert(0, open_verl_path)

        from verl.utils.seqlen_balancing import rearrange_micro_batches

        max_token_len = 40000
        try:
            micro_batches, idx = rearrange_micro_batches(
                td,
                max_token_len=max_token_len,
                dp_group=None,
                num_batches_divided_by=None,
                same_micro_num_in_dp=False,
                min_num_micro_batch=None,
                use_dynamic_bsz_balance=True,
            )
            return {"ok": True, "idx": idx}
        except AssertionError as e:
            return {"ok": False, "err": str(e)}

    batch = build_batch()
    batch = left_right_2_no_padding(batch)
    shards = batch.chunk(chunks=2)

    futures = [worker_process.remote(shard, OPEN_VERL_PATH) for shard in shards]
    results = ray.get(futures)

    for i, res in enumerate(results):
        if res["ok"]:
            print(f"[driver] shard {i} ok, idx={res['idx']}")
        else:
            print(f"[driver] shard {i} error: {res['err']}")

    ray.shutdown()

def main():
    run_direct()
    run_ray_dispatch()

if __name__ == "__main__":
    main()


```

