### PR TITLE
[fsdp] fix: pass dp_group to prepare_dynamic_batch to fix CUDA deadlock

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -465,7 +465,9 @@ class DataParallelPPOActor(BasePPOActor):
 
         if use_dynamic_bsz:
             max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
-            micro_batches, batch_idx_list = prepare_dynamic_batch(data, max_token_len=max_token_len)
+            micro_batches, batch_idx_list = prepare_dynamic_batch(
+                data, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+            )
         else:
             micro_batches = data.split(micro_batch_size)
 
@@ -557,7 +559,9 @@ class DataParallelPPOActor(BasePPOActor):
             for batch_idx, mini_batch in enumerate(mini_batches):
                 if self.config.use_dynamic_bsz:
                     max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
-                    micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                    micro_batches, _ = prepare_dynamic_batch(
+                        mini_batch, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+                    )
                 else:
                     self.gradient_accumulation = (
                         self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu


### PR DESCRIPTION
### What does this PR do?

Fix FSDP training deadlock caused by missing `dp_group` in `prepare_dynamic_batch` calls in `dp_actor.py`. This is the FSDP counterpart of #5451 (which fixed the same bug for megatron workers).

### Root cause

After f5c34bb added a `dp_group is not None` guard in `verl/utils/seqlen_balancing.py` ([line 391](https://github.com/verl-project/verl/blob/c179476754150a5384f96d56b622a8f6330d2c04/verl/utils/seqlen_balancing.py#L391)), the FSDP actor's calls to `prepare_dynamic_batch` in `dp_actor.py` (which do not pass `dp_group`) silently skip the `num_micro_batches` all_reduce across data-parallel ranks.

Under dynamic batching (`use_dynamic_bsz=True`), verl dispatches unique data to every rank (`dp_rank=self.rank` at `fsdp_workers.py:191`). Each rank independently computes `num_micro_batches = ceildiv(total_seqlen, max_token_len)`. Different sequence length distributions cause different ranks to compute different micro-batch counts. When one rank finishes its micro-batch loop while another is still in a forward pass, FSDP collectives (AllGather/ReduceScatter) deadlock because not all ranks are at the same collective call.

**Fix**: pass `torch.distributed.group.WORLD` as `dp_group` in both `compute_log_prob` (line 468) and `update_policy` (line 560) in `dp_actor.py`. This triggers an `all_reduce(MAX)` across all ranks, ensuring every rank iterates the same number of micro-batches.

`WORLD` is correct for all verl FSDP parallelism configs:
- Pure FSDP (`fsdp_size=-1`): all ranks in one group
- HSDP (`fsdp_size < world_size`): both FSDP and DDP collectives need sync
- Ulysses SP: SP peers share data (same count naturally); DP peers need sync

### Test

Validated on 2-node EKS cluster (8x NVIDIA A10G, 4 GPUs/node):

**Config**: FSDP v2, TP=2, `use_dynamic_bsz=True`, `use_remove_padding=True`, `gradient_checkpointing=True`, `ppo_max_token_len_per_gpu=4096`, Qwen2.5-0.5B-Instruct, GSM8K GRPO.

| | Without fix | With fix |
|---|---|---|
| Ray | Deadlock at step 1-9 (100% repro) | 4/4 clean 72-step runs |

**Diagnosis**: py-spy on deadlocked workers showed 4 ranks on the same node stuck at different training phases (3 in `_forward_micro_batch`, 1 in `_optimizer_step`) — confirming rank desynchronization from unequal micro-batch counts.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
