### PR TITLE
[megatron] feat: fused kernel suppport for new model engine

### DIFF
--- a/verl/models/mcore/__init__.py
+++ b/verl/models/mcore/__init__.py
@@ -16,6 +16,7 @@
 from .registry import (
     get_mcore_forward_fn,
     get_mcore_forward_fused_fn,
+    get_mcore_forward_fused_no_padding_fn,
     get_mcore_forward_no_padding_fn,
     get_mcore_weight_converter,
     hf_to_mcore_config,
@@ -28,5 +29,6 @@ __all__ = [
     "get_mcore_forward_fn",
     "get_mcore_weight_converter",
     "get_mcore_forward_fused_fn",
+    "get_mcore_forward_fused_no_padding_fn",
     "get_mcore_forward_no_padding_fn",
 ]

--- a/verl/models/mcore/registry.py
+++ b/verl/models/mcore/registry.py
@@ -23,7 +23,7 @@ import torch
 import torch.nn as nn
 
 from .model_forward import gptmodel_forward_no_padding, model_forward_gen
-from .model_forward_fused import fused_forward_model_gen
+from .model_forward_fused import fused_forward_model_gen, fused_forward_no_padding_gen
 
 
 class SupportedVLM(Enum):
@@ -65,6 +65,18 @@ def get_mcore_forward_fused_fn(hf_config) -> Callable:
     else:
         # default to language model
         return fused_forward_model_gen(False)
+
+
+def get_mcore_forward_fused_no_padding_fn(hf_config) -> Callable:
+    """
+    Get the fused forward function for no-padding inputs.
+    """
+    assert len(hf_config.architectures) == 1, "Only one architecture is supported for now"
+    if hf_config.architectures[0] in supported_vlm:
+        return fused_forward_no_padding_gen(True)
+    else:
+        # default to language model
+        return fused_forward_no_padding_gen(False)
 
 
 # ruff: noqa

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -41,12 +41,7 @@ from verl.utils.profiler import DistProfiler, DistProfilerExtension, ProfilerCon
 from verl.utils.py_functional import append_to_dict
 from verl.utils.tensordict_utils import maybe_fix_3d_position_ids
 from verl.utils.torch_functional import allgather_dict_into_dict
-from verl.workers.config import (
-    ActorConfig,
-    HFModelConfig,
-    RolloutConfig,
-    TrainingWorkerConfig,
-)
+from verl.workers.config import ActorConfig, HFModelConfig, RolloutConfig, TrainingWorkerConfig
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
 from verl.workers.utils.losses import ppo_loss
 
@@ -88,7 +83,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
             )
 
         # we use the one defined in model
+        # TODO: this is not elegant and should refactor later
         self.engine_config.use_remove_padding = self.model_config.use_remove_padding
+        self.engine_config.use_fused_kernels = self.model_config.use_fused_kernels
 
         if repatch is not None:
             # NPU MindSpeed patch, will be refactored with MindSpeedEngine.


### PR DESCRIPTION
### What does this PR do?

Add `fused_forward_no_padding` method so that model engine can also support fused kernels.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Tested on 8*A800 GPUs with triton version 3.5.1 using DAPO-Math-17k dataset with DAPO and using Moonlight-16B-A3B, the training curves are closely matched by either disabling or enabling fused kernels, and even enabling fused kernels has better rollout training mismatch level.

<img width="1066" height="570" alt="image" src="https://github.com/user-attachments/assets/a9258800-83a6-417b-ad34-a138fc02114c" />
<img width="3178" height="1152" alt="image" src="https://github.com/user-attachments/assets/fa64375d-6271-4ca4-82da-27a5c4c0730b" />
<img width="3164" height="1138" alt="image" src="https://github.com/user-attachments/assets/9c28c015-7aa3-4065-a18a-54677ff4fef5" />
<img width="1082" height="1154" alt="image" src="https://github.com/user-attachments/assets/c1107247-f359-4e9a-a38c-d7574aecc3f6" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
