### PR TITLE
[BREAKING][single_controller] refactor: remove Ray leakage from base interface

### DIFF
--- a/examples/split_placement/main_ppo_split.py
+++ b/examples/split_placement/main_ppo_split.py
@@ -148,8 +148,8 @@ def main_task(config):
     from verl.trainer.ppo.ray_trainer import ResourcePoolManager, Role
 
     role_worker_mapping = {
-        Role.ActorRollout: ray.remote(ActorRolloutRefWorker),
-        Role.Critic: ray.remote(CriticWorker),
+        Role.ActorRollout: ActorRolloutRefWorker,
+        Role.Critic: CriticWorker,
     }
 
     # NOTE: initialze two resource pool
@@ -173,7 +173,7 @@ def main_task(config):
 
     # use reference model
     if need_reference_policy(config):
-        role_worker_mapping[Role.RefPolicy] = ray.remote(ActorRolloutRefWorker)
+        role_worker_mapping[Role.RefPolicy] = ActorRolloutRefWorker
         mapping[Role.RefPolicy] = actor_rollout_ref_pool_id
 
     reward_fn = RewardManager(tokenizer=tokenizer, num_examine=0)

--- a/scripts/megatron_merge_lora.py
+++ b/scripts/megatron_merge_lora.py
@@ -85,9 +85,7 @@ def main_task(config):
     pprint(OmegaConf.to_container(config, resolve=True))  # resolve=True will eval symbol values
     OmegaConf.resolve(config)
 
-    ray_cls_with_init = RayClassWithInitArgs(
-        cls=ray.remote(CustomSaveWorker), config=config.actor_rollout_ref, role="actor"
-    )
+    ray_cls_with_init = RayClassWithInitArgs(cls=CustomSaveWorker, config=config.actor_rollout_ref, role="actor")
     resource_pool = RayResourcePool(process_on_nodes=[config.trainer.n_gpus_per_node] * config.trainer.nnodes)
 
     worker = RayWorkerGroup(

--- a/tests/checkpoint_engine/test_special_server_adapter.py
+++ b/tests/checkpoint_engine/test_special_server_adapter.py
@@ -79,7 +79,7 @@ async def test_server_adapter(init_config):
     # 2.1 create checkpoint engine worker group
     rollout_pool = RayResourcePool(process_on_nodes=[4], max_colocate_count=3)
     ray_cls_with_init = RayClassWithInitArgs(
-        cls=ray.remote(CheckpointEngineWorker),
+        cls=CheckpointEngineWorker,
         model_config=model_config,
         rollout_config=rollout_config,
     )

--- a/tests/checkpoint_engine/test_utils.py
+++ b/tests/checkpoint_engine/test_utils.py
@@ -14,7 +14,6 @@
 import asyncio
 from typing import Generator
 
-import ray
 import torch
 from transformers import AutoModelForCausalLM
 
@@ -130,7 +129,7 @@ def create_trainer_worker_group(
     )
 
     ray_cls_with_init = RayClassWithInitArgs(
-        cls=ray.remote(TrainingWorkerTest),
+        cls=TrainingWorkerTest,
         config=trainer_config,
         checkpoint_engine_config=checkpoint_engine_config,
     )
@@ -155,7 +154,7 @@ async def create_rollout_worker_group(
 ) -> tuple[RayWorkerGroup, list[MockReplica]]:
     # create rollout worker group
     ray_cls_with_init = RayClassWithInitArgs(
-        cls=ray.remote(CheckpointEngineWorkerTest),
+        cls=CheckpointEngineWorkerTest,
         model_config=model_config,
         rollout_config=rollout_config,
         check_allclose=check_allclose,

--- a/tests/experimental/agent_loop/agent_utils.py
+++ b/tests/experimental/agent_loop/agent_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ray
 from omegaconf import DictConfig
 
 from verl.checkpoint_engine import CheckpointEngineManager
@@ -29,7 +28,7 @@ def init_agent_loop_manager(config: DictConfig) -> AgentLoopManager | RayWorkerG
     # =========================== 1. Create hybrid ActorRollout workers ===========================
     actor_rollout_cls = AsyncActorRolloutRefWorker
     role_worker_mapping = {
-        Role.ActorRollout: ray.remote(actor_rollout_cls),
+        Role.ActorRollout: actor_rollout_cls,
     }
 
     global_pool_id = "global_pool"

--- a/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
+++ b/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
@@ -91,7 +91,7 @@ def test_agent_reward_loop_standalone():
     resource_pool_manager.create_resource_pool()
     resource_pool = resource_pool_manager.resource_pool_dict[global_pool_id]
     actor_rollout_cls = RayClassWithInitArgs(
-        cls=ray.remote(actor_rollout_cls), config=config.actor_rollout_ref, role="actor_rollout"
+        cls=actor_rollout_cls, config=config.actor_rollout_ref, role="actor_rollout"
     )
     actor_rollout_wg = RayWorkerGroup(
         resource_pool=resource_pool, ray_cls_with_init=actor_rollout_cls, device_name=get_device_name()

--- a/tests/models/test_engine.py
+++ b/tests/models/test_engine.py
@@ -120,7 +120,7 @@ def test_actor_engine(strategy):
         device_count=device_count,
         model=get_test_language_model(device_count),
     )
-    ray_cls_with_init = RayClassWithInitArgs(cls=ray.remote(TrainingWorker), config=config)
+    ray_cls_with_init = RayClassWithInitArgs(cls=TrainingWorker, config=config)
     resource_pool = RayResourcePool(process_on_nodes=[device_count])
     wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init)
     # init model
@@ -261,7 +261,7 @@ def test_critic_engine(strategy):
     config = create_training_config(
         model_type="value_model", strategy=strategy, device_count=device_count, model=value_model_path
     )
-    ray_cls_with_init = RayClassWithInitArgs(cls=ray.remote(TrainingWorker), config=config)
+    ray_cls_with_init = RayClassWithInitArgs(cls=TrainingWorker, config=config)
     resource_pool = RayResourcePool(process_on_nodes=[device_count])
     wg = RayWorkerGroup(resource_pool=resource_pool, ray_cls_with_init=ray_cls_with_init)
     # init model

--- a/tests/single_controller/check_worker_alive/main.py
+++ b/tests/single_controller/check_worker_alive/main.py
@@ -23,7 +23,6 @@ from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 
 
-@ray.remote
 class TestActor(Worker):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/single_controller/detached_worker/server.py
+++ b/tests/single_controller/detached_worker/server.py
@@ -40,7 +40,6 @@ from verl.utils.megatron.optimizer import get_megatron_optimizer, init_megatron_
 from verl.utils.megatron_utils import get_model, mcore_model_parallel_config
 
 
-@ray.remote
 class Trainer(Worker):
     def __init__(self):
         super().__init__()

--- a/tests/single_controller/test_auto_padding_on_cpu.py
+++ b/tests/single_controller/test_auto_padding_on_cpu.py
@@ -26,7 +26,6 @@ from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePoo
 DataProtoConfig.auto_padding = True
 
 
-@ray.remote
 class Actor(Worker):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/single_controller/test_colocated_workers.py
+++ b/tests/single_controller/test_colocated_workers.py
@@ -26,7 +26,6 @@ from verl.single_controller.ray.base import (
 from verl.utils.device import get_device_name
 
 
-@ray.remote
 class Actor(Worker):
     def __init__(self) -> None:
         super().__init__()
@@ -37,7 +36,6 @@ class Actor(Worker):
         return data
 
 
-@ray.remote
 class Critic(Worker):
     def __init__(self, config) -> None:
         super().__init__()

--- a/tests/single_controller/test_colocated_workers_fused.py
+++ b/tests/single_controller/test_colocated_workers_fused.py
@@ -26,7 +26,6 @@ from verl.single_controller.ray.base import (
 from verl.utils.device import get_device_name
 
 
-@ray.remote
 class Actor(Worker):
     def __init__(self) -> None:
         super().__init__()
@@ -37,7 +36,6 @@ class Actor(Worker):
         return data
 
 
-@ray.remote
 class Critic(Worker):
     def __init__(self, config) -> None:
         super().__init__()

--- a/tests/single_controller/test_data_transfer.py
+++ b/tests/single_controller/test_data_transfer.py
@@ -30,7 +30,6 @@ from verl.utils.device import get_device_name
 from verl.utils.ray_utils import parallel_put
 
 
-@ray.remote
 class DummyWorker(Worker):
     def __init__(self):
         super().__init__()

--- a/tests/single_controller/test_decorator_on_cpu.py
+++ b/tests/single_controller/test_decorator_on_cpu.py
@@ -36,7 +36,6 @@ def ray_init_shutdown():
 
 
 # Define a simple worker for testing
-@ray.remote
 class DecoratorTestWorker(Worker):
     def __init__(self, initial_value=0):
         super().__init__()

--- a/tests/single_controller/test_device_mesh_register.py
+++ b/tests/single_controller/test_device_mesh_register.py
@@ -25,7 +25,6 @@ from verl.single_controller.base.decorator import make_nd_compute_dataproto_disp
 from verl.utils.device import get_device_name, get_nccl_backend
 
 
-@ray.remote
 class TestActor(Worker):
     def __init__(self):
         super().__init__()

--- a/tests/single_controller/test_driverfunc_to_worker.py
+++ b/tests/single_controller/test_driverfunc_to_worker.py
@@ -28,7 +28,6 @@ os.environ["RAY_DEDUP_LOGS"] = "0"
 os.environ["NCCL_DEBUG"] = "WARN"
 
 
-@ray.remote
 class ModelActor(Worker):
     def __init__(self):
         pass

--- a/tests/single_controller/test_fused_workers_on_cpu.py
+++ b/tests/single_controller/test_fused_workers_on_cpu.py
@@ -24,7 +24,6 @@ from verl.single_controller.ray.base import (
 )
 
 
-@ray.remote
 class Actor(Worker):
     def __init__(self) -> None:
         super().__init__()
@@ -35,7 +34,6 @@ class Actor(Worker):
         return x
 
 
-@ray.remote
 class Critic(Worker):
     def __init__(self, val) -> None:
         super().__init__()
@@ -53,7 +51,6 @@ cls_dict = {"actor": actor_cls, "critic": critic_cls}
 FusedBaseClass = create_colocated_worker_raw_cls(cls_dict)
 
 
-@ray.remote
 class HybridWorker(FusedBaseClass):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def foo(self, x):

--- a/tests/single_controller/test_high_level_scheduling_api.py
+++ b/tests/single_controller/test_high_level_scheduling_api.py
@@ -21,7 +21,6 @@ from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePoo
 from verl.utils.device import get_device_name
 
 
-@ray.remote
 class TestActor(Worker):
     # TODO: pass *args and **kwargs is bug prone and not very convincing
     def __init__(self, cuda_visible_devices=None) -> None:

--- a/tests/single_controller/test_nested_worker.py
+++ b/tests/single_controller/test_nested_worker.py
@@ -47,7 +47,7 @@ def test_nested_worker():
 
     # create 4 workers, each hold a GPU
     resource_pool = RayResourcePool([4], use_gpu=True)
-    class_with_args = RayClassWithInitArgs(cls=ray.remote(TestActor), x=2)
+    class_with_args = RayClassWithInitArgs(cls=TestActor, x=2)
 
     worker_group = RayWorkerGroup(
         resource_pool=resource_pool,
@@ -60,7 +60,7 @@ def test_nested_worker():
 
     assert output == [2, 3, 4, 5]
 
-    class_with_args = RayClassWithInitArgs(cls=ray.remote(TestHighLevelActor), x=2)
+    class_with_args = RayClassWithInitArgs(cls=TestHighLevelActor, x=2)
     high_level_worker_group = RayWorkerGroup(
         resource_pool=resource_pool,
         ray_cls_with_init=class_with_args,

--- a/tests/single_controller/test_ray_class_with_init_args_on_cpu.py
+++ b/tests/single_controller/test_ray_class_with_init_args_on_cpu.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for RayClassWithInitArgs mixin injection.
+
+Verifies that RayWorkerMixin is automatically injected into Worker subclasses,
+pre-decorated classes are rejected, and non-Worker classes pass through unchanged.
+Does not require a live Ray cluster or GPU — ray.remote is called only to create
+decorated class objects, not to launch remote tasks.
+"""
+
+import unittest
+
+import ray
+
+from verl.single_controller.base import Worker
+from verl.single_controller.ray.base import (
+    RayClassWithInitArgs,
+    RayWorkerMixin,
+    unwrap_ray_remote,
+)
+
+
+class RayClassWithInitArgsMixinInjectionTest(unittest.TestCase):
+    def test_mixin_placed_before_worker_in_mro(self):
+        """RayWorkerMixin must appear before Worker in the MRO so its overrides take effect."""
+
+        class Actor(Worker):
+            pass
+
+        cia = RayClassWithInitArgs(cls=Actor)
+        raw = unwrap_ray_remote(cia.cls)
+        mro = raw.__mro__
+
+        mixin_idx = next(i for i, c in enumerate(mro) if c is RayWorkerMixin)
+        worker_idx = next(i for i, c in enumerate(mro) if c is Worker)
+        self.assertLess(mixin_idx, worker_idx)
+
+    def test_pre_decorated_class_raises(self):
+        """@ray.remote-decorated classes must not be passed; use plain classes instead."""
+
+        @ray.remote
+        class Actor(Worker):
+            pass
+
+        with self.assertRaises(ValueError):
+            RayClassWithInitArgs(cls=Actor)
+
+    def test_class_already_having_mixin_not_double_injected(self):
+        """Worker subclass already inheriting RayWorkerMixin should not get it added again."""
+
+        class Actor(RayWorkerMixin, Worker):
+            pass
+
+        cia = RayClassWithInitArgs(cls=Actor)
+        raw = unwrap_ray_remote(cia.cls)
+
+        mro_classes = raw.__mro__
+        mixin_count = sum(1 for c in mro_classes if c is RayWorkerMixin)
+        self.assertEqual(mixin_count, 1)
+
+    def test_plain_non_worker_class_not_modified(self):
+        """Plain classes that do not inherit Worker pass through without mixin injection."""
+
+        class NotAWorker:
+            pass
+
+        cia = RayClassWithInitArgs(cls=NotAWorker)
+        raw = unwrap_ray_remote(cia.cls)
+
+        self.assertFalse(issubclass(raw, RayWorkerMixin))
+
+    def test_kwargs_preserved_through_injection(self):
+        """Constructor kwargs passed to RayClassWithInitArgs are preserved."""
+
+        class Actor(Worker):
+            def __init__(self, x=0):
+                pass
+
+        cia = RayClassWithInitArgs(cls=Actor, x=42)
+
+        self.assertEqual(cia.kwargs, {"x": 42})
+
+    def test_original_class_name_preserved(self):
+        """The injected class should retain the original class name for observability."""
+
+        class MySpecialWorker(Worker):
+            pass
+
+        cia = RayClassWithInitArgs(cls=MySpecialWorker)
+        raw = unwrap_ray_remote(cia.cls)
+
+        self.assertEqual(raw.__name__, "MySpecialWorker")
+
+    def test_registered_methods_visible_on_injected_class(self):
+        """Methods decorated with @register must still be accessible after injection."""
+        from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch, register
+
+        class Actor(Worker):
+            @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+            def compute(self):
+                pass
+
+        cia = RayClassWithInitArgs(cls=Actor)
+        raw = unwrap_ray_remote(cia.cls)
+
+        method = getattr(raw, "compute", None)
+        self.assertIsNotNone(method)
+        self.assertTrue(hasattr(method, MAGIC_ATTR))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_controller/test_ray_collectives.py
+++ b/tests/single_controller/test_ray_collectives.py
@@ -29,7 +29,6 @@ from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 
 
-@ray.remote
 class Actor(Worker):
     @register(Dispatch.ONE_TO_ALL)
     def init(self):
@@ -43,7 +42,6 @@ class Actor(Worker):
         collective.send(tensor=tensor, dst_rank=1, group_name=self.group_name)
 
 
-@ray.remote
 class Rollout(Worker):
     @register(Dispatch.ONE_TO_ALL)
     def init(self):

--- a/tests/single_controller/test_ray_local_envs_on_cpu.py
+++ b/tests/single_controller/test_ray_local_envs_on_cpu.py
@@ -23,7 +23,6 @@ from verl.single_controller.base.worker import Worker
 from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
 
 
-@ray.remote
 class TestActor(Worker):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/single_controller/test_split_resource_pool.py
+++ b/tests/single_controller/test_split_resource_pool.py
@@ -29,7 +29,6 @@ from verl.single_controller.ray.base import (
 from verl.utils.device import get_device_name, get_nccl_backend
 
 
-@ray.remote
 class Actor(Worker):
     def __init__(self, worker_id) -> None:
         super().__init__()

--- a/tests/single_controller/test_worker_group_basics.py
+++ b/tests/single_controller/test_worker_group_basics.py
@@ -52,7 +52,6 @@ def get_ray_remote_options() -> str:
     return dict(num_cpus=0.1)
 
 
-@ray.remote
 class TestActor(Worker):
     # TODO: pass *args and **kwargs is bug prone and not very convincing
     def __init__(self, x) -> None:

--- a/tests/single_controller/test_worker_group_torch.py
+++ b/tests/single_controller/test_worker_group_torch.py
@@ -26,7 +26,6 @@ from verl.single_controller.ray.base import RayClassWithInitArgs, RayResourcePoo
 from verl.utils.device import get_device_name
 
 
-@ray.remote
 class TestAllGatherActor(Worker):
     def __init__(self, size) -> None:
         super().__init__()
@@ -46,7 +45,6 @@ class TestAllGatherActor(Worker):
         return output
 
 
-@ray.remote
 class TestAllGatherActorV2(Worker):
     def __init__(self, size) -> None:
         super().__init__()

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -302,7 +302,7 @@ class CheckpointEngineWorker(Worker):
         return self.server_adapter.is_leader_rank
 
 
-_worker_cls = ray.remote(CheckpointEngineWorker)
+_worker_cls = CheckpointEngineWorker
 
 
 class CheckpointEngineManager:

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -94,13 +94,13 @@ def create_role_worker_mapping(config):
 
     train_role = Role.ActorRollout if config.async_training.use_trainer_do_validate else Role.Actor
     role_worker_mapping = {
-        train_role: ray.remote(DetachActorWorker),
-        Role.Critic: ray.remote(CriticWorker),
+        train_role: DetachActorWorker,
+        Role.Critic: CriticWorker,
     }
 
     # Add reference policy (if KL loss or reward is required)
     if need_reference_policy(config):
-        role_worker_mapping[Role.RefPolicy] = ray.remote(DetachActorWorker)
+        role_worker_mapping[Role.RefPolicy] = DetachActorWorker
 
     return role_worker_mapping, ray_worker_group_cls
 

--- a/verl/experimental/one_step_off_policy/main_ppo.py
+++ b/verl/experimental/one_step_off_policy/main_ppo.py
@@ -84,13 +84,13 @@ def create_role_worker_mapping(config):
     ray_worker_group_cls = RayWorkerGroup
 
     role_worker_mapping = {
-        Role.Actor: ray.remote(DetachActorWorker),
-        Role.Critic: ray.remote(TrainingWorker),
+        Role.Actor: DetachActorWorker,
+        Role.Critic: TrainingWorker,
     }
 
     # Add reference policy (if KL loss or reward is required)
     if need_reference_policy(config):
-        role_worker_mapping[Role.RefPolicy] = ray.remote(DetachActorWorker)
+        role_worker_mapping[Role.RefPolicy] = DetachActorWorker
 
     return role_worker_mapping, ray_worker_group_cls
 

--- a/verl/experimental/vla/main_ppo.py
+++ b/verl/experimental/vla/main_ppo.py
@@ -114,10 +114,10 @@ def main_task(config):
         raise NotImplementedError
 
     role_worker_mapping = {
-        # Role.Critic: ray.remote(RobActorRolloutRefWorker),
-        Role.ActorRollout: ray.remote(RobActorRolloutRefWorker),
-        # Role.RefPolicy: ray.remote(RobActorRolloutRefWorker),
-        Role.Env: ray.remote(EnvWorker),
+        # Role.Critic: RobActorRolloutRefWorker,
+        Role.ActorRollout: RobActorRolloutRefWorker,
+        # Role.RefPolicy: RobActorRolloutRefWorker,
+        Role.Env: EnvWorker,
     }
 
     train_rollout_pool_id = "train_rollout_pool"

--- a/verl/experimental/vla/main_sac.py
+++ b/verl/experimental/vla/main_sac.py
@@ -80,8 +80,8 @@ def main_task(config):
         raise NotImplementedError
 
     role_worker_mapping = {
-        Role.ActorRollout: ray.remote(RobActorRolloutRefWorker),
-        Role.Env: ray.remote(EnvWorker),
+        Role.ActorRollout: RobActorRolloutRefWorker,
+        Role.Env: EnvWorker,
     }
 
     # setup resource pool manager

--- a/verl/experimental/vla/workers/env/env_loop_wg_test.py
+++ b/verl/experimental/vla/workers/env/env_loop_wg_test.py
@@ -87,7 +87,7 @@ env_cfg = OmegaConf.create(cfg_dict)
 
 gpu_pool = RayResourcePool([ENV_WORKERS_NUM], use_gpu=True)
 # RayEnvWorker = ray.remote(num_gpus=1)(EnvWorker)
-ray_cls_with_init = RayClassWithInitArgs(cls=ray.remote(EnvWorker), config=env_cfg)
+ray_cls_with_init = RayClassWithInitArgs(cls=EnvWorker, config=env_cfg)
 
 env_wg = RayWorkerGroup(gpu_pool, ray_cls_with_init)
 

--- a/verl/single_controller/base/__init__.py
+++ b/verl/single_controller/base/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 from .worker import Worker
-from .worker_group import ClassWithInitArgs, ResourcePool, WorkerGroup
+from .worker_group import ClassWithInitArgs, ResourcePool, ResourcePoolManager, WorkerGroup
 
-__all__ = ["Worker", "WorkerGroup", "ClassWithInitArgs", "ResourcePool"]
+__all__ = ["Worker", "WorkerGroup", "ClassWithInitArgs", "ResourcePool", "ResourcePoolManager"]

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -229,14 +229,15 @@ def dispatch_nd_compute(dp_rank_mapping: list[int], dp_size, worker_group, *args
     import os
 
     from verl.single_controller.base.worker_group import WorkerGroup
-    from verl.utils.ray_utils import parallel_put
 
     assert isinstance(worker_group, WorkerGroup)
 
-    max_workers = max(1, min(len(args[0]), os.cpu_count()))
+    if worker_group.backend == "ray":
+        from verl.utils.ray_utils import parallel_put
 
-    args = [parallel_put(arg, max_workers=max_workers) for arg in args]
-    kwargs = {k: parallel_put(v, max_workers=max_workers) for k, v in kwargs.items()}
+        max_workers = max(1, min(len(args[0]), os.cpu_count()))
+        args = [parallel_put(arg, max_workers=max_workers) for arg in args]
+        kwargs = {k: parallel_put(v, max_workers=max_workers) for k, v in kwargs.items()}
 
     all_args = []
     for arg in args:

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -20,12 +20,8 @@ import socket
 import warnings
 from dataclasses import dataclass
 
-import ray
-
 from verl.utils.device import (
-    get_torch_device,
     get_visible_devices_keyword,
-    is_npu_available,
 )
 
 from .decorator import Dispatch, Execute, register
@@ -48,12 +44,9 @@ class DistGlobalInfo:
 
 
 class WorkerHelper:
-    @staticmethod
-    def _get_node_ip():
-        if os.getenv("WG_BACKEND", None) == "ray":
-            return ray.util.get_node_ip_address()
-        else:
-            raise NotImplementedError("WG_BACKEND now just support ray mode.")
+    def _get_node_ip(self):
+        """Return the IP address of the current node. Subclasses must implement this."""
+        raise NotImplementedError("Subclasses must implement _get_node_ip()")
 
     @staticmethod
     def _get_free_port():
@@ -229,10 +222,6 @@ class Worker(WorkerHelper):
         return self.fused_worker_dict.get(worker_name, None)
 
     def _setup_env_cuda_visible_devices(self):
-        from verl.utils.ray_utils import ray_noset_visible_devices
-
-        is_ray_noset_visible_devices = ray_noset_visible_devices()
-
         # Prevent use of clashing `{CUDA/HIP/ROCR}_VISIBLE_DEVICES``
         rocr_val = os.environ.get("ROCR_VISIBLE_DEVICES", None)
         hip_val = os.environ.get("HIP_VISIBLE_DEVICES", None)
@@ -269,16 +258,6 @@ class Worker(WorkerHelper):
             cuda_val = os.environ.pop("ROCR_VISIBLE_DEVICES")
             os.environ["CUDA_VISIBLE_DEVICES"] = cuda_val
             rocr_val = None
-
-        if is_ray_noset_visible_devices:
-            # NOTE: Ray will automatically set the *_VISIBLE_DEVICES
-            # environment variable for each actor, unless
-            # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set,
-            # so we need to set local rank when the flag is set.
-            device_name = "NPU" if is_npu_available else "GPU"
-            local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
-            os.environ["LOCAL_RANK"] = local_rank
-            get_torch_device().set_device(int(local_rank))
 
     def _configure_with_store(self, store: dict):
         """

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -19,6 +19,7 @@ import logging
 import signal
 import threading
 import time
+from abc import ABC, abstractmethod
 from typing import Any, Callable
 
 from .decorator import MAGIC_ATTR, Dispatch, get_predefined_dispatch_fn, get_predefined_execute_fn
@@ -126,7 +127,28 @@ class WorkerGroup:
     The class provides methods for worker management, aliveness checking, and method binding.
     """
 
+    backend = None
     fused_worker_execute_fn_name = "_fuw_execute"
+
+    @classmethod
+    def cls_with_init_args(cls):
+        """Return the ClassWithInitArgs class for this backend. Subclasses must implement."""
+        raise NotImplementedError
+
+    @staticmethod
+    def create_colocated_worker_cls(class_dict):
+        """Create a colocated worker class from the class_dict. Subclasses must implement."""
+        raise NotImplementedError
+
+    @staticmethod
+    def get(future):
+        """Resolve a future/ref from this backend. Subclasses must implement."""
+        raise NotImplementedError
+
+    @staticmethod
+    def worker_group_kwargs(config):
+        """Return backend-specific kwargs for WorkerGroup construction."""
+        return {}
 
     def __init__(self, resource_pool: ResourcePool, **kwargs) -> None:
         self._is_init_with_detached_workers = resource_pool is None
@@ -253,3 +275,20 @@ class WorkerGroup:
                     raise ValueError(f"Fail to set method_name {method_name}") from e
 
         return method_names
+
+
+class ResourcePoolManager(ABC):
+    """Interface for resource pool managers. Backend implementations (e.g. RayResourcePoolManager)
+    own all fields and construction logic."""
+
+    @abstractmethod
+    def create_resource_pool(self):
+        """Initialize resource pools."""
+
+    @abstractmethod
+    def get_resource_pool(self, role) -> ResourcePool:
+        """Return the resource pool assigned to the given role."""
+
+    @abstractmethod
+    def get_n_gpus(self) -> int:
+        """Return the total number of GPUs across all resource pools."""

--- a/verl/single_controller/ray/__init__.py
+++ b/verl/single_controller/ray/__init__.py
@@ -15,6 +15,7 @@
 from .base import (
     RayClassWithInitArgs,
     RayResourcePool,
+    RayResourcePoolManager,
     RayWorkerGroup,
     ResourcePoolManager,
     SubRayResourcePool,
@@ -25,6 +26,7 @@ from .base import (
 __all__ = [
     "RayClassWithInitArgs",
     "RayResourcePool",
+    "RayResourcePoolManager",
     "SubRayResourcePool",
     "RayWorkerGroup",
     "ResourcePoolManager",

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -28,10 +28,36 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy, Place
 from verl.protocol import DataProto, _padding_size_key
 from verl.single_controller.base import ClassWithInitArgs, ResourcePool, Worker, WorkerGroup
 from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch
-from verl.utils.device import get_device_name
+from verl.single_controller.base.worker_group import ResourcePoolManager as _BaseResourcePoolManager
+from verl.utils.device import get_device_name, get_torch_device, is_npu_available
 from verl.utils.py_functional import temp_env_var
 
-__all__ = ["Worker"]
+__all__ = ["Worker", "RayWorkerMixin"]
+
+
+class RayWorkerMixin:
+    """Ray-specific mixin providing Ray-based implementations for _get_node_ip
+    and the NOSET device setup logic.
+
+    This mixin is automatically injected into Worker subclasses when they are
+    used with RayClassWithInitArgs, so user-defined workers only need to inherit
+    from Worker directly.
+    """
+
+    def _get_node_ip(self):
+        return ray.util.get_node_ip_address()
+
+    def _setup_env_cuda_visible_devices(self):
+        super()._setup_env_cuda_visible_devices()
+
+        from verl.utils.ray_utils import ray_noset_visible_devices
+
+        if ray_noset_visible_devices():
+            device_name = "NPU" if is_npu_available else "GPU"
+            local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
+            os.environ["LOCAL_RANK"] = local_rank
+            get_torch_device().set_device(int(local_rank))
+
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -179,7 +205,7 @@ class SubRayResourcePool(RayResourcePool):
 
 
 @dataclass
-class ResourcePoolManager:
+class RayResourcePoolManager(_BaseResourcePoolManager):
     """
     Define a resource pool specification. Resource pool will be initialized first.
     """
@@ -205,7 +231,6 @@ class ResourcePoolManager:
                 process_on_nodes=process_on_nodes, use_gpu=True, max_colocate_count=3, name_prefix=resource_pool_name
             )
             self.resource_pool_dict[resource_pool_name] = resource_pool
-
         self._check_resource_available()
 
     def get_resource_pool(self, role) -> RayResourcePool:
@@ -233,6 +258,9 @@ class ResourcePoolManager:
             raise ValueError(
                 f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}"
             )
+
+
+ResourcePoolManager = RayResourcePoolManager
 
 
 def extract_pg_from_exist(
@@ -337,8 +365,20 @@ class RayClassWithInitArgs(ClassWithInitArgs):
     """
 
     def __init__(self, cls, *args, **kwargs) -> None:
-        # self._options = kwargs.pop('options', dict())
-        super().__init__(cls, *args, **kwargs)
+        if hasattr(cls, "__ray_actor_class__"):
+            raise ValueError(
+                f"Pass the plain class to RayClassWithInitArgs, not a @ray.remote-decorated one. "
+                f"Use update_options() to set Ray actor options. Got: {cls}"
+            )
+
+        # Inject RayWorkerMixin into Worker subclasses so users only need to write
+        # `class Actor(Worker)` without any Ray-specific base classes.
+        raw_cls = cls
+        if isinstance(raw_cls, type) and issubclass(raw_cls, Worker) and not issubclass(raw_cls, RayWorkerMixin):
+            raw_cls = type(raw_cls.__name__, (RayWorkerMixin, raw_cls), {"__module__": raw_cls.__module__})
+
+        ray_cls = ray.remote(raw_cls)
+        super().__init__(ray_cls, *args, **kwargs)
         self._options = {}
         self._additional_resource = {}
 
@@ -416,10 +456,52 @@ class RayWorkerGroup(WorkerGroup):
     and scheduling strategies.
     """
 
+    backend = "ray"
+
+    @classmethod
+    def cls_with_init_args(cls):
+        """Return RayClassWithInitArgs for this backend."""
+        return RayClassWithInitArgs
+
+    @staticmethod
+    def create_colocated_worker_cls(class_dict):
+        """Delegate to the module-level create_colocated_worker_cls."""
+        return create_colocated_worker_cls(class_dict=class_dict)
+
+    @staticmethod
+    def get(future):
+        """Resolve a Ray ObjectRef."""
+        return ray.get(future)
+
+    @staticmethod
+    def worker_group_kwargs(config):
+        """Return Ray-specific kwargs for WorkerGroup construction.
+
+        Extracted from RayPPOTrainer.init_workers() in the original ray_trainer.py.
+        """
+        from omegaconf import OmegaConf
+
+        wg_kwargs = {}
+        if OmegaConf.select(config.trainer, "ray_wait_register_center_timeout") is not None:
+            wg_kwargs["ray_wait_register_center_timeout"] = config.trainer.ray_wait_register_center_timeout
+        if OmegaConf.select(config.global_profiler, "steps") is not None:
+            wg_kwargs["profile_steps"] = OmegaConf.select(config.global_profiler, "steps")
+            # Only require nsight worker options when tool is nsys
+            if OmegaConf.select(config.global_profiler, "tool") == "nsys":
+                assert (
+                    OmegaConf.select(config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                    is not None
+                ), "worker_nsight_options must be set when using nsys with profile_steps"
+                wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
+                    OmegaConf.select(config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
+                )
+        return wg_kwargs
+
     def __init__(
         self,
         resource_pool: RayResourcePool = None,
         ray_cls_with_init: RayClassWithInitArgs = None,
+        cls_with_init: RayClassWithInitArgs = None,
         bin_pack: bool = True,
         name_prefix: str = None,
         detached=False,
@@ -432,7 +514,8 @@ class RayWorkerGroup(WorkerGroup):
 
         Args:
             resource_pool: Resource pool for worker allocation
-            ray_cls_with_init: Class with initialization arguments for workers
+            ray_cls_with_init: Class with initialization arguments for workers (deprecated, use cls_with_init)
+            cls_with_init: Class with initialization arguments for workers
             bin_pack: Whether to use strict bin packing for resource allocation
             name_prefix: Prefix for worker names
             detached: Whether workers should be detached
@@ -440,6 +523,17 @@ class RayWorkerGroup(WorkerGroup):
             ray_wait_register_center_timeout: Timeout for waiting on register center
             **kwargs: Additional keyword arguments
         """
+        if cls_with_init is None and ray_cls_with_init is not None:
+            import warnings
+
+            warnings.warn(
+                "`ray_cls_with_init` is deprecated and will be removed in a future version. "
+                "Please use `cls_with_init` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            cls_with_init = ray_cls_with_init
+        ray_cls_with_init = cls_with_init
         self._master_addr = kwargs.pop("master_addr", None)
         self._master_port = kwargs.pop("master_port", None)
         self.use_gpu = kwargs.pop("use_gpu", resource_pool.use_gpu if resource_pool is not None else True)
@@ -958,7 +1052,7 @@ def _bind_workers_method_to_parent(cls, key, user_defined_cls):
                 raise ValueError(f"Fail to set method_name {method_name}") from e
 
 
-def _unwrap_ray_remote(cls):
+def unwrap_ray_remote(cls):
     if hasattr(cls, "__ray_actor_class__"):
         cls = cls.__ray_actor_class__
     return cls
@@ -986,7 +1080,7 @@ def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):
     cls_dict = {}
     init_args_dict = {}
     worker_cls = _determine_fsdp_megatron_base_class(
-        [cls.cls.__ray_actor_class__.__mro__ for cls in class_dict.values()]
+        [unwrap_ray_remote(cls.cls).__mro__ for cls in class_dict.values()]
     )
     assert issubclass(worker_cls, Worker), f"worker_cls {worker_cls} should be a subclass of Worker"
     print(f"colocated worker base class {worker_cls}")
@@ -1003,7 +1097,7 @@ def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):
             super().__init__()
             self.worker_dict = {}
             for key, user_defined_cls in cls_dict.items():
-                user_defined_cls = _unwrap_ray_remote(user_defined_cls)
+                user_defined_cls = unwrap_ray_remote(user_defined_cls)
                 # directly instantiate the class without remote
                 # in worker class, e.g. <verl.single_controller.base.worker.Worker>
                 # when DISABLE_WORKER_INIT == 1 it will return immediately
@@ -1014,12 +1108,10 @@ def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):
 
     # now monkey-patch the methods from inner class to WorkerDict
     for key, user_defined_cls in cls_dict.items():
-        user_defined_cls = _unwrap_ray_remote(user_defined_cls)
+        user_defined_cls = unwrap_ray_remote(user_defined_cls)
         _bind_workers_method_to_parent(WorkerDict, key, user_defined_cls)
 
-    remote_cls = ray.remote(WorkerDict)
-    remote_cls = RayClassWithInitArgs(cls=remote_cls)
-    return remote_cls
+    return RayClassWithInitArgs(cls=WorkerDict)
 
 
 FusedWorkerCLSName = "FusedWorker"
@@ -1043,7 +1135,7 @@ def create_colocated_worker_raw_cls(class_dict: dict[str, RayClassWithInitArgs])
         The same as `FusedWorker.fused_worker_dict`, enables underlying class to access other
         underlying classes.
     """
-    raw_cls_dict = {cls_name: _unwrap_ray_remote(cia.cls) for cls_name, cia in class_dict.items()}
+    raw_cls_dict = {cls_name: unwrap_ray_remote(cia.cls) for cls_name, cia in class_dict.items()}
     init_args_dict = {cls_name: cia.args for cls_name, cia in class_dict.items()}
     init_kwargs_dict = {cls_name: cia.kwargs for cls_name, cia in class_dict.items()}
     cls_names = list(class_dict.keys())
@@ -1113,8 +1205,7 @@ def create_colocated_worker_cls_fused(class_dict: dict[str, RayClassWithInitArgs
     """
     raw_colocated_worker_cls = create_colocated_worker_raw_cls(class_dict)
 
-    remote_cls = ray.remote(raw_colocated_worker_cls)
-    cia = RayClassWithInitArgs(cls=remote_cls)
+    cia = RayClassWithInitArgs(cls=raw_colocated_worker_cls)
     cia.fused_worker_used = True
 
     return cia

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -25,7 +25,7 @@ from omegaconf import OmegaConf
 from verl.experimental.dataset.sampler import AbstractSampler
 from verl.experimental.reward_loop import migrate_legacy_reward_impl
 from verl.trainer.constants_ppo import get_ppo_ray_runtime_env
-from verl.trainer.ppo.ray_trainer import RayPPOTrainer
+from verl.trainer.ppo.ray_trainer import PPOTrainer
 from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
 from verl.utils.device import auto_set_device, is_cuda_available
@@ -144,7 +144,7 @@ class TaskRunner:
                 role = Role.ActorRolloutRef
             else:
                 role = Role.ActorRollout
-            self.role_worker_mapping[role] = ray.remote(actor_rollout_cls)
+            self.role_worker_mapping[role] = actor_rollout_cls
             self.mapping[role] = "global_pool"
             return actor_rollout_cls, ray_worker_group_cls
 
@@ -173,7 +173,7 @@ class TaskRunner:
         else:
             raise NotImplementedError
 
-        self.role_worker_mapping[Role.ActorRollout] = ray.remote(actor_rollout_cls)
+        self.role_worker_mapping[Role.ActorRollout] = actor_rollout_cls
         self.mapping[Role.ActorRollout] = "global_pool"
         return actor_rollout_cls, ray_worker_group_cls
 
@@ -212,7 +212,7 @@ class TaskRunner:
 
         from verl.trainer.ppo.ray_trainer import Role
 
-        self.role_worker_mapping[Role.Critic] = ray.remote(CriticWorker)
+        self.role_worker_mapping[Role.Critic] = CriticWorker
         self.mapping[Role.Critic] = "global_pool"
 
     def init_resource_pool_mgr(self, config):
@@ -263,7 +263,7 @@ class TaskRunner:
             return
 
         if need_reference_policy(config):
-            self.role_worker_mapping[Role.RefPolicy] = ray.remote(ref_policy_cls)
+            self.role_worker_mapping[Role.RefPolicy] = ref_policy_cls
             self.mapping[Role.RefPolicy] = "global_pool"
 
     def run(self, config):
@@ -340,13 +340,13 @@ class TaskRunner:
         train_sampler = create_rl_sampler(config.data, train_dataset)
 
         # Initialize the PPO trainer.
-        trainer = RayPPOTrainer(
+        trainer = PPOTrainer(
             config=config,
             tokenizer=tokenizer,
             processor=processor,
             role_worker_mapping=self.role_worker_mapping,
             resource_pool_manager=resource_pool_manager,
-            ray_worker_group_cls=ray_worker_group_cls,
+            worker_group_cls=ray_worker_group_cls,
             train_dataset=train_dataset,
             val_dataset=val_dataset,
             collate_fn=collate_fn,

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """
 PPO Trainer with Ray-based single controller.
-This trainer supports model-agonistic model initialization with huggingface
+This trainer supports model-agnostic model initialization with huggingface.
 """
 
 import json
@@ -37,8 +37,8 @@ from verl import DataProto
 from verl.checkpoint_engine import CheckpointEngineManager
 from verl.experimental.dataset.sampler import AbstractCurriculumSampler
 from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
-from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup, ResourcePoolManager
-from verl.single_controller.ray.base import create_colocated_worker_cls
+from verl.single_controller.base import WorkerGroup
+from verl.single_controller.ray import RayWorkerGroup, ResourcePoolManager
 from verl.trainer.config import AlgoConfig
 from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
@@ -218,15 +218,18 @@ def compute_advantage(
     return data
 
 
-class RayPPOTrainer:
-    """Distributed PPO trainer using Ray for scalable reinforcement learning.
+class PPOTrainer:
+    """Distributed PPO trainer with injectable backend.
 
     This trainer orchestrates distributed PPO training across multiple nodes and GPUs,
-    managing actor rollouts, critic training, and reward computation with Ray backend.
+    managing actor rollouts, critic training, and reward computation.
     Supports various model architectures including FSDP, Megatron, vLLM, and SGLang integration.
+
+    To use a different backend, replace RayWorkerGroup and RayClassWithInitArgs with the
+    corresponding backend-specific implementations and pass them via worker_group_cls.
     """
 
-    # TODO: support each role have individual ray_worker_group_cls,
+    # TODO: support each role have individual worker_group_cls,
     # i.e., support different backend of different role
     def __init__(
         self,
@@ -234,31 +237,45 @@ class RayPPOTrainer:
         tokenizer,
         role_worker_mapping: dict[Role, WorkerType],
         resource_pool_manager: ResourcePoolManager,
-        ray_worker_group_cls: type[RayWorkerGroup] = RayWorkerGroup,
+        worker_group_cls: type[WorkerGroup] = None,
         processor=None,
         train_dataset: Optional[Dataset] = None,
         val_dataset: Optional[Dataset] = None,
         collate_fn=None,
         train_sampler: Optional[Sampler] = None,
         device_name=None,
+        ray_worker_group_cls: type[WorkerGroup] = None,
     ):
         """
-        Initialize distributed PPO trainer with Ray backend.
+        Initialize distributed PPO trainer.
         Note that this trainer runs on the driver process on a single CPU/GPU node.
 
         Args:
             config: Configuration object containing training parameters.
             tokenizer: Tokenizer used for encoding and decoding text.
             role_worker_mapping (dict[Role, WorkerType]): Mapping from roles to worker classes.
-            resource_pool_manager (ResourcePoolManager): Manager for Ray resource pools.
-            ray_worker_group_cls (RayWorkerGroup, optional): Class for Ray worker groups. Defaults to RayWorkerGroup.
+            resource_pool_manager (ResourcePoolManager): Manager for resource pools.
+            worker_group_cls: Class for worker groups (backend-agnostic).
             processor: Optional data processor, used for multimodal data
             train_dataset (Optional[Dataset], optional): Training dataset. Defaults to None.
             val_dataset (Optional[Dataset], optional): Validation dataset. Defaults to None.
             collate_fn: Function to collate data samples into batches.
             train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
             device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
+            ray_worker_group_cls: Deprecated. Use worker_group_cls instead.
         """
+        if worker_group_cls is None and ray_worker_group_cls is not None:
+            import warnings
+
+            warnings.warn(
+                "ray_worker_group_cls is deprecated, use worker_group_cls instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            worker_group_cls = ray_worker_group_cls
+
+        self.worker_group_cls = worker_group_cls if worker_group_cls is not None else RayWorkerGroup
+        self.ray_worker_group_cls = self.worker_group_cls
 
         # Store the tokenizer for text processing
         self.tokenizer = tokenizer
@@ -280,7 +297,6 @@ class RayPPOTrainer:
         self.use_rm = need_reward_model(self.config)
 
         self.use_critic = need_critic(self.config)
-        self.ray_worker_group_cls = ray_worker_group_cls
         self.device_name = device_name if device_name else self.config.trainer.device
         self.validation_generations_logger = ValidationGenerationsLogger(
             project_name=self.config.trainer.project_name,
@@ -302,8 +318,6 @@ class RayPPOTrainer:
         self.use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
-
-        self.checkpoint_manager = None
 
     def _create_dataloader(self, train_dataset, val_dataset, collate_fn, train_sampler: Optional[Sampler]):
         """
@@ -672,12 +686,14 @@ class RayPPOTrainer:
         return self._val_metrics_update(data_sources, sample_uids, reward_extra_infos_dict, sample_turns)
 
     def init_workers(self):
-        """Initialize distributed training workers using Ray backend.
+        """Initialize distributed training workers.
 
         Creates:
-        1. Ray resource pools from configuration
+        1. Resource pools from configuration
         2. Worker groups for each role (actor, critic, etc.)
         """
+        _ClsWithInitArgs = self.worker_group_cls.cls_with_init_args()
+
         self.resource_pool_manager.create_resource_pool()
 
         self.resource_pool_to_cls = {pool: {} for pool in self.resource_pool_manager.resource_pool_dict.values()}
@@ -686,7 +702,7 @@ class RayPPOTrainer:
         actor_role = Role.ActorRolloutRef if Role.ActorRolloutRef in self.role_worker_mapping else Role.ActorRollout
         if self.hybrid_engine:
             actor_rollout_resource_pool = self.resource_pool_manager.get_resource_pool(actor_role)
-            actor_rollout_cls = RayClassWithInitArgs(
+            actor_rollout_cls = _ClsWithInitArgs(
                 cls=self.role_worker_mapping[actor_role],
                 config=self.config.actor_rollout_ref,
                 role=str(actor_role),
@@ -723,13 +739,13 @@ class RayPPOTrainer:
                     checkpoint_config=orig_critic_cfg.checkpoint,
                 )
 
-            critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
+            critic_cls = _ClsWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)
             self.resource_pool_to_cls[resource_pool][str(Role.Critic)] = critic_cls
 
         # create reference policy if needed
         if self.use_reference_policy and Role.RefPolicy in self.role_worker_mapping:
             resource_pool = self.resource_pool_manager.get_resource_pool(Role.RefPolicy)
-            ref_policy_cls = RayClassWithInitArgs(
+            ref_policy_cls = _ClsWithInitArgs(
                 self.role_worker_mapping[Role.RefPolicy],
                 config=self.config.actor_rollout_ref,
                 role=str(Role.RefPolicy),
@@ -742,29 +758,16 @@ class RayPPOTrainer:
         # Instead, directly pass different resource pool to different worker groups.
         # See https://github.com/volcengine/verl/blob/master/examples/ray/tutorial.ipynb for more information.
         all_wg = {}
-        wg_kwargs = {}  # Setting up kwargs for RayWorkerGroup
-        if OmegaConf.select(self.config.trainer, "ray_wait_register_center_timeout") is not None:
-            wg_kwargs["ray_wait_register_center_timeout"] = self.config.trainer.ray_wait_register_center_timeout
-        if OmegaConf.select(self.config.global_profiler, "steps") is not None:
-            wg_kwargs["profile_steps"] = OmegaConf.select(self.config.global_profiler, "steps")
-            # Only require nsight worker options when tool is nsys
-            if OmegaConf.select(self.config.global_profiler, "tool") == "nsys":
-                assert (
-                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
-                    is not None
-                ), "worker_nsight_options must be set when using nsys with profile_steps"
-                wg_kwargs["worker_nsight_options"] = OmegaConf.to_container(
-                    OmegaConf.select(self.config.global_profiler.global_tool_config.nsys, "worker_nsight_options")
-                )
+        wg_kwargs = self.worker_group_cls.worker_group_kwargs(self.config)
         wg_kwargs["device_name"] = self.device_name
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
             if not class_dict:
                 continue
-            worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
-            wg_dict = self.ray_worker_group_cls(
+            worker_dict_cls = self.worker_group_cls.create_colocated_worker_cls(class_dict=class_dict)
+            wg_dict = self.worker_group_cls(
                 resource_pool=resource_pool,
-                ray_cls_with_init=worker_dict_cls,
+                cls_with_init=worker_dict_cls,
                 **wg_kwargs,
             )
             spawn_wg = wg_dict.spawn(prefix_set=class_dict.keys())
@@ -1606,3 +1609,6 @@ class RayPPOTrainer:
                 if hasattr(self.train_dataset, "on_batch_end"):
                     # The dataset may be changed after each training batch
                     self.train_dataset.on_batch_end(batch=batch)
+
+
+RayPPOTrainer = PPOTrainer

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -125,7 +125,7 @@ class SFTTrainer:
         n_gpus_per_node = self.config.trainer.n_gpus_per_node
         nnodes = self.config.trainer.nnodes
         self.resource_pool = RayResourcePool(process_on_nodes=[n_gpus_per_node] * nnodes)
-        ray_cls_with_init = RayClassWithInitArgs(ray.remote(TrainingWorker), config=config)
+        ray_cls_with_init = RayClassWithInitArgs(TrainingWorker, config=config)
         self.training_client = RayWorkerGroup(
             resource_pool=self.resource_pool,
             ray_cls_with_init=ray_cls_with_init,

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -18,7 +18,6 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Callable, Optional
 
-import ray
 from omegaconf import DictConfig
 from pydantic import BaseModel
 from ray.actor import ActorHandle
@@ -210,10 +209,8 @@ class RolloutReplica(ABC):
         """Get rollout worker actor class for colocated and standalone mode."""
         from verl.checkpoint_engine.base import CheckpointEngineWorker
 
-        rollout_worker_actor_cls = ray.remote(CheckpointEngineWorker)
-
         return RayClassWithInitArgs(
-            cls=rollout_worker_actor_cls,
+            cls=CheckpointEngineWorker,
             rollout_config=self.config,
             model_config=self.model_config,
             replica_rank=self.replica_rank,


### PR DESCRIPTION
### What does this PR do?

Removes Ray-specific concepts from `verl/single_controller/base/` so the base interface is backend-agnostic. Previously `Worker` called `ray.util.get_node_ip_address()`, `ResourcePoolManager` was a Ray-coupled dataclass, and `decorator.py` did inline `import ray` throughout. This PR establishes a clean abstraction boundary and introduces an explicit backend extension model. Additionally, the `ray_trainer.py` is now no longer tied to Ray -- it is backend injectable. 

### Test

CPU tests:
```
uv run pytest -s -x tests/single_controller/test_ray_class_with_init_args_on_cpu.py
```
Main GRPO training can run e2e (`verl.trainer.main_ppo`)

### Design & Code Changes

**Backend Extension Pattern**

User-defined worker classes only inherit from the base `Worker` class which is backend agnostic.

```python
class MyActorWorker(Worker):
    ...
```
**Backend-specific logic is handled via a Mixin injected automatically by the backend's worker group.** When a caller uses `RayWorkerGroup`, `RayClassWithInitArgs.__init__` dynamically injects `RayWorkerMixin` into any plain `Worker` subclass before wrapping it with `ray.remote`. `RayWorkerMixin` provides the Ray-specific implementations of `_get_node_ip()` and the NOSET device setup logic that previously lived in the base `Worker` class.

**`base/worker.py`**: `WorkerHelper._get_node_ip` made abstract; Ray-specific NOSET device logic removed from `_setup_env_cuda_visible_devices`.

**`base/worker_group.py`**: `WorkerGroup` gains explicit extension points (`cls_with_init_args`, `create_colocated_worker_cls`, `get`, `worker_group_kwargs`, `backend`). `ResourcePoolManager` becomes a pure ABC with three abstract methods — no fields, no Ray imports.

**`base/decorator.py`**: `parallel_put` gated behind `worker_group.backend == "ray"`.

**`ray/base.py`**: `RayWorkerMixin` introduced and auto-injected by `RayClassWithInitArgs`. `RayResourcePoolManager` implements the ABC. `RayWorkerGroup` implements all `WorkerGroup` extension points.

**`ray_trainer.py`**: `RayPPOTrainer` renamed to `PPOTrainer`; `RayPPOTrainer = PPOTrainer` kept as a backwards-compatibility alias. The trainer is effectively backend injectable. 

### API Changes 

**Before** — user classes had to be wrapped at the call site:

```python
role_worker_mapping = {
    Role.ActorRollout: ray.remote(ActorRolloutRefWorker),
    Role.Critic: ray.remote(CriticWorker),
}
ray_cls = RayClassWithInitArgs(cls=ray.remote(MyWorker), ...)
```

**After** — pass plain classes; the backend handles wrapping:

```python
role_worker_mapping = {
    Role.ActorRollout: ActorRolloutRefWorker,
    Role.Critic: CriticWorker,
}
ray_cls = RayClassWithInitArgs(cls=MyWorker, ...)
```

**BREAKING**: `RayClassWithInitArgs` now raises `ValueError` if passed an already-`@ray.remote`-decorated class. This is to simplify the codebase and there's no safe way to silently stripping the decoration and preserve the options (e.g. `num_gpus`, `max_restarts`) set on it. 

Deprecation shims preserved:
- `PPOTrainer` is the new name; `RayPPOTrainer = PPOTrainer` kept as alias
- `RayWorkerGroup.__init__` accepts deprecated `ray_cls_with_init` kwarg
- `ResourcePoolManager` alias in `ray/__init__.py` -> `RayResourcePoolManager`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
