### PR TITLE
[perf] feat: support partial-token window profiling for rollout in verl

### DIFF
--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
@@ -63,6 +63,8 @@ Use parameters in each role's ``profiler.tool_config.npu`` to control npu profil
 
 -  analysis: Enables automatic data parsing.
 -  discrete: Whether to enable discrete mode.
+-  profile_token_start: Effective only for the rollout role; defines the start response-token index for rollout decoding collection. It is applied only when valid (0-based, ``profile_token_end > profile_token_start``, and the window is within response length).
+-  profile_token_end: Effective only for the rollout role; defines the stop response-token index (exclusive) for rollout decoding collection. It is applied only when valid (0-based, ``profile_token_end > profile_token_start``, and the window is within response length).
 
 
 Examples
@@ -122,6 +124,9 @@ Discrete Mode Collection
                tool_config:
                   npu:
                      discrete: True  # Must be enabled in Agent Loop mode
+                     # Optional response-token window for engine-side collection; if not set, the entire rollout stage is collected
+                     profile_token_start: 12
+                     profile_token_end: 46
          # ref follow actor settings
 
 **Agent Loop Mode Description**:

--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
@@ -55,6 +55,8 @@ Last updated: 12/20/2025.
 
 -  analysis: 启用自动数据解析。
 -  discrete: 使用离散模式。
+-  profile_token_start：仅在 rollout role 下生效，用于指定 rollout 解码阶段的采集起始 response token；参数合法时生效（从 0 开始，满足 ``profile_token_end > profile_token_start``，且区间在 response 长度内）。
+-  profile_token_end：仅在 rollout role 下生效，用于指定 rollout 解码阶段的采集结束 response token（右边界不包含）；参数合法时生效（从 0 开始，满足 ``profile_token_end > profile_token_start``，且区间在 response 长度内）。
 
 示例
 ----
@@ -114,6 +116,9 @@ Last updated: 12/20/2025.
                tool_config:
                   npu:
                      discrete: True  # Agent Loop 模式下必须开启离散模式
+                     # 可选：按 response token 区间采集；不设置 start/stop 时采集整个 rollout 阶段
+                     profile_token_start: 12
+                     profile_token_end: 46
          # ref follow actor settings
 
 **Agent Loop 模式说明**：

--- a/docs/perf/torch_profiling.md
+++ b/docs/perf/torch_profiling.md
@@ -34,6 +34,8 @@ You can customize the PyTorch Profiler behavior using the following fields under
     *   **`memory`**: Track tensor memory allocation/free.
     *   **`shapes`**: Record shapes of operator inputs.
     *   **`stack`**: Record source code file and line number.
+* **`profile_token_start`**: Effective only for the rollout role; defines the start response-token index for rollout decoding collection. It is applied only when valid (0-based, `profile_token_end > profile_token_start`, and within response length).
+* **`profile_token_end`**: Effective only for the rollout role; defines the stop response-token index (exclusive) for rollout decoding collection. It is applied only when valid (0-based, `profile_token_end > profile_token_start`, and within response length).
 * **`schedule`**: (Advanced) configuration for `wait`, `warmup`, `active`, `repeat` cycles.
 
 ## Examples
@@ -86,6 +88,11 @@ actor_rollout_ref:
       tool_config:
         torch:
           discrete: True # REQUIRED 
+          # Optional response-token window for rollout engine side collection.
+          # If start/stop are not set, the entire rollout stage is collected.
+          # Collect tokens in [12, 46), i.e. token index 12~45.
+          profile_token_start: 12
+          profile_token_end: 46
   # ref follow actor settings
 ```
 

--- a/tests/utils/test_server_profiler.py
+++ b/tests/utils/test_server_profiler.py
@@ -18,6 +18,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from verl.utils.profiler.config import (
+    NPUToolConfig,
     ProfilerConfig,
     TorchProfilerToolConfig,
     build_sglang_profiler_args,
@@ -48,6 +49,25 @@ class TestServerProfilerArgs(unittest.TestCase):
             self.assertTrue(profiler_config_dict["torch_profiler_with_stack"])
             self.assertTrue(profiler_config_dict["torch_profiler_record_shapes"])
             self.assertTrue(profiler_config_dict["torch_profiler_with_memory"])
+            self.assertEqual(profiler_config_dict["delay_iterations"], 0)
+            self.assertEqual(profiler_config_dict["max_iterations"], 0)
+
+    def test_build_vllm_profiler_args_with_profile_window(self):
+        tool_config = TorchProfilerToolConfig(contents=["stack"], profile_token_start=12, profile_token_end=46)
+        config = ProfilerConfig(save_path="/tmp/test", tool_config=tool_config)
+
+        args = build_vllm_profiler_args(config, tool_config, rank=1)
+        profiler_config_dict = json.loads(args["profiler_config"])
+        self.assertEqual(profiler_config_dict["delay_iterations"], 12)
+        self.assertEqual(profiler_config_dict["max_iterations"], 34)
+
+    def test_build_vllm_profiler_args_with_npu_profile_window(self):
+        tool_config = NPUToolConfig(contents=["npu"], profile_token_start=5, profile_token_end=13)
+        config = ProfilerConfig(save_path="/tmp/test", tool_config=tool_config)
+        args = build_vllm_profiler_args(config, tool_config, rank=0)
+        profiler_config_dict = json.loads(args["profiler_config"])
+        self.assertEqual(profiler_config_dict["delay_iterations"], 5)
+        self.assertEqual(profiler_config_dict["max_iterations"], 8)
 
     def test_build_sglang_profiler_args(self):
         # Case 1: Basic features
@@ -58,6 +78,15 @@ class TestServerProfilerArgs(unittest.TestCase):
         self.assertEqual(args["output_dir"], "/tmp/test/agent_loop_rollout_replica_0")
         self.assertTrue(args["with_stack"])
         self.assertTrue(args["record_shapes"])
+        self.assertIsNone(args["start_step"])
+        self.assertIsNone(args["num_steps"])
+
+    def test_build_sglang_profiler_args_with_profile_window(self):
+        tool_config = TorchProfilerToolConfig(contents=["stack"], profile_token_start=7, profile_token_end=16)
+        config = ProfilerConfig(save_path="/tmp/test", tool_config=tool_config)
+        args = build_sglang_profiler_args(config, tool_config, rank=0)
+        self.assertEqual(args["start_step"], 7)
+        self.assertEqual(args["num_steps"], 9)
 
 
 class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -371,10 +371,14 @@ actor_rollout_ref:
           level: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.level,level0}
           analysis: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.analysis,false}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -336,10 +336,14 @@ actor_rollout_ref:
           level: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.level,level0}
           analysis: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.analysis,false}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -343,10 +343,14 @@ actor_rollout_ref:
           level: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.level,level0}
           analysis: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.analysis,false}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -334,10 +334,14 @@ actor_rollout_ref:
           level: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.level,level0}
           analysis: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.analysis,false}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+          profile_token_start: null
+          profile_token_end: null
         precision_debugger:
           _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
           config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}

--- a/verl/trainer/config/profiler/profiler.yaml
+++ b/verl/trainer/config/profiler/profiler.yaml
@@ -35,6 +35,14 @@ tool_config:
     # True for each task has its own database, False for all tasks in one training step share one database.
     discrete: False
 
+    # Start collecting profiler data from this response-token index.
+    # null means collect from the first response token (full collection start).
+    profile_token_start: null
+
+    # Stop collecting profiler data at this response-token index (exclusive).
+    # null means collect until the end (full collection).
+    profile_token_end: null
+
     name: npu
 
 
@@ -57,6 +65,14 @@ tool_config:
 
     # True for each task has its own database, False for all tasks in one training step share one database.
     discrete: false
+
+    # Start collecting profiler data from this response-token index.
+    # null means collect from the first response token (full collection start).
+    profile_token_start: null
+
+    # Stop collecting profiler data at this response-token index (exclusive).
+    # null means collect until the end (full collection).
+    profile_token_end: null
 
     name: torch
 

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -392,6 +392,14 @@ profiler:
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.npu.discrete,false}
 
+      # Start collecting profiler data from this response-token index.
+      # null means collect from the first response token (full collection start).
+      profile_token_start: null
+
+      # Stop collecting profiler data at this response-token index (exclusive).
+      # null means collect until the end (full collection).
+      profile_token_end: null
+
     # torch profiler config
     torch:
 
@@ -404,6 +412,15 @@ profiler:
 
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+
+      # Start collecting profiler data from this response-token index.
+      # null means collect from the first response token (full collection start).
+      profile_token_start: null
+
+      # Stop collecting profiler data at this response-token index (exclusive).
+      # null means collect until the end (full collection).
+      profile_token_end: null
+
 
     # msprobe precision debugger config
     precision_debugger:

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -42,6 +42,12 @@ class TorchProfilerToolConfig(BaseConfig):
     # options: cuda, cpu, memory, shapes, stack
     contents: list[str] = field(default_factory=list)
     discrete: bool = False
+    # Start collecting profiler data from this response-token index.
+    # None means collect from the beginning.
+    profile_token_start: Optional[int] = None
+    # Stop collecting profiler data at this response-token index (exclusive).
+    # None means collect until the end.
+    profile_token_end: Optional[int] = None
     name: str = "torch"
 
     def __post_init__(self) -> None:
@@ -52,6 +58,14 @@ class TorchProfilerToolConfig(BaseConfig):
                 f"Profiler contents only supports {__support_contents}, but gets {content}"
             )
         assert isinstance(self.contents, list), f"Profiler contents must be of type list, got {type(self.contents)}"
+        start = self.profile_token_start
+        stop = self.profile_token_end
+        for name, value in (("profile_token_start", start), ("profile_token_end", stop)):
+            if value is not None:
+                assert isinstance(value, int), f"{name} must be int or None, got {type(value)}"
+                assert value >= 0, f"{name} must be >= 0, got {value}"
+        if start is not None and stop is not None:
+            assert stop > start, f"profile_token_end must be > profile_token_start, got start={start}, stop={stop}"
 
 
 @dataclass
@@ -116,6 +130,12 @@ class NPUToolConfig(NsightToolConfig):
 
     # Whether to automatically parse the data.
     analysis: bool = False
+    # Start collecting profiler data from this response-token index.
+    # None means collect from the beginning.
+    profile_token_start: Optional[int] = None
+    # Stop collecting profiler data at this response-token index (exclusive).
+    # None means collect until the end.
+    profile_token_end: Optional[int] = None
 
     name: str = "npu"
 
@@ -131,6 +151,14 @@ class NPUToolConfig(NsightToolConfig):
         assert self.level in ["level_none", "level0", "level1", "level2"], (
             f"Profiler level only supports level0, 1, 2, and level_none, but gets {self.level}"
         )
+        start = self.profile_token_start
+        stop = self.profile_token_end
+        for name, value in (("profile_token_start", start), ("profile_token_end", stop)):
+            if value is not None:
+                assert isinstance(value, int), f"{name} must be int or None, got {type(value)}"
+                assert value >= 0, f"{name} must be >= 0, got {value}"
+        if start is not None and stop is not None:
+            assert stop > start, f"profile_token_end must be > profile_token_start, got start={start}, stop={stop}"
 
 
 @dataclass
@@ -221,6 +249,13 @@ def build_vllm_profiler_args(profiler_config: ProfilerConfig, tool_config: BaseC
     # vLLM >= 0.13.0 supports controlling profiler via arguments.
     # While it maintains backward compatibility with environment variables,
     # we provide arguments explicitly to align with the new API style.
+    profile_token_start = getattr(tool_config, "profile_token_start", None)
+    profile_token_end = getattr(tool_config, "profile_token_end", None)
+
+    # vLLM uses 0 to indicate immediate start / no upper bound.
+    delay_iterations = profile_token_start if profile_token_start is not None else 0
+    max_iterations = (profile_token_end - delay_iterations) if profile_token_end is not None else 0
+
     return {
         "profiler_config": json.dumps(
             {
@@ -229,6 +264,9 @@ def build_vllm_profiler_args(profiler_config: ProfilerConfig, tool_config: BaseC
                 "torch_profiler_with_memory": with_memory,
                 "torch_profiler_with_stack": with_stack,
                 "torch_profiler_record_shapes": record_shapes,
+                "delay_iterations": delay_iterations,
+                "max_iterations": max_iterations,
+                "ignore_frontend": "true",
             }
         )
     }
@@ -253,8 +291,20 @@ def build_sglang_profiler_args(profiler_config: ProfilerConfig, tool_config: Bas
     if "memory" in contents:
         warnings.warn("SGLang profiler does not support memory profiling. Ignoring memory content.", stacklevel=2)
 
+    profile_token_start = getattr(tool_config, "profile_token_start", None)
+    profile_token_end = getattr(tool_config, "profile_token_end", None)
+    # SGLang API uses Optional[int], keep None for "not set" and map 0 to "no upper bound".
+    start_step = profile_token_start
+    num_steps = (
+        profile_token_end - (profile_token_start if profile_token_start is not None else 0)
+        if profile_token_end is not None
+        else None
+    )
+
     return {
         "output_dir": os.path.join(profiler_config.save_path, f"agent_loop_rollout_replica_{rank}"),
         "with_stack": "stack" in contents or "module" in contents,
         "record_shapes": "shapes" in contents,
+        "start_step": start_step,
+        "num_steps": num_steps,
     }

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -15,8 +15,7 @@
 import functools
 from typing import Callable, Optional
 
-from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize
-from .config import ProfilerConfig, TorchMemoryToolConfig
+from .config import ProfilerConfig
 
 
 def mark_start_range(
@@ -84,7 +83,7 @@ class DistProfiler:
         self, rank: int, config: Optional[ProfilerConfig] = None, tool_config: Optional[object] = None, **kwargs
     ):
         # Default config
-        if not config:
+        if config is None:
             config = ProfilerConfig(ranks=[], enable=False, tool_config=None)
 
         if tool_config is None:
@@ -130,6 +129,8 @@ class DistProfiler:
 
             self._impl = _Torch(rank=rank, config=config, tool_config=tool_config)
         elif self._tool == "torch_memory":
+            from .torch_memory_profile import TorchMemoryProfiler
+
             self._impl = TorchMemoryProfiler(rank=rank, config=config, tool_config=tool_config)
         elif self._tool == "precision_debugger":
             from .precision_debugger_profile import PrecisionDebuggerProfiler as _Precision
@@ -140,23 +141,33 @@ class DistProfiler:
             self._impl = _NoOpProfiler()
 
     def check_enable(self):
+        """Return whether profiling is enabled by configuration."""
         return self._enable
 
     def check_this_rank(self):
+        """Return whether current rank should perform profiling."""
         return self._this_rank
 
     def check_this_step(self):
+        """Return whether current global step is marked for profiling."""
         return self._this_step
 
     def is_discrete_mode(self):
+        """Return whether profiler backend runs in discrete mode."""
         return self._discrete
 
     def start(self, **kwargs):
+        """Profiler switch for the Ray main flow; sets `this_step=True`.
+
+        Args:
+            **kwargs: Runtime arguments forwarded to backend `start`.
+        """
         if self.check_enable() and self.check_this_rank():
             self._this_step = True
             return getattr(self._impl, "start", lambda **_: None)(**kwargs)
 
     def stop(self):
+        """Profiler switch for the Ray main flow; sets `this_step=False`."""
         if self.check_enable() and self.check_this_rank():
             self._this_step = False
             return getattr(self._impl, "stop", lambda: None)()
@@ -170,6 +181,12 @@ class DistProfiler:
         category: Optional[str] = None,
         **kwargs_outer,
     ) -> Callable:
+        """Decorate instance methods with backend profiler annotations.
+
+        The wrapped function is executed directly if profiling is disabled,
+        not selected for current rank/step, or backend annotate fails.
+        """
+
         def decorator(func):
             @functools.wraps(func)
             def wrapper(self_instance, *args, **kwargs_inner):
@@ -205,86 +222,6 @@ class _NoOpProfiler:
 
     def stop(self):
         return
-
-
-class TorchMemoryProfiler:
-    """Profiler that dumps CUDA memory snapshots at step boundaries.
-
-    Behavior:
-    - On first construction (per process), enable memory history recording if CUDA is available
-    - On start(step=X), remember sub_dir for this step
-    - On stop(), dump a memory snapshot into config.save_path under the remembered sub_dir
-    """
-
-    _memory_history_enabled: bool = False
-
-    def __init__(
-        self, rank: int, config: Optional[ProfilerConfig], tool_config: Optional[TorchMemoryToolConfig] = None
-    ):
-        # Always respond to explicit start/stop calls for torch_memory tool,
-        # regardless of per-role enable flag, to align with global step control.
-        self.enable = True
-        if not config:
-            config = ProfilerConfig(ranks=[])
-        self.config = config
-        self.rank = rank
-        self.this_step = False
-        self.sub_dir = None
-        self.sampler = MemorySnapshotSampler()
-
-        # Get parameters from tool_config, with fallback to defaults
-        if tool_config:
-            self.trace_alloc_max_entries = tool_config.trace_alloc_max_entries
-            self.stack_depth = tool_config.stack_depth
-        else:
-            self.trace_alloc_max_entries = 100_000
-            self.stack_depth = 32
-
-        # Best-effort enable memory history once
-        if not TorchMemoryProfiler._memory_history_enabled:
-            try:
-                enable_memory_visualize(
-                    trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth
-                )
-            except Exception:
-                # silently ignore if not supported
-                pass
-            TorchMemoryProfiler._memory_history_enabled = True
-
-    def start(self, **kwargs):
-        if not self.enable:
-            return
-        if not self._should_profile_this_rank():
-            return
-        profile_step = kwargs.get("profile_step", None)
-        # Keep ranks aligned under same folder name
-        self.sub_dir = f"step{profile_step}" if profile_step is not None else None
-        self.this_step = True
-
-    def stop(self):
-        if not self.enable or not self.this_step:
-            return
-        self.this_step = False
-        if not self._should_profile_this_rank():
-            return
-        out_dir = self.config.save_path or "outputs/profile"
-        tag = "torch_memory"
-        # Dump snapshot; all ranks write into same sub_dir
-        try:
-            self.sampler.dump_memory_snapshot(out_dir=out_dir, tag=tag, sub_dir=self.sub_dir)
-        except Exception:
-            pass
-        # Clear memory history
-        if TorchMemoryProfiler._memory_history_enabled:
-            clear_memory_history(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
-
-    def _should_profile_this_rank(self) -> bool:
-        if self.config.all_ranks:
-            return True
-        if self.config.ranks:
-            return self.rank in self.config.ranks
-        # default rank 0
-        return self.rank == 0
 
 
 class DistProfilerExtension:

--- a/verl/utils/profiler/torch_memory_profile.py
+++ b/verl/utils/profiler/torch_memory_profile.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize
+from .config import ProfilerConfig, TorchMemoryToolConfig
+
+
+class TorchMemoryProfiler:
+    """Profiler that dumps CUDA memory snapshots at step boundaries.
+
+    Behavior:
+    - On first construction (per process), enable memory history recording if CUDA is available
+    - On start(step=X), remember sub_dir for this step
+    - On stop(), dump a memory snapshot into config.save_path under the remembered sub_dir
+    """
+
+    _memory_history_enabled: bool = False
+
+    def __init__(
+        self, rank: int, config: Optional[ProfilerConfig], tool_config: Optional[TorchMemoryToolConfig] = None
+    ):
+        # Always respond to explicit start/stop calls for torch_memory tool,
+        # regardless of per-role enable flag, to align with global step control.
+        self.enable = True
+        if not config:
+            config = ProfilerConfig(ranks=[])
+        self.config = config
+        self.rank = rank
+        self.this_step = False
+        self.sub_dir = None
+        self.sampler = MemorySnapshotSampler()
+
+        # Get parameters from tool_config, with fallback to defaults
+        if tool_config:
+            self.trace_alloc_max_entries = tool_config.trace_alloc_max_entries
+            self.stack_depth = tool_config.stack_depth
+        else:
+            self.trace_alloc_max_entries = 100_000
+            self.stack_depth = 32
+
+        # Best-effort enable memory history once
+        if not TorchMemoryProfiler._memory_history_enabled:
+            try:
+                enable_memory_visualize(
+                    trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth
+                )
+            except Exception:
+                # silently ignore if not supported
+                pass
+            TorchMemoryProfiler._memory_history_enabled = True
+
+    def start(self, **kwargs):
+        if not self.enable:
+            return
+        if not self._should_profile_this_rank():
+            return
+        profile_step = kwargs.get("profile_step", None)
+        # Keep ranks aligned under same folder name
+        self.sub_dir = f"step{profile_step}" if profile_step is not None else None
+        self.this_step = True
+
+    def stop(self):
+        if not self.enable or not self.this_step:
+            return
+        self.this_step = False
+        if not self._should_profile_this_rank():
+            return
+        out_dir = self.config.save_path or "outputs/profile"
+        tag = "torch_memory"
+        # Dump snapshot; all ranks write into same sub_dir
+        try:
+            self.sampler.dump_memory_snapshot(out_dir=out_dir, tag=tag, sub_dir=self.sub_dir)
+        except Exception:
+            pass
+        # Clear memory history
+        if TorchMemoryProfiler._memory_history_enabled:
+            clear_memory_history(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
+
+    def _should_profile_this_rank(self) -> bool:
+        if self.config.all_ranks:
+            return True
+        if self.config.ranks:
+            return self.rank in self.config.ranks
+        # default rank 0
+        return self.rank == 0


### PR DESCRIPTION
### What does this PR do?

Adds partial response-token profiling for rollout in verl. In long-context RL, profiling the full decode produces very large traces; collecting only a key token range reduces data volume and speeds up parsing/analysis.

verl exposes **profile_token_start / profile_token_end** (half-open window on response tokens) and maps them to rollout backends:

**vLLM:** delay_iterations ← start; max_iterations ← end - start
**SGLang:** start_step ← start; num_steps ← end - start

Also moves TorchMemoryProfiler into verl/utils/profiler/torch_memory_profile.py, aligned with other profiler tools (nvtx_profile.py, torch_profile.py, etc.). Docs updated in Ascend profiling (ZH/EN) and docs/perf/torch_profiling.md.


<img width="571" height="406" alt="image" src="https://github.com/user-attachments/assets/437cd54a-b915-4426-bf7c-ee20414c5ca7" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

| Scene | Discrete Mode | With Stack | with_memory | Record Shapes | Steps | Ranks | Status |
|-------|---------------|-----------|-------------|---------------|-------|-------|--------|
| vLLM 0.18.0 + NPU | TRUE | FALSE | FALSE | FALSE | [2] | [1] | pass |
| vLLM 0.18.0 + NPU | TRUE | TRUE | TRUE | TRUE | [2] | All | pass |
| vLLM 0.18.0 + GPU | TRUE | FALSE | FALSE | FALSE | [2] | [1] | pass |
| vLLM 0.18.0 + GPU | TRUE | TRUE | TRUE | TRUE | [2] | All | pass |
| SGLang 0.5.10 + NPU | TRUE | FALSE | FALSE | FALSE | [2] | [1] | pass |
| SGLang 0.5.10 + NPU | TRUE | TRUE | TRUE | TRUE | [2] | All | pass |
| SGLang 0.5.10 + GPU | TRUE | FALSE | FALSE | FALSE | [2] | [1] | pass |
| SGLang 0.5.10 + GPU | TRUE | TRUE | TRUE | TRUE | [2] | All | pass |

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```bash
    actor_rollout_ref.rollout.profiler.tool_config.npu.profile_token_start=20
    actor_rollout_ref.rollout.profiler.tool_config.npu.profile_token_end=80
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
