### PR TITLE
[reward] fix: disable signal.alarm() in math_verify to fix silent scoring failure in Ray workers

### DIFF
--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -23,9 +23,10 @@ _GOLD_TARGETS = (LatexExtractionConfig(),)
 _PRED_TARGETS = (ExprExtractionConfig(), LatexExtractionConfig())
 
 
-def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0) -> bool:
+def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0) -> float:
     ret_score = 0.0
 
+    # Wrap the ground truth in \boxed{} format for verification
     ground_truth_boxed = "\\boxed{" + ground_truth + "}"
     try:
         # Use parsing_timeout=None and timeout_seconds=None to disable


### PR DESCRIPTION
math_verify's math_metric() wrapper internally calls signal.alarm() for timeouts. signal.alarm() only works in
the main thread, so when veRL's Ray-based reward workers call compute_score() from a non-main thread, it raises
ValueError. This exception is silently caught by the broad `except Exception` handler, causing all MATH scores
to return 0.

Replace math_metric() with direct calls to parse() and verify() using parsing_timeout=None and
timeout_seconds=None to bypass signal-based timeouts entirely. The reward function's own timeout (default 300s
in Ray) still provides protection against runaway computations.

Also fix except clause ordering: TimeoutException (a subclass of Exception) was unreachable after the bare
`except Exception` handler.

### What does this PR do?

Fixes `math_verify` reward scoring silently returning 0 for all MATH problems when running in Ray-based reward
workers. The root cause is `signal.alarm()` (used internally by `math_metric()`) which only works in the main
thread — Ray workers run in non-main threads, causing a `ValueError` that gets swallowed by `except Exception:
pass`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/volcengine/verl/pulls?q=is%3Apr+math_verify+signal
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated on Qwen3-8B GRPO training with GSM8K + MATH datasets on 4x B300:

- **Before fix**: MATH training rewards = 0 for all samples. MATH L1-2 eval accuracy came only from GSM8K
generalization.
- **After fix**: MATH training rewards correctly computed (mean reward 0.448 at step 1). MATH L1-2 baseline
accuracy = 75.4%.

Bug reproduces whenever `math_verify`-based reward scoring runs in Ray workers (non-main thread).

### API and Usage Example

No API changes — same `compute_score(model_output, ground_truth)` signature.

### Design & Code Changes

1. Replace `math_metric()` wrapper with direct `parse()` + `verify()` calls
2. Pass `parsing_timeout=None` and `timeout_seconds=None` to skip `signal.alarm()`
3. Move `except TimeoutException` before `except Exception` so it's reachable
4. Hoist extraction config tuples to module-level constants (avoid re-creating per call)

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit
  checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs) — no doc changes
  needed (internal implementation fix).
- [ ] Add unit or end-to-end test(s) — bug only manifests in non-main threads (Ray workers). Validated by
  training experiment. A thread-based unit test is possible but fragile.
- [ ] Once PR is ready for CI, will send message in `ci-request` channel.