### PR TITLE
[training_utils] feat: use flash_attn cross_entropy loss in FusedLinearForPPO

### DIFF
--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -15,7 +15,13 @@
 from typing import Optional
 
 import torch
-from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
+
+try:
+    from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
+
+    _FLASH_ATTN_CROSS_ENTROPY_AVAILABLE = True
+except ImportError:
+    _FLASH_ATTN_CROSS_ENTROPY_AVAILABLE = False
 
 
 def _fused_linear_for_ppo_fwd(
@@ -31,12 +37,14 @@ def _fused_linear_for_ppo_fwd(
     probs = logits.softmax(dim=-1)
     entropy = torch.logsumexp(logits, dim=-1) - torch.sum(probs * logits, dim=-1)
 
-    # Reference:
-    # log_probs = logits.log_softmax(dim=-1) # [N, V]
-    # token_log_probs = log_probs.gather(-1, input_ids.unsqueeze(-1)).squeeze(-1) # [N]
-    # log_probs are fp32 here because of fp32 logits
-    per_token_entropy_loss = cross_entropy_loss(logits, input_ids)[0]
-    token_log_probs = -per_token_entropy_loss
+    if _FLASH_ATTN_CROSS_ENTROPY_AVAILABLE:
+        per_token_entropy_loss = cross_entropy_loss(logits, input_ids)[0]
+        token_log_probs = -per_token_entropy_loss
+    else:
+        # Fallback to original PyTorch implementation
+        log_probs = logits.log_softmax(dim=-1)
+        token_log_probs = log_probs.gather(-1, input_ids.unsqueeze(-1)).squeeze(-1)
+
     assert token_log_probs.dtype == torch.float32
     return token_log_probs, entropy.to(orig_dtype)
 


### PR DESCRIPTION
### What does this PR do?

Replace manual `log_softmax` + `gather` with flash_attn's triton `cross_entropy_loss` in `FusedLinearForPPO` for better performance. Also keeps `log_probs` in fp32 instead of downcasting, preserving numerical precision.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+cross_entropy+FusedLinearForPPO
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated by comparing `token_log_probs` and `entropy` outputs against the original implementation — results match within fp32 tolerance.

### API and Usage Example

No API changes. `FusedLinearForPPO` usage remains the same.

### Design & Code Changes

- Import `cross_entropy_loss` from `flash_attn.ops.triton.cross_entropy`
- In `_fused_linear_for_ppo_fwd`: replace `log_softmax` + `gather` with `cross_entropy_loss` to compute `token_log_probs`
- Keep `token_log_probs` as fp32 (no longer downcast to `orig_dtype`)
- In `FusedLinearForPPOFunction.forward`: explicitly allocate `log_probs` tensor as fp32 via `torch.zeros` instead of `hidden_states.new_zeros` (which inherits bf16)

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is a performance optimization with no behavioral change — existing tests cover correctness.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).

cc @wuxibin89 @pengwu22 