### PR TITLE
[data] fix: Fix tensor size mismatch in AgentLoopWorker

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -540,11 +540,52 @@ class AgentLoopWorker:
         #   e.g., [0,0,0,0,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,0,0,0,0]
 
         # TODO(wuxibin): remove padding and use tensordict.
+        max_prompt_len = self.rollout_config.prompt_length
+        max_response_len = self.rollout_config.response_length
+
+        # [fix] "Sizes of tensors must match except in dimension 0"
+        # max_prompt_len tokens (right portion) to preserve the most recent context.
+        prompt_ids = output.prompt_ids
+        if isinstance(prompt_ids, list):
+            if len(prompt_ids) > max_prompt_len:
+                logger.warning(
+                    f"prompt_ids length {len(prompt_ids)} exceeds max_prompt_len {max_prompt_len}, truncating."
+                )
+                prompt_ids = prompt_ids[-max_prompt_len:]
+        elif isinstance(prompt_ids, torch.Tensor):
+            prompt_ids = prompt_ids.flatten()
+            if prompt_ids.numel() > max_prompt_len:
+                logger.warning(
+                    f"prompt_ids length {prompt_ids.numel()} exceeds max_prompt_len {max_prompt_len}, truncating."
+                )
+                prompt_ids = prompt_ids[-max_prompt_len:]
+
+        response_ids = output.response_ids
+        if isinstance(response_ids, list):
+            if len(response_ids) > max_response_len:
+                logger.warning(
+                    f"response_ids length {len(response_ids)} exceeds max_response_len {max_response_len}, truncating."
+                )
+                response_ids = response_ids[:max_response_len]
+        elif isinstance(response_ids, torch.Tensor):
+            response_ids = response_ids.flatten()
+            if response_ids.numel() > max_response_len:
+                logger.warning(
+                    f"response_ids length {response_ids.numel()} exceeds max_response_len {max_response_len}, truncating."
+                )
+                response_ids = response_ids[:max_response_len]
+
+        response_mask_ids = output.response_mask
+        if isinstance(response_mask_ids, list):
+            response_mask_ids = response_mask_ids[:max_response_len]
+        elif isinstance(response_mask_ids, torch.Tensor):
+            response_mask_ids = response_mask_ids.flatten()[:max_response_len]
+
         self.tokenizer.padding_side = "left"
         prompt_output = self.tokenizer.pad(
-            {"input_ids": output.prompt_ids},
+            {"input_ids": prompt_ids},
             padding="max_length",
-            max_length=self.rollout_config.prompt_length,
+            max_length=max_prompt_len,
             return_tensors="pt",
             return_attention_mask=True,
         )
@@ -554,9 +595,9 @@ class AgentLoopWorker:
 
         self.tokenizer.padding_side = "right"
         response_output = self.tokenizer.pad(
-            {"input_ids": output.response_ids},
+            {"input_ids": response_ids},
             padding="max_length",
-            max_length=self.rollout_config.response_length,
+            max_length=max_response_len,
             return_tensors="pt",
             return_attention_mask=True,
         )
@@ -565,9 +606,9 @@ class AgentLoopWorker:
             response_output["attention_mask"] = response_output["attention_mask"].unsqueeze(0)
 
         response_mask_output = self.tokenizer.pad(
-            {"input_ids": output.response_mask},
+            {"input_ids": response_mask_ids},
             padding="max_length",
-            max_length=self.rollout_config.response_length,
+            max_length=max_response_len,
             return_tensors="pt",
             return_attention_mask=False,
         )
@@ -576,8 +617,9 @@ class AgentLoopWorker:
 
         response_logprobs = None
         if output.response_logprobs is not None:
-            pad_size = self.rollout_config.response_length - len(output.response_logprobs)
-            response_logprobs = torch.tensor(output.response_logprobs + [0.0] * pad_size).unsqueeze(0)
+            truncated_logprobs = output.response_logprobs[:max_response_len]
+            pad_size = max_response_len - len(truncated_logprobs)
+            response_logprobs = torch.tensor(truncated_logprobs + [0.0] * pad_size).unsqueeze(0)
 
         response_mask = response_mask_output["input_ids"] * response_output["attention_mask"]
         attention_mask = torch.cat([prompt_output["attention_mask"], response_output["attention_mask"]], dim=1)
@@ -595,8 +637,10 @@ class AgentLoopWorker:
                 raise TypeError(f"Unsupported type for routed_experts: {type(output.routed_experts)}")
             routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
 
-            # Calculate start position: left padding means original prompt starts at the end
-            start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
+            # Calculate start position: left padding means original prompt starts at the end.
+            # Use the (possibly truncated) prompt_ids length, not the original output.prompt_ids.
+            actual_prompt_len = len(prompt_ids) if isinstance(prompt_ids, list) else prompt_ids.numel()
+            start_pos = prompt_output["input_ids"].shape[1] - actual_prompt_len
             end_pos = min(start_pos + length, total_length)
 
             # Add boundary checks for robustness

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -571,7 +571,8 @@ class AgentLoopWorker:
             response_ids = response_ids.flatten()
             if response_ids.numel() > max_response_len:
                 logger.warning(
-                    f"response_ids length {response_ids.numel()} exceeds max_response_len {max_response_len}, truncating."
+                    f"response_ids length {response_ids.numel()} exceeds "
+                    f"max_response_len {max_response_len}, truncating."
                 )
                 response_ids = response_ids[:max_response_len]
 

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -416,11 +416,19 @@ class ToolAgentLoop(AgentLoopBase):
             # TODO: append malformed tool_call to the prompt: invalid function name or arguments
             tool_name = tool_call.name
             tool_args = json.loads(tool_call.arguments)
+            logger.info(f"[ToolCall] request_id={agent_data.request_id} tool={tool_name} args={tool_args}")
             tool = self.tools[tool_name]
             kwargs = tools_kwargs.get(tool_name, {})
             instance_id, _ = await tool.create(create_kwargs=kwargs.get("create_kwargs", {}))
             tool_execution_response, tool_reward, res = await tool.execute(
                 instance_id, tool_args, agent_data=agent_data
+            )
+            has_image = bool(getattr(tool_execution_response, "image", None))
+            has_video = bool(getattr(tool_execution_response, "video", None))
+            logger.info(
+                f"[ToolCall] done tool={tool_name} reward={tool_reward} "
+                f"has_image={has_image} has_video={has_video} "
+                f"response_text_len={len(tool_execution_response.text or '')}"
             )
         except Exception as e:
             logger.warning(f"Error when executing tool: {e}")


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related 
GitHub issues and PRs that help with the review.

Fix tensor size mismatch in `AgentLoopWorker` when using vlms with agent loop.

---

When training Qwen3-VL using the multi-turn agent loop, the following `RuntimeError` is raised:

```
RuntimeError: Sizes of tensors must match except in dimension 0.
Expected size 1956 but got size 1952 for tensor number 4 in the list.
```

Full stack trace:
```
File "verl/trainer/ppo/ray_trainer.py", line 1449, in fit
    gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
File "verl/experimental/agent_loop/agent_loop.py", line 949, in generate_sequences
    output = DataProto.concat(outputs)
File "verl/protocol.py", line 941, in concat
    new_batch = torch.cat(batch_lst, dim=0)
File "tensordict/_torch_func.py", line 371, in _cat
    out[key] = torch.cat(items, dim)
RuntimeError: Sizes of tensors must match except in dimension 0.
Expected size 1956 but got size 1952 for tensor number 4 in the list.
```

---

**Noted that I set data.filter_overlong_prompts=False to improve the robustness of the framework code under this configuration.**
The bug is in `AgentLoopWorker._agent_loop_postprocess()`. The padding step uses `tokenizer.pad()` with `padding="max_length"`:


```python
prompt_output = self.tokenizer.pad(
    {"input_ids": output.prompt_ids},
    padding="max_length",
    max_length=self.rollout_config.prompt_length,
    ...
)
```

`tokenizer.pad()` only pads sequences shorter than `max_length`; it doesn't truncate sequences that exceed it.

Neither gets truncated to `max_prompt_length` (e.g., 512). After padding, the tensors remain at their original variable lengths. When `DataProto.concat()` tries to `torch.cat` tensors from all 8 workers along dim=0, dimensions must match except dim=0. The mismatch (1956 vs. 1952) causes the crash.

The "tensor number 4" in the error message refers to the output of worker index 4 — the first worker processing prompt 2 — which is exactly where the size diverges from workers 0–3.

---

Before calling `tokenizer.pad()`, explicitly truncate each sequence to its configured maximum length:

- **`prompt_ids`**: keep the **last** `max_prompt_len` tokens (left-truncation, consistent with `padding_side="left"` and `truncation="left"`)
- **`response_ids`**, **`response_mask`**, **`response_logprobs`**: keep the **first** `max_response_len` tokens (right-truncation)

Also fixes the `routed_experts` start-position calculation, which previously used `len(output.prompt_ids)` (original length) instead of the truncated length.

A `logger.warning` is emitted whenever truncation occurs, so oversized prompts are visible in training logs.

``` bash
export WANDB_MODE=online
export FORCE_QWENVL_VIDEO_READER="torchcodec"

PROJECT_DIR=/path/to/verl
CONFIG_PATH=${PROJECT_DIR}/examples/tools/config

CKPT_DIR=${PROJECT_DIR}/checkpoints
PROJECT_NAME="videos"
EXPERIMENT_NAME="qwen3-vl-4b-instruct"

MODEL_PATH=/path/to/Qwen3-VL-4B-Instruct

TRAIN_DATA_PATH=/path/to/data.parquet
VAL_DATA_PATH=/path/to/data.parquet

TOOL_CONFIG_PATH=${PROJECT_DIR}/examples/tools/config/mcp_tool_config.yaml

mkdir -p ${CKPT_DIR}/${PROJECT_NAME}/${EXPERIMENT_NAME}

python3 -m verl.trainer.main_ppo \
  --config-path=${CONFIG_PATH} \
  --config-name=timer1_multiturn_grpo \
  algorithm.adv_estimator=grpo \
  data.train_batch_size=8 \
  data.filter_overlong_prompts=False \
  data.max_prompt_length=2048 \
  data.max_response_length=1024 \
  data.truncation=left \
  data.return_raw_chat=True \
  data.dataloader_num_workers=0 \
  data.return_multi_modal_inputs=False \
  actor_rollout_ref.model.path=${MODEL_PATH} \
  actor_rollout_ref.actor.optim.lr=1e-6 \
  actor_rollout_ref.model.use_remove_padding=True \
  actor_rollout_ref.actor.ppo_mini_batch_size=8 \
  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.actor.use_kl_loss=True \
  actor_rollout_ref.actor.kl_loss_coef=0.001 \
  actor_rollout_ref.actor.kl_loss_type=low_var_kl \
  actor_rollout_ref.actor.entropy_coeff=0 \
  actor_rollout_ref.model.enable_gradient_checkpointing=True \
  actor_rollout_ref.actor.fsdp_config.param_offload=False \
  actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
  actor_rollout_ref.rollout.name=sglang \
  actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
  actor_rollout_ref.rollout.n=4 \
  actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.ref.fsdp_config.param_offload=False \
  actor_rollout_ref.actor.ulysses_sequence_parallel_size=2 \
  algorithm.use_kl_in_reward=False \
  trainer.critic_warmup=0 \
  trainer.logger='[console,wandb]' \
  trainer.project_name=${PROJECT_NAME} \
  trainer.experiment_name=${EXPERIMENT_NAME} \
  trainer.n_gpus_per_node=8 \
  trainer.nnodes=1 \
  trainer.default_local_dir=${CKPT_DIR}/${PROJECT_NAME}/${EXPERIMENT_NAME} \
  trainer.save_freq=1000 \
  trainer.test_freq=1000 \
  data.train_files=${TRAIN_DATA_PATH} \
  data.val_files=${VAL_DATA_PATH} \
  actor_rollout_ref.rollout.multi_turn.tool_config_path=${TOOL_CONFIG_PATH} \
  trainer.total_epochs=1 \
  trainer.val_before_train=False \
  trainer.rollout_data_dir=${CKPT_DIR}/${PROJECT_NAME}/${EXPERIMENT_NAME}/rollout \
  custom_reward_function.path=${PROJECT_DIR}/custom_rewards_v2p/reward.py \
  +custom_reward_function.reward_kwargs.use_iou_reward=False \
  actor_rollout_ref.rollout.multi_turn.tokenization_sanity_check_mode=disable \
  actor_rollout_ref.rollout.agent.default_agent_loop=tool_agent
```



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

No changes that can not be tested by CI.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

No new APIs were introduced.

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
