### PR TITLE
[rollout] fix: enable FP8 quantization for SGLang rollout in fully async mode.

### DIFF
--- a/verl/utils/fp8_utils.py
+++ b/verl/utils/fp8_utils.py
@@ -19,6 +19,7 @@ import os
 import torch
 
 from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
+from verl.workers.rollout.utils import ensure_async_iterator
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -82,12 +83,12 @@ class FP8QuantizerHelper:
         logger.debug(f"Skip quantization: {param_name}")
         return False
 
-    def quant_weights_by_name(self, weights, dtype=torch.bfloat16):
+    async def quant_weights_by_name(self, weights, dtype=torch.bfloat16):
         """FP8 quantization based on parameter name using a memory-efficient generator.
 
 
         Args:
-            weights: Generator or iterable of (name, tensor) pairs
+            weights: Generator, AsyncGenerator, or iterable of (name, tensor) pairs
             dtype: Data type for intermediate computation
 
         Yields:
@@ -101,7 +102,7 @@ class FP8QuantizerHelper:
         if weight_block_size is None:
             raise ValueError("weight_block_size not found in quant_config")
 
-        for k, v in weights:
+        async for k, v in ensure_async_iterator(weights):
             # Check if quantization is needed
             if not self.should_quantize_param(k):
                 yield (k, v)

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -100,7 +100,8 @@ class ServerAdapter(BaseRollout):
         device_mesh: DeviceMesh,
         replica_rank: int = -1,
     ):
-        if config.get("quantization", None) == "fp8":
+        super().__init__(config, model_config, device_mesh)
+        if self.config.get("quantization", None) == "fp8":
             import sglang
             from packaging import version
 
@@ -114,8 +115,7 @@ class ServerAdapter(BaseRollout):
                 "weight_block_size": [128, 128],
             }
             fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
-            model_config.hf_config.quantization_config = fp8_block_quant_kwargs
-        super().__init__(config, model_config, device_mesh)
+            self.model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         self._engine: AsyncHttpServerAdapter = None
 
         rank = int(os.environ["RANK"])


### PR DESCRIPTION
### What does this PR do?
This PR enables FP8 quantization for SGLang rollout in fully async mode.
1. Async weight iteration for FP8 quantization
Because `checkpoint_engine.receive_weights()` returns an async generator in standalone mode, the previous sync `for` loop over weights raised `TypeError: 'async_generator' object is not iterable`. We changed `quant_weights_by_name` to an async generator using `ensure_async_iterator(weights)` to support both sync and async inputs.
2. FP8 config setup order
The engine uses `OmegaConf.set_struct(True)`, `hf_config` is not available on the raw config before `super().__init__()` runs, so setting FP8 quantization config before init raised `ConfigAttributeError: Key 'hf_config' is not in struct`. We now set `model_config.hf_config.quantization_config` after `super().__init__()` so `model_config` is fully initialized first.




### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
