### PR TITLE
[algo] fix: fix loss scale factor in fsdp when use token-mean mode

### DIFF
--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -55,11 +55,20 @@ class DataParallelPPOActor(BasePPOActor):
         actor_optimizer (torch.optim.Optimizer, optional): Actor optimizer. Defaults to None.
     """
 
-    def __init__(self, config: ActorConfig, actor_module: nn.Module, actor_optimizer: torch.optim.Optimizer = None):
+    def __init__(
+        self,
+        config: ActorConfig,
+        actor_module: nn.Module,
+        actor_optimizer: torch.optim.Optimizer = None,
+        dp_size: int = 1,
+        dp_group=None,
+    ):
         """When optimizer is None, it is Reference Policy"""
         super().__init__(config)
         self.actor_module = actor_module
         self.actor_optimizer = actor_optimizer
+        self.dp_size = dp_size
+        self.dp_group = dp_group
         role = "Ref" if actor_optimizer is None else "Actor"
 
         self.use_remove_padding = self.config.get("use_remove_padding", False)
@@ -465,7 +474,12 @@ class DataParallelPPOActor(BasePPOActor):
 
         if use_dynamic_bsz:
             max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
-            micro_batches, batch_idx_list = prepare_dynamic_batch(data, max_token_len=max_token_len)
+            micro_batches, batch_idx_list = prepare_dynamic_batch(
+                data,
+                max_token_len=max_token_len,
+                dp_group=self.dp_group,
+                same_micro_num_in_dp=True,
+            )
         else:
             micro_batches = data.split(micro_batch_size)
 
@@ -555,11 +569,38 @@ class DataParallelPPOActor(BasePPOActor):
         }
         for _ in range(self.config.ppo_epochs):
             for batch_idx, mini_batch in enumerate(mini_batches):
-                mini_batch_num_tokens = mini_batch.batch["response_mask"].sum().item()
+                local_num_tokens = mini_batch.batch["response_mask"].sum().to(get_device_id())
+                local_batch_size = (mini_batch.batch["response_mask"].sum(dim=-1) > 0).float().sum().to(get_device_id())
+
+                if self.dp_size > 1:
+                    global_num_tokens = local_num_tokens.clone()
+                    torch.distributed.all_reduce(
+                        global_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.dp_group
+                    )
+                    global_batch_size = local_batch_size.clone()
+                    torch.distributed.all_reduce(
+                        global_batch_size, op=torch.distributed.ReduceOp.SUM, group=self.dp_group
+                    )
+                else:
+                    global_num_tokens = local_num_tokens
+                    global_batch_size = local_batch_size
+
+                self.config.global_batch_info.update(
+                    {
+                        "dp_size": self.dp_size,
+                        "batch_num_tokens": global_num_tokens.item(),
+                        "global_batch_size": int(global_batch_size.item()),
+                    }
+                )
 
                 if self.config.use_dynamic_bsz:
                     max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
-                    micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                    micro_batches, _ = prepare_dynamic_batch(
+                        mini_batch,
+                        max_token_len=max_token_len,
+                        dp_group=self.dp_group,
+                        same_micro_num_in_dp=True,
+                    )
                 else:
                     self.gradient_accumulation = (
                         self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
@@ -580,13 +621,6 @@ class DataParallelPPOActor(BasePPOActor):
                     loss_agg_mode = self.config.loss_agg_mode
 
                     calculate_entropy = self.config.calculate_entropy or (entropy_coeff != 0)
-
-                    if loss_agg_mode == "token-mean":
-                        loss_scale_factor = response_mask.sum().item() / max(mini_batch_num_tokens, 1)
-                    elif self.config.use_dynamic_bsz:
-                        loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
-                    else:
-                        loss_scale_factor = 1 / self.gradient_accumulation
 
                     # all return: (bsz, response_length)
                     outputs = self._forward_micro_batch(
@@ -643,7 +677,12 @@ class DataParallelPPOActor(BasePPOActor):
 
                     policy_loss = pg_loss
                     if calculate_entropy and entropy is not None:
-                        entropy_agg = agg_loss(loss_mat=entropy, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                        entropy_agg = agg_loss(
+                            loss_mat=entropy,
+                            loss_mask=response_mask,
+                            loss_agg_mode=loss_agg_mode,
+                            **self.config.global_batch_info,
+                        )
                         micro_batch_metrics["actor/entropy"] = entropy_agg.detach().item()
                         if entropy_coeff != 0:
                             policy_loss -= entropy_agg * entropy_coeff
@@ -654,23 +693,24 @@ class DataParallelPPOActor(BasePPOActor):
                         kld = kl_penalty(
                             logprob=log_prob, ref_logprob=ref_log_prob, kl_penalty=self.config.kl_loss_type
                         )
-                        kl_loss = agg_loss(loss_mat=kld, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+                        kl_loss = agg_loss(
+                            loss_mat=kld,
+                            loss_mask=response_mask,
+                            loss_agg_mode=loss_agg_mode,
+                            **self.config.global_batch_info,
+                        )
 
                         policy_loss = policy_loss + kl_loss * self.config.kl_loss_coef
-                        metrics["actor/kl_loss"] += kl_loss.detach().item() * loss_scale_factor
+                        metrics["actor/kl_loss"] += kl_loss.detach().item()
                         micro_batch_metrics["actor/kl_coef"] = self.config.kl_loss_coef
 
-                    if self.config.use_dynamic_bsz:
-                        # relative to the dynamic bsz
-                        loss = policy_loss * loss_scale_factor
-                    else:
-                        loss = policy_loss * loss_scale_factor
+                    loss = policy_loss
                     if self.scaler is not None:
                         self.scaler.scale(loss).backward()
                     else:
                         loss.backward()
 
-                    metrics["actor/pg_loss"] += pg_loss.detach().item() * loss_scale_factor
+                    metrics["actor/pg_loss"] += pg_loss.detach().item()
                     append_to_dict(metrics, micro_batch_metrics)
 
                 grad_norm = self._optimizer_step()

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -920,8 +920,18 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         if self._is_actor:
             actor_cfg = omega_conf_to_dataclass(self.config.actor)
+            if self.ulysses_device_mesh is not None:
+                actor_dp_size = self.ulysses_device_mesh["dp"].size()
+                actor_dp_group = self.ulysses_device_mesh["dp"].get_group()
+            else:
+                actor_dp_size = torch.distributed.get_world_size()
+                actor_dp_group = torch.distributed.group.WORLD
             self.actor = DataParallelPPOActor(
-                config=actor_cfg, actor_module=self.actor_module_fsdp, actor_optimizer=self.actor_optimizer
+                config=actor_cfg,
+                actor_module=self.actor_module_fsdp,
+                actor_optimizer=self.actor_optimizer,
+                dp_size=actor_dp_size,
+                dp_group=actor_dp_group,
             )
 
         if self._is_rollout:


### PR DESCRIPTION
### What does this PR do?

The problem is illustrated in https://github.com/verl-project/verl/issues/5625.

This PR fixes it. 

Use the new engine's loss calculation method (`verl/workers/engine/fsdp/transformer_impl.py`). Before updating each mini-batch, use allreduce to get the global batch size and token count, and then place them into `confg.global_batch_info` (similar to the new engine). This makes the `loss_scale_factor` unnecessary (since the scaling in agg_loss already considers the global context).



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### Design & Code Changes


1. Modified `DataParallelPPOActor.update_policy()`: before calculating each mini-batch, use all_reduce to obtain the global batch size and token count, and place them into `confg.global_batch_info`.
```python
            for batch_idx, mini_batch in enumerate(mini_batches):
                local_num_tokens = mini_batch.batch["response_mask"].sum().to(get_device_id())
                local_batch_size = (mini_batch.batch["response_mask"].sum(dim=-1) > 0).float().sum().to(get_device_id())

                if self.dp_size > 1:
                    global_num_tokens = local_num_tokens.clone()
                    torch.distributed.all_reduce(
                        global_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.dp_group
                    )
                    global_batch_size = local_batch_size.clone()
                    torch.distributed.all_reduce(
                        global_batch_size, op=torch.distributed.ReduceOp.SUM, group=self.dp_group
                    )
                else:
                    global_num_tokens = local_num_tokens
                    global_batch_size = local_batch_size

                self.config.global_batch_info.update(
                    {
                        "dp_size": self.dp_size,
                        "batch_num_tokens": global_num_tokens.item(),
                        "global_batch_size": int(global_batch_size.item()),
                    }
                )
```

2. Removed `loss_scale_factor` from `DataParallelPPOActor.update_policy()` as it is no longer needed.
3. Modified the `prepare_dynamic_batch` parameters, setting `same_micro_num_in_dp=True`. If the number of micro-batches differs, it can lead to inconsistent communication order across ranks.
```python
                    micro_batches, _ = prepare_dynamic_batch(
                        mini_batch,
                        max_token_len=max_token_len,
                        dp_group=self.dp_group,
                        same_micro_num_in_dp=True,
                    )
```
4. Modified `DataParallelPPOActor.__init__` to pass dp_group and dp_size related parameters.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
