### PR TITLE
[tool] refactor: centralized tool registry and decorator-based registration

### DIFF
--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,5 +1,4 @@
-# Copyright 2023-2024 SGLang Team
-# Copyright 2025 ModelBest Inc. and/or its affiliates
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from verl.tools.base_tool import BaseTool
-from verl.tools.registry import ToolRegistry, register_tool
-from verl.tools.schemas import OpenAIFunctionToolSchema, ToolResponse
-
-__all__ = [
-    "BaseTool",
-    "OpenAIFunctionToolSchema",
-    "ToolRegistry",
-    "ToolResponse",
-    "register_tool",
-]

--- a/tests/tools/test_tool_registry_on_cpu.py
+++ b/tests/tools/test_tool_registry_on_cpu.py
@@ -1,0 +1,262 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from verl.tools.base_tool import BaseTool
+from verl.tools.registry import ToolRegistry, register_tool
+from verl.tools.schemas import OpenAIFunctionToolSchema
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_schema(name: str = "test_func") -> OpenAIFunctionToolSchema:
+    return OpenAIFunctionToolSchema.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "A test tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "string", "description": "input"},
+                    },
+                    "required": ["x"],
+                },
+            },
+        }
+    )
+
+
+class _DummyTool(BaseTool):
+    def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
+        super().__init__(config, tool_schema)
+
+
+def _can_import(module_name: str) -> bool:
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests: ToolRegistry core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry:
+    def setup_method(self):
+        self._snapshot = dict(ToolRegistry._registry)
+
+    def teardown_method(self):
+        ToolRegistry._registry.clear()
+        ToolRegistry._registry.update(self._snapshot)
+
+    def test_register_and_get(self):
+        @register_tool("my_tool")
+        class MyTool(BaseTool):
+            pass
+
+        assert ToolRegistry.contains("my_tool")
+        assert ToolRegistry.get("my_tool") is MyTool
+
+    def test_list_tools_includes_registered(self):
+        @register_tool("listed_tool")
+        class ListedTool(BaseTool):
+            pass
+
+        assert "listed_tool" in ToolRegistry.list_tools()
+
+    def test_get_unknown_raises_key_error(self):
+        with pytest.raises(KeyError, match="not_registered"):
+            ToolRegistry.get("not_registered")
+
+    def test_contains_false_for_unknown(self):
+        assert not ToolRegistry.contains("nonexistent_tool_xyz")
+
+    def test_duplicate_registration_overwrites_with_warning(self):
+        @register_tool("dup_tool")
+        class First(BaseTool):
+            pass
+
+        @register_tool("dup_tool")
+        class Second(BaseTool):
+            pass
+
+        assert ToolRegistry.get("dup_tool") is Second
+
+    def test_clear(self):
+        @register_tool("clearable")
+        class Tmp(BaseTool):
+            pass
+
+        assert ToolRegistry.contains("clearable")
+        ToolRegistry.clear()
+        assert not ToolRegistry.contains("clearable")
+
+
+# ---------------------------------------------------------------------------
+# Tests: Built-in tools are registered
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinToolRegistration:
+    """Verify that importing the built-in tool modules populates the registry."""
+
+    def test_gsm8k_registered(self):
+        import verl.tools.gsm8k_tool  # noqa: F401
+
+        assert ToolRegistry.contains("gsm8k")
+
+    def test_geo3k_registered(self):
+        import verl.tools.geo3k_tool  # noqa: F401
+
+        assert ToolRegistry.contains("geo3k")
+
+    @pytest.mark.skipif(
+        not _can_import("fastmcp"),
+        reason="fastmcp not installed",
+    )
+    def test_mcp_base_registered(self):
+        import verl.tools.mcp_base_tool  # noqa: F401
+
+        assert ToolRegistry.contains("mcp_base")
+
+
+# ---------------------------------------------------------------------------
+# Tests: initialize_tools_from_config with tool_name
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeToolsFromConfig:
+    """Test that tool configs using ``tool_name`` work alongside ``class_name``."""
+
+    def _write_config(self, content: str) -> str:
+        fd, path = tempfile.mkstemp(suffix=".yaml")
+        os.close(fd)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def test_class_name_still_works(self):
+        """Backward-compat: ``class_name`` resolves via importlib as before."""
+        from verl.tools.utils.tool_registry import initialize_tools_from_config
+
+        config_path = self._write_config(
+            """
+tools:
+  - class_name: "verl.tools.gsm8k_tool.Gsm8kTool"
+    config:
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "calc_gsm8k_reward"
+        description: "test"
+        parameters:
+          type: "object"
+          properties:
+            answer:
+              type: "string"
+              description: "answer"
+          required: ["answer"]
+"""
+        )
+        try:
+            tools = initialize_tools_from_config(config_path)
+            assert len(tools) == 1
+            assert tools[0].name == "calc_gsm8k_reward"
+        finally:
+            os.unlink(config_path)
+
+    def test_tool_name_registry_lookup(self):
+        """New path: ``tool_name`` resolves via ToolRegistry."""
+        from verl.tools.utils.tool_registry import initialize_tools_from_config
+
+        config_path = self._write_config(
+            """
+tools:
+  - tool_name: "gsm8k"
+    config:
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "calc_gsm8k_reward"
+        description: "test"
+        parameters:
+          type: "object"
+          properties:
+            answer:
+              type: "string"
+              description: "answer"
+          required: ["answer"]
+"""
+        )
+        try:
+            tools = initialize_tools_from_config(config_path)
+            assert len(tools) == 1
+            assert tools[0].name == "calc_gsm8k_reward"
+        finally:
+            os.unlink(config_path)
+
+    def test_missing_both_keys_raises(self):
+        """Config with neither ``tool_name`` nor ``class_name`` should error."""
+        from verl.tools.utils.tool_registry import initialize_tools_from_config
+
+        config_path = self._write_config(
+            """
+tools:
+  - config:
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "bad"
+        description: "no class"
+        parameters:
+          type: "object"
+          properties: {}
+          required: []
+"""
+        )
+        try:
+            with pytest.raises(ValueError, match="tool_name.*class_name"):
+                initialize_tools_from_config(config_path)
+        finally:
+            os.unlink(config_path)
+
+
+# ---------------------------------------------------------------------------
+# Tests: BaseTool uses logger instead of print
+# ---------------------------------------------------------------------------
+
+
+class TestBaseToolLogging:
+    def test_init_does_not_print(self, capsys):
+        """BaseTool.__init__ should not produce stdout output."""
+        schema = _make_schema()
+        _DummyTool(config={}, tool_schema=schema)
+        captured = capsys.readouterr()
+        assert captured.out == "", "BaseTool.__init__ should use logger, not print()"

--- a/verl/tools/base_tool.py
+++ b/verl/tools/base_tool.py
@@ -13,12 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import logging
+import os
 from typing import Any, Optional
 from uuid import uuid4
 
 from verl.utils.rollout_trace import rollout_trace_op
 
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 class BaseTool:
@@ -38,7 +43,7 @@ class BaseTool:
         self.tool_schema = tool_schema or self.get_openai_tool_schema()
         assert self.tool_schema is not None, "Tool schema is not set!"
         self.name = self.tool_schema.function.name
-        print(json.dumps(self.tool_schema.model_dump(exclude_unset=True, exclude_none=True), indent=2))
+        logger.info(json.dumps(self.tool_schema.model_dump(exclude_unset=True, exclude_none=True), indent=2))
 
     def get_openai_tool_schema(self) -> OpenAIFunctionToolSchema:
         return self.tool_schema

--- a/verl/tools/geo3k_tool.py
+++ b/verl/tools/geo3k_tool.py
@@ -23,12 +23,14 @@ from verl.utils.reward_score import geo3k
 from verl.utils.rollout_trace import rollout_trace_op
 
 from .base_tool import BaseTool
+from .registry import register_tool
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+@register_tool("geo3k")
 class Geo3kTool(BaseTool):
     """A demo tool for calculating the reward of geo3k.
     - `get_openai_tool_schema`: return the tool schema in OpenAI format.

--- a/verl/tools/gsm8k_tool.py
+++ b/verl/tools/gsm8k_tool.py
@@ -22,12 +22,14 @@ from verl.utils.reward_score import gsm8k
 from verl.utils.rollout_trace import rollout_trace_op
 
 from .base_tool import BaseTool
+from .registry import register_tool
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+@register_tool("gsm8k")
 class Gsm8kTool(BaseTool):
     """A demo tool for calculating the reward of gsm8k.
 

--- a/verl/tools/image_zoom_in_tool.py
+++ b/verl/tools/image_zoom_in_tool.py
@@ -27,6 +27,7 @@ import ray.actor
 from qwen_vl_utils import fetch_image
 
 from .base_tool import BaseTool
+from .registry import register_tool
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,7 @@ def init_visual_execution_pool(
         raise NotImplementedError("Process mode is not implemented yet")
 
 
+@register_tool("image_zoom_in")
 class ImageZoomInTool(BaseTool):
     """A tool for zooming in on an image by cropping it based on a bounding box.
 

--- a/verl/tools/mcp_base_tool.py
+++ b/verl/tools/mcp_base_tool.py
@@ -24,12 +24,14 @@ from verl.tools.utils.mcp_clients.McpClientManager import ClientManager
 from verl.utils.rollout_trace import rollout_trace_op
 
 from .base_tool import BaseTool
+from .registry import register_tool
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+@register_tool("mcp_base")
 class MCPBaseTool(BaseTool):
     def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
         super().__init__(config, tool_schema)

--- a/verl/tools/mcp_search_tool.py
+++ b/verl/tools/mcp_search_tool.py
@@ -18,6 +18,7 @@ import os
 import re
 
 from verl.tools.mcp_base_tool import MCPBaseTool
+from verl.tools.registry import register_tool
 
 from .schemas import OpenAIFunctionToolSchema
 
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+@register_tool("mcp_search")
 class MCPSearchTool(MCPBaseTool):
     def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
         super().__init__(config, tool_schema)

--- a/verl/tools/registry.py
+++ b/verl/tools/registry.py
@@ -1,0 +1,90 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from verl.tools.base_tool import BaseTool
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class ToolRegistry:
+    """Global registry for tool classes.
+
+    Mirrors the registration pattern used by ``_agent_loop_registry`` and
+    ``ToolParser._registry`` elsewhere in the codebase.  Tools can self-register
+    via the ``@register_tool`` decorator **or** be resolved at runtime from a
+    fully-qualified class name (backward-compatible path).
+    """
+
+    _registry: dict[str, type[BaseTool]] = {}
+
+    @classmethod
+    def register(cls, tool_name: str):
+        """Decorator that registers a ``BaseTool`` subclass under *tool_name*.
+
+        Usage::
+
+            @ToolRegistry.register("gsm8k")
+            class Gsm8kTool(BaseTool):
+                ...
+        """
+
+        def decorator(subclass: type[BaseTool]) -> type[BaseTool]:
+            if tool_name in cls._registry:
+                existing = cls._registry[tool_name]
+                fqdn_existing = f"{existing.__module__}.{existing.__qualname__}"
+                fqdn_new = f"{subclass.__module__}.{subclass.__qualname__}"
+                logger.warning(
+                    f"Tool '{tool_name}' is already registered as {fqdn_existing}. Overwriting with {fqdn_new}."
+                )
+            cls._registry[tool_name] = subclass
+            return subclass
+
+        return decorator
+
+    @classmethod
+    def get(cls, tool_name: str) -> type[BaseTool]:
+        """Return the tool class registered under *tool_name*.
+
+        Raises ``KeyError`` if *tool_name* has not been registered.
+        """
+        if tool_name not in cls._registry:
+            raise KeyError(f"Tool '{tool_name}' is not registered. Available tools: {list(cls._registry.keys())}")
+        return cls._registry[tool_name]
+
+    @classmethod
+    def list_tools(cls) -> list[str]:
+        """Return the names of all registered tools."""
+        return list(cls._registry.keys())
+
+    @classmethod
+    def contains(cls, tool_name: str) -> bool:
+        """Check whether *tool_name* is registered."""
+        return tool_name in cls._registry
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all entries. Intended for testing only."""
+        cls._registry.clear()
+
+
+# Convenience alias so users can write ``@register_tool("name")``
+register_tool = ToolRegistry.register

--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -23,6 +23,7 @@ from uuid import uuid4
 import ray
 
 from verl.tools.base_tool import BaseTool
+from verl.tools.registry import register_tool
 from verl.utils.reward_score.sandbox_fusion.utils import _process_single_case
 from verl.utils.rollout_trace import rollout_trace_op
 
@@ -98,6 +99,7 @@ def init_execution_pool(
         # return ray.util.multiprocessing.Pool(processes=num_workers)
 
 
+@register_tool("sandbox_fusion")
 class SandboxFusionTool(BaseTool):
     """A tool for executing the code using sanbox fusion image.
 

--- a/verl/tools/search_tool.py
+++ b/verl/tools/search_tool.py
@@ -29,6 +29,7 @@ from verl.tools.utils.search_r1_like_utils import perform_single_search_batch
 from verl.utils.rollout_trace import rollout_trace_op
 
 from .base_tool import BaseTool
+from .registry import register_tool
 from .schemas import OpenAIFunctionToolSchema, ToolResponse
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,7 @@ def init_search_execution_pool(
         raise NotImplementedError("Process mode is not implemented yet")
 
 
+@register_tool("search")
 class SearchTool(BaseTool):
     """Search tool for retrieving information using external retrieval services.
 


### PR DESCRIPTION
### What does this PR do?

Refactors the tool registration system to use a centralized, decorator-based 
`ToolRegistry`, aligning with the existing AgentLoop pattern. Introduces `@register_tool("name")` decorator. Maintains full backward compatibility for `class_name` lookups. Directly addresses Q1 Roadmap item in [#4880.](https://github.com/verl-project/verl/issues/4880)

### Test

Added tests covering registry CRUD, built-in auto-registration, and config-based initialization.

### API and Usage Example

```python
@register_tool("myself")
class MyTool(BaseTool): ...

# config.yaml
tools:
  - tool_name: "myself"  # New registry lookup
    config: {type: native}
```

### Design & Code Changes

New: verl/tools/registry.py for the core registry logic.
Update: verl/tools/utils/tool_registry.py to support `tool_name` resolution.
Update: Applied `@register_tool` to all 7 built-in tool modules.
Refactor: `BaseTool` now uses logging instead of print.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
