### PR TITLE
[sglang_rollout] feat: enable dynamic LoRA refresh for SGLang rollout

### DIFF
--- a/tests/workers/rollout/rollout_sglang/test_http_server_engine.py
+++ b/tests/workers/rollout/rollout_sglang/test_http_server_engine.py
@@ -366,6 +366,7 @@ class TestHttpServerEngineAdapter:
             mock_post.assert_called_with(
                 "http://localhost:8000/test_endpoint",
                 json={"param": "value"},
+                headers={"Content-Type": "application/json; charset=utf-8"},
                 timeout=adapter.timeout,
             )
 
@@ -382,7 +383,11 @@ class TestHttpServerEngineAdapter:
             result = adapter._make_request("test_endpoint", method="GET")
 
             assert result == {"data": "test"}
-            mock_get.assert_called_with("http://localhost:8000/test_endpoint", timeout=adapter.timeout)
+            mock_get.assert_called_with(
+                "http://localhost:8000/test_endpoint",
+                headers={"Content-Type": "application/json; charset=utf-8"},
+                timeout=adapter.timeout,
+            )
 
     def test_make_request_non_master(self, mock_launch_server_process):
         """Test request from non-master node returns empty dict."""
@@ -757,7 +762,10 @@ class TestAsyncHttpServerEngineAdapter:
 
             # Verify post was called
             mock_session.post.assert_called_once_with(
-                "http://localhost:8000/test_endpoint", json={"param": "value"}, timeout=adapter.timeout
+                "http://localhost:8000/test_endpoint",
+                json={"param": "value"},
+                timeout=adapter.timeout,
+                headers={"Content-Type": "application/json; charset=utf-8"},
             )
 
     @pytest.mark.asyncio
@@ -787,7 +795,11 @@ class TestAsyncHttpServerEngineAdapter:
 
             # Validate
             assert result == {"data": "test"}
-            mock_session.get.assert_called_once_with("http://localhost:8000/test_endpoint", timeout=adapter.timeout)
+            mock_session.get.assert_called_once_with(
+                "http://localhost:8000/test_endpoint",
+                timeout=adapter.timeout,
+                headers={"Content-Type": "application/json; charset=utf-8"},
+            )
 
     @pytest.mark.asyncio
     async def test_make_async_request_non_master(self, mock_launch_server_process):

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -687,6 +687,11 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         peft_model = getattr(self.actor_module_fsdp, "_fsdp_wrapped_module", self.actor_module_fsdp)
         if hasattr(peft_model, "peft_config"):  # LoRA
             peft_config = peft_model.peft_config.get("default", None)
+            # SGLang servers load base weights from `model_path` at launch. When using LoRA training,
+            # the base model weights are typically frozen, so we don't need to sync base weights via
+            # the rollout weight-update path. Mark base as "synced" to only collect LoRA params.
+            if self.config.rollout.get("name", None) == "sglang" and not self.base_sync_done:
+                self.base_sync_done = True
             params = collect_lora_params(
                 module=self.actor_module_fsdp,
                 layered_summon=self.config.rollout.get("layered_summon", False),

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -358,6 +358,10 @@ class SGLangHttpServer:
             # video_data=video_data,
         }
 
+        engine_kwargs = (self.config.get("engine_kwargs", {}) or {}).get("sglang", {}) or {}
+        if engine_kwargs.get("enable_lora", False):
+            request["lora_path"] = f"verl_policy_{self.replica_rank}_{self.node_rank}"
+
         if self.config.enable_rollout_routing_replay:
             request.update({"return_routed_experts": True})
 

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -15,10 +15,13 @@
 # limitations under the License.
 from __future__ import annotations
 
+import dataclasses
+import json
 import logging
 import multiprocessing as mp
 import os
-from typing import Generator
+from pathlib import Path
+from typing import AsyncIterator, Generator
 
 import ray
 import sglang.srt.entrypoints.engine
@@ -38,6 +41,7 @@ from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
 from verl.workers.rollout.sglang_rollout.http_server_engine import AsyncHttpServerAdapter
 from verl.workers.rollout.sglang_rollout.utils import get_named_tensor_buckets
+from verl.workers.rollout.utils import ensure_async_iterator
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -152,11 +156,19 @@ class ServerAdapter(BaseRollout):
             f"server address: {server_address}, port: {server_port}"
         )
         host = f"[{server_address}]" if is_valid_ipv6_address(server_address) else server_address
+        engine_kwargs = (self.config.get("engine_kwargs", {}) or {}).get("sglang", {}) or {}
+        adapter_kwargs = {}
+        server_args_fields = {f.name for f in dataclasses.fields(ServerArgs)}
+        if "api_key" in server_args_fields:
+            adapter_kwargs["api_key"] = engine_kwargs.get("api_key", None)
+        if "admin_api_key" in server_args_fields:
+            adapter_kwargs["admin_api_key"] = engine_kwargs.get("admin_api_key", None)
         self._engine = AsyncHttpServerAdapter(
             model_path=self.model_config.local_path,
             host=host,
             port=server_port,
             launch_server=False,
+            **adapter_kwargs,
             trust_remote_code=self.model_config.trust_remote_code,
         )
 
@@ -201,16 +213,112 @@ class ServerAdapter(BaseRollout):
                 self.model_config.hf_config.quantization_config,
                 dtype=self.model_config.hf_config.dtype,
             )
+            for params_batch in get_named_tensor_buckets(weights, update_weights_bucket_bytes):
+                await sgl_update_weights(
+                    engine=self._engine,
+                    params_batch=params_batch,
+                    device_mesh_key="infer_tp",
+                    device_mesh=self.device_mesh,
+                )
         else:
-            weights = weights
+            engine_kwargs = (self.config.get("engine_kwargs", {}) or {}).get("sglang", {}) or {}
+            enable_lora = bool(engine_kwargs.get("enable_lora", False))
+            if not enable_lora:
+                async for params_batch in get_named_tensor_buckets(weights, update_weights_bucket_bytes):
+                    await sgl_update_weights(
+                        engine=self._engine,
+                        params_batch=params_batch,
+                        device_mesh_key="infer_tp",
+                        device_mesh=self.device_mesh,
+                    )
+            else:
+                lora_items: list[tuple[str, torch.Tensor]] = []
 
-        async for params_batch in get_named_tensor_buckets(weights, update_weights_bucket_bytes):
-            await sgl_update_weights(
-                engine=self._engine,
-                params_batch=params_batch,
-                device_mesh_key="infer_tp",
-                device_mesh=self.device_mesh,
-            )
+                async def _base_weight_iter() -> AsyncIterator[tuple[str, torch.Tensor]]:
+                    async for name, t in ensure_async_iterator(weights):
+                        if "lora_" in name:
+                            lora_items.append((name, t))
+                        else:
+                            yield name, t
+
+                async for params_batch in get_named_tensor_buckets(_base_weight_iter(), update_weights_bucket_bytes):
+                    await sgl_update_weights(
+                        engine=self._engine,
+                        params_batch=params_batch,
+                        device_mesh_key="infer_tp",
+                        device_mesh=self.device_mesh,
+                    )
+
+                if lora_items:
+                    lora_name = f"verl_policy_{self.replica_rank}_{self.node_rank}"
+                    adapter_dir = Path(f"/dev/shm/verl_sglang_lora_{self.replica_rank}_{self.node_rank}")
+                    adapter_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+                    try:
+                        adapter_dir.chmod(0o700)
+                    except OSError as e:
+                        logger.warning(f"Failed to chmod LoRA adapter dir '{adapter_dir}' to 0700: {e}")
+
+                    # Build a PEFT-compatible adapter config for SGLang.
+                    # Note: SGLang needs explicit module names to infer LoRA hidden dims.
+                    target_modules_val = engine_kwargs.get("lora_target_modules", None)
+                    target_modules = None
+                    if target_modules_val:
+                        if isinstance(target_modules_val, str):
+                            try:
+                                target_modules = json.loads(target_modules_val)
+                            except Exception:
+                                s = target_modules_val.strip()
+                                if s.startswith("[") and s.endswith("]"):
+                                    items = [p.strip().strip("\"'") for p in s[1:-1].split(",")]
+                                    items = [p for p in items if p]
+                                    target_modules = items
+                        else:
+                            try:
+                                target_modules = list(target_modules_val)
+                            except Exception:
+                                target_modules = None
+                    if not (
+                        isinstance(target_modules, list)
+                        and target_modules
+                        and all(isinstance(x, str) for x in target_modules)
+                    ):
+                        target_modules = [
+                            "q_proj",
+                            "k_proj",
+                            "v_proj",
+                            "o_proj",
+                            "gate_proj",
+                            "up_proj",
+                            "down_proj",
+                        ]
+                    from peft import LoraConfig, TaskType  # type: ignore
+
+                    peft_cfg = LoraConfig(
+                        r=int(self.model_config.lora_rank),
+                        lora_alpha=int(self.model_config.lora_alpha),
+                        target_modules=target_modules,
+                        bias="none",
+                        task_type=TaskType.CAUSAL_LM,
+                        inference_mode=True,
+                    ).to_dict()
+                    peft_cfg["task_type"] = peft_cfg["task_type"].value if peft_cfg.get("task_type") else None
+                    peft_cfg["peft_type"] = peft_cfg["peft_type"].value if peft_cfg.get("peft_type") else None
+                    peft_cfg["target_modules"] = list(peft_cfg.get("target_modules") or target_modules)
+                    (adapter_dir / "adapter_config.json").write_text(json.dumps(peft_cfg), encoding="utf-8")
+
+                    from safetensors.torch import save_file  # type: ignore
+
+                    lora_state = {k: v.detach().cpu() for k, v in lora_items}
+                    tmp_path = adapter_dir / "adapter_model.safetensors.tmp"
+                    out_path = adapter_dir / "adapter_model.safetensors"
+                    save_file(lora_state, str(tmp_path))
+                    os.replace(tmp_path, out_path)
+
+                    try:
+                        await self._engine.unload_lora_adapter(lora_name)
+                    except Exception as e:
+                        logger.warning(f"Failed to unload LoRA adapter '{lora_name}', proceeding with load: {e}")
+                    await self._engine.load_lora_adapter(lora_name=lora_name, lora_path=str(adapter_dir), pinned=False)
 
         if self.device_mesh["infer_tp"].get_local_rank() == 0:
             await self._engine.flush_cache()


### PR DESCRIPTION
## Summary

This PR makes **SGLang rollout compatible with LoRA training** in VERL by refreshing LoRA adapters dynamically (unload + load) on each `update_weights()` call, without restarting the SGLang server.

In practice, this unblocks RL/RLHF training with **Qwen-family models + LoRA + SGLang** (when using an SGLang version that supports Qwen LoRA initialization; see “Notes / Requirements” below).

## Problem

With SGLang as the rollout backend and LoRA enabled, the rollout server cannot be kept in sync with training reliably:

- **SGLang applies LoRA only when a request specifies `lora_path`**. VERL’s SGLang generate path did not pass `lora_path`, so rollouts could silently run without the currently-trained adapter.
- **SGLang keeps LoRA weights in a separate adapter pool**, so the generic tensor-based weight sync path (`update_weights_from_tensor`) cannot update LoRA weights by parameter names like `*.lora_A.weight`.
- In some configurations, weight updates could also crash because the worker attempted to treat base weights as “not synced” and materialized tensors on CPU, while SGLang’s weight-update path expects GPU tensors.

## What changed

- **SGLang HTTP client**: add sync + async wrappers for SGLang’s `/load_lora_adapter` and `/unload_lora_adapter` endpoints.
- **Rollout request**: when LoRA is enabled, include `lora_path` in each generate request so the currently-loaded adapter is actually applied.
- **Dynamic refresh on `update_weights()`**:
  - Split incoming weights into “base” vs “LoRA” items.
  - Save LoRA tensors to a PEFT-style adapter directory (written atomically, using `safetensors`).
  - Call `unload_lora_adapter()` then `load_lora_adapter()` for a fixed adapter name derived from replica/node rank.
- **Stability**:
  - Treat base weights as preloaded by the SGLang server for LoRA training (so we don’t try to sync base weights through the rollout update path).
  - Treat HTTP 400 from `unload_lora_adapter` as a benign “not loaded” case during refresh.

## Notes / Requirements

- This implementation intentionally uses **file-based** adapter refresh (`load_lora_adapter` / `unload_lora_adapter`) and does **not** switch to the in-memory tensor endpoint.
- This assumes the SGLang server loads base model weights from `model_path` at startup and (as is typical for LoRA training) base weights are not updated during training; only LoRA parameters are refreshed.
- For Qwen-family models, LoRA init requires an SGLang version where `get_hidden_dim()` can handle common HF module names like `q_proj` in the fallback path. If you run into `NotImplementedError: get_hidden_dim not implemented for q_proj`, please use an SGLang build that includes the corresponding fix (or any newer release that contains it).

## How to reproduce

The easiest repro in this repo is:

```bash
DATA_DIR="$HOME/data/gsm8k"
MODEL="Qwen/Qwen3-0.6B"
LORA_TARGETS='[q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj]'

RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1 \
PYTHONUNBUFFERED=1 \
python3 -m verl.trainer.main_ppo \
  algorithm.adv_estimator=grpo_vectorized \
  data.train_files="${DATA_DIR}/train.parquet" \
  data.val_files="${DATA_DIR}/test.parquet" \
  data.train_batch_size=16 \
  data.max_prompt_length=512 \
  data.max_response_length=256 \
  actor_rollout_ref.model.path="${MODEL}" \
  actor_rollout_ref.model.lora_rank=32 \
  actor_rollout_ref.model.lora_alpha=32 \
  actor_rollout_ref.model.target_modules=all-linear \
  actor_rollout_ref.actor.ppo_mini_batch_size=16 \
  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.rollout.name=sglang \
  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
  actor_rollout_ref.rollout.gpu_memory_utilization=0.60 \
  actor_rollout_ref.rollout.load_format=safetensors \
  actor_rollout_ref.rollout.n=4 \
  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
  +actor_rollout_ref.rollout.engine_kwargs.sglang.enable_lora=True \
  +actor_rollout_ref.rollout.engine_kwargs.sglang.max_lora_rank=32 \
  +actor_rollout_ref.rollout.engine_kwargs.sglang.lora_target_modules="${LORA_TARGETS}" \
  trainer.logger=console \
  trainer.val_before_train=False \
  trainer.n_gpus_per_node=1 \
  trainer.nnodes=1 \
  trainer.total_training_steps=1
```

This runs a short baseline vs patched comparison (20 steps) and validates that training no longer crashes when SGLang+LoRA is enabled and that rollouts apply the refreshed adapter.
