### PR TITLE
[trainer] fix: fixed an issue where mindspeed's backend context parallelism feature functioned incorrectly

### DIFF
--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -49,7 +49,7 @@ class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
         # so the CP ring-rank initialization wrapper is not registered on the first pass.
         if repatch is not None:
             repatch_config = dict(self.engine_config.get("override_transformer_config", {}))
-            repatch_config["use_flash_attn"] = True
+            repatch_config.setdefault("use_flash_attn", True)
             if self.engine_config.context_parallel_size > 1:
                 repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
             repatch(repatch_config)

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -41,9 +41,16 @@ class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
     ):
         super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
 
-        repatch_config = self.engine_config.get("override_transformer_config", {})
-        repatch_config["use_flash_attn"] = True
-        if self.engine_config.context_parallel_size > 1:
-            repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
-
-        repatch(repatch_config)
+    def _init_device_mesh(self):
+        # repatch must happen before initialize_model_parallel so that
+        # initialize_model_parallel_cp_wrapper is in effect when the call is made.
+        # The initial MindSpeed patch pass sees context_parallel_size=1 (default) because
+        # verl passes CP size via hydra config rather than --context-parallel-size CLI arg,
+        # so the CP ring-rank initialization wrapper is not registered on the first pass.
+        if repatch is not None:
+            repatch_config = dict(self.engine_config.get("override_transformer_config", {}))
+            repatch_config["use_flash_attn"] = True
+            if self.engine_config.context_parallel_size > 1:
+                repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
+            repatch(repatch_config)
+        super()._init_device_mesh()


### PR DESCRIPTION


### What does this PR do?

Fixed the bug reported by CI at https://github.com/verl-project/verl/actions/runs/23277953416/job/67684832631

---

The root cause of this problem is that the timing of the MindSpeed patch is too late. The specific mechanism is as follows: 

#### Error Chain
When MindSpeed is patched for the first time (when `mindspeed.megatron_adaptor` is imported), it calls `get_mindspeed_args()` to parse command-line arguments. Since verl passes parameters via Hydra (`engine.context_parallel_size=2`) instead of standard CLI arguments (`--context-parallel-size 2`), MindSpeed's argparse retrieves a default value of context_parallel_size=1.

Consequently, the check in [context_parallel_feature.py](https://github.com/Ascend/MindSpeed/blob/d04da29191a09dc1d664d6de6a7852a3385613a7/mindspeed/features_manager/context_parallel/context_parallel_feature.py#L39):
```python
if int(getattr(args, 'context_parallel_size', 1)) > 1:  # → False!
```
skips the registration of `initialize_model_parallel_cp_wrapper` (responsible for initializing CP ring ranks).
When `MegatronEngine.__init__` calls `_init_device_mesh()` → `mpu.initialize_model_parallel()` executes, there is no CP wrapper in place, so `_CONTEXT_PARALLEL_RANKS_FOR_RING_INTRA_WINDOW` remains permanently None.

Subsequently, `MindspeedEngineWithLMHead.__init__` calls `repatch(repatch_config)` with the correct CP size, and `MindSpeedCPDotProductAttention` is patched in — but `initialize_model_parallel` has already completed execution.

During forward propagation, `MindSpeedCPDotProductAttention.forward` calls `get_ring_ranks_for_intra_window()` → triggers AssertionError: Context parallel ranks for ring intra window not initialized.


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
