### PR TITLE
[doc] chore: add note for kimi ckpt engine

### DIFF
--- a/verl/checkpoint_engine/README.md
+++ b/verl/checkpoint_engine/README.md
@@ -31,6 +31,13 @@ This mode requires the P2P feature of checkpoint_engine. Please ensure you have 
 
 In addition, during the installation of checkpoint-engine[p2p], the transfer engine will be installed. However, This library has no prebuilt packages for Ascend devices and must be compiled from source. For detailed compilation instructions, see: [transfer-engine: ascend direct](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/design/transfer-engine/ascend_direct_transport.md)
 
+Note: Important Configuration for Ascend Devices
+If you are using CANN version >= 8.5.0 on Ascend devices, you must set the following environment variable to enable intra-node ROCE:
+
+```bash
+export HCCL_INTRA_ROCE_ENABLE=1
+```
+
 ### Benchmark
 1. benchmark setup
 - model: Qwen/Qwen3-30B-A3B-Base


### PR DESCRIPTION
### What does this PR do?

When using a newer version of CANN, HCCL_INTRA_ROCE_ENABLE must be enabled. Otherwise, H2D transfers default to HCCS, which leads to execution timeouts.