### PR TITLE
[perf, training_utils, fsdp, ray, worker] fix: Add set_numa_affinity() for the whole RL pipeline

### DIFF
--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -423,6 +423,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
     def __init__(self, config: DictConfig, role: str, **kwargs):
         Worker.__init__(self)
+        set_numa_affinity()
         self.config = config
         self.role = role
         self.actor: TrainingWorker = None

--- a/verl/workers/fsdp_workers.py
+++ b/verl/workers/fsdp_workers.py
@@ -56,6 +56,7 @@ from verl.utils.device import (
     get_torch_device,
     set_expandable_segments,
 )
+from verl.utils.distributed import set_numa_affinity
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.fs import copy_to_local
 from verl.utils.fsdp_utils import (
@@ -151,6 +152,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         self.config = config
         import torch.distributed
+
+        set_numa_affinity()
 
         if not torch.distributed.is_initialized():
             rank = int(os.environ.get("RANK", 0))
@@ -1288,6 +1291,9 @@ class CriticWorker(Worker, DistProfilerExtension):
         import torch.distributed
 
         self.config = config
+
+        set_numa_affinity()
+
         if not torch.distributed.is_initialized():
             torch.distributed.init_process_group(
                 backend=get_nccl_backend(),


### PR DESCRIPTION
### What does this PR do?

Add `set_numa_affinity()` for the whole RL pipeline, tested on AWS `p5` instances with one single node.
- On top of https://github.com/verl-project/verl/pull/5627

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+numa
   1. https://github.com/verl-project/verl/pull/3471 adds the util function for Megatron
   2. https://github.com/verl-project/verl/pull/5627 adds it for `sft_trainer_ray.py` training for `SFT` with `ray`, and the current PR extends it to `RL` 
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

1. Baseline: `102374-run-rl-base-01-j` without `numa` changes
2. After PR: `102375-run-rl-numa-01-j` with `numa` changes



#### 1. Key Metrics

1. `timing_s/step`
    - `avg`: `59.282 ==> 46.877 (-12.406s, -20.9%)`
    - `std`: `2.420 ==> 1.103 (-54.4%)` or improvement of `2.2x`
2. `timing_s/update_weights`: This is where **most** the gain (reduction in `timing_s/step`, `99.9% = 12.397 / 12.406`) from
    - `avg`: `45.314 ==> 32.917 (-12.397s, -27.4%)`
    - `std`: `2.132 ==> 0.410 (-80.8%)` or improvement of `5.2x`
3. `timing_s/update_actor`
    - `avg`: `2.159 ==> 2.092 (-3.1%)`
    - `std`: `0.139 ==> 0.057 (-59.0%)` or improvement of `2.4x`

```
[01/02] File ../verl_config_pbtxt-622e8539--102375-run-rl-numa-01-j-01-ns01-tp01-bs16-pad0--20260317.120642/events.out.tfevents.1773778668.ip-10-4-145-27.1209001.0:
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.064 [+  0.001] (  0.002),   0.064)  # perf/mfu/actor
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # perf/mfu/actor_infer
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.078 [+  0.001] (  0.002),   0.078)  # perf/mfu/critic
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.224 [+  0.003] (  0.026),   0.216)  # timing_per_token_ms/gen
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.042 [-  0.001] (  0.001),   0.041)  # timing_per_token_ms/update_actor
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.034 [-  0.001] (  0.001),   0.034)  # timing_per_token_ms/update_critic
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.815 [+  0.262] (  0.971),   3.570)  # timing_s/agent_loop/generate_sequences/max
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.564 [+  0.002] (  0.041),   1.566)  # timing_s/agent_loop/generate_sequences/mean
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.676 [-  0.003] (  0.090),   0.686)  # timing_s/agent_loop/generate_sequences/min
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.815 [+  0.262] (  0.971),   3.570)  # timing_s/agent_loop/slowest/generate_sequences
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  8.255 [+  0.119] (  0.973),   7.966)  # timing_s/gen
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 46.877 [- 12.406] (  1.103),  46.729)  # timing_s/step
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.092 [-  0.066] (  0.057),   2.073)  # timing_s/update_actor
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.720 [-  0.028] (  0.016),   1.718)  # timing_s/update_critic
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 32.917 [- 12.397] (  0.410),  33.017)  # timing_s/update_weights
```


#### 2. All Metrics

```
+ python /fsx/ubuntu/users/sliuxl/tb.py --files '../*run-rl-????-01-j*/events*' --metric '*' --cutoff 0
2026-03-17 22:10:05,747 [tb.py:206] WARNING - Unknonw metric `*`!
2026-03-17 22:10:05,748 [tb.py:216] INFO - 

[00/02] File ../verl_config_pbtxt-622e8539--102374-run-rl-base-01-j-01-ns01-tp01-bs16-pad0--20260317.120605/events.out.tfevents.1773774744.ip-10-4-145-27.1099921.0:
2026-03-17 22:10:05,902 [tb.py:235] INFO - Set benchmark with index 0
2026-03-17 22:10:05,903 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.315 [   0.000] (  0.014),   0.314)  # actor/entropy
2026-03-17 22:10:05,903 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.102 [   0.000] (  0.014),   0.097)  # actor/grad_norm
2026-03-17 22:10:05,903 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/kl_loss
2026-03-17 22:10:05,903 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/lr
2026-03-17 22:10:05,903 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/pg_clipfrac
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/pg_clipfrac_lower
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.001),   0.000)  # actor/pg_loss
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/ppo_kl
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  4.868 [   0.000] (  0.484),   4.875)  # critic/advantages/max
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/advantages/mean
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -5.222 [   0.000] (  1.004),  -4.955)  # critic/advantages/min
2026-03-17 22:10:05,904 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 47.775 [   0.000] ( 48.364),  26.152)  # critic/grad_norm
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/lr
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/returns/max
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.550 [   0.000] (  0.036),   0.548)  # critic/returns/mean
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -0.000 [   0.000] (  0.000),   0.000)  # critic/returns/min
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/rewards/max
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.590 [   0.000] (  0.036),   0.586)  # critic/rewards/mean
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/rewards/min
2026-03-17 22:10:05,905 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/score/max
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.590 [   0.000] (  0.036),   0.586)  # critic/score/mean
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/score/min
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  8.458 [   0.000] (  1.858),   8.188)  # critic/values/max
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.895 [   0.000] (  0.529),   0.656)  # critic/values/mean
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -6.561 [   0.000] (  2.024),  -7.219)  # critic/values/min
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/vf_clipfrac
2026-03-17 22:10:05,906 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -9.220 [   0.000] (  4.708),  -8.853)  # critic/vf_explained_var
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.463 [   0.000] (  0.899),   1.211)  # critic/vf_loss
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.896 [   0.000] (  0.530),   0.655)  # critic/vpred_mean
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6296.133 [   0.000] (195.412), 6294.000)  # global_seqlen/balanced_max
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6254.000 [   0.000] (173.395), 6268.000)  # global_seqlen/balanced_min
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6884.311 [   0.000] (389.114), 6825.000)  # global_seqlen/max
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6263.539 [   0.000] (174.383), 6273.750)  # global_seqlen/mean
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (5663.578 [   0.000] (264.189), 5684.000)  # global_seqlen/min
2026-03-17 22:10:05,907 [tb.py:264] INFO - [45/58] : (avg (std), med) = (1220.733 [   0.000] (446.603), 1098.000)  # global_seqlen/minmax_diff
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/max
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/mean
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/min
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = (264.000 [   0.000] (  0.784), 263.811)  # perf/cpu_memory_used_gb
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 26.503 [   0.000] (  0.000),  26.503)  # perf/max_memory_allocated_gb
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 26.865 [   0.000] (  0.000),  26.865)  # perf/max_memory_reserved_gb
2026-03-17 22:10:05,908 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.062 [   0.000] (  0.002),   0.062)  # perf/mfu/actor
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # perf/mfu/actor_infer
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.076 [   0.000] (  0.003),   0.076)  # perf/mfu/critic
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (105.786 [   0.000] (  4.231), 105.742)  # perf/throughput
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 59.282 [   0.000] (  2.420),  58.871)  # perf/time_per_step
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (50108.311 [   0.000] (1395.068), 50190.000)  # perf/total_num_tokens
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # prompt_length/clip_ratio
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (184.022 [   0.000] ( 18.081), 181.000)  # prompt_length/max
2026-03-17 22:10:05,909 [tb.py:264] INFO - [45/58] : (avg (std), med) = (103.503 [   0.000] (  2.018), 103.633)  # prompt_length/mean
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 68.422 [   0.000] (  3.370),  69.000)  # prompt_length/min
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response/aborted_ratio
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response_length/clip_ratio
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (675.178 [   0.000] (137.678), 637.000)  # response_length/max
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (287.968 [   0.000] (  9.989), 287.859)  # response_length/mean
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (113.356 [   0.000] ( 16.885), 116.000)  # response_length/min
2026-03-17 22:10:05,910 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response_length_non_aborted/clip_ratio
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (675.178 [   0.000] (137.678), 637.000)  # response_length_non_aborted/max
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (287.968 [   0.000] (  9.989), 287.859)  # response_length_non_aborted/mean
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (113.356 [   0.000] ( 16.885), 116.000)  # response_length_non_aborted/min
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.003 [   0.000] (  0.000),   0.003)  # timing_per_token_ms/adv
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.221 [   0.000] (  0.020),   0.215)  # timing_per_token_ms/gen
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.043 [   0.000] (  0.003),   0.043)  # timing_per_token_ms/update_actor
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.035 [   0.000] (  0.001),   0.035)  # timing_per_token_ms/update_critic
2026-03-17 22:10:05,911 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.012 [   0.000] (  0.000),   0.012)  # timing_per_token_ms/values
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.151 [   0.000] (  0.010),   0.150)  # timing_s/adv
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.553 [   0.000] (  0.733),   3.368)  # timing_s/agent_loop/generate_sequences/max
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.562 [   0.000] (  0.052),   1.558)  # timing_s/agent_loop/generate_sequences/mean
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.678 [   0.000] (  0.086),   0.695)  # timing_s/agent_loop/generate_sequences/min
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/max
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/mean
2026-03-17 22:10:05,912 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/min
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.553 [   0.000] (  0.733),   3.368)  # timing_s/agent_loop/slowest/generate_sequences
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/slowest/num_preempted
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (122.733 [   0.000] ( 26.920), 115.000)  # timing_s/agent_loop/slowest/prompt_length
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (674.889 [   0.000] (138.000), 637.000)  # timing_s/agent_loop/slowest/response_length
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/slowest/tool_calls
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/max
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/mean
2026-03-17 22:10:05,913 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/min
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  8.136 [   0.000] (  0.807),   7.906)  # timing_s/gen
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.153 [   0.000] (  0.024),   1.152)  # timing_s/old_log_prob
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/reward
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/start_profile
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 59.282 [   0.000] (  2.420),  58.871)  # timing_s/step
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/stop_profile
2026-03-17 22:10:05,914 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/testing
2026-03-17 22:10:05,914 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.159 [   0.000] (  0.139),   2.119)  # timing_s/update_actor
2026-03-17 22:10:05,915 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.747 [   0.000] (  0.027),   1.739)  # timing_s/update_critic
2026-03-17 22:10:05,915 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 45.314 [   0.000] (  2.132),  44.978)  # timing_s/update_weights
2026-03-17 22:10:05,915 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.606 [   0.000] (  0.012),   0.604)  # timing_s/values
2026-03-17 22:10:05,915 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # training/epoch
2026-03-17 22:10:05,915 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 33.000 [   0.000] ( 12.987),  33.000)  # training/global_step
2026-03-17 22:10:05,915 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/max
2026-03-17 22:10:05,915 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/mean
2026-03-17 22:10:05,915 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/min
2026-03-17 22:10:05,915 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/openai/gsm8k/reward/mean@1
2026-03-17 22:10:05,915 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-core/openai/gsm8k/acc/mean@1
2026-03-17 22:10:05,915 [tb.py:216] INFO - 

[01/02] File ../verl_config_pbtxt-622e8539--102375-run-rl-numa-01-j-01-ns01-tp01-bs16-pad0--20260317.120642/events.out.tfevents.1773778668.ip-10-4-145-27.1209001.0:
2026-03-17 22:10:06,067 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.313 [-  0.002] (  0.013),   0.313)  # actor/entropy
2026-03-17 22:10:06,067 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.093 [-  0.009] (  0.012),   0.089)  # actor/grad_norm
2026-03-17 22:10:06,067 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/kl_loss
2026-03-17 22:10:06,067 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/lr
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/pg_clipfrac
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/pg_clipfrac_lower
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -0.000 [-  0.000] (  0.001),  -0.000)  # actor/pg_loss
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # actor/ppo_kl
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  4.813 [-  0.055] (  0.566),   4.610)  # critic/advantages/max
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [-  0.000] (  0.000),  -0.000)  # critic/advantages/mean
2026-03-17 22:10:06,068 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -5.060 [+  0.161] (  0.677),  -5.252)  # critic/advantages/min
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 35.996 [- 11.779] ( 23.521),  28.220)  # critic/grad_norm
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/lr
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/returns/max
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.558 [+  0.008] (  0.049),   0.558)  # critic/returns/mean
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -0.000 [   0.000] (  0.000),   0.000)  # critic/returns/min
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/rewards/max
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.593 [+  0.003] (  0.047),   0.602)  # critic/rewards/mean
2026-03-17 22:10:06,069 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/rewards/min
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.000 [   0.000] (  0.000),   1.000)  # critic/score/max
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.593 [+  0.003] (  0.047),   0.602)  # critic/score/mean
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/score/min
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  7.823 [-  0.635] (  1.198),   7.844)  # critic/values/max
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.546 [-  0.350] (  0.158),   0.535)  # critic/values/mean
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -6.472 [+  0.089] (  1.741),  -6.250)  # critic/values/min
2026-03-17 22:10:06,070 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # critic/vf_clipfrac
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -8.943 [+  0.277] (  5.105),  -7.124)  # critic/vf_explained_var
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.229 [-  0.234] (  0.636),   1.016)  # critic/vf_loss
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.546 [-  0.350] (  0.158),   0.534)  # critic/vpred_mean
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6330.356 [+ 34.222] (202.791), 6331.000)  # global_seqlen/balanced_max
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6259.067 [+  5.067] (154.587), 6277.000)  # global_seqlen/balanced_min
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6952.444 [+ 68.133] (350.426), 6854.000)  # global_seqlen/max
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (6271.689 [+  8.150] (152.935), 6288.750)  # global_seqlen/mean
2026-03-17 22:10:06,071 [tb.py:264] INFO - [45/58] : (avg (std), med) = (5646.444 [- 17.133] (229.971), 5649.000)  # global_seqlen/min
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (1306.000 [+ 85.267] (449.761), 1171.000)  # global_seqlen/minmax_diff
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/max
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/mean
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.000 [   0.000] (  0.000),   2.000)  # num_turns/min
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (264.026 [+  0.026] (  0.839), 263.913)  # perf/cpu_memory_used_gb
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 26.503 [   0.000] (  0.000),  26.503)  # perf/max_memory_allocated_gb
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 26.865 [   0.000] (  0.000),  26.865)  # perf/max_memory_reserved_gb
2026-03-17 22:10:06,072 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.064 [+  0.001] (  0.002),   0.064)  # perf/mfu/actor
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # perf/mfu/actor_infer
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.078 [+  0.001] (  0.002),   0.078)  # perf/mfu/critic
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (133.850 [+ 28.064] (  4.065), 134.410)  # perf/throughput
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 46.877 [- 12.406] (  1.103),  46.729)  # perf/time_per_step
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (50173.511 [+ 65.200] (1223.480), 50310.000)  # perf/total_num_tokens
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # prompt_length/clip_ratio
2026-03-17 22:10:06,073 [tb.py:264] INFO - [45/58] : (avg (std), med) = (184.022 [   0.000] ( 18.081), 181.000)  # prompt_length/max
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (103.503 [   0.000] (  2.018), 103.633)  # prompt_length/mean
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 68.422 [   0.000] (  3.370),  69.000)  # prompt_length/min
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response/aborted_ratio
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response_length/clip_ratio
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (723.889 [+ 48.711] (184.377), 680.000)  # response_length/max
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (288.478 [+  0.509] (  8.344), 289.672)  # response_length/mean
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (112.244 [-  1.111] ( 17.298), 113.000)  # response_length/min
2026-03-17 22:10:06,074 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # response_length_non_aborted/clip_ratio
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (723.889 [+ 48.711] (184.377), 680.000)  # response_length_non_aborted/max
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (288.478 [+  0.509] (  8.344), 289.672)  # response_length_non_aborted/mean
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (112.244 [-  1.111] ( 17.298), 113.000)  # response_length_non_aborted/min
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.003 [-  0.000] (  0.000),   0.003)  # timing_per_token_ms/adv
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.224 [+  0.003] (  0.026),   0.216)  # timing_per_token_ms/gen
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.042 [-  0.001] (  0.001),   0.041)  # timing_per_token_ms/update_actor
2026-03-17 22:10:06,075 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.034 [-  0.001] (  0.001),   0.034)  # timing_per_token_ms/update_critic
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.012 [-  0.000] (  0.000),   0.012)  # timing_per_token_ms/values
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.150 [-  0.001] (  0.016),   0.146)  # timing_s/adv
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.815 [+  0.262] (  0.971),   3.570)  # timing_s/agent_loop/generate_sequences/max
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.564 [+  0.002] (  0.041),   1.566)  # timing_s/agent_loop/generate_sequences/mean
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.676 [-  0.003] (  0.090),   0.686)  # timing_s/agent_loop/generate_sequences/min
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/max
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/mean
2026-03-17 22:10:06,076 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/num_preempted/min
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  3.815 [+  0.262] (  0.971),   3.570)  # timing_s/agent_loop/slowest/generate_sequences
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( -1.000 [   0.000] (  0.000),  -1.000)  # timing_s/agent_loop/slowest/num_preempted
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (125.644 [+  2.911] ( 26.593), 121.000)  # timing_s/agent_loop/slowest/prompt_length
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (723.889 [+ 49.000] (184.377), 680.000)  # timing_s/agent_loop/slowest/response_length
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/slowest/tool_calls
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/max
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/mean
2026-03-17 22:10:06,077 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/agent_loop/tool_calls/min
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  8.255 [+  0.119] (  0.973),   7.966)  # timing_s/gen
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.132 [-  0.021] (  0.022),   1.130)  # timing_s/old_log_prob
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [+  0.000] (  0.000),   0.000)  # timing_s/reward
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [-  0.000] (  0.000),   0.000)  # timing_s/start_profile
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 46.877 [- 12.406] (  1.103),  46.729)  # timing_s/step
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [-  0.000] (  0.000),   0.000)  # timing_s/stop_profile
2026-03-17 22:10:06,078 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # timing_s/testing
2026-03-17 22:10:06,078 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  2.092 [-  0.066] (  0.057),   2.073)  # timing_s/update_actor
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  1.720 [-  0.028] (  0.016),   1.718)  # timing_s/update_critic
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 32.917 [- 12.397] (  0.410),  33.017)  # timing_s/update_weights
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.593 [-  0.012] (  0.017),   0.589)  # timing_s/values
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # training/epoch
2026-03-17 22:10:06,079 [tb.py:264] INFO - [45/58] : (avg (std), med) = ( 33.000 [   0.000] ( 12.987),  33.000)  # training/global_step
2026-03-17 22:10:06,079 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/max
2026-03-17 22:10:06,079 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/mean
2026-03-17 22:10:06,079 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/num_turns/min
2026-03-17 22:10:06,079 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-aux/openai/gsm8k/reward/mean@1
2026-03-17 22:10:06,079 [tb.py:264] INFO - [00/06] : (avg (std), med) = (  0.000 [   0.000] (  0.000),   0.000)  # val-core/openai/gsm8k/acc/mean@1
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

N.A.


### Design & Code Changes

Same to:
1. #3471 and
5. #5627 

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
