### PR TITLE
 [megatron, fsdp] feat: DP workload balance for SFT

### DIFF
--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -324,7 +324,7 @@ class SFTTrainer:
 
                     global_idx = torch.tensor([j for partition in global_partition_lst for j in partition])
 
-                    data = tu.reorder_tensordict(data, global_idx)
+                    data = tu.index_select_tensor_dict(data, global_idx)
 
                 # start profile in SPMD mode
                 if global_step == self.start_profile_step:

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -345,51 +345,6 @@ def chunk_tensordict(td: TensorDict, chunks: int) -> list[TensorDict]:
     return tds
 
 
-def reorder_tensordict(data: TensorDict, index: list[int]) -> TensorDict:
-    """Reorder a TensorDict along dimension zero according to given indices.
-
-    Reorders the elements of a TensorDict based on the provided index list.
-    Handles nested tensors specially since they don't support standard
-    tensor indexing operations.
-
-    Args:
-        data: The TensorDict to reorder.
-        index: A list of integers representing the new order. Must contain
-            values from 0 to n-1 (or 1 to n), where n is len(data).
-
-    Returns:
-        A new TensorDict with elements reordered according to index.
-
-    Raises:
-        AssertionError: If the length of index does not match len(data).
-
-    Note:
-        - Nested tensors are handled specially via unbind and rebind
-        - Regular tensors use standard tensor indexing
-    """
-    assert len(index) == len(data), f"index length {len(index)} must match data length {len(data)}"
-
-    # Normalize index to 0-based if it's 1-based
-    min_idx = min(index)
-    if min_idx == 1:
-        index = [i - 1 for i in index]
-
-    # Find nested tensor keys
-    nested_tensor_keys = {key for key, value in data.items() if isinstance(value, torch.Tensor) and value.is_nested}
-
-    # Build a new TensorDict for non-nested tensors using index-based selection
-    regular_items = {k: v[index] for k, v in data.items() if k not in nested_tensor_keys}
-    output = TensorDict(regular_items, batch_size=data.batch_size, device=data.device)
-
-    # Handle nested tensors by unbinding, reordering, and rebinding
-    for key in nested_tensor_keys:
-        unbound = data[key].unbind(dim=0)
-        reordered = [unbound[i] for i in index]
-        output[key] = torch.nested.as_nested_tensor(reordered, layout=torch.jagged)
-
-    return output
-
-
 def get_tensordict(tensor_dict: dict[str, torch.Tensor | list], non_tensor_dict: dict = None) -> TensorDict:
     """Create a TensorDict from tensors and non-tensor data.
 


### PR DESCRIPTION
### What does this PR do?

Migrate the DP workload balancing feature from RL to SFT: 
https://github.com/verl-project/verl/pull/3605

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: workload balance
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
trainer.balance_batch=True
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

Same as https://github.com/verl-project/verl/pull/3605. Except one using TensorDict, one using DataProto

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
