### PR TITLE
[worker] feat: Avoid redundant base weight sync when engine doesn't sleep

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -615,7 +615,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             # main memory can trade sync time to avoid OOM
             self.rollout.sleep_level = 1
 
-            do_lora_base_sync = not self.base_sync_done or self.rollout.sleep_level != 1
+            do_lora_base_sync = (not self.base_sync_done) or (
+                self.rollout.sleep_level != 1 and self.config.rollout.free_cache_engine
+            )
 
         if do_lora_base_sync:
             per_tensor_base_params, _ = self.actor.engine.get_per_tensor_param(

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -705,6 +705,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # When sleep_level=2, base model weights are destroyed during each sleep cycle.
         # separately collect and update LoRA weights and base model weights through their respective interfaces.
         # Here: params contains LoRA weights, base_model_params contains base model weights.
+        # Only needed if the rollout engine actually sleeps/frees weights (free_cache_engine=True).
         if (
             peft_config is not None
             and getattr(self.rollout, "sleep_level", None) == 2

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -694,7 +694,9 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
             # main memory can trade sync time to avoid OOM
             self.rollout.sleep_level = 1
 
-            do_lora_base_sync = not self.base_sync_done or self.rollout.sleep_level != 1
+            do_lora_base_sync = (not self.base_sync_done) or (
+                self.rollout.sleep_level != 1 and self.config.rollout.free_cache_engine
+            )
 
         if self.bridge is not None:
             if self.vanilla_bridge:


### PR DESCRIPTION
### What does this PR do?

Fixed unnecessary base weight syncing for **LoRA sleep_level=2** when `rollout.free_cache_engine=False`

> **Impact:** up to **26% faster end-to-end** training in some cases

When `free_cache_engine=False`, the rollout engine is not actually sleeping in a way that destroys base weights, so syncing base weights is redundant work.

### Changes
- Only collect send `base_model_params` when `sleep_level==2` **and** `rollout.free_cache_engine=True`.

### Perf (Qwen3-1.7B, 20 steps, mean over steps 1-20, tested on 2 rtx3090)

| metric | baseline (ms/token) | patched (ms/token) | delta (ms/token) | delta % |
| --- | ---: | ---: | ---: | ---: |
| timing_per_token_ms/gen | 0.845 | 0.559 | -0.286 | -33.9% |
| timing_per_token_ms/update_actor | 0.251 | 0.252 | 0.001 | +0.48% |
| timing_per_token_ms/all | 1.097 | 0.811 | -0.286 | **-26.02%** |

<img width="3000" height="900" alt="image" src="https://github.com/user-attachments/assets/57b21918-fa1f-470c-b073-9767244aaee0" />

### Checklist
- [x] Fix applied
- [x] Local perf run   plot attached
- [ ] Added regression test (not included in this PR)
