### PR TITLE
[fsdp, veomni, trainer] fix: restrict npu-patch scope to avoid veomni backend interference

### DIFF
--- a/verl/__init__.py
+++ b/verl/__init__.py
@@ -71,7 +71,6 @@ if is_npu_available:
     except AttributeError:
         pass
 
-
     # In verl, the driver process aggregates the computation results of workers via Ray.
     # Therefore, after a worker completes its computation job, it will package the output
     # using tensordict and transfer it to the CPU. Since the `to` operation of tensordict

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -108,17 +108,12 @@ class FSDPEngine(BaseEngine):
         self.mode = None
 
         self.rank = torch.distributed.get_rank()
-        
+
         # Apply NPU patches for FSDP backend
-        from verl.utils.device import is_npu_available
-        if is_npu_available:
-            try:
-                import verl.models.transformers.npu_patch  # noqa
-                if self.rank == 0:
-                    logger.info("Applied NPU patches for FSDP backend")
-            except Exception as e:
-                logger.warning(f"Failed to apply NPU patches: {e}")
-        
+        from .utils import apply_npu_fsdp_patches
+
+        apply_npu_fsdp_patches()
+
         # build device mesh for Ulysses Sequence Parallel
 
         self.use_remove_padding = self.model_config.use_remove_padding

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -157,16 +157,11 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 timeout=datetime.timedelta(seconds=self.config.get("nccl_timeout", 600)),
                 init_method=os.environ.get("DIST_INIT_METHOD", None),
             )
-        
+
         # Apply NPU patches for FSDP backend
-        from verl.utils.device import is_npu_available
-        if is_npu_available:
-            try:
-                import verl.models.transformers.npu_patch  # noqa
-                if torch.distributed.get_rank() == 0:
-                    logger.info("Applied NPU patches for FSDP backend")
-            except Exception as e:
-                logger.warning(f"Failed to apply NPU patches: {e}")
+        from verl.workers.engine.fsdp.utils import apply_npu_fsdp_patches
+
+        apply_npu_fsdp_patches()
 
         # build device mesh for FSDP
         world_size = torch.distributed.get_world_size()


### PR DESCRIPTION
### What does this PR do?

as title.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
