### PR TITLE
fix: little Ascend NPU implementation bug fix

### DIFF
--- a/docs/ascend_tutorial/ascend_quick_start.rst
+++ b/docs/ascend_tutorial/ascend_quick_start.rst
@@ -196,6 +196,7 @@ verl 中昇腾暂不支持生态库如下：
             data.filter_overlong_prompts=True \
             data.truncation='error' \
             actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
+            +actor_rollout_ref.model.override_config.attn_implementation=sdpa \
             actor_rollout_ref.actor.optim.lr=5e-7 \
             actor_rollout_ref.model.use_remove_padding=False \
             actor_rollout_ref.actor.entropy_coeff=0.001 \

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -183,7 +183,6 @@ def get_device_capability(device_id: int = 0) -> tuple[int | None, int | None]:
 
     return major, minor
 
-
 def get_npu_versions() -> tuple[str, str]:
     """Get the software version and CANN toolkit version for NPU devices.
 
@@ -194,12 +193,12 @@ def get_npu_versions() -> tuple[str, str]:
         RuntimeError: If unable to retrieve version information
     """
     # Check npu-smi software version
-    result = subprocess.run(["npu-smi", "info", "-t", "board", "-i", "1"], capture_output=True, text=True, check=True)
+    result = subprocess.run(["npu-smi", "info"], capture_output=True, text=True, check=True)
 
     # Parse software version from output
     software_version = None
     for line in result.stdout.split("\n"):
-        if "Software Version" in line:
+        if "Version" in line:
             # Extract version from line like: "Software Version : 25.3.rc1.2"
             parts = line.split(":")
             if len(parts) > 1:


### PR DESCRIPTION
### What does this PR do?

> This PR fixes a device-check bug `verl/utils/device.py` that frequently occurs when running VeRL on Ascend NPUs in cloud server container , as well as an error in the launch command in `docs/ascend_tutorial/ascend_quick_start`.


