### PR TITLE
[rollout] feat: support eagle3 speculative decode in rollout

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -275,6 +275,24 @@ checkpoint_engine:
   # Additional keyword arguments to pass to the checkpoint engine constructor
   engine_kwargs: {}
 
+# Configuration for speculative decoding
+speculative:
+
+  # Target class for speculative config
+  _target_: verl.workers.config.SpeculativeConfig
+
+  # whether enable speculative in rollout
+  enable: false
+
+  # The speculative decoding method to use (e.g., "eagle3")
+  method: eagle3
+
+  # Number of draft tokens to generate in one speculative step
+  num_speculative_tokens: 1
+
+  # Path to the draft model checkpoint; if empty, default path is used
+  draft_model_path: ""
+
 # trace rollout data
 trace:
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -31,6 +31,7 @@ __all__ = [
     "PrometheusConfig",
     "RolloutConfig",
     "CheckpointEngineConfig",
+    "SpeculativeConfig",
 ]
 
 
@@ -133,6 +134,20 @@ class CheckpointEngineConfig(BaseConfig):
     # Additional keyword arguments for checkpoint engine
     engine_kwargs: dict = field(default_factory=dict)
 
+@dataclass
+class SpeculativeConfig(BaseConfig):
+    """
+    Configuration for speculative rollout
+    """
+
+    # whether enable speculative in rollout
+    enable: bool = False
+    # The speculative decoding method to use
+    method: str = "eagle3"
+    # Number of draft tokens to generate in one speculative step
+    num_speculative_tokens: int = 1
+    # Path to the draft model checkpoint; if empty, default path is used
+    draft_model_path: Optional[str] = ""
 
 @dataclass
 class RolloutConfig(BaseConfig):
@@ -242,6 +257,8 @@ class RolloutConfig(BaseConfig):
     enable_sleep_mode: bool = True
 
     mtp: MtpConfig = field(default_factory=MtpConfig)
+
+    speculative: SpeculativeConfig = field(default_factory=SpeculativeConfig)
 
     qat: Optional[dict] = None
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -205,6 +205,14 @@ class vLLMColocateWorkerExtension:
             model_config = self.model_runner.vllm_config.model_config
             process_weights_after_loading(model, model_config, self.device)
 
+        # draft model weight is reset so that require reload weight
+        if self.vllm_config.speculative_config:
+            from vllm.model_executor.model_loader import get_model_loader
+            loader = get_model_loader(self.model_runner.vllm_config.load_config)
+            loader.load_weights(self.model_runner.drafter.model, self.vllm_config.speculative_config.draft_model_config)
+            process_weights_after_loading(self.model_runner.drafter.model,
+                                          self.vllm_config.speculative_config.draft_model_config, self.device)
+
     def _update_weights(self, weights: list[tuple[str, torch.Tensor]], peft_config: dict, base_sync_done: bool):
         if peft_config and base_sync_done:
             weights = dict(weights)

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -351,6 +351,18 @@ class vLLMHttpServer:
             }
             args["speculative_config"] = speculative_config
 
+        # eagle3
+        if self.config.speculative.enable:
+            assert not self.config.mtp.enable, (
+                "MTP speculative decoding and Eagle3 speculative decoding cannot be enabled at the same time."
+            )
+            speculative_config = {
+                "method": self.config.speculative.method,
+                "num_speculative_tokens": self.config.speculative.num_speculative_tokens,
+                "model": self.config.speculative.draft_model_path,
+            }
+            args["speculative_config"] = speculative_config
+
         if self.config.data_parallel_size > 1:
             assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
                 "gpus_per_node should be divisible by tensor_model_parallel_size"


### PR DESCRIPTION
### What does this PR do?
add speculative config in rollout config for support eagle3 speculative decode in rollout

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
We compare the training performance of Eagle3 with the baseline on the GSM8K dataset using the PPO algorithm and the Qwen3-32B model on npu-A3.
It achieves very strong performance, with an average improvement of 51.51% during the rollout phase over the first 10 steps, and an end-to-end training gain of 42.20%. Moreover, the trend of the reward remains largely consistent.
<img width="1174" height="636" alt="image" src="https://github.com/user-attachments/assets/ff6f205e-1f6e-4ac8-81b5-298c3ff491bb" /> 
<img width="1176" height="636" alt="image" src="https://github.com/user-attachments/assets/31b7d923-ed68-4168-af5f-4558af94f8b3" />
<img width="1180" height="646" alt="image" src="https://github.com/user-attachments/assets/b9ea8cfc-2452-47ff-8774-862bd8143cc8" />


### API and Usage Example

You can add the following parameters to your training script to enable eagle3 speculative inference.

```python
actor_rollout_ref.rollout.speculative.enable=True
actor_rollout_ref.rollout.speculative.method="eagle3"
actor_rollout_ref.rollout.speculative.num_speculative_tokens=1 
actor_rollout_ref.rollout.speculative.draft_model_path="{your draft model path}"
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
