### PR TITLE
[feat][training_utils] State-based metrics

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -74,219 +74,286 @@ class TestReduceMetrics(unittest.TestCase):
 class TestMetric(unittest.TestCase):
     """Tests for the Metric class."""
 
+    # ================= init tests =================
     def test_init_with_string_aggregation(self):
         """Test Metric initialization with string aggregation type."""
         metric = Metric(aggregation="mean")
         self.assertEqual(metric.aggregation, AggregationType.MEAN)
-        self.assertEqual(metric.values, [])
+        self.assertEqual(metric.count, 0)
 
     def test_init_with_enum_aggregation(self):
         """Test Metric initialization with AggregationType enum."""
         metric = Metric(aggregation=AggregationType.SUM)
         self.assertEqual(metric.aggregation, AggregationType.SUM)
-        self.assertEqual(metric.values, [])
+        self.assertEqual(metric.count, 0)
 
     def test_init_with_value(self):
         """Test Metric initialization with an initial value."""
-        metric = Metric(aggregation="mean", value=5.0)
-        self.assertEqual(metric.values, [5.0])
+        x = 5.0
+        metric = Metric(aggregation="mean", value=x)
+        self.assertEqual(metric.count, 1)
+        self.assertEqual(metric.aggregate(), x)
 
     def test_init_with_invalid_aggregation(self):
         """Test Metric initialization with invalid aggregation type."""
         with self.assertRaises(ValueError):
             Metric(aggregation="invalid")
 
-    def test_append_float(self):
-        """Test appending float values."""
+    # ================= accumulate tests =================
+    def test_accumulate_float(self):
+        """Test accumulating float values."""
         metric = Metric(aggregation="mean")
-        metric.append(1.0)
-        metric.append(2.0)
-        self.assertEqual(metric.values, [1.0, 2.0])
+        x1, x2 = 1.0, 2.0
+        metric.accumulate(x1)
+        metric.accumulate(x2)
+        self.assertEqual(metric.count, 2)
+        self.assertEqual(metric.aggregate(), np.mean([x1, x2]))
 
-    def test_append_int(self):
-        """Test appending int values."""
+    def test_accumulate_int(self):
+        """Test accumulating int values."""
         metric = Metric(aggregation="mean")
-        metric.append(1)
-        metric.append(2)
-        self.assertEqual(metric.values, [1, 2])
+        x1, x2 = 1, 2
+        metric.accumulate(x1)
+        metric.accumulate(x2)
+        self.assertEqual(metric.count, 2)
+        self.assertEqual(metric.aggregate(), np.mean([x1, x2]))
 
-    def test_append_tensor(self):
-        """Test appending scalar tensor values."""
+    def test_accumulate_scalar_tensor(self):
+        """Test accumulating scalar tensor values."""
         metric = Metric(aggregation="mean")
-        metric.append(torch.tensor(3.0))
-        metric.append(torch.tensor(4.0))
-        self.assertEqual(metric.values, [3.0, 4.0])
+        x1, x2 = torch.tensor(3.0), torch.tensor(4.0)
+        metric.accumulate(x1)
+        metric.accumulate(x2)
+        self.assertEqual(metric.count, 2)
+        self.assertEqual(metric.aggregate(), np.mean([x1, x2]))
 
-    def test_append_non_scalar_tensor_raises(self):
-        """Test that appending non-scalar tensor raises ValueError."""
+    def test_accumulate_tensor_flattens(self):
+        """Test accumulating non-scalar tensors flattens their values."""
+        metric = Metric(aggregation="sum")
+        tensor = torch.tensor([1.0, 2.0])
+        metric.accumulate(tensor)
+        self.assertEqual(metric.count, 2)
+        self.assertEqual(metric.aggregate(), tensor.sum().item())
+
+    def test_accumulate_scalar_ndarray(self):
+        """Test accumulating scalar numpy array values."""
         metric = Metric(aggregation="mean")
-        with self.assertRaises(ValueError):
-            metric.append(torch.tensor([1.0, 2.0]))
+        x1, x2 = np.array(3.0), np.array(5.0)
+        metric.accumulate(x1)
+        metric.accumulate(x2)
+        self.assertEqual(metric.count, 2)
+        self.assertEqual(metric.aggregate(), np.mean([x1, x2]))
 
-    def test_append_metric(self):
-        """Test appending another Metric extends values."""
-        metric1 = Metric(aggregation="mean", value=1.0)
-        metric1.append(2.0)
+    def test_accumulate_ndarray_flattens(self):
+        """Test accumulating numpy arrays flattens their values."""
+        metric = Metric(aggregation="sum")
+        array = np.array([[1.0, 2.0], [3.0, 4.0]])
+        metric.accumulate(array)
+        self.assertEqual(metric.count, array.size)
+        self.assertEqual(metric.aggregate(), array.sum())
 
-        metric2 = Metric(aggregation="mean", value=3.0)
-        metric2.append(metric1)
-
-        self.assertEqual(metric2.values, [3.0, 1.0, 2.0])
-
-    def test_extend_with_list(self):
-        """Test extending with a list of values."""
+    def test_accumulate_list(self):
+        """Test accumulating a list of values."""
         metric = Metric(aggregation="mean")
-        metric.extend([1.0, 2.0, 3.0])
-        self.assertEqual(metric.values, [1.0, 2.0, 3.0])
+        ls = [1.0, 2.0, 3.0]
+        metric.accumulate(ls)
+        self.assertEqual(metric.count, len(ls))
+        self.assertEqual(metric.aggregate(), np.mean(ls))
 
-    def test_extend_with_metric(self):
-        """Test extending with another Metric."""
-        metric1 = Metric(aggregation="mean")
-        metric1.extend([1.0, 2.0])
+    def test_accumulate_metric(self):
+        """Test accumulating another Metric merges aggregate state."""
+        ls = [1.0, 2.0, 3.0]
+        metric1 = Metric(aggregation="mean", value=ls[0])
+        metric1.accumulate(ls[1:-1])
 
-        metric2 = Metric(aggregation="mean")
-        metric2.extend([3.0, 4.0])
-        metric2.extend(metric1)
+        metric2 = Metric(aggregation="mean", value=ls[-1])
+        metric2.accumulate(metric1)
 
-        self.assertEqual(metric2.values, [3.0, 4.0, 1.0, 2.0])
+        self.assertEqual(metric2.count, len(ls))
+        self.assertEqual(metric2.aggregate(), np.mean(ls))
 
-    def test_extend_aggregation_mismatch_raises(self):
-        """Test that extending with mismatched aggregation raises ValueError."""
+    def test_accumulate_aggregation_mismatch_raises(self):
+        """Test that accumulating mismatched aggregation raises ValueError."""
         metric1 = Metric(aggregation="mean")
         metric2 = Metric(aggregation="sum")
 
         with self.assertRaises(ValueError):
-            metric1.extend(metric2)
+            metric1.accumulate(metric2)
 
+    def test_accumulate_empty_list_is_noop(self):
+        """Test accumulating an empty list leaves metric empty."""
+        metric = Metric(aggregation="sum")
+        metric.accumulate([])
+        self.assertEqual(metric.count, 0)
+        self.assertTrue(np.isnan(metric.aggregate()))
+
+    def test_accumulate_tuple(self):
+        """Test accumulating a tuple of scalar values."""
+        metric = Metric(aggregation="sum")
+        tup = (1.0, 2.0, 3.0)
+        metric.accumulate(tup)
+        self.assertEqual(metric.count, len(tup))
+        self.assertEqual(metric.aggregate(), sum(list(tup)))
+
+    def test_accumulate_nested_list_raises(self):
+        """Test nested lists are rejected."""
+        metric = Metric(aggregation="mean")
+        with self.assertRaises(ValueError):
+            metric.accumulate([[1.0], [2.0]])
+
+    def test_accumulate_list_of_tensors_raises(self):
+        """Test Python sequences of tensors are rejected."""
+        metric = Metric(aggregation="mean")
+        with self.assertRaises(ValueError):
+            metric.accumulate([torch.tensor(1.0), torch.tensor(2.0)])
+
+    # ================= aggregate tests =================
     def test_aggregate_mean(self):
         """Test aggregation with mean."""
         metric = Metric(aggregation="mean")
-        metric.extend([1.0, 2.0, 3.0, 4.0])
-        self.assertEqual(metric.aggregate(), 2.5)
+        ls = [1.0, 2.0, 3.0, 4.0]
+        metric.accumulate(ls)
+        self.assertEqual(metric.aggregate(), np.mean(ls))
 
     def test_aggregate_sum(self):
         """Test aggregation with sum."""
         metric = Metric(aggregation="sum")
-        metric.extend([1.0, 2.0, 3.0, 4.0])
-        self.assertEqual(metric.aggregate(), 10.0)
+        ls = [1.0, 2.0, 3.0, 4.0]
+        metric.accumulate(ls)
+        self.assertEqual(metric.aggregate(), sum(ls))
 
     def test_aggregate_min(self):
         """Test aggregation with min."""
         metric = Metric(aggregation="min")
-        metric.extend([3.0, 1.0, 4.0, 2.0])
-        self.assertEqual(metric.aggregate(), 1.0)
+        ls = [3.0, 1.0, 4.0, 2.0]
+        metric.accumulate(ls)
+        self.assertEqual(metric.aggregate(), min(ls))
 
     def test_aggregate_max(self):
         """Test aggregation with max."""
         metric = Metric(aggregation="max")
-        metric.extend([3.0, 1.0, 4.0, 2.0])
-        self.assertEqual(metric.aggregate(), 4.0)
+        ls = [3.0, 1.0, 4.0, 2.0]
+        metric.accumulate(ls)
+        self.assertEqual(metric.aggregate(), max(ls))
 
-    def test_aggregate_dp_sum_mean(self):
-        """Test aggregate_dp with SUM and MEAN aggregations."""
-        # Test with SUM: mean over DP ranks, then sum
-        metric1 = Metric(aggregation="sum")
-        metric1.extend([1.0, 2.0])
+    def test_aggregate_empty_returns_nan(self):
+        """Test aggregating an empty metric returns NaN."""
+        self.assertTrue(np.isnan(Metric(aggregation="mean").aggregate()))
 
-        metric2 = Metric(aggregation="sum")
-        metric2.extend([3.0, 4.0])
+    # ================= union tests =================
+    def test_union_sum_mean(self):
+        """Test union with SUM and MEAN aggregations."""
+        ls1, ls2 = [1.0, 2.0], [3.0, 4.0]
+        metric1 = Metric(aggregation="sum", value=ls1)
+        metric2 = Metric(aggregation="sum", value=ls2)
+        self.assertEqual(Metric.union(metric1, metric2).aggregate(), sum(ls1 + ls2))
 
-        result = Metric.aggregate_dp([metric1, metric2])
+        metric4 = Metric(aggregation="mean", value=ls1)
+        metric5 = Metric(aggregation="mean", value=ls2)
+        self.assertEqual(Metric.union(metric4, metric5).aggregate(), np.mean(ls1 + ls2))
 
-        # value_arrays = [[1.0, 2.0], [3.0, 4.0]]
-        # mean over axis 0 = [2.0, 3.0]
-        # sum = 5.0
-        self.assertEqual(result, 5.0)
-
-        # Test with MEAN: mean over DP ranks, then mean
-        metric4 = Metric(aggregation="mean")
-        metric4.extend([1.0, 2.0])
-
-        metric5 = Metric(aggregation="mean")
-        metric5.extend([3.0, 4.0])
-
-        result = Metric.aggregate_dp([metric4, metric5])
-
-        # value_arrays = [[1.0, 2.0], [3.0, 4.0]]
-        # mean over axis 0 = [2.0, 3.0]
-        # mean = 2.5
-        self.assertEqual(result, 2.5)
-
-    def test_aggregate_dp_min_max(self):
-        """Test aggregate_dp with MIN and MAX aggregations."""
-        # Test with MAX: flatten, then max
+    def test_union_min_max(self):
+        """Test union with MIN and MAX aggregations."""
         metric1 = Metric(aggregation="max")
-        metric1.extend([1.0, 2.0])
+        ls1, ls2 = [1.0, 2.0], [3.0, 4.0]
+        metric1.accumulate(ls1)
 
         metric2 = Metric(aggregation="max")
-        metric2.extend([3.0, 4.0])
+        metric2.accumulate(ls2)
 
-        result = Metric.aggregate_dp([metric1, metric2])
+        self.assertEqual(Metric.union(metric1, metric2).aggregate(), max(ls1 + ls2))
 
-        # value_arrays = [[1.0, 2.0], [3.0, 4.0]]
-        # flatten = [1.0, 2.0, 3.0, 4.0]
-        # max = 4.0
-        self.assertEqual(result, 4.0)
-
-        # Test with MIN: flatten, then min
         metric4 = Metric(aggregation="min")
-        metric4.extend([1.0, 2.0])
+        metric4.accumulate(ls1)
 
         metric5 = Metric(aggregation="min")
-        metric5.extend([3.0, 4.0])
+        metric5.accumulate(ls2)
 
-        result = Metric.aggregate_dp([metric4, metric5])
+        self.assertEqual(Metric.union(metric4, metric5).aggregate(), min(ls1 + ls2))
 
-        # value_arrays = [[1.0, 2.0], [3.0, 4.0]]
-        # flatten = [1.0, 2.0, 3.0, 4.0]
-        # min = 1.0
-        self.assertEqual(result, 1.0)
-
-    def test_aggregate_dp_mismatched_lengths(self):
-        """Test aggregate_dp raises error with mismatched value lengths."""
-        metric1 = Metric(aggregation="sum")
-        metric1.extend([1.0, 2.0])
-
-        metric2 = Metric(aggregation="sum")
-        metric2.extend([3.0, 4.0, 5.0])  # Different length
-
+    def test_union_empty_raises(self):
+        """Test union raises on empty input."""
         with self.assertRaises(ValueError):
-            Metric.aggregate_dp([metric1, metric2])
+            Metric.union()
 
-    def test_from_dict(self):
-        """Test from_dict creates Metrics from dictionary."""
-        data = {"loss": 1.0, "accuracy": 0.9}
-        metrics = Metric.from_dict(data, aggregation="mean")
+    def test_union_aggregation_mismatch_raises(self):
+        """Test union raises on mismatched aggregations."""
+        metric1 = Metric(aggregation="sum")
+        metric2 = Metric(aggregation="mean")
+        with self.assertRaises(ValueError):
+            Metric.union(metric1, metric2)
 
-        self.assertIn("loss", metrics)
-        self.assertIn("accuracy", metrics)
-        self.assertEqual(metrics["loss"].values, [1.0])
-        self.assertEqual(metrics["accuracy"].values, [0.9])
-        self.assertEqual(metrics["loss"].aggregation, AggregationType.MEAN)
+    def test_union_does_not_mutate_inputs(self):
+        """Test union leaves input metrics unchanged."""
+        ls1, ls2 = [1.0, 2.0], [3.0, 4.0]
+        metric1 = Metric(aggregation="sum", value=ls1)
+        metric2 = Metric(aggregation="sum", value=ls2)
+        merged = Metric.union(metric1, metric2)
 
-    def test_init_list(self):
-        """Test init_list creates new empty Metric with same aggregation."""
-        metric = Metric(aggregation="max")
-        metric.extend([1.0, 2.0])
+        self.assertEqual(metric1.aggregate(), sum(ls1))
+        self.assertEqual(metric2.aggregate(), sum(ls2))
+        self.assertEqual(merged.aggregate(), sum(ls1 + ls2))
 
-        new_metric = metric.init_list()
+    def test_union_weighted_mean_across_unequal_counts(self):
+        """Test union computes weighted means across uneven local counts."""
+        ls1, ls2, ls3, ls4 = [1.0] * 25, [2.0] * 24, [3.0] * 25, [4.0] * 26
+        metric1 = Metric(aggregation="mean", value=ls1)
+        metric2 = Metric(aggregation="mean", value=ls2)
+        metric3 = Metric(aggregation="mean", value=ls3)
+        metric4 = Metric(aggregation="mean", value=ls4)
 
-        self.assertEqual(new_metric.aggregation, AggregationType.MAX)
-        self.assertEqual(new_metric.values, [])
+        self.assertEqual(Metric.union(metric1, metric2, metric3, metric4).aggregate(), np.mean(ls1 + ls2 + ls3 + ls4))
 
+    # ================= dp aggregate =================
+    def test_aggregate_dp_sum_averages_across_ranks(self):
+        """Test DP aggregation for SUM metrics averages rank contributions."""
+        ls1, ls2 = [1.0, 2.0], [3.0, 4.0]
+        metric1 = Metric(aggregation="sum", value=ls1)
+        metric2 = Metric(aggregation="sum", value=ls2)
+        self.assertEqual(Metric.aggregate_dp([metric1, metric2]), np.mean([sum(ls1), sum(ls2)]))
+
+    def test_aggregate_dp_mean_is_weighted(self):
+        """Test DP aggregation for MEAN metrics remains weighted by count."""
+        ls1, ls2, ls3, ls4 = [1.0] * 25, [2.0] * 24, [3.0] * 25, [4.0] * 26
+        metrics = [
+            Metric(aggregation="mean", value=ls1),
+            Metric(aggregation="mean", value=ls2),
+            Metric(aggregation="mean", value=ls3),
+            Metric(aggregation="mean", value=ls4),
+        ]
+        self.assertAlmostEqual(Metric.aggregate_dp(metrics), np.mean(ls1 + ls2 + ls3 + ls4))
+
+    def test_aggregate_dp_min_max(self):
+        """Test DP aggregation for MIN and MAX metrics uses global extrema."""
+        ls1, ls2 = [3.0, 1.0], [4.0, 2.0]
+        metric_min_1 = Metric(aggregation="min", value=ls1)
+        metric_min_2 = Metric(aggregation="min", value=ls2)
+        self.assertEqual(Metric.aggregate_dp([metric_min_1, metric_min_2]), min(ls1 + ls2))
+
+        metric_max_1 = Metric(aggregation="max", value=ls1)
+        metric_max_2 = Metric(aggregation="max", value=ls2)
+        self.assertEqual(Metric.aggregate_dp([metric_max_1, metric_max_2]), max(ls1 + ls2))
+
+    def test_aggregate_dp_empty_raises(self):
+        """Test DP aggregation raises on empty input."""
+        with self.assertRaises(ValueError):
+            Metric.aggregate_dp([])
+
+    # ================= reduce metrics tests =================
     def test_reduce_metrics_with_metric(self):
         """Test reduce_metrics correctly handles Metric objects."""
+        ls1, ls2 = [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]
         metric = Metric(aggregation="mean")
-        metric.extend([1.0, 2.0, 3.0])
+        metric.accumulate(ls1)
 
         metrics = {
             "custom_metric": metric,
-            "list_metric": [4.0, 5.0, 6.0],
+            "list_metric": ls2,
         }
         result = reduce_metrics(metrics)
 
-        self.assertEqual(result["custom_metric"], 2.0)
-        self.assertEqual(result["list_metric"], 5.0)
+        self.assertEqual(result["custom_metric"], np.mean(ls1))
+        self.assertEqual(result["list_metric"], np.mean(ls2))
 
 
 class TestComputeDataMetrics(unittest.TestCase):

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -11,15 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Metrics utils.
-"""
+"""Metrics utils."""
 
+import logging
+import os
 from enum import Enum
 from typing import Any, Optional, Union
 
 import numpy as np
 import torch
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, Any]:
@@ -65,16 +68,16 @@ class AggregationType(Enum):
     MAX = "max"
 
 
-NumericType = int, float, torch.Tensor, np.ndarray
 Numeric = int | float | torch.Tensor | np.ndarray
 
 
 class Metric:
     """
-    A metric aggregator for collecting and aggregating numeric values.
+    A metric aggregator.
 
-    This class accumulates numeric values (int, float, or scalar tensors) and computes
-    an aggregate statistic based on the specified aggregation type (MEAN, SUM, MIN, or MAX).
+    This class stores metric states for specified aggregation type.
+    New values are added via `accumulate`, and multiple metrics can be merged via
+    `union` or by accumulating another Metric instance.
 
     Args:
         aggregation: The aggregation method to use. Can be a string ("mean", "sum", "min", "max")
@@ -83,8 +86,8 @@ class Metric:
 
     Example:
         >>> metric = Metric(aggregation="mean", value=1.0)
-        >>> metric.append(2.0)
-        >>> metric.append(3.0)
+        >>> metric.accumulate(2.0)
+        >>> metric.accumulate(3.0)
         >>> metric.aggregate()
         2.0
     """
@@ -96,68 +99,87 @@ class Metric:
             self.aggregation = aggregation
         if not isinstance(self.aggregation, AggregationType):
             raise ValueError(f"Unsupported aggregation type: {aggregation}")
-        self.values = []
+        self.count = 0
+        self.total = 0.0
+        self.value = float("inf") if self.aggregation == AggregationType.MIN else float("-inf")
         if value is not None:
-            self.append(value)
+            self.accumulate(value)
 
-    def append(self, value: Union[Numeric, "Metric"]) -> None:
-        if isinstance(value, Metric):
-            self.extend(value)
-            return
+    @staticmethod
+    def _flatten_values(value: Numeric | list[Numeric] | tuple[Numeric, ...]) -> list[float | int]:
+        if isinstance(value, int | float):
+            return [value]
         if isinstance(value, torch.Tensor):
-            if value.numel() != 1:
-                raise ValueError("Only scalar tensors can be converted to float")
-            value = value.detach().item()
-        if not isinstance(value, NumericType):
-            raise ValueError(f"Unsupported value type: {type(value)}")
-        self.values.append(value)
+            return value.detach().cpu().flatten().tolist()
+        if isinstance(value, np.ndarray):
+            return value.flatten().tolist()
+        if isinstance(value, list | tuple):
+            if not all(isinstance(item, int | float) for item in value):
+                raise ValueError("Lists and tuples passed to Metric.accumulate must contain only int or float values")
+            return list(value)
+        raise ValueError(f"Unsupported value type: {type(value)}")
 
-    def extend(self, values: Union["Metric", list[Numeric]]) -> None:
-        if isinstance(values, Metric):
-            if values.aggregation != self.aggregation:
-                raise ValueError(f"Aggregation type mismatch: {self.aggregation} != {values.aggregation}")
-            values = values.values
-        for value in values:
-            self.append(value)
+    def accumulate(self, value: Union[Numeric, "Metric", list[Numeric], tuple[Numeric, ...]]) -> None:
+        if isinstance(value, Metric):
+            if value.aggregation != self.aggregation:
+                raise ValueError(f"Aggregation type mismatch: {self.aggregation} != {value.aggregation}")
+            if value.count == 0:
+                return
+            match self.aggregation:
+                case AggregationType.SUM | AggregationType.MEAN:
+                    self.total += value.total
+                case AggregationType.MIN:
+                    self.value = min(self.value, value.value)
+                case AggregationType.MAX:
+                    self.value = max(self.value, value.value)
+            self.count += value.count
+            return
+
+        values = self._flatten_values(value)
+        if not values:
+            return
+        match self.aggregation:
+            case AggregationType.SUM | AggregationType.MEAN:
+                self.total += sum(values)
+            case AggregationType.MIN:
+                self.value = min(self.value, min(values))
+            case AggregationType.MAX:
+                self.value = max(self.value, max(values))
+        self.count += len(values)
 
     def aggregate(self) -> float:
-        return self._aggregate(self.values, self.aggregation)
-
-    @classmethod
-    def _aggregate(cls, values: list[Numeric], aggregation: AggregationType) -> float:
-        match aggregation:
+        if self.count == 0:
+            logging.warning("Aggregating metric with no values. Returning NaN.")
+            return float("nan")
+        match self.aggregation:
             case AggregationType.MEAN:
-                return np.mean(values)
+                return self.total / self.count
             case AggregationType.SUM:
-                return np.sum(values)
-            case AggregationType.MIN:
-                return np.min(values)
-            case AggregationType.MAX:
-                return np.max(values)
-
-    @classmethod
-    def aggregate_dp(cls, metric_lists: list["Metric"]) -> float:
-        if not metric_lists:
-            raise ValueError("Cannot aggregate an empty list of metrics.")
-        value_lists = [ml.values for ml in metric_lists]
-        if not all(len(ls) == len(value_lists[0]) for ls in value_lists):
-            raise ValueError(
-                f"All Metric instances must have the same number of values "
-                f"for dp aggregation: {[len(ls) for ls in value_lists]}"
-            )
-        value_arrays = np.array(value_lists)  # [num_dp, num_grad_accumulation]
-        aggregation = metric_lists[0].aggregation
-        match aggregation:
-            case AggregationType.SUM | AggregationType.MEAN:
-                return cls._aggregate(
-                    values=np.mean(value_arrays, axis=0), aggregation=aggregation
-                )  # mean over dp ranks
+                return self.total
             case AggregationType.MIN | AggregationType.MAX:
-                return cls._aggregate(values=value_arrays.flatten(), aggregation=aggregation)  # min/max over all values
+                return self.value
 
     @classmethod
-    def from_dict(cls, data: dict[str, Numeric], aggregation: str | AggregationType) -> dict[str, "Metric"]:
-        return {key: cls(value=value, aggregation=aggregation) for key, value in data.items()}
+    def union(cls, *metrics: "Metric") -> "Metric":
+        if not metrics:
+            raise ValueError("Cannot union an empty set of metrics.")
+        aggregation = metrics[0].aggregation
+        merged = cls(aggregation=aggregation)
+        for metric in metrics:
+            if metric.aggregation != aggregation:
+                raise ValueError(f"Aggregation type mismatch: {aggregation} != {metric.aggregation}")
+            merged.accumulate(metric)
+        return merged
 
-    def init_list(self) -> "Metric":
-        return Metric(aggregation=self.aggregation)
+    @classmethod
+    def aggregate_dp(cls, metrics: list["Metric"]) -> float:
+        """Aggregate a list of Metric instances across data parallel ranks.
+        For SUM metrics, this averages the contributions from each rank.
+        """
+        if not metrics:
+            raise ValueError("Cannot aggregate an empty set of metrics.")
+        merged = cls.union(*metrics)
+        result = merged.aggregate()
+        if merged.aggregation == AggregationType.SUM:
+            result /= len(metrics)
+        return result

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -200,9 +200,11 @@ def append_to_dict(data: dict, new_data: dict, prefix: str = ""):
     for key, val in new_data.items():
         new_key = f"{prefix}{key}" if not key.startswith(prefix) else key
         if new_key not in data:
-            data[new_key] = val.init_list() if isinstance(val, Metric) else []
+            data[new_key] = Metric(val.aggregation) if isinstance(val, Metric) else []
         if isinstance(val, list):
             data[new_key].extend(val)
+        elif isinstance(val, Metric):
+            data[new_key].accumulate(val)
         else:
             data[new_key].append(val)
 

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -158,7 +158,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
         entropy_coeff = config.entropy_coeff
         policy_loss -= entropy_coeff * entropy_loss
-        metrics["actor/entropy_loss"] = Metric(value=entropy_loss, aggregation=metric_aggregation)
+        metrics["actor/entropy_loss"] = Metric(value=entropy[response_mask], aggregation=AggregationType.MEAN)
 
     # add kl loss
     if config.use_kl_loss:
@@ -170,7 +170,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
 
         policy_loss += kl_loss * config.kl_loss_coef
-        metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
+        metrics["kl_loss"] = Metric(value=kld[response_mask], aggregation=AggregationType.MEAN)
         metrics["kl_coef"] = config.kl_loss_coef
 
     return policy_loss, metrics

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -145,7 +145,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens
     # Ex: in compute_policy_loss_vanilla, pg_metrics are pg_clipfrac, ppo_kl, pg_clipfrac_lower
-    pg_metrics = Metric.from_dict(pg_metrics, aggregation=AggregationType.MEAN)
+    pg_metrics = {key: Metric(AggregationType.MEAN, value) for key, value in pg_metrics.items()}
 
     metrics.update(pg_metrics)
     metrics["actor/pg_loss"] = Metric(value=pg_loss, aggregation=metric_aggregation)


### PR DESCRIPTION
## What does this PR do?

Adds state-based metric tracking. There are three motivations for this change:

1. Overhead
2. Ensuring correct token mean when global counts are not available
3. Enabling different number of accumulations across ranks

### Overhead

The current way of logging metrics relies on keeping a list of all of accumulated values: https://github.com/verl-project/verl/blob/592cb07268b8bc1d778fc64892525e762bc78b11/verl/utils/metric/utils.py#L99

If many values are accumulated across many metrics, this can add overhead. 

### Token Mean

The global count of tokens is needed for computing the mean loss across all tokens globally (across parallel ranks). In the multi-teacher on-policy distillation (MOPD) PR (#5164) batch elements come from different tasks, eg math and coding, and the numbers of coding tokens vs math tokens can differ across ranks and micro-batches. For these metrics, the metric object should track the running sum and count directly so that a correct weighted mean can be recovered when metrics are merged.

Note that this way of computing the global mean is different from other metrics, such as `pg_metrics`, where the global number of tokens is computed by all-gathering:

https://github.com/verl-project/verl/blob/592cb07268b8bc1d778fc64892525e762bc78b11/verl/workers/engine_workers.py#L266-L267

However, we already all-gather metrics:

https://github.com/verl-project/verl/blob/592cb07268b8bc1d778fc64892525e762bc78b11/verl/workers/engine_workers.py#L184-L188

State-based metrics avoid a second all-gather for per-task counts and avoid needing a separate metric-specific plumbing path for global token counts, since the metric itself carries the numerator/denominator state needed for merging. 

### Uneven accumulation numbers 

Currently, the function for accumulating losses across gradient accumulation steps and DP ranks is:

https://github.com/verl-project/verl/blob/592cb07268b8bc1d778fc64892525e762bc78b11/verl/utils/metric/utils.py#L139-L156

This does not support the case where a metric has been accumulated a variable number of times on different ranks. For example, consider a batch of 100 with 30 math problems and 70 coding problems. On rank 0, there might be 20 math problems, and on rank 1, there might be 10. If using a micro-batch size of 2, this will lead to 10 loss values on rank 0 and 5 on rank 1, leading to an error in the above function

### Solution

Replace list-based metric tracking with state-based metric tracking.

Instead of storing all values for a metric, each metric stores only the state needed for its aggregation type. For example:

- `MEAN`: running sum and count
- `SUM`: running sum
- `MIN`: running minimum
- `MAX`: running maximum

This has three benefits:

1. lower overhead, since metric storage no longer scales with the number of accumulations
2. correct global mean computation 
3. support for uneven accumulation counts across ranks without requiring identical list lengths

This PR also keeps a DP-specific aggregation path for engine metrics. In particular, `SUM` metrics are not reduced by plain union across DP ranks. They are averaged across ranks during DP aggregation to preserve the semantics introduced in earlier engine metric fixes for globally scaled losses.

### Test

```bash
python3 -m pytest tests/trainer/ppo/test_metric_utils_on_cpu.py
```

### Design & Code Changes

Instead of saving all values for a metric, store state for each metric. For example, if a metric uses mean reduction, keep a running sum and number of elements.

The metric API is updated around stateful accumulation and merge:

- `Metric.accumulate(...)` updates the running state from scalars, tensors, arrays, flat Python sequences, or another metric of the same aggregation type
- `Metric.union(...)` merges metrics into a new metric using aggregation-specific state merge logic
- `Metric.aggregate_dp(...)` performs DP-aware aggregation; for `SUM` metrics it averages across DP ranks rather than scaling with the number of ranks

This preserves existing engine metric semantics while removing the old list-length requirement for cross-rank metric aggregation.
