### PR TITLE
[algo,trainer,worker,fsdp,cfg,doc] feat: add SDPO (Self-Distillation Policy Optimization)

### DIFF
--- a/docs/algo/sdpo.md
+++ b/docs/algo/sdpo.md
@@ -1,0 +1,54 @@
+# Self-Distillation Policy Optimization (SDPO)
+
+Last updated: 03/03/2026.
+
+SDPO is a policy optimization variant that augments actor updates with self-distillation from successful trajectories in the same rollout batch.
+
+Paper: [Self-Distillation Policy Optimization](https://arxiv.org/abs/2601.20802).
+
+## Core Idea
+
+At each training step:
+
+1. Rollout responses are grouped by sample `uid`.
+2. Successful responses (above `success_reward_threshold`) are reused as demonstrations.
+3. Optionally, environment feedback is included in the reprompt.
+4. A teacher prompt is built per sample and concatenated with the original response tokens.
+5. The actor is updated with PPO-style optimization where policy loss is replaced by SDPO distillation loss (`loss_mode=sdpo`).
+6. A colocated teacher is updated with EMA from the student weights.
+
+## Key Configs
+
+- `actor_rollout_ref.actor.policy_loss.loss_mode: sdpo`
+- `actor_rollout_ref.actor.self_distillation.full_logit_distillation`
+- `actor_rollout_ref.actor.self_distillation.distillation_topk`
+- `actor_rollout_ref.actor.self_distillation.alpha`
+- `actor_rollout_ref.actor.self_distillation.success_reward_threshold`
+- `actor_rollout_ref.actor.self_distillation.teacher_regularization` (`ema`, `trust_region`, or `none`)
+- `actor_rollout_ref.actor.self_distillation.teacher_update_rate` (or `ema_update_rate` alias)
+- `actor_rollout_ref.actor.self_distillation.include_environment_feedback`
+- `actor_rollout_ref.actor.self_distillation.environment_feedback_only_without_solution`
+
+## Current Constraints in verl
+
+- SDPO is only supported with legacy worker mode (not model-engine worker mode).
+- SDPO requires `fsdp` / `fsdp2` actor strategy.
+- SDPO cannot be combined with a separate KL reference policy (`use_kl_in_reward` or `use_kl_loss` reference path).
+- Distillation with multimodal actor inputs is currently not supported.
+- Trust-region teacher regularization requires `actor_rollout_ref.actor.use_fused_kernels=false`.
+
+## Minimal Usage
+
+Use the preset config:
+
+```bash
+python3 -m verl.trainer.main_ppo --config-name sdpo
+```
+
+Or override from `ppo_trainer`:
+
+```bash
+python3 -m verl.trainer.main_ppo \
+  actor_rollout_ref.actor.policy_loss.loss_mode=sdpo \
+  actor_rollout_ref.actor.self_distillation.ema_update_rate=0.05
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ verl is fast with:
    algo/rollout_corr_math.md
    algo/otb.md
    algo/dppo.md
+   algo/sdpo.md
 
 .. toctree::
    :maxdepth: 1

--- a/examples/sdpo_trainer/run_qwen2_5_3b_sdpo.sh
+++ b/examples/sdpo_trainer/run_qwen2_5_3b_sdpo.sh
@@ -1,4 +1,5 @@
-# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#!/usr/bin/env bash
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import BasePPOActor
-from .dp_actor import DataParallelPPOActor, TrustRegionTeacher
+set -euo pipefail
 
-__all__ = ["BasePPOActor", "DataParallelPPOActor", "TrustRegionTeacher"]
+MODEL_PATH="${MODEL_PATH:-Qwen/Qwen2.5-3B-Instruct}"
+TRAIN_FILE="${TRAIN_FILE:-"${HOME}/data/gsm8k/train.parquet"}"
+VAL_FILE="${VAL_FILE:-"${HOME}/data/gsm8k/test.parquet"}"
+EXP_NAME="${EXP_NAME:-qwen2.5-3b-sdpo}"
+
+python3 -m verl.trainer.main_ppo \
+  --config-name=sdpo \
+  actor_rollout_ref.model.path="${MODEL_PATH}" \
+  data.train_files="${TRAIN_FILE}" \
+  data.val_files="${VAL_FILE}" \
+  trainer.experiment_name="${EXP_NAME}"

--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -14,6 +14,7 @@
 
 import random
 import unittest
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -21,6 +22,7 @@ import torch
 
 import verl.trainer.ppo.core_algos
 from verl.trainer.ppo.core_algos import (
+    compute_self_distillation_loss,
     compute_gae_advantage_return,
     compute_grpo_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
@@ -311,6 +313,140 @@ def test_grpo_and_vectorized_equivalence(batch_size: int, seq_len: int, num_grou
     assert ret1.shape == ret2.shape == (batch_size, seq_len)
     assert torch.allclose(adv1, adv2, rtol=1e-5, atol=1e-6)
     assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
+
+
+def test_compute_self_distillation_loss_full_logit_alpha_endpoints():
+    student_all_log_probs = torch.log_softmax(torch.randn(2, 3, 7), dim=-1)
+    teacher_all_log_probs = torch.log_softmax(torch.randn(2, 3, 7), dim=-1)
+    student_log_probs = student_all_log_probs[..., 0]
+    teacher_log_probs = teacher_all_log_probs[..., 0]
+    response_mask = torch.ones(2, 3)
+
+    cfg_alpha_fwd = SimpleNamespace(
+        full_logit_distillation=True,
+        distillation_topk=None,
+        distillation_add_tail=True,
+        alpha=0.0,
+        is_clip=None,
+    )
+    cfg_alpha_rev = SimpleNamespace(
+        full_logit_distillation=True,
+        distillation_topk=None,
+        distillation_add_tail=True,
+        alpha=1.0,
+        is_clip=None,
+    )
+
+    loss_fwd, metrics_fwd = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg_alpha_fwd,
+        student_all_log_probs=student_all_log_probs,
+        teacher_all_log_probs=teacher_all_log_probs,
+    )
+    loss_rev, metrics_rev = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg_alpha_rev,
+        student_all_log_probs=student_all_log_probs,
+        teacher_all_log_probs=teacher_all_log_probs,
+    )
+
+    assert torch.isfinite(loss_fwd)
+    assert torch.isfinite(loss_rev)
+    assert not torch.allclose(loss_fwd, loss_rev)
+    assert "self_distillation/loss" in metrics_fwd
+    assert "self_distillation/kl_type_code" in metrics_rev
+
+
+def test_compute_self_distillation_loss_topk_and_masking():
+    student_topk_log_probs = torch.log_softmax(torch.randn(1, 4, 3), dim=-1)
+    teacher_topk_log_probs = torch.log_softmax(torch.randn(1, 4, 3), dim=-1)
+    student_log_probs = torch.randn(1, 4)
+    teacher_log_probs = torch.randn(1, 4)
+    response_mask = torch.ones(1, 4)
+
+    cfg = SimpleNamespace(
+        full_logit_distillation=True,
+        distillation_topk=3,
+        distillation_add_tail=True,
+        alpha=0.5,
+        is_clip=None,
+    )
+
+    loss_topk, metrics_topk = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg,
+        student_topk_log_probs=student_topk_log_probs,
+        teacher_topk_log_probs=teacher_topk_log_probs,
+    )
+    assert torch.isfinite(loss_topk)
+    assert metrics_topk["self_distillation/use_topk"] == 1.0
+
+    zero_mask = torch.zeros(1, dtype=torch.float32)
+    loss_masked, metrics_masked = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg,
+        student_topk_log_probs=student_topk_log_probs,
+        teacher_topk_log_probs=teacher_topk_log_probs,
+        self_distillation_mask=zero_mask,
+    )
+    assert torch.allclose(loss_masked, torch.tensor(0.0, dtype=loss_masked.dtype, device=loss_masked.device))
+    assert metrics_masked["self_distillation/mask_fraction"] == 0.0
+
+
+def test_compute_self_distillation_loss_optional_is_clip():
+    student_all_log_probs = torch.log_softmax(torch.randn(2, 3, 5), dim=-1)
+    teacher_all_log_probs = torch.log_softmax(torch.randn(2, 3, 5), dim=-1)
+    student_log_probs = student_all_log_probs[..., 0]
+    teacher_log_probs = teacher_all_log_probs[..., 0]
+    old_log_probs = student_log_probs + 5.0
+    response_mask = torch.ones(2, 3)
+
+    cfg_no_clip = SimpleNamespace(
+        full_logit_distillation=True,
+        distillation_topk=None,
+        distillation_add_tail=True,
+        alpha=0.5,
+        is_clip=None,
+    )
+    cfg_clip = SimpleNamespace(
+        full_logit_distillation=True,
+        distillation_topk=None,
+        distillation_add_tail=True,
+        alpha=0.5,
+        is_clip=2.0,
+    )
+
+    loss_no_clip, _ = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg_no_clip,
+        old_log_probs=old_log_probs,
+        student_all_log_probs=student_all_log_probs,
+        teacher_all_log_probs=teacher_all_log_probs,
+    )
+    loss_clip, metrics_clip = compute_self_distillation_loss(
+        student_log_probs=student_log_probs,
+        teacher_log_probs=teacher_log_probs,
+        response_mask=response_mask,
+        self_distillation_config=cfg_clip,
+        old_log_probs=old_log_probs,
+        student_all_log_probs=student_all_log_probs,
+        teacher_all_log_probs=teacher_all_log_probs,
+    )
+
+    assert torch.isfinite(loss_no_clip)
+    assert torch.isfinite(loss_clip)
+    assert loss_clip < loss_no_clip
+    assert metrics_clip["self_distillation/is_clip"] == 2.0
 
 
 if __name__ == "__main__":

--- a/tests/workers/actor/test_special_dp_actor.py
+++ b/tests/workers/actor/test_special_dp_actor.py
@@ -22,7 +22,7 @@ from transformers import AutoModelForCausalLM, Qwen3Config
 from verl import DataProto
 from verl.utils.device import get_device_name
 from verl.workers.actor.dp_actor import DataParallelPPOActor
-from verl.workers.config import FSDPActorConfig, OptimizerConfig
+from verl.workers.config import FSDPActorConfig, OptimizerConfig, PolicyLossConfig, SelfDistillationConfig
 
 
 class MockTransformerModel(nn.Module):
@@ -298,6 +298,74 @@ class TestDataParallelPPOActor(unittest.TestCase):
             else:
                 self.assertIsInstance(metrics[key], (float, int))
                 self.assertTrue(torch.isfinite(torch.tensor(metrics[key])))
+
+    def test_update_policy_sdpo_branch(self):
+        """Test that SDPO update path runs and emits SDPO metrics with teacher batch keys."""
+        sdpo_config = FSDPActorConfig(
+            strategy="fsdp2",
+            ppo_mini_batch_size=4,
+            ppo_micro_batch_size_per_gpu=2,
+            ppo_epochs=1,
+            clip_ratio=0.2,
+            entropy_coeff=0.01,
+            grad_clip=1.0,
+            use_dynamic_bsz=False,
+            use_torch_compile=False,
+            ulysses_sequence_parallel_size=1,
+            optim=OptimizerConfig(lr=1e-6),
+            rollout_n=1,
+            policy_loss=PolicyLossConfig(loss_mode="sdpo"),
+            self_distillation=SelfDistillationConfig(
+                teacher_regularization="none",
+                full_logit_distillation=True,
+                distillation_topk=16,
+            ),
+        )
+        sdpo_model = MockTransformerModel(vocab_size=1000, hidden_size=64).to(self.device)
+        sdpo_optimizer = torch.optim.Adam(sdpo_model.parameters(), lr=1e-4)
+        sdpo_actor = DataParallelPPOActor(
+            config=sdpo_config,
+            actor_module=sdpo_model,
+            actor_optimizer=sdpo_optimizer,
+        )
+
+        batch_size = 4
+        prompt_length = 8
+        response_length = 4
+        total_length = prompt_length + response_length
+        vocab_size = 1000
+
+        input_ids = torch.randint(0, vocab_size, (batch_size, total_length)).to(self.device)
+        attention_mask = torch.ones(batch_size, total_length).to(self.device)
+        position_ids = torch.arange(total_length).unsqueeze(0).expand(batch_size, -1).to(self.device)
+        responses = input_ids[:, -response_length:]
+        response_mask = torch.ones(batch_size, response_length).to(self.device)
+        old_log_probs = torch.randn(batch_size, response_length).to(self.device) * 0.1
+        advantages = torch.randn(batch_size, response_length).to(self.device) * 0.5
+        self_distillation_mask = torch.ones(batch_size, dtype=torch.float32).to(self.device)
+
+        tensor_dict = TensorDict(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "position_ids": position_ids,
+                "responses": responses,
+                "response_mask": response_mask,
+                "old_log_probs": old_log_probs,
+                "advantages": advantages,
+                "teacher_input_ids": input_ids.clone(),
+                "teacher_attention_mask": attention_mask.clone(),
+                "teacher_position_ids": position_ids.clone(),
+                "self_distillation_mask": self_distillation_mask,
+            },
+            batch_size=[batch_size],
+        )
+
+        data = DataProto(batch=tensor_dict, meta_info={"temperature": 1.0})
+        metrics = sdpo_actor.update_policy(data)
+        self.assertIn("actor/pg_loss", metrics)
+        self.assertIn("self_distillation/loss", metrics)
+        self.assertIn("self_distillation/empty_target_batch", metrics)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -134,6 +134,39 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+    self_distillation:
+      _target_: verl.workers.config.SelfDistillationConfig
+      full_logit_distillation: true
+      distillation_topk: 100
+      distillation_add_tail: true
+      alpha: 0.5
+      success_reward_threshold: 0.5
+      teacher_regularization: ema
+      teacher_update_rate: null
+      ema_update_rate: 0.05
+      max_reprompt_len: 10240
+      reprompt_truncation: right
+      dont_reprompt_on_self_success: true
+      remove_thinking_from_demonstration: true
+      include_environment_feedback: true
+      environment_feedback_only_without_solution: true
+      is_clip: 2
+      reprompt_template: '{prompt}{solution}{feedback}
+
+
+        Correctly solve the original question.'
+      solution_template: '
+
+        Correct solution:
+
+
+        {successful_previous_attempt}'
+      feedback_template: '
+
+        The following is feedback from your unsuccessful earlier attempt:
+
+
+        {feedback_raw}'
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -117,6 +117,39 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+    self_distillation:
+      _target_: verl.workers.config.SelfDistillationConfig
+      full_logit_distillation: true
+      distillation_topk: 100
+      distillation_add_tail: true
+      alpha: 0.5
+      success_reward_threshold: 0.5
+      teacher_regularization: ema
+      teacher_update_rate: null
+      ema_update_rate: 0.05
+      max_reprompt_len: 10240
+      reprompt_truncation: right
+      dont_reprompt_on_self_success: true
+      remove_thinking_from_demonstration: true
+      include_environment_feedback: true
+      environment_feedback_only_without_solution: true
+      is_clip: 2
+      reprompt_template: '{prompt}{solution}{feedback}
+
+
+        Correctly solve the original question.'
+      solution_template: '
+
+        Correct solution:
+
+
+        {successful_previous_attempt}'
+      feedback_template: '
+
+        The following is feedback from your unsuccessful earlier attempt:
+
+
+        {feedback_raw}'
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -126,6 +126,39 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+    self_distillation:
+      _target_: verl.workers.config.SelfDistillationConfig
+      full_logit_distillation: true
+      distillation_topk: 100
+      distillation_add_tail: true
+      alpha: 0.5
+      success_reward_threshold: 0.5
+      teacher_regularization: ema
+      teacher_update_rate: null
+      ema_update_rate: 0.05
+      max_reprompt_len: 10240
+      reprompt_truncation: right
+      dont_reprompt_on_self_success: true
+      remove_thinking_from_demonstration: true
+      include_environment_feedback: true
+      environment_feedback_only_without_solution: true
+      is_clip: 2
+      reprompt_template: '{prompt}{solution}{feedback}
+
+
+        Correctly solve the original question.'
+      solution_template: '
+
+        Correct solution:
+
+
+        {successful_previous_attempt}'
+      feedback_template: '
+
+        The following is feedback from your unsuccessful earlier attempt:
+
+
+        {feedback_raw}'
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -115,6 +115,39 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+    self_distillation:
+      _target_: verl.workers.config.SelfDistillationConfig
+      full_logit_distillation: true
+      distillation_topk: 100
+      distillation_add_tail: true
+      alpha: 0.5
+      success_reward_threshold: 0.5
+      teacher_regularization: ema
+      teacher_update_rate: null
+      ema_update_rate: 0.05
+      max_reprompt_len: 10240
+      reprompt_truncation: right
+      dont_reprompt_on_self_success: true
+      remove_thinking_from_demonstration: true
+      include_environment_feedback: true
+      environment_feedback_only_without_solution: true
+      is_clip: 2
+      reprompt_template: '{prompt}{solution}{feedback}
+
+
+        Correctly solve the original question.'
+      solution_template: '
+
+        Correct solution:
+
+
+        {successful_previous_attempt}'
+      feedback_template: '
+
+        The following is feedback from your unsuccessful earlier attempt:
+
+
+        {feedback_raw}'
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -57,7 +57,7 @@ policy_loss:
   # # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
   _target_: verl.workers.config.PolicyLossConfig
 
-  # Loss function mode: vanilla / clip-cov / kl-cov /gpg from https://arxiv.org/abs/2505.22617
+  # Loss function mode: vanilla / clip-cov / kl-cov / gpg from https://arxiv.org/abs/2505.22617 / sdpo from https://arxiv.org/abs/2601.20802
   loss_mode: "vanilla"
 
   # Ratio of tokens to be clipped for clip-cov loss
@@ -132,11 +132,11 @@ checkpoint:
 
   # Whether to save checkpoints asynchronously. Only effective for Megatron as of now.
   async_save: False
-  
+
   # Mbridge config extension.
   # when vanilla_mbridge=True, and your filesystem is a distributed filesystem,(which means you write a file in node A
   # and you can read the file in node B immediately)
-  # set `mbridge_config.distributed_filesystem=True` and `mbridge_config.memory_efficient=True` to 
+  # set `mbridge_config.distributed_filesystem=True` and `mbridge_config.memory_efficient=True` to
   # speed up the checkpoint saving by 10x speed.
   mbridge_config: {}
 
@@ -162,7 +162,7 @@ optim:
 # Whether to use custom fused kernels (e.g., FlashAttention, fused MLP)
 use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
 
-# profile the actor model in `update_policy` 
+# profile the actor model in `update_policy`
 profiler:
 
   # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
@@ -174,7 +174,7 @@ profiler:
 
   # whether enable profile on Actor
   enable: False
-  
+
   # Whether to profile all ranks.
   all_ranks: False
 
@@ -192,10 +192,10 @@ profiler:
 
       # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
       _target_: verl.utils.profiler.config.NsightToolConfig
-    
+
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: ${oc.select:global_profiler.global_tool_config.nsys.discrete}
-    
+
     # npu config
     npu:
 
@@ -214,7 +214,7 @@ profiler:
 
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: False
-    
+
     # torch profiler config
     torch:
 
@@ -240,6 +240,84 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+# self-distillation config
+self_distillation:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl.workers.config.SelfDistillationConfig
+
+  # Distillation is enabled when policy_loss.loss_mode == "sdpo"
+
+  # Whether to use full-logit KL distillation
+  full_logit_distillation: True
+
+  # Top-k for logit distillation; null uses full logits
+  distillation_topk: 100
+
+  # Whether to add a tail bucket when using distillation_topk
+  distillation_add_tail: True
+
+  # KL interpolation coefficient: 0.0=forward KL, 1.0=reverse KL, in-between=JSD
+  alpha: 0.5
+
+  # Minimum sequence reward to be considered successful
+  success_reward_threshold: 0.5
+
+  # Teacher regularization mode
+  # Options: ema, trust_region, none
+  teacher_regularization: ema
+
+  # Teacher update/mixing rate in [0,1]
+  # If null, falls back to ema_update_rate for backward compatibility
+  teacher_update_rate: null
+
+  # Deprecated alias for teacher_update_rate
+  ema_update_rate: 0.05
+
+  # Maximum length of the reprompted prompt
+  max_reprompt_len: 10240
+
+  # Truncation method for the reprompted prompt
+  # Options: left, right
+  reprompt_truncation: right
+
+  # Whether to not reprompt on self-success
+  dont_reprompt_on_self_success: True
+
+  # Whether to remove <think>...</think> tags from successful demonstrations before reprompting
+  remove_thinking_from_demonstration: True
+
+  # Whether to include environment feedback in reprompting for wrong attempts
+  # If True and feedback exists: use reprompt_template_feedback_solution (with solution) or reprompt_template_feedback (without solution)
+  include_environment_feedback: True
+
+  # If True, only use feedback when no solution is available (ignore feedback when solution exists)
+  # Requires include_environment_feedback=True to have any effect
+  environment_feedback_only_without_solution: True
+
+  # IS clip for loss; null disables IS weighting
+  is_clip: 2
+
+  # Reprompting template - available variables: prompt, successful_previous_attempt, feedback
+  reprompt_template: |-
+    {prompt}{solution}{feedback}
+
+    Correctly solve the original question.
+
+  # Solution template - available variables: successful_previous_attempt
+  solution_template: |-
+
+    Correct solution:
+
+    {successful_previous_attempt}
+
+  # Feedback template - available variables: feedback_raw
+  feedback_template: |-
+
+    The following is feedback from your unsuccessful earlier attempt:
+
+    {feedback_raw}
+
 # Router replay configuration for MoE models
 router_replay:
 
@@ -258,4 +336,3 @@ router_replay:
   # File path to load recorded routing decisions for replay
   # Required when mode is 'replay'
   replay_file: null
-

--- a/verl/trainer/config/sdpo.yaml
+++ b/verl/trainer/config/sdpo.yaml
@@ -1,0 +1,26 @@
+defaults:
+  - ppo_trainer
+  - _self_
+
+actor_rollout_ref:
+  actor:
+    policy_loss:
+      loss_mode: sdpo
+    self_distillation:
+      teacher_regularization: ema
+      teacher_update_rate: 0.05
+      max_reprompt_len: 10240
+      is_clip: 2.0
+  rollout:
+    n: 8
+    calculate_log_probs: true
+
+algorithm:
+  adv_estimator: grpo
+  norm_adv_by_std_in_grpo: false
+  rollout_correction:
+    rollout_is: token
+    rollout_is_threshold: 2.0
+
+data:
+  train_batch_size: 32

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -126,6 +126,15 @@ class TaskRunner:
         from verl.trainer.ppo.ray_trainer import Role
 
         use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+        self_distillation_cfg = config.actor_rollout_ref.actor.get("self_distillation", None)
+        loss_mode = config.actor_rollout_ref.actor.policy_loss.get("loss_mode", "vanilla")
+        self_distillation_needs_ref = self_distillation_cfg is not None and loss_mode == "sdpo"
+        if self_distillation_needs_ref and need_reference_policy(config):
+            raise ValueError("SDPO cannot share the reference policy with KL regularization.")
+        if self_distillation_needs_ref and use_legacy_worker_impl == "disable":
+            raise ValueError("SDPO requires the legacy worker implementation to colocate the teacher.")
+        if self_distillation_needs_ref and config.actor_rollout_ref.actor.strategy not in {"fsdp", "fsdp2"}:
+            raise ValueError("SDPO currently supports FSDP/FSDP2 actor strategy only.")
 
         # use new model engine implementation
         if use_legacy_worker_impl == "disable":
@@ -173,8 +182,9 @@ class TaskRunner:
         else:
             raise NotImplementedError
 
-        self.role_worker_mapping[Role.ActorRollout] = ray.remote(actor_rollout_cls)
-        self.mapping[Role.ActorRollout] = "global_pool"
+        actor_role = Role.ActorRolloutRef if self_distillation_needs_ref else Role.ActorRollout
+        self.role_worker_mapping[actor_role] = ray.remote(actor_rollout_cls)
+        self.mapping[actor_role] = "global_pool"
         return actor_rollout_cls, ray_worker_group_cls
 
     def add_critic_worker(self, config):

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Optional
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 from omegaconf import DictConfig
 
 import verl.utils.torch_functional as verl_F
@@ -1086,6 +1087,163 @@ def agg_loss(
     return loss
 
 
+def compute_self_distillation_loss(
+    student_log_probs: torch.Tensor,
+    teacher_log_probs: torch.Tensor,
+    response_mask: torch.Tensor,
+    self_distillation_config: Any,
+    old_log_probs: Optional[torch.Tensor] = None,
+    student_all_log_probs: Optional[torch.Tensor] = None,
+    teacher_all_log_probs: Optional[torch.Tensor] = None,
+    student_topk_log_probs: Optional[torch.Tensor] = None,
+    teacher_topk_log_probs: Optional[torch.Tensor] = None,
+    self_distillation_mask: Optional[torch.Tensor] = None,
+    loss_agg_mode: str = "token-mean",
+    rollout_is_weights: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Compute the SDPO distillation loss for actor updates.
+
+    Args:
+        student_log_probs: Student token log-probabilities, shape (batch_size, response_length).
+        teacher_log_probs: Teacher token log-probabilities, shape (batch_size, response_length).
+        response_mask: Response token mask, shape (batch_size, response_length).
+        self_distillation_config: SDPO self-distillation config object.
+        old_log_probs: Optional old policy log-probabilities for IS clipping.
+        student_all_log_probs: Optional student full-vocab log-probabilities for full-logit distillation.
+        teacher_all_log_probs: Optional teacher full-vocab log-probabilities for full-logit distillation.
+        student_topk_log_probs: Optional student top-k log-probabilities for top-k distillation.
+        teacher_topk_log_probs: Optional teacher top-k log-probabilities for top-k distillation.
+        self_distillation_mask: Optional per-sample SDPO mask; masked samples are excluded from distillation.
+        loss_agg_mode: Loss aggregation mode.
+        rollout_is_weights: Optional rollout correction IS weights.
+
+    Returns:
+        tuple[torch.Tensor, dict[str, Any]]:
+            - Distillation loss scalar.
+            - Metrics dictionary for debugging and monitoring.
+    """
+
+    metrics = {}
+
+    loss_mask = response_mask
+    if self_distillation_mask is not None:
+        loss_mask = loss_mask * self_distillation_mask.unsqueeze(1)
+
+    distill_variant = "rkl_token"
+    if self_distillation_config.full_logit_distillation:
+        use_topk = self_distillation_config.distillation_topk is not None
+        distill_variant = "full_logit_topk" if use_topk else "full_logit_all"
+        if use_topk:
+            if student_topk_log_probs is None or teacher_topk_log_probs is None:
+                raise ValueError("top-k distillation requires student_topk_log_probs and teacher_topk_log_probs.")
+
+            def add_tail(log_probs: torch.Tensor) -> torch.Tensor:
+                # Compute tail log-probability using logsumexp for numerical stability
+                # log(1 - sum(p_i)) = log(1 - exp(log_sum_exp(log(p_i))))
+                log_s = torch.logsumexp(log_probs, dim=-1, keepdim=True)
+                # Clamp to avoid log_s >= 0 (sum(probs) >= 1).
+                log_s = torch.clamp(log_s, max=-1e-7)
+                # 1 - exp(x) = -(exp(x) - 1) with better precision from expm1.
+                tail_log = torch.log(-torch.expm1(log_s))
+                return torch.cat([log_probs, tail_log], dim=-1)
+
+            def renorm_topk_log_probs(logp: torch.Tensor) -> torch.Tensor:
+                logZ = torch.logsumexp(logp, dim=-1, keepdim=True)
+                return logp - logZ
+
+            student_distill_log_probs = student_topk_log_probs
+            teacher_distill_log_probs = teacher_topk_log_probs
+            if self_distillation_config.distillation_add_tail:
+                student_distill_log_probs = add_tail(student_distill_log_probs)
+                teacher_distill_log_probs = add_tail(teacher_distill_log_probs)
+            else:
+                student_distill_log_probs = renorm_topk_log_probs(student_distill_log_probs)
+                teacher_distill_log_probs = renorm_topk_log_probs(teacher_distill_log_probs)
+        else:
+            if student_all_log_probs is None or teacher_all_log_probs is None:
+                raise ValueError("full_logit_distillation requires student_all_log_probs and teacher_all_log_probs.")
+            student_distill_log_probs = student_all_log_probs
+            teacher_distill_log_probs = teacher_all_log_probs
+
+        kl_type_code = 0.0
+        if self_distillation_config.alpha == 0.0:
+            kl_loss = F.kl_div(student_distill_log_probs, teacher_distill_log_probs, reduction="none", log_target=True)
+        elif self_distillation_config.alpha == 1.0:
+            kl_type_code = 1.0
+            kl_loss = F.kl_div(teacher_distill_log_probs, student_distill_log_probs, reduction="none", log_target=True)
+        else:
+            kl_type_code = 2.0
+            # Compute the log of the mixture distribution
+            # log(a + b) = log(exp(log(a)) + exp(log(b))) -> for mixture
+            alpha = torch.tensor(
+                self_distillation_config.alpha,
+                dtype=student_distill_log_probs.dtype,
+                device=student_distill_log_probs.device,
+            )
+            mixture_log_probs = torch.logsumexp(
+                torch.stack(
+                    [
+                        student_distill_log_probs + torch.log(1 - alpha),
+                        teacher_distill_log_probs + torch.log(alpha),
+                    ]
+                ),
+                dim=0,
+            )
+            kl_teacher = F.kl_div(mixture_log_probs, teacher_distill_log_probs, reduction="none", log_target=True)
+            kl_student = F.kl_div(mixture_log_probs, student_distill_log_probs, reduction="none", log_target=True)
+            # Compute the generalized Jensen-Shannon divergence.
+            kl_loss = torch.lerp(kl_student, kl_teacher, alpha)
+
+        per_token_loss = kl_loss.sum(-1)
+    else:
+        assert self_distillation_config.alpha == 1.0, "Only reverse KL is supported for non-full-logit distillation"
+        log_ratio = student_log_probs - teacher_log_probs
+        per_token_loss = log_ratio.detach() * student_log_probs
+
+    is_clip = self_distillation_config.is_clip
+    if is_clip is not None:
+        if old_log_probs is None:
+            raise ValueError("old_log_probs is required for distillation IS ratio.")
+
+        negative_approx_kl = (student_log_probs - old_log_probs).detach()
+        negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
+        ratio = torch.exp(negative_approx_kl).clamp(max=is_clip)
+        per_token_loss = per_token_loss * ratio
+
+    # Apply rollout correction weights if provided
+    if rollout_is_weights is not None:
+        per_token_loss = per_token_loss * rollout_is_weights
+
+    loss = agg_loss(
+        loss_mat=per_token_loss,
+        loss_mask=loss_mask,
+        loss_agg_mode=loss_agg_mode,
+        batch_num_tokens=loss_mask.sum().clamp(min=1.0),
+    )
+    metrics.update(
+        {
+            "self_distillation/loss": loss.detach().item(),
+            "self_distillation/alpha": float(self_distillation_config.alpha),
+            "self_distillation/full_logit_distillation": float(self_distillation_config.full_logit_distillation),
+            "self_distillation/use_topk": float(self_distillation_config.distillation_topk is not None),
+            "self_distillation/topk_value": float(self_distillation_config.distillation_topk or 0),
+            "self_distillation/mask_fraction": loss_mask.float().mean().item(),
+            "self_distillation/variant_code": {
+                "rkl_token": 3.0,
+                "full_logit_topk": 1.0,
+                "full_logit_all": 0.0,
+            }[distill_variant],
+            "self_distillation/kl_type_code": (
+                kl_type_code if self_distillation_config.full_logit_distillation else 3.0
+            ),
+            "self_distillation/is_clip": (
+                float(self_distillation_config.is_clip) if self_distillation_config.is_clip is not None else -1.0
+            ),
+        }
+    )
+    return loss, metrics
+
+
 @deprecated("verl.trainer.ppo.core_algos.compute_policy_loss_vanilla")
 def compute_policy_loss(
     old_log_prob,
@@ -2028,8 +2186,8 @@ def kl_penalty(logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor, kl_pe
 
     """
     The expectation of k1 and k3 estimator is the expected value of KL, but the expected gradient of k1 and k3
-    estimator is not the expected gradient of KL. On the other hand k2 estimator gives right gradient estimator, 
-    so we use a straight through trick here if the kl_penalty method ends with '+', e.g., k3+. 
+    estimator is not the expected gradient of KL. On the other hand k2 estimator gives right gradient estimator,
+    so we use a straight through trick here if the kl_penalty method ends with '+', e.g., k3+.
     """
     backward_score = 0.5 * (logprob - ref_logprob).square()
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -20,6 +20,7 @@ This trainer supports model-agonistic model initialization with huggingface
 
 import json
 import os
+import re
 import uuid
 from collections import defaultdict
 from copy import deepcopy
@@ -56,6 +57,7 @@ from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, shou
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.import_utils import load_class_from_fqn
+from verl.utils.model import compute_position_id_with_mask
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.rollout_skip import RolloutSkip
@@ -262,6 +264,12 @@ class RayPPOTrainer:
 
         # Store the tokenizer for text processing
         self.tokenizer = tokenizer
+        loss_mode = config.actor_rollout_ref.actor.policy_loss.get("loss_mode", "vanilla")
+        if loss_mode == "sdpo":
+            self.tokenizer.padding_side = "left"
+            reprompt_truncation = config.actor_rollout_ref.actor.get("self_distillation", {}).get("reprompt_truncation")
+            if reprompt_truncation in {"left", "right"}:
+                self.tokenizer.truncation_side = reprompt_truncation
         self.processor = processor
         self.config = config
 
@@ -471,8 +479,235 @@ class RayPPOTrainer:
         # Log to each configured logger
         self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
 
+    @staticmethod
+    def _collect_feedback(
+        include_environment_feedback: bool,
+        reward_extra_infos_dict: Optional[dict[str, Any]],
+        batch_size: int,
+    ) -> list[Any]:
+        """Collect non-empty textual environment feedback from reward extras."""
+        feedback_list: list[Any] = [None] * batch_size
+        if include_environment_feedback and reward_extra_infos_dict is not None:
+            raw_feedback = reward_extra_infos_dict.get("feedback", [])
+            if isinstance(raw_feedback, np.ndarray):
+                raw_feedback = raw_feedback.tolist()
+            for i in range(min(len(raw_feedback), batch_size)):
+                if isinstance(raw_feedback[i], str) and raw_feedback[i].strip():
+                    feedback_list[i] = raw_feedback[i]
+        return feedback_list
+
+    def _collect_solutions_by_uid(
+        self, batch: DataProto, reward_tensor: torch.Tensor, success_reward_threshold: float
+    ) -> dict[Any, list[int]]:
+        """Collect successful sample indices per UID based on sequence-level reward threshold."""
+        seq_scores = reward_tensor.sum(dim=-1).detach().cpu().numpy()
+        uids = batch.non_tensor_batch["uid"]
+        success_by_uid: dict[Any, list[int]] = defaultdict(list)
+        for idx, uid in enumerate(uids):
+            if seq_scores[idx] >= success_reward_threshold:
+                success_by_uid[uid].append(idx)
+        return success_by_uid
+
+    @staticmethod
+    def _remove_thinking_trace(text: str) -> str:
+        """Remove <think>...</think> sections from a demonstration."""
+        return re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+
+    def _get_solution(
+        self,
+        idx: int,
+        success_by_uid: dict[Any, list[int]],
+        uids: list[Any],
+        response_texts: list[str],
+        dont_reprompt_on_self_success: bool = False,
+        remove_thinking_from_demonstration: bool = False,
+    ) -> Optional[str]:
+        """Select a successful demonstration for one sample from its UID group."""
+        uid = uids[idx]
+        solution_idxs = success_by_uid[uid]
+        if dont_reprompt_on_self_success:
+            solution_idxs = [j for j in solution_idxs if j != idx]
+        if len(solution_idxs) == 0:
+            return None
+        solution_idx = solution_idxs[0]
+        solution_str = response_texts[solution_idx]
+        if remove_thinking_from_demonstration:
+            solution_str = self._remove_thinking_trace(solution_str)
+        return solution_str
+
+    def _maybe_build_self_distillation_batch(
+        self,
+        batch: DataProto,
+        reward_tensor: torch.Tensor,
+        reward_extra_infos_dict: Optional[dict[str, list]] = None,
+    ) -> Optional[tuple[DataProto, dict[str, float]]]:
+        """Build SDPO teacher inputs and distillation masks when loss_mode is set to ``sdpo``."""
+        self_distillation_cfg = self.config.actor_rollout_ref.actor.get("self_distillation", None)
+        loss_mode = self.config.actor_rollout_ref.actor.policy_loss.get("loss_mode", "vanilla")
+        if self_distillation_cfg is None or loss_mode != "sdpo":
+            return None
+
+        if "raw_prompt" not in batch.non_tensor_batch:
+            raise ValueError("SDPO requires `raw_prompt` in non_tensor_batch to build teacher prompts.")
+        if "uid" not in batch.non_tensor_batch:
+            raise ValueError("SDPO requires `uid` in non_tensor_batch.")
+
+        device = batch.batch["input_ids"].device
+        responses = batch.batch["responses"]
+        response_mask = batch.batch["response_mask"]
+        batch_size = batch.batch.batch_size[0]
+
+        response_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in responses]
+        raw_prompts = batch.non_tensor_batch["raw_prompt"]
+
+        prompt_texts: list[str] = []
+        for messages in raw_prompts:
+            if len(messages) == 0:
+                prompt_texts.append("")
+                continue
+            content = messages[-1].get("content", "")
+            if not isinstance(content, str):
+                raise ValueError("SDPO currently only supports textual single-turn prompts.")
+            prompt_texts.append(content)
+
+        feedback_list = self._collect_feedback(
+            include_environment_feedback=self_distillation_cfg.include_environment_feedback,
+            reward_extra_infos_dict=reward_extra_infos_dict,
+            batch_size=batch_size,
+        )
+
+        success_by_uid = self._collect_solutions_by_uid(
+            batch,
+            reward_tensor,
+            success_reward_threshold=self_distillation_cfg.success_reward_threshold,
+        )
+        solution_strs = [
+            self._get_solution(
+                i,
+                success_by_uid,
+                batch.non_tensor_batch["uid"],
+                response_texts,
+                self_distillation_cfg.dont_reprompt_on_self_success,
+                self_distillation_cfg.get("remove_thinking_from_demonstration", False),
+            )
+            for i in range(batch_size)
+        ]
+
+        def _build_teacher_message(i: int) -> list[dict]:
+            system_messages = raw_prompts[i][:-1]
+            has_solution = solution_strs[i] is not None
+            has_feedback = feedback_list[i] is not None
+            feedback_only_without_solution = self_distillation_cfg.get(
+                "environment_feedback_only_without_solution",
+                False,
+            )
+            use_feedback = has_feedback and (not feedback_only_without_solution or not has_solution)
+
+            solution_section = ""
+            if has_solution:
+                solution_section = self_distillation_cfg.solution_template.format(
+                    successful_previous_attempt=solution_strs[i]
+                )
+
+            feedback_section = ""
+            if use_feedback:
+                feedback_section = self_distillation_cfg.feedback_template.format(feedback_raw=feedback_list[i])
+
+            if use_feedback or has_solution:
+                reprompt_text = self_distillation_cfg.reprompt_template.format(
+                    prompt=prompt_texts[i],
+                    solution=solution_section,
+                    feedback=feedback_section,
+                )
+            else:
+                reprompt_text = prompt_texts[i]
+
+            return system_messages + [{"role": "user", "content": reprompt_text}]
+
+        messages = [_build_teacher_message(i) for i in range(batch_size)]
+        apply_kwargs = dict(self.config.data.get("apply_chat_template_kwargs", {}))
+        chat_template_kwargs = dict(
+            tokenize=True,
+            return_tensors="pt",
+            return_dict=True,
+            add_generation_prompt=True,
+            max_length=self_distillation_cfg.max_reprompt_len,
+            padding=True,
+            truncation=True,
+            **apply_kwargs,
+        )
+        try:
+            teacher_prompt = self.tokenizer.apply_chat_template(
+                messages,
+                continue_final_message=False,
+                **chat_template_kwargs,
+            )
+        except TypeError:
+            teacher_prompt = self.tokenizer.apply_chat_template(messages, **chat_template_kwargs)
+
+        if isinstance(teacher_prompt, torch.Tensor):
+            teacher_prompt_input_ids = teacher_prompt
+            pad_token_id = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else 0
+            teacher_prompt_attention_mask = (teacher_prompt_input_ids != pad_token_id).to(dtype=torch.long)
+        else:
+            teacher_prompt_input_ids = teacher_prompt["input_ids"]
+            teacher_prompt_attention_mask = teacher_prompt.get("attention_mask")
+            if teacher_prompt_attention_mask is None:
+                teacher_prompt_attention_mask = torch.ones_like(teacher_prompt_input_ids, dtype=torch.long)
+
+        response_mask_dtype = teacher_prompt_attention_mask.dtype
+        teacher_input_ids = torch.cat([teacher_prompt_input_ids.to(device), responses], dim=1)
+        teacher_attention_mask = torch.cat(
+            [teacher_prompt_attention_mask.to(device), response_mask.to(device, dtype=response_mask_dtype)],
+            dim=1,
+        )
+        teacher_position_ids = compute_position_id_with_mask(teacher_attention_mask)
+
+        feedback_only_without_solution = self_distillation_cfg.get("environment_feedback_only_without_solution", False)
+        feedback_used = [
+            feedback_list[i] is not None and (not feedback_only_without_solution or solution_strs[i] is None)
+            for i in range(batch_size)
+        ]
+        self_distillation_mask = torch.tensor(
+            [solution_strs[i] is not None or feedback_used[i] for i in range(batch_size)],
+            dtype=torch.float32,
+            device=device,
+        )
+
+        unique_uids = set(batch.non_tensor_batch["uid"])
+        num_with_feedback_available = sum(1 for f in feedback_list if f is not None)
+        num_with_feedback_used = sum(1 for f in feedback_used if f)
+        num_with_solution = sum(1 for s in solution_strs if s is not None)
+        metrics = {
+            "self_distillation/success_group_fraction": len(
+                [uid for uid in unique_uids if len(success_by_uid[uid]) > 0]
+            )
+            / len(unique_uids),
+            "self_distillation/success_sample_fraction": num_with_solution / batch_size,
+            "self_distillation/feedback_available_fraction": num_with_feedback_available / batch_size,
+            "self_distillation/feedback_used_fraction": num_with_feedback_used / batch_size,
+            "self_distillation/reprompt_sample_fraction": self_distillation_mask.float().mean().item(),
+        }
+        return (
+            DataProto.from_dict(
+                tensors={
+                    "teacher_input_ids": teacher_input_ids,
+                    "teacher_attention_mask": teacher_attention_mask,
+                    "teacher_position_ids": teacher_position_ids,
+                    "self_distillation_mask": self_distillation_mask,
+                }
+            ),
+            metrics,
+        )
+
     def _get_gen_batch(self, batch: DataProto) -> DataProto:
-        reward_keys = set({"data_source", "reward_model", "extra_info", "uid"}) & batch.non_tensor_batch.keys()
+        reward_keys = {
+            "data_source",
+            "reward_model",
+            "extra_info",
+            "uid",
+            "raw_prompt",
+        } & batch.non_tensor_batch.keys()
 
         # pop those keys for generation
         batch_keys_to_pop = []
@@ -1375,6 +1610,15 @@ class RayPPOTrainer:
 
                         # extract reward_tensor and reward_extra_infos_dict for training
                         reward_tensor, reward_extra_infos_dict = extract_reward(batch)
+                        self_distillation_data = self._maybe_build_self_distillation_batch(
+                            batch,
+                            reward_tensor,
+                            reward_extra_infos_dict,
+                        )
+                        if self_distillation_data is not None:
+                            self_distillation_batch, self_distillation_metrics = self_distillation_data
+                            batch = batch.union(self_distillation_batch)
+                            metrics.update(self_distillation_metrics)
 
                     # Operating Mode Selection:
                     # - Bypass mode: Sets old_log_probs = rollout_log_probs (2 policies: π_rollout, π_θ)

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -19,6 +19,8 @@ Single Process Actor
 
 import logging
 import os
+from types import SimpleNamespace
+from typing import Optional
 
 import torch
 from torch import nn
@@ -27,7 +29,7 @@ from torch.distributed.tensor import DTensor
 
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
-from verl.trainer.ppo.core_algos import agg_loss, get_policy_loss_fn, kl_penalty
+from verl.trainer.ppo.core_algos import agg_loss, compute_self_distillation_loss, get_policy_loss_fn, kl_penalty
 from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
@@ -36,11 +38,11 @@ from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import prepare_dynamic_batch, restore_dynamic_batch
 from verl.utils.torch_dtypes import PrecisionType
 from verl.utils.torch_functional import logprobs_from_logits
-from verl.utils.ulysses import gather_outputs_and_unpad, ulysses_pad, ulysses_pad_and_slice_inputs
+from verl.utils.ulysses import gather_outputs_and_unpad, slice_input_tensor, ulysses_pad, ulysses_pad_and_slice_inputs
 from verl.workers.actor import BasePPOActor
 from verl.workers.config import ActorConfig
 
-__all__ = ["DataParallelPPOActor"]
+__all__ = ["DataParallelPPOActor", "TrustRegionTeacher"]
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -60,6 +62,7 @@ class DataParallelPPOActor(BasePPOActor):
         super().__init__(config)
         self.actor_module = actor_module
         self.actor_optimizer = actor_optimizer
+        self.teacher_module: Optional[nn.Module] = None
         role = "Ref" if actor_optimizer is None else "Actor"
 
         self.use_remove_padding = self.config.get("use_remove_padding", False)
@@ -110,8 +113,86 @@ class DataParallelPPOActor(BasePPOActor):
                 f"{self.use_fused_kernels=} or {self.use_prefix_grouper=} for now."
             )
 
+    def _update_teacher_ema(self) -> None:
+        self_distillation_cfg = getattr(self.config, "self_distillation", None)
+        loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
+        if not self_distillation_cfg or loss_mode != "sdpo":
+            return
+        teacher_regularization = self._resolve_teacher_regularization(self_distillation_cfg)
+        if teacher_regularization != "ema":
+            return
+        teacher_update_rate = self._resolve_teacher_update_rate(self_distillation_cfg)
+        if teacher_update_rate == 0.0:
+            return
+        if self.teacher_module is None or self.teacher_module is self.actor_module:
+            raise ValueError("EMA teacher requires a separate teacher_module in the actor worker.")
+        with torch.no_grad():
+            for teacher_param, student_param in zip(
+                self.teacher_module.parameters(),
+                self.actor_module.parameters(),
+            ):
+                student_data = student_param.data.to(device=teacher_param.device)
+                teacher_param.data.mul_(1.0 - teacher_update_rate).add_(student_data, alpha=teacher_update_rate)
+
+    def _update_teacher(self) -> None:
+        """Update teacher state after optimizer step based on configured regularization mode."""
+        self._update_teacher_ema()
+
+    @staticmethod
+    def _resolve_teacher_regularization(self_distillation_cfg) -> str:
+        teacher_regularization = getattr(self_distillation_cfg, "teacher_regularization", "ema")
+        canonical_regularization = {
+            "ema": "ema",
+            "trust_region": "trust_region",
+            "trust-region": "trust_region",
+            "trustregion": "trust_region",
+            "none": "none",
+        }
+        resolved = canonical_regularization.get(str(teacher_regularization).lower())
+        if resolved is None:
+            raise ValueError(
+                "teacher_regularization must be one of {'ema', 'trust_region', 'none'}, "
+                f"got {teacher_regularization}."
+            )
+        return resolved
+
+    @staticmethod
+    def _resolve_teacher_update_rate(self_distillation_cfg) -> float:
+        # teacher_update_rate is the new canonical name. ema_update_rate remains as backward-compatible alias.
+        teacher_update_rate = getattr(self_distillation_cfg, "teacher_update_rate", None)
+        legacy_ema_update_rate = getattr(self_distillation_cfg, "ema_update_rate", 0.05)
+        return float(legacy_ema_update_rate if teacher_update_rate is None else teacher_update_rate)
+
+    @staticmethod
+    def _has_non_empty_multi_modal_inputs(multi_modal_inputs) -> bool:
+        if multi_modal_inputs is None:
+            return False
+        for inputs in multi_modal_inputs:
+            if inputs is None:
+                continue
+            inputs = getattr(inputs, "data", inputs)
+            if isinstance(inputs, dict):
+                if not inputs:
+                    continue
+                for value in inputs.values():
+                    if value is None:
+                        continue
+                    if isinstance(value, torch.Tensor) and value.numel() == 0:
+                        continue
+                    return True
+            else:
+                return True
+        return False
+
     def _forward_micro_batch(
-        self, micro_batch: dict[str, torch.Tensor], temperature: float, calculate_entropy: bool = False
+        self,
+        micro_batch: dict[str, torch.Tensor],
+        temperature: float,
+        calculate_entropy: bool = False,
+        return_all_logps: bool = False,
+        distill_topk: Optional[int] = None,
+        topk_indices: Optional[torch.Tensor] = None,
+        module: Optional[nn.Module] = None,
     ) -> dict[str, torch.Tensor]:
         """
         Returns:
@@ -121,9 +202,20 @@ class DataParallelPPOActor(BasePPOActor):
                     entropys: (bs, response_len)
                 if calculate_sum_pi_squared is False:
                     sum_pi_squared: (bs, response_len)
+                if distill_topk or topk_indices is set:
+                    topk_logps: (bs, response_len, k)
+                    topk_indices: (bs, response_len, k)
         """
         calculate_sum_pi_squared = self.config.get("calculate_sum_pi_squared", False)
         sum_pi_squared_checkpointing = self.config.get("sum_pi_squared_checkpointing", False)
+        use_topk = distill_topk is not None or topk_indices is not None
+        compute_all_logps = return_all_logps and not use_topk
+        return_topk_indices = use_topk and topk_indices is None
+        if (return_all_logps or use_topk) and self.use_fused_kernels:
+            raise ValueError("Logit distillation requires disabling fused kernels.")
+
+        model = module or self.actor_module
+
         # PrefixGrouper path for shared-prefix optimization
         if self.use_prefix_grouper:
             can_use_pg = (
@@ -131,13 +223,15 @@ class DataParallelPPOActor(BasePPOActor):
                 and not self.use_ulysses_sp
                 and not self.use_fused_kernels
                 and not self.use_dynamic_bsz
+                and not return_all_logps
+                and not use_topk
             )
             if can_use_pg and "response_mask" in micro_batch and "uid" in micro_batch:
                 from verl.trainer.ppo.prefix_grouper_utils import forward_micro_batch_with_prefix_grouper
 
                 return forward_micro_batch_with_prefix_grouper(
                     micro_batch=micro_batch,
-                    model=self.actor_module,
+                    model=model,
                     temperature=temperature,
                     calculate_entropy=calculate_entropy,
                     device_name=self.device_name,
@@ -211,9 +305,9 @@ class DataParallelPPOActor(BasePPOActor):
 
                 # pad and slice the inputs if sp > 1
                 if self.use_ulysses_sp:
-                    is_vlm_model = hasattr(
-                        getattr(self.actor_module, "module", self.actor_module).config, "vision_config"
-                    )
+                    model_base = getattr(model, "module", model)
+                    model_config = getattr(model_base, "config", None)
+                    is_vlm_model = hasattr(model_config, "vision_config")
                     if is_vlm_model:
                         # vlm model's inputs will be sliced after embedding
                         input_ids_rmpad, position_ids_rmpad, pad_size = ulysses_pad(
@@ -241,7 +335,7 @@ class DataParallelPPOActor(BasePPOActor):
                     extra_args["temperature"] = temperature
                     extra_args["return_dict"] = True
 
-                output = self.actor_module(
+                output = model(
                     input_ids=input_ids_rmpad,
                     attention_mask=None,
                     position_ids=position_ids_rmpad,
@@ -257,6 +351,7 @@ class DataParallelPPOActor(BasePPOActor):
                 else:
                     logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
                     logits_rmpad.div_(temperature)
+                    all_logps_rmpad = torch.log_softmax(logits_rmpad, dim=-1) if compute_all_logps else None
 
                     # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
                     inplace_backward = True
@@ -276,6 +371,31 @@ class DataParallelPPOActor(BasePPOActor):
                             if not self.config.entropy_checkpointing
                             else torch.utils.checkpoint.checkpoint(self.compute_entropy_from_logits, logits_rmpad)
                         )
+
+                    if use_topk:
+                        if topk_indices is None:
+                            topk = min(distill_topk, logits_rmpad.shape[-1])
+                            topk_logits_rmpad, topk_indices_rmpad = torch.topk(logits_rmpad, topk, dim=-1)
+                        else:
+                            topk = topk_indices.size(-1)
+                            full_topk_indices = torch.zeros(
+                                batch_size,
+                                seqlen,
+                                topk,
+                                device=topk_indices.device,
+                                dtype=topk_indices.dtype,
+                            )
+                            full_topk_indices[:, -response_length - 1 : -1, :] = topk_indices
+                            topk_indices_rmpad = index_first_axis(
+                                rearrange(full_topk_indices, "b s k -> (b s) k"), indices
+                            )
+                            if self.use_ulysses_sp:
+                                topk_indices_rmpad = slice_input_tensor(
+                                    topk_indices_rmpad.unsqueeze(0), dim=1, padding=True
+                                ).squeeze(0)
+                            topk_logits_rmpad = torch.gather(logits_rmpad, dim=-1, index=topk_indices_rmpad)
+                        logsumexp_rmpad = torch.logsumexp(logits_rmpad, dim=-1, keepdim=True)
+                        topk_logps_rmpad = topk_logits_rmpad - logsumexp_rmpad
 
                     # Compute sum_pi_squared if requested (for optimal_token_baseline)
                     if calculate_sum_pi_squared:
@@ -303,6 +423,20 @@ class DataParallelPPOActor(BasePPOActor):
                             unpad_dim=0,
                             padding_size=pad_size,
                         )
+                    if use_topk:
+                        topk_logps_rmpad = gather_outputs_and_unpad(
+                            topk_logps_rmpad,
+                            gather_dim=0,
+                            unpad_dim=0,
+                            padding_size=pad_size,
+                        )
+                        if return_topk_indices:
+                            topk_indices_rmpad = gather_outputs_and_unpad(
+                                topk_indices_rmpad,
+                                gather_dim=0,
+                                unpad_dim=0,
+                                padding_size=pad_size,
+                            )
                     if calculate_sum_pi_squared:
                         sum_pi_squared_rmpad = gather_outputs_and_unpad(
                             sum_pi_squared_rmpad, gather_dim=0, unpad_dim=0, padding_size=pad_size
@@ -312,6 +446,12 @@ class DataParallelPPOActor(BasePPOActor):
                     log_probs = log_probs[:0]
                     if calculate_entropy:
                         entropy_rmpad = entropy_rmpad[:0]
+                    if compute_all_logps:
+                        all_logps_rmpad = all_logps_rmpad[:0]
+                    if use_topk:
+                        topk_logps_rmpad = topk_logps_rmpad[:0]
+                        if return_topk_indices:
+                            topk_indices_rmpad = topk_indices_rmpad[:0]
 
                 # pad back to (bsz, seqlen)
                 if calculate_entropy:
@@ -328,6 +468,27 @@ class DataParallelPPOActor(BasePPOActor):
                         batch=batch_size,
                         seqlen=seqlen,
                     )
+                if compute_all_logps:
+                    full_all_logps = pad_input(
+                        hidden_states=all_logps_rmpad,
+                        indices=indices,
+                        batch=batch_size,
+                        seqlen=seqlen,
+                    )
+                if use_topk:
+                    full_topk_logps = pad_input(
+                        hidden_states=topk_logps_rmpad,
+                        indices=indices,
+                        batch=batch_size,
+                        seqlen=seqlen,
+                    )
+                    if return_topk_indices:
+                        full_topk_indices = pad_input(
+                            hidden_states=topk_indices_rmpad,
+                            indices=indices,
+                            batch=batch_size,
+                            seqlen=seqlen,
+                        )
                 full_log_probs = pad_input(
                     hidden_states=log_probs.unsqueeze(-1),
                     indices=indices,
@@ -342,6 +503,12 @@ class DataParallelPPOActor(BasePPOActor):
                     # (bsz, response_length)
                     sum_pi_squared = full_sum_pi_squared.squeeze(-1)[:, -response_length - 1 : -1]
                 log_probs = full_log_probs.squeeze(-1)[:, -response_length - 1 : -1]  # (bsz, response_length)
+                if compute_all_logps:
+                    all_logps = full_all_logps[:, -response_length - 1 : -1, :]
+                if use_topk:
+                    topk_logps = full_topk_logps[:, -response_length - 1 : -1, :]
+                    if return_topk_indices:
+                        topk_indices = full_topk_indices[:, -response_length - 1 : -1, :]
 
             else:  # not using rmpad and no ulysses sp
                 extra_args = {}
@@ -349,7 +516,7 @@ class DataParallelPPOActor(BasePPOActor):
                     extra_args["temperature"] = temperature
                     extra_args["return_dict"] = True
 
-                output = self.actor_module(
+                output = model(
                     input_ids=input_ids,
                     attention_mask=attention_mask,
                     position_ids=position_ids,
@@ -368,6 +535,16 @@ class DataParallelPPOActor(BasePPOActor):
                     logits.div_(temperature)
                     logits = logits[:, -response_length - 1 : -1, :]  # (bsz, response_length, vocab_size)
                     log_probs = logprobs_from_logits(logits, micro_batch["responses"])
+                    if compute_all_logps:
+                        all_logps = torch.log_softmax(logits, dim=-1)
+                    if use_topk:
+                        if topk_indices is None:
+                            topk = min(distill_topk, logits.size(-1))
+                            topk_logits, topk_indices = torch.topk(logits, topk, dim=-1)
+                        else:
+                            topk_logits = torch.gather(logits, dim=-1, index=topk_indices)
+                        logsumexp = torch.logsumexp(logits, dim=-1, keepdim=True)
+                        topk_logps = topk_logits - logsumexp
                     if calculate_entropy:
                         if not self.config.entropy_checkpointing:
                             entropy = verl_F.entropy_from_logits(logits)  # (bsz, response_length)
@@ -386,6 +563,12 @@ class DataParallelPPOActor(BasePPOActor):
                 outputs["entropys"] = entropy
             if calculate_sum_pi_squared:
                 outputs["sum_pi_squared"] = sum_pi_squared
+            if compute_all_logps:
+                outputs["all_logps"] = all_logps
+            if use_topk:
+                outputs["topk_logps"] = topk_logps
+                if return_topk_indices:
+                    outputs["topk_indices"] = topk_indices
             return outputs
 
     def _optimizer_step(self):
@@ -402,7 +585,6 @@ class DataParallelPPOActor(BasePPOActor):
         if isinstance(grad_norm, DTensor):
             grad_norm = grad_norm.full_tensor()
 
-        # if grad_norm is not finite, skip the update
         if self.scaler is not None:
             self.scaler.step(self.actor_optimizer)
             self.scaler.update()
@@ -418,7 +600,6 @@ class DataParallelPPOActor(BasePPOActor):
             from verl.utils.qat import invalidate_all_scales
 
             invalidate_all_scales(self.actor_module)
-
         return grad_norm
 
     @GPUMemoryLogger(role="dp actor", logger=logger)
@@ -512,6 +693,40 @@ class DataParallelPPOActor(BasePPOActor):
 
         temperature = data.meta_info["temperature"]  # temperature must be in the data.meta_info to avoid silent error
         pad_token_id = data.meta_info.get("pad_token_id", 0)
+        loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
+
+        self_distillation_enabled = loss_mode == "sdpo"
+        self_distillation_cfg = getattr(self.config, "self_distillation", None)
+        teacher_regularization = "ema"
+        teacher_update_rate = 0.0
+        trust_region_teacher: Optional[nn.Module] = None
+        if self_distillation_enabled:
+            self_distillation_required_keys = [
+                "teacher_input_ids",
+                "teacher_attention_mask",
+                "teacher_position_ids",
+                "self_distillation_mask",
+            ]
+            missing = set(self_distillation_required_keys) - set(data.batch.keys())
+            if missing:
+                raise ValueError(f"SDPO is enabled but required teacher keys are missing: {sorted(missing)}")
+            teacher_regularization = self._resolve_teacher_regularization(self_distillation_cfg)
+            teacher_update_rate = self._resolve_teacher_update_rate(self_distillation_cfg)
+            if teacher_regularization == "trust_region":
+                if self.use_fused_kernels:
+                    raise ValueError("SDPO trust-region teacher requires use_fused_kernels=False.")
+                if self.teacher_module is None:
+                    raise ValueError("Trust-region teacher requires a reference teacher_module.")
+                if isinstance(self.teacher_module, TrustRegionTeacher):
+                    trust_region_teacher = self.teacher_module
+                else:
+                    if self.teacher_module is self.actor_module:
+                        raise ValueError("Trust-region teacher requires a separate reference teacher_module.")
+                    trust_region_teacher = TrustRegionTeacher(
+                        ref_module=self.teacher_module,
+                        student_module=self.actor_module,
+                        mix_coef=teacher_update_rate,
+                    )
 
         select_keys = [
             "responses",
@@ -526,6 +741,8 @@ class DataParallelPPOActor(BasePPOActor):
             select_keys.append("prompts")
         if self.config.use_kl_loss:
             select_keys.append("ref_log_prob")
+        if self_distillation_enabled:
+            select_keys.extend(self_distillation_required_keys)
         # Include pre-computed IS weights if present in batch
         # Weights are computed centrally in trainer and added to batch when algorithm.rollout_is=True
         if "rollout_is_weights" in data.batch.keys():
@@ -535,6 +752,9 @@ class DataParallelPPOActor(BasePPOActor):
             select_keys.append("rollout_log_probs")
 
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
+        has_non_empty_multi_modal_inputs = self._has_non_empty_multi_modal_inputs(
+            data.non_tensor_batch.get("multi_modal_inputs")
+        )
         non_tensor_select_keys = []
         if has_multi_modal_inputs:
             non_tensor_select_keys.append("multi_modal_inputs")
@@ -553,6 +773,7 @@ class DataParallelPPOActor(BasePPOActor):
             "actor/pg_loss": 0.0,
             "actor/kl_loss": 0.0,
         }
+        did_update = False
         for _ in range(self.config.ppo_epochs):
             for batch_idx, mini_batch in enumerate(mini_batches):
                 if self.config.use_dynamic_bsz:
@@ -578,6 +799,11 @@ class DataParallelPPOActor(BasePPOActor):
                     loss_agg_mode = self.config.loss_agg_mode
 
                     calculate_entropy = self.config.calculate_entropy or (entropy_coeff != 0)
+                    self_distillation_mask = (
+                        model_inputs.get("self_distillation_mask") if self_distillation_enabled else None
+                    )
+                    if self_distillation_enabled and has_non_empty_multi_modal_inputs:
+                        raise ValueError("SDPO does not support multi-modal inputs in actor.update_policy.")
 
                     if self.config.use_dynamic_bsz:
                         loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
@@ -585,11 +811,23 @@ class DataParallelPPOActor(BasePPOActor):
                         loss_scale_factor = 1 / self.gradient_accumulation
 
                     # all return: (bsz, response_length)
+                    return_all_logps = False
+                    distill_topk = None
+                    if self_distillation_enabled and self_distillation_cfg.full_logit_distillation:
+                        distill_topk = self_distillation_cfg.distillation_topk
+                        return_all_logps = distill_topk is None
                     outputs = self._forward_micro_batch(
-                        model_inputs, temperature=temperature, calculate_entropy=calculate_entropy
+                        model_inputs,
+                        temperature=temperature,
+                        calculate_entropy=calculate_entropy,
+                        return_all_logps=return_all_logps,
+                        distill_topk=distill_topk,
                     )
                     log_prob = outputs["log_probs"]
                     entropy = outputs["entropys"] if calculate_entropy else None
+                    student_all_logps = outputs.get("all_logps") if return_all_logps else None
+                    student_topk_logps = outputs.get("topk_logps") if distill_topk else None
+                    student_topk_indices = outputs.get("topk_indices") if distill_topk else None
 
                     # for fully_async_policy
                     if hasattr(self.config, "use_rollout_log_probs") and self.config.use_rollout_log_probs:
@@ -600,28 +838,66 @@ class DataParallelPPOActor(BasePPOActor):
                         else:
                             old_log_prob = model_inputs["old_log_probs"]
 
-                    loss_mode = self.config.policy_loss.get("loss_mode", "vanilla")
                     # vanilla -> verl.trainer.ppo.core_algos.compute_policy_loss_vanilla
 
                     # Extract pre-computed rollout correction weights if present
                     # Weights are computed centrally in trainer and added when algorithm.rollout_is=True
                     rollout_is_weights = model_inputs.get("rollout_is_weights", None)
 
-                    # gpg -> verl.trainer.ppo.core_algos.compute_policy_loss_gpg
-                    # clip_cov -> verl.trainer.ppo.core_algos.compute_policy_loss_clip_cov
-                    policy_loss_fn = get_policy_loss_fn(loss_mode)
+                    if self_distillation_enabled:
+                        teacher_inputs = {
+                            "responses": model_inputs["responses"],
+                            "input_ids": model_inputs["teacher_input_ids"],
+                            "attention_mask": model_inputs["teacher_attention_mask"],
+                            "position_ids": model_inputs["teacher_position_ids"],
+                        }
+                        teacher_model = trust_region_teacher or self.teacher_module or self.actor_module
+                        with torch.no_grad():
+                            teacher_outputs = self._forward_micro_batch(
+                                teacher_inputs,
+                                temperature=temperature,
+                                calculate_entropy=False,
+                                return_all_logps=return_all_logps,
+                                distill_topk=distill_topk,
+                                topk_indices=student_topk_indices,
+                                module=teacher_model,
+                            )
+                        teacher_log_prob = teacher_outputs["log_probs"]
+                        teacher_all_logps = teacher_outputs.get("all_logps") if return_all_logps else None
+                        teacher_topk_logps = teacher_outputs.get("topk_logps") if distill_topk else None
+                        pg_loss, pg_metrics = compute_self_distillation_loss(
+                            student_log_probs=log_prob,
+                            teacher_log_probs=teacher_log_prob,
+                            response_mask=response_mask,
+                            self_distillation_config=self_distillation_cfg,
+                            old_log_probs=old_log_prob,
+                            student_all_log_probs=student_all_logps,
+                            teacher_all_log_probs=teacher_all_logps,
+                            student_topk_log_probs=student_topk_logps,
+                            teacher_topk_log_probs=teacher_topk_logps,
+                            self_distillation_mask=self_distillation_mask,
+                            loss_agg_mode=loss_agg_mode,
+                            rollout_is_weights=rollout_is_weights,
+                        )
 
-                    # Compute policy loss (any function is expected to return 2 values)
-                    pg_loss, pg_metrics = policy_loss_fn(
-                        old_log_prob=old_log_prob,
-                        log_prob=log_prob,
-                        advantages=advantages,
-                        response_mask=response_mask,
-                        loss_agg_mode=loss_agg_mode,
-                        config=self.config,
-                        rollout_is_weights=rollout_is_weights,
-                    )
-                    micro_batch_metrics.update(pg_metrics)
+                        pg_metrics["self_distillation/empty_target_batch"] = self_distillation_mask.sum().item() == 0
+                        micro_batch_metrics.update(pg_metrics)
+                    else:
+                        # gpg -> verl.trainer.ppo.core_algos.compute_policy_loss_gpg
+                        # clip_cov -> verl.trainer.ppo.core_algos.compute_policy_loss_clip_cov
+                        policy_loss_fn = get_policy_loss_fn(loss_mode)
+
+                        # Compute policy loss (any function is expected to return 2 values)
+                        pg_loss, pg_metrics = policy_loss_fn(
+                            old_log_prob=old_log_prob,
+                            log_prob=log_prob,
+                            advantages=advantages,
+                            response_mask=response_mask,
+                            loss_agg_mode=loss_agg_mode,
+                            config=self.config,
+                            rollout_is_weights=rollout_is_weights,
+                        )
+                        micro_batch_metrics.update(pg_metrics)
 
                     # Skip if using bypass_mode loss (metrics already computed in pg_metrics)
                     rollout_log_prob = model_inputs.get("rollout_log_probs", None)
@@ -670,7 +946,39 @@ class DataParallelPPOActor(BasePPOActor):
                     append_to_dict(metrics, micro_batch_metrics)
 
                 grad_norm = self._optimizer_step()
+                if torch.isfinite(grad_norm).item():
+                    did_update = True
                 mini_batch_metrics = {"actor/grad_norm": grad_norm.detach().item()}
                 append_to_dict(metrics, mini_batch_metrics)
         self.actor_optimizer.zero_grad()
+        if did_update:
+            self._update_teacher()
         return metrics
+
+
+class TrustRegionTeacher(nn.Module):
+    def __init__(self, ref_module: nn.Module, student_module: nn.Module, mix_coef: float):
+        super().__init__()
+        self.ref_module = ref_module
+        self.student_module = student_module
+        self.mix_coef = float(mix_coef)
+        if not 0.0 <= self.mix_coef <= 1.0:
+            raise ValueError(f"mix_coef must be in [0,1], got {self.mix_coef}")
+
+    @staticmethod
+    def _extract_logits(output) -> torch.Tensor:
+        if hasattr(output, "logits"):
+            return output.logits
+        if isinstance(output, tuple):
+            return output[0]
+        if isinstance(output, dict):
+            return output["logits"]
+        raise ValueError(f"Unsupported model output type for trust-region teacher: {type(output)}")
+
+    def forward(self, *args, **kwargs):
+        ref_output = self.ref_module(*args, **kwargs)
+        student_output = self.student_module(*args, **kwargs)
+        ref_logits = self._extract_logits(ref_output)
+        student_logits = self._extract_logits(student_output)
+        logits = torch.lerp(ref_logits, student_logits, self.mix_coef)
+        return SimpleNamespace(logits=logits)

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -28,6 +28,7 @@ from .optimizer import OptimizerConfig
 
 __all__ = [
     "PolicyLossConfig",
+    "SelfDistillationConfig",
     "RouterReplayConfig",
     "ActorConfig",
     "FSDPActorConfig",
@@ -36,6 +37,80 @@ __all__ = [
     "QATConfig",
     "TorchTitanActorConfig",
 ]
+
+
+@dataclass
+class SelfDistillationConfig(BaseConfig):
+    """Configuration for self-distillation loss.
+
+    Args:
+        Distillation is enabled when policy_loss.loss_mode == "sdpo".
+        full_logit_distillation (bool): Whether to use full-logit KL distillation.
+        alpha (float): KL interpolation coefficient.
+            0.0=forward KL, 1.0=reverse KL, in-between=JSD.
+        success_reward_threshold (float): Minimum sequence reward to be considered successful.
+        teacher_regularization (str): Teacher regularization mode.
+            Options: "ema", "trust_region", "none".
+        teacher_update_rate (Optional[float]): Teacher update/mixing rate in [0,1].
+            If null, falls back to ema_update_rate.
+        ema_update_rate (float): Deprecated alias for teacher_update_rate.
+        distillation_topk (Optional[int]): If set, use top-k logits for distillation.
+        distillation_add_tail (bool): Whether to add a tail bucket for top-k distillation.
+        max_reprompt_len (int): Maximum length of the reprompted prompt.
+        reprompt_truncation (str): Truncation method for the reprompted prompt
+            (recommended to use "right" or "error").
+        dont_reprompt_on_self_success (bool): Whether to not reprompt on self-success.
+        remove_thinking_from_demonstration (bool): Whether to remove <think>...</think>
+            tags from successful demonstrations before reprompting.
+        is_clip (Optional[float]): Clip value for distillation IS ratio; None disables IS weighting.
+        reprompt_template (str): Template for reprompting. Uses {prompt}, {solution}, {feedback} placeholders.
+        solution_template (str): Template for formatting solution section.
+            Uses {successful_previous_attempt} placeholder.
+        feedback_template (str): Template for formatting feedback section. Uses {feedback_raw} placeholder.
+        include_environment_feedback (bool): Whether to include environment feedback
+            in reprompting for wrong attempts.
+        environment_feedback_only_without_solution (bool): If True, only use feedback
+            when no solution is available (ignore feedback when solution exists).
+    """
+
+    full_logit_distillation: bool = True
+    alpha: float = 0.0
+    success_reward_threshold: float = 1.0
+    teacher_regularization: str = "ema"
+    teacher_update_rate: Optional[float] = None
+    ema_update_rate: float = 0.05
+    distillation_topk: Optional[int] = None
+    distillation_add_tail: bool = True
+    max_reprompt_len: int = 10240
+    reprompt_truncation: str = "right"
+    dont_reprompt_on_self_success: bool = False
+    remove_thinking_from_demonstration: bool = False
+    is_clip: Optional[float] = None
+    reprompt_template: str = "{prompt}{solution}{feedback}\n\nCorrectly solve the original question.\n"
+    solution_template: str = "\nCorrect solution:\n\n{successful_previous_attempt}\n\n"
+    feedback_template: str = "\nThe following is feedback from your unsuccessful earlier attempt:\n\n{feedback_raw}\n\n"
+    include_environment_feedback: bool = False
+    environment_feedback_only_without_solution: bool = False
+
+    def __post_init__(self):
+        if not 0.0 <= self.alpha <= 1.0:
+            raise ValueError(f"self_distillation.alpha must be in [0,1], got {self.alpha}")
+        valid_regularization_modes = {"ema", "trust_region", "none"}
+        if self.teacher_regularization not in valid_regularization_modes:
+            raise ValueError(
+                "self_distillation.teacher_regularization must be one of "
+                f"{sorted(valid_regularization_modes)}, got {self.teacher_regularization}"
+            )
+        if not 0.0 <= self.ema_update_rate <= 1.0:
+            raise ValueError(f"self_distillation.ema_update_rate must be in [0,1], got {self.ema_update_rate}")
+        if self.teacher_update_rate is not None and not 0.0 <= self.teacher_update_rate <= 1.0:
+            raise ValueError(f"self_distillation.teacher_update_rate must be in [0,1], got {self.teacher_update_rate}")
+        if self.distillation_topk is not None and self.distillation_topk <= 0:
+            raise ValueError(
+                f"self_distillation.distillation_topk must be a positive integer, got {self.distillation_topk}"
+            )
+        if self.is_clip is not None and self.is_clip <= 0:
+            raise ValueError(f"self_distillation.is_clip must be positive, got {self.is_clip}")
 
 
 @dataclass
@@ -74,7 +149,7 @@ class PolicyLossConfig(BaseConfig):
     The inheritance from BaseConfig provides omegaconf.DictConfig-like interface for a dataclass config.
 
     Args:
-        loss_mode (str): Loss function mode. Options: 'vanilla', 'clip-cov', 'kl-cov', 'gpg'.
+        loss_mode (str): Loss function mode. Options: 'vanilla', 'clip-cov', 'kl-cov', 'gpg', 'sdpo'.
         clip_cov_ratio (float): Ratio of tokens to be clipped for clip-cov loss.
         clip_cov_lb (float): Lower bound for clip-cov loss.
         clip_cov_ub (float): Upper bound for clip-cov loss.
@@ -175,6 +250,7 @@ class ActorConfig(BaseConfig):
     engine: BaseConfig = field(default_factory=BaseConfig)
     rollout_n: int = MISSING  # must be override by sampling config
     model_config: HFModelConfig = field(default_factory=BaseConfig)
+    self_distillation: SelfDistillationConfig = field(default_factory=SelfDistillationConfig)
     router_replay: RouterReplayConfig = field(default_factory=RouterReplayConfig)
 
     # Store global batch info for loss aggregation:

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -848,7 +848,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def init_model(self):
-        from verl.workers.actor import DataParallelPPOActor
+        from verl.workers.actor import DataParallelPPOActor, TrustRegionTeacher
 
         # This is used to import external_lib into the huggingface systems
         import_external_libs(self.config.model.get("external_lib", None))
@@ -958,6 +958,22 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 if use_prefix_grouper:
                     self.config.ref.use_prefix_grouper = use_prefix_grouper
             self.ref_policy = DataParallelPPOActor(config=self.config.ref, actor_module=self.ref_module_fsdp)
+            if self._is_actor:
+                self_distillation_cfg = self.config.actor.get("self_distillation", None)
+                loss_mode = self.config.actor.policy_loss.get("loss_mode", "vanilla")
+                if self_distillation_cfg is not None and loss_mode == "sdpo":
+                    teacher_regularization = self_distillation_cfg.get("teacher_regularization", "ema")
+                    teacher_update_rate = self_distillation_cfg.get(
+                        "teacher_update_rate", self_distillation_cfg.get("ema_update_rate", 0.05)
+                    )
+                    if str(teacher_regularization).lower() in {"trust_region", "trust-region", "trustregion"}:
+                        self.actor.teacher_module = TrustRegionTeacher(
+                            ref_module=self.ref_module_fsdp,
+                            student_module=self.actor_module_fsdp,
+                            mix_coef=float(teacher_update_rate),
+                        )
+                    else:
+                        self.actor.teacher_module = self.ref_module_fsdp
 
         if self._is_actor:
             self.flops_counter = FlopsCounter(self.actor_model_config)


### PR DESCRIPTION
### What does this PR do?
This PR adds **SDPO (Self-Distillation Policy Optimization)** as a new policy loss mode in verl, enabled via:
- `actor_rollout_ref.actor.policy_loss.loss_mode=sdpo`

Key points:
- Adds `SelfDistillationConfig` under `actor_rollout_ref.actor.self_distillation` (disabled by default unless `loss_mode=sdpo`).
- Trainer constructs SDPO “reprompted teacher context” inputs + masks and passes them through the training batch.
- Actor update computes SDPO self-distillation loss (full-logit or top-k(+tail) distillation, optional IS clipping).
- Adds an example config (`verl/trainer/config/sdpo.yaml`) and SDPO documentation.
- No behavior change for existing algorithms/configs unless `loss_mode=sdpo` is selected.

Reference implementation / upstream: https://github.com/lasgroup/SDPO

The open PR implementing on-policy distillation is vaguely related: https://github.com/verl-project/verl/pull/4897

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [...](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+distillation)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
