### PR TITLE
[trtllm,rollout] fix hang issue from VLM codepath

### DIFF
--- a/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
@@ -453,17 +453,20 @@ class ServerAdapter(BaseRollout):
             cur_available_bytes = total_available_bytes
             cur_handles = []
 
-        # Only the leader rank can query supports_partial_loading; broadcast the result to all ranks
-        # in this DP replica so non-leaders can use it below. Must use get_global_rank(group, 0)
-        # instead of src=0 because each DP replica has a different leader global rank.
-        exclude_dp_group = self.hybrid_device_mesh["exclude_dp"].get_group()
-        spl_tensor = torch.zeros(1, dtype=torch.int32)
-        if self.is_leader_rank:
-            supports_partial_loading = await self.get_supports_partial_loading()
-            spl_tensor[0] = int(supports_partial_loading)
-        leader_global_rank = dist.get_global_rank(exclude_dp_group, 0)
-        await asyncio.to_thread(dist.broadcast, spl_tensor, src=leader_global_rank, group=exclude_dp_group)
-        supports_partial_loading = bool(spl_tensor.item())
+        # Non-VLM never supports partial loading. For VLM, leader queries and broadcasts to all
+        # ranks in the DP replica; use get_global_rank(group, 0) since each replica has a different leader.
+        is_vlm = self.model_config.hf_config is not None and hasattr(self.model_config.hf_config, "vision_config")
+        if not is_vlm:
+            supports_partial_loading = False
+        else:
+            exclude_dp_group = self.hybrid_device_mesh["exclude_dp"].get_group()
+            spl_tensor = torch.zeros(1, dtype=torch.int32)
+            if self.is_leader_rank:
+                supports_partial_loading = await self.get_supports_partial_loading()
+                spl_tensor[0] = int(supports_partial_loading)
+            leader_global_rank = dist.get_global_rank(exclude_dp_group, 0)
+            await asyncio.to_thread(dist.broadcast, spl_tensor, src=leader_global_rank, group=exclude_dp_group)
+            supports_partial_loading = bool(spl_tensor.item())
 
         for name, param in weights:
             if supports_partial_loading:


### PR DESCRIPTION
### What does this PR do?

Fix a hang issue in trtllm's multinode rollout caused by the recently merged VLM MR (#5149).

- The bug: src=0 means global rank 0. But global rank 0 is only the leader of DP replica 0. For replica 1, 2, etc., their exclude_dp group doesn't include global rank 0 at all.

- The fix: dist.get_global_rank(exclude_dp_group, 0) converts local rank 0 within this group to the actual global rank of that group's leader. Each DP replica's leader gets its own correct
  global rank, so the broadcast always uses a rank that's actually in the group.
  

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
