### PR TITLE
[tool, rollout] fix: handle optional interaction kwargs

### DIFF
--- a/tests/experimental/agent_loop/test_tool_agent_loop_interaction_kwargs_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_agent_loop_interaction_kwargs_on_cpu.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.experimental.agent_loop.agent_loop import DictConfigWrap
+from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
+from verl.interactions.base import BaseInteraction
+from verl.utils.dataset.rl_dataset import RLHFDataset
+from verl.workers.rollout.replica import TokenOutput
+
+
+class _FakeTokenizer:
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: Optional[list[dict]] = None,
+        add_generation_prompt: bool = True,
+        tokenize: bool = True,
+        **kwargs: Any,
+    ):
+        del tools, add_generation_prompt, kwargs
+        if not tokenize:
+            return "<prompt>"
+        # Return different lengths for 1 vs 2 messages so system prompt extraction works.
+        return [101, 102, 103] if len(messages) == 1 else [101, 102, 103, 104, 105]
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = True) -> str:
+        del ids, skip_special_tokens
+        return "<decoded>"
+
+
+class _FakeServerManager:
+    async def generate(
+        self,
+        request_id: str,
+        *,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+    ) -> TokenOutput:
+        del request_id, prompt_ids, sampling_params, image_data, video_data
+        return TokenOutput(token_ids=[11, 12], log_probs=[0.0, 0.0])
+
+
+class DummyInteraction(BaseInteraction):
+    def __init__(self, config: dict[str, Any]):
+        super().__init__(config=config)
+        self.started: bool = False
+
+    async def start_interaction(self, instance_id: Optional[str] = None, **kwargs) -> str:
+        del kwargs
+        self.started = True
+        return await super().start_interaction(instance_id=instance_id)
+
+    async def generate_response(
+        self, instance_id: str, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> tuple[bool, str, float, dict[str, Any]]:
+        del instance_id, messages, kwargs
+        return True, "done", 0.0, {}
+
+
+_DUMMY_INTERACTION_CLS = "tests.experimental.agent_loop.test_tool_agent_loop_interaction_kwargs_on_cpu.DummyInteraction"
+
+
+def _make_loop(*, interaction_config_path: str) -> ToolAgentLoop:
+    config = OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "rollout": {
+                    "prompt_length": 16,
+                    "response_length": 16,
+                    "multi_turn": {
+                        "max_user_turns": 1,
+                        "max_assistant_turns": 1,
+                        "max_parallel_calls": 1,
+                        "max_tool_response_length": 64,
+                        "tool_response_truncate_side": "left",
+                        "tool_config_path": None,
+                        "format": "hermes",
+                        "interaction_config_path": interaction_config_path,
+                    },
+                }
+            },
+            "data": {"apply_chat_template_kwargs": {}},
+        }
+    )
+
+    trainer_config = DictConfigWrap(config)
+    dataset_config = DictConfigWrap(config.data)
+    return ToolAgentLoop(
+        trainer_config=trainer_config,
+        server_manager=_FakeServerManager(),
+        tokenizer=_FakeTokenizer(),
+        processor=None,
+        dataset_cls=RLHFDataset,
+        dataset_config=dataset_config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_agent_loop_allows_missing_interaction_kwargs_on_cpu(tmp_path):
+    interaction_config = {
+        "interaction": [
+            {
+                "name": "dummy",
+                "class_name": _DUMMY_INTERACTION_CLS,
+                "config": {},
+            }
+        ]
+    }
+    interaction_path = tmp_path / "interaction.json"
+    interaction_path.write_text(json.dumps(interaction_config))
+
+    loop = _make_loop(interaction_config_path=str(interaction_path))
+    out = await loop.run(
+        sampling_params={},
+        raw_prompt=[{"role": "user", "content": "hi"}],
+        extra_info={},
+    )
+    assert out.response_ids == [11, 12]
+
+
+@pytest.mark.asyncio
+async def test_tool_agent_loop_raises_on_unknown_interaction_name_on_cpu(tmp_path):
+    interaction_config = {
+        "interaction": [
+            {
+                "name": "dummy",
+                "class_name": _DUMMY_INTERACTION_CLS,
+                "config": {},
+            }
+        ]
+    }
+    interaction_path = tmp_path / "interaction.json"
+    interaction_path.write_text(json.dumps(interaction_config))
+
+    loop = _make_loop(interaction_config_path=str(interaction_path))
+    with pytest.raises(ValueError, match="Interaction 'nope' not found in interaction_map"):
+        await loop.run(
+            sampling_params={},
+            raw_prompt=[{"role": "user", "content": "hi"}],
+            extra_info={"interaction_kwargs": {"name": "nope"}},
+        )

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -259,7 +259,7 @@ class ToolAgentLoop(AgentLoopBase):
         _, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids)
 
         # Handle interaction if needed
-        if self.interaction_config_file:
+        if self.interaction_config_file and agent_data.interaction is not None:
             assistant_message = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.decode(agent_data.response_ids, skip_special_tokens=True)
             )

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -151,7 +151,12 @@ class ToolAgentLoop(AgentLoopBase):
             interaction_kwargs = kwargs["extra_info"].get("interaction_kwargs", None) or {}
             interaction_name = interaction_kwargs.get("name", None)
 
-            if interaction_name and interaction_name in self.interaction_map:
+            if interaction_name:
+                if interaction_name not in self.interaction_map:
+                    raise ValueError(
+                        f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: "
+                        f"{list(self.interaction_map.keys())}"
+                    )
                 interaction = self.interaction_map[interaction_name]
                 await interaction.start_interaction(request_id, **interaction_kwargs)
 

--- a/verl/experimental/fully_async_policy/agent_loop/partial_tool_agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/partial_tool_agent_loop.py
@@ -97,7 +97,12 @@ class AsyncPartialToolAgentLoop(ToolAgentLoop):
             interaction_kwargs = kwargs["extra_info"].get("interaction_kwargs", None) or {}
             interaction_name = interaction_kwargs.get("name", None)
 
-            if interaction_name and interaction_name in self.interaction_map:
+            if interaction_name:
+                if interaction_name not in self.interaction_map:
+                    raise ValueError(
+                        f"Interaction '{interaction_name}' not found in interaction_map. Available interactions: "
+                        f"{list(self.interaction_map.keys())}"
+                    )
                 interaction = self.interaction_map[interaction_name]
                 await interaction.start_interaction(request_id, **interaction_kwargs)
 


### PR DESCRIPTION
### What does this PR do?

> Improves robustness of multi-turn tool agent loops when using an interaction config: samples without `extra_info.interaction_kwargs` are treated as having no interaction, while misconfigured `interaction_kwargs.name` values fail fast.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+ToolAgentLoop+interaction_kwargs
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- `pre-commit run --all-files --show-diff-on-failure --color=always`
- Added CPU unit test: `tests/experimental/agent_loop/test_tool_agent_loop_interaction_kwargs_on_cpu.py`

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# When interaction_config_path is set, rows can omit interaction configuration:
extra_info = {}

# Rows that want interaction should provide a valid name:
extra_info = {"interaction_kwargs": {"name": "weather"}}

# If a name is provided but not configured, the loop now raises ValueError.
```

### Design & Code Changes

- Make `interaction_kwargs` optional when an interaction config is present.
- Only enter `INTERACTING` / process assistant messages when an interaction is actually initialized.
- Raise on unknown `interaction_kwargs.name` to avoid silently skipping misconfigurations.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] (not required) Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Covered by new CPU unit test.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] (not related) If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.