### PR TITLE
[fsdp,algo] feat: add use_length_grouped_bsz to reduce padding waste in FSDP training

### DIFF
--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -409,6 +409,7 @@ actor_rollout_ref:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear
@@ -635,6 +636,7 @@ critic:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -376,6 +376,7 @@ actor_rollout_ref:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear
@@ -571,6 +572,7 @@ critic:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -153,6 +153,7 @@ actor_rollout_ref:
     entropy_from_logits_with_chunking: false
     entropy_checkpointing: false
     use_remove_padding: ${oc.select:actor_rollout_ref.model.use_remove_padding,false}
+    use_length_grouped_bsz: ${oc.select:actor_rollout_ref.model.use_length_grouped_bsz,false}
   ref:
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: ${actor_rollout_ref.actor.strategy}
@@ -383,6 +384,7 @@ actor_rollout_ref:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear
@@ -591,6 +593,7 @@ critic:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -365,6 +365,7 @@ actor_rollout_ref:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear
@@ -563,6 +564,7 @@ critic:
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
+    use_length_grouped_bsz: false
     lora_rank: 0
     lora_alpha: 16
     target_modules: all-linear

--- a/verl/trainer/config/actor/dp_actor.yaml
+++ b/verl/trainer/config/actor/dp_actor.yaml
@@ -42,3 +42,5 @@ entropy_checkpointing: False
 # Whether to remove padding tokens in inputs during training
 use_remove_padding: ${oc.select:actor_rollout_ref.model.use_remove_padding,false}
 
+# Whether to use length-grouped micro-batches.
+use_length_grouped_bsz: ${oc.select:actor_rollout_ref.model.use_length_grouped_bsz,false}

--- a/verl/trainer/config/model/hf_model.yaml
+++ b/verl/trainer/config/model/hf_model.yaml
@@ -39,6 +39,11 @@ enable_activation_offload: False
 # whether to use remove padding. Only valid when we use hf model definition
 use_remove_padding: True
 
+# Whether to use length-grouped micro-batches in FSDP training,
+# greedily packing similar-length sequences to reduce per-micro-batch padding.
+# Mutually exclusive with use_remove_padding and Ulysses SP.
+use_length_grouped_bsz: false
+
 # Set to positive value to enable LoRA (e.g., 32)
 lora_rank: 0
 

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -624,3 +624,75 @@ def get_group_balanced_partitions(
         sample_partitions.append(sorted(sample_indices))
 
     return sample_partitions
+
+
+def get_length_grouped_micro_batches(
+    batch,
+    max_token_len: int,
+    dp_group=None,
+    same_micro_num_in_dp: bool = True,
+):
+    """Split a batch into micro-batches that group sequences by length to minimize padding.
+
+    Greedy algorithm: sort sequences by length (descending) and pack into micro-batches
+    such that ``len(micro_batch) * max_seq_in_micro_batch <= max_token_len``.
+
+    Used when ``use_remove_padding`` (sequence packing) is unavailable, e.g. for
+    Mamba/SSM-based models.
+
+    Args:
+        batch: TensorDict containing nested ``input_ids`` with jagged layout.
+        max_token_len: Maximum number of tokens per micro-batch (after padding).
+        dp_group: torch.distributed group for data-parallel sync.
+        same_micro_num_in_dp: If True, ensure same micro-batch count across DP ranks.
+
+    Returns:
+        List[TensorDict]: the micro-batches.
+        List[List[int]]: index lists mapping each micro-batch back to original positions.
+    """
+    input_ids = batch["input_ids"]
+    assert input_ids.is_nested, "get_length_grouped_micro_batches requires nested input_ids"
+    sequence_lengths = input_ids.offsets().diff().cpu().tolist()
+
+    sorted_sequence_lengths_with_idx = sorted(
+        [(length, idx) for idx, length in enumerate(sequence_lengths)], key=lambda x: x[0], reverse=True
+    )
+
+    micro_batches_idx = []
+    current_micro_batch = []
+    current_max_len = 0
+
+    for length, idx in sorted_sequence_lengths_with_idx:
+        new_max_len = max(current_max_len, length)
+        new_batch_size = len(current_micro_batch) + 1
+        if current_micro_batch and new_batch_size * new_max_len > max_token_len:
+            micro_batches_idx.append(current_micro_batch)
+            current_micro_batch = [idx]
+            current_max_len = length
+        else:
+            current_micro_batch.append(idx)
+            current_max_len = new_max_len
+
+    if current_micro_batch:
+        micro_batches_idx.append(current_micro_batch)
+
+    # Ensure all DP ranks end up with the same number of micro-batches by splitting
+    # the largest batches on lagging ranks. Required because the optimizer step is
+    # synchronized across DP ranks.
+    if same_micro_num_in_dp and dist.is_initialized():
+        num_micro_batches_tensor = torch.tensor([len(micro_batches_idx)], device=get_device_name())
+        dist.all_reduce(num_micro_batches_tensor, op=dist.ReduceOp.MAX, group=dp_group)
+        max_num_micro_batches = num_micro_batches_tensor.cpu().item()
+        while len(micro_batches_idx) < max_num_micro_batches:
+            largest_batch_idx = max(range(len(micro_batches_idx)), key=lambda i: len(micro_batches_idx[i]))
+            largest_batch = micro_batches_idx[largest_batch_idx]
+            assert len(largest_batch) > 1, (
+                f"Cannot split micro-batches further to reach {max_num_micro_batches} on rank "
+                f"{dist.get_rank(dp_group)}: largest remaining batch has only one sequence."
+            )
+            mid = len(largest_batch) // 2
+            micro_batches_idx[largest_batch_idx] = largest_batch[:mid]
+            micro_batches_idx.append(largest_batch[mid:])
+
+    micro_batches = [tu.index_select_tensor_dict(batch, partition) for partition in micro_batches_idx]
+    return micro_batches, micro_batches_idx

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -296,6 +296,11 @@ class FSDPActorConfig(ActorConfig):
         entropy_checkpointing (bool): Whether to use gradient checkpointing for entropy computation.
         fsdp_config (dict[str, Any]): Configuration for FSDP settings.
         use_remove_padding (bool): Whether to remove padding tokens in inputs during training
+            via sequence packing (varlen attention). Incompatible with use_length_grouped_bsz.
+        use_length_grouped_bsz (bool): Whether to build micro-batches by greedily grouping
+            sequences of similar length, reducing padding waste when re-padding jagged
+            tensors for the model forward pass. Useful for models that cannot use
+            sequence packing (e.g. Mamba/SSM). Incompatible with use_remove_padding.
     """
 
     strategy: str = "fsdp"
@@ -305,6 +310,7 @@ class FSDPActorConfig(ActorConfig):
     entropy_checkpointing: bool = False
     fsdp_config: FSDPEngineConfig = field(default_factory=FSDPEngineConfig)
     use_remove_padding: bool = False
+    use_length_grouped_bsz: bool = False
     use_rollout_log_probs: bool = False
 
     def __post_init__(self):

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -118,6 +118,7 @@ class HFModelConfig(BaseConfig):
     enable_activation_offload: bool = False
 
     use_remove_padding: bool = True
+    use_length_grouped_bsz: bool = False
 
     # TODO: unify fsdp and megatron lora config
     # fsdp lora related. We may setup a separate config later

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -122,6 +122,10 @@ class FSDPEngine(BaseEngine):
         # build device mesh for Ulysses Sequence Parallel
 
         self.use_remove_padding = self.model_config.use_remove_padding
+        if self.model_config.use_length_grouped_bsz and self.use_remove_padding:
+            raise ValueError("Cannot enable both use_length_grouped_bsz and use_remove_padding")
+        if self.model_config.use_length_grouped_bsz and self.engine_config.ulysses_sequence_parallel_size > 1:
+            raise ValueError("use_length_grouped_bsz is not compatible with Ulysses sequence parallelism")
 
         self._init_device_mesh()
 
@@ -615,6 +619,7 @@ class FSDPEngine(BaseEngine):
         )
         tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens.item())
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
+        tu.assign_non_tensor(data, use_length_grouped_bsz=self.model_config.use_length_grouped_bsz)
 
         micro_batches, indices = prepare_micro_batches(
             data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -23,7 +23,11 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.device import is_npu_available
 from verl.utils.py_functional import append_to_dict
-from verl.utils.seqlen_balancing import rearrange_micro_batches, restore_dynamic_batch
+from verl.utils.seqlen_balancing import (
+    get_length_grouped_micro_batches,
+    rearrange_micro_batches,
+    restore_dynamic_batch,
+)
 
 
 def enable_full_determinism(seed: int):
@@ -67,11 +71,24 @@ def prepare_micro_batches(
     Prepare micro batches from data.
     """
     use_dynamic_bsz = tu.get_non_tensor_data(data=data, key="use_dynamic_bsz", default=True)
+    use_length_grouped_bsz = tu.get_non_tensor_data(data=data, key="use_length_grouped_bsz", default=False)
     sp_size = tu.get_non_tensor_data(data=data, key="sp_size", default=1)
 
     force_group_size = tu.get_non_tensor_data(data=data, key="force_group_size", default=1)
 
-    if use_dynamic_bsz:
+    if use_length_grouped_bsz:
+        assert "max_token_len_per_gpu" in data.keys(), (
+            "max_token_len_per_gpu must be set when use_length_grouped_bsz is True"
+        )
+        max_token_len_per_gpu = data["max_token_len_per_gpu"]
+        max_token_len = max_token_len_per_gpu * sp_size
+        micro_batches, batch_idx_list = get_length_grouped_micro_batches(
+            batch=data,
+            max_token_len=max_token_len,
+            dp_group=dp_group,
+            same_micro_num_in_dp=same_micro_num_in_dp,
+        )
+    elif use_dynamic_bsz:
         assert "max_token_len_per_gpu" in data.keys(), "max_token_len_per_gpu must be set when use_dynamic_bsz is True"
         max_token_len_per_gpu = data["max_token_len_per_gpu"]
         max_token_len = max_token_len_per_gpu * sp_size

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -340,6 +340,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
             max_token_len_per_gpu=self.engine_config.max_token_len_per_gpu,
             micro_batch_size_per_gpu=self.engine_config.micro_batch_size_per_gpu,
             use_fused_kernels=self.engine_config.use_fused_kernels,
+            use_length_grouped_bsz=self.model_config.use_length_grouped_bsz,
         )
 
         for key, val in default_keys.items():
@@ -394,6 +395,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
             max_token_len_per_gpu=self.engine_config.infer_max_token_len_per_gpu,
             micro_batch_size_per_gpu=self.engine_config.infer_micro_batch_size_per_gpu,
             use_fused_kernels=self.engine_config.use_fused_kernels,
+            use_length_grouped_bsz=self.model_config.use_length_grouped_bsz,
         )
 
         for key, val in default_keys.items():


### PR DESCRIPTION
## Summary

For models that cannot use sequence packing (e.g. Mamba/SSM), training under FSDP wastes compute on padded tokens. This PR adds an opt-in `use_length_grouped_bsz` option that mitigates that waste by greedily grouping sequences of similar length into micro-batches.

(See [blog post](https://www.ai21.com/blog/padding-minimization-efficiency/) for the broader motivation behind padding-aware micro-batching.)

## Approach

When `actor_rollout_ref.model.use_length_grouped_bsz=True`:

- Sort sequences in the batch by length (descending).
- Greedily pack them into micro-batches such that `len(micro_batch) * max_seq_in_micro_batch <= max_token_len_per_gpu`.
- All-reduce the micro-batch count across DP ranks (split the largest batches on lagging ranks) so the optimizer step stays synchronized.

Off by default. Mutually exclusive with `use_remove_padding` and Ulysses SP.

## Files

- `verl/utils/seqlen_balancing.py`: new helper `get_length_grouped_micro_batches()` returning `(micro_batches, indices)`, mirroring the contract of `rearrange_micro_batches`.
- `verl/workers/engine/utils.py`: dispatcher branch for `use_length_grouped_bsz` in `prepare_micro_batches`.
- `verl/workers/engine/fsdp/transformer_impl.py`: validation guards (mutually exclusive with `use_remove_padding` and Ulysses SP).
- `verl/workers/engine_workers.py`: forwards the flag through to training and inference data.
- Configs: new `use_length_grouped_bsz` field in model + actor configs (YAML + dataclass), plus the regenerated `_generated_ppo_*` yamls.

## Benchmarks

10-step GRPO on Qwen 2.5 3B-Instruct / GSM8K / 1x4 H100. Mean of `timing_s/update_actor` over steps 2-10:

| Config | mean update_actor (s) |
|---|---|
| `use_remove_padding=True` (rmpad) | 2.235 |
| **`use_length_grouped_bsz=True`** | **2.475** |
| dense (no rmpad, no dynamic_bsz) | 11.692 |

`use_length_grouped_bsz` is **~4.7x faster than dense** and **~10.7% slower than `use_remove_padding`**.

## Test Plan

- [x] 10-step GRPO run with `use_length_grouped_bsz=True` completes end-to-end on Qwen 2.5 3B / GSM8K / 1x4 H100.
- [x] Comparison runs with `use_remove_padding` and dense-padding baselines reproduce the speedup.

This PR was developed with AI assistance.