### PR TITLE
[trainer] fix: MLFlow publishing metrics failure should be non-blocking.

### DIFF
--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -331,7 +331,18 @@ class _MlflowLoggingAdapter:
         import mlflow
 
         results = {self._sanitize_key(k): v for k, v in data.items()}
-        mlflow.log_metrics(metrics=results, step=step)
+        for _attempt in range(MLFLOW_MAX_ATTEMPTS):
+            try:
+                mlflow.log_metrics(metrics=results, step=step)
+                return
+            except Exception as error:
+                # No sleep between retries — this runs per training step, so we avoid blocking.
+                msg = "mlflow.log_metrics failed (attempt %d/%d): %s"
+                args = (_attempt + 1, MLFLOW_MAX_ATTEMPTS, error)
+                if _attempt < MLFLOW_MAX_ATTEMPTS - 1:
+                    self.logger.info(msg, *args)
+                else:
+                    self.logger.warning(msg, *args)
 
 
 def _compute_mlflow_params_from_objects(params) -> dict[str, Any]:


### PR DESCRIPTION
### What does this PR do?

MLFlow publishing metrics failure should be non-blocking: **NOT** using `sleep`ing, as since that time point, it may or may not be reproducible, and it should **not block** training progress.
- It's pretty rare to see MLFlow getting exceptions during training, but it happened
- A followup of MLFlow issue during initialization in #5548


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Aopen+is%3Apr+mlflow
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

#### 1. After PR
Rerun an E2E job: No issues
- It's pretty **rare** to see the transition from `OK` to `!OK` state though ...


#### 0. Before PR

Might be a credential rotation issue (though rare).

```
(TaskRunner pid=2406908) Save metrics to file /fsx/ubuntu/users/sliuxl/outputs/sliuxl-averl--qwen2d5_0d5b_inst--gsm8k_2048/averl_feature_config_pbtxt-825266b2--12819-test-rl-0adv-00-j-01-ns01-tp01-bs16-pad0-base--20260326.130943/metrics.jsonl for epoch=0/self.global_steps=11
Training Progress:  62%|██████▎   | 10/16 [04:00<02:34, 25.75s/it]
(WorkerDict pid=2408348) [rank:0] Update policy with 128 samples: multi_turn=False, self.config.use_dynamic_bsz=True
(WorkerDict pid=2408348) [rank:0] self.config.ppo_mini_batch_size=128; len(mini_batches)=1; self.config.ppo_epochs=1;
(WorkerDict pid=2408348) [rank:0] use_dynamic_bsz=True -> self.config.ppo_max_token_len_per_gpu=49152, minibatch: 1/len(mini_batches)=1, len(micro_batches)=2, batch_sizes='64,64';
(WorkerDict pid=2408348) [Train:ppo_epoch=0/1|step=0/1]: actor/pg_clipfrac:['0.000', '0.000'] - actor/ppo_kl:['0.000', '0.000'] - actor/pg_clipfrac_lower:['0.000', '0.000'] - actor/kl_coef:['0.001', '0.001'] - actor/grad_norm:['0.040'] - actor/batch_loss:['0.000']
(TaskRunner pid=2406908) /AWSBedrockVerl/verl/utils/tracking.py:366: UserWarning: Error ending MLflow run: Error when retrieving credentials from Ec2InstanceMetadata: No credentials found in credential_source referenced in profile default
(TaskRunner pid=2406908)   warnings.warn(f"Error ending MLflow run: {e}")
Training Progress:  62%|██████▎   | 10/16 [04:22<02:37, 26.25s/it]
[2026-03-26 20:18:40,326][/AWSBedrockVerl/verl/trainer/main_ppo.py][ERROR] - Exception occurred during training: ray::TaskRunner.run() (pid=2406908, ip=10.4.145.27, actor_id=29eccd011c2ca51698c5b29301000000, repr=<main_ppo.TaskRunner object at 0x727e22819790>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/AWSBedrockVerl/verl/trainer/main_ppo.py", line 396, in run
    trainer.fit()
  File "/AWSBedrockVerl/verl/trainer/ppo/ray_trainer.py", line 1929, in fit
    logger.log(data=metrics, step=self.global_steps)
  File "/AWSBedrockVerl/verl/utils/tracking.py", line 201, in log
    logger_instance.log(data=data, step=step)
  File "/AWSBedrockVerl/verl/utils/tracking.py", line 355, in log
    mlflow.log_metrics(metrics=results, step=step)
  File "/usr/local/lib/python3.12/site-packages/mlflow/tracking/fluent.py", line 1246, in log_metrics
    return MlflowClient().log_batch(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/tracking/client.py", line 2697, in log_batch
    return self._tracking_client.log_batch(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/telemetry/track.py", line 30, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/tracking/_tracking_service/client.py", line 584, in log_batch
    self.store.log_batch(run_id=run_id, metrics=metrics_batch, params=[], tags=[])
  File "/usr/local/lib/python3.12/site-packages/mlflow/store/tracking/rest_store.py", line 982, in log_batch
    self._call_endpoint(LogBatch, req_body)
  File "/usr/local/lib/python3.12/site-packages/mlflow/store/tracking/rest_store.py", line 233, in _call_endpoint
    return call_endpoint(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/utils/rest_utils.py", line 625, in call_endpoint
    response = http_request(**call_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/utils/rest_utils.py", line 255, in http_request
    kwargs["auth"] = fetch_auth(host_creds.auth)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/mlflow/tracking/request_auth/registry.py", line 53, in fetch_auth
    return auth_provider.get_auth()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sagemaker_mlflow/auth_provider.py", line 47, in get_auth
    return AuthBoto(self.host_metadata_provider.region, self._get_auth_service_name(), assume_role_arn)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sagemaker_mlflow/auth.py", line 59, in __init__
    self.creds = session.get_credentials()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/boto3/session.py", line 219, in get_credentials
    return self._session.get_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/session.py", line 522, in get_credentials
    ).load_credentials()
      ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/credentials.py", line 2211, in load_credentials
    creds = provider.load()
            ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/credentials.py", line 1595, in load
    return self._load_creds_via_assume_role(self._profile_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/credentials.py", line 1610, in _load_creds_via_assume_role
    source_credentials = self._resolve_source_credentials(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/credentials.py", line 1775, in _resolve_source_credentials
    return self._resolve_credentials_from_source(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/botocore/credentials.py", line 1836, in _resolve_credentials_from_source
    raise CredentialRetrievalError(
botocore.exceptions.CredentialRetrievalError: Error when retrieving credentials from Ec2InstanceMetadata: No credentials found in credential_source referenced in profile default
Error executing job with overrides: ['actor_rollout_ref.actor.entropy_coeff=0', 'actor_rollout_ref.actor.fsdp_config.fsdp_size=-1', 'actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16',
```

### API and Usage Example

N.A.

### Design & Code Changes

N.A.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
    * N.A.
