### PR TITLE
[vllm] fix: npu disable flash_attn for RotaryEmbedding

### DIFF
--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -177,14 +177,15 @@ def patch_vllm013_rotary_emb():
 
 
 if is_torch_npu_available(check_device=False):
+    import vllm
+    from packaging import version
     _VLLM_VERSION = version.parse(vllm.__version__)
     if _VLLM_VERSION >= version.parse("0.13.0"):
         # Disable flash_attn in RotaryEmbedding (NPU) when VLLM >= 0.13
         patch_vllm013_rotary_emb()
+
     VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2 = bool(int(os.getenv("VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2", "1")))
     if VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2:
-        import vllm
-        from packaging import version
         # only support vllm 0.13 and 0.11 now.
         if _VLLM_VERSION >= version.parse("0.13.0"):
             from vllm_ascend import ascend_forward_context


### PR DESCRIPTION
### Summary
bugfix: Incorrectly imported flash_attn in RotaryEmbed when using vLLM > 0.13 on NPU

### Quenstion

When running on NPU with the vllm_ascend backend, a ModuleNotFoundError: No module named 'flash_attn.ops'; 'flash_attn' is not a package occurs.
This is because the mindspeed and megatron backends introduce flash_attn as a dummy module from mindspeed_dummy.py.However, the vllm_ascend backend does not depend on or use flash_attn, especially the apply_rotary_emb_flash_attn function in the ApplyRotaryEmb class.
This fix skips the invalid flash_attn import path for NPU + vLLM > 0.13 and avoids loading unused flash-attention related code.

### Fix
In the vllm_async_server function, add checks for both VLLM version ≥ 0.13 and NPU availability.When both conditions are satisfied, patch the __init__ method of RotaryEmbed to prevent incorrect import of flash_attn.