### PR TITLE
[megatron] fix: checkpoints uses `fully_reshardable` by default when supported

### DIFF
--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -33,7 +33,7 @@ def apply_patch():
     )
     from packaging import version
 
-    mcore_013 = version.parse(megatron.core.__version__) >= version.parse("0.13.0rc0")
+    mcore_ge_013 = version.parse(megatron.core.__version__) >= version.parse("0.13.0")
 
     def patch_get_query_key_value_tensors(
         self,
@@ -270,7 +270,7 @@ def apply_patch():
         # Adjust key, value for inference
         # ===================================================
         # rotary_pos_emb = None
-        if mcore_013:
+        if mcore_ge_013:
             query, key, value, _, attn_mask_type, _ = self._adjust_key_value_for_inference(
                 inference_context, query, key, value, rotary_pos_emb=None
             )

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -42,6 +42,8 @@ actor_rollout_ref:
       use_dist_checkpointing: false
       dist_checkpointing_path: null
       dist_checkpointing_prefix: ''
+      dist_ckpt_optim_fully_reshardable: true
+      distrib_optim_fully_reshardable_mem_efficient: false
       seed: 42
       override_ddp_config: {}
       override_transformer_config:
@@ -186,6 +188,8 @@ actor_rollout_ref:
       use_dist_checkpointing: false
       dist_checkpointing_path: null
       dist_checkpointing_prefix: ''
+      dist_ckpt_optim_fully_reshardable: true
+      distrib_optim_fully_reshardable_mem_efficient: false
       seed: ${oc.select:actor_rollout_ref.actor.megatron.seed,42}
       override_ddp_config: {}
       override_transformer_config: ${oc.select:actor_rollout_ref.actor.megatron.override_transformer_config,{}}
@@ -452,6 +456,8 @@ critic:
     use_dist_checkpointing: false
     dist_checkpointing_path: null
     dist_checkpointing_prefix: ''
+    dist_ckpt_optim_fully_reshardable: true
+    distrib_optim_fully_reshardable_mem_efficient: false
     seed: 42
     override_ddp_config: {}
     override_transformer_config:

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -43,6 +43,13 @@ dist_checkpointing_path: null
 # distributed checkpointing prefix, e.g. Nemo2 will append prefix 'module.' to the state dict keys
 dist_checkpointing_prefix: ''
 
+# Make optimizer distributed checkpoint fully reshardable (TP/PP/EP/DP) as opposed to plain DP reshardability
+dist_ckpt_optim_fully_reshardable: True
+
+# Use as little memory as possible during save and load by using Gloo.
+# Has effect only when `dist_ckpt_optim_fully_reshardable` is enabled
+distrib_optim_fully_reshardable_mem_efficient: False
+
 # oc.select: default val for ref.megatron.seed
 seed: 42
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -97,6 +97,8 @@ class McoreEngineConfig(EngineConfig):
         use_distributed_optimizer (bool): Whether to use distributed optimizer.
         use_dist_checkpointing (bool): Whether to use distributed checkpointing.
         dist_checkpointing_path (Optional[str]): Path for distributed checkpointing.
+        dist_ckpt_optim_fully_reshardable (bool): Use fully reshardable optimizer checkpoints.
+        distrib_optim_fully_reshardable_mem_efficient (bool): Use memory-efficient fully reshardable format.
         seed (int): Random seed for reproducibility.
         override_ddp_config (dict[str, Any]): Override configuration for DDP.
         override_transformer_config (dict[str, Any]): Override configuration for transformer.
@@ -118,6 +120,8 @@ class McoreEngineConfig(EngineConfig):
     use_dist_checkpointing: bool = False
     dist_checkpointing_path: Optional[str] = None
     dist_checkpointing_prefix: str = ""
+    dist_ckpt_optim_fully_reshardable: bool = False
+    distrib_optim_fully_reshardable_mem_efficient: bool = False
     override_ddp_config: dict[str, Any] = field(default_factory=dict)
     override_transformer_config: dict[str, Any] = field(default_factory=dict)
     override_mcore_model_config: dict[str, Any] = field(default_factory=dict)

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -286,7 +286,18 @@ class MegatronEngine(BaseEngine):
         self.optimizer = self._build_optimizer()
         self.lr_scheduler = self._build_lr_scheduler()
 
-        tmp_config = OmegaConf.create({"model": {"path": self.model_config.local_path}})
+        full_reshardable = self.engine_config.dist_ckpt_optim_fully_reshardable
+        mem_eff = self.engine_config.distrib_optim_fully_reshardable_mem_efficient
+
+        tmp_config = OmegaConf.create(
+            {
+                "model": {"path": self.model_config.local_path},
+                "megatron": {
+                    "dist_ckpt_optim_fully_reshardable": full_reshardable,
+                    "distrib_optim_fully_reshardable_mem_efficient": mem_eff,
+                },
+            }
+        )
 
         role = "actor" if not self.is_value_model else "critic"
 


### PR DESCRIPTION

### What does this PR do?

Resolves #4303
Resolves https://github.com/verl-project/verl/issues/5128#issuecomment-3823328518

Refer to https://github.com/NVIDIA-NeMo/Megatron-Bridge/blob/40b1cf87d33c570aa6d000eeca3efca21be3e866/src/megatron/bridge/training/checkpointing.py#L2295-L2305

For newer APIs and fixing removed flattened_range

- https://github.com/NVIDIA/Megatron-LM/commit/2b11af0a10bbfbbd95c62b704a14a9727f229b50
- https://github.com/NVIDIA/Megatron-LM/commit/5ab481cb45efc72add12f8ba0378e849b3d2bc50

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

<sub>✨ Presented to you with <a href="https://macaron.im/mindlab">Mind Lab</a> - A Lab for Experiential Intelligence.</sub>