### PR TITLE
[single_controller] fix: correct spelling error 'procecss' -> 'process'

### DIFF
--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -135,9 +135,9 @@ class WorkerGroup:
 
         if resource_pool is not None:
             # handle the case when WorkGroup is attached to an existing one
-            self._procecss_dispatch_config = resource_pool()
+            self._process_dispatch_config = resource_pool()
         else:
-            self._procecss_dispatch_config = None
+            self._process_dispatch_config = None
 
         self._workers = []
         self._worker_names = []


### PR DESCRIPTION
### What does this PR do?

> This PR used to correct spelling error '`procecss`' in `verl/verl/single_controller/base/worker_group.py`

<img width="689" height="106" alt="image" src="https://github.com/user-attachments/assets/81373822-31cb-4f2c-ba36-09db1e3d519a" />

The correct spelling should be '`process`' rather than 'proce **c** ss'

### Test

> Command `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always ` passed.
