### PR TITLE
[rollout] fix: agent loop copy read-only routed_experts before torch conversion

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Optional
 
 import numpy as np
@@ -23,6 +24,7 @@ from omegaconf import OmegaConf
 
 from verl.experimental.agent_loop.agent_loop import (
     AgentLoopMetrics,
+    AgentLoopOutput,
     AgentLoopWorker,
     DictConfigWrap,
     _InternalAgentLoopOutput,
@@ -63,6 +65,8 @@ class _FakeServerManager:
 
 
 class _FakeTokenizer:
+    padding_side = "right"
+
     def apply_chat_template(
         self,
         messages: list[dict[str, Any]],
@@ -75,6 +79,36 @@ class _FakeTokenizer:
         del messages, tools, add_generation_prompt, tokenize, kwargs
         # Minimal tokenization: return a small prompt.
         return [101, 102]
+
+    def pad(
+        self,
+        encoded_inputs: dict[str, list[int]],
+        *,
+        padding: str,
+        max_length: int,
+        return_tensors: str,
+        return_attention_mask: bool,
+    ) -> dict[str, torch.Tensor]:
+        del padding, return_tensors
+        input_ids = encoded_inputs["input_ids"]
+        if len(input_ids) > max_length:
+            if self.padding_side == "left":
+                input_ids = input_ids[-max_length:]
+            else:
+                input_ids = input_ids[:max_length]
+
+        pad_len = max_length - len(input_ids)
+        if self.padding_side == "left":
+            padded_ids = [0] * pad_len + input_ids
+            attention_mask = [0] * pad_len + [1] * len(input_ids)
+        else:
+            padded_ids = input_ids + [0] * pad_len
+            attention_mask = [1] * len(input_ids) + [0] * pad_len
+
+        output = {"input_ids": torch.tensor([padded_ids], dtype=torch.long)}
+        if return_attention_mask:
+            output["attention_mask"] = torch.tensor([attention_mask], dtype=torch.long)
+        return output
 
     def decode(self, ids: list[int] | torch.Tensor, skip_special_tokens: bool = True) -> str:
         del ids, skip_special_tokens
@@ -212,3 +246,49 @@ async def test_agent_loop_extra_fields_schema_stable_for_training_concat_on_cpu(
     # And the list-typed fields are actually lists (not missing / scalar).
     assert merged.non_tensor_batch["turn_scores"][0] == []
     assert merged.non_tensor_batch["tool_rewards"][0] == []
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
+    class _DummyWorker:
+        _compute_multi_modal_inputs = AgentLoopWorker._compute_multi_modal_inputs
+        _compute_position_ids = AgentLoopWorker._compute_position_ids
+        _compute_score = AgentLoopWorker._compute_score
+
+        def __init__(self):
+            self.tokenizer = _FakeTokenizer()
+            self.rollout_config = OmegaConf.create({"prompt_length": 4, "response_length": 4})
+            self.processor = None
+            self.reward_loop_worker_handles = None
+
+    routed_experts = np.arange(8, dtype=np.int64).reshape(4, 2, 1)
+    routed_experts.setflags(write=False)
+    assert not routed_experts.flags.writeable
+
+    output = AgentLoopOutput(
+        prompt_ids=[101, 102],
+        response_ids=[11, 12],
+        response_mask=[1, 1],
+        routed_experts=routed_experts,
+        metrics=AgentLoopMetrics(),
+        extra_fields={},
+    )
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            message="The given NumPy array is not writable.*",
+            category=UserWarning,
+        )
+        internal = await AgentLoopWorker._agent_loop_postprocess(
+            _DummyWorker(),
+            output,
+            raw_prompt=[{"role": "user", "content": "hi"}],
+        )
+
+    expected = torch.tensor(routed_experts.copy()).unsqueeze(0)
+    assert internal.routed_experts is not None
+    assert internal.routed_experts.shape == (1, 8, 2, 1)
+    torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
+    assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0
+    assert torch.count_nonzero(internal.routed_experts[:, 6:]) == 0

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -637,7 +637,10 @@ class AgentLoopWorker:
             total_length = input_ids.shape[1]
             length, layer_num, topk_num = output.routed_experts.shape
             if isinstance(output.routed_experts, np.ndarray):
-                experts_tensor = torch.from_numpy(output.routed_experts)
+                routed_experts_array = output.routed_experts
+                if not routed_experts_array.flags.writeable:
+                    routed_experts_array = routed_experts_array.copy()
+                experts_tensor = torch.from_numpy(routed_experts_array)
             elif isinstance(output.routed_experts, torch.Tensor):
                 experts_tensor = output.routed_experts
             else:


### PR DESCRIPTION
### What does this PR do?

Avoid PyTorch warning when routed_experts is a non-writable NumPy array while preserve existing behavior for writable arrays and tensors. Also added CPU regression coverage for `_agent_loop_postprocess`

```log
verl/experimental/agent_loop/agent_loop.py:591: UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:213.)
experts_tensor = torch.from_numpy(output.routed_experts)
```

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
