### PR TITLE
[algo] fix: seq mean and default scale factor `loss_mask.shape[-1]` as in seq-mean-token-sum-norm

### DIFF
--- a/examples/dppo_trainer/run_qwen30b_dppo.sh
+++ b/examples/dppo_trainer/run_qwen30b_dppo.sh
@@ -58,7 +58,7 @@ bypass_mode=True
 # We recommand using Dr.GRPO to remove the length and difficulty bias in original GRPO.
 # See Section 3.1 in https://arxiv.org/pdf/2503.20783 for more details.
 norm_adv_by_std_in_grpo=False               # remove the difficulty bias
-loss_agg_mode="seq-mean-token-sum"          # remove the length bias
+loss_agg_mode="seq-mean-token-sum-norm"     # remove the length bias
 
 # reference policy
 use_kl_in_reward=False


### PR DESCRIPTION
### What does this PR do?

This PR:

1. fixes the "seq-mean" semantics in "seq-mean-token-sum-norm", which is missing in the previous implementation; (Note that here this is implemented by merging the "seq-mean-token-sum" part of "seq-mean-token-sum-norm" into the "seq-mean-token-sum" branch.)
2. reverts to the design that defaults `loss_scale_factor` to the horizon `loss_mask.shape[-1]`, which is actually a reasonable design;
3. reverts the `loss_agg_mode` to "seq-mean-token-sum-norm" in PR #5397 

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

See the CI.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
