### PR TITLE
[misc] fix: include config files for experimental entrypoints in package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,5 @@ verl = [
   "version/*",
   "trainer/config/*.yaml",
   "trainer/config/*/*.yaml",
+  "experimental/*/config/*.yaml",
 ]

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,11 @@ setup(
     extras_require=extras_require,
     package_data={
         "": ["version/*"],
-        "verl": ["trainer/config/*.yaml"],
+        "verl": [
+            "trainer/config/*.yaml",
+            "trainer/config/*/*.yaml",
+            "experimental/*/config/*.yaml",
+        ],
     },
     include_package_data=True,
     long_description=long_description,


### PR DESCRIPTION
### What does this PR do?

Adds config files in `verl/experimental/` to package data in both `pyproject.toml` and `setup.py`. This ensures that config files for experimental entrypoints are included when verl is installed via pip (non-editable mode).

This PR, together with #5209, is necessary to run the experimental entrypoints when verl is installed in non-edit mode.

**Additional fix:** Also adds `trainer/config/*/*.yaml` pattern to `setup.py` to match what's already in `pyproject.toml`, ensuring nested trainer config files (in subdirectories like `actor/`, `critic/`, etc.) are included. This fixes an existing inconsistency between the two files.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+package+data https://github.com/volcengine/verl/pulls?q=is%3Apr+experimental
- [x] Format the PR title as `[{modules}] {type}: {description}` ✓

### Test

No tests needed - this only modifies packaging metadata. The correctness can be verified by:
1. Installing verl via `pip install .` (non-editable)
2. Confirming that files exist: `python -c "import verl.experimental.fully_async_policy.config; print(verl.experimental.fully_async_policy.config.__file__)"`
3. Running an experimental entrypoint

### API and Usage Example

No API changes. This fix enables existing experimental entrypoints to work when installed via pip.

### Design & Code Changes

**Changes:**
- `pyproject.toml`: Add `experimental/*/config/*.yaml` pattern
- `setup.py`: Add both `trainer/config/*/*.yaml` (fix existing bug) and `experimental/*/config/*.yaml`

**Why both files?** Python packaging uses different files depending on the build backend, so both need to be consistent.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): All checks passed ✓
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs) - Not needed (internal packaging fix)
- [x] Add unit or end-to-end test(s) - This is packaging metadata that only affects pip-installed packages, not editable installs used in CI.
- [ ] CI request
- [x] Recipe submodule - Not applicable
