### PR TITLE
[trainer,misc] fix: fix multiple bugs in fully async trainings

### DIFF
--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
@@ -27,6 +27,9 @@ async_training:
   # whether to use trainer do_validate
   use_trainer_do_validate: False
 
+  # wether validation is performed concurrently with rollouts
+  parallel_validate_and_rollout: False
+
 
 # Rollout config
 rollout:
@@ -48,6 +51,9 @@ rollout:
 
   # Test frequency, how many times a parameter update triggers a validation
   test_freq: 1
+
+  # Max concurrent samples processed per rollout replica
+  max_concurrent_samples_per_replica: 16
 
 data:
   # Number of samples generated, currently only support 1

--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
@@ -27,6 +27,9 @@ async_training:
   # whether to use trainer do_validate
   use_trainer_do_validate: False
 
+  # wether validation is performed concurrently with rollouts
+  parallel_validate_and_rollout: False
+
 # Rollout config
 rollout:
 
@@ -47,6 +50,9 @@ rollout:
 
   # Test frequency, how many times a parameter update triggers a validation
   test_freq: 1
+
+  # Max concurrent samples processed per rollout replica
+  max_concurrent_samples_per_replica: 16
 
 data:
   # Number of samples generated, currently only support 1

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -206,11 +206,9 @@ class FullyAsyncTaskRunner:
     def _create_rollouter(self, config) -> None:
         rollouter = FullyAsyncRollouter.remote(
             config=config,
-            tokenizer=self.components["tokenizer"],
             role_worker_mapping=None,
             resource_pool_manager=create_resource_pool_manager(config, roles=[Role.Rollout]),
             ray_worker_group_cls=self.components["ray_worker_group_cls"],
-            processor=self.components["processor"],
             device_name=config.trainer.device,
         )
 
@@ -229,11 +227,9 @@ class FullyAsyncTaskRunner:
 
         trainer = FullyAsyncTrainer.remote(
             config=config,
-            tokenizer=self.components["tokenizer"],
             role_worker_mapping=trainer_role_mapping,
             resource_pool_manager=create_resource_pool_manager(config, roles=list(trainer_role_mapping.keys())),
             ray_worker_group_cls=self.components["ray_worker_group_cls"],
-            processor=self.components["processor"],
             device_name=config.trainer.device,
         )
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -211,7 +211,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 / (self.required_samples * self.config.async_training.trigger_parameter_sync_step)
             )
 
-            self.max_concurrent_samples = len(self.async_rollout_manager.server_handles) * 16
+            self.max_concurrent_samples = len(self.async_rollout_manager.server_handles) * self.config.rollout.get("max_concurrent_samples_per_replica", 16)
             self.max_concurrent_samples = min(self.max_concurrent_samples, self.max_required_samples)
             self.max_queue_size = self.max_required_samples
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -211,7 +211,9 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 / (self.required_samples * self.config.async_training.trigger_parameter_sync_step)
             )
 
-            self.max_concurrent_samples = len(self.async_rollout_manager.server_handles) * self.config.rollout.get("max_concurrent_samples_per_replica", 16)
+            self.max_concurrent_samples = len(self.async_rollout_manager.server_handles) * self.config.rollout.get(
+                "max_concurrent_samples_per_replica", 16
+            )
             self.max_concurrent_samples = min(self.max_concurrent_samples, self.max_required_samples)
             self.max_queue_size = self.max_required_samples
 
@@ -548,9 +550,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                         tasks_to_wait = set(self.active_tasks) if self.active_tasks else set()
 
                     if tasks_to_wait:
-                        done_tasks, _ = await asyncio.wait(
-                            tasks_to_wait, return_when=asyncio.FIRST_COMPLETED
-                        )
+                        done_tasks, _ = await asyncio.wait(tasks_to_wait, return_when=asyncio.FIRST_COMPLETED)
                         for task in done_tasks:
                             await task
 
@@ -564,9 +564,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                     tasks_to_wait = set(self.active_tasks) if self.active_tasks else set()
 
                 if tasks_to_wait:
-                    done_tasks, _ = await asyncio.wait(
-                        tasks_to_wait, return_when=asyncio.FIRST_COMPLETED
-                    )
+                    done_tasks, _ = await asyncio.wait(tasks_to_wait, return_when=asyncio.FIRST_COMPLETED)
                     for task in done_tasks:
                         await task
 

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -609,6 +609,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             f"current_param_version to {self.current_param_version}"
         )
         print(f"[FullyAsyncTrainer] Resuming from  {global_step_folder}")
+        if self.progress_bar is not None:
+            self.progress_bar.n = max(0, self.global_steps - 1)
+            self.progress_bar.refresh()
 
         actor_path = os.path.join(global_step_folder, "actor")
         critic_path = os.path.join(global_step_folder, str(Role.Critic))

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -365,7 +365,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         self._log_validation_data()
         # 2. perform addtional parameter_sync and validate if trainer already updated
         if self.current_param_version % self.config.rollout.test_freq != 0 or self.local_trigger_step > 1:
-            await self._trigger_parameter_sync_after_step(validate=True, global_steps=self.global_steps)
+            await self._trigger_parameter_sync_after_step(validate=True)
             ray.get(self.param_synchronizer.wait_last_valid.remote())
             self._log_validation_data()
         self.progress_bar.close()

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -53,19 +53,30 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
     def __init__(
         self,
         config,
-        tokenizer,
         role_worker_mapping: dict[Role, WorkerType],
         resource_pool_manager: ResourcePoolManager,
         ray_worker_group_cls: RayWorkerGroup = RayWorkerGroup,
-        processor=None,
         device_name=None,
     ):
         # ==================== RayPPOTrainer config ====================
 
-        # Store the tokenizer for text processing
-        self.tokenizer = tokenizer
-        self.processor = processor
         self.config = config
+
+        # Load tokenizer/processor locally in remote actor to avoid serialization issues
+        # with trust_remote_code models (transformers_modules not available in remote env)
+        from verl.utils import hf_processor, hf_tokenizer
+        from verl.utils.fs import copy_to_local
+
+        local_path = copy_to_local(
+            config.actor_rollout_ref.model.path,
+            use_shm=config.actor_rollout_ref.model.get("use_shm", False),
+        )
+        trust_remote_code = config.actor_rollout_ref.model.get(
+            "trust_remote_code", config.data.get("trust_remote_code", False)
+        )
+
+        self.tokenizer = hf_tokenizer(local_path, trust_remote_code=trust_remote_code)
+        self.processor = hf_processor(local_path, trust_remote_code=trust_remote_code, use_fast=True)
 
         self.hybrid_engine = config.actor_rollout_ref.hybrid_engine
         assert not self.hybrid_engine
@@ -146,7 +157,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             from verl.trainer.main_ppo import create_rl_dataset
             from verl.utils.dataset.rl_dataset import collate_fn
 
-            val_dataset = create_rl_dataset(config.data.val_files, config.data, tokenizer, processor)
+            val_dataset = create_rl_dataset(config.data.val_files, config.data, self.tokenizer, self.processor)
             rollout_gpus = config.rollout.nnodes * config.rollout.n_gpus_per_node
             print(f"[FullyAsyncTrainer] split before val_dataset total len: {len(val_dataset)}")
             split_dataset = val_dataset.split(total_gpus)

--- a/verl/experimental/fully_async_policy/param_sync.py
+++ b/verl/experimental/fully_async_policy/param_sync.py
@@ -142,6 +142,7 @@ class ParameterSynchronizer:
             ray.get(self.wait_last_update)
         if self.wait_last_resume:
             ray.get(self.wait_last_resume)
+        ray.get(self.rollouter.wait_validate_task.remote())
         if self.validate_task:
             ray.get(self.validate_task)
         print(f"[ParameterSynchronizer] Wait last validate cost: {time.time() - start_time:.2f} seconds")


### PR DESCRIPTION
### What does this PR do?

Fixes several independent bugs in fully async training that could cause deadlocks (due to incorrect use of the async lock), serialization failures (when using `trust_remote_code=True` for the tokenizer), and incorrect validation behavior (not properly running at the end of training). Also adds a config parameter to make `max_concurrent_samples` configurable.

Related: #4808 (tokenizer serialization in Ray actors)

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+fully+async+fix https://github.com/volcengine/verl/pulls?q=is%3Apr+fully+async+lock https://github.com/volcengine/verl/pulls?q=is%3Apr+fully+async
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

These bugs were found and fixed during extended fully async training runs.
- Deadlocks after parameter syncs.
- Monitoring loop not printing output.
- Serialization errors during initialization when `data.trust_remote_code=True`.
- Validation not running at the end of training.

The fixes were validated by running complete training jobs end-to-end without hitting the bugs.

### API and Usage Example

**Removed constructor parameters** (breaking for direct instantiation, but `fully_async_main.py` is the only caller):

```python
# Before
FullyAsyncRollouter.remote(config=config, tokenizer=tokenizer, processor=processor, ...)
FullyAsyncTrainer.remote(config=config, tokenizer=tokenizer, processor=processor, ...)

# After – tokenizer/processor loaded locally inside the remote actor
FullyAsyncRollouter.remote(config=config, ...)
FullyAsyncTrainer.remote(config=config, ...)
```

**New optional config key** (defaults to 16, backward-compatible):
```yaml
rollout:
  max_concurrent_samples_per_replica: 16  # new, was hardcoded
```

### Design & Code Changes

**1. Fix asyncio deadlocks in the sample processing loop** (`fully_async_rollouter.py`)

`asyncio.wait()` was called while holding `self.lock` while waiting for active tasks to finish, preventing any other coroutine from acquiring it during the wait, causing deadlocks. Fixed by copying `active_tasks` under the lock, releasing the lock before calling `asyncio.wait()`, then re-acquiring it to remove completed tasks. The same pattern is applied in `pause()`: `asyncio.gather()` is now called outside the lock; the lock is re-acquired afterwards to call `active_tasks.clear()`.

**2. Fix tokenizer/processor serialization with `trust_remote_code` models** (`fully_async_rollouter.py`, `fully_async_trainer.py`, `fully_async_main.py`)

Passing a tokenizer loaded with `trust_remote_code=True` as a Ray remote constructor argument fails because `transformers_modules` is not available in the remote actor's Python process. Removed `tokenizer` and `processor` from both constructors; each remote actor now loads them locally via `hf_tokenizer()` / `hf_processor()` and `copy_to_local()`.

**3. Fix validation loop during and at end of run** (`fully_async_rollouter.py`, `param_sync.py`)

Three related issues:
- In the non-parallel validation path, `_validate_wrapper()` (a sync blocking call) was called directly without first resuming the rollout manager. Changed to `await async_rollout_manager.resume()` + `await do_validate_async()`.
- In the parallel validation path, `validate_task.get()` (invalid blocking call on an asyncio `Task`) was used instead of `await validate_task`.
- `ParameterSynchronizer.wait_last_valid()` did not wait for the background `validate_task` spawned by `parallel_validate_and_rollout=True` at end of run. Added `wait_validate_task()` remote method to `FullyAsyncRollouter` and called it from `wait_last_valid`.

**4. Add missing keys to fully async config files** (`config/fully_async_ppo_trainer.yaml`, `config/fully_async_ppo_megatron_trainer.yaml`)

Added `async_training.parallel_validate_and_rollout` and `rollout.max_concurrent_samples_per_replica` to both config files so users can discover and configure these options. The latter determines the maximum concurrent samples that are processed in the rollout loop (previously hard-coded to 16 per rollout replica).

**5. Fix progress bar on resume** (`fully_async_trainer.py`)

- Progress bar was always initialized at step 0 even on resume. Fixed to set `progress_bar.n = global_steps - 1` after loading checkpoint.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (not necessary)
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: difficult to test without end-to-end tests, and there are already such tests for fully async trainings.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. (Not applicable — no recipe submodule changes.)
