### PR TITLE
[trainer,ray] fix: avoid serializing remote-code critic config in legacy ray workers

### DIFF
--- a/tests/trainer/ppo/test_ray_trainer_critic_cfg.py
+++ b/tests/trainer/ppo/test_ray_trainer_critic_cfg.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for critic config construction in RayPPOTrainer."""
+
+from omegaconf import OmegaConf
+
+from verl.trainer.ppo import ray_trainer
+
+
+def test_build_critic_cfg_for_worker_skips_driver_dataclass_in_legacy_mode(monkeypatch):
+    config = OmegaConf.create({"critic": {"strategy": "fsdp", "model": {"path": "dummy"}}})
+    called = {"value": False}
+
+    def _fake_omega_conf_to_dataclass(_):
+        called["value"] = True
+        return {"converted": True}
+
+    monkeypatch.setattr(ray_trainer, "omega_conf_to_dataclass", _fake_omega_conf_to_dataclass)
+
+    critic_cfg = ray_trainer.build_critic_cfg_for_worker(config, use_legacy_worker_impl="auto")
+
+    assert critic_cfg is config.critic
+    assert called["value"] is False
+
+
+def test_build_critic_cfg_for_worker_keeps_dataclass_path_in_new_worker_mode(monkeypatch):
+    config = OmegaConf.create({"critic": {"strategy": "fsdp", "model": {"path": "dummy"}}})
+
+    def _fake_omega_conf_to_dataclass(_):
+        return {"converted": True}
+
+    monkeypatch.setattr(ray_trainer, "omega_conf_to_dataclass", _fake_omega_conf_to_dataclass)
+
+    critic_cfg = ray_trainer.build_critic_cfg_for_worker(config, use_legacy_worker_impl="disable")
+
+    assert critic_cfg == {"converted": True}

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -66,6 +66,18 @@ from verl.workers.config import FSDPEngineConfig
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
 
+def build_critic_cfg_for_worker(config, use_legacy_worker_impl):
+    """Build critic worker config with safe serialization behavior.
+
+    In legacy worker mode (auto/enable), keep critic config as DictConfig and let the
+    worker instantiate dataclass/HF objects locally. This avoids serializing remote-code
+    objects (e.g. modules under `transformers_modules.*`) from driver to workers.
+    """
+    if use_legacy_worker_impl in ["auto", "enable"]:
+        return config.critic
+    return omega_conf_to_dataclass(config.critic)
+
+
 def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
     """Apply KL penalty to the token-level rewards.
 
@@ -703,9 +715,7 @@ class RayPPOTrainer:
         if self.use_critic:
             resource_pool = self.resource_pool_manager.get_resource_pool(Role.Critic)
 
-            from verl.workers.config import CriticConfig
-
-            critic_cfg: CriticConfig = omega_conf_to_dataclass(self.config.critic)
+            critic_cfg = build_critic_cfg_for_worker(self.config, self.use_legacy_worker_impl)
 
             if self.use_legacy_worker_impl == "disable":
                 # convert critic_cfg into TrainingWorkerConfig


### PR DESCRIPTION
### What does this PR do?

This PR fixes a Ray actor init failure that occurs in the legacy critic worker path when `trust_remote_code=True`.

- Symptom: `ModuleNotFoundError: No module named 'transformers_modules'`
- Surface error: `ray.exceptions.ActorDiedError` during `WorkerDict.__init__()`
- Scope: Ray + legacy critic worker mode (`trainer.use_legacy_worker_impl in ["auto", "enable"]`)

Root cause is driver-side eager conversion of critic config (`omega_conf_to_dataclass(config.critic)`), which can carry remote-code dynamic module references across process boundaries.

Fix:
- Legacy mode (`auto` / `enable`): pass `DictConfig` to worker
- New mode (`disable`): keep existing dataclass conversion behavior

Closes #4482.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+ray+trust_remote_code
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+transformers_modules
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Added regression unit tests:
- `tests/trainer/ppo/test_ray_trainer_critic_cfg.py`
  - `test_build_critic_cfg_for_worker_skips_driver_dataclass_in_legacy_mode`
  - `test_build_critic_cfg_for_worker_keeps_dataclass_path_in_new_worker_mode`

Validation:
- Internal distributed environment validation succeeded (single-node and multi-process launch modes)
- Master log confirms: `2 passed` and `[DONE] Tests completed successfully.`

### API and Usage Example

No API / CLI / config-key change.

```python
# No user-facing usage change in this PR.
```

### Design & Code Changes

- `verl/trainer/ppo/ray_trainer.py`
  - Add `build_critic_cfg_for_worker(config, use_legacy_worker_impl)`
  - Use mode-specific critic config construction in `RayPPOTrainer.init_workers()`
    - legacy mode -> `DictConfig`
    - new mode -> dataclass conversion
- `tests/trainer/ppo/test_ray_trainer_critic_cfg.py`
  - Add regression coverage for both code paths

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).  
      Not required for this PR (internal config-construction timing change only, no user-facing API/behavior doc impact).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Added unit test file under `tests/trainer/ppo/`.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.  
      Not applicable (this PR is not related to `recipe`).
