### PR TITLE
[trainer] feat: Add metric for zero advantage responses in RL training.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+parameterized
 pytest
 pre-commit
 py-spy

--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
+from parameterized import parameterized
 
 from verl.trainer.ppo.metric_utils import (
     bootstrap_metric,
@@ -540,6 +541,45 @@ class TestProcessValidationMetrics(unittest.TestCase):
 
         # For bootstrap with n=2, the majority vote could be either A or B
         # depending on the random sampling, so we don't check the exact value
+
+
+class TestZeroAdvMetrics(unittest.TestCase):
+    """Tests for zero-advantage metrics in compute_data_metrics."""
+
+    def _make_batch(self, advantages):
+        batch = MagicMock()
+        bs, seq = advantages.shape
+        batch.batch = {
+            "advantages": advantages,
+            "attention_mask": torch.ones((bs, seq * 2)),
+            "response_mask": torch.ones((bs, seq)),
+            "responses": torch.zeros((bs, seq)),
+            "returns": torch.ones((bs, seq)),
+            "token_level_rewards": torch.ones((bs, seq)),
+            "token_level_scores": torch.ones((bs, seq)),
+        }
+        return batch
+
+    @parameterized.expand(
+        (
+            # (name, advantages, expected_count, expected_ratio)
+            ("all_nonzero_2", ((0.1, 0.2), (0.3, 0.4)), 0, 0.0),
+            ("some_zero_2", ((0.0, 0.0), (0.3, 0.4)), 1, 0.5),
+            ("all_zero_2", ((0.0, 0.0), (0.0, 0.0)), 2, 1.0),
+            ("all_zero_1", ((0.0, 0.0),), 1, 1.0),
+            ("some_zero_3", ((0.0, 0.0), (0.3, 0.4), (0.5, 0.6)), 1, 1.0 / 3),
+            ("some_zero_4", ((0.0, 0.0), (0.0, 0.0), (0.3, 0.4), (0.5, 0.6)), 2, 0.5),
+            ("below_eps", ((1e-9, 1e-10), (0.3, 0.4)), 1, 0.5),
+            ("at_eps", ((1e-8, 0.0), (0.3, 0.4)), 0, 0.0),
+            ("above_eps", ((1e-7, 0.0), (0.3, 0.4)), 0, 0.0),
+        )
+    )
+    def test_zero_adv_count_and_ratio(self, _name, advantages, expected_count, expected_ratio):
+        batch = self._make_batch(torch.tensor(advantages))
+        metrics = compute_data_metrics(batch, use_critic=False)
+
+        self.assertEqual(metrics["critic/advantages/zero_adv_count"], expected_count)
+        self.assertAlmostEqual(metrics["critic/advantages/zero_adv_ratio"], expected_ratio)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -26,6 +26,8 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.utils.import_utils import deprecated
 
+ZERO_ADV_EPS = 1e-8
+
 
 @deprecated("verl.utils.metric.reduce_metrics")
 def reduce_metrics(metrics: dict[str, list[Any]]) -> dict[str, Any]:
@@ -136,6 +138,10 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
     valid_adv = torch.masked_select(advantages, response_mask)
     valid_returns = torch.masked_select(returns, response_mask)
 
+    # Per-response zero-advantage ratio: responses whose advantage is zero contribute no policy gradient.
+    max_abs_adv = (advantages.abs() * response_mask).max(dim=-1).values  # (bs,)
+    num_zero_adv = (max_abs_adv < ZERO_ADV_EPS).sum().item()
+    num_responses = max_abs_adv.numel()
     if use_critic:
         values = batch.batch["values"]
         valid_values = torch.masked_select(values, response_mask)
@@ -170,6 +176,8 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
         "critic/advantages/mean": torch.mean(valid_adv).detach().item(),
         "critic/advantages/max": torch.max(valid_adv).detach().item(),
         "critic/advantages/min": torch.min(valid_adv).detach().item(),
+        "critic/advantages/zero_adv_count": num_zero_adv,
+        "critic/advantages/zero_adv_ratio": num_zero_adv / num_responses if num_responses > 0 else 0.0,
         # returns
         "critic/returns/mean": torch.mean(valid_returns).detach().item(),
         "critic/returns/max": torch.max(valid_returns).detach().item(),


### PR DESCRIPTION
### What does this PR do?

Add metric for zero advantage responses in RL training, non-trivial even when validation accuracy is still low:


1. Running Qwen2.5 `0.5B` model for a quick run with `GSM8k`. It ran `16` steps only, and the stats drop the most noisy data: First `3` and last `1` steps:
- On average, it has `62.89%` (std `15.23%`) responses with `0` advantage
- **NOTE**: This is the first PR to kick off further optimization to speed up RL training: We've seen `GPT-OSS-20B` RL training by skipping those responses
    1. `timing_s/step` improvement of `-13.9%`
    2. `timing_s/update_actor` improvement of `-55.2%`  and
    3. The same `loss` for validation dataset after `1` epoch

```
2026-03-27 01:13:25,037 [tb.py:264] INFO - [12/16] : (avg (std), med) = (  644.0000 [     0.0000] (  155.9316),   612.0000)  # critic/advantages/zero_adv_count
2026-03-27 01:13:25,037 [tb.py:264] INFO - [12/16] : (avg (std), med) = (    0.6289 [     0.0000] (    0.1523),     0.5977)  # critic/advantages/zero_adv_ratio
```

2. For `GPT-OSS-20B` on `GSM8k`
- `timing_s/update_actor` consistently improves over the baseline, as `critic/advantages/zero_adv_ratio` continues to improve with more `steps`

<img width="1582" height="682" alt="Screenshot 2026-03-27 at 09 50 04--timing-and-loss" src="https://github.com/user-attachments/assets/25ad3544-44f1-4daf-8a1f-64cb3518c713" />

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+zero+adv+is%3Aopen
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`

### Test

#### 0. E2E Job

```
(sliuxl-verl-github) ~$ grep zero_adv /tmp/log.txt
2026-03-27 01:13:25,037 [tb.py:264] INFO - [12/16] : (avg (std), med) = (  644.0000 [     0.0000] (  155.9316),   612.0000)  # critic/advantages/zero_adv_count
2026-03-27 01:13:25,037 [tb.py:264] INFO - [12/16] : (avg (std), med) = (    0.6289 [     0.0000] (    0.1523),     0.5977)  # critic/advantages/zero_adv_ratio


(sliuxl-verl-github) ~$ tail -93 /tmp/log.txt
+ python /fsx/ubuntu/users/sliuxl/tb.py --files 'events*' --metric '*' --drop_first 3 --drop_last 1 --format 10.4f
2026-03-27 01:13:24,975 [tb.py:206] WARNING - Unknonw metric `*`!
2026-03-27 01:13:24,976 [tb.py:216] INFO - 

[00/01] File events.out.tfevents.1774572693.ip-10-4-145-27.2670507.0:
2026-03-27 01:13:25,024 [tb.py:235] INFO - Set benchmark with index 0
2026-03-27 01:13:25,035 [tb.py:264] INFO - [12/16] : (avg (std), med) = (    0.6252 [     0.0000] (    0.0614),     0.6279)  # actor/entropy
2026-03-27 01:13:25,035 [tb.py:264] INFO - [12/16] : (avg (std), med) = (    0.0370 [     0.0000] (    0.0094),     0.0409)  # actor/grad_norm
...
```

#### 1. Unit Test

```
(sliuxl-verl-github) github/verl$ git log -1
commit ea9a2cb31afd4efc04407a8efc18611a012f8ec4 (HEAD -> dev-zero-adv, origin/dev-zero-adv)
Author: Xinle Sheila Liu <sliuxl@amazon.com>
Date:   Thu Mar 26 22:24:10 2026 +0000

    Add metric for zero advantage responses in RL training.


(sliuxl-verl-github) github/verl$ python tests/trainer/ppo/test_metric_utils_on_cpu.py
................................./fsx/ubuntu/miniconda3/envs/sliuxl-verl-github/lib/python3.12/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
/fsx/ubuntu/miniconda3/envs/sliuxl-verl-github/lib/python3.12/site-packages/numpy/core/_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
...........
----------------------------------------------------------------------
Ran 44 tests in 0.146s

OK
```

### API and Usage Example

N.A.: Should be auto-generated with other RL metrics


### Design & Code Changes

N.A.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)

