### PR TITLE
[rollout] feat: configurable token2text field mapping and tokenizer fallback in tracing,

### DIFF
--- a/docs/advance/agent_loop.rst
+++ b/docs/advance/agent_loop.rst
@@ -1,7 +1,7 @@
 Agent Loop
 ==========
 
-Last updated: 07/17/2025.
+Last updated: 03/14/2026.
 
 .. versionadded:: 0.4.2
    [status: alpha]
@@ -229,6 +229,24 @@ they can call ``AsyncLLMServerManager.generate`` to generate response_ids.
                List[int]: List of generated token ids.
            """
            ...
+
+Tracing in AsyncLLMServerManager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``AsyncLLMServerManager.generate`` is decorated with ``rollout_trace_op`` and uses customized ``token2text_fields`` to decode token IDs. Since ``prompt_ids`` is an input argument (not part of the return value) and the output field is named ``token_ids`` (not ``response_ids``), the default token-to-text mapping does not apply. Instead, the decorator is configured with explicit field mappings:
+
+.. code:: python
+
+   from verl.utils.rollout_trace import rollout_trace_op, Token2TextField
+
+   @rollout_trace_op(token2text_fields=[
+       Token2TextField(source="input", field="prompt_ids", decode_to="prompt_text"),
+       Token2TextField(source="output", field="token_ids", decode_to="response_text"),
+   ])
+   async def generate(self, request_id, *, prompt_ids, sampling_params):
+       ...
+
+Since ``AsyncLLMServerManager`` does not carry its own tokenizer, the ``AgentLoopWorker`` passes its tokenizer to ``RolloutTraceConfig.init(tokenizer=...)`` at initialization time, making it available as a global fallback for all traced functions on the worker. See :doc:`Trace Function Usage Instructions <rollout_trace>` for more details.
 
 Next
 ----

--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -1,7 +1,7 @@
 Trace Function Usage Instructions
 ========================================
 
-Last updated: 07/10/2025.
+Last updated: 03/14/2026.
 
 Applicable Scenarios
 --------------------
@@ -68,6 +68,48 @@ There are 2 functions used for tracing:
 1. ``rollout_trace_op``: This is a decorator function used to mark the functions to trace. In default, only few method has it, you can add it to more functions to trace more infor.
 2. ``rollout_trace_attr``: This function is used to mark the entry of a trajectory and input some info to trace. If you add new type of agent, you may need to add it to enable trace.
 
+Customized Token-to-Text Field Mapping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, when ``token2text`` is enabled, ``rollout_trace_op`` looks for ``result.prompt_ids`` and ``result.response_ids`` in the decorated function's output and decodes them into ``prompt_text`` and ``response_text``. However, not all traced functions follow this convention — for example, ``AsyncLLMServerManager.generate`` takes ``prompt_ids`` as an **input** argument and returns ``token_ids`` as the output.
+
+To handle such cases, you can use the ``Token2TextField`` dataclass and the ``token2text_fields`` parameter of ``rollout_trace_op`` to customize which fields are decoded and where they come from.
+
+``Token2TextField`` has three attributes:
+
+- ``source``: Where to find the token IDs — ``"input"`` reads from the decorated function's arguments, ``"output"`` reads from its return value.
+- ``field``: Name of the field containing the token IDs.
+- ``decode_to``: Name of the target field for the decoded text in the trace output.
+
+Example usage:
+
+.. code-block:: python
+
+   from verl.utils.rollout_trace import rollout_trace_op, Token2TextField
+
+   # Default usage (backward compatible) — decodes result.prompt_ids and result.response_ids
+   @rollout_trace_op
+   async def run(self, ...):
+       ...
+
+   # Customized field mapping — decode prompt_ids from input and token_ids from output
+   @rollout_trace_op(token2text_fields=[
+       Token2TextField(source="input", field="prompt_ids", decode_to="prompt_text"),
+       Token2TextField(source="output", field="token_ids", decode_to="response_text"),
+   ])
+   async def generate(self, ...):
+       ...
+
+Global Tokenizer Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, ``token2text`` required the traced class instance to have a ``self.tokenizer`` attribute. Now, a global tokenizer can be set via ``RolloutTraceConfig.init(tokenizer=...)`` as a fallback. The tokenizer resolution order is:
+
+1. ``self.tokenizer`` on the class instance (per-instance, supports multi-model setups).
+2. ``RolloutTraceConfig.get_tokenizer()`` — global fallback set at init time.
+
+This is useful for classes like ``AsyncLLMServerManager`` that do not carry their own tokenizer. The ``AgentLoopWorker`` passes its tokenizer to ``RolloutTraceConfig.init()`` so that all traced functions on the worker can decode token IDs.
+
 
 Usage of wandb weave
 --------------------
@@ -95,7 +137,7 @@ After executing the training, on the project page, you can see the WEAVE sidebar
 
 Each Trace project corresponds to a trajectory. You can filter and select the trajectories you need to view by step, sample_index, rollout_n, and experiment_name.
 
-After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the input and output content.
+After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the input and output content. With customized ``token2text_fields``, you can also decode token IDs from other traced functions (e.g., ``AsyncLLMServerManager.generate``).
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/weave_trace_list.png?raw=true
 
@@ -136,7 +178,7 @@ For example, searching for ``"tags.step = '1'"`` can display all trajectories of
 
 Opening one of the trajectories allows you to view each function call process within it.
 
-After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the content.
+After enabling token2text, prompt_text and response_text will be automatically added to the output of ToolAgentLoop.run, making it convenient to view the content. With customized ``token2text_fields``, you can also decode token IDs from other traced functions (e.g., ``AsyncLLMServerManager.generate``).
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/mlflow_trace_view.png?raw=true
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -41,6 +41,7 @@ from verl.utils.model import compute_position_id_with_mask
 from verl.utils.ray_utils import auto_await, get_event_loop
 from verl.utils.rollout_trace import (
     RolloutTraceConfig,
+    Token2TextField,
     rollout_trace_attr,
     rollout_trace_op,
 )
@@ -132,7 +133,12 @@ class AsyncLLMServerManager:
         # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
         self._load_balancer.release_server.remote(server_id=server_id)
 
-    @rollout_trace_op
+    @rollout_trace_op(
+        token2text_fields=[
+            Token2TextField(source="input", field="prompt_ids", decode_to="prompt_text"),
+            Token2TextField(source="output", field="token_ids", decode_to="response_text"),
+        ]
+    )
     async def generate(
         self,
         request_id,
@@ -449,6 +455,7 @@ class AgentLoopWorker:
             trace_config.get("backend"),
             trace_config.get("token2text", False),
             trace_config.get("max_samples_per_step_per_worker", None),
+            tokenizer=self.tokenizer,
         )
 
     async def generate_sequences(self, batch: DataProto) -> DataProto:

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -17,6 +17,7 @@ import functools
 import inspect
 import os
 from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Optional
 
 from pydantic import BaseModel
@@ -24,6 +25,39 @@ from pydantic import BaseModel
 from verl.utils.ray_utils import get_event_loop
 
 _trace_enabled: ContextVar[bool] = ContextVar("_trace_enabled", default=True)
+
+
+@dataclass
+class Token2TextField:
+    """Configuration for a single token-to-text field mapping in rollout tracing.
+
+    When ``token2text`` is enabled globally via :class:`RolloutTraceConfig`,
+    each :class:`Token2TextField` tells the :func:`rollout_trace_op` decorator
+    where to find a list of token IDs and what name to give the decoded text in
+    the trace output.
+
+    Args:
+        source: Where to find the token IDs -- ``"input"`` to read from the
+            decorated function's arguments, ``"output"`` to read from its
+            return value.
+        field: Name of the field containing the token IDs.
+        decode_to: Name of the target field for the decoded text that will
+            appear in the trace output.
+    """
+
+    source: str  # "input" or "output"
+    field: str
+    decode_to: str
+
+
+# Default fields used when ``token2text_fields`` is not explicitly provided to
+# ``rollout_trace_op``.  This preserves backward compatibility with the
+# original hard-coded behaviour that looked for ``result.prompt_ids`` and
+# ``result.response_ids``.
+_DEFAULT_TOKEN2TEXT_FIELDS = [
+    Token2TextField(source="output", field="prompt_ids", decode_to="prompt_text"),
+    Token2TextField(source="output", field="response_ids", decode_to="response_text"),
+]
 
 
 class RolloutTraceConfig:
@@ -52,6 +86,7 @@ class RolloutTraceConfig:
     project_name: str = None
     experiment_name: str = None
     max_samples_per_step_per_worker: Optional[int] = None
+    tokenizer: Optional[object] = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -73,6 +108,7 @@ class RolloutTraceConfig:
         backend: str,
         token2text: bool = False,
         max_samples_per_step_per_worker: Optional[int] = None,
+        tokenizer: Optional[object] = None,
     ):
         config = cls.get_instance()
         if config._initialized:
@@ -83,6 +119,7 @@ class RolloutTraceConfig:
         config.project_name = project_name
         config.experiment_name = experiment_name
         config.max_samples_per_step_per_worker = max_samples_per_step_per_worker
+        config.tokenizer = tokenizer
 
         if backend == "weave":
             import weave
@@ -114,6 +151,10 @@ class RolloutTraceConfig:
     @classmethod
     def enable_token2text(cls) -> Optional[bool]:
         return cls.get_instance().token2text
+
+    @classmethod
+    def get_tokenizer(cls) -> Optional[object]:
+        return cls.get_instance().tokenizer
 
     @classmethod
     def reset(cls):
@@ -179,113 +220,218 @@ def rollout_trace_attr(
         yield
 
 
-def rollout_trace_op(func):
-    @functools.wraps(func)
-    async def async_wrapper(self, *args, **kwargs):
-        if not _trace_enabled.get():
-            return await func(self, *args, **kwargs)
+def _resolve_tokenizer(self):
+    """Resolve the tokenizer to use for token2text decoding.
 
-        backend = RolloutTraceConfig.get_backend()
-        enable_token2text = RolloutTraceConfig.enable_token2text()
-        if backend is None:
-            return await func(self, *args, **kwargs)
+    Resolution order:
+    1. ``self.tokenizer`` — per-instance tokenizer (supports multi-model setups
+       where different traced objects use different tokenizers).
+    2. ``RolloutTraceConfig.get_tokenizer()`` — global fallback set once per
+       worker at init time (for classes that don't carry their own tokenizer,
+       e.g. ``AsyncLLMServerManager``).
 
-        sig = inspect.signature(func)
-        bound_args = sig.bind(self, *args, **kwargs)
-        bound_args.apply_defaults()
-        inputs = dict(bound_args.arguments)
-        del inputs["self"]
+    Returns:
+        A tokenizer object with a ``decode`` method, or ``None``.
+    """
+    tokenizer = getattr(self, "tokenizer", None)
+    if tokenizer is not None and hasattr(tokenizer, "decode"):
+        return tokenizer
+    tokenizer = RolloutTraceConfig.get_tokenizer()
+    if tokenizer is not None and hasattr(tokenizer, "decode"):
+        return tokenizer
+    return None
 
-        async def add_token2text(self, result):
-            if hasattr(result, "prompt_ids") and hasattr(self, "tokenizer") and hasattr(self.tokenizer, "decode"):
-                # Use model_dump() for Pydantic models to get a proper copy,
-                # otherwise vars() returns a reference to internal __dict__ which
-                # can cause serialization issues with MLflow
-                if isinstance(result, BaseModel):
-                    _result = result.model_dump()
-                else:
-                    _result = dict(vars(result))
-                loop = get_event_loop()
-                if hasattr(result, "prompt_ids"):
-                    prompt_text = await loop.run_in_executor(None, self.tokenizer.decode, result.prompt_ids)
-                    _result["prompt_text"] = prompt_text
 
-                if hasattr(result, "response_ids"):
-                    response_text = await loop.run_in_executor(None, self.tokenizer.decode, result.response_ids)
-                    _result["response_text"] = response_text
-                return _result
-            return result
+async def _add_token2text(self, result, inputs, token2text_fields):
+    """Decode token ID fields into text and return an enriched copy for tracing.
 
-        if backend == "weave":
-            tracer = RolloutTraceConfig.get_client()
-            from weave.trace.context import call_context
+    This is used internally by :func:`rollout_trace_op` to convert token IDs
+    (from either the function's inputs or outputs) into human-readable text
+    that gets recorded in the trace.
 
-            cur_attributes = {**call_context.call_attributes.get()}
-            call = tracer.create_call(op=func.__qualname__, inputs=inputs, attributes=cur_attributes)
-            try:
-                result = await func(self, *args, **kwargs)
+    Args:
+        self: The class instance.  If it has a ``tokenizer`` attribute with a
+            ``decode`` method, that tokenizer is used; otherwise falls back to
+            the global tokenizer stored in :class:`RolloutTraceConfig`.
+        result: The return value of the decorated function.
+        inputs: Dict of the decorated function's bound arguments (excluding
+            ``self``).
+        token2text_fields: List of :class:`Token2TextField` describing which
+            fields to decode.  If ``None``, falls back to
+            :data:`_DEFAULT_TOKEN2TEXT_FIELDS`.
 
-                if enable_token2text:
-                    _result = await add_token2text(self, result)
-                    tracer.finish_call(call, output=_result)
-                else:
+    Returns:
+        A dict copy of *result* enriched with decoded text fields, or the
+        original *result* unchanged when no fields could be decoded.
+    """
+    tokenizer = _resolve_tokenizer(self)
+    if tokenizer is None:
+        return result
+
+    effective_fields = token2text_fields if token2text_fields is not None else _DEFAULT_TOKEN2TEXT_FIELDS
+
+    loop = get_event_loop()
+    decoded: dict[str, str] = {}
+
+    for field_cfg in effective_fields:
+        token_ids = None
+        if field_cfg.source == "input":
+            token_ids = inputs.get(field_cfg.field)
+        elif field_cfg.source == "output":
+            if hasattr(result, field_cfg.field):
+                token_ids = getattr(result, field_cfg.field)
+            elif isinstance(result, dict):
+                token_ids = result.get(field_cfg.field)
+
+        if token_ids is not None:
+            text = await loop.run_in_executor(None, tokenizer.decode, token_ids)
+            decoded[field_cfg.decode_to] = text
+
+    if not decoded:
+        return result
+
+    # Create a mutable dict copy of the result and add decoded fields.
+    # Use model_dump() for Pydantic models to get a proper copy;
+    # otherwise vars() returns a reference to internal __dict__ which
+    # can cause serialization issues with MLflow.
+    if isinstance(result, BaseModel):
+        _result = result.model_dump()
+    elif isinstance(result, dict):
+        _result = dict(result)
+    else:
+        _result = dict(vars(result))
+
+    _result.update(decoded)
+    return _result
+
+
+def rollout_trace_op(func=None, *, token2text_fields=None):
+    """Decorator that traces function calls with the configured tracing backend.
+
+    Can be used in two forms:
+
+    1. Without arguments (backward compatible)::
+
+        @rollout_trace_op
+        async def run(self, ...): ...
+
+    2. With explicit token-to-text field mappings::
+
+        @rollout_trace_op(token2text_fields=[
+            Token2TextField(source="input", field="prompt_ids", decode_to="prompt_text"),
+            Token2TextField(source="output", field="token_ids", decode_to="response_text"),
+        ])
+        async def generate(self, ...): ...
+
+    When ``token2text`` is enabled globally (via :class:`RolloutTraceConfig`)
+    and ``token2text_fields`` is provided, the decorator decodes the specified
+    token ID fields and includes the decoded text in the trace output.  When
+    ``token2text_fields`` is ``None`` (the default), it falls back to the
+    legacy behaviour of looking for ``result.prompt_ids`` and
+    ``result.response_ids``.
+
+    Args:
+        func: The function being decorated (set automatically when used
+            without parentheses).
+        token2text_fields: Optional list of :class:`Token2TextField`
+            specifying which fields to decode.  ``None`` means use defaults.
+    """
+
+    def _decorator(fn):
+        fields = token2text_fields  # capture in closure
+
+        @functools.wraps(fn)
+        async def async_wrapper(self, *args, **kwargs):
+            if not _trace_enabled.get():
+                return await fn(self, *args, **kwargs)
+
+            backend = RolloutTraceConfig.get_backend()
+            enable_token2text = RolloutTraceConfig.enable_token2text()
+            if backend is None:
+                return await fn(self, *args, **kwargs)
+
+            sig = inspect.signature(fn)
+            bound_args = sig.bind(self, *args, **kwargs)
+            bound_args.apply_defaults()
+            inputs = dict(bound_args.arguments)
+            del inputs["self"]
+
+            if backend == "weave":
+                tracer = RolloutTraceConfig.get_client()
+                from weave.trace.context import call_context
+
+                cur_attributes = {**call_context.call_attributes.get()}
+                call = tracer.create_call(op=fn.__qualname__, inputs=inputs, attributes=cur_attributes)
+                try:
+                    result = await fn(self, *args, **kwargs)
+
+                    if enable_token2text:
+                        _result = await _add_token2text(self, result, inputs, fields)
+                        tracer.finish_call(call, output=_result)
+                    else:
+                        tracer.finish_call(call, output=result)
+
+                    return result
+
+                except Exception as e:
+                    tracer.finish_call(call, exception=e)
+                    raise e
+            elif backend == "mlflow":
+                import mlflow
+
+                with mlflow.start_span(name=fn.__qualname__) as span:
+                    span.set_inputs(inputs)
+                    result = await fn(self, *args, **kwargs)
+                    if enable_token2text:
+                        _result = await _add_token2text(self, result, inputs, fields)
+                        span.set_outputs(_result)
+                    else:
+                        span.set_outputs(result)
+
+                return result
+
+            else:
+                return await fn(self, *args, **kwargs)
+
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            if not _trace_enabled.get():
+                return fn(self, *args, **kwargs)
+
+            backend = RolloutTraceConfig.get_backend()
+            if backend is None:
+                return fn(self, *args, **kwargs)
+
+            sig = inspect.signature(fn)
+            bound_args = sig.bind(self, *args, **kwargs)
+            bound_args.apply_defaults()
+            inputs = dict(bound_args.arguments)
+            del inputs["self"]
+
+            if backend == "weave":
+                tracer = RolloutTraceConfig.get_client()
+                from weave.trace.context import call_context
+
+                cur_attributes = {**call_context.call_attributes.get()}
+                call = tracer.create_call(op=fn.__qualname__, inputs=inputs, attributes=cur_attributes)
+                try:
+                    result = fn(self, *args, **kwargs)
                     tracer.finish_call(call, output=result)
+                    return result
+                except Exception as e:
+                    tracer.finish_call(call, exception=e)
+                    raise e
+            elif backend == "mlflow":
+                import mlflow
 
-                return result
+                return mlflow.trace(fn)(self, *args, **kwargs)
+            else:
+                return fn(self, *args, **kwargs)
 
-            except Exception as e:
-                tracer.finish_call(call, exception=e)
-                raise e
-        elif backend == "mlflow":
-            import mlflow
+        return async_wrapper if inspect.iscoroutinefunction(fn) else wrapper
 
-            with mlflow.start_span(name=func.__qualname__) as span:
-                span.set_inputs(inputs)
-                result = await func(self, *args, **kwargs)
-                if enable_token2text:
-                    _result = await add_token2text(self, result)
-                    span.set_outputs(_result)
-                else:
-                    span.set_outputs(result)
-
-            return result
-
-        else:
-            return await func(self, *args, **kwargs)
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        if not _trace_enabled.get():
-            return func(self, *args, **kwargs)
-
-        backend = RolloutTraceConfig.get_backend()
-        if backend is None:
-            return func(self, *args, **kwargs)
-
-        sig = inspect.signature(func)
-        bound_args = sig.bind(self, *args, **kwargs)
-        bound_args.apply_defaults()
-        inputs = dict(bound_args.arguments)
-        del inputs["self"]
-
-        if backend == "weave":
-            tracer = RolloutTraceConfig.get_client()
-            from weave.trace.context import call_context
-
-            cur_attributes = {**call_context.call_attributes.get()}
-            call = tracer.create_call(op=func.__qualname__, inputs=inputs, attributes=cur_attributes)
-            try:
-                result = func(self, *args, **kwargs)
-                tracer.finish_call(call, output=result)
-                return result
-            except Exception as e:
-                tracer.finish_call(call, exception=e)
-                raise e
-        elif backend == "mlflow":
-            import mlflow
-
-            return mlflow.trace(func)(self, *args, **kwargs)
-        else:
-            return func(self, *args, **kwargs)
-
-    return async_wrapper if inspect.iscoroutinefunction(func) else wrapper
+    if func is not None:
+        # Called as @rollout_trace_op (without parentheses)
+        return _decorator(func)
+    # Called as @rollout_trace_op(...) (with parentheses)
+    return _decorator


### PR DESCRIPTION
### What does this PR do?

Improves `rollout_trace_op` decorator to support flexible token-to-text decoding configuration. Previously, `token2text` was hard-coded to look for `result.prompt_ids` and `result.response_ids` on the output, and required `self.tokenizer` on the traced class. This made it impossible to use with classes like `AsyncLLMServerManager` whose output (`TokenOutput`) has `token_ids` (not `response_ids`), whose input (not output) contains `prompt_ids`, and which has no `tokenizer` attribute.

This PR introduces:

1. `Token2TextField` dataclass -- lets users specify which fields to decode, from `"input"` or `"output"`, and what to name the decoded text.
2. Parameterized `@rollout_trace_op(token2text_fields=[...])` -- the decorator now accepts optional field mappings while remaining backward compatible with `@rollout_trace_op` (no parentheses).
3. `_resolve_tokenizer` fallback chain -- resolves tokenizer via `self.tokenizer` first (supports multi-model setups), then falls back to RolloutTraceConfig.get_tokenizer() (global, set at worker init time). This allows classes without their own tokenizer to still benefit from `token2text`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/issues?q=is%3Aissue%20state%3Aclosed%20trace
#4457 
https://github.com/verl-project/verl/issues?q=is%3Aissue%20state%3Aopen%20mlflow
#3515 
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Tested with MLflow backend tracing on ALFWorld multi-turn agent interaction:

`ToolAgentLoop.run` continues to trace prompt_ids/response_ids from output (default fields, backward compatible).
`AsyncLLMServerManager.generate` now correctly decodes `prompt_ids` from input and `token_ids` from output using the global fallback tokenizer.

I test it using gsm8k multiturn setting with mlflow.

Before implementing this feature, we can't get useful information from the input and output of `AsyncLLMServerManager.generate` even we enable token2text. We can only get the complete interaction trajectory from  the output of `ToolAgentLoop.run`, which, however, is inconvenient for user to distinguish bewteen users' prompt and assistant's answer, especially when there are many turns and add previous interaction as agent memory into users' prompt:
<img width="1541" height="1424" alt="image" src="https://github.com/user-attachments/assets/1b24682b-cbbf-4446-802c-28badc36c39c" />
<img width="1551" height="1422" alt="image" src="https://github.com/user-attachments/assets/dba64670-7e33-468a-992b-5629d999e193" />
<img width="1880" height="1244" alt="image" src="https://github.com/user-attachments/assets/406132b3-bf6c-4ce0-bd33-3fa4916a98a9" />
<img width="1861" height="754" alt="image" src="https://github.com/user-attachments/assets/2367768b-c7e6-446f-9cc6-6185b207d155" />

After implementing it, we can inspect input and output text for each turn seperately:

<img width="2276" height="1432" alt="image" src="https://github.com/user-attachments/assets/0018b4da-c4d6-4e30-b344-7f80903405d0" />


### API and Usage Example

Backward compatible -- existing `@rollout_trace_op` usage (no parentheses) works unchanged:

```python
@rollout_trace_op
async def run(self, ...):
    ...
```

New parameterized form -- specify custom field mappings:

```python
from verl.utils.rollout_trace import rollout_trace_op, Token2TextField

@rollout_trace_op(
    token2text_fields=[
        Token2TextField(source="input",  field="prompt_ids", decode_to="prompt_text"),
        Token2TextField(source="output", field="token_ids",  decode_to="response_text"),
    ]
)
async def generate(self, request_id, prompt_ids, ...):
    ...
```

Global fallback tokenizer -- set once at worker init:

```python
RolloutTraceConfig.init(
    project_name=...,
    experiment_name=...,
    backend=...,
    token2text=True,
    tokenizer=self.tokenizer,  # new optional parameter
)
```

### Design & Code Changes

| File | Change |
|------|--------|
| `verl/utils/rollout_trace.py` | Add `Token2TextField` dataclass and `_DEFAULT_TOKEN2TEXT_FIELDS` for configurable field mapping |
| `verl/utils/rollout_trace.py` | Add `_resolve_tokenizer()` with fallback chain: `self.tokenizer` → `RolloutTraceConfig.get_tokenizer()` |
| `verl/utils/rollout_trace.py` | Add `tokenizer` attribute + `get_tokenizer()` to `RolloutTraceConfig`; add `tokenizer` param to `init()` |
| `verl/utils/rollout_trace.py` | Refactor `rollout_trace_op` to support parameterized `(token2text_fields=...)` form while keeping bare `@rollout_trace_op` backward compatible |
| `verl/utils/rollout_trace.py` | Extract and generalize `_add_token2text()` to handle both input/output sources and use resolved tokenizer |
| `verl/experimental/agent_loop/agent_loop.py` | `AsyncLLMServerManager.generate`: use `@rollout_trace_op(token2text_fields=[...])` to map `input.prompt_ids` and `output.token_ids` |
| `verl/experimental/agent_loop/agent_loop.py` | `AgentLoopWorker.__init__`: pass `tokenizer=self.tokenizer` to `RolloutTraceConfig.init()` |

All changes are **non-breaking**: the `rollout_trace_op` decorator, `RolloutTraceConfig.init()`, and `_add_token2text` all maintain their existing signatures via optional parameters and default values.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: it seems quite difficult
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
