### PR TITLE
[megatron] fix: pass use_distributed_optimizer to ddp_config in vanilla mbridge path

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -292,12 +292,22 @@ def make_megatron_module(
             # Extract TransformerConfig from the created model
             tf_config = get_model_config(model[0] if isinstance(model, list) else model)
         else:
+            # Build ddp_config dict with use_distributed_optimizer, same as provider path
+            ddp_config = None
+            if wrap_config.wrap_with_ddp:
+                ddp_config_dict = {
+                    "use_distributed_optimizer": wrap_config.use_distributed_optimizer,
+                }
+                if override_ddp_config is not None:
+                    ddp_config_dict.update(override_ddp_config)
+                ddp_config = ddp_config_dict
+
             model = bridge.get_model(
                 post_model_creation_callbacks=post_model_creation_callbacks,
                 wrap_with_ddp=wrap_config.wrap_with_ddp,
                 fp16=tf_config.fp16,
                 bf16=tf_config.bf16,
-                ddp_config=override_ddp_config,
+                ddp_config=ddp_config,
             )
 
         if isinstance(tf_config, MLATransformerConfig):


### PR DESCRIPTION
## Summary

In make_megatron_module(), the vanilla mbridge code path (the else branch when provider is None) passes override_ddp_config directly to bridge.get_model(). Since override_ddp_config is typically None or an empty dict, the use_distributed_optimizer setting from wrap_config is never propagated to the DDP config.

This causes the vanilla mbridge path to default to use_distributed_optimizer=True, using reduce-scatter for gradient sync even when the user has set use_distributed_optimizer=False (which should use all-reduce).

The provider path already handles this correctly by building a ddp_config_dict that includes use_distributed_optimizer from wrap_config, then merging user overrides on top.

## Fix

Apply the same pattern to the vanilla mbridge path: before calling bridge.get_model(), build a ddp_config dict that includes use_distributed_optimizer from wrap_config, then merge override_ddp_config on top. Only build the dict when wrap_with_ddp is True (matching the provider path behavior).

## Test plan

- Verified the fix mirrors the existing provider path logic (lines 268-280)
- The change is minimal and only affects the ddp_config passed to bridge.get_model() in the vanilla mbridge path