### PR TITLE
[perf, training_utils] fix: Run gc regularly in trainer/sft_trainer.py to avoid spikes in step time.

### DIFF
--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -84,6 +84,12 @@ trainer:
   nnodes: 1
   n_gpus_per_node: 1
 
+  # GC frequency: Disabling automatic GC avoids periodic spikes in step time.
+  #   -1: Default Python GC behavior (backward compatible).
+  #    0: Disable GC entirely.
+  #   N>0: Disable automatic GC and manually collect every N steps.
+  gc_freq: -1
+
   profile_interval: [-1, -1]
 
 global_profiler:

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import gc
 import os
 from functools import partial
 
@@ -347,96 +348,113 @@ class SFTTrainer:
 
         train_time = 0
         total_tokens = 0
-        for epoch in range(start_epoch, self.config.trainer.total_epochs):
-            self.train_sampler.set_epoch(epoch=epoch)
 
-            aggressive_empty_cache(force_sync=True)
-            log_gpu_memory_usage(f"rank {self.rank}: At start of epoch {epoch}", logger=logger)
+        # gc_freq >= 0: Disable automatic GC, manually collect every gc_freq steps (0 = never).
+        # gc_freq < 0: Backward compatible, don't touch GC (Python's default automatic GC).
+        gc_freq = getattr(self.config.trainer, "gc_freq", -1)
+        if gc_freq >= 0:
+            gc.disable()
+            log_with_rank(f"GC disabled (gc_freq={gc_freq})", logger=logger, rank=0, log_only_rank_0=True)
 
-            for step_in_epoch, data in enumerate(
-                tqdm(
-                    self.train_dataloader,
-                    initial=global_step % self.steps_per_epoch if epoch == start_epoch else 0,
-                    total=self.steps_per_epoch,
-                    desc=f"Epoch {epoch + 1}/{self.config.trainer.total_epochs}",
-                    disable=not is_logging,
-                )
-            ):
-                global_step += 1
+        try:
+            for epoch in range(start_epoch, self.config.trainer.total_epochs):
+                self.train_sampler.set_epoch(epoch=epoch)
 
-                # construct tensordict
-                data = tu.get_tensordict(tensor_dict=data, non_tensor_dict=meta_info)
-                batch_seqlens = self._get_batch_seqlens(data=data)
-                # this is necessary. Otherwise, it is interpreted as NonTensorStack
-                batch_seqlens_ntd = NonTensorData(batch_seqlens)
+                aggressive_empty_cache(force_sync=True)
+                log_gpu_memory_usage(f"rank {self.rank}: At start of epoch {epoch}", logger=logger)
 
-                tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens_ntd)
+                for step_in_epoch, data in enumerate(
+                    tqdm(
+                        self.train_dataloader,
+                        initial=global_step % self.steps_per_epoch if epoch == start_epoch else 0,
+                        total=self.steps_per_epoch,
+                        desc=f"Epoch {epoch + 1}/{self.config.trainer.total_epochs}",
+                        disable=not is_logging,
+                    )
+                ):
+                    global_step += 1
 
-                # start profile in SPMD mode
-                if global_step == self.start_profile_step:
-                    self.training_client.start_profile()
-                # train for on batch
-                output = self.training_client.train_batch(data=data)
+                    # construct tensordict
+                    data = tu.get_tensordict(tensor_dict=data, non_tensor_dict=meta_info)
+                    batch_seqlens = self._get_batch_seqlens(data=data)
+                    # this is necessary. Otherwise, it is interpreted as NonTensorStack
+                    batch_seqlens_ntd = NonTensorData(batch_seqlens)
 
-                if global_step == self.end_profile_step:
-                    self.training_client.stop_profile()
+                    tu.assign_non_tensor(data, update_lr_scheduler=True, global_token_num=batch_seqlens_ntd)
 
-                if self.engine.is_mp_src_rank_with_outputs():
-                    metrics = tu.get(output, "metrics")
+                    # start profile in SPMD mode
+                    if global_step == self.start_profile_step:
+                        self.training_client.start_profile()
+                    # train for on batch
+                    output = self.training_client.train_batch(data=data)
 
-                    # TODO: we can actual accumulate metrics for N steps and perform aggregate metrics
-                    for k in ["loss", "grad_norm", "lr", "mfu"]:
-                        if k in metrics.keys():
-                            value = metrics.pop(k)
-                            metrics[f"train/{k}"] = value
-
-                    metrics["train/global_tokens"] = torch.sum(
-                        torch.tensor(batch_seqlens, device=self.device_name)
-                    ).item()
-                    total_tokens += metrics["train/global_tokens"]
-                    metrics["train/total_tokens(B)"] = total_tokens / 1e9
-
-                    if self.engine.get_data_parallel_rank() == 0:
-                        tracking.log(data=metrics, step=global_step)
-
-                is_last_step = global_step >= self.total_training_steps
-                is_valid_step = global_step % self.test_freq == 0
-                is_save_step = global_step % self.save_freq == 0
-
-                # early exit or validation step
-                if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
-                    # Perform validation
-                    val_losses = []
-                    for val_data in self.val_dataloader:
-                        val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
-                        output = self.training_client.infer_batch(val_data)
-
-                        if self.engine.is_mp_src_rank_with_outputs():
-                            metrics = tu.get(output, "metrics")
-                            val_losses.append(metrics["loss"])
+                    if global_step == self.end_profile_step:
+                        self.training_client.stop_profile()
 
                     if self.engine.is_mp_src_rank_with_outputs():
-                        val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
-                        # average over data parallel group
-                        dp_group = self.engine.get_data_parallel_group()
-                        if dp_group is not None:
-                            torch.distributed.all_reduce(val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+                        metrics = tu.get(output, "metrics")
 
-                    if is_logging:
-                        metric = {"val/loss": val_loss.detach().item()}
-                        tracking.log(data=metric, step=global_step)
-                        last_valid_metric = metric
-                    torch.distributed.barrier()
+                        # TODO: we can actual accumulate metrics for N steps and perform aggregate metrics
+                        for k in ["loss", "grad_norm", "lr", "mfu"]:
+                            if k in metrics.keys():
+                                value = metrics.pop(k)
+                                metrics[f"train/{k}"] = value
 
-                if is_last_step or (self.save_freq > 0 and is_save_step):
-                    aggressive_empty_cache(force_sync=True)
-                    self.ckpt_handler.save_checkpoint(step=global_step)
+                        metrics["train/global_tokens"] = torch.sum(
+                            torch.tensor(batch_seqlens, device=self.device_name)
+                        ).item()
+                        total_tokens += metrics["train/global_tokens"]
+                        metrics["train/total_tokens(B)"] = total_tokens / 1e9
 
-                if is_last_step:
-                    if is_logging:
-                        print(f"Total time for train steps: {train_time:.2f}s")
-                        print(f"Final validation metrics: {last_valid_metric}")
-                    return
+                        if self.engine.get_data_parallel_rank() == 0:
+                            tracking.log(data=metrics, step=global_step)
+
+                    if gc_freq > 0 and global_step % gc_freq == 0:
+                        gc.collect()
+
+                    is_last_step = global_step >= self.total_training_steps
+                    is_valid_step = global_step % self.test_freq == 0
+                    is_save_step = global_step % self.save_freq == 0
+
+                    # early exit or validation step
+                    if is_last_step and self.val_dataloader is not None or (self.test_freq > 0 and is_valid_step):
+                        # Perform validation
+                        val_losses = []
+                        for val_data in self.val_dataloader:
+                            val_data = tu.get_tensordict(tensor_dict=val_data, non_tensor_dict=meta_info)
+                            output = self.training_client.infer_batch(val_data)
+
+                            if self.engine.is_mp_src_rank_with_outputs():
+                                metrics = tu.get(output, "metrics")
+                                val_losses.append(metrics["loss"])
+
+                        if self.engine.is_mp_src_rank_with_outputs():
+                            val_loss = torch.mean(torch.tensor(val_losses, device=self.device_name))
+                            # average over data parallel group
+                            dp_group = self.engine.get_data_parallel_group()
+                            if dp_group is not None:
+                                torch.distributed.all_reduce(
+                                    val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group
+                                )
+
+                        if is_logging:
+                            metric = {"val/loss": val_loss.detach().item()}
+                            tracking.log(data=metric, step=global_step)
+                            last_valid_metric = metric
+                        torch.distributed.barrier()
+
+                    if is_last_step or (self.save_freq > 0 and is_save_step):
+                        aggressive_empty_cache(force_sync=True)
+                        self.ckpt_handler.save_checkpoint(step=global_step)
+
+                    if is_last_step:
+                        if is_logging:
+                            print(f"Total time for train steps: {train_time:.2f}s")
+                            print(f"Final validation metrics: {last_valid_metric}")
+                        return
+        finally:
+            if gc_freq >= 0:
+                gc.enable()
 
 
 def run_sft(config):


### PR DESCRIPTION
### What does this PR do?

Run gc regularly in trainer/sft_trainer.py to avoid spikes in step time.
- **NOTE**: ~~Current PR is on top of https://github.com/verl-project/verl/pull/5579~~


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+gc
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test


**I: Step Time**
It decreases training step time consistently with `gc_freq=1` (Dropping first `10` steps and last `3` steps):
- All jobs run on the same node `ip-10-4-145-27`, to reduce inconsistency across different nodes

1. `Median` time: `0.8652 ==> 0.7247 (-16.2%)`
2. `Avg` time: `0.8828 ==> 0.7324 (-17.0%)`
3. `Std` time also decreases `0.0696 ==> 0.0362 (-48.0%)` or improvement of `1.92x`
     * Important to compare across experiments whether step time reduction/ MFU increase is **significant**

**II: MFU**

`MFU` increases slightly on the `worker` as well, from `gc_freq = -1 to 1`:
1. `avg` MFU increases `0.2221 ==> 0.2297 (+3.4%)`: `2026-03-13 17:34:52,918 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2297 [+    0.0076] (    0.0020),     0.2301)  # train/mfu`
2. `std` MFU decreases `00093 ==> 0.0020 (-78.5%)` or improvement of `4.7x`

```
../gc_config_pbtxt-5d4ffd4f--92593-run-main-gc-03-j-01-seq04k-ns01-sp01-bs01-pad1-gc-1--20260313.100151/sliuxl-qwen2d5_3b-verl-92593.out:hostname=ip-10-4-145-27
../gc_config_pbtxt-5d4ffd4f--92594-run-main-gc-03-j-02-seq04k-ns01-sp01-bs01-pad1-gc0--20260313.100156/sliuxl-qwen2d5_3b-verl-92594.out:hostname=ip-10-4-145-27
../gc_config_pbtxt-5d4ffd4f--92595-run-main-gc-03-j-03-seq04k-ns01-sp01-bs01-pad1-gc1--20260313.100201/sliuxl-qwen2d5_3b-verl-92595.out:hostname=ip-10-4-145-27
../gc_config_pbtxt-5d4ffd4f--92596-run-main-gc-03-j-04-seq04k-ns01-sp01-bs01-pad1-gc5--20260313.100206/sliuxl-qwen2d5_3b-verl-92596.out:hostname=ip-10-4-145-27


../gc_config_pbtxt-5d4ffd4f--92593-run-main-gc-03-j-01-seq04k-ns01-sp01-bs01-pad1-gc-1--20260313.100151/run_verl.sh:    trainer.gc_freq=-1 \
../gc_config_pbtxt-5d4ffd4f--92594-run-main-gc-03-j-02-seq04k-ns01-sp01-bs01-pad1-gc0--20260313.100156/run_verl.sh:    trainer.gc_freq=0 \
../gc_config_pbtxt-5d4ffd4f--92595-run-main-gc-03-j-03-seq04k-ns01-sp01-bs01-pad1-gc1--20260313.100201/run_verl.sh:    trainer.gc_freq=1 \
../gc_config_pbtxt-5d4ffd4f--92596-run-main-gc-03-j-04-seq04k-ns01-sp01-bs01-pad1-gc5--20260313.100206/run_verl.sh:    trainer.gc_freq=5 \
```

#### 1. `Step Time`
```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-main-gc-03*/events*' --metric 'train/time(s)' --format 10.4f
2026-03-13 17:34:42,155 [tb.py:235] INFO - Set benchmark with index 0
2026-03-13 17:34:42,156 [tb.py:264] INFO - [243/256] ../gc_config_pbtxt-5d4ffd4f--92593-run-main-gc-03-j-01-seq04k-ns01-sp01-bs01-pad1-gc-1--20260313.100151/events.out.tfevents.1773421377.ip-10-4-145-27.2342312.0: (avg (std), med) = (    0.8828 (    0.0696),     0.8652)  # train/time(s)
2026-03-13 17:34:42,246 [tb.py:264] INFO - [243/256] ../gc_config_pbtxt-5d4ffd4f--92594-run-main-gc-03-j-02-seq04k-ns01-sp01-bs01-pad1-gc0--20260313.100156/events.out.tfevents.1773421852.ip-10-4-145-27.2346125.0: (avg (std), med) = (    0.8562 (    0.0977),     0.9187)  # train/time(s)
2026-03-13 17:34:42,336 [tb.py:264] INFO - [243/256] ../gc_config_pbtxt-5d4ffd4f--92595-run-main-gc-03-j-03-seq04k-ns01-sp01-bs01-pad1-gc1--20260313.100201/events.out.tfevents.1773422312.ip-10-4-145-27.2349978.0: (avg (std), med) = (    0.7324 (    0.0362),     0.7247)  # train/time(s)
2026-03-13 17:34:42,428 [tb.py:264] INFO - [243/256] ../gc_config_pbtxt-5d4ffd4f--92596-run-main-gc-03-j-04-seq04k-ns01-sp01-bs01-pad1-gc5--20260313.100206/events.out.tfevents.1773422840.ip-10-4-145-27.2353891.0: (avg (std), med) = (    0.7509 (    0.0366),     0.7474)  # train/time(s)
```

#### 2. All Metrics

1. `data/train_seq_len*` metrics are exactly the same
3. `train/time(s)` decrease and `train/mfu` increases

```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-main-gc-03*/events*' --metric '*' --format 10.4f
2026-03-13 17:34:52,636 [tb.py:206] WARNING - Unknonw metric `*`!
2026-03-13 17:34:52,636 [tb.py:216] INFO - 

[00/04] File ../gc_config_pbtxt-5d4ffd4f--92593-run-main-gc-03-j-01-seq04k-ns01-sp01-bs01-pad1-gc-1--20260313.100151/events.out.tfevents.1773421377.ip-10-4-145-27.2342312.0:
2026-03-13 17:34:52,729 [tb.py:235] INFO - Set benchmark with index 0
2026-03-13 17:34:52,730 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    8.0000 [     0.0000] (    0.0000),     8.0000)  # data/train_seq_len_count
2026-03-13 17:34:52,730 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_max
2026-03-13 17:34:52,730 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_mean
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_median
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_min
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # data/train_seq_len_std
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2912 [     0.0000] (    0.1269),     0.2669)  # train/grad_norm
2026-03-13 17:34:52,731 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0199 [     0.0000] (    0.0046),     0.0199)  # train/loss
2026-03-13 17:34:52,732 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-13 17:34:52,732 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2221 [     0.0000] (    0.0093),     0.2253)  # train/mfu
2026-03-13 17:34:52,732 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.8828 [     0.0000] (    0.0696),     0.8652)  # train/time(s)
2026-03-13 17:34:52,732 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-13 17:34:52,732 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
2026-03-13 17:34:52,732 [tb.py:216] INFO - 

[01/04] File ../gc_config_pbtxt-5d4ffd4f--92594-run-main-gc-03-j-02-seq04k-ns01-sp01-bs01-pad1-gc0--20260313.100156/events.out.tfevents.1773421852.ip-10-4-145-27.2346125.0:
2026-03-13 17:34:52,823 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    8.0000 [     0.0000] (    0.0000),     8.0000)  # data/train_seq_len_count
2026-03-13 17:34:52,823 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_max
2026-03-13 17:34:52,823 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_mean
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_median
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_min
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # data/train_seq_len_std
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2900 [-    0.0012] (    0.1189),     0.2685)  # train/grad_norm
2026-03-13 17:34:52,824 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0199 [     0.0000] (    0.0046),     0.0199)  # train/loss
2026-03-13 17:34:52,825 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-13 17:34:52,825 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2288 [+    0.0067] (    0.0029),     0.2290)  # train/mfu
2026-03-13 17:34:52,825 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.8562 [-    0.0266] (    0.0977),     0.9187)  # train/time(s)
2026-03-13 17:34:52,825 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-13 17:34:52,825 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
2026-03-13 17:34:52,825 [tb.py:216] INFO - 

[02/04] File ../gc_config_pbtxt-5d4ffd4f--92595-run-main-gc-03-j-03-seq04k-ns01-sp01-bs01-pad1-gc1--20260313.100201/events.out.tfevents.1773422312.ip-10-4-145-27.2349978.0:
2026-03-13 17:34:52,916 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    8.0000 [     0.0000] (    0.0000),     8.0000)  # data/train_seq_len_count
2026-03-13 17:34:52,916 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_max
2026-03-13 17:34:52,916 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_mean
2026-03-13 17:34:52,916 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_median
2026-03-13 17:34:52,917 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_min
2026-03-13 17:34:52,917 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # data/train_seq_len_std
2026-03-13 17:34:52,917 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-13 17:34:52,917 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2897 [-    0.0015] (    0.1242),     0.2696)  # train/grad_norm
2026-03-13 17:34:52,917 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0198 [-    0.0000] (    0.0046),     0.0200)  # train/loss
2026-03-13 17:34:52,918 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-13 17:34:52,918 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2297 [+    0.0076] (    0.0020),     0.2301)  # train/mfu
2026-03-13 17:34:52,918 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.7324 [-    0.1504] (    0.0362),     0.7247)  # train/time(s)
2026-03-13 17:34:52,918 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-13 17:34:52,918 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
2026-03-13 17:34:52,918 [tb.py:216] INFO - 

[03/04] File ../gc_config_pbtxt-5d4ffd4f--92596-run-main-gc-03-j-04-seq04k-ns01-sp01-bs01-pad1-gc5--20260313.100206/events.out.tfevents.1773422840.ip-10-4-145-27.2353891.0:
2026-03-13 17:34:53,009 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    8.0000 [     0.0000] (    0.0000),     8.0000)  # data/train_seq_len_count
2026-03-13 17:34:53,009 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_max
2026-03-13 17:34:53,009 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_mean
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_median
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = ( 4096.0000 [     0.0000] (    0.0000),  4096.0000)  # data/train_seq_len_min
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # data/train_seq_len_std
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2907 [-    0.0005] (    0.1227),     0.2702)  # train/grad_norm
2026-03-13 17:34:53,010 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0199 [+    0.0000] (    0.0046),     0.0200)  # train/loss
2026-03-13 17:34:53,011 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-13 17:34:53,011 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2289 [+    0.0068] (    0.0020),     0.2292)  # train/mfu
2026-03-13 17:34:53,011 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.7509 [-    0.1320] (    0.0366),     0.7474)  # train/time(s)
2026-03-13 17:34:53,011 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-13 17:34:53,011 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
```

### API and Usage Example

Add `trainer.gc_freq=1` to training config:

```
../gc_config_pbtxt-5d4ffd4f--92595-run-main-gc-03-j-03-seq04k-ns01-sp01-bs01-pad1-gc1--20260313.100201/run_verl.sh:    trainer.gc_freq=1 \
```

### Design & Code Changes

N.A.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
