### PR TITLE
[single_controller] fix: remove duplicate import of 'time' package

### DIFF
--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -16,7 +16,6 @@ the class of WorkerGroup
 """
 
 import logging
-import signal
 import threading
 import time
 from typing import Any, Callable
@@ -110,7 +109,7 @@ def check_workers_alive(workers: list, is_alive: Callable, gap_time: float = 1) 
         gap_time (float):
             Time interval between checks
     """
-    import time
+    import signal
 
     while True:
         for worker in workers:


### PR DESCRIPTION
### What does this PR do?

> This PR used to remove dupliacate import of `time` package and switch `signal` package to local lazying loading mode for better performance in `verl/single_controller/base/worker_group.py`.

#### 1. Fix the duplicate import of `time` package

I found that the `time` package was imported twice in line 24 and line 113. 

**The first time import:** 

<img width="715" height="201" alt="image" src="https://github.com/user-attachments/assets/fc2552c8-6a22-44d4-964f-b82ea5058e68" />
---

**The second time import:** 

<img width="715" height="333" alt="image" src="https://github.com/user-attachments/assets/9ce4fea0-63f9-4153-bebc-6d623addeba2" />

**Where time is used** 

**The first used place is in line 120 in `check_works_alive`（a top-level function）** 

<img width="752" height="337" alt="image" src="https://github.com/user-attachments/assets/0b38c86f-5cba-41bd-b4d7-514ed4e584b5" />

**The second used place is in line 162 in `_block_until_all_workers_alive`（a member function of WorkerGroup class）** 

<img width="623" height="152" alt="image" src="https://github.com/user-attachments/assets/d51f753e-c78f-4e1c-a0b1-1829636e0263" />

#### 2. Switch the import of `signal` package to local lazying loading mode for better performance

I found that the `signal` package only used in `check_workers_alive` this function in `verl/single_controller/base/worker_group.py`.

The `time` package was previously imported locally but had redundant entries in the header. I think the local import of `time` package is for better performance.

Following this pattern, I have refactored the `signal` package to use local loading for better performance."

```
- 19 import signal
......
- 113 import time
+ 113 import signal
```