### PR TITLE
[misc] fix: make the assert user-friendly for `get_tensordict`

### DIFF
--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -401,7 +401,7 @@ def get_tensordict(tensor_dict: dict[str, torch.Tensor | list], non_tensor_dict:
             # Convert to NonTensorStack to handle nested structures
             tensor_dict[key] = NonTensorStack.from_list([NonTensorData(item) for item in val])
 
-        assert isinstance(val, torch.Tensor | list)
+        assert isinstance(val, torch.Tensor | list), f"{key} -> {type(val)} isn't of 'torch.Tensor | list' type"
 
         if batch_size is None:
             batch_size = val.size(0) if isinstance(val, torch.Tensor) else len(val)


### PR DESCRIPTION
### What does this PR do?

This PR adds the missing assert message.

Before:

```
  File "verl/utils/tensordict_utils.py", line 374, in get_tensordict
    assert isinstance(val, torch.Tensor | list)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```
the user has no idea which `key` is the problem, and what type the `val` has

After:

```
    assert isinstance(val, torch.Tensor | list), f"{key} -> {type(val)} isn't of 'torch.Tensor | list' type"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: log_probs -> <class 'NoneType'> isn't of 'torch.Tensor | list' type
```
now the user knows how to fix the issue, as both the `key` is known and the type of the value.


