### PR TITLE
[model] feat: add registration and config converter for Qwen 2.5-Omni

### DIFF
--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -30,6 +30,7 @@ class SupportedVLM(Enum):
     QWEN2_5_VL = "Qwen2_5_VLForConditionalGeneration"
     QWEN3_MOE_VL = "Qwen3VLMoeForConditionalGeneration"
     QWEN3_VL = "Qwen3VLForConditionalGeneration"
+    QWEN2_5_OMNI = "Qwen2_5OmniForConditionalGeneration"
 
 
 supported_vlm = [member.value for member in SupportedVLM]
@@ -83,6 +84,7 @@ from .config_converter import (
     hf_to_mcore_config_qwen2_5_vl,
     hf_to_mcore_config_qwen2moe,
     hf_to_mcore_config_qwen3moe,
+    hf_to_mcore_config_qwen2_5_omni,
 )
 from .model_initializer import (
     BaseModelInitializer,
@@ -118,6 +120,7 @@ class SupportedModel(Enum):
     LLAMA_TOKEN_CLASSIFICATION = "LlamaForTokenClassification"
     QWEN3_MOE_VL = "Qwen3VLMoeForConditionalGeneration"
     QWEN3_VL = "Qwen3VLForConditionalGeneration"
+    QWEN2_5_OMNI = "Qwen2_5OmniForConditionalGeneration"
     GPT_OSS = "GptOssForCausalLM"
     MiMO = "MiMoForCausalLM"
 
@@ -135,6 +138,7 @@ MODEL_CONFIG_CONVERTER_REGISTRY: dict[SupportedModel, Callable[[PretrainedConfig
     SupportedModel.QWEN3_MOE: hf_to_mcore_config_qwen3moe,
     SupportedModel.QWEN3_TOKEN_CLASSIFICATION: hf_to_mcore_config_dense,
     SupportedModel.LLAMA_TOKEN_CLASSIFICATION: hf_to_mcore_config_dense,
+    SupportedModel.QWEN2_5_OMNI: hf_to_mcore_config_qwen2_5_omni,
 }
 
 # Registry for model initializers
@@ -170,6 +174,7 @@ MODEL_FORWARD_REGISTRY: dict[SupportedModel, Callable] = {
     SupportedModel.LLAMA_TOKEN_CLASSIFICATION: model_forward_gen(),
     SupportedModel.GPT_OSS: model_forward_gen(),
     SupportedModel.MiMO: model_forward_gen(),
+    # SupportedModel.QWEN2_5_OMNI: model_forward_gen(True),  # not implemented
 }
 
 # Registry for model forward functions
@@ -190,6 +195,7 @@ MODEL_FORWARD_NOPAD_REGISTRY: dict[SupportedModel, Callable] = {
     SupportedModel.LLAMA_TOKEN_CLASSIFICATION: gptmodel_forward_no_padding,
     SupportedModel.GPT_OSS: gptmodel_forward_no_padding,
     SupportedModel.MiMO: gptmodel_forward_no_padding,
+    # SupportedModel.QWEN2_5_OMNI: gptmodel_forward_no_padding,  # not implemented
 }
 
 # Registry for model forward functions
@@ -208,6 +214,7 @@ MODEL_FORWARD_FUSED_REGISTRY: dict[SupportedModel, Callable] = {
     SupportedModel.GLM4_MOE: fused_forward_model_gen(),
     SupportedModel.GPT_OSS: fused_forward_model_gen(),
     SupportedModel.MiMO: fused_forward_model_gen(),
+    # SupportedModel.QWEN2_5_OMNI: fused_forward_model_gen(True),  # not implemented
 }
 
 # Registry for model weight converters


### PR DESCRIPTION
## What does this PR do?

This PR introduces the initial registration and configuration conversion logic for the Qwen 2.5-Omni model within the veRL framework.

## Key Changes

- **Model Registration**: Added `QWEN2_5_OMNI` to the `SupportedVLM` and `SupportedModel` enums in `verl/models/mcore/registry.py`.

- **Config Converter**: Implemented `hf_to_mcore_config_qwen2_5_omni` in `verl/models/mcore/config_converter.py`.
  - This converter specifically addresses the nested configuration structure of the Omni model: `Qwen2_5OmniConfig` → `thinker_config` → `text_config`.
  - It correctly extracts `mrope_section` from `rope_parameters` to support multimodal rotary positional embeddings (mRoPE).

- **Forward Registry Skeleton**: Added commented-out entries for `MODEL_FORWARD` registries as placeholders for the upcoming implementation.

## Implementation Details

The implementation was developed by:

- Analyzing the `Qwen2_5OmniForConditionalGeneration` structure in the Hugging Face transformers library.
- Referencing established patterns in ms-swift for Omni model training support to ensure compatibility with existing community standards.

## Future Work (Next Steps)

This PR serves as the foundation for full Qwen 2.5-Omni support. Immediate follow-up PRs will include:

- **Weight Converter**: Implementation to map HF checkpoints to Megatron-Core tensors.
- **Model Initializer**: Implementation of the initialization logic.
- **Forward Activation**: Enabling the Forward Registries (standard, no-pad, and fused).

## Technical Summary (中文)

本次 PR 实现了 Qwen 2.5-Omni 模型在 veRL 中的基础注册与配置转换逻辑：

- **嵌套配置解析**：成功处理了 Omni 模型特有的 `thinker_config` 嵌套结构，准确提取核心文本参数。
- **mRoPE 支持**：从配置中提取并映射了多模态旋转位置编码参数。
- **架构对齐**：参考了 ms-swift 的实现经验，确保与现有社区多模态训练标准保持一致。
