### PR TITLE
[gdpo] Fix reward misplacement for fully-padded responses

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -417,7 +417,12 @@ def compute_gdpo_outcome_advantage(
         )
         device = token_level_rewards.device
         prompt_length = batch["prompts"].size(1)
-        valid_response_length = batch["attention_mask"][:, prompt_length:].sum(dim=1) - 1
+        response_attention = batch["attention_mask"][:, prompt_length:]
+        valid_response_length = response_attention.sum(dim=1) - 1
+        # Mask for responses that have at least one valid token
+        has_response = response_attention.sum(dim=1) > 0
+        # Clamp to avoid negative indexing for fully-padded responses
+        valid_response_length = valid_response_length.clamp(min=0)
 
         score_list = []
         for key in gdpo_reward_keys:
@@ -430,6 +435,8 @@ def compute_gdpo_outcome_advantage(
             rm_score = torch.tensor(np.asarray(comp, dtype=np.float32), device=device)
             rm_scores = torch.zeros_like(response_mask, dtype=torch.float32)
             rm_scores[torch.arange(rm_scores.size(0), device=device), valid_response_length] = rm_score
+            # Zero out scores for fully-padded responses to avoid misplaced rewards
+            rm_scores[~has_response] = 0.0
             score_list.append(rm_scores)
 
         gdpo_weights = config.get("gdpo_reward_weights", None)


### PR DESCRIPTION
## Problem
When a response is fully padded, `valid_response_length` becomes -1. PyTorch's negative indexing then places the reward at an incorrect position in the tensor, silently corrupting the GDPO advantage computation.

## Fix
Add a guard to skip reward placement when `valid_response_length <= 0`, preventing the negative index from corrupting advantage calculations.

## Testing
- Verified the fix handles the edge case correctly with CPU-based unit validation
- No impact on normal (non-fully-padded) responses