### PR TITLE
[tool] fix: add timeout for MCP tool calls

### DIFF
--- a/verl/tools/utils/mcp_clients/McpClientManager.py
+++ b/verl/tools/utils/mcp_clients/McpClientManager.py
@@ -62,7 +62,7 @@ class MCPClientManager:
 
         client = self.get_client_with_tool_name(tool_name)
         async with client:
-            return await client.call_tool_mcp(tool_name, parameters)
+            return await asyncio.wait_for(client.call_tool_mcp(tool_name, parameters), timeout=timeout)
 
     async def fetch_tool_schemas(self, tool_selected_list: list[str]) -> list[dict]:
         tool_schemas = []


### PR DESCRIPTION
### What does this PR do?

> Prevent hangs when calling MCP tools by enforcing a timeout around `call_tool_mcp` in `MCPClientManager.call_tool()`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+McpClientManager+wait_for+call_tool_mcp+timeout
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` (local) passed.

### API and Usage Example

> No API change beyond existing `timeout` parameter behavior. On timeout, `asyncio.TimeoutError` will be raised.

```python
# Example usage
result = await ClientManager.call_tool(
    tool_name="some_tool",
    parameters={"foo": "bar"},
    timeout=30,
)
```

### Design & Code Changes

- Wrap `client.call_tool_mcp(...)` in `asyncio.wait_for(..., timeout=timeout)`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] (not needed) Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] (not needed) Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: the change is a one-line timeout wrapper around a networked MCP tool call; a meaningful test would need a hermetic fastmcp transport/mock or an integration harness, which isn’t currently present here.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] (not relevant) If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.