### PR TITLE
[trainer,ckpt,rollout] fix: wake up rollout replicas when actor update is skipped by critic warmup

### DIFF
--- a/.github/workflows/e2e_ascend.yml
+++ b/.github/workflows/e2e_ascend.yml
@@ -109,6 +109,11 @@ jobs:
           ray stop --force
           bash tests/special_npu/run_qwen2_5_05b_grpo.sh
           rm -rf $HOME/ckpts
+      - name: Running gsm8k e2e training tests with GRPO on ASCEND NPU (skip actor update via critic warmup)
+        run: |
+          ray stop --force
+          bash tests/special_npu/run_qwen2_5_05b_grpo_critic_warmup_skip_actor.sh
+          rm -rf $HOME/ckpts
       - name: Running gsm8k e2e training tests with GRPO on ASCEND NPU (MindSpeed backend)
         run: |
           ray stop --force

--- a/tests/special_npu/run_qwen2_5_05b_grpo_critic_warmup_skip_actor.sh
+++ b/tests/special_npu/run_qwen2_5_05b_grpo_critic_warmup_skip_actor.sh
@@ -1,0 +1,48 @@
+set -x
+
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${HOME}/.cache/models/${MODEL_ID}}
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=128 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=5e-7 \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_mode="FULL_AND_PIECEWISE" \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.n=2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    trainer.critic_warmup=10 \
+    trainer.logger=console \
+    trainer.project_name='verl_grpo_example_gsm8k' \
+    trainer.experiment_name='qwen2_5_05b_grpo_critic_warmup_skip_actor' \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=2 $@

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -24,7 +24,8 @@ from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
 from verl.utils.distributed import initialize_global_process_group_ray
 from verl.utils.ray_utils import auto_await
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig, RolloutConfig
-from verl.workers.rollout import BaseRollout, RolloutReplica, get_rollout_class
+from verl.workers.rollout import BaseRollout, get_rollout_class
+from verl.workers.rollout.replica import RolloutMode, RolloutReplica
 
 
 class TensorMeta(TypedDict):
@@ -395,10 +396,26 @@ class CheckpointEngineManager:
         """Sleep all rollout replicas: free weight and kv_cache device memory."""
         await asyncio.gather(*[r.sleep() for r in self.replicas])
 
-    @auto_await
-    async def wake_up_replicas(self):
-        """Resume all rollout replicas: recover kv_cache and weights device memory."""
+    async def _direct_wake_up_replicas(self):
+        """Directly wake rollout replicas without any fallback weight sync."""
         await asyncio.gather(*[r.wake_up() for r in self.replicas])
+
+    @auto_await
+    async def wake_up_replicas(self, global_steps: int = None):
+        """Resume rollout replicas without forcing a full actor update when possible.
+
+        For colocated and standalone rollout replicas, we can directly wake the inference
+        engines. Hybrid rollout servers recover through ``update_weights()``, so we fall
+        back to that path when needed.
+
+        Args:
+            global_steps: The global steps of the trainer, forwarded when fallback weight
+                update is required.
+        """
+        if any(replica.rollout_mode == RolloutMode.HYBRID for replica in self.replicas):
+            await self.update_weights(global_steps=global_steps)
+            return
+        await self._direct_wake_up_replicas()
 
     @auto_await
     async def update_weights(self, global_steps: int = None):
@@ -439,7 +456,7 @@ class CheckpointEngineManager:
         )
 
         # 7. resume replicas to recover kv_cache (for free_cache_engine scenarios)
-        await self.wake_up_replicas()
+        await self._direct_wake_up_replicas()
 
         # 8. resume all unfinished requests for partial rollout
         await asyncio.gather(*[r.resume_generation() for r in self.replicas])

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1534,6 +1534,12 @@ class RayPPOTrainer:
 
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)
+                    elif self.config.actor_rollout_ref.rollout.free_cache_engine:
+                        # Rollout replicas were put to sleep after generation. When actor update is
+                        # skipped by critic warmup, there is no trailing update_weights() call to
+                        # wake them back up for the next step.
+                        with marked_timer("wake_up_rollout", timing_raw, color="red"):
+                            self.checkpoint_manager.wake_up_replicas(self.global_steps)
 
                     # Log rollout generations if enabled
                     rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)


### PR DESCRIPTION
When free_cache_engine=True, PPO sleeps rollout replicas after each rollout. Normally the actor update path calls checkpoint_manager.update_weights(), which also wakes the rollout engine back up for the next step.

However, when actor update is skipped because trainer.critic_warmup > global_steps, that wake-up never happens. As a result, the next rollout may start with the inference engine still in sleep state and trigger downstream vLLM runtime errors.

This change adds a lightweight checkpoint manager wake-up path and invokes it at the end of the PPO step only when actor update is skipped by critic warmup. For colocated and standalone replicas it directly calls replica.wake_up(); for hybrid replicas it falls back to update_weights(global_steps).

### What does this PR do?

Fixes a PPO trainer bug on the `critic_warmup` skip-actor path.

When `actor_rollout_ref.rollout.free_cache_engine=True`, rollout replicas are put into sleep state after each rollout to release weights / KV cache. In the normal path, the step later enters actor update and calls `checkpoint_manager.update_weights()`, which also wakes the rollout engine back up.

However, if actor update is skipped because `trainer.critic_warmup > global_steps`, that `update_weights()` call is skipped as well. The rollout engine then remains asleep into the next step, which can surface as downstream vLLM / Ascend NPU runtime failures instead of a clear logical error.

This PR adds a lightweight rollout wake-up path and calls it only on the `critic_warmup` skip-actor branch.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [https://github.com/verl-project/verl/pulls?q=is%3Apr+free_cache_engine](https://github.com/verl-project/verl/pulls?q=is%3Apr+free_cache_engine)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

I encounterd this bug on Ascend NPU, so i validated on Ascend NPU only.

I currently only have access to Ascend NPU hardware and do not have an NVIDIA GPU environment available, so I could not verify this fix on NVIDIA GPU locally.

Before this fix, the trainer will crash after step 1, logs: [link, crashed on line 1051](https://pastebin.ubuntu.com/p/8zswCjPW9h/)

After this fix, it can finish step 2: [link, finished step 2 on line 914](https://pastebin.ubuntu.com/p/VPZ42YFv3P/)

### API and Usage Example

No API or config change.

### Design & Code Changes

- Add `checkpoint_manager.wake_up_replicas(global_steps=None)` as a lightweight recovery path.
- For colocated / standalone rollout replicas, directly call `replica.wake_up()`.
- For hybrid rollout replicas, fall back to `trainer.update_weights(global_steps)` semantics via `checkpoint_manager.update_weights(global_steps)`.
- In PPO training, when actor update is skipped because `trainer.critic_warmup > global_steps`
  and `free_cache_engine=True`, call the lightweight wake-up path at the end of the step.
- Keep the default behavior unchanged for the normal actor-update path.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). No need for edit the docs.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. Might be a Ascend Only bug, so add ci only for Ascend E2E tests.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not related.
