### PR TITLE
[megatron] fix: missing model offload to CPU for forward_only mode

### DIFF
--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -319,6 +319,8 @@ class MegatronEngine(BaseEngine):
         if self.engine_config.forward_only:
             self.optimizer = None
             self.lr_scheduler = None
+            self.to(device="cpu", model=self._is_offload_param, optimizer=False, grad=False)
+            log_gpu_memory_usage("After offload model during init (forward_only)", logger=logger)
             return
 
         self.optimizer = self._build_optimizer()


### PR DESCRIPTION
### What does this PR do?

Fix a bug where model parameters were not offloaded to CPU during initialization when MegatronEngine is in forward_only mode (e.g., inference/rollout workers) with param_offload enabled.
In MegatronEngine.initialize(), when forward_only=True, the method returns early before reaching the self.to(device="cpu", ...) call in the training path, causing model parameters to remain on GPU even when param_offload is configured. This leads to unnecessary GPU memory consumption for inference/rollout workers.
This PR adds the offload call before the early return, ensuring model parameters are properly moved to CPU when param_offload is enabled in forward_only mode.

