### PR TITLE
[trainer] fix: skip dataloader state restore when resuming at epoch boundary

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1001,8 +1001,18 @@ class RayPPOTrainer:
         # TODO: from remote not implemented yet
         dataloader_local_path = os.path.join(global_step_folder, "data.pt")
         if os.path.exists(dataloader_local_path):
-            dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
-            self.train_dataloader.load_state_dict(dataloader_state_dict)
+            steps_per_epoch = len(self.train_dataloader)
+            at_epoch_boundary = steps_per_epoch > 0 and self.global_steps % steps_per_epoch == 0
+            if at_epoch_boundary:
+                print(
+                    f"Skipping dataloader state restore: global_steps={self.global_steps} "
+                    f"is at an epoch boundary (steps_per_epoch={steps_per_epoch}). "
+                    f"The saved state marks the dataloader as exhausted. "
+                    f"Next epoch will iterate from scratch."
+                )
+            else:
+                dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
+                self.train_dataloader.load_state_dict(dataloader_state_dict)
         else:
             print(f"Warning: No dataloader state found at {dataloader_local_path}, will start from scratch")
 


### PR DESCRIPTION

### What does this PR do?

When resuming from a checkpoint saved at an exact epoch boundary (`global_steps % steps_per_epoch == 0`), training silently exits with 0 new training steps and no error message.

**Root cause (two conditions combine):**

1. In `fit()`, `current_epoch = self.global_steps // len(self.train_dataloader)` evaluates to `1` when `global_steps=60` and `steps_per_epoch=60`, so the training loop starts at `range(1, 2)`, skipping epoch 0's iteration entirely.

2. The saved `data.pt` marks the `StatefulDataLoader` as exhausted (end of epoch 0). `StatefulDataLoader` applies the saved state only on the **first** `iter()` call — which is now epoch 1's loop. That iterator immediately exhausts, producing 0 batches.

Result: WandB calls `finish()`, the progress bar stays at `60/120`, and the process exits cleanly with no error and no training steps executed.

**Fix:** Detect the epoch boundary condition in `_load_checkpoint` and skip `load_state_dict` when `global_steps % steps_per_epoch == 0`. At the boundary the saved state carries no useful positional information (the epoch is already complete), so skipping restoration is semantically correct and allows the next epoch to iterate from scratch.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/volcengine/verl/pulls?q=dataloader+resume+epoch

### Test

Validated manually: GRPO training on Qwen3-VL-4B with `total_epochs=2`, `steps_per_epoch=60`, `total_training_steps=120`. Resuming from `global_step_60` via `trainer.resume_mode=resume_path` previously exited immediately at `60/120` with no error. After this fix, training correctly resumes and runs steps 61–120 to completion.

### API and Usage Example

No API changes. No config changes. Behavior change only occurs when `global_steps % steps_per_epoch == 0` at resume time, which previously caused silent failure.

### Design & Code Changes

Only `verl/trainer/ppo/ray_trainer.py` is modified, within `_load_checkpoint`:

```python
# Before
if os.path.exists(dataloader_local_path):
    dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
    self.train_dataloader.load_state_dict(dataloader_state_dict)

# After
if os.path.exists(dataloader_local_path):
    steps_per_epoch = len(self.train_dataloader)
    at_epoch_boundary = steps_per_epoch > 0 and self.global_steps % steps_per_epoch == 0
    if at_epoch_boundary:
        print(
            f"Skipping dataloader state restore: global_steps={self.global_steps} "
            f"is at an epoch boundary (steps_per_epoch={steps_per_epoch}). "
            f"The saved state marks the dataloader as exhausted. "
            f"Next epoch will iterate from scratch."
        )
    else:
        dataloader_state_dict = torch.load(dataloader_local_path, weights_only=False)
        self.train_dataloader.load_state_dict(dataloader_state_dict)
```

Net change: +9 lines. All other resume scenarios (mid-epoch resume, fresh training, missing `data.pt`) are unaffected.

### Checklist Before Submitting

- [x] Read the [[Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [[pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [[the documentation](https://github.com/volcengine/verl/tree/main/docs)](https://github.com/volcengine/verl/tree/main/docs). — Not required for this bug fix.
- [x] Add unit or end-to-end test(s). — Not feasible as a unit test without mocking the full trainer; validated manually with real GRPO training run.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel in the verl Slack workspace.