### PR TITLE
[trtllm] fix: reduce peak mem usage during update_weight()

### DIFF
--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -198,7 +198,7 @@ def gptmodel_forward_no_padding(
             }
             model_kwargs["labels"] = args["label"].contiguous()
             model_kwargs["loss_mask"] = args["loss_mask"].contiguous()
-        if logits_processor_args and 'loss_mask' in logits_processor_args:
+        if logits_processor_args and "loss_mask" in logits_processor_args:
             logits_processor_args.pop("loss_mask")
 
         # For VLM model, need to pass bshd format `input_ids` and `attention_mask`.
@@ -252,7 +252,7 @@ def gptmodel_forward_no_padding(
             }
             model_kwargs["labels"] = args["label"].contiguous()
             model_kwargs["loss_mask"] = args["loss_mask"].contiguous()
-        if logits_processor_args and 'loss_mask' in logits_processor_args:
+        if logits_processor_args and "loss_mask" in logits_processor_args:
             logits_processor_args.pop("loss_mask")
 
         output_orig = model(


### PR DESCRIPTION
### What does this PR do?

Clear cache right after update_weight() in the trainer process to avoid OOM due to peak memory usage during weight update. 

### Notes
For a Qwen2-7B TP4 single node, it saves around ~7GB. 

Below are with and without this MR + https://github.com/verl-project/verl/pull/5208

1. DAPO / TP4 / single node / Qwen2.5-Math-7B /  aime-2024 

<img width="407" height="319" alt="image" src="https://github.com/user-attachments/assets/638ff7a0-7593-47b6-b29d-32570b86f03a" />

<img width="796" height="319" alt="image" src="https://github.com/user-attachments/assets/10dec224-0086-4503-b9e3-a36b4637b4f6" />

https://wandb.ai/nvidia/verify-MR-5208-mem-fixes?nw=nwusererinh

2. GRPO / TP4 & TP1 / Qwen2-7B / gsm8k, math

<img width="967" height="542" alt="image" src="https://github.com/user-attachments/assets/dd74ede5-8dde-4a85-8f5c-57c46f8e75a1" />
<img width="427" height="641" alt="image" src="https://github.com/user-attachments/assets/db67d07f-4b0c-4b61-9b10-5d920590261d" />

<img width="969" height="547" alt="image" src="https://github.com/user-attachments/assets/5f1e2157-5dc9-4378-95a0-2b0eecb7a85b" />

https://wandb.ai/nvidia/kl-loss-check?nw=nwusererinh

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
