### PR TITLE
[fsdp] fix: use non-inplace div for activation-offloaded logits views

### DIFF
--- a/tests/workers/actor/test_inplace_div_activation_offload.py
+++ b/tests/workers/actor/test_inplace_div_activation_offload.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test that temperature scaling in dp_actor handles activation-offloaded views.
+
+FSDP2 + activation_offload wraps squeeze() in a custom autograd Function.
+The resulting view cannot be modified inplace — PyTorch raises RuntimeError
+because div_() would override the custom backward. This test verifies that
+the conditional inplace/non-inplace division in _forward_micro_batch works
+correctly in both grad-enabled and no-grad contexts.
+"""
+
+import unittest
+
+import torch
+
+
+class _MockActivationOffload(torch.autograd.Function):
+    """Simulates the custom autograd Function that activation_offload wraps around squeeze().
+
+    When activation_offload is active, squeeze() returns a view through a custom
+    autograd Function (SqueezeBackward1). Inplace ops on such views raise RuntimeError.
+    """
+
+    @staticmethod
+    def forward(ctx, x):
+        return x.squeeze(0)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad.unsqueeze(0)
+
+
+def _apply_temperature(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    """Local copy of dp_actor._apply_temperature (avoids importing verl which requires ray)."""
+    if torch.is_grad_enabled():
+        return logits / temperature
+    return logits.div_(temperature)
+
+
+class TestInplaceDivActivationOffload(unittest.TestCase):
+    """Verify temperature scaling handles activation-offloaded views correctly."""
+
+    def test_inplace_div_fails_on_activation_offload_view(self):
+        """Inplace div_ on an activation-offloaded view raises RuntimeError."""
+        x = torch.randn(1, 4, requires_grad=True)
+        view = _MockActivationOffload.apply(x)  # simulates activation offload squeeze
+        with self.assertRaises(RuntimeError):
+            view.div_(2.0)
+
+    def test_non_inplace_div_works_on_activation_offload_view(self):
+        """Non-inplace division on an activation-offloaded view works."""
+        x = torch.randn(1, 4, requires_grad=True)
+        view = _MockActivationOffload.apply(x)
+        result = view / 2.0  # non-inplace
+        self.assertEqual(result.shape, (4,))
+        self.assertTrue(torch.allclose(result, x.squeeze(0) / 2.0))
+
+    def test_conditional_div_with_grad_enabled(self):
+        """With grad enabled (training), uses non-inplace division."""
+        x = torch.randn(1, 4, requires_grad=True)
+        view = _MockActivationOffload.apply(x)
+        # Should not raise — uses non-inplace path
+        result = _apply_temperature(view, 0.7)
+        self.assertTrue(torch.allclose(result, x.squeeze(0) / 0.7))
+
+    def test_conditional_div_with_no_grad(self):
+        """With no_grad (compute_log_prob), uses inplace division."""
+        x = torch.randn(1, 4)
+        expected = x.squeeze(0) / 0.7
+        logits = x.squeeze(0)  # normal squeeze, no custom autograd
+        with torch.no_grad():
+            result = _apply_temperature(logits, 0.7)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_inplace_div_safe_on_offload_view_under_no_grad(self):
+        """Under no_grad, inplace div_ on an activation-offloaded view does not raise."""
+        x = torch.randn(1, 4, requires_grad=True)
+        view = _MockActivationOffload.apply(x)
+        with torch.no_grad():
+            view.div_(2.0)  # should NOT raise — autograd tracking is disabled
+
+    def test_gradient_flows_through_non_inplace_path(self):
+        """Non-inplace division preserves gradient flow through activation-offloaded views."""
+        x = torch.randn(1, 4, requires_grad=True)
+        view = _MockActivationOffload.apply(x)
+        result = _apply_temperature(view, 0.7)
+        result.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -43,6 +43,20 @@ from verl.workers.config import ActorConfig
 __all__ = ["DataParallelPPOActor"]
 
 logger = logging.getLogger(__file__)
+
+
+def _apply_temperature(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+    """Apply temperature scaling, handling activation-offloaded views correctly.
+
+    FSDP2 + activation_offload wraps squeeze() in a custom autograd Function.
+    Inplace div_() on such views raises RuntimeError. Use non-inplace division
+    when gradients are enabled (training), inplace when disabled (compute_log_prob).
+    """
+    if torch.is_grad_enabled():
+        return logits / temperature
+    return logits.div_(temperature)
+
+
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
@@ -256,7 +270,7 @@ class DataParallelPPOActor(BasePPOActor):
 
                 else:
                     logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
-                    logits_rmpad.div_(temperature)
+                    logits_rmpad = _apply_temperature(logits_rmpad, temperature)
 
                     # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
                     inplace_backward = True
@@ -365,7 +379,7 @@ class DataParallelPPOActor(BasePPOActor):
                 else:
                     logits = output.logits
 
-                    logits.div_(temperature)
+                    logits = _apply_temperature(logits, temperature)
                     logits = logits[:, -response_length - 1 : -1, :]  # (bsz, response_length, vocab_size)
                     log_probs = logprobs_from_logits(logits, micro_batch["responses"])
                     if calculate_entropy:

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -45,7 +45,7 @@ __all__ = ["DataParallelPPOActor"]
 logger = logging.getLogger(__file__)
 
 
-def _apply_temperature(logits: torch.Tensor, temperature: float) -> torch.Tensor:
+def _apply_temperature(logits: torch.Tensor, temperature) -> torch.Tensor:
     """Apply temperature scaling, handling activation-offloaded views correctly.
 
     FSDP2 + activation_offload wraps squeeze() in a custom autograd Function.

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -81,6 +81,18 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 device_name = get_device_name()
 
 
+def _apply_temperature(logits: torch.Tensor, temperature) -> torch.Tensor:
+    """Apply temperature scaling, handling activation-offloaded views correctly.
+
+    FSDP2 + activation_offload wraps squeeze() in a custom autograd Function.
+    Inplace div_() on such views raises RuntimeError. Use non-inplace division
+    when gradients are enabled (training), inplace when disabled (compute_log_prob).
+    """
+    if torch.is_grad_enabled():
+        return logits / temperature
+    return logits.div_(temperature)
+
+
 class FSDPEngine(BaseEngine):
     """
     Concrete Engine implementation using PyTorch FullyShardedDataParallel (FSDP).
@@ -1003,7 +1015,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 entropy_rmpad = output.entropy.squeeze(0)  # (total_nnz,)
             else:
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
-                logits_rmpad.div_(temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))
+                logits_rmpad = _apply_temperature(logits_rmpad, temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))
 
                 # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
                 inplace_backward = True
@@ -1062,7 +1074,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 logits = output.logits  # (bsz, response_length, vocab_size)
                 temperature = output_args["temperature"]  # (bsz,)
                 temperature = temperature.unsqueeze(-1).unsqueeze(-1)
-                logits.div_(temperature.clamp(min=1e-8).to(logits.dtype))
+                logits = _apply_temperature(logits, temperature.clamp(min=1e-8).to(logits.dtype))
 
                 if calculate_entropy:
                     if not self.engine_config.entropy_checkpointing:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1015,7 +1015,9 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 entropy_rmpad = output.entropy.squeeze(0)  # (total_nnz,)
             else:
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
-                logits_rmpad = _apply_temperature(logits_rmpad, temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))
+                logits_rmpad = _apply_temperature(
+                    logits_rmpad, temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype)
+                )
 
                 # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
                 inplace_backward = True


### PR DESCRIPTION
### What does this PR do?

Fixes a `RuntimeError` in `dp_actor.py` (legacy workers) and `engine/fsdp/transformer_impl.py` (engine workers) when using FSDP2 with `activation_offload=True`.

When activation offload is enabled, `squeeze()` is wrapped in a custom autograd Function (`SqueezeBackward1`), producing a view that cannot be modified inplace. PyTorch raises `RuntimeError` because `div_()` would corrupt the custom backward function attached to the view.

Both `div_(temperature)` call sites in `_forward_micro_batch` are affected (the `use_remove_padding` path at line 259 and the non-rmpad path at line 371).

### Checklist Before Starting

- [x] Search for similar PRs: [inplace div activation offload](https://github.com/volcengine/verl/pulls?q=is%3Apr+inplace+div+activation+offload)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

**Production validation:** Verified during GRPO training with FSDP2 + `activation_offload=True` on 8xH200. The `RuntimeError` no longer occurs.

**Unit test:** Added `tests/workers/actor/test_inplace_div_activation_offload.py` (CPU-only, runs with `pytest` directly — no `torchrun` or distributed setup required):

| Test | Verifies |
|------|----------|
| `test_inplace_div_fails_on_activation_offload_view` | Inplace `div_()` raises `RuntimeError` on activation-offloaded views |
| `test_non_inplace_div_works_on_activation_offload_view` | Non-inplace `/` works on such views |
| `test_conditional_div_with_grad_enabled` | Conditional logic selects non-inplace path when grad is enabled |
| `test_conditional_div_with_no_grad` | Conditional logic selects inplace path under `no_grad()` |
| `test_inplace_div_safe_on_offload_view_under_no_grad` | Inplace `div_()` is safe on offloaded views under `no_grad()` |
| `test_gradient_flows_through_non_inplace_path` | Gradients propagate correctly through the non-inplace path |

### API and Usage Example

No API changes.

### Design & Code Changes

Both `div_(temperature)` calls in `_forward_micro_batch` are replaced with a conditional:

```diff
- logits.div_(temperature)
+ if torch.is_grad_enabled():
+     logits = logits / temperature  # non-inplace for activation offload views
+ else:
+     logits.div_(temperature)
```

**Why conditional rather than always non-inplace?** `compute_log_prob` and `compute_ref_log_prob` run under `torch.no_grad()`, where activation offload is inactive and inplace `div_()` is safe. Keeping `div_()` on this path avoids allocating a second full copy of the logits tensor — which can be significant (e.g., ~5.6 GB for a 19K-token sequence with vocab_size=151936 in bf16).

`update_policy` runs with grad enabled, so it takes the non-inplace path — this is the only codepath where the `RuntimeError` occurs.

**Out of scope:** `megatron_actor.py` and `torchtitan/transformer_impl.py` contain the same `div_(temperature)` pattern. If those paths also support `activation_offload=True`, they may need the same fix.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). — N/A, no user-facing API change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows): `tests/workers/actor/test_inplace_div_activation_offload.py` (CPU-only, runs with `pytest`).
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1). — Will request after review.
- [x] If your PR is related to the `recipe` submodule, update the reference. — N/A.