### PR TITLE
[fsdp, perf] fix: skip redundant to(cuda) and gc.collect in train_mode when offload is disabled

### DIFF
--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -242,6 +242,9 @@ class BaseEngineCtx:
     def _context_switch(self, device):
         if self.disable_auto_offload:
             return
+        if device != "cpu":
+            if not self.engine.is_param_offload_enabled and not self.engine.is_optimizer_offload_enabled:
+                return
         if self.mode == "eval":
             self.engine.to(device=device, model=self.engine.is_param_offload_enabled, optimizer=False, grad=False)
         elif self.mode == "train":


### PR DESCRIPTION
### What does this PR do?

`BaseEngineCtx._context_switch()` unconditionally calls `engine.to("cuda")` on every training step entry, even when `param_offload` and `optimizer_offload` are both disabled and the model/optimizer are already on GPU. This triggers a redundant FSDP module tree traversal via `load_fsdp_model_to_gpu` (~150ms) and a full `gc.collect()` (~295ms), wasting ~450ms per step.

For Qwen3-30B-A3B SFT training on 8×H100 with FSDP2 and LoRA, this represents ~13% of a 3.5s training step (w/ gsm8k dataset).

This PR adds an early return in `_context_switch()` when entering GPU mode (`device != "cpu"`) and both offloads are disabled, skipping the unnecessary `to()` call entirely.

### Test

Validated via nsys profiling on Qwen3-30B-A3B SFT with FSDP2 + LoRA (8×H100, `param_offload=False`, `optimizer_offload=False`):

| Metric | Before | After |
|--------|--------|-------|
| `train_mode_enter` | ~450ms | <1ms |
| Step time | ~3.5s | ~3.05s |
| Throughput improvement | — | ~13% |

The fix is a no-op when either offload is enabled — the existing code path runs unchanged.

### Design & Code Changes

Single change in `verl/workers/engine/base.py`, `BaseEngineCtx._context_switch()`:

```python
def _context_switch(self, device):
    if self.disable_auto_offload:
        return
    # Skip when entering GPU mode with no offload configured —
    # model and optimizer are already on device.
    if device != "cpu":
        if not self.engine.is_param_offload_enabled and not self.engine.is_optimizer_offload_enabled:
            return
    # ... existing logic unchanged ...
```

The guard checks two conditions:
1. We're entering GPU mode (not exiting to CPU)
2. Neither param nor optimizer offload is enabled

When both hold, the model and optimizer have been on GPU since `initialize()` and were never moved to CPU (the `__exit__` path already respects offload flags). The `to()` call, its FSDP tree traversal, and `gc.collect()` are pure overhead.
