### PR TITLE
[rollout,vllm] Fix DP args and local_rank for Ray NOSET_VISIBLE_DEVICES

### DIFF
--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -178,31 +178,39 @@ class vLLMColocateWorkerExtension:
             from verl.utils.ray_utils import ray_noset_visible_devices
 
             if ray_noset_visible_devices():
-                vllm_config = kwargs.get("vllm_config") or (args[0] if len(args) > 0 else None)
+                # NOTE: vLLM passes different worker init args across versions/executors.
+                # Try to extract `parallel_config` + `rank` from kwargs first, then fall back to
+                # common positional layouts.
+                parallel_config = kwargs.get("parallel_config")
+                if parallel_config is None:
+                    vllm_config = kwargs.get("vllm_config")
+                    if vllm_config is not None:
+                        parallel_config = getattr(vllm_config, "parallel_config", None)
+                if parallel_config is None and len(args) > 1:
+                    parallel_config = args[1]
+                if parallel_config is None and len(args) > 0:
+                    parallel_config = getattr(args[0], "parallel_config", None)
+
                 rank = kwargs.get("rank")
-                if rank is None and len(args) > 2 and isinstance(args[2], int):
-                    rank = args[2]
-                if rank is not None:
+                if rank is None:
+                    for idx in (3, 2):
+                        if len(args) > idx and isinstance(args[idx], int):
+                            rank = args[idx]
+                            break
+
+                if parallel_config is not None and rank is not None:
                     rank = int(rank)
-
-                parallel_config = getattr(vllm_config, "parallel_config", None) if vllm_config is not None else None
-                dp_size = getattr(parallel_config, "data_parallel_size", 1) if parallel_config is not None else 1
-
-                if rank is not None and int(dp_size or 1) > 1:
-                    tp = getattr(parallel_config, "tensor_parallel_size", 1) if parallel_config is not None else 1
-                    pp = getattr(parallel_config, "pipeline_parallel_size", 1) if parallel_config is not None else 1
-                    tp_pp = int(tp or 1) * int(pp or 1)
-                    if tp_pp > 0:
-                        corrected_local_rank = rank % tp_pp
-
-                        if "local_rank" in kwargs:
-                            kwargs["local_rank"] = corrected_local_rank
-                        elif len(args) > 1 and isinstance(args[1], int):
-                            args = list(args)
-                            args[1] = corrected_local_rank
-                            args = tuple(args)
-
-                        os.environ["LOCAL_RANK"] = str(corrected_local_rank)
+                    dp_size = getattr(parallel_config, "data_parallel_size", 1)
+                    if int(dp_size or 1) > 1:
+                        tp = getattr(parallel_config, "tensor_parallel_size", 1)
+                        pp = getattr(parallel_config, "pipeline_parallel_size", 1)
+                        tp_pp = int(tp or 1) * int(pp or 1)
+                        if tp_pp > 0:
+                            corrected_local_rank = rank % tp_pp
+                            # vLLM worker reads LOCAL_RANK during initialization.
+                            os.environ["LOCAL_RANK"] = str(corrected_local_rank)
+                            if "local_rank" in kwargs:
+                                kwargs["local_rank"] = corrected_local_rank
         except Exception as e:
             logger.debug("Skip vLLM local_rank adjustment: %s", e)
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -308,15 +308,15 @@ class vLLMHttpServer:
             }
             args["speculative_config"] = speculative_config
 
-        if self.config.expert_parallel_size > 1:
+        if self.config.data_parallel_size > 1 or self.config.expert_parallel_size > 1:
             assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
                 "gpus_per_node should be divisible by tensor_model_parallel_size"
             )
             data_parallel_size_local = self.gpus_per_node // self.config.tensor_model_parallel_size
             assert len(self.workers) == data_parallel_size_local * self.config.tensor_model_parallel_size, (
                 f"num workers ({len(self.workers)}) should be equal to dp_size_local "
+                f"({data_parallel_size_local}) * tp_size ({self.config.tensor_model_parallel_size})"
             )
-            f"({data_parallel_size_local}) * tp_size ({self.config.tensor_model_parallel_size})"
 
             args.update(
                 {

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -41,7 +41,7 @@ from torch.multiprocessing.reductions import reduce_tensor
 
 from verl import DataProto
 from verl.third_party.vllm import VLLM_SLEEP_LEVEL, get_version
-from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_support_ipc
+from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_npu_available, is_support_ipc
 from verl.utils.torch_dtypes import PrecisionType
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
@@ -78,6 +78,27 @@ class ServerAdapter(BaseRollout):
         self.server_handle: ray.actor.ActorHandle = None
 
         rank = int(os.environ["RANK"])
+
+        # When Ray is launched with `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1`, it will not
+        # set `CUDA_VISIBLE_DEVICES` per actor. In DP setups, vLLM expects `LOCAL_RANK` to be the
+        # local rank within TP×PP (and DP will adjust it internally). If we use Ray's accelerator
+        # IDs directly, it can become out-of-range after DP adjustment.
+        from verl.utils.ray_utils import ray_noset_visible_devices
+
+        if ray_noset_visible_devices():
+            if self.config.data_parallel_size > 1:
+                tp_pp = self.config.tensor_model_parallel_size * self.config.pipeline_model_parallel_size
+                assert tp_pp > 0, (
+                    "Expected tensor_model_parallel_size * pipeline_model_parallel_size > 0, "
+                    f"got tp={self.config.tensor_model_parallel_size}, pp={self.config.pipeline_model_parallel_size}"
+                )
+                local_rank = rank % tp_pp
+            else:
+                device_name = "NPU" if is_npu_available else "GPU"
+                local_rank = int(ray.get_runtime_context().get_accelerator_ids()[device_name][0])
+            os.environ["LOCAL_RANK"] = str(local_rank)
+            get_torch_device().set_device(int(local_rank))
+
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])
         rollout_world_size = (
             self.config.tensor_model_parallel_size


### PR DESCRIPTION
## Summary
- Fix A: ensure vLLM receives DP CLI args when `data_parallel_size > 1` (not only when EP is enabled).
- Fix B: when running under Ray with `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` and `data_parallel_size > 1`,
  compute the correct vLLM-local `LOCAL_RANK` (local rank within TP×PP) to avoid `DP adjusted local rank ... out of bounds`
  and incorrect GPU binding.
- This is a refinement of the comments from PR #5152

## Context / Motivation
In DP configs (typically `dp=2,tp=1,pp=1,nnodes=1`):
- vLLM could start without DP settings if the condition was tied only to EP.
- Under Ray NOSET, using `ray.get_runtime_context().get_accelerator_ids()` to derive local rank can produce a rank that becomes
  out-of-bounds after vLLM DP adjustment.

## Checklist
- [x] Bug fixed
- [x] Repro / test plan included
- [ ] Regression test (real Ray+vLLM e2e)