### PR TITLE
[rollout] fix: prompt2text decoding for `SingleTurnAgentLoop`

### DIFF
--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
 from verl.tools.utils.tool_registry import initialize_tools_from_config
 from verl.utils.profiler import simple_timer
+from verl.utils.rollout_trace import rollout_trace_op
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -36,7 +37,8 @@ class SingleTurnAgentLoop(AgentLoopBase):
         tool_config_path = self.config.data.tool_config_path
         tool_list = initialize_tools_from_config(tool_config_path) if tool_config_path else []
         self.tool_schemas = [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True) for tool in tool_list]
-
+    
+    @rollout_trace_op
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
 


### PR DESCRIPTION
Fixes #5276

## What does this PR do?

Fixes prompt IDs not being decoded for `SingleTurnAgentLoop`. Issue was the single agent loop lacked the `rollout_trace_op` decorator.

# Patch: Add Weave Tracing to SingleTurnAgentLoop

## Summary

Add `@rollout_trace_op` decorator to `SingleTurnAgentLoop.run()` to enable Weave tracing with `token2text` support.

## Problem

When using `SingleTurnAgentLoop` (the default agent), Weave traces only show `AsyncLLMServerManager.generate` calls. The `token2text=True` option doesn't add `prompt_text` and `response_text` fields to the trace output.

<img width="2299" height="1332" alt="Screenshot 2026-02-10 142923" src="https://github.com/user-attachments/assets/fb8c8285-e6f5-41f7-a38d-d7d8a44e6f5a" />

This happens because `SingleTurnAgentLoop.run()` lacks the `@rollout_trace_op` decorator that `ToolAgentLoop.run()` has.

| Component | Has `@rollout_trace_op`? |
|-----------|-------------------------|
| `ToolAgentLoop.run` | Yes |
| `SingleTurnAgentLoop.run` | **No** (missing) |
| `AsyncLLMServerManager.generate` | Yes |

## Solution

Add the `@rollout_trace_op` decorator to `SingleTurnAgentLoop.run()`.

### File Changed

`verl/experimental/agent_loop/single_turn_agent_loop.py`

### Diff

```diff
 from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput, register
 from verl.tools.utils.tool_registry import initialize_tools_from_config
 from verl.utils.profiler import simple_timer
+from verl.utils.rollout_trace import rollout_trace_op

 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -40,6 +41,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         tool_list = initialize_tools_from_config(tool_config_path) if tool_config_path else []
         self.tool_schemas = [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True) for tool in tool_list]

+    @rollout_trace_op
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
```

## Why This Works

`SingleTurnAgentLoop.run()` already returns `AgentLoopOutput` with the required fields:
- `prompt_ids` (line 71)
- `response_ids` (line 72)

The `add_token2text` function in `rollout_trace.py` checks for these exact fields. Once the method is decorated and traced, `token2text=True` correctly adds `prompt_text` and `response_text` to the output.

## Result

After this patch:
- `SingleTurnAgentLoop.run` appears as parent traces in Weave (matching `ToolAgentLoop` behavior)
- `token2text=True` adds `prompt_text` and `response_text` fields
- `AsyncLLMServerManager.generate` appears as nested child traces

<img width="2305" height="1327" alt="Screenshot 2026-02-11 083010" src="https://github.com/user-attachments/assets/baea4ada-face-42ee-b507-97ecca23538a" />
