### PR TITLE
[data] fix: use %-style format placeholders in logger.warning()

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -362,7 +362,7 @@ class RLHFDataset(Dataset):
         interaction_kwargs = row_dict.get("extra_info", {}).get("interaction_kwargs", {})
         need_tools_kwargs = row_dict.get("extra_info", {}).get("need_tools_kwargs", self.need_tools_kwargs)
         if need_tools_kwargs and not tools_kwargs:
-            logger.warning("tools_kwargs is empty for index {}, data source: {}", index, row_dict["data_source"])
+            logger.warning("tools_kwargs is empty for index %s, data source: %s", index, row_dict["data_source"])
         row_dict["index"] = index
         row_dict["tools_kwargs"] = tools_kwargs
         row_dict["interaction_kwargs"] = interaction_kwargs


### PR DESCRIPTION
### What does this PR do?

Fixes a `TypeError` in `verl/utils/dataset/rl_dataset.py` caused by using `str.format()`-style `{}` placeholders in `logger.warning()`. Python's `logging` module expects `%`-style formatting (`%s`, `%d`). The `{}` placeholders cause a `TypeError` on every dataloader item where `tools_kwargs` is empty, flooding training logs with tracebacks.

### Checklist Before Starting

- [x] Search for similar PRs: [query link](https://github.com/volcengine/verl/pulls?q=is%3Apr+logger+format+rl_dataset)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

This is a one-line logging fix. Verified the `TypeError` no longer occurs during multi-turn RL training with tool-use tasks.

### API and Usage Example

No API changes.

### Design & Code Changes

```diff
- logger.warning("tools_kwargs is empty for index {}, data source: {}", index, row_dict["data_source"])
+ logger.warning("tools_kwargs is empty for index %s, data source: %s", index, row_dict["data_source"])
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): ruff, ruff format, mypy all pass.
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). N/A — no user-facing change.
- [x] Add unit or end-to-end test(s). Not feasible for a logging format fix — the behavior is a runtime TypeError that only surfaces when `tools_kwargs` is empty during training.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [x] If your PR is related to the `recipe` submodule, update the reference. N/A.