### PR TITLE
[algo] fix: loss metrics inflated by num_mini_batches * ppo_epochs

### DIFF
--- a/tests/metric/test_loss_metric_inflation.py
+++ b/tests/metric/test_loss_metric_inflation.py
@@ -1,0 +1,184 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that loss metrics are correctly averaged across mini-batches and ppo_epochs.
+
+Regression test for a bug introduced by PR #4711 where actor/pg_loss,
+actor/kl_loss, and critic/vf_loss were accumulated as float scalars via +=
+across ALL mini-batches and epochs. Since reduce_metrics calls np.mean on
+each value, floats pass through as-is (np.mean(scalar) == scalar), so the
+final metric was a sum instead of a mean — inflated by
+(num_mini_batches * ppo_epochs).
+
+The fix accumulates loss within each mini-batch's micro-batches, then appends
+the mini-batch total to a list via append_to_dict. This way reduce_metrics
+correctly averages across mini-batches and epochs.
+"""
+
+import unittest
+
+import numpy as np
+
+from verl.utils.metric.utils import reduce_metrics
+from verl.utils.py_functional import append_to_dict
+
+
+class TestLossMetricInflation(unittest.TestCase):
+    """Test the metrics aggregation pattern used in dp_actor and dp_critic."""
+
+    def _simulate_old_metrics(self, loss_values, scale_factors, num_mini_batches, ppo_epochs):
+        """
+        Simulate the OLD (buggy) pattern from PR #4711.
+
+        loss_values: list of per-micro-batch loss values
+        scale_factors: list of scale factors (1/grad_accum for each micro-batch)
+        Each mini-batch has len(loss_values)//num_mini_batches micro-batches.
+        """
+        metrics = {"actor/pg_loss": 0.0}  # float, not list
+        micro_batches_per_mini = len(loss_values) // num_mini_batches
+
+        idx = 0
+        for _epoch in range(ppo_epochs):
+            for _mb in range(num_mini_batches):
+                for _ub in range(micro_batches_per_mini):
+                    metrics["actor/pg_loss"] += loss_values[idx % len(loss_values)] * scale_factors[idx % len(scale_factors)]
+                    idx += 1
+
+        # reduce_metrics: np.mean on a float returns the float as-is
+        return reduce_metrics(metrics)["actor/pg_loss"]
+
+    def _simulate_new_metrics(self, loss_values, scale_factors, num_mini_batches, ppo_epochs):
+        """
+        Simulate the NEW (fixed) pattern.
+
+        Loss is accumulated per mini-batch, then appended to list.
+        reduce_metrics averages the list across mini-batches and epochs.
+        """
+        metrics = {}
+        micro_batches_per_mini = len(loss_values) // num_mini_batches
+
+        idx = 0
+        for _epoch in range(ppo_epochs):
+            for _mb in range(num_mini_batches):
+                mini_batch_loss = 0.0
+                for _ub in range(micro_batches_per_mini):
+                    mini_batch_loss += loss_values[idx % len(loss_values)] * scale_factors[idx % len(scale_factors)]
+                    idx += 1
+                # append mini-batch total to list
+                append_to_dict(metrics, {"actor/pg_loss": mini_batch_loss})
+
+        return reduce_metrics(metrics)["actor/pg_loss"]
+
+    def test_single_mini_batch_single_epoch(self):
+        """When num_mini_batches=1, ppo_epochs=1: old and new should agree."""
+        # 4 micro-batches, grad_accum=4, scale_factor=0.25 each
+        losses = [1.0, 2.0, 3.0, 4.0]
+        scales = [0.25, 0.25, 0.25, 0.25]
+
+        old = self._simulate_old_metrics(losses, scales, num_mini_batches=1, ppo_epochs=1)
+        new = self._simulate_new_metrics(losses, scales, num_mini_batches=1, ppo_epochs=1)
+
+        # sum(loss_i * 0.25) = (1+2+3+4)*0.25 = 2.5
+        self.assertAlmostEqual(old, 2.5)
+        self.assertAlmostEqual(new, 2.5)
+
+    def test_two_mini_batches_old_inflated(self):
+        """With 2 mini-batches: old code returns sum, new returns mean."""
+        # 2 mini-batches, each with 2 micro-batches, grad_accum=2, scale=0.5
+        losses = [1.0, 2.0, 3.0, 4.0]  # mb1: [1,2], mb2: [3,4]
+        scales = [0.5, 0.5, 0.5, 0.5]
+
+        old = self._simulate_old_metrics(losses, scales, num_mini_batches=2, ppo_epochs=1)
+        new = self._simulate_new_metrics(losses, scales, num_mini_batches=2, ppo_epochs=1)
+
+        # mini-batch 1: 1*0.5 + 2*0.5 = 1.5
+        # mini-batch 2: 3*0.5 + 4*0.5 = 3.5
+        # Old: sum = 5.0 (inflated by 2x)
+        # New: mean([1.5, 3.5]) = 2.5
+        self.assertAlmostEqual(old, 5.0)
+        self.assertAlmostEqual(new, 2.5)
+
+    def test_two_epochs_old_inflated(self):
+        """With 2 ppo_epochs: old code returns sum, new returns mean."""
+        losses = [1.0, 2.0]
+        scales = [0.5, 0.5]
+
+        old = self._simulate_old_metrics(losses, scales, num_mini_batches=1, ppo_epochs=2)
+        new = self._simulate_new_metrics(losses, scales, num_mini_batches=1, ppo_epochs=2)
+
+        # Each epoch: 1*0.5 + 2*0.5 = 1.5
+        # Old: 1.5 + 1.5 = 3.0 (inflated by 2x)
+        # New: mean([1.5, 1.5]) = 1.5
+        self.assertAlmostEqual(old, 3.0)
+        self.assertAlmostEqual(new, 1.5)
+
+    def test_two_mini_batches_two_epochs(self):
+        """Combined: 2 mini-batches * 2 epochs = 4x inflation in old code."""
+        losses = [1.0, 1.0, 1.0, 1.0]
+        scales = [0.5, 0.5, 0.5, 0.5]
+
+        old = self._simulate_old_metrics(losses, scales, num_mini_batches=2, ppo_epochs=2)
+        new = self._simulate_new_metrics(losses, scales, num_mini_batches=2, ppo_epochs=2)
+
+        # Each mini-batch: 1*0.5 + 1*0.5 = 1.0
+        # 4 mini-batch iterations total (2 epochs * 2 mini-batches)
+        # Old: sum of all = 4.0 (inflated by 4x)
+        # New: mean([1.0, 1.0, 1.0, 1.0]) = 1.0
+        self.assertAlmostEqual(old, 4.0)
+        self.assertAlmostEqual(new, 1.0)
+
+    def test_inflation_factor(self):
+        """Verify inflation factor = num_mini_batches * ppo_epochs."""
+        losses = [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+        scales = [1/3, 1/3, 1/3, 1/3, 1/3, 1/3]  # 3 micro-batches per mini-batch
+
+        num_mini_batches = 2
+        ppo_epochs = 3
+        inflation_factor = num_mini_batches * ppo_epochs  # 6
+
+        old = self._simulate_old_metrics(losses, scales, num_mini_batches, ppo_epochs)
+        new = self._simulate_new_metrics(losses, scales, num_mini_batches, ppo_epochs)
+
+        self.assertAlmostEqual(old / new, inflation_factor)
+
+    def test_metrics_dict_types(self):
+        """After fix, all metric values should be lists (not mixed float/list)."""
+        metrics = {}
+
+        # Simulate fixed pattern: loss appended at mini-batch boundary
+        for _mb in range(3):
+            mini_batch_loss = 1.5
+            micro_metrics = {"actor/entropy": 0.3, "actor/clipfrac": 0.1}
+            append_to_dict(metrics, micro_metrics)
+            append_to_dict(metrics, micro_metrics)  # 2 micro-batches
+
+            mini_batch_metrics = {
+                "actor/pg_loss": mini_batch_loss,
+                "actor/kl_loss": 0.0,
+                "actor/grad_norm": 0.5,
+            }
+            append_to_dict(metrics, mini_batch_metrics)
+
+        # All values should be lists
+        for key, val in metrics.items():
+            self.assertIsInstance(val, list, f"metrics['{key}'] should be a list, got {type(val)}")
+
+        # reduce_metrics should work correctly on all-list dict
+        reduced = reduce_metrics(metrics)
+        self.assertAlmostEqual(reduced["actor/pg_loss"], 1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -431,10 +431,7 @@ class DataParallelPPOActor(BasePPOActor):
 
         on_policy = len(mini_batches) == 1 and self.config.ppo_epochs == 1
 
-        metrics = {
-            "actor/pg_loss": 0.0,
-            "actor/kl_loss": 0.0,
-        }
+        metrics = {}
         for _ in range(self.config.ppo_epochs):
             for batch_idx, mini_batch in enumerate(mini_batches):
                 if self.config.use_dynamic_bsz:
@@ -447,6 +444,8 @@ class DataParallelPPOActor(BasePPOActor):
                     micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
 
                 self.actor_optimizer.zero_grad()
+                mini_batch_pg_loss = 0.0
+                mini_batch_kl_loss = 0.0
 
                 for micro_batch in micro_batches:
                     micro_batch = micro_batch.to(get_device_id())
@@ -533,7 +532,7 @@ class DataParallelPPOActor(BasePPOActor):
                         kl_loss = agg_loss(loss_mat=kld, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
 
                         policy_loss = policy_loss + kl_loss * self.config.kl_loss_coef
-                        metrics["actor/kl_loss"] += kl_loss.detach().item() * loss_scale_factor
+                        mini_batch_kl_loss += kl_loss.detach().item() * loss_scale_factor
                         micro_batch_metrics["actor/kl_coef"] = self.config.kl_loss_coef
 
                     if self.config.use_dynamic_bsz:
@@ -546,11 +545,15 @@ class DataParallelPPOActor(BasePPOActor):
                     else:
                         loss.backward()
 
-                    metrics["actor/pg_loss"] += pg_loss.detach().item() * loss_scale_factor
+                    mini_batch_pg_loss += pg_loss.detach().item() * loss_scale_factor
                     append_to_dict(metrics, micro_batch_metrics)
 
                 grad_norm = self._optimizer_step()
-                mini_batch_metrics = {"actor/grad_norm": grad_norm.detach().item()}
+                mini_batch_metrics = {
+                    "actor/pg_loss": mini_batch_pg_loss,
+                    "actor/kl_loss": mini_batch_kl_loss,
+                    "actor/grad_norm": grad_norm.detach().item(),
+                }
                 append_to_dict(metrics, mini_batch_metrics)
         self.actor_optimizer.zero_grad()
         return metrics

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -192,9 +192,7 @@ class DataParallelPPOCritic(BasePPOCritic):
     def update_critic(self, data: DataProto):
         # make sure we are in training mode
         self.critic_module.train()
-        metrics = {
-            "critic/vf_loss": 0.0,
-        }
+        metrics = {}
 
         select_keys = ["input_ids", "responses", "response_mask", "attention_mask", "position_ids", "values", "returns"]
         has_multi_modal_inputs = "multi_modal_inputs" in data.non_tensor_batch.keys()
@@ -218,6 +216,7 @@ class DataParallelPPOCritic(BasePPOCritic):
                     micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
 
                 self.critic_optimizer.zero_grad()
+                mini_batch_vf_loss = 0.0
 
                 for micro_batch in micro_batches:
                     micro_batch = micro_batch.to(get_device_id())
@@ -253,11 +252,14 @@ class DataParallelPPOCritic(BasePPOCritic):
                         }
                     )
 
-                    metrics["critic/vf_loss"] += vf_loss.detach().item() * loss_scale_factor
+                    mini_batch_vf_loss += vf_loss.detach().item() * loss_scale_factor
                     append_to_dict(metrics, micro_batch_metrics)
 
                 grad_norm = self._optimizer_step()
-                mini_batch_metrics = {"critic/grad_norm": grad_norm.detach().item()}
+                mini_batch_metrics = {
+                    "critic/vf_loss": mini_batch_vf_loss,
+                    "critic/grad_norm": grad_norm.detach().item(),
+                }
                 append_to_dict(metrics, mini_batch_metrics)
         self.critic_optimizer.zero_grad()
         return metrics


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where `actor/pg_loss`, `actor/kl_loss`, and `critic/vf_loss` metrics are inflated by a factor of `num_mini_batches × ppo_epochs`.

**Root cause**: PR #4711 changed loss metric accumulation from list-based (`append_to_dict`) to float-scalar (`+= ... * loss_scale_factor`) to fix double-scaling. However, this introduced a new issue: the float scalar accumulates across ALL mini-batches and epochs without resetting. When `reduce_metrics` later calls `np.mean()` on the value, a scalar passes through as-is (`np.mean(float) == float`), so the final metric is a **sum** instead of a **mean**.

**Impact**: Logged metrics only — training dynamics are unaffected. With `num_mini_batches=4, ppo_epochs=2`, the reported loss is 8× the actual per-mini-batch value, making it difficult to compare runs or detect real training issues.

**Fix**: Accumulate loss within each mini-batch using local variables (`mini_batch_pg_loss`, `mini_batch_kl_loss`, `mini_batch_vf_loss`), then `append_to_dict` at the mini-batch boundary. This way `reduce_metrics` correctly averages across all mini-batch iterations.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+loss+metric+inflation
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

6 unit tests in `tests/metric/test_loss_metric_inflation.py`:

- `test_single_mini_batch_single_epoch` — old and new agree when there's no multi-iteration
- `test_two_mini_batches_old_inflated` — old=5.0 (2× inflated), new=2.5 (correct)
- `test_two_epochs_old_inflated` — old=3.0 (2× inflated), new=1.5 (correct)
- `test_two_mini_batches_two_epochs` — old=4.0 (4× inflated), new=1.0 (correct)
- `test_inflation_factor` — verifies `old/new == num_mini_batches * ppo_epochs`
- `test_metrics_dict_types` — all metric values are lists after fix (no mixed float/list)

### Design & Code Changes

**`verl/workers/actor/dp_actor.py`**:
- Initialize `metrics = {}` (was `{"actor/pg_loss": 0.0, "actor/kl_loss": 0.0}`)
- Add `mini_batch_pg_loss` and `mini_batch_kl_loss` local variables, scoped per mini-batch iteration
- Accumulate into locals during micro-batch loop, then `append_to_dict` at mini-batch boundary

**`verl/workers/critic/dp_critic.py`**:
- Same pattern: `mini_batch_vf_loss` local variable, scoped per mini-batch iteration

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [x] Add unit tests to cover the fix
- [ ] CI request in Slack