### PR TITLE
[rollout] feat: global request-level load balancer single source routing

### DIFF
--- a/tests/checkpoint_engine/test_special_server_adapter.py
+++ b/tests/checkpoint_engine/test_special_server_adapter.py
@@ -197,7 +197,14 @@ async def test_server_adapter(init_config):
 
     # 2. create standalone rollout with AgentLoopManager
     agent_loop_manager = await AgentLoopManager.create(config=init_config)
-    server_handles = [server._server_handle for server in agent_loop_manager.rollout_replicas]
+    servers = list(
+        zip(
+            agent_loop_manager.server_addresses,
+            [server._server_handle for server in agent_loop_manager.rollout_replicas],
+            strict=True,
+        )
+    )
+    load_balancer_handle = agent_loop_manager.global_load_balancer
 
     # 3. create checkpoint engine manager
     checkpoint_manager = CheckpointEngineManager(
@@ -212,7 +219,9 @@ async def test_server_adapter(init_config):
         [{"role": "user", "content": "Please write an article about the geography of America, at least 1000 words."}],
     ] * n
 
-    server_manager = AsyncLLMServerManager(config=init_config, server_handles=server_handles)
+    server_manager = AsyncLLMServerManager(
+        config=init_config, servers=servers, load_balancer_handle=load_balancer_handle
+    )
 
     # 4. test update_weights with global_steps=None
     await _run_update_weights_with_global_steps_none(
@@ -233,7 +242,9 @@ async def test_server_adapter(init_config):
     )
 
     # 6. test FullyAsyncLLMServerManager with partial rollout resume
-    server_manager = FullyAsyncLLMServerManager(config=init_config, server_handles=server_handles)
+    server_manager = FullyAsyncLLMServerManager(
+        config=init_config, servers=servers, load_balancer_handle=load_balancer_handle
+    )
     await _run_server_manager_with_resume(
         initial_steps=4,
         train_steps=3,

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -23,7 +23,7 @@ from transformers.utils import get_json_schema
 
 from tests.experimental.agent_loop.agent_utils import init_agent_loop_manager
 from verl.checkpoint_engine import CheckpointEngineManager
-from verl.experimental.agent_loop.agent_loop import get_trajectory_info
+from verl.experimental.agent_loop.agent_loop import GlobalRequestLoadBalancer, get_trajectory_info
 from verl.protocol import DataProto
 from verl.tools.base_tool import BaseTool, OpenAIFunctionToolSchema
 from verl.tools.schemas import ToolResponse
@@ -453,3 +453,70 @@ async def test_get_trajectory_info():
     trajectory_info = await get_trajectory_info(step, index, validate=False)
 
     assert trajectory_info == expected_info
+
+
+# ──────────────────────────────────────────────────────────────────────
+# GlobalRequestLoadBalancer unit tests (lightweight, no GPU required)
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def ray_for_lb():
+    ray.init(ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+class TestLoadBalancerRouting:
+    """Least-loaded selection."""
+
+    def test_distributes_across_servers(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1", "s2"])
+        servers = [ray.get(lb.acquire_server.remote(request_id=f"r{i}")) for i in range(3)]
+        assert sorted(servers) == ["s0", "s1", "s2"]
+
+    def test_new_requests_route_to_least_loaded(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1", "s2"])
+        # Load s0 with 3 inflight requests
+        ray.get(lb.acquire_server.remote(request_id="a"))  # -> s0
+        ray.get(lb.acquire_server.remote(request_id="a"))  # sticky -> s0
+        ray.get(lb.acquire_server.remote(request_id="a"))  # sticky -> s0
+        # Load s1 with 1 inflight request
+        ray.get(lb.acquire_server.remote(request_id="b"))  # -> s1
+        # s2 has 0 inflight, so next new request must go to s2
+        s_new = ray.get(lb.acquire_server.remote(request_id="d"))
+        assert s_new == "s2"
+
+    def test_release_rebalances(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1"])
+        s0 = ray.get(lb.acquire_server.remote(request_id="r0"))
+        s1 = ray.get(lb.acquire_server.remote(request_id="r1"))
+        assert s0 != s1
+        ray.get(lb.release_server.remote(server_id=s0))
+        ray.get(lb.release_server.remote(server_id=s1))
+        s2 = ray.get(lb.acquire_server.remote(request_id="r2"))
+        s3 = ray.get(lb.acquire_server.remote(request_id="r3"))
+        assert s2 != s3
+
+    def test_release_invalid_server_raises(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1"])
+        with pytest.raises(ray.exceptions.RayTaskError, match="Invalid server_id") as excinfo:
+            ray.get(lb.release_server.remote(server_id="nonexistent"))
+        assert "Invalid server_id" in str(excinfo.value)
+
+    def test_release_without_inflight_raises(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1"])
+        with pytest.raises(ray.exceptions.RayTaskError, match="no inflight") as excinfo:
+            ray.get(lb.release_server.remote(server_id="s1"))
+        assert "no inflight" in str(excinfo.value)
+
+
+class TestLoadBalancerStickySession:
+    """Request-level sticky session."""
+
+    def test_same_request_id_same_server(self, ray_for_lb):
+        lb = GlobalRequestLoadBalancer.remote(server_actor_ids=["s0", "s1", "s2", "s3"])
+        s0 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))
+        ray.get(lb.release_server.remote(server_id=s0))
+        s1 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))
+        assert s0 == s1

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
-import heapq
 import logging
 import os
 import random
@@ -52,6 +51,42 @@ from verl.workers.rollout.replica import TokenOutput, get_rollout_replica_class
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+DEFAULT_ROUTING_CACHE_SIZE = 10000
+
+
+@ray.remote
+class GlobalRequestLoadBalancer:
+    """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers."""
+
+    def __init__(self, server_actor_ids: list[str], max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE):
+        if not server_actor_ids:
+            raise ValueError("server_actor_ids must be non-empty")
+
+        self._inflight_requests: dict[str, int] = {sid: 0 for sid in server_actor_ids}
+        self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
+
+    def acquire_server(self, request_id: str) -> str:
+        """Acquire a server for the given request, reusing the same server for multi-turn conversations."""
+        # request-level sticky (multi-turn: same conversation -> same server)
+        if request_id in self._request_id_to_server:
+            server_id = self._request_id_to_server[request_id]
+            self._inflight_requests[server_id] += 1
+            return server_id
+
+        # new request: route to least loaded server
+        server_id = min(self._inflight_requests, key=self._inflight_requests.get)
+        self._request_id_to_server[request_id] = server_id
+        self._inflight_requests[server_id] += 1
+        return server_id
+
+    def release_server(self, server_id: str) -> None:
+        """Release a server after a request completes, decrementing its inflight count."""
+        if server_id not in self._inflight_requests:
+            raise ValueError(f"Invalid server_id for release: {server_id}")
+        if self._inflight_requests[server_id] <= 0:
+            raise ValueError(f"Release called with no inflight requests on server {server_id}")
+        self._inflight_requests[server_id] -= 1
+
 
 def _get_rollout_and_model_config(config: DictConfig) -> tuple[DictConfig, DictConfig]:
     # TODO: backward compatibility, remove this once we switch to new trainer.
@@ -64,39 +99,38 @@ def _get_rollout_and_model_config(config: DictConfig) -> tuple[DictConfig, DictC
 class AsyncLLMServerManager:
     """
     A class to manage multiple OpenAI compatible LLM servers. This class provides
-    - Load balance: least requests load balancing
+    - Load balance: least in-flight requests load balancing via global coordination
     - Sticky session: send multi-turn chat completions to same server for automatic prefix caching
     """
 
-    def __init__(self, config: DictConfig, server_handles: list[ray.actor.ActorHandle], max_cache_size: int = 10000):
+    def __init__(
+        self,
+        config: DictConfig,
+        servers: list[tuple[str, ray.actor.ActorHandle]],
+        load_balancer_handle: ray.actor.ActorHandle,
+    ):
         """Initialize the AsyncLLMServerManager.
 
         Args:
             config (DictConfig): whole config for main entrypoint.
-            server_handles (List[ray.actor.ActorHandle]): OpenAI compatible LLM server actor handles.
-            max_cache_size (int, optional): max cache size for request_id to server mapping. Defaults to 10000.
+            servers (list[tuple[str, ray.actor.ActorHandle]]): (address, handle) pairs for each LLM server.
+            load_balancer_handle (ray.actor.ActorHandle): shared global load balancer actor.
         """
         self.config = config
-        self.server_handles = server_handles
-        random.shuffle(self.server_handles)
+        self._load_balancer = load_balancer_handle
+        self._server_id_to_handle: dict[str, ray.actor.ActorHandle] = dict(servers)
 
-        # Least requests load balancing
-        self.weighted_serveres = [[0, idx, server] for idx, server in enumerate(self.server_handles)]
-        heapq.heapify(self.weighted_serveres)
+    async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
+        server_id = await self._load_balancer.acquire_server.remote(request_id=request_id)
+        handle = self._server_id_to_handle.get(server_id)
+        if handle is None:
+            raise RuntimeError(f"Unknown server_id returned by load balancer: {server_id}")
+        return server_id, handle
 
-        # LRU cache to map request_id to server
-        self.request_id_to_server = LRUCache(maxsize=max_cache_size)
-
-    def _choose_server(self, request_id: str) -> ray.actor.ActorHandle:
-        # TODO: implement server pressure awareness load balancing
-        if request_id in self.request_id_to_server:
-            return self.request_id_to_server[request_id]
-
-        _, _, server = self.weighted_serveres[0]
-        self.weighted_serveres[0][0] += 1
-        heapq.heapreplace(self.weighted_serveres, self.weighted_serveres[0])
-        self.request_id_to_server[request_id] = server
-        return server
+    def _release_server(self, server_id: str) -> None:
+        # Fire-and-forget: release is just a counter decrement, no need to await.
+        # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
+        self._load_balancer.release_server.remote(server_id=server_id)
 
     @rollout_trace_op
     async def generate(
@@ -118,15 +152,18 @@ class AsyncLLMServerManager:
         Returns:
             TokenOutput: token output
         """
-        server = self._choose_server(request_id)
-        output = await server.generate.remote(
-            request_id=uuid4().hex,  # use new request_id for each turn
-            prompt_ids=prompt_ids,
-            sampling_params=sampling_params,
-            image_data=image_data,
-            video_data=video_data,
-        )
-        return output
+        server_id, server = await self._acquire_server(request_id)
+        try:
+            output = await server.generate.remote(
+                request_id=uuid4().hex,  # use new request_id for each turn
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+                video_data=video_data,
+            )
+            return output
+        finally:
+            self._release_server(server_id)
 
 
 class AgentLoopMetrics(BaseModel):
@@ -355,16 +392,24 @@ class AgentLoopWorker:
 
     Args:
         config (DictConfig): whole config for main entrypoint.
-        server_handles (List[ray.actor.ActorHandle]): OpenAI compatible LLM server actor handles.
+        servers (list[tuple[str, ray.actor.ActorHandle]]): (address, handle) pairs for each LLM server.
         reward_loop_worker_handles (List[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
     """
 
     def __init__(
         self,
         config: DictConfig,
-        server_handles: list[ray.actor.ActorHandle],
+        servers: list[tuple[str, ray.actor.ActorHandle]],
+        load_balancer_handle: ray.actor.ActorHandle,
         reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
     ):
+        """Initialize agent loop manager.
+        Args:
+            config (DictConfig): YAML config.
+            servers (list[tuple[str, ray.actor.ActorHandle]]): (address, handle) pairs for each LLM server.
+            load_balancer_handle (ray.actor.ActorHandle): shared global load balancer actor.
+            reward_loop_worker_handles (list[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
+        """
         self.config = config
         rollout_config, model_config = _get_rollout_and_model_config(config)
         self.rollout_config: RolloutConfig = omega_conf_to_dataclass(rollout_config)
@@ -372,7 +417,11 @@ class AgentLoopWorker:
 
         # for recipe to change
         if not hasattr(self, "server_manager"):
-            self.server_manager = AsyncLLMServerManager(config, server_handles)
+            self.server_manager = AsyncLLMServerManager(
+                config,
+                servers,
+                load_balancer_handle=load_balancer_handle,
+            )
 
         self.dataset_cls = get_dataset_class(config.data)
         self.reward_loop_worker_handles = reward_loop_worker_handles
@@ -885,6 +934,7 @@ class AgentLoopManager:
         """Create agent loop manager."""
         instance = cls(config, worker_group, rollout_resource_pool, reward_loop_worker_handles)
         await instance._initialize_llm_servers()
+        await instance._init_global_load_balancer()
         await instance._init_agent_loop_workers()
         return instance
 
@@ -938,6 +988,8 @@ class AgentLoopManager:
     async def _init_agent_loop_workers(self):
         self.agent_loop_workers = []
         num_workers = self.rollout_config.agent.num_workers
+        load_balancer_handle = self.global_load_balancer
+        servers = list(zip(self.server_addresses, self.server_handles, strict=True))
 
         node_ids = [node["NodeID"] for node in ray.nodes() if node["Alive"] and node["Resources"].get("CPU", 0) > 0]
         for i in range(num_workers):
@@ -949,8 +1001,19 @@ class AgentLoopManager:
                     scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                         node_id=node_id, soft=True
                     ),
-                ).remote(self.config, self.server_handles, self.reward_loop_worker_handles)
+                ).remote(
+                    self.config,
+                    servers,
+                    load_balancer_handle,
+                    self.reward_loop_worker_handles,
+                )
             )
+
+    async def _init_global_load_balancer(self) -> None:
+        self.global_load_balancer = GlobalRequestLoadBalancer.remote(
+            server_actor_ids=self.server_addresses,
+            max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
+        )
 
     @auto_await
     async def generate_sequences(self, prompts: DataProto) -> DataProto:

--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -150,15 +150,18 @@ class FullyAsyncLLMServerManager(AsyncLLMServerManager):
             - Element 1 (list[float]): Log probabilities for the response token IDs.
             - Element 2 (bool): A flag or status indicating cancellation.
         """
-        server = self._choose_server(request_id)
-        output = await server.generate_for_partial.remote(
-            request_id=request_id,
-            prompt_ids=prompt_ids,
-            sampling_params=sampling_params,
-            image_data=image_data,
-            video_data=video_data,
-        )
-        return output
+        server_id, server = await self._acquire_server(request_id=request_id)
+        try:
+            output = await server.generate_for_partial.remote(
+                request_id=request_id,
+                prompt_ids=prompt_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+                video_data=video_data,
+            )
+            return output
+        finally:
+            self._release_server(server_id)
 
 
 @ray.remote
@@ -166,11 +169,21 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
     def __init__(
         self,
         config: DictConfig,
-        server_handles: list[ray.actor.ActorHandle],
+        servers: list[tuple[str, ray.actor.ActorHandle]],
+        load_balancer_handle: ray.actor.ActorHandle,
         reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
     ):
-        self.server_manager = FullyAsyncLLMServerManager(config, server_handles)
-        super().__init__(config, server_handles, reward_loop_worker_handles)
+        self.server_manager = FullyAsyncLLMServerManager(
+            config,
+            servers,
+            load_balancer_handle=load_balancer_handle,
+        )
+        super().__init__(
+            config,
+            servers,
+            load_balancer_handle,
+            reward_loop_worker_handles,
+        )
         # A shared cancellation event for all agent loops running on this worker.
         self.cancellation_event = asyncio.Event()
 
@@ -235,7 +248,7 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
         return outputs, is_cancel
 
     def _addition_process(self, output: DataProto):
-        """collect metirics"""
+        """collect metrics"""
         metrics = output.meta_info.pop("metrics")  # List[Dict[str, str]]
         processing_times_list = [item["generate_sequences"] for item in metrics]
         tool_calls_times_list = [item["tool_calls"] for item in metrics]
@@ -253,7 +266,7 @@ class FullyAsyncAgentLoopWorker(AgentLoopWorker):
     ) -> AgentLoopOutput:
         # Completed, return directly
         if kwargs["output"] is not None and not kwargs["output"].extra_fields.get("is_cancel", False):
-            logger.info("In _partial_run_agent_loop, already completed, return derictly!")
+            logger.info("In _partial_run_agent_loop, already completed, return directly!")
             return kwargs["output"]
         try:
             with rollout_trace_attr(


### PR DESCRIPTION
## Summary

This PR is **Task 1 (Phase 1)** for routing roadmap (#5442):

- Introduce global `GlobalRequestLoadBalancer` as runtime single source of truth for routing.
- Keep request-level sticky (`request_id -> server`) + least-loaded routing.

## Code Scope

- `verl/experimental/agent_loop/agent_loop.py`
  - global LB routing path (`acquire/release`)
- `verl/experimental/fully_async_policy/agent_loop/agent_loop.py`
  - keep required wiring only
- `tests/experimental/agent_loop/test_basic_agent_loop.py`
  - load balancer behavior tests aligned with current strategy

## Experiment Configuration (Copied)

Model/Data:
- Model: **Qwen2.5-VL-32B**
- Data: **osworld.json**
- Machine: **3 * H100 Nodes**

Runtime config (from run):
```bash
MAX_ASSISTANT_TURNS=50
MAX_PROMPT_LENGTH=24488
RESPONSE_LENGTH=512
MAX_TOKENS=512
NNODES=3
N_GPU_PER_NODE=8
HARDWARE=3 x H100 nodes
SP_SIZE=1
MICRO_BATCH_SIZE_PER_GPU=1
PPO_MINI_BATCH_SIZE=6
TRAIN_BATCH_SIZE=24
ROLLOUT_N=16
STRATEGY=fsdp2
ENGINE=vllm
DUMP_VALIDATION_DATA=true
DUMP_ROLLOUT_DATA=false
DUMP_TASK_SCORES=false
DUMP_ROLLOUT_TIMING=true
FILTER_GROUPS=true
DETERMINISTIC=false
TRAJECTORY_SPLITTING=true
USE_FLEX_ATTENTION_HETERO=false
DUMMY_MODE=disabled
RAY_DASHBOARD_ADDRESS=http://127.0.0.1:8265
nsys_prof=false
ENABLE_PROMETHEUS_MONITORING=true
PROMETHEUS_PORT=9090
SCRIPT_DIR=/home/ubuntu/verl-grounding
PROMETHEUS_CONFIG_FILE=/home/ubuntu/verl-grounding/gui_scripts/vllm_monitoring/prometheus.yaml
PROMETHEUS_SERVED_MODEL_NAME=qwen2_5_vl_32b
EXPERIMENT_NAME=gui-agent-fsdp2-gb24-3nodes-20260223_145012
HF_MODEL_PATH=/mnt/data2/models_and_datasets/sft-32b-bigs1-1027-s2-0103-osworld
TRAIN_DATA_PATH=data/nongoogledrive_02_04_no_infeasible_and_chart_editing_train.json
TEST_DATA_PATH=data/nongoogledrive_02_04_no_infeasible_and_chart_editing_test.json
PROJECT_NAME=verl_grounding
SAVE_PATH=/mnt/data2/saves/verl_grounding/gui-agent-fsdp2-gb24-3nodes-20260223_145012
ALL_OFFLOAD=true
ACTOR_PARAM_OFFLOAD=true
ACTOR_GRAD_OFFLOAD=true
ACTOR_OPTIMIZER_OFFLOAD=true
REF_PARAM_OFFLOAD=true
PROMETHEUS_PARAMS='actor_rollout_ref.rollout.disable_log_stats=False actor_rollout_ref.rollout.prometheus.enable=True actor_rollout_ref.rollout.prometheus.port=9090 actor_rollout_ref.rollout.prometheus.file=/home/ubuntu/verl-grounding/gui_scripts/vllm_monitoring/prometheus.yaml actor_rollout_ref.rollout.prometheus.served_model_name=qwen2_5_vl_32b'
```


## Load Distribution Comparison (Placeholder)

Before (baseline):
<img width="1121" height="474" alt="148a35c49293e9a79fe25d2877d2670f" src="https://github.com/user-attachments/assets/771d4e09-77df-4a7e-b071-fe7fc570c2a4" />


After (optimized):
<img width="1152" height="491" alt="d516d2756af159a4b2b86d9228e8ac38" src="https://github.com/user-attachments/assets/7b6a1f8d-18d9-494a-9243-42edea6386a4" />

## Metrics (Before PR -> After PR)

| Metric | Baseline | Optimized | Delta |
|---|---:|---:|---:|
| `agent_loop/per_step/generate_sequences/mean` | `6.3596` s | `4.5312` s | `-1.8285` s (`-28.75%`) |
| `agent_loop/slowest/total_time` | `899.3761` s | `724.6898` s | `-174.6863` s (`-19.42%`) |

