### PR TITLE
[trainer] fix: convert numpy types to native Python types in MultiTurnSFTDataset

### DIFF
--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -250,7 +250,7 @@ class MultiTurnSFTDataset(Dataset):
         Returns:
             messages: List of messages with replaced placeholder.
         """
-        messages: list = example[self.messages_key]
+        messages: list = convert_nested_value_to_list_recursive(example[self.messages_key])
         images = example[self.image_key] if self.image_key in example else []
         videos = example[self.video_key] if self.video_key in example else []
 
@@ -293,6 +293,8 @@ class MultiTurnSFTDataset(Dataset):
         enable_thinking = (
             self.enable_thinking[item] if self.enable_thinking is not None else self.enable_thinking_default
         )
+        if enable_thinking is not None:
+            enable_thinking = bool(enable_thinking)
 
         # 1. tokenize each message
         input_ids, loss_mask, attention_mask, multi_modal_inputs = [], [], [], {}


### PR DESCRIPTION
## Summary
- When reading from parquet files, pandas DataFrame iloc[item].to_dict() returns values with numpy types (numpy.bool_, numpy.ndarray, etc.)
- These numpy types cause ValueError when passed to Jinja2 template rendering in apply_chat_template(), because Jinja cannot evaluate numpy arrays in boolean expressions
- Root cause: __getitem__ reads directly from self.dataframe which contains raw numpy types, bypassing the pre-processed self.messages

## Error
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

## Fix
- Apply convert_nested_value_to_list_recursive to row_dict right after reading from the dataframe
- Convert enable_thinking to native bool since it is read separately from self.enable_thinking list