### PR TITLE
[megatron,rollout] fix: verl v0.6.1 fix duplicate DP input & support MoE EP/ETP selection

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -55,6 +55,9 @@ data_parallel_size: 1
 # EP size for rollout
 expert_parallel_size: 1
 
+# Whether to use EP for fused MoE or use ETP
+enable_expert_parallel: False
+
 # PP size for rollout.
 pipeline_model_parallel_size: 1
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -137,6 +137,7 @@ class RolloutConfig(BaseConfig):
     free_cache_engine: bool = True
     data_parallel_size: int = 1
     expert_parallel_size: int = 1
+    enable_expert_parallel: bool = False
     tensor_model_parallel_size: int = 2
     pipeline_model_parallel_size: int = 1
     max_num_batched_tokens: int = 8192

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -405,10 +405,13 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
         model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model, dataclass_type=HFModelConfig)
 
         # 2. build rollout device mesh
-        infer_tp = self.config.rollout.tensor_model_parallel_size * self.config.rollout.data_parallel_size
+        # infer_tp = pure TP size (dispatch splits data per TP group independently)
+        # Internal DP is handled by vLLM's parallel groups, not by verl dispatch
+        # Total dp = ExternalDP * internal_DP = world_size / (TP * PP)
+        infer_tp = self.config.rollout.tensor_model_parallel_size
         infer_pp = self.config.rollout.pipeline_model_parallel_size
         infer_world_size = infer_tp * infer_pp
-        dp = self.world_size // infer_world_size
+        dp = self.world_size // infer_world_size  # = ExternalDP * internal_DP
         assert self.world_size % infer_world_size == 0, (
             f"rollout world_size: {self.world_size} is not divisible by infer_world_size: {infer_world_size}"
         )

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout_spmd.py
@@ -157,6 +157,12 @@ class vLLMRollout(BaseRollout):
         assert tensor_parallel_size <= torch.distributed.get_world_size(), (
             "tensor parallel size should be less than or equal to the world size"
         )
+        data_parallel_size = self.config.get("data_parallel_size", 1)
+        enable_expert_parallel = self.config.get("enable_expert_parallel", False)
+        dp_ep_kwargs = {}
+        if data_parallel_size > 1:
+            dp_ep_kwargs["data_parallel_size"] = data_parallel_size
+        dp_ep_kwargs["enable_expert_parallel"] = enable_expert_parallel
         max_num_batched_tokens = self.config.get("max_num_batched_tokens", 8192)
 
         rope_scaling_config = getattr(model_hf_config, "rope_scaling", None)
@@ -247,6 +253,7 @@ class vLLMRollout(BaseRollout):
             enable_prefix_caching=config.enable_prefix_caching,
             trust_remote_code=trust_remote_code,
             seed=config.get("seed", 0),
+            **dp_ep_kwargs,
             **compilation_config,
             **self.lora_kwargs,
             **engine_kwargs,


### PR DESCRIPTION
### What does this PR do?

#5568 对齐verl和vllm的并行划分策略，使得TP/DP/EP混合并行时行为正确，同时增加enable_expert_parallel参数配置开关，使得在进入vllm的FusedMoEParallelConfig时，可选MoE走EP并行还是ETP切分，之前没有参数传入，默认走ETP。
请注意，当DP*TP<world_size，存在ExternalDP时，vllm内部需要修改部分代码防止rank越界：

vim /opt/vllm_v0.11.0/vllm/config/parallel.py
ParallelConfig.__post_init__函数中393行，self.data_parallel_rank = int(os.environ["RANK"])  // (self.world_size // self.data_parallel_size)的计算需要稍作修改
```python
        if self.data_parallel_size > 1 or self.data_parallel_size_local == 0:
            # Data parallel was specified in the engine args.
            if self.distributed_executor_backend == "external_launcher":
                # For external launcher,
                # we need to set the data parallel rank automatically.
                # Use modulo to handle ExternalDP: global RANK may exceed
                # world_size (= TP*PP*DP) when multiple ExternalDP replicas
                # share the same torch.distributed world.
                rank_within_replica = int(os.environ["RANK"]) \
                    % self.world_size
                self.data_parallel_rank = rank_within_replica \
                    // (self.world_size // self.data_parallel_size)
                logger.info("Set data_parallel_rank to %d automatically "
                            "(global RANK=%s, world_size=%d).",
                            self.data_parallel_rank,
                            os.environ.get("RANK"), self.world_size)
            if not self._data_parallel_master_port_list:
                self._data_parallel_master_port_list = get_open_ports_list(5)
            self.data_parallel_master_port = \
                self._data_parallel_master_port_list.pop()
```

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
actor_rollout_ref.rollout.enable_expert_parallel=False
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
