### PR TITLE
[rollout] feat: add custom sampling parameters for rollout generation

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -438,6 +438,12 @@ class AgentLoopWorker:
             sampling_params["top_p"] = config.val_kwargs.top_p
             sampling_params["top_k"] = config.val_kwargs.top_k
             sampling_params["temperature"] = config.val_kwargs.temperature
+            if config.val_kwargs.sampling_kwargs is not None:
+                sampling_params = (
+                    OmegaConf.to_container(config.val_kwargs.sampling_kwargs, resolve=True) | sampling_params
+                )
+        elif config.sampling_kwargs is not None:
+            sampling_params = OmegaConf.to_container(config.sampling_kwargs, resolve=True) | sampling_params
 
         # by default, we assume it's a single turn agent
         if "agent_name" not in batch.non_tensor_batch:

--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -19,7 +19,7 @@ from typing import Any, Optional, Sequence
 import hydra
 import numpy as np
 import ray
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from verl.experimental.agent_loop.agent_loop import (
     AgentLoopManager,
@@ -109,6 +109,12 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
         if batch.meta_info.get("validate", False):
             sampling_params["top_p"] = config.val_kwargs.top_p
             sampling_params["temperature"] = config.val_kwargs.temperature
+            if config.val_kwargs.sampling_kwargs is not None:
+                sampling_params = (
+                    OmegaConf.to_container(config.val_kwargs.sampling_kwargs, resolve=True) | sampling_params
+                )
+        elif config.sampling_kwargs is not None:
+            sampling_params = OmegaConf.to_container(config.sampling_kwargs, resolve=True) | sampling_params
 
         if "agent_name" not in batch.non_tensor_batch:
             default_agent_loop = config.agent.default_agent_loop

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -204,6 +204,7 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    sampling_kwargs: null
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -242,6 +243,7 @@ actor_rollout_ref:
       top_k: -1
       top_p: 1.0
       temperature: 0
+      sampling_kwargs: null
       'n': 1
       do_sample: false
     multi_turn:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -195,6 +195,7 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    sampling_kwargs: null
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -233,6 +234,7 @@ actor_rollout_ref:
       top_k: -1
       top_p: 1.0
       temperature: 0
+      sampling_kwargs: null
       'n': 1
       do_sample: false
     multi_turn:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -16,6 +16,9 @@ top_k: -1
 # Top-p sampling parameter. Default 1.0.
 top_p: 1
 
+# Custom sampling kwargs: Default null (no kwargs)
+sampling_kwargs: null
+
 # typically the same as data max prompt length
 # same as data.max_prompt_length if it exists
 prompt_length: ${oc.select:data.max_prompt_length,512}
@@ -143,6 +146,9 @@ val_kwargs:
 
   # Sampling temperature for rollout.
   temperature: 0
+
+  # Custom sampling kwargs: Default null (no kwargs)
+  sampling_kwargs: null
 
   # whether to repeat n times for validation
   n: 1

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 from omegaconf import MISSING
 
@@ -41,6 +41,7 @@ class SamplingConfig(BaseConfig):
     top_p: float = 1.0
     do_sample: bool = True
     n: int = 1
+    sampling_kwargs: Optional[dict[str, Any]] = None
 
 
 @dataclass
@@ -145,6 +146,7 @@ class RolloutConfig(BaseConfig):
     do_sample: bool = True
     n: int = 1
     repetition_penalty: float = 1.0
+    sampling_kwargs: Optional[dict[str, Any]] = None
 
     # Early termination threshold for multi-turn rollout in sglang.
     # Abort remaining requests when (1 - over_sample_rate) * total_requests are completed.


### PR DESCRIPTION
### What does this PR do?

Adds a `sampling_kwargs` field to `RolloutConfig` and `SamplingConfig`, allowing users to pass arbitrary sampling parameters at runtime without modifying hardcoded configurations. This enables experimental flexibility for testing custom sampling strategies.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+sampling
- [x] Format the PR title as `[rollout] feat: add custom sampling parameters for rollout generation`

### Test

This feature has been tested with the `stop` parameter to verify custom sampling kwargs are properly applied. An alternative test was also run without sampling kwargs to confirm backward compatibility - the code runs normally when `sampling_kwargs` is not specified.

Manual testing can be done by:
1. Setting `actor_rollout_ref.rollout.sampling_kwargs` in config YAML (e.g., with `stop: ["\n"]`)
2. Running a training job and verifying custom params are applied
3. Running without `sampling_kwargs` to verify backward compatibility
4. Checking validation batches use `val_kwargs.sampling_kwargs` when set

### API and Usage Example

```yaml
# In your config YAML or via CLI overrides:
actor_rollout_ref:
  rollout:
    sampling_kwargs:
      stop: ["\n"]
      frequency_penalty: 0.5
    val_kwargs:
      sampling_kwargs:
        stop: ["\n", "User:"]
```

### Design & Code Changes

**High-level design:**
- Adds optional `sampling_kwargs: Optional[dict[str, Any]]` to both `RolloutConfig` and `SamplingConfig` dataclasses
- In agent loop workers, custom kwargs are merged with default sampling params using dict merge operator (`|`)
- Uses `OmegaConf.to_container()` to properly convert OmegaConf DictConfig objects to regular dicts before merging
- Validation batches check `config.val_kwargs.sampling_kwargs` first, falling back to `config.sampling_kwargs`

**Specific changes:**
1. `verl/workers/config/rollout.py`: Add `sampling_kwargs` fields to dataclasses
2. `verl/trainer/config/rollout/rollout.yaml`: Document the new fields with comments
3. Agent loop files: Apply custom kwargs with proper OmegaConf handling
4. Generated YAML configs updated automatically by pre-commit hook

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] Apply pre-commit checks: `pre-commit run --all-files`
- [x] Add documentation (YAML comments included)
- [ ] Tests: This change is difficult to unit test without full rollout infrastructure. Manual testing described above.
- [ ] Request CI in Slack `ci-request` channel