### PR TITLE
[veomni] fix: Update the prepare_model_inputs method of VeOmniEngine to align with the latest modifications of VeOmni

### DIFF
--- a/examples/sft/vlm/run_qwen3_vl_2b.sh
+++ b/examples/sft/vlm/run_qwen3_vl_2b.sh
@@ -44,6 +44,18 @@ FSDP_ENGINE_CONFIG="\
     engine.strategy=${FSDP_STRATEGY} \
     engine.fsdp_size=${FSDP_SIZE}"
 
+VEOMNI_ENGINE_CONFIG="\
+    engine=${backend} \
+    optim=${backend} \
+    optim.lr=2e-5 \
+    optim.lr_warmup_steps_ratio=0.01 \
+    optim.weight_decay=0.1 \
+    optim.betas="[0.9,0.95]" \
+    optim.clip_grad=1.0 \
+    optim.lr_min=2e-6 \
+    optim.lr_scheduler_type=cosine \
+    engine.ulysses_parallel_size=${SP_SIZE} \
+    engine.fsdp_size=${FSDP_SIZE}"
 
 MEGATRON_ENGINE_CONFIG="\
     engine=${backend} \
@@ -66,11 +78,15 @@ MEGATRON_ENGINE_CONFIG="\
 if [ "$backend" = "fsdp" ]; then
     ENGINE_CONFIG="$FSDP_ENGINE_CONFIG"
     echo "Using fsdp engine"
-    exp_name=pokemon-qwen3-2b-${backend}-${FSDP_STRATEGY}-sp${SP_SIZE}-fsdp-1202a1
+    exp_name=pokemon-qwen3-vl-2b-${backend}-${FSDP_STRATEGY}-sp${SP_SIZE}-fsdp-1202a1
+elif [ "$backend" = "veomni" ]; then
+    ENGINE_CONFIG="$VEOMNI_ENGINE_CONFIG"
+    echo "Using veomni engine"
+    exp_name=pokemon-qwen3-vl-2b-${backend}-sp${SP_SIZE}-veomni-1202a1
 else
     ENGINE_CONFIG="$MEGATRON_ENGINE_CONFIG"
     echo "Using megatron engine"
-    exp_name=pokemon-qwen3-2b-${backend}-tp${TP_SIZE}-pp${PP_SIZE}-vpp${VPP_SIZE}-cp${CP_SIZE}-megatron-1202a1
+    exp_name=pokemon-qwen3-vl-2b-${backend}-tp${TP_SIZE}-pp${PP_SIZE}-vpp${VPP_SIZE}-cp${CP_SIZE}-megatron-1202a1
 fi
 
 CKPT_HOME=${CKPT_HOME:-$HOME/open_verl/sft/${project_name}/${exp_name}}

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -279,9 +279,11 @@ class VeOmniEngineConfig(EngineConfig):
             2. `sdpa`
             3. `flash_attention_2`
             4. `flash_attention_3`
-            5. `veomni_flash_attention_2_with_sp`
-            6. `veomni_flash_attention_3_with_sp`
-            7. `native-sparse`
+            5. `flash_attention_4`
+            6. `veomni_flash_attention_2_with_sp`
+            7. `veomni_flash_attention_3_with_sp`
+            8. `veomni_flash_attention_4_with_sp`
+            9. `native-sparse`  
             default "flash_attention_2"
             Note: In case VeOmni add more attn_implementation, please check https://github.com/ByteDance-Seed/VeOmni/
         moe_implementation (str): MoE implementation to use.
@@ -303,7 +305,7 @@ class VeOmniEngineConfig(EngineConfig):
         mixed_precision (Optional[dict[str, Any]]): Mixed precision configuration for FSDP, default None
 
     """
-
+    _mutable_fields = EngineConfig._mutable_fields | {"attn_implementation"}
     wrap_policy: dict[str, Any] = field(default_factory=dict)
     offload_policy: bool = False
     reshard_after_forward: bool = True
@@ -334,7 +336,20 @@ class VeOmniEngineConfig(EngineConfig):
     def __post_init__(self):
         super().__post_init__()
         assert self.strategy in ["veomni"], f"strategy {self.strategy} not supported"
-
+        if self.ulysses_parallel_size > 1:
+            replacements = {
+                "flash_attention_2": "veomni_flash_attention_2_with_sp",
+                "flash_attention_3": "veomni_flash_attention_3_with_sp",
+                "flash_attention_4": "veomni_flash_attention_4_with_sp",
+            }
+            if self.attn_implementation in replacements:
+                new_impl = replacements[self.attn_implementation]
+                warnings.warn(
+                    f"Sequence Parallel is enabled (ulysses_parallel_size={self.ulysses_parallel_size}), "
+                    f"automatically replacing attn_implementation from '{self.attn_implementation}' "
+                    f"to '{new_impl}'"
+                )
+                self.attn_implementation = new_impl
 
 @dataclass
 class TorchtitanEngineConfig(EngineConfig):

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -283,7 +283,7 @@ class VeOmniEngineConfig(EngineConfig):
             6. `veomni_flash_attention_2_with_sp`
             7. `veomni_flash_attention_3_with_sp`
             8. `veomni_flash_attention_4_with_sp`
-            9. `native-sparse`  
+            9. `native-sparse`
             default "flash_attention_2"
             Note: In case VeOmni add more attn_implementation, please check https://github.com/ByteDance-Seed/VeOmni/
         moe_implementation (str): MoE implementation to use.
@@ -305,6 +305,7 @@ class VeOmniEngineConfig(EngineConfig):
         mixed_precision (Optional[dict[str, Any]]): Mixed precision configuration for FSDP, default None
 
     """
+
     _mutable_fields = EngineConfig._mutable_fields | {"attn_implementation"}
     wrap_policy: dict[str, Any] = field(default_factory=dict)
     offload_policy: bool = False
@@ -347,9 +348,11 @@ class VeOmniEngineConfig(EngineConfig):
                 warnings.warn(
                     f"Sequence Parallel is enabled (ulysses_parallel_size={self.ulysses_parallel_size}), "
                     f"automatically replacing attn_implementation from '{self.attn_implementation}' "
-                    f"to '{new_impl}'"
+                    f"to '{new_impl}'",
+                    stacklevel=2,
                 )
                 self.attn_implementation = new_impl
+
 
 @dataclass
 class TorchtitanEngineConfig(EngineConfig):

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -894,6 +894,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
             input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=1)  # (1, total_nnz)
 
             # pad and slice the inputs if sp > 1
+            # VeOmniEngine's position_ids will be sliced after precompute fa kwargs
             if self.use_ulysses_sp:
                 is_vlm_model = hasattr(getattr(self.module, "module", self.module).config, "vision_config")
                 if is_vlm_model:

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -26,6 +26,7 @@ from veomni.distributed.offloading import build_activation_offloading_context
 from veomni.distributed.torch_parallelize import build_parallelize_model
 from veomni.models.auto import build_foundation_model
 from veomni.optim import build_lr_scheduler, build_optimizer
+from veomni.utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
 
 import verl.utils.torch_functional as verl_F
 from verl.trainer.config import CheckpointConfig
@@ -499,95 +500,83 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__exit__(exc_type, exc_value, traceback)
 
 
-@dataclass
-class OmniSequenceShardCollator:
-    """
-    Data collator to chunk inputs along the sequence length.
-    """
+def sp_slice(feature: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    sp_size = parallel_state.get_parallel_state().sp_size
+    sp_rank = parallel_state.get_parallel_state().sp_rank
+    seq_length = feature.size(dim)
+    sp_chunk_size = seq_length // sp_size
+    return feature.narrow(dim, sp_rank * sp_chunk_size, sp_chunk_size)
+    
+def sp_padding(
+    feature: torch.Tensor,
+    dim: int = -1,
+    pad_value: int = 0,
+    pad_scale: int = 1,
+) -> torch.Tensor:
+    seq_length = feature.size(dim)
 
-    # features to slice sequence dimension
-    sp_slice_features: dict[str, int] = field(
-        default_factory=lambda: {
-            "input_ids": -1,
-            "labels": -1,
-            "pixel_values": 0,
-            "pixel_values_videos": 0,
-        },
-        metadata={"help": "features to slice sequence dimension."},
-    )
+    sp_size = parallel_state.get_parallel_state().sp_size
+    scale_sp_size = sp_size * pad_scale
+    sp_chunk_size = (seq_length + scale_sp_size - 1) // scale_sp_size
+    pad_size = sp_chunk_size * scale_sp_size - seq_length
+    if pad_size == 0:
+        return feature
 
-    # features to padding sequence dimension
-    padding_features: dict[str, int] = field(
-        default_factory=lambda: {
-            "pixel_values": 0,
-        },
-        metadata={"help": "features to padding sequence dimension."},
-    )
-
-    # padding scale for padding features
-    padding_scale: dict[str, int] = field(
-        default_factory=lambda: {"pixel_values": 4}, metadata={"help": "padding scale for padding features."}
-    )
-
-    def __post_init__(self):
-        self.sp_size = parallel_state.get_parallel_state().sp_size
-        self.sp_rank = parallel_state.get_parallel_state().sp_rank
-
-    def sp_slice(self, feature: torch.Tensor, dim: int = -1) -> dict[str, "torch.Tensor"]:
-        seq_length = feature.size(dim)
-        sp_chunk_size = (seq_length + self.sp_size - 1) // self.sp_size
-        return feature.narrow(dim, self.sp_rank * sp_chunk_size, sp_chunk_size)
-
-    def sp_padding(
-        self, tensor: "torch.Tensor", dim: int = -1, pad_value: int = 0, pad_scale: int = 1
-    ) -> "torch.Tensor":
-        """
-        Pads a tensor with pad_length to aligns tensor with sp size.
-        """
-        seq_length = tensor.size(dim)
-        scale_sp_size = self.sp_size * pad_scale
-
-        sp_chunk_size = (seq_length + scale_sp_size - 1) // scale_sp_size
-        pad_size = sp_chunk_size * scale_sp_size - seq_length
-        if pad_size == 0:
-            return tensor
-
-        pad_shape = list(tensor.shape)
-        pad_shape[dim] = pad_size
-        pad = torch.full(pad_shape, fill_value=pad_value, dtype=tensor.dtype, device=tensor.device)
-        return torch.cat((tensor, pad), dim=dim)
-
-    def __call__(self, batch: Sequence[dict[str, "torch.Tensor"]]) -> dict[str, "torch.Tensor"]:
-        for key in batch.keys():
-            if key in self.padding_features.keys():
-                batch[key] = self.sp_padding(
-                    batch[key],
-                    dim=self.sp_slice_features.get(key, -1),
-                    pad_value=self.padding_features[key],
-                    pad_scale=self.padding_scale.get(key, 1),
-                )
-
-        # sp slice
-        for key in batch.keys():
-            if key in self.sp_slice_features.keys():
-                batch[key] = self.sp_slice(batch[key], dim=self.sp_slice_features[key])
-
-        return batch
+    pad_shape = list(feature.shape)
+    pad_shape[dim] = pad_size
+    pad = torch.full(pad_shape, fill_value=pad_value, dtype=feature.dtype, device=feature.device)
+    return torch.cat((feature, pad), dim=dim)
 
 
 @EngineRegistry.register(model_type="language_model", backend=["veomni"], device=["cuda", "npu"])
 class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
     def prepare_model_inputs(self, micro_batch: TensorDict):
-        # TODO: Cannot work properly for qwen_vl ulysses
+        """
+        Process model inputs according to VeOmni SequenceParallelCollator.
+        
+        This method extends the parent class's prepare_model_inputs method, primarily used for input processing in sequence parallel training scenarios:
+        1. Precompute parameters required for flash attention
+        2. Slice position_ids
+        3. Slice input_ids for VLM models
+        4. Pad and slice pixel_values
+        
+        Args:
+            micro_batch (TensorDict): Micro batch data containing model inputs
+            
+        Returns:
+            Tuple[Dict, Dict]: Processed model inputs and output arguments
+        """
         model_inputs, output_args = super().prepare_model_inputs(micro_batch)
-        input_ids_rmpad = model_inputs["input_ids"]
-        if self.module.config.model_type in VL_TYPE2INDEX.keys():
-            image_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["IMAGE_INPUT_INDEX"]
-            video_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["VIDEO_INPUT_INDEX"]
-            model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
+        use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
 
-            if parallel_state.get_parallel_state().sp_enabled:
-                omni_sequence_shard_collator = OmniSequenceShardCollator()
-                omni_sequence_shard_collator(model_inputs)
+        if use_remove_padding and parallel_state.get_parallel_state().sp_enabled:
+            # precompute flash attention kwargs
+            position_ids = model_inputs["position_ids"]
+            if position_ids.dim() == 3:
+                position_ids = position_ids[0]
+            (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+            model_inputs.update(
+                {
+                    "cu_seq_lens_q": cu_seq_lens_q,
+                    "cu_seq_lens_k": cu_seq_lens_k,
+                    "max_length_q": max_length_q,
+                    "max_length_k": max_length_k,
+                }
+            )
 
+            # position_ids has been padded but not slice, so we need to slice it here
+            model_inputs["position_ids"] = sp_slice(model_inputs["position_ids"], dim=-1)
+            is_vlm_model = hasattr(getattr(self.module, "module", self.module).config, "vision_config")
+            if is_vlm_model:
+                # input_ids has been padded but not sliced
+                image_mask = model_inputs["input_ids"] == self.module.config.image_token_id
+                video_mask = model_inputs["input_ids"] == self.module.config.video_token_id
+                model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
+                model_inputs["input_ids"] = sp_slice(model_inputs["input_ids"], dim=-1)
+
+            if "pixel_values" in model_inputs:
+                model_inputs["pixel_values"] = sp_padding(model_inputs["pixel_values"], dim=0, pad_scale=4)
+                model_inputs["pixel_values"] = sp_slice(model_inputs["pixel_values"], dim=0)
+            
+            # TODO: support pad and slice pixel_value_videos
         return model_inputs, output_args

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -14,8 +14,7 @@
 
 
 import logging
-from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Optional
 
 import torch
 import torch.distributed as dist
@@ -47,7 +46,6 @@ from ..fsdp.transformer_impl import FSDPEngine, FSDPEngineWithLMHead
 from ..utils import enable_full_determinism, postprocess_batch_func, prepare_micro_batches
 from .utils import (
     MOE_PARAM_HANDERS,
-    VL_TYPE2INDEX,
     load_veomni_model_to_gpu,
     load_veomni_optimizer,
     offload_veomni_model_to_cpu,
@@ -506,7 +504,8 @@ def sp_slice(feature: torch.Tensor, dim: int = -1) -> torch.Tensor:
     seq_length = feature.size(dim)
     sp_chunk_size = seq_length // sp_size
     return feature.narrow(dim, sp_rank * sp_chunk_size, sp_chunk_size)
-    
+
+
 def sp_padding(
     feature: torch.Tensor,
     dim: int = -1,
@@ -533,20 +532,28 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
     def prepare_model_inputs(self, micro_batch: TensorDict):
         """
         Process model inputs according to VeOmni SequenceParallelCollator.
-        
-        This method extends the parent class's prepare_model_inputs method, primarily used for input processing in sequence parallel training scenarios:
+
+        This method extends the parent class's prepare_model_inputs method, primarily used for input processing
+        in sequence parallel training scenarios:
         1. Precompute parameters required for flash attention
         2. Slice position_ids
         3. Slice input_ids for VLM models
         4. Pad and slice pixel_values
-        
+
         Args:
             micro_batch (TensorDict): Micro batch data containing model inputs
-            
+
         Returns:
             Tuple[Dict, Dict]: Processed model inputs and output arguments
         """
         model_inputs, output_args = super().prepare_model_inputs(micro_batch)
+
+        is_vlm_model = hasattr(getattr(self.module, "module", self.module).config, "vision_config")
+        if is_vlm_model:
+            image_mask = model_inputs["input_ids"] == self.module.config.image_token_id
+            video_mask = model_inputs["input_ids"] == self.module.config.video_token_id
+            model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
+
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
 
         if use_remove_padding and parallel_state.get_parallel_state().sp_enabled:
@@ -554,7 +561,9 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             position_ids = model_inputs["position_ids"]
             if position_ids.dim() == 3:
                 position_ids = position_ids[0]
-            (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(position_ids)
+            (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(
+                position_ids
+            )
             model_inputs.update(
                 {
                     "cu_seq_lens_q": cu_seq_lens_q,
@@ -566,17 +575,13 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
 
             # position_ids has been padded but not slice, so we need to slice it here
             model_inputs["position_ids"] = sp_slice(model_inputs["position_ids"], dim=-1)
-            is_vlm_model = hasattr(getattr(self.module, "module", self.module).config, "vision_config")
             if is_vlm_model:
                 # input_ids has been padded but not sliced
-                image_mask = model_inputs["input_ids"] == self.module.config.image_token_id
-                video_mask = model_inputs["input_ids"] == self.module.config.video_token_id
-                model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
                 model_inputs["input_ids"] = sp_slice(model_inputs["input_ids"], dim=-1)
 
             if "pixel_values" in model_inputs:
                 model_inputs["pixel_values"] = sp_padding(model_inputs["pixel_values"], dim=0, pad_scale=4)
                 model_inputs["pixel_values"] = sp_slice(model_inputs["pixel_values"], dim=0)
-            
+
             # TODO: support pad and slice pixel_value_videos
         return model_inputs, output_args


### PR DESCRIPTION
### What does this PR do?

This PR aligns with the latest release (v0.1.7) of veomni and introduces lightweight optimizations to the veomni backend implementation:
1. Auto-replacement of `attn_implementation`:
   Referencing [veomni](https://github.com/ByteDance-Seed/VeOmni/blob/a18e9944d568f9007bf9647b6f7b528990e124dc/veomni/arguments/arguments_types.py#L566), the PR adds support for automatic replacement of `attn_implementation` when `sp>1`.

2. Optimization of `prepare_model_inputs` in VeOmniEngine:
   - Following [veomni](https://github.com/ByteDance-Seed/VeOmni/blob/a18e9944d568f9007bf9647b6f7b528990e124dc/veomni/data/data_collator.py#L339), the `prepare_model_inputs` method is optimized to support precomputation of `fa_kwargs`.
   - The calculation logic for `image_mask` and `video_mask` in VLM is optimized, enabling placeholder tokens to be retrieved directly from the model config.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
