### PR TITLE
[perf, trainer, training_utils, ray, worker] fix: Add set_numa_affinity() for engine workers: TrainingWorker.

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -34,7 +34,7 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_device_name, set_expandable_segments
-from verl.utils.distributed import initialize_global_process_group_ray
+from verl.utils.distributed import initialize_global_process_group_ray, set_numa_affinity
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.memory_utils import aggressive_empty_cache
 from verl.utils.metric.utils import Metric
@@ -78,6 +78,8 @@ class TrainingWorker(Worker, DistProfilerExtension):
         from verl.workers.engine import BaseEngine, EngineRegistry
 
         initialize_global_process_group_ray(timeout_second=None)
+
+        set_numa_affinity()
 
         self.config = config
         self.model_config = self.config.model_config


### PR DESCRIPTION
### What does this PR do?

Add `set_numa_affinity()` for engine workers: `TrainingWorker`.
- We find a consistent performance gap of `sft_trainer.py` vs `sft_trainer_ray.py` on SFT jobs on AWS `p5` instances, and this PR **reduces** the gap though still **not** fully resolved

**Before PR**:
- Gap is `0.2292 ==> 0.2064 (-9.95%)`
```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-ray-08-????-j*/events*' --metric train/mfu --format 10.4f
2026-03-16 21:45:48,423 [tb.py:206] WARNING - Unknonw metric `train/mfu`!
2026-03-16 21:45:48,467 [tb.py:235] INFO - Set benchmark with index 0
2026-03-16 21:45:48,468 [tb.py:264] INFO - [243/256] ../sft_ray_config_pbtxt-ce3b5040--101684-run-ray-08-base-j-01-seq04k-ns01-sp01-bs01-pad1-spmd--20260316.125636/events.out.tfevents.1773691117.ip-10-4-145-27.4009372.0: (avg (std), med) = (    0.2292 (    0.0052),     0.2301)  # train/mfu
2026-03-16 21:45:48,512 [tb.py:264] INFO - [243/256] ../sft_ray_config_pbtxt-ce3b5040--101685-run-ray-08-base-j-02-seq04k-ns01-sp01-bs01-pad1-ray--20260316.125641/events.out.tfevents.1773691587.ip-10-4-145-27.4013100.0: (avg (std), med) = (    0.2064 (    0.0229),     0.2122)  # train/mfu
```

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+numa
    * #3471 adds the util function for `Megatron`
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

**After PR**

#### 1. `train/mfu`

Metric `train/mfu` improvement, dropping first `10` steps and last `3` steps:

1. `avg`: `0.2064 ==> 0.2189 (+6.1%)`
2. `std`: `0.0229 ==> 0.0081 (-64.6%)` or improvement of `2.8x`

```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-ray-0[89]*ray*/events*' --metric train/mfu --format 10.4f
2026-03-16 21:38:17,874 [tb.py:206] WARNING - Unknonw metric `train/mfu`!
2026-03-16 21:38:17,921 [tb.py:235] INFO - Set benchmark with index 0
2026-03-16 21:38:17,921 [tb.py:264] INFO - [243/256] ../sft_ray_config_pbtxt-ce3b5040--101685-run-ray-08-base-j-02-seq04k-ns01-sp01-bs01-pad1-ray--20260316.125641/events.out.tfevents.1773691587.ip-10-4-145-27.4013100.0: (avg (std), med) = (    0.2064 (    0.0229),     0.2122)  # train/mfu
2026-03-16 21:38:17,965 [tb.py:264] INFO - [243/256] ../sft_ray_config_pbtxt-ce3b5040--101705-run-ray-09-numa-j-02-seq04k-ns01-sp01-bs01-pad1-ray--20260316.141110/events.out.tfevents.1773696080.ip-10-4-145-27.18170.0: (avg (std), med) = (    0.2189 (    0.0081),     0.2204)  # train/mfu
```

#### 2. All Metrics

```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-ray-0[89]*ray*/events*' --metric '*' --format 10.4f
2026-03-16 21:38:26,932 [tb.py:206] WARNING - Unknonw metric `*`!
2026-03-16 21:38:26,932 [tb.py:216] INFO - 

[00/02] File ../sft_ray_config_pbtxt-ce3b5040--101685-run-ray-08-base-j-02-seq04k-ns01-sp01-bs01-pad1-ray--20260316.125641/events.out.tfevents.1773691587.ip-10-4-145-27.4013100.0:
2026-03-16 21:38:26,978 [tb.py:235] INFO - Set benchmark with index 0
2026-03-16 21:38:26,979 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-16 21:38:26,979 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2974 [     0.0000] (    0.1332),     0.2682)  # train/grad_norm
2026-03-16 21:38:26,979 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0199 [     0.0000] (    0.0047),     0.0200)  # train/loss
2026-03-16 21:38:26,980 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-16 21:38:26,980 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2064 [     0.0000] (    0.0229),     0.2122)  # train/mfu
2026-03-16 21:38:26,980 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-16 21:38:26,980 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
2026-03-16 21:38:26,980 [tb.py:216] INFO - 

[01/02] File ../sft_ray_config_pbtxt-ce3b5040--101705-run-ray-09-numa-j-02-seq04k-ns01-sp01-bs01-pad1-ray--20260316.141110/events.out.tfevents.1773696080.ip-10-4-145-27.18170.0:
2026-03-16 21:38:27,023 [tb.py:264] INFO - [243/256] : (avg (std), med) = (32768.0000 [     0.0000] (    0.0000), 32768.0000)  # train/global_tokens
2026-03-16 21:38:27,024 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.8776 [+    0.5802] (    9.1371),     0.2680)  # train/grad_norm
2026-03-16 21:38:27,024 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0199 [+    0.0000] (    0.0046),     0.0201)  # train/loss
2026-03-16 21:38:27,024 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # train/lr
2026-03-16 21:38:27,024 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.2189 [+    0.0125] (    0.0081),     0.2204)  # train/mfu
2026-03-16 21:38:27,024 [tb.py:264] INFO - [243/256] : (avg (std), med) = (    0.0043 [     0.0000] (    0.0023),     0.0043)  # train/total_tokens(B)
2026-03-16 21:38:27,024 [tb.py:264] INFO - [00/01] : (avg (std), med) = (    0.0000 [     0.0000] (    0.0000),     0.0000)  # val/loss
```

### API and Usage Example

N.A.

### Design & Code Changes

Similar to #3471 

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
