### PR TITLE
[trainer] fix: Misaligned FSDP SFT loss mask

### DIFF
--- a/verl/utils/dataset/sft_dataset.py
+++ b/verl/utils/dataset/sft_dataset.py
@@ -189,9 +189,9 @@ class SFTDataset(Dataset):
         position_ids = compute_position_id_with_mask(attention_mask)
 
         loss_mask = attention_mask.clone()
-        if prompt_length > 1:
-            # mask out prompt for SFT.
-            loss_mask[: min(prompt_length, loss_mask.size(0))] = 0
+
+        # mask out prompt for SFT.
+        loss_mask[: min(prompt_length, loss_mask.size(0))] = 0
 
         return {
             "input_ids": input_ids,


### PR DESCRIPTION
### What does this PR do?

A previous PR #3287 had a fix for the SFT loss mask which worked for MultiTurnSFTDataset but introduced a new bug when using SFTDataset. This would result in shifting the loss mask by one when using single turn SFT, and the loss would falsely be calculated on the last prompt id and not be calculated on the eos token id, which makes the model fail to learn how to terminate a turn as reported in #3562.

This PR fixes SFTDataset, following the logic of MultiTurnSFTDataset. It makes more sense to leave the loss mask shifting to the sft trainer and not the sft dataset.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Example output before fix:
<img width="594" height="539" alt="Screenshot 2026-02-20 at 15 12 14" src="https://github.com/user-attachments/assets/6ae61ed8-c73a-458b-99bc-bd792cf48b55" />

Example output after fix:
<img width="590" height="217" alt="Screenshot 2026-02-20 at 15 12 52" src="https://github.com/user-attachments/assets/64ab23e9-2c1f-48b7-84b2-6b8141bf16f1" />

### Design & Code Changes

**Before** l.195-200 in verl/utils/dataset/sft_dataset.py
```python
        loss_mask = attention_mask.clone()
        if prompt_length > 1:
            # mask out prompt for SFT.
            loss_mask[: min(prompt_length, loss_mask.size(0)) - 1] = 0
        # mask out the last token in response
        loss_mask[min(prompt_length + response_length, loss_mask.size(0)) - 1] = 0
```

**After**
```python
        loss_mask = attention_mask.clone()
        if prompt_length > 1:
            # mask out prompt for SFT.
            loss_mask[: min(prompt_length, loss_mask.size(0))] = 0
```

We now delegate the loss shifting to fsdp_sft_trainer.py, which is what fix #3287 did when using `MultiTurnSFTDataset`. This also aligns with verl/trainer/sft_trainer.py, which delegates the loss mask shifting to the sft_loss function, in verl/workers/utils/losses.py l.44-45: 
```python
        # left-shift the loss mask by one token to align with log_prob
        loss_mask_flatten = torch.roll(loss_mask_flatten, shifts=-1, dims=0)
```

### Explanation
An example explanation on the token level. We will ignore padding for simplicity.
Example text: "User: Hi\nAssistant: Hello EOS"
input_ids: `[User, :, Hi, \n, Assistant, :, Hello, EOS]`

prompt_length = 6, response_length=2

#### In SFTDataset:
**Before**
loss_mask is initialized with: `[1, 1, 1, 1, 1, 1, 1, 1]`
then `loss_mask[: min(prompt_length, loss_mask.size(0)) - 1] = 0`
so loss_mask[:5] = 0
loss_mask: `[0, 0, 0, 0, 0, 1, 1, 1]`
then: `loss_mask[min(prompt_length + response_length, loss_mask.size(0)) - 1] = 0`
loss_mask: `[0, 0, 0, 0, 0, 1, 1, 0]`

then in fsdp_sft_trainer.py, we get:
`loss_mask = batch.pop("loss_mask")[:, 1:].reshape(-1).to(self.device_name)`
loss_mask: `[0, 0, 0, 0, 1, 1, 0]`

Now when calculating loss:
`labels = input_ids[:, 1:].contiguous()`
labels:         `[:, Hi, \n, Assistant, :, Hello, EOS]`
loss_mask: `[0, 0, 0, 0, 1, 1, 0]`
We end up calculating the loss on `:` and `Hello` but the model should learn how to output `Hello` and `EOS`.

**After**
loss_mask is initialized with: `[1, 1, 1, 1, 1, 1, 1, 1]`
then `loss_mask[: min(prompt_length, loss_mask.size(0))] = 0`
so loss_mask[:6] = 0
loss_mask: `[0, 0, 0, 0, 0, 0, 1, 1]`
`loss_mask = batch.pop("loss_mask")[:, 1:].reshape(-1).to(self.device_name)`
loss_mask: `[0, 0, 0, 0, 0, 1, 1]`
The loss is correctly calculated on `Hello` and `EOS`.

#### In MultiTurnSFTDataset:
```python
  if message["role"] == "assistant":
      loss_mask = torch.ones_like(attention_mask)
      # mask out generation prompt if assistant message
      loss_mask[: len(self.generation_prompt)] = 0
  else:
      loss_mask = torch.zeros_like(attention_mask)
...
  for i, message in enumerate(messages):
      final_loss_mask.append(_loss_mask)
```
Since we have user message: `[User, :, Hi, \n]`, assistant message: `[Assistant, :, Hello, EOS]` with assistant generation prompt: `[Assistant, :]`, with len(generation_prompt) = 2, the loss mask is constructed like this:
user message loss mask: `[0, 0, 0, 0]`
assistant message loss mask: `[0, 0, 1, 1]`
Final loss mask: `[0, 0, 0, 0, 0, 0, 1, 1]` This is correct.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
