### PR TITLE
[docker] feat: add Vertex AI compatible Dockerfile with vLLM rollout

### DIFF
--- a/docker/vertex/Dockerfile.vllm
+++ b/docker/vertex/Dockerfile.vllm
@@ -42,6 +42,6 @@ RUN pip install "transformers>=4.56.0,<5.0.0" "numpy<1.27" "numba==0.61.2"
 
 # Uninstall uvloop: verl's fsdp_workers.py calls asyncio.get_event_loop() which
 # raises RuntimeError under uvloop when no running loop exists in the thread
-RUN pip uninstall -y uvloop 2>/dev/null; true
+RUN pip uninstall -y uvloop
 
 CMD ["bash"]


### PR DESCRIPTION
### What does this PR do?

Add `docker/vertex/Dockerfile.vllm` for running verl on Google Cloud Vertex AI with vLLM as the rollout engine.

The existing `nvidia/cuda`-based Dockerfiles (`Dockerfile.stable.vllm`, `Dockerfile.stable.sglang`) do not work on Vertex AI because its container runtime fails to inject GPU drivers (`nvidia-smi` unavailable, `torch.cuda.device_count()=0`).

This Dockerfile uses `verlai/verl:app-verl0.6-*` as the base image (Vertex AI GPU compatible) and builds vLLM 0.8.5 from source to match the base image's PyTorch 2.8.0+cu128 ABI. The pre-built vLLM wheel targets `torch==2.6.0`, causing `undefined symbol` errors at runtime.

Key workarounds:
- **vLLM from source**: avoids ABI mismatch between vLLM's `_C.abi3.so` (built for torch 2.6) and the base image's torch 2.8
- **transformers < 5.0**: verl 0.6 imports `AutoModelForVision2Seq`, removed in transformers 5.x
- **numpy < 1.27**: numba 0.61.2 (vLLM dependency) requires numpy <= 1.26
- **uvloop uninstall**: verl's `fsdp_workers.py` calls `asyncio.get_event_loop()` which raises `RuntimeError` under uvloop

### Checklist Before Starting

- [x] Search for similar PRs: [vertex ai](https://github.com/volcengine/verl/pulls?q=is%3Apr+vertex+ai)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Tested on Vertex AI with:
- Machine: `a3-highgpu-8g` (8x H100 80GB)
- Training: GRPO + LoRA (rank=16) on Qwen3-8B
- Dataset: GSM8K
- Framework: verl v0.6.0 + vLLM 0.8.5 + FSDP
- Rollout: vLLM SPMD mode (TP=2, DP=4)
- Result: Training completed successfully across 15 epochs
- WandB metrics logged correctly (reward, clip_fraction, KL divergence)

### API and Usage Example

```bash
# Build
docker build -f docker/vertex/Dockerfile.vllm -t verl-vertex-vllm:latest .

# Submit to Vertex AI (example)
# Set NVIDIA_VISIBLE_DEVICES=all in environment_variables
# Set VLLM_USE_V1=0 to disable vLLM V1 engine (LoRA + torch.compile incompatibility)
```

### Design & Code Changes

Single new file: `docker/vertex/Dockerfile.vllm` (47 lines)

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a Dockerfile only — CI validation requires Vertex AI infrastructure which is not available in GitHub Actions.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
