### PR TITLE
[reward] perf: batch tokenizer.decode() in reward managers

### DIFF
--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -52,12 +52,8 @@ class BatchRewardManager(AbstractRewardManager):
         prompt_len = prompt_ids.shape[-1]
         valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
 
-        responses_str = []
-        for i in range(len(data)):
-            valid_len = valid_response_lengths[i]
-            valid_response_ids = response_ids[i][:valid_len]
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
-            responses_str.append(response_str)
+        all_valid_response_ids = [response_ids[i][:valid_response_lengths[i]] for i in range(len(data))]
+        responses_str = self.tokenizer.batch_decode(all_valid_response_ids, skip_special_tokens=True)
 
         ground_truths = [item.non_tensor_batch["reward_model"].get("ground_truth", None) for item in data]
         data_sources = data.non_tensor_batch[self.reward_fn_key]

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -68,24 +68,34 @@ class DAPORewardManager(AbstractRewardManager):
 
         already_print_data_sources = {}
 
+        # Pre-collect valid token ids for batch decoding
+        all_valid_prompt_ids = []
+        all_valid_response_ids = []
+        valid_response_lengths = []
         for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
-
+            data_item = data[i]
             prompt_ids = data_item.batch["prompts"]
-
             prompt_length = prompt_ids.shape[-1]
-
             valid_prompt_length = data_item.batch["attention_mask"][:prompt_length].sum()
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
-
             response_ids = data_item.batch["responses"]
             valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
             valid_response_ids = response_ids[:valid_response_length]
+            all_valid_prompt_ids.append(valid_prompt_ids)
+            all_valid_response_ids.append(valid_response_ids)
+            valid_response_lengths.append(valid_response_length)
 
-            # decode
-            prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
-            eos_token = self.tokenizer.eos_token
+        # Batch decode all prompts and responses at once
+        all_prompt_strs = self.tokenizer.batch_decode(all_valid_prompt_ids, skip_special_tokens=True)
+        all_response_strs = self.tokenizer.batch_decode(all_valid_response_ids, skip_special_tokens=True)
+
+        eos_token = self.tokenizer.eos_token
+        for i in range(len(data)):
+            data_item = data[i]  # DataProtoItem
+
+            prompt_str = all_prompt_strs[i]
+            response_str = all_response_strs[i]
+            valid_response_length = valid_response_lengths[i]
             if response_str.endswith(eos_token):
                 response_str = response_str[: -len(eos_token)]
 

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -56,23 +56,33 @@ class NaiveRewardManager(AbstractRewardManager):
 
         already_print_data_sources = {}
 
+        # Pre-collect valid token ids for batch decoding
+        all_valid_prompt_ids = []
+        all_valid_response_ids = []
+        valid_response_lengths = []
         for i in range(len(data)):
-            data_item = data[i]  # DataProtoItem
-
+            data_item = data[i]
             prompt_ids = data_item.batch["prompts"]
-
             prompt_length = prompt_ids.shape[-1]
-
             valid_prompt_length = data_item.batch["attention_mask"][:prompt_length].sum()
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
-
             response_ids = data_item.batch["responses"]
             valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
             valid_response_ids = response_ids[:valid_response_length]
+            all_valid_prompt_ids.append(valid_prompt_ids)
+            all_valid_response_ids.append(valid_response_ids)
+            valid_response_lengths.append(valid_response_length)
 
-            # decode
-            prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
-            response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
+        # Batch decode all prompts and responses at once
+        all_prompt_strs = self.tokenizer.batch_decode(all_valid_prompt_ids, skip_special_tokens=True)
+        all_response_strs = self.tokenizer.batch_decode(all_valid_response_ids, skip_special_tokens=True)
+
+        for i in range(len(data)):
+            data_item = data[i]  # DataProtoItem
+
+            prompt_str = all_prompt_strs[i]
+            response_str = all_response_strs[i]
+            valid_response_length = valid_response_lengths[i]
 
             ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
             data_source = data_item.non_tensor_batch[self.reward_fn_key]


### PR DESCRIPTION
## Summary

Replace per-item `tokenizer.decode()` loops with `tokenizer.batch_decode()` in 3 reward managers (`NaiveRewardManager`, `DAPORewardManager`, `BatchRewardManager`), matching the pattern already used by `PrimeRewardManager`.

## Changes

- **`naive.py`**: Replace per-item decode loop with `batch_decode()` + zip
- **`dapo.py`**: Same refactor for `DAPORewardManager`
- **`batch.py`**: Same refactor for `BatchRewardManager.verify()`

## Benchmark

CPU benchmark (gpt2 tokenizer, ~256 tokens/seq):

| Batch Size | Per-item | batch_decode | Speedup |
|------------|----------|-------------|---------|
| 64 | 3.86 ms | 3.14 ms | 1.23x |
| 256 | 14.53 ms | 12.52 ms | 1.16x |
| 512 | 31.83 ms | 26.62 ms | 1.20x |
| 1024 | 62.69 ms | 54.61 ms | 1.15x |

Consistent 15-23% speedup across batch sizes. Gains should be larger with GPU tokenizers and longer sequences in real RLHF workloads.

## Correctness

- Output is identical (no padding tokens, same skip_special_tokens behavior)
- Follows the exact same pattern as `PrimeRewardManager` which already uses `batch_decode()`
