### PR TITLE
[megatron] fix: avoid mindspeed rope and attention synchronization

### DIFF
--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -400,12 +400,12 @@ def preprocess_thd_no_padding(
 
     packed_seq_params = PackedSeqParams(
         qkv_format="thd",
-        cu_seqlens_q=cu_seqlens_padded,
+        cu_seqlens_q=cu_seqlens_padded.cpu(),
         max_seqlen_q=max_seqlen_in_batch,
-        cu_seqlens_kv=cu_seqlens_padded,
+        cu_seqlens_kv=cu_seqlens_padded.cpu(),
         max_seqlen_kv=max_seqlen_in_batch,
-        cu_seqlens_q_padded=cu_seqlens_padded,
-        cu_seqlens_kv_padded=cu_seqlens_padded,
+        cu_seqlens_q_padded=cu_seqlens_padded.cpu(),
+        cu_seqlens_kv_padded=cu_seqlens_padded.cpu(),
     )
     if pre_process:
         return input_ids_rmpad.unsqueeze(0), packed_seq_params


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

By default `cu_seqlens` is generated on device, and causing synchronization during [rope](https://github.com/NVIDIA/Megatron-LM/blob/251a7545f7f08a26240c2957910eb358d9cddf8c/megatron/core/models/common/embeddings/rope_utils.py#L204) and [attention](https://gitcode.com/Ascend/MindSpeed/blob/master/mindspeed/te/pytorch/attention/dot_product_attention/backend.py#L80) when using Mindspeed backend. This pr fix it by move `cu_seqlens` to cpu before forward.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

before:
<img width="2210" height="1170" alt="image" src="https://github.com/user-attachments/assets/6df1f90b-7dcd-42ce-a280-0576bf53fa88" />
after:
<img width="2104" height="852" alt="image" src="https://github.com/user-attachments/assets/5571c202-58a7-4e1d-9985-2f1098cabcb7" />



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
