### PR TITLE
[training_utils] fix: use response_lens.max() instead of offsets().max() for nested tensor max_response_len

### DIFF
--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -14,7 +14,6 @@
 
 
 import torch
-import torch.nn.functional as F
 from tensordict import TensorDict
 
 from verl.trainer.ppo.core_algos import agg_loss, compute_value_loss, get_policy_loss_fn, kl_penalty
@@ -54,44 +53,6 @@ def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
     return loss, {}
 
-
-def _slice_response_from_unpad_output(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor:
-    """Slice response from unpad model output.
-
-    Args:
-        tensor: model output tensor of shape [bsz, 1]
-        data: TensorDict with "prompt_ids", "response_ids", "attention_mask"
-
-    Returns:
-        tensor: sliced response tensor of shape [bsz, max_response_len]
-    """
-    values = tensor.values() if tensor.is_nested else tensor
-    prompt_ids = data["prompts"]
-    response_ids = data["responses"]
-    attention_mask = data["attention_mask"]
-
-    if prompt_ids.is_nested:
-        prompt_lens = prompt_ids.offsets().diff()
-        response_lens = response_ids.offsets().diff()
-        max_response_len = response_ids.offsets().max().item()
-    else:
-        assert not attention_mask.is_nested
-        prompt_lens = attention_mask[:, : prompt_ids.shape[1]].sum(dim=1)
-        response_lens = attention_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-        max_response_len = response_ids.shape[1]
-
-    sequence_lens = prompt_lens + response_lens
-    sequence_offsets = sequence_lens.cumsum(dim=0)
-    assert sequence_offsets[-1].item() == values.shape[0]
-
-    response_list = []
-    for resp_len, seq_offset in zip(response_lens, sequence_offsets, strict=True):
-        pad_size = max_response_len - resp_len
-        # left-shift model output by one token for log_probs/values
-        response_list.append(F.pad(values[seq_offset - resp_len - 1 : seq_offset - 1], (0, pad_size)))
-
-    output = torch.stack(response_list, dim=0)
-    return output
 
 
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
@@ -188,7 +149,7 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     Returns:
         value loss
     """
-    vpreds = _slice_response_from_unpad_output(model_output["values"], data)  # (bsz, response_length)
+    vpreds = no_padding_2_padding(model_output["values"], data)  # (bsz, response_length)
 
     values = data["values"]
     returns = data["returns"]


### PR DESCRIPTION
### What does this PR do?

Removes the duplicate `_slice_response_from_unpad_output()` function from `losses.py` and replaces its single call site in `value_loss()` with the existing `no_padding_2_padding()` from `padding.py` (already imported at line 26).

The removed function had a bug: it used `response_ids.offsets().max()` for nested tensors, which returns the cumulative offset sum (total token count) instead of the max individual response length. For example, with responses of length `[3, 5, 4]`:
- `offsets() = [0, 3, 8, 12]`
- `offsets().max() = 12` (wrong — total token count)
- `response_lens.max() = 5` (correct — longest response)

Rather than fixing this one line, per maintainer suggestion, we remove the duplicate entirely and use `no_padding_2_padding()` which already handles this correctly.

Search query: https://github.com/verl-project/verl/pulls?q=is%3Apr+_slice_response_from_unpad_output

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+_slice_response_from_unpad_output
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

The change replaces a buggy private function with the correct public function that is already used throughout the codebase (e.g., in `ray_trainer.py` for `_compute_values`, `_compute_ref_log_prob`, `_compute_log_prob`, and `_compute_entropy`).

`no_padding_2_padding` is covered by existing tests and is exercised in every PPO training run via the model engine path.

### Design & Code Changes

1. **Removed** `_slice_response_from_unpad_output()` (38 lines) — buggy duplicate
2. **Replaced** call in `value_loss()` with `no_padding_2_padding()` — already imported
3. **Removed** unused `import torch.nn.functional as F`

Net change: **-40 lines, +1 line**

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).