### PR TITLE
feat(tools): add local thread pool option for tool execution

### DIFF
--- a/docs/amd_tutorial/amd_vllm_page.rst
+++ b/docs/amd_tutorial/amd_vllm_page.rst
@@ -39,3 +39,33 @@ Due to potential issues with CUDA graph capture in ROCm, we've found that vLLM's
 Our investigation shows that ROCm may trigger an unexpected crash when attempting to capture large batches with CUDA graph. One workaround is to set ``actor_rollout_ref.rollout.cudagraph_capture_sizes`` to values such as ``[1, 2, 4, 8, 16, 32, 64]`` (change depending on your GPU memory size).
 
 Then, you can choose to enable CUDA graph by setting ``actor_rollout_ref.rollout.enforce_eager`` to ``False`` in your verl configuration file.
+
+
+Optimize Tool Execution Latency (Sandbox Fusion)
+--------------------------------------------------------------
+
+When using tool-calling features (e.g., Sandbox Fusion code interpreter) on AMD GPUs, you may
+observe significantly higher per-step latency compared to NVIDIA GPUs. This is because the
+default execution path uses a Ray actor-based execution pool, where Ray's pickle serialization
+and IPC communication may have different performance characteristics on ROCm.
+
+**Workaround**: Set ``use_ray_execution_pool: false`` in your tool configuration to bypass Ray
+actor overhead and use a local thread pool instead:
+
+.. code-block:: yaml
+
+    tools:
+      - class_name: "recipe.retool.retool.CustomSandboxFusionTool"
+        config:
+          sandbox_fusion_url: "http://localhost:8080/run_code"
+          num_workers: 128
+          use_ray_execution_pool: false  # Bypass Ray actor IPC, recommended for AMD
+          # ... other config ...
+
+This switches to ``asyncio.run_in_executor`` with a local semaphore for concurrency control,
+eliminating the Ray actor serialization overhead while maintaining the same functionality.
+
+.. note::
+
+   The local thread pool mode is recommended for single-node training. For multi-node setups
+   where distributed rate limiting is required, keep ``use_ray_execution_pool: true``.

--- a/docs/sglang_multiturn/sandbox_fusion.rst
+++ b/docs/sglang_multiturn/sandbox_fusion.rst
@@ -80,6 +80,34 @@ Configuration Parameters
 +----------------------------+--------------------------------------------------------------+
 | `sandbox_fusion_url`       | URL for the veFaas sandbox execution service                 |
 +----------------------------+--------------------------------------------------------------+
+| `use_ray_execution_pool`   | Use Ray actor pool for tool execution. When set to False,    |
+|                            | uses a local thread pool with asyncio instead. Default: False|
++----------------------------+--------------------------------------------------------------+
+| `memory_limit_mb`          | Memory limit (in MB) for each code execution. Default: 1024  |
++----------------------------+--------------------------------------------------------------+
+
+Execution Mode
+-----------------
+
+``SandboxFusionTool`` supports two execution modes controlled by the ``use_ray_execution_pool`` configuration:
+
+- **Ray Execution Pool** (``use_ray_execution_pool: true``): The default mode in previous versions.
+  Uses a Ray actor-based execution pool with a distributed rate limiter (``TokenBucketWorker``).
+  This mode supports distributed rate limiting across multiple nodes and is suitable for
+  multi-node training setups.
+
+- **Local Thread Pool** (``use_ray_execution_pool: false``): Uses ``asyncio.run_in_executor``
+  with a local ``threading.Semaphore`` for concurrency control. This mode bypasses Ray actor
+  IPC serialization overhead and can significantly reduce tool-call latency, especially on
+  AMD ROCm platforms where Ray's pickle serialization for GPU tensors may introduce higher
+  overhead. This mode is recommended for single-node training.
+
+.. note::
+
+   On AMD GPUs (e.g., MI300X/MI308X) with ROCm, the Ray actor-based execution pool may
+   exhibit noticeably higher latency compared to NVIDIA GPUs due to differences in IPC
+   communication patterns and the HIP compatibility layer. If you observe slow tool-call
+   performance on AMD platforms, set ``use_ray_execution_pool: false`` in your tool config.
 
 Rate Limiting Design
 -----------------------

--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 import os
 import threading
@@ -75,8 +76,9 @@ class ExecutionWorker:
 
     def execute(self, fn: Callable[..., T], *fn_args, **fn_kwargs) -> T:
         with ExitStack() as stack:
-            stack.callback(self.rate_limit_worker.release.remote)
-            ray.get(self.rate_limit_worker.acquire.remote())
+            if self.rate_limit_worker is not None:
+                stack.callback(self.rate_limit_worker.release.remote)
+                ray.get(self.rate_limit_worker.acquire.remote())
             try:
                 return fn(*fn_args, **fn_kwargs)
             except Exception as e:
@@ -136,12 +138,14 @@ class SandboxFusionTool(BaseTool):
         self.default_timeout = config.get("default_timeout", 30)
         self.default_language = config.get("default_language", "python")
         self.enable_global_rate_limit = config.get("enable_global_rate_limit", True)
+        self.use_ray_execution_pool = config.get("use_ray_execution_pool", False)
         self.execution_pool = init_execution_pool(
             num_workers=self.num_workers,
             enable_global_rate_limit=self.enable_global_rate_limit,
             rate_limit=self.rate_limit,
             mode=PoolMode.ThreadMode,
         )
+        self._thread_semaphore = threading.Semaphore(self.num_workers)
         self.sandbox_fusion_url = config.get("sandbox_fusion_url", "")
         self.memory_limit_mb = config.get("memory_limit_mb", 1024)
         if self.sandbox_fusion_url == "":
@@ -172,7 +176,18 @@ class SandboxFusionTool(BaseTool):
         if not isinstance(code, str):
             code = str(code)
 
-        result = await self.execution_pool.execute.remote(self.execute_code, instance_id, code, timeout, language)
+        if self.use_ray_execution_pool:
+            result = await self.execution_pool.execute.remote(self.execute_code, instance_id, code, timeout, language)
+        else:
+            # Bypass Ray IPC: run blocking HTTP call directly in a thread pool,
+            # using a semaphore to limit concurrency (same as num_workers).
+            self._thread_semaphore.acquire()
+            try:
+                result = await asyncio.get_running_loop().run_in_executor(
+                    None, self.execute_code, instance_id, code, timeout, language
+                )
+            finally:
+                self._thread_semaphore.release()
         # sandbox has no score or metrics, use Nones
         if isinstance(result, ToolResponse):
             return result, None, None

--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -145,7 +145,7 @@ class SandboxFusionTool(BaseTool):
             rate_limit=self.rate_limit,
             mode=PoolMode.ThreadMode,
         )
-        self._thread_semaphore = threading.Semaphore(self.num_workers)
+        self._async_semaphore = asyncio.Semaphore(self.num_workers)
         self.sandbox_fusion_url = config.get("sandbox_fusion_url", "")
         self.memory_limit_mb = config.get("memory_limit_mb", 1024)
         if self.sandbox_fusion_url == "":
@@ -179,15 +179,10 @@ class SandboxFusionTool(BaseTool):
         if self.use_ray_execution_pool:
             result = await self.execution_pool.execute.remote(self.execute_code, instance_id, code, timeout, language)
         else:
-            # Bypass Ray IPC: run blocking HTTP call directly in a thread pool,
-            # using a semaphore to limit concurrency (same as num_workers).
-            self._thread_semaphore.acquire()
-            try:
+            async with self._async_semaphore:
                 result = await asyncio.get_running_loop().run_in_executor(
                     None, self.execute_code, instance_id, code, timeout, language
                 )
-            finally:
-                self._thread_semaphore.release()
         # sandbox has no score or metrics, use Nones
         if isinstance(result, ToolResponse):
             return result, None, None


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/verl-project/verl/issues/5646

Add a `use_ray_execution_pool` config option to `SandboxFusionTool` that allows users to choose between Ray actor-based execution pool and a local thread pool for tool execution.

**Motivation**: On AMD ROCm platforms (e.g., MI300X/MI308X), Ray actor-based tool calls exhibit significantly higher latency compared to NVIDIA GPUs, due to differences in IPC communication patterns and the HIP compatibility layer. The local thread pool mode bypasses Ray actor serialization overhead using `asyncio.run_in_executor` with a local `threading.Semaphore`, which is effective for single-node training.

**Changes**:
- Add `use_ray_execution_pool` config option (default: `False`) to `SandboxFusionTool`
- Fix `ExecutionWorker.execute()` crash when `enable_global_rate_limit` is set to `False` (null check for `rate_limit_worker`)
- Add AMD platform documentation for tool execution latency optimization

**Related recipe PR**: https://github.com/verl-project/verl-recipe/pull/69

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+sandbox_fusion+thread+pool
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test 
https://github.com/verl-project/verl/issues/5646#issue-4093150942
Validated on AMD MI308X (ROCm) single-node setup:
- Local thread pool mode (`use_ray_execution_pool: false`): tool-call latency significantly reduced
- Ray execution pool mode (`use_ray_execution_pool: true`): behavior unchanged, backward compatible
- Verified on NVIDIA GPUs: no regression

### API and Usage Example

Set `use_ray_execution_pool` in tool config YAML:

```yaml
tools:
  - class_name: "recipe.retool.retool.CustomSandboxFusionTool"
    config:
      sandbox_fusion_url: "http://localhost:8080/run_code"
      num_workers: 128
      use_ray_execution_pool: false  # Use local thread pool (recommended for AMD)
      # ... other config ...
```
### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) ... If not feasible, explain why:
  The sandbox fusion tool requires a running sandbox HTTP service for testing.
  The change is a config-controlled execution path switch with no new logic.
  Existing e2e test (run_gsm8k_fsdp_sgl_multiturn_sf_tool.sh) covers the tool
  execution flow and can verify both modes by toggling use_ray_execution_pool.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule...
  The recipe submodule reference will be updated after the companion PR
  (https://github.com/verl-project/verl-recipe/pull/69) is merged.