### PR TITLE
[geo_mean] Fix DP-inconsistent loss aggregation bypassing agg_loss()

### DIFF
--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1941,7 +1941,8 @@ def compute_policy_loss_geo_mean(
         response_mask (torch.Tensor):
             Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
         loss_agg_mode (str, optional):
-            not used
+            Not directly used (geo_mean operates at sequence level), but the function
+            performs DP-aware aggregation using config.global_batch_info.
     """
 
     assert config is not None
@@ -1987,7 +1988,15 @@ def compute_policy_loss_geo_mean(
         )
         pg_losses = pg_losses * seq_is_weights
 
-    pg_loss = torch.mean(pg_losses)
+    # DP-aware sequence-level aggregation (pg_losses is already per-sequence)
+    seq_mask = (response_mask.sum(dim=-1) > 0).float()
+    global_batch_size = config.global_batch_info.get("global_batch_size", None)
+    dp_size = config.global_batch_info.get("dp_size", 1)
+    if global_batch_size is None:
+        if dp_size > 1:
+            raise ValueError("global_batch_size is required when dp_size > 1 for geo_mean loss")
+        global_batch_size = seq_mask.sum()
+    pg_loss = (pg_losses * seq_mask).sum() / global_batch_size * dp_size
 
     # higher: ratio is too large that need clamp to clip_high (when adv > 0)
     clipped = torch.ne(negative_approx_kl, negative_approx_kl_clamp)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1941,8 +1941,8 @@ def compute_policy_loss_geo_mean(
         response_mask (torch.Tensor):
             Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
         loss_agg_mode (str, optional):
-            Not directly used (geo_mean operates at sequence level), but the function
-            performs DP-aware aggregation using config.global_batch_info.
+            Not directly used (geo_mean operates at sequence level); aggregation is
+            performed via agg_loss with "seq-mean-token-sum" mode.
     """
 
     assert config is not None
@@ -1988,15 +1988,15 @@ def compute_policy_loss_geo_mean(
         )
         pg_losses = pg_losses * seq_is_weights
 
-    # DP-aware sequence-level aggregation (pg_losses is already per-sequence)
-    seq_mask = (response_mask.sum(dim=-1) > 0).float()
-    global_batch_size = config.global_batch_info.get("global_batch_size", None)
-    dp_size = config.global_batch_info.get("dp_size", 1)
-    if global_batch_size is None:
-        if dp_size > 1:
-            raise ValueError("global_batch_size is required when dp_size > 1 for geo_mean loss")
-        global_batch_size = seq_mask.sum()
-    pg_loss = (pg_losses * seq_mask).sum() / global_batch_size * dp_size
+    # DP-aware sequence-level aggregation using the existing agg_loss helper.
+    # pg_losses is 1D (per-sequence), so we reshape it to 2D and use "seq-mean-token-sum"
+    # to correctly compute the sequence-level mean.
+    pg_loss = agg_loss(
+        loss_mat=pg_losses.unsqueeze(-1),
+        loss_mask=(response_mask.sum(dim=-1) > 0).float().unsqueeze(-1),
+        loss_agg_mode="seq-mean-token-sum",
+        **config.global_batch_info,
+    )
 
     # higher: ratio is too large that need clamp to clip_high (when adv > 0)
     clipped = torch.ne(negative_approx_kl, negative_approx_kl_clamp)


### PR DESCRIPTION
## Problem
In the geometric mean loss computation, `torch.mean()` is used directly instead of the `agg_loss()` helper. This bypasses the DP-aware aggregation logic, causing the effective learning rate to scale incorrectly with `dp_size` during multi-GPU training.

## Fix
Replace `torch.mean()` with the proper `agg_loss()` call to ensure consistent loss scaling across data-parallel ranks.

## Testing
- CPU validation confirms the fix uses the correct aggregation path
- No impact on single-GPU training