### PR TITLE
[megatron] fix: add FP8 block quantization padding for EngineWorker

### DIFF
--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -169,13 +169,15 @@ def gptmodel_forward_no_padding(
     pad_token_id=None,
     data_format: str = "thd",
     enable_mtp: bool = False,
-    use_fp8_padding: bool = False,
 ):
     """Default forward pass for GPT models with optional sequence packing."""
 
     assert data_format in ["thd", "bshd"], "data_format must be 'thd' or 'bshd'"
     pre_process = unwrap_model(model).pre_process
     post_process = unwrap_model(model).post_process
+
+    fp8 = unwrap_model(model).config.fp8
+    use_fp8_padding = fp8 in ["e4m3", "hybrid"]
 
     model_kwargs = {}
     if "pixel_values" in multi_modal_inputs:

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -146,10 +146,12 @@ def fused_forward_no_padding_gen(vision_model: bool = False):
         temperature: float,
         calculate_entropy: bool,
         pad_token_id: int,
-        use_fp8_padding: bool = False,
     ):
         pre_process = unwrap_model(model).pre_process
         post_process = unwrap_model(model).post_process
+
+        fp8 = unwrap_model(model).config.fp8
+        use_fp8_padding = fp8 in ["e4m3", "hybrid"]
 
         input_ids_rmpad, packed_seq_params = preprocess_thd_no_padding(
             input_ids, pre_process=pre_process, use_fp8_padding=use_fp8_padding

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -725,11 +725,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
         else:
             raise NotImplementedError(f"Pad mode {pad_mode} is not supported for megatron engine")
 
-        fp8 = self.engine_config.override_transformer_config.get("fp8", None)
-        if fp8 is None and self.tf_config is not None:
-            fp8 = getattr(self.tf_config, "fp8", None)
-        use_fp8_padding = fp8 in ("e4m3", "hybrid")
-
         from verl.models.mcore import get_mcore_forward_no_padding_fn
 
         if use_fused_kernels:
@@ -759,7 +754,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 temperature=temperature_value,
                 calculate_entropy=calculate_entropy,
                 pad_token_id=self.model_config.tokenizer.pad_token_id,
-                use_fp8_padding=use_fp8_padding,
             )
         else:
             if not isinstance(temperature, torch.Tensor):
@@ -808,7 +802,6 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 pad_token_id=self.model_config.tokenizer.pad_token_id,
                 data_format="thd" if self.engine_config.use_remove_padding else "bshd",
                 enable_mtp=self.model_config.mtp.enable_train,
-                use_fp8_padding=use_fp8_padding,
             )
 
         # Router replay: switch to backward replay mode for next backward pass


### PR DESCRIPTION
### What does this PR do?

When running FP8 e2e training (blockwise quantization) with EngineWorker (`use_legacy_worker_impl="disable"`), TransformerEngine's `Float8BlockQuantizer` assertion fails because the packed sequence lengths are not aligned to 128-element blocks.

The legacy worker path (`preprocess_packed_seqs`) already has FP8 padding logic, but the EngineWorker path (`preprocess_thd_no_padding` and `preprocess_bshd_no_padding`) was missing it entirely. Additionally, the EngineWorker's `forward_step` was not reading the FP8 config or passing it to the preprocessing functions.

### Root Cause

Three issues combined to cause the failure:

1. **Missing FP8 padding in `preprocess_thd_no_padding`**: The EngineWorker's thd-format preprocessor did not pad sequences for FP8 block quantization alignment (unlike `preprocess_packed_seqs` which already did).

2. **Missing FP8 padding in `preprocess_bshd_no_padding`**: When `use_remove_padding=False` (the default), the bshd-format preprocessor is used instead of thd, and it also lacked FP8 padding.

3. **FP8 config not threaded through**: `MegatronEngineWithLMHead.forward_step` did not read the FP8 config or pass `use_fp8_padding` to the forward functions (`gptmodel_forward_no_padding` / `fused_forward_no_padding`).


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

#### `verl/models/mcore/util.py`
- Add `_compute_fp8_thd_align_size` helper to share FP8 alignment logic between `preprocess_packed_seqs` and `preprocess_thd_no_padding`
- Add `use_fp8_padding` parameter to `preprocess_thd_no_padding`: pads per-sequence to `lcm(16, align_size)` and total length to `align_size * 128`, matching the legacy path
- Add `use_fp8_padding` parameter to `preprocess_bshd_no_padding`: computes the minimal `max_seqlen` alignment such that `batch_size * max_seqlen / tp_size` is divisible by 128, while maintaining SP alignment to `tp_size`

#### `verl/models/mcore/model_forward.py`
- Add `use_fp8_padding` parameter to `gptmodel_forward_no_padding`
- Pass `use_fp8_padding` to all `preprocess_thd_no_padding` and `preprocess_bshd_no_padding` call sites (6 total)

#### `verl/models/mcore/model_forward_fused.py`
- Add `use_fp8_padding` parameter to `fused_forward_no_padding`
- Pass `use_fp8_padding` to `preprocess_thd_no_padding` call sites (2 total)

#### `verl/workers/engine/megatron/transformer_impl.py`
- In `MegatronEngineWithLMHead.forward_step`, read FP8 config from `engine_config.override_transformer_config` (with fallback to `tf_config.fp8`) and compute `use_fp8_padding`
- Pass `use_fp8_padding` to both fused and non-fused forward function calls

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
