### PR TITLE
[megatron] feat: empty_cache after save_ckpt

### DIFF
--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -950,6 +950,7 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
             offload_megatron_model_to_cpu(self.actor_module)
         if self.checkpoint_mananager.checkpoint_config.async_save and self._is_offload_optimizer:
             offload_megatron_optimizer(self.actor_optimizer)
+        aggressive_empty_cache(force_sync=True)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def async_calls_finalize_fn_exec(self, blocking=False):
@@ -1284,3 +1285,4 @@ class CriticWorker(MegatronWorker, DistProfilerExtension):
         )
         if self._is_offload_param:
             offload_megatron_model_to_cpu(self.critic_module)
+        aggressive_empty_cache(force_sync=True)


### PR DESCRIPTION
### What does this PR do?

empty_cache after save_ckpt to avoid Engine wakeup OOM.

save ckpt involves NCCL to collect opt states which could cause memory fragments.

