### PR TITLE
[config] fix: sync chat_template from tokenizer to processor for multimodal base models (e.g. Qwen3.5)

### DIFF
--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -158,6 +158,15 @@ class HFModelConfig(BaseConfig):
             self.tokenizer = hf_tokenizer(self.local_tokenizer_path, trust_remote_code=self.trust_remote_code)
             self.processor = hf_processor(self.local_tokenizer_path, trust_remote_code=self.trust_remote_code)
 
+        # For base models (e.g. Qwen3.5-2b-Base), the processor may not have a chat_template
+        # while the tokenizer does. Sync it so that processor.apply_chat_template() works.
+        if (
+            self.processor is not None
+            and not getattr(self.processor, "chat_template", None)
+            and getattr(self.tokenizer, "chat_template", None)
+        ):
+            self.processor.chat_template = self.tokenizer.chat_template
+
         if self.custom_chat_template is not None:
             if self.processor is not None:
                 self.processor.chat_template = self.custom_chat_template


### PR DESCRIPTION
## Summary

When using a multimodal base model (e.g., `Qwen3.5-2b-Base`) for SFT training, `processor.apply_chat_template()` fails because the processor's `chat_template` is `None`.

## Problem

For multimodal base models, `AutoTokenizer` and `AutoProcessor` behave differently regarding `chat_template`:

- `AutoTokenizer.from_pretrained()` correctly loads `chat_template` from `tokenizer_config.json`
- `AutoProcessor.from_pretrained()` returns a processor (e.g. `Qwen3VLProcessor`) with `chat_template = None`, because the processor config does not include this field for base models

This can be reproduced with:

```python
from transformers import AutoTokenizer, AutoProcessor

path = "Qwen/Qwen3.5-2b-Base"
tok = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
proc = AutoProcessor.from_pretrained(path, trust_remote_code=True)

print(type(tok).__name__)           # TokenizersBackend
print(type(proc).__name__)          # Qwen3VLProcessor
print(bool(tok.chat_template))      # True
print(bool(proc.chat_template))     # False  <-- problem here
```

In verl, `HFModelConfig.get_processor()` returns the processor when available, and downstream code (e.g., `rl_dataset.py`, `chat_template.py`) calls `processor.apply_chat_template()` on it directly. With a multimodal base model, this fails because the processor has no `chat_template`.

While `custom_chat_template` can work around this, it requires users to manually extract the template string from `tokenizer_config.json` and pass it in — which is error-prone and unnecessary since the tokenizer already has the correct template loaded.

This issue affects **multimodal base models** specifically:
- For text-only base models, `hf_processor()` returns `None` and `get_processor()` falls back to the tokenizer — no problem.
- For instruction-tuned multimodal models, both the tokenizer and processor already have `chat_template` set — no problem.

## Fix

In `HFModelConfig.__post_init__()`, after loading both the tokenizer and processor, if the processor exists but has no `chat_template` while the tokenizer does, automatically sync it from the tokenizer to the processor. The sync runs before the `custom_chat_template` override, so user-specified templates still take precedence.

## Test Plan

- Verified on `Qwen3.5-2b-Base`: after the fix, `processor.chat_template` is correctly synced from tokenizer and SFT training proceeds without error
- No impact on instruction-tuned models where the processor already has a `chat_template`
- `custom_chat_template` override still works as expected (applied after the sync)