### PR TITLE
Revert "[rollout] feat: automatically resume generation on abort"

### DIFF
--- a/tests/checkpoint_engine/test_special_server_adapter.py
+++ b/tests/checkpoint_engine/test_special_server_adapter.py
@@ -14,24 +14,22 @@
 import asyncio
 import os
 
-import numpy as np
 import pytest
 import ray
 from omegaconf import DictConfig
+from openai import AsyncOpenAI
 
 from tests.checkpoint_engine.test_utils import create_trainer_worker_group
 from verl.checkpoint_engine import CheckpointEngineManager, CheckpointEngineWorker
-from verl.experimental.agent_loop import AgentLoopManager
-from verl.protocol import DataProto
 from verl.single_controller.ray import (
     RayClassWithInitArgs,
     RayResourcePool,
     RayWorkerGroup,
 )
-from verl.utils import hf_tokenizer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_device_name
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig, RolloutConfig
+from verl.workers.rollout.replica import get_rollout_replica_class
 
 
 @pytest.fixture
@@ -45,7 +43,7 @@ def init_config() -> DictConfig:
     config.trainer.nnodes = 1
     config.actor_rollout_ref.model.path = os.path.expanduser("~/models/Qwen/Qwen3-VL-2B-Instruct")
     config.actor_rollout_ref.rollout.name = os.environ["ROLLOUT_NAME"]
-    config.actor_rollout_ref.rollout.response_length = 4096
+    config.actor_rollout_ref.rollout.skip_tokenizer_init = False
     config.actor_rollout_ref.rollout.checkpoint_engine.backend = "nccl" if get_device_name() == "cuda" else "hccl"
 
     return config
@@ -58,7 +56,7 @@ async def test_server_adapter(init_config):
             "env_vars": {
                 "TOKENIZERS_PARALLELISM": "true",
                 "NCCL_DEBUG": "WARN",
-                "VLLM_LOGGING_LEVEL": "DEBUG",
+                "VLLM_LOGGING_LEVEL": "INFO",
                 "VLLM_USE_V1": "1",
                 "VLLM_DISABLE_COMPILE_CACHE": "1",
             }
@@ -89,51 +87,34 @@ async def test_server_adapter(init_config):
     )
 
     # 2.2 create rollout replicas
-    agent_loop_manager = await AgentLoopManager.create(init_config, rollout)
+    rollout_replica_class = get_rollout_replica_class(rollout_config.name)
+    rollout_replicas = [
+        rollout_replica_class(
+            replica_rank=replica_rank,
+            config=rollout_config,
+            model_config=model_config,
+        )
+        for replica_rank in range(2)
+    ]
+    await asyncio.gather(*[replica.init_hybrid(rollout) for replica in rollout_replicas])
 
     # 3. create checkpoint engine manager
     checkpoint_manager = CheckpointEngineManager(
-        backend=checkpoint_engine_config.backend, trainer=trainer, replicas=agent_loop_manager.rollout_replicas
+        backend=checkpoint_engine_config.backend, trainer=trainer, replicas=rollout_replicas
     )
-
-    # 4. generate sequences
-    raw_prompts = [
-        [{"role": "user", "content": "Please write an article about the history of China, at least 1000 words."}],
-        [{"role": "user", "content": "Please write an article about the history of America, at least 1000 words."}],
-        [{"role": "user", "content": "Please write an article about the geography of China, at least 1000 words."}],
-        [{"role": "user", "content": "Please write an article about the geography of America, at least 1000 words."}],
-    ]
-    batch = DataProto(
-        non_tensor_batch={
-            "raw_prompt": np.array(raw_prompts),
-            "agent_name": np.array(["single_turn_agent"] * len(raw_prompts)),
-            "data_source": np.array(["openai/gsm8k"] * len(raw_prompts)),
-            "reward_model": np.array([{"style": "rule", "ground_truth": "1.0"}] * len(raw_prompts)),
-        },
-    )
-    n = 4
-    batch = batch.repeat(n)
-    task = asyncio.create_task(agent_loop_manager.generate_sequences(prompts=batch))
-
-    # 5. update weights to interrupt generate sequences
     for i in range(3):
-        await asyncio.sleep(3)
         await checkpoint_manager.update_weights()
-        print(f"update weights {i} done")
 
-    # 6. wait for generate sequences task done
-    result = await task
-    prompts = result.batch["prompts"]
-    responses = result.batch["responses"]
-    tokenizer = hf_tokenizer(init_config.actor_rollout_ref.model.path)
-    for i in range(len(result)):
-        print("=" * 20)
-        print("[PROMPT]", tokenizer.decode(prompts[i], skip_special_tokens=True))
-        print("[RESPONSE]", tokenizer.decode(responses[i], skip_special_tokens=True))
+        server_addresses = rollout_replicas[i % len(rollout_replicas)].server_address
+        client = AsyncOpenAI(
+            api_key="123-abc",
+            base_url=f"http://{server_addresses}/v1",
+        )
 
-    start_model_version = result.non_tensor_batch["start_model_version"]
-    finish_model_version = result.non_tensor_batch["finish_model_version"]
-    assert np.all(start_model_version == 0), f"start_model_version should be 0, but got {start_model_version}"
-    assert np.all(finish_model_version == 3), f"finish_model_version should be 3, but got {finish_model_version}"
+        completion = await client.chat.completions.create(
+            model=init_config.actor_rollout_ref.model.path,
+            messages=[{"role": "user", "content": "What can you do?"}],
+        )
+        print("[OUTPUT]:", completion.choices[0].message.content)
 
     ray.shutdown()

--- a/tests/experimental/agent_loop/agent_utils.py
+++ b/tests/experimental/agent_loop/agent_utils.py
@@ -83,7 +83,7 @@ def init_agent_loop_manager(config: DictConfig) -> AgentLoopManager | RayWorkerG
     else:
         rm_resource_pool = None
     # =========================== 2. Create AgentLoopManager ===========================
-    agent_loop_manager = AgentLoopManager.create(
+    agent_loop_manager = AgentLoopManager(
         config=config,
         worker_group=actor_rollout_wg,
         rm_resource_pool=rm_resource_pool,

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -77,7 +77,7 @@ def test_single_turn(init_config):
         }
     )
 
-    agent_loop_manager = AgentLoopManager.create(init_config)
+    agent_loop_manager = AgentLoopManager(init_config)
     tokenizer = hf_tokenizer(init_config.actor_rollout_ref.model.path)
     reward_fn = load_reward_manager(
         init_config, tokenizer, num_examine=0, **init_config.reward_model.get("reward_kwargs", {})
@@ -226,7 +226,7 @@ def test_tool_agent(init_config):
     init_config.actor_rollout_ref.rollout.multi_turn.tool_config_path = tool_config_path
     init_config.actor_rollout_ref.rollout.multi_turn.max_parallel_calls = 2
     init_config.actor_rollout_ref.rollout.calculate_log_probs = True
-    agent_loop_manager = AgentLoopManager.create(init_config)
+    agent_loop_manager = AgentLoopManager(init_config)
 
     # =========================== 2. Generate sequences  ===========================
     raw_prompts = [

--- a/tests/experimental/agent_loop/test_multi_modal.py
+++ b/tests/experimental/agent_loop/test_multi_modal.py
@@ -164,7 +164,7 @@ def test_multimodal_tool_agent(init_config):
     init_config.actor_rollout_ref.rollout.multi_turn.tool_config_path = tool_config_path
     init_config.actor_rollout_ref.rollout.multi_turn.max_parallel_calls = 1
     init_config.actor_rollout_ref.rollout.multi_turn.max_user_turns = 1
-    agent_loop_manager = AgentLoopManager.create(init_config)
+    agent_loop_manager = AgentLoopManager(init_config)
 
     # =========================== 2. Generate sequences with multimodal prompts ===========================
     raw_prompts = [
@@ -309,7 +309,7 @@ def test_multimodal_single_turn_agent(init_config):
     init_config.actor_rollout_ref.rollout.n = n
     init_config.actor_rollout_ref.rollout.multi_turn.max_parallel_calls = 1
     init_config.actor_rollout_ref.rollout.multi_turn.max_user_turns = 1
-    agent_loop_manager = AgentLoopManager.create(init_config)
+    agent_loop_manager = AgentLoopManager(init_config)
 
     # =========================== 2. Generate sequences with multimodal prompts ===========================
     # Create a simple test image

--- a/tests/experimental/reward_loop/test_agent_loop_reward_manager.py
+++ b/tests/experimental/reward_loop/test_agent_loop_reward_manager.py
@@ -74,7 +74,7 @@ def test_agent_loop_reward_manager():
     config.custom_reward_function.name = "compute_score_gsm8k"
 
     # 1. init reward model manager
-    agent_loop_manager = AgentLoopManager.create(config)
+    agent_loop_manager = AgentLoopManager(config)
 
     # 2. init test data
     local_folder = os.path.expanduser("~/data/gsm8k/")

--- a/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
+++ b/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
@@ -97,7 +97,7 @@ def test_agent_loop_reward_manager():
     )
     actor_rollout_wg.init_model()
 
-    agent_loop_manager = AgentLoopManager.create(config, worker_group=actor_rollout_wg)
+    agent_loop_manager = AgentLoopManager(config, worker_group=actor_rollout_wg)
     # sleep rollout replicas
     checkpoint_manager = CheckpointEngineManager(
         backend=config.actor_rollout_ref.rollout.checkpoint_engine.backend,
@@ -105,7 +105,7 @@ def test_agent_loop_reward_manager():
         replicas=agent_loop_manager.rollout_replicas,
     )
     checkpoint_manager.sleep_replicas()
-    reward_loop_manager = RewardLoopManager.create(config, rm_resource_pool=resource_pool)
+    reward_loop_manager = RewardLoopManager(config, rm_resource_pool=resource_pool)
 
     # 2. init test data
     local_folder = os.path.expanduser("~/data/gsm8k/")

--- a/tests/experimental/reward_loop/test_math_verify.py
+++ b/tests/experimental/reward_loop/test_math_verify.py
@@ -63,7 +63,7 @@ def test_agent_loop_reward_manager():
     config.custom_reward_function.name = "compute_score_math_verify"
 
     # 1. init reward model manager
-    agent_loop_manager = AgentLoopManager.create(config)
+    agent_loop_manager = AgentLoopManager(config)
 
     # 2. init test data
     local_folder = os.path.expanduser("~/data/math/")

--- a/tests/experimental/reward_loop/test_reward_model_disrm.py
+++ b/tests/experimental/reward_loop/test_reward_model_disrm.py
@@ -135,7 +135,7 @@ def test_reward_model_manager():
     config.reward_model.rollout.response_length = 4096
 
     # 1. init reward model manager
-    reward_loop_manager = RewardLoopManager.create(config)
+    reward_loop_manager = RewardLoopManager(config)
 
     # 2. init test data
     rollout_tokenizer = hf_tokenizer(rollout_model_name)

--- a/tests/experimental/reward_loop/test_reward_model_genrm.py
+++ b/tests/experimental/reward_loop/test_reward_model_genrm.py
@@ -138,7 +138,7 @@ def test_reward_model_manager():
     config.reward_model.rollout.response_length = 4096
 
     # 1. init reward model manager
-    reward_loop_manager = RewardLoopManager.create(config)
+    reward_loop_manager = RewardLoopManager(config)
 
     # 2. init test data
     rollout_tokenizer = hf_tokenizer(rollout_model_name)

--- a/tests/workers/rollout/rollout_vllm/test_vllm_abort.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_abort.py
@@ -156,7 +156,6 @@ def test_vllm_abort():
         print("   Calling abort_all_requests...")
         abort_start = time.perf_counter()
         abort_result = ray.get(server_handle.abort_all_requests.remote())
-        ray.get(server_handle.resume_all_requests.remote())
         abort_time = time.perf_counter() - abort_start
 
         print(f"   Abort took: {abort_time * 1000:.2f}ms")
@@ -186,7 +185,7 @@ def test_vllm_abort():
             if output is None:
                 timeout_count += 1
                 print(f"[{i}] {request_id}: TIMEOUT")
-            elif output.stop_reason == "abort":
+            elif output.stop_reason == "aborted":
                 aborted_count += 1
                 print(f"[{i}] {request_id}: ABORTED ({len(output.token_ids)} tokens)")
                 print(f"Partial Output: {tokenizer.decode(output.token_ids)}")

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -41,15 +41,14 @@ from verl.utils.chat_template import initialize_system_prompt
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.fs import copy_to_local
 from verl.utils.model import compute_position_id_with_mask
-from verl.utils.ray_utils import auto_await, get_event_loop
+from verl.utils.ray_utils import get_event_loop
 from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
     rollout_trace_op,
 )
 from verl.utils.transferqueue_utils import tqbridge
-from verl.workers.rollout.base import TokenOutput
-from verl.workers.rollout.replica import get_rollout_replica_class
+from verl.workers.rollout.replica import TokenOutput, get_rollout_replica_class
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -865,6 +864,11 @@ class AgentLoopManager:
         self.worker_group = worker_group
         self.reward_model_manager = None
         self.reward_router_address = None
+        if self.config.reward_model.enable and self.config.reward_model.enable_resource_pool:
+            from verl.experimental.reward_loop import RewardModelManager
+
+            self.reward_model_manager = RewardModelManager(config.reward_model, rm_resource_pool)
+            self.reward_router_address = self.reward_model_manager.get_router_address()
 
         # for recipe to change
         if not hasattr(self, "rollout_replica_class"):
@@ -872,30 +876,10 @@ class AgentLoopManager:
         if not hasattr(self, "agent_loop_workers_class"):
             self.agent_loop_workers_class = ray.remote(AgentLoopWorker)
 
-    @classmethod
-    @auto_await
-    async def create(
-        cls,
-        config: DictConfig,
-        worker_group: RayWorkerGroup = None,
-        rollout_resource_pool: RayResourcePool = None,
-        rm_resource_pool: RayResourcePool = None,
-    ):
-        """Create agent loop manager."""
+        self._initialize_llm_servers(rollout_resource_pool)
+        self._init_agent_loop_workers()
 
-        instance = cls(config, worker_group, rollout_resource_pool, rm_resource_pool)
-
-        if config.reward_model.enable and config.reward_model.enable_resource_pool:
-            from verl.experimental.reward_loop import RewardModelManager
-
-            instance.reward_model_manager = await RewardModelManager.create(config.reward_model, rm_resource_pool)
-            instance.reward_router_address = instance.reward_model_manager.get_router_address()
-
-        await instance._initialize_llm_servers(rollout_resource_pool)
-        instance._init_agent_loop_workers()
-        return instance
-
-    async def _initialize_llm_servers(self, rollout_resource_pool: RayResourcePool):
+    def _initialize_llm_servers(self, rollout_resource_pool: RayResourcePool):
         rollout_world_size = (
             self.config.actor_rollout_ref.rollout.tensor_model_parallel_size
             * self.config.actor_rollout_ref.rollout.data_parallel_size
@@ -921,16 +905,16 @@ class AgentLoopManager:
         ]
 
         if self.worker_group and rollout_config.name != "trtllm":
-            await asyncio.gather(*[server.init_hybrid(self.worker_group) for server in self.rollout_replicas])
+            self._run_all([server.init_hybrid(self.worker_group) for server in self.rollout_replicas])
         elif self.worker_group and rollout_config.name == "trtllm":
-            await asyncio.gather(
-                *[
+            self._run_all(
+                [
                     server.init_hybrid_colocated(self.worker_group, rollout_resource_pool)
                     for server in self.rollout_replicas
                 ]
             )
         else:
-            await asyncio.gather(*[server.init_standalone() for server in self.rollout_replicas])
+            self._run_all([server.init_standalone() for server in self.rollout_replicas])
 
         self.server_handles = [server._server_handle for server in self.rollout_replicas]
         self.server_addresses = [server._server_address for server in self.rollout_replicas]
@@ -960,8 +944,7 @@ class AgentLoopManager:
                 ).remote(self.config, self.server_handles, self.reward_router_address)
             )
 
-    @auto_await
-    async def generate_sequences(self, prompts: DataProto) -> DataProto:
+    def generate_sequences(self, prompts: DataProto) -> DataProto:
         """Split input batch and dispatch to agent loop workers.
 
         Args:
@@ -976,8 +959,8 @@ class AgentLoopManager:
             self.reward_model_manager.wake_up()
 
         chunkes = prompts.chunk(len(self.agent_loop_workers))
-        outputs = await asyncio.gather(
-            *[
+        outputs = ray.get(
+            [
                 worker.generate_sequences.remote(chunk)
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
             ]
@@ -1020,17 +1003,20 @@ class AgentLoopManager:
 
         return timing
 
-    @auto_await
-    async def clear_kv_cache(self):
+    def clear_kv_cache(self):
         """Clear all rollout kv cache, but don`t sleep."""
-        await asyncio.gather(*[replica.clear_kv_cache() for replica in self.rollout_replicas])
+        self._run_all([replica.clear_kv_cache() for replica in self.rollout_replicas])
 
-    @auto_await
-    async def start_profile(self, **kwargs):
+    def start_profile(self, **kwargs):
         """Start profiling on all rollout replicas."""
-        await asyncio.gather(*[replica.start_profile(**kwargs) for replica in self.rollout_replicas])
+        self._run_all([replica.start_profile(**kwargs) for replica in self.rollout_replicas])
 
-    @auto_await
-    async def stop_profile(self):
+    def stop_profile(self):
         """Stop profiling on all rollout replicas."""
-        await asyncio.gather(*[replica.stop_profile() for replica in self.rollout_replicas])
+        self._run_all([replica.stop_profile() for replica in self.rollout_replicas])
+
+    def _run_all(self, tasks: list[asyncio.Task]):
+        async def run_all():
+            await asyncio.gather(*tasks)
+
+        asyncio.run(run_all())

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -80,9 +80,5 @@ class SingleTurnAgentLoop(AgentLoopBase):
             multi_modal_data=multi_modal_data,
             num_turns=2,
             metrics=metrics,
-            extra_fields={
-                "start_model_version": output.start_model_version,
-                "finish_model_version": output.finish_model_version,
-            },
         )
         return output

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -240,14 +240,6 @@ class ToolAgentLoop(AgentLoopBase):
         else:
             agent_data.metrics["num_preempted"] += output.num_preempted if output.num_preempted is not None else 0
 
-        # update start_model_version and finish_model_version for staleness control
-        agent_data.extra_fields["start_model_version"] = min(
-            agent_data.extra_fields.get("start_model_version", 0), output.start_model_version
-        )
-        agent_data.extra_fields["finish_model_version"] = max(
-            agent_data.extra_fields.get("finish_model_version", 0), output.finish_model_version
-        )
-
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
         agent_data.prompt_ids += agent_data.response_ids

--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -252,7 +252,7 @@ class FullyAsyncAgentLoopManager(AgentLoopManager):
         if self.config.reward_model.enable and self.config.reward_model.enable_resource_pool:
             from verl.experimental.reward_loop import RewardModelManager
 
-            self.reward_model_manager = await RewardModelManager.create(self.config.reward_model, self.rm_resource_pool)
+            self.reward_model_manager = RewardModelManager(self.config.reward_model, self.rm_resource_pool)
             self.reward_router_address = self.reward_model_manager.get_router_address()
 
         await self._initialize_llm_servers_async()

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -28,7 +28,6 @@ from verl.single_controller.ray.base import RayResourcePool
 from verl.trainer.ppo.reward import get_custom_reward_fn
 from verl.utils import hf_tokenizer
 from verl.utils.fs import copy_to_local
-from verl.utils.ray_utils import auto_await
 
 from .reward_manager import get_reward_manager_cls
 from .reward_model import RewardModelManager
@@ -251,24 +250,14 @@ class RewardLoopManager:
 
     def __init__(self, config: DictConfig, rm_resource_pool: RayResourcePool = None):
         self.config = config
-        self.reward_model_manager = None
-        self.reward_router_address = None
+        if self.config.reward_model.enable:
+            self.reward_model_manager = RewardModelManager(config.reward_model, rm_resource_pool)
+            self.reward_router_address = self.reward_model_manager.get_router_address()
+        else:
+            self.reward_model_manager = None
+            self.reward_router_address = None
 
-    @classmethod
-    @auto_await
-    async def create(
-        cls,
-        config: DictConfig,
-        rm_resource_pool: RayResourcePool = None,
-    ):
-        instance = cls(config, rm_resource_pool)
-
-        if config.reward_model.enable:
-            instance.reward_model_manager = await RewardModelManager.create(config.reward_model, rm_resource_pool)
-            instance.reward_router_address = instance.reward_model_manager.get_router_address()
-
-        instance._init_reward_loop_workers()
-        return instance
+        self._init_reward_loop_workers()
 
     def _init_reward_loop_workers(self):
         self.reward_loop_workers = []
@@ -324,3 +313,9 @@ class RewardLoopManager:
         return DataProto(
             batch=batch, non_tensor_batch=non_tensor_batch, meta_info={"reward_extra_keys": reward_extra_keys}
         )
+
+    def _run_all(self, tasks: list[asyncio.Task]):
+        async def run_all():
+            return await asyncio.gather(*tasks)
+
+        return asyncio.run(run_all())

--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -17,7 +17,6 @@ import logging
 import os
 
 from verl.single_controller.ray.base import RayResourcePool, split_resource_pool
-from verl.utils.ray_utils import auto_await
 from verl.workers.config import HFModelConfig, RewardModelConfig
 from verl.workers.rollout.replica import get_rollout_replica_class
 
@@ -42,23 +41,13 @@ class RewardModelManager:
         """
         self.config = config
         self.resource_pool = resource_pool
+        self._initialize_llm_servers()
+        self._initialize_router()
+        assert self.config.rollout.skip_tokenizer_init is False, "Reward model should not skip tokenizer init."
+        if self.config.rollout.free_cache_engine:
+            self.sleep()
 
-    @classmethod
-    @auto_await
-    async def create(
-        cls,
-        config: RewardModelConfig,
-        resource_pool: RayResourcePool = None,
-    ):
-        instance = cls(config, resource_pool)
-        await instance._initialize_llm_servers()
-        instance._initialize_router()
-        assert config.rollout.skip_tokenizer_init is False, "Reward model should not skip tokenizer init."
-        if config.rollout.free_cache_engine:
-            await instance.sleep()
-        return instance
-
-    async def _initialize_llm_servers(self):
+    def _initialize_llm_servers(self):
         rollout_world_size = self.config.rollout.tensor_model_parallel_size
         world_size = (
             self.resource_pool.world_size
@@ -88,14 +77,14 @@ class RewardModelManager:
         if self.resource_pool:
             split_resource_pools = split_resource_pool(self.resource_pool, split_size=rollout_world_size)
             assert len(split_resource_pools) == len(self.rollout_replicas)
-            await asyncio.gather(
-                *[
+            self._run_all(
+                [
                     server.init_colocated(resource_pool)
                     for server, resource_pool in zip(self.rollout_replicas, split_resource_pools, strict=True)
                 ]
             )
         else:
-            await asyncio.gather(*[server.init_standalone() for server in self.rollout_replicas])
+            self._run_all([server.init_standalone() for server in self.rollout_replicas])
         self.server_handles = [server._server_handle for server in self.rollout_replicas]
         self.server_addresses = [server._server_address for server in self.rollout_replicas]
 
@@ -115,12 +104,16 @@ class RewardModelManager:
     def get_router_address(self):
         return self.router_address
 
-    @auto_await
-    async def wake_up(self):
+    def wake_up(self):
         """Wake up all rollout replica instances."""
-        await asyncio.gather(*[replica.wake_up() for replica in self.rollout_replicas])
+        self._run_all([replica.wake_up() for replica in self.rollout_replicas])
 
-    @auto_await
-    async def sleep(self):
+    def sleep(self):
         """Sleep all rollout replica instances."""
-        await asyncio.gather(*[replica.sleep() for replica in self.rollout_replicas])
+        self._run_all([replica.sleep() for replica in self.rollout_replicas])
+
+    def _run_all(self, tasks: list[asyncio.Task]):
+        async def run_all():
+            await asyncio.gather(*tasks)
+
+        asyncio.run(run_all())

--- a/verl/experimental/transfer_queue/ray_trainer.py
+++ b/verl/experimental/transfer_queue/ray_trainer.py
@@ -849,7 +849,7 @@ class RayPPOTrainer:
             else:
                 rm_resource_pool = None
 
-            self.async_rollout_manager = AgentLoopManager.create(
+            self.async_rollout_manager = AgentLoopManager(
                 config=self.config,
                 worker_group=self.actor_rollout_wg,
                 rm_resource_pool=rm_resource_pool,

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -820,7 +820,7 @@ class RayPPOTrainer:
 
                 self.config.reward_model.n_gpus_per_node = self.config.trainer.n_gpus_per_node
                 resource_pool = self.resource_pool_manager.get_resource_pool(Role.RewardModel)
-                self.reward_loop_manager = RewardLoopManager.create(
+                self.reward_loop_manager = RewardLoopManager(
                     config=self.config,
                     rm_resource_pool=resource_pool,
                 )
@@ -909,7 +909,7 @@ class RayPPOTrainer:
         else:
             rm_resource_pool = None
 
-        self.async_rollout_manager = AgentLoopManager.create(
+        self.async_rollout_manager = AgentLoopManager(
             config=self.config,
             worker_group=self.actor_rollout_wg,
             rollout_resource_pool=actor_rollout_resource_pool,

--- a/verl/workers/rollout/base.py
+++ b/verl/workers/rollout/base.py
@@ -11,17 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
-import functools
+
 import importlib
-import logging
-import os
 from abc import ABC, abstractmethod
-from copy import deepcopy
-from typing import Any, Generator, Optional
+from typing import Generator
 
 import torch
-from pydantic import BaseModel
 from torch.distributed.device_mesh import DeviceMesh
 
 from verl import DataProto
@@ -29,9 +24,6 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.workers.config import HFModelConfig, RolloutConfig
 
 __all__ = ["BaseRollout"]
-
-logger = logging.getLogger(__file__)
-logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class BaseRollout(ABC):
@@ -108,142 +100,3 @@ def get_rollout_class(rollout_name: str, mode: str = "async") -> type[BaseRollou
     module_name, class_name = fqdn.rsplit(".", 1)
     rollout_module = importlib.import_module(module_name)
     return getattr(rollout_module, class_name)
-
-
-class TokenOutput(BaseModel):
-    token_ids: list[int]
-    """response token ids"""
-    log_probs: Optional[list[float]] = None
-    """logprobs of response token ids"""
-    routed_experts: Optional[Any] = None
-    """routed experts of response token ids"""
-    stop_reason: Optional[str] = None
-    """stop reason: 'completed', 'aborted', or None for unknown"""
-    num_preempted: Optional[int] = None
-    """number of preempted times for metric calculation"""
-    start_model_version: Optional[int] = 0
-    """model version when the request is started"""
-    finish_model_version: Optional[int] = 0
-    """model version when the request is finished"""
-
-
-def resume_on_abort(func):
-    """Automatically resume generation when the rollout is interrupted for updating weights,
-    this can make AgentLoop agnostic to the rollout interruption.
-    """
-
-    @functools.wraps(func)
-    async def wrapper(
-        self,
-        prompt_ids: list[int],
-        sampling_params: dict[str, Any],
-        request_id: str,
-        image_data: Optional[list[Any]] = None,
-        video_data: Optional[list[Any]] = None,
-        **kwargs,
-    ):
-        limit_key = None
-        if "max_tokens" in sampling_params:
-            limit_key = "max_tokens"
-        elif "max_new_tokens" in sampling_params:
-            limit_key = "max_new_tokens"
-        original_max_tokens = sampling_params.get(limit_key) if limit_key else None
-
-        final_output = TokenOutput(
-            token_ids=[],
-            log_probs=[],
-            num_preempted=0,
-            start_model_version=self.model_version,
-        )
-
-        retry_count = 0
-        while True:
-            # 1. wait for weight finish
-            await self.resume_event.wait()
-
-            # 2. continue generate
-            output: TokenOutput = await func(
-                self,
-                prompt_ids=prompt_ids + final_output.token_ids,
-                sampling_params=deepcopy(sampling_params),
-                request_id=f"{request_id}_{retry_count}",
-                image_data=image_data,
-                video_data=video_data,
-                **kwargs,
-            )
-
-            # 3. merge output into final_output
-            final_output.token_ids.extend(output.token_ids)
-            if output.log_probs is not None:
-                final_output.log_probs.extend(output.log_probs)
-            if output.routed_experts is not None:
-                if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
-                else:
-                    final_output.routed_experts = torch.cat([final_output.routed_experts, output.routed_experts], dim=0)
-            if output.num_preempted is not None:
-                final_output.num_preempted += output.num_preempted
-            final_output.stop_reason = output.stop_reason
-
-            # 4. update max_new_tokens
-            if original_max_tokens is not None:
-                sampling_params[limit_key] = original_max_tokens - len(final_output.token_ids)
-                if len(final_output.token_ids) >= original_max_tokens:
-                    final_output.stop_reason = "length"
-                    break
-
-            if output.stop_reason != "abort":
-                break
-            retry_count += 1
-            logger.debug(
-                f"Resume generation for request {request_id} after abort, retry count: {retry_count}, "
-                f"output token_ids: {len(output.token_ids)}, final_output token_ids: {len(final_output.token_ids)}"
-            )
-
-        final_output.finish_model_version = self.model_version
-        return final_output
-
-    return wrapper
-
-
-class BaseRolloutServer(ABC):
-    """Base class for rollout server.
-
-    Args:
-        model_version: initial model version of the rollout server.
-    """
-
-    def __init__(self, model_version: int = 0):
-        self.resume_event = asyncio.Event()
-        self.resume_event.set()
-        self.model_version = model_version
-
-    @resume_on_abort
-    async def generate(
-        self,
-        prompt_ids: list[int],
-        sampling_params: dict[str, Any],
-        request_id: str,
-        image_data: Optional[list[Any]] = None,
-        video_data: Optional[list[Any]] = None,
-        priority: int = 0,
-    ) -> TokenOutput:
-        raise NotImplementedError
-
-    @abstractmethod
-    async def abort_all_requests(self):
-        """Abort all requests with partial rollout."""
-        self.resume_event.clear()
-
-    async def resume_all_requests(self):
-        """Resume all requests with partial rollout."""
-        self.model_version += 1
-        self.resume_event.set()
-
-    @abstractmethod
-    async def start_profile(self, **kwargs):
-        raise NotImplementedError
-
-    @abstractmethod
-    async def stop_profile(self, **kwargs):
-        raise NotImplementedError

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -16,9 +16,10 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Callable
+from typing import Any, Callable, Optional
 
 from omegaconf import DictConfig
+from pydantic import BaseModel
 from ray.actor import ActorHandle
 
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, ResourcePoolManager
@@ -27,6 +28,19 @@ from verl.utils.device import is_torch_npu_available
 from verl.workers.config import HFModelConfig, RolloutConfig
 
 logger = logging.getLogger(__file__)
+
+
+class TokenOutput(BaseModel):
+    token_ids: list[int]
+    """response token ids"""
+    log_probs: Optional[list[float]] = None
+    """logprobs of response token ids"""
+    routed_experts: Optional[Any] = None
+    """routed experts of response token ids"""
+    stop_reason: Optional[str] = None
+    """stop reason: 'completed', 'aborted', or None for unknown"""
+    num_preempted: Optional[int] = None
+    """number of preempted times for metric calculation"""
 
 
 class RolloutMode(Enum):
@@ -219,11 +233,15 @@ class RolloutReplica(ABC):
 
     async def abort_all_requests(self):
         """Partial rollout: abort and save all unfinished requests in each rollout server."""
-        await asyncio.gather(*[server.abort_all_requests.remote() for server in self.servers])
+        # TODO(wuxibin)
+        # await asyncio.gather(*[server.abort_all_requests.remote() for server in self.servers])
+        print(f"abort all requests in rollout replica {self.replica_rank}")
 
     async def resume_all_requests(self):
         """Partial rollout: resume all unfinished requests in each rollout server."""
-        await asyncio.gather(*[server.resume_all_requests.remote() for server in self.servers])
+        # TODO(wuxibin)
+        # await asyncio.gather(*[server.resume_all_requests.remote() for server in self.servers])
+        print(f"resume all requests in rollout replica {self.replica_rank}")
 
     async def clear_kv_cache(self):
         """reset kv cache in each rollout server."""

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -45,8 +45,7 @@ from verl.utils.device import get_visible_devices_keyword
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler.profile import DistProfiler
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.base import BaseRolloutServer, TokenOutput, resume_on_abort
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.sglang_rollout.sglang_rollout import ServerAdapter, _set_envs_and_config
 from verl.workers.rollout.utils import get_max_position_embeddings, run_unvicorn
 
@@ -137,7 +136,7 @@ class SGLangProfilerArgsBuilder:
         }, self.auto_stop_profiling
 
 
-class SGLangHttpServer(BaseRolloutServer):
+class SGLangHttpServer:
     """SGLang http server in single node, this is equivalent to launch server with command line:
     ```
     python -m sglang.launch_server --node-rank 0 --nnode 1 ...
@@ -164,7 +163,6 @@ class SGLangHttpServer(BaseRolloutServer):
         cuda_visible_devices: str,
         base_gpu_id: int,
     ):
-        super().__init__()
         print(f"SGLang http server: {rollout_mode=}, {replica_rank=}, {node_rank=}, {nnodes=}, {cuda_visible_devices=}")
         os.environ[visible_devices_keyword] = cuda_visible_devices
 
@@ -396,7 +394,6 @@ class SGLangHttpServer(BaseRolloutServer):
         obj = ReleaseMemoryOccupationReqInput(tags=["kv_cache"])
         await self.tokenizer_manager.release_memory_occupation(obj, None)
 
-    @resume_on_abort
     async def generate(
         self,
         prompt_ids: torch.Tensor,
@@ -448,8 +445,6 @@ class SGLangHttpServer(BaseRolloutServer):
         generate_request = GenerateReqInput(**request)
 
         output = await self.tokenizer_manager.generate_request(generate_request, None).__anext__()
-        finish_reason = output["meta_info"]["finish_reason"]
-        finish_reason = finish_reason["type"] if finish_reason else None
         if return_logprob:
             output_token_logprobs = output["meta_info"]["output_token_logprobs"]
             log_probs, token_ids = zip(
@@ -477,9 +472,7 @@ class SGLangHttpServer(BaseRolloutServer):
                     -1, hf_config.num_hidden_layers, hf_config.num_experts_per_tok
                 )
 
-        return TokenOutput(
-            token_ids=token_ids, log_probs=log_probs, routed_experts=routed_experts, stop_reason=finish_reason
-        )
+        return TokenOutput(token_ids=token_ids, log_probs=log_probs, routed_experts=routed_experts)
 
     async def start_profile(self, **kwargs):
         if (
@@ -500,17 +493,6 @@ class SGLangHttpServer(BaseRolloutServer):
             and not self._auto_stop_profiling
         ):
             await self.tokenizer_manager.stop_profile()
-
-    async def abort_all_requests(self):
-        """Abort all requests with partial rollout."""
-        self.resume_event.clear()
-
-        while True:
-            self.tokenizer_manager.abort_request(abort_all=True)
-            is_locked = await self.tokenizer_manager.model_update_lock.is_locked()
-            if not is_locked:
-                break
-            await asyncio.sleep(1.0)
 
 
 _rollout_worker_actor_cls = ray.remote(ServerAdapter)

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -42,8 +42,7 @@ from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler.profile import DistProfiler
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
-from verl.workers.rollout.base import BaseRolloutServer, TokenOutput, resume_on_abort
-from verl.workers.rollout.replica import RolloutMode, RolloutReplica
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.utils import get_max_position_embeddings, run_unvicorn
 from verl.workers.rollout.vllm_rollout import ServerAdapter
 from verl.workers.rollout.vllm_rollout.utils import (
@@ -76,7 +75,7 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
 
 
-class vLLMHttpServer(BaseRolloutServer):
+class vLLMHttpServer:
     """vLLM http server in single node, this is equivalent to launch server with command line:
     ```
     vllm serve --tensor-parallel-size=8 ...
@@ -106,7 +105,6 @@ class vLLMHttpServer(BaseRolloutServer):
             nnodes (int): number of nodes.
             cuda_visible_devices (str): cuda visible devices.
         """
-        super().__init__()
         os.environ[get_visible_devices_keyword()] = cuda_visible_devices
 
         self.config: RolloutConfig = omega_conf_to_dataclass(config)
@@ -444,7 +442,6 @@ class vLLMHttpServer(BaseRolloutServer):
         self.task = asyncio.create_task(asyncio.to_thread(run_headless_wrapper))
         self.task.add_done_callback(on_run_headless_done)
 
-    @resume_on_abort
     async def generate(
         self,
         prompt_ids: list[int],
@@ -528,9 +525,16 @@ class vLLMHttpServer(BaseRolloutServer):
             routed_experts = final_res.outputs[0].routed_experts
 
         # Determine stop reason from finish_reason
-        stop_reason = final_res.outputs[0].finish_reason
+        finish_reason = final_res.outputs[0].finish_reason
+        if finish_reason == "abort":
+            stop_reason = "aborted"
+        elif finish_reason in ("stop", "length"):
+            stop_reason = "completed"
+        else:
+            stop_reason = finish_reason  # for more stop reason in the future
 
         num_preempted = None
+
         if hasattr(final_res.outputs[0], "num_preempted"):
             num_preempted = final_res.outputs[0].num_preempted
 
@@ -603,37 +607,39 @@ class vLLMHttpServer(BaseRolloutServer):
                 - aborted_count: Number of requests aborted
                 - request_ids: List of aborted request IDs
         """
-        self.resume_event.clear()
+        try:
+            # Take an atomic snapshot to avoid race conditions with the vLLM engine thread
+            request_states_snapshot = list(self.engine.output_processor.request_states.items())
+            request_ids = [req_id for req_id, _ in request_states_snapshot]
 
-        # Take an atomic snapshot to avoid race conditions with the vLLM engine thread
-        request_states_snapshot = list(self.engine.output_processor.request_states.items())
-        request_ids = [req_id for req_id, _ in request_states_snapshot]
+            if not request_ids:
+                return {"aborted_count": 0, "request_ids": []}
 
-        if not request_ids:
-            return {"aborted_count": 0, "request_ids": []}
+            # For each request, create an abort output and put it to its queue
+            # This allows the generator to receive the aborted result
+            from vllm.v1.engine import FinishReason
 
-        # For each request, create an abort output and put it to its queue
-        # This allows the generator to receive the aborted result
-        from vllm.v1.engine import FinishReason
+            for _, req_state in request_states_snapshot:
+                request_output = req_state.make_request_output(
+                    [], pooling_output=None, finish_reason=FinishReason.ABORT, stop_reason=None
+                )
+                req_state.queue.put(request_output)
 
-        for _, req_state in request_states_snapshot:
-            request_output = req_state.make_request_output(
-                [], pooling_output=None, finish_reason=FinishReason.ABORT, stop_reason=None
-            )
-            req_state.queue.put(request_output)
+            # Abort requests in the output processor and engine core
+            self.engine.output_processor.abort_requests(request_ids)
+            await self.engine.engine_core.abort_requests_async(request_ids)
 
-        # Abort requests in the output processor and engine core
-        self.engine.output_processor.abort_requests(request_ids)
-        await self.engine.engine_core.abort_requests_async(request_ids)
-        await self.engine.wait_for_requests_to_drain()
+            # Try to reset prefix cache to ensure clean state
+            if reset_prefix_cache:
+                await self.clear_kv_cache()
+                logger.info("Prefix cache reset after abort")
 
-        # Try to reset prefix cache to ensure clean state
-        if reset_prefix_cache:
-            await self.clear_kv_cache()
-            logger.info("Prefix cache reset after abort")
+            logger.info(f"Aborted {len(request_ids)} requests: {request_ids}")
+            return {"aborted_count": len(request_ids), "request_ids": request_ids}
 
-        logger.info(f"Aborted {len(request_ids)} requests: {request_ids}")
-        return {"aborted_count": len(request_ids), "request_ids": request_ids}
+        except Exception as e:
+            logger.error(f"Error aborting requests: {e}")
+            return {"aborted_count": 0, "request_ids": [], "error": str(e)}
 
     async def abort_request(self, request_id: str, reset_prefix_cache: bool = True) -> dict[str, Any]:
         """Abort a specific generation request.


### PR DESCRIPTION
An automatic resume on generate is not a good design.
Researchers should be noticed when to resume and it can be controlled by researcher.

Also, partial rollout is an algorithm, it should not be implemented in rollout server, which is a backend module

Reverts verl-project/verl#5071