### PR TITLE
[model] fix: handle both tuple and object return types from Qwen3-VL visual encoder

### DIFF
--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -134,6 +134,17 @@ def get_rope_index(
     return position_ids
 
 
+def _unpack_visual_output(visual_output):
+    """Unpack the output from the visual encoder, handling both tuple and object return types.
+
+    Newer versions of transformers return an object with `pooler_output` and `deepstack_features`
+    attributes instead of a plain tuple.
+    """
+    if hasattr(visual_output, "pooler_output"):
+        return visual_output.pooler_output, visual_output.deepstack_features
+    return visual_output
+
+
 def _get_input_embeds(
     model: "Qwen3VLForConditionalGeneration",
     input_ids: torch.LongTensor,
@@ -147,7 +158,9 @@ def _get_input_embeds(
     image_mask, video_mask = None, None
     if pixel_values is not None:
         pixel_values = pixel_values.type(model.visual.dtype)
-        image_embeds, deepstack_image_embeds = model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds, deepstack_image_embeds = _unpack_visual_output(
+            model.visual(pixel_values, grid_thw=image_grid_thw)
+        )
         n_image_tokens = (input_ids == model.config.image_token_id).sum().item()
         n_image_features = image_embeds.shape[0]
         if n_image_tokens != n_image_features:
@@ -165,7 +178,9 @@ def _get_input_embeds(
 
     if pixel_values_videos is not None:
         pixel_values_videos = pixel_values_videos.type(model.visual.dtype)
-        video_embeds, deepstack_video_embeds = model.visual(pixel_values_videos, grid_thw=video_grid_thw)
+        video_embeds, deepstack_video_embeds = _unpack_visual_output(
+            model.visual(pixel_values_videos, grid_thw=video_grid_thw)
+        )
         n_video_tokens = (input_ids == model.config.video_token_id).sum().item()
         n_video_features = video_embeds.shape[0]
         if n_video_tokens != n_video_features:
@@ -210,7 +225,9 @@ def _get_input_embeds(
         patch_dim = config.in_channels * config.temporal_patch_size * config.patch_size**2
         pixel_values = torch.zeros((16, patch_dim), dtype=inputs_embeds.dtype, device=inputs_embeds.device)
         image_grid_thw = torch.tensor([[1, 4, 4]], dtype=torch.long, device=inputs_embeds.device)
-        image_embeds, dummy_deepstack_image_embeds = model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds, dummy_deepstack_image_embeds = _unpack_visual_output(
+            model.visual(pixel_values, grid_thw=image_grid_thw)
+        )
         inputs_embeds += 0.0 * image_embeds.mean()
         for emb in dummy_deepstack_image_embeds or []:
             inputs_embeds += 0.0 * emb.mean()


### PR DESCRIPTION
### What does this PR do?

Fix compatibility issue with Qwen3-VL visual encoder that returns different output formats depending on the `transformers` version. Newer versions return an object with `pooler_output` and `deepstack_features` attributes instead of a plain tuple, causing `ValueError: too many values to unpack`.

### Checklist Before Starting

- [x] Search for similar PRs: [query link](https://github.com/verl-project/verl/pulls?q=is%3Apr+qwen3-vl+visual+encoder)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Verified with `transformers>=4.49` where Qwen3-VL visual encoder returns the new object format. The fix handles both the old tuple return and the new object return via `hasattr(visual_output, "pooler_output")` check.

### API and Usage Example

No API changes. This is an internal compatibility fix.

### Design & Code Changes

- In `verl/models/transformers/qwen3_vl.py`, the `_get_input_embeds` function now checks the visual encoder output type before unpacking:
  - If the output has a `pooler_output` attribute (new format), access `pooler_output` and `deepstack_features` as attributes
  - Otherwise, unpack as a tuple (old format)
- Applied consistently to all 3 call sites: image processing, video processing, and dummy visual forward pass

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (N/A - bug fix, no doc changes needed)
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. Not feasible: requires specific transformers version with Qwen3-VL model weights to test visual encoder output format.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit. (N/A)