### PR TITLE
[megatron, algo] fix: position_ids shape mismatch in preprocess_thd_no_padding for router replay

### DIFF
--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -340,7 +340,7 @@ def preprocess_thd_no_padding(
     shape[0] = sum(seqlens_in_batch_padded_cpu) // cp_size
     if pre_process:
         input_ids_rmpad = torch.zeros(shape, dtype=input_ids.dtype, device=input_ids.device)
-        position_ids_rmpad = torch.zeros(shape, dtype=torch.long, device=input_ids.device)
+        position_ids_rmpad = torch.zeros(shape[0], dtype=torch.long, device=input_ids.device)
         if need_roll:
             saved_roll_dict = {}
             saved_position_roll_dict = {}


### PR DESCRIPTION
### What does this PR do?

Fixes a `RuntimeError` in `preprocess_thd_no_padding` when called from the R3 router replay path (`set_router_replay_data`).

The function allocates `position_ids_rmpad` using the full multi-dimensional `shape` derived from `input_ids`. When `set_router_replay_data` passes `layers_topk_idx` — a nested tensor with shape `[bs, seq_len, num_layers, topk]` — `position_ids_rmpad` inherits the extra dimensions (e.g., `[packed_len, 48, 8]`), causing the `torch.arange` assignment to crash with:

```
RuntimeError: The expanded size of the tensor (8) must match the existing size (14165) at non-singleton dimension 2. Target sizes: [14165, 48, 8]. Tensor sizes: [14165]
```

The bug was introduced in #5219 (`[algo] feat: support router replay in MegatronEngine`), which reuses `preprocess_thd_no_padding` (originally written for 1D-per-sample `input_ids`) with multi-dimensional `layers_topk_idx` tensors.

**Fix:** Use `shape[0]` (scalar packed sequence length) instead of the full `shape` for `position_ids_rmpad`, since position IDs are always 1D sequence indices regardless of the input tensor's extra dimensions.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/issues?q=preprocess_thd_no_padding+position_ids_rmpad
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated by running Qwen3-30B-A3B MoE training with Megatron backend and R3 router replay enabled (`router_replay.mode=R3`, `use_remove_padding=True`).

- **Before fix:** Crashes immediately at the first `compute_log_prob` call in `_compute_old_log_prob` with the shape mismatch error above.
- **After fix:** Training proceeds past `compute_log_prob` without errors.

The standard (non-R3) code path is unaffected because `set_router_replay_data` is only called when router replay is enabled, and `preprocess_thd_no_padding` with normal `input_ids` tensors (1D per sample) produces `shape = [packed_len]`, so `shape[0]` and `shape` are equivalent.

### API and Usage Example

No API changes. This is a one-line internal bugfix.

### Design & Code Changes

Single line change in `verl/models/mcore/util.py`, function `preprocess_thd_no_padding`:

```python
# Before (bug): position_ids_rmpad inherits all dimensions from input_ids
position_ids_rmpad = torch.zeros(shape, dtype=torch.long, device=input_ids.device)

# After (fix): position_ids are always 1D sequence indices
position_ids_rmpad = torch.zeros(shape[0], dtype=torch.long, device=input_ids.device)
```

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). — N/A, no doc changes needed for a one-line bugfix.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: The bug only manifests with a real MoE model running Megatron backend with R3 router replay on multi-GPU, which requires significant GPU resources not available in CI. The fix is a single-line change with clear correctness reasoning. Happy to add a mock-based unit test if requested by reviewers.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. — N/A, not related to recipe.