### PR TITLE
[algo] feat: Exception for agg_loss when `dp_size > 1` but global information is absent & fix: correct & consistent loss aggregation for "seq-mean-token-sum-norm"

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1078,8 +1078,8 @@ def agg_loss(
     elif loss_agg_mode == "seq-mean-token-sum-norm":
         if loss_scale_factor is None:
             raise ValueError(
-                f"WARNING: {loss_agg_mode=} but {loss_scale_factor=}. "
-                f'If not intented for custom scaling factor, try setting loss_agg_mode="seq-mean-token-sum".'
+                f"{loss_agg_mode=} but {loss_scale_factor=}. "
+                'If not intented for custom scaling factor, try setting loss_agg_mode="seq-mean-token-sum".'
             )
         seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)
         loss = torch.sum(seq_losses) / loss_scale_factor * dp_size


### PR DESCRIPTION
### What does this PR do?

This PR:

1. adds exceptions when global information is not provided when `dp_size > 1`, since this prevents correct global aggregation;
2. adds `* dp_size` for "seq-mean-token-sum-norm" to cancel out the DP mean, making it parallelism-invariant and consistent with other options.

~**Discussion**: Should we also cancel out the DP mean in "seq-mean-token-sum-norm"?~

- If adding, the logic will be more consistent across different options.
- If not, it keeps the best backward-compatibility.

For now, only a comment is added while the code is left as is.

Welcome to leave some comments or directly commit your modification.

cc @PeterSH6 @vermouth1992 @wuxibin89

**Conclusion**: The design principle of `agg_loss` is to be parallelism-invariant. So we should also cancel out the DP mean for "seq-mean-token-sum-norm".

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

See the CI.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
