### PR TITLE
[model,cfg] fix: type annotation for Lora target_modules

### DIFF
--- a/tests/workers/config/test_model_config_on_cpu.py
+++ b/tests/workers/config/test_model_config_on_cpu.py
@@ -52,6 +52,21 @@ class TestHFModelConfigCPU:
         # Verify the list was merged correctly
         assert list(merged.target_modules) == ["k_proj", "o_proj", "q_proj", "v_proj"]
 
+    def test_target_modules_accepts_none_via_omegaconf(self):
+        """Test that target_modules still accepts None values."""
+
+        cfg_from_dataclass = OmegaConf.structured(HFModelConfig)
+
+        cli_config = OmegaConf.create(
+            {
+                "path": self.model_path,
+                "target_modules": None,
+            }
+        )
+
+        merged = OmegaConf.merge(cfg_from_dataclass, cli_config)
+        assert merged.target_modules is None
+
     def test_target_modules_accepts_string_via_omegaconf(self):
         """Test that target_modules still accepts string values."""
 
@@ -77,5 +92,5 @@ class TestHFModelConfigCPU:
             }
         )
         merged_config = OmegaConf.merge(base_config, invalid_cli_config)
-        with pytest.raises(TypeError):  # Or AssertionError with current implementation
+        with pytest.raises(TypeError):
             OmegaConf.to_object(merged_config)

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -204,15 +204,19 @@ class HFModelConfig(BaseConfig):
         if getattr(self.hf_config, "model_type", None) == "kimi_vl":
             self.hf_config.text_config.topk_method = "greedy"
 
-        # Ensure target_modules is a str or list[str]
-        if self.target_modules is None:
-            self.target_modules = "all-linear"
-        if not isinstance(self.target_modules, (str, list)):
-            raise TypeError(f"target_modules must be a string or a list of strings, but got {type(self.target_modules).__name__}")
-        if isinstance(self.target_modules, list):
-            for x in self.target_modules:
-                if not isinstance(x, str):
-                    raise TypeError(f"All elements in target_modules list must be strings, but found {type(x).__name__}")
+        # Ensure target_modules is a str or list[str] (only if not None)
+        if self.target_modules is not None:
+            if not isinstance(self.target_modules, (str | list)):
+                raise TypeError(
+                    "target_modules must be a string or a list of strings, "
+                    f"but got {type(self.target_modules).__name__}"
+                )
+            if isinstance(self.target_modules, list):
+                for x in self.target_modules:
+                    if not isinstance(x, str):
+                        raise TypeError(
+                            f"All elements in target_modules list must be strings, but found {type(x).__name__}"
+                        )
 
     def get_processor(self):
         return self.processor if self.processor is not None else self.tokenizer


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/verl-project/verl/issues/5222

[PeftConfig](https://huggingface.co/docs/peft/en/package_reference/lora#peft.LoraConfig.target_modules) from PEFT supports passing a list of strings as `target_modules`.

However, target_modules is annotated as `Optional[str]` in `verl/workers/config/model.py` which leads to runtime errors when trying to override its default `"all-linear"` value with e.g. a list encoded as JSON string e.g. `["q_proj","v_proj"]`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [c] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Added unit test that caught the error (allows replication if you switch the type back to `Optional[str]`)

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```bash
# Users should now be able to pass
python -m verl.trainer.main_ppo \
    actor_rollout_ref.model.target_modules='["k_proj","o_proj"]'
```

### Design & Code Changes

I tried setting the type to `Optional[str | list[str]]` but was getting an OmegaConf error because it doesn't support unions in structured configs: https://github.com/omry/omegaconf/issues/144

Instead I opted for `Any` and added type checks in `__post_init__`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
