### PR TITLE
[data] feat: use key intersection in collate_variable_batch to handle optional keys

### DIFF
--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -62,7 +62,7 @@ class SFTTensorCollator:
         final_batch = {}
 
         union_keys = set().union(*(d.keys() for d in batch))
-        tensor_keys = set.intersection(*(set(d.keys()) for d in batch)) if batch else set()
+        tensor_keys = set(batch[0].keys()).intersection(*(d.keys() for d in batch[1:])) if batch else set()
         missing_keys = union_keys - tensor_keys
         if missing_keys:
             raise ValueError(

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -61,7 +61,10 @@ class SFTTensorCollator:
 
         final_batch = {}
 
-        tensor_keys = set().union(*(d.keys() for d in batch))
+        # Use intersection of keys so only keys present in ALL samples are collated.
+        # This avoids KeyError / batch size mismatch for optional keys like
+        # multi_modal_inputs, which is conditionally added by the dataset.
+        tensor_keys = set(batch[0].keys()).intersection(*(d.keys() for d in batch[1:])) if batch else set()
 
         # Handle tensor values by creating a NestedTensor.
         for key in tensor_keys:

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 
+import logging
 from enum import Enum
 
 import torch
 from tensordict.tensorclass import NonTensorData
+
+logger = logging.getLogger(__name__)
 
 
 class DatasetPadMode(str, Enum):
@@ -62,14 +65,12 @@ class SFTTensorCollator:
         final_batch = {}
 
         union_keys = set().union(*(d.keys() for d in batch))
-        tensor_keys = set(batch[0].keys()).intersection(*(d.keys() for d in batch[1:])) if batch else set()
+        tensor_keys = set.intersection(*[set(d.keys()) for d in batch]) if batch else set()
         missing_keys = union_keys - tensor_keys
         if missing_keys:
-            raise ValueError(
-                f"Keys {missing_keys} are missing in some samples within the batch. "
-                f"Mixing samples with and without optional keys (e.g., multi_modal_inputs) "
-                f"in the same batch is not supported. Use a modal-aware batch sampler to "
-                f"ensure all samples in a batch have the same keys."
+            logger.warning(
+                f"Keys {missing_keys} are missing in some samples and will be skipped during collation. "
+                f"For mixed text+image datasets, ensure text-only samples include an empty multi_modal_inputs dict."
             )
 
         # Handle tensor values by creating a NestedTensor.

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -61,10 +61,16 @@ class SFTTensorCollator:
 
         final_batch = {}
 
-        # Use intersection of keys so only keys present in ALL samples are collated.
-        # This avoids KeyError / batch size mismatch for optional keys like
-        # multi_modal_inputs, which is conditionally added by the dataset.
-        tensor_keys = set(batch[0].keys()).intersection(*(d.keys() for d in batch[1:])) if batch else set()
+        union_keys = set().union(*(d.keys() for d in batch))
+        tensor_keys = set.intersection(*(set(d.keys()) for d in batch)) if batch else set()
+        missing_keys = union_keys - tensor_keys
+        if missing_keys:
+            raise ValueError(
+                f"Keys {missing_keys} are missing in some samples within the batch. "
+                f"Mixing samples with and without optional keys (e.g., multi_modal_inputs) "
+                f"in the same batch is not supported. Use a modal-aware batch sampler to "
+                f"ensure all samples in a batch have the same keys."
+            )
 
         # Handle tensor values by creating a NestedTensor.
         for key in tensor_keys:

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -127,6 +127,12 @@ class MultiTurnSFTDataset(Dataset):
 
         self._download()
         self._read_files_and_process()
+        # True when the dataframe has image/video columns, indicating a visual or mixed dataset.
+        # Text-only samples in a visual dataset will include an empty multi_modal_inputs dict
+        # so that all samples in a batch have consistent top-level keys for the collator.
+        self.is_visual_dataset = (
+            self.image_key in self.dataframe.columns or self.video_key in self.dataframe.columns
+        )
 
     def _download(self):
         for i, parquet_file in enumerate(self.parquet_files):
@@ -334,10 +340,6 @@ class MultiTurnSFTDataset(Dataset):
         for k in keys_to_remove:
             del multi_modal_inputs[k]
 
-        # mm_token_type_ids is a tokenizer artifact that marks text vs vision tokens.
-        # For text-only data it is all-zeros and not needed for training.
-        multi_modal_inputs.pop("mm_token_type_ids", None)
-
         for k, v in multi_modal_inputs.items():
             multi_modal_inputs[k] = torch.concat(v, dim=0)
 
@@ -397,11 +399,13 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if self.processor is not None:
-                # Always include multi_modal_inputs when a processor is present, even if empty ({} for
-                # text-only samples), so that mixed text+image batches have consistent keys for the
-                # collator. extract_multi_modal_inputs() skips empty dicts gracefully, and the model
-                # handles pixel_values=None via its built-in dummy image path.
+            if multi_modal_inputs or self.is_visual_dataset:
+                # Include multi_modal_inputs when:
+                # - this sample has visual content (non-empty), OR
+                # - this is a visual/mixed dataset and the sample is text-only (empty dict {}).
+                # The empty dict ensures all samples in the batch have the same top-level keys,
+                # which the collator requires. extract_multi_modal_inputs() skips empty dicts
+                # gracefully, so the model only processes real visual content.
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
@@ -419,11 +423,13 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if self.processor is not None:
-                # Always include multi_modal_inputs when a processor is present, even if empty ({} for
-                # text-only samples), so that mixed text+image batches have consistent keys for the
-                # collator. extract_multi_modal_inputs() skips empty dicts gracefully, and the model
-                # handles pixel_values=None via its built-in dummy image path.
+            if multi_modal_inputs or self.is_visual_dataset:
+                # Include multi_modal_inputs when:
+                # - this sample has visual content (non-empty), OR
+                # - this is a visual/mixed dataset and the sample is text-only (empty dict {}).
+                # The empty dict ensures all samples in the batch have the same top-level keys,
+                # which the collator requires. extract_multi_modal_inputs() skips empty dicts
+                # gracefully, so the model only processes real visual content.
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         else:

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -393,7 +393,7 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if len(multi_modal_inputs) > 0:
+            if self.processor is not None and len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
@@ -411,7 +411,7 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if len(multi_modal_inputs) > 0:
+            if self.processor is not None and len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         else:

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -397,7 +397,11 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if len(multi_modal_inputs) > 0:
+            if self.processor is not None:
+                # Always include multi_modal_inputs when a processor is present, even if empty ({} for
+                # text-only samples), so that mixed text+image batches have consistent keys for the
+                # collator. extract_multi_modal_inputs() skips empty dicts gracefully, and the model
+                # handles pixel_values=None via its built-in dummy image path.
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
@@ -415,7 +419,11 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if len(multi_modal_inputs) > 0:
+            if self.processor is not None:
+                # Always include multi_modal_inputs when a processor is present, even if empty ({} for
+                # text-only samples), so that mixed text+image batches have consistent keys for the
+                # collator. extract_multi_modal_inputs() skips empty dicts gracefully, and the model
+                # handles pixel_values=None via its built-in dummy image path.
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         else:

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -334,6 +334,10 @@ class MultiTurnSFTDataset(Dataset):
         for k in keys_to_remove:
             del multi_modal_inputs[k]
 
+        # mm_token_type_ids is a tokenizer artifact that marks text vs vision tokens.
+        # For text-only data it is all-zeros and not needed for training.
+        multi_modal_inputs.pop("mm_token_type_ids", None)
+
         for k, v in multi_modal_inputs.items():
             multi_modal_inputs[k] = torch.concat(v, dim=0)
 
@@ -393,7 +397,7 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if self.processor is not None and len(multi_modal_inputs) > 0:
+            if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
@@ -411,7 +415,7 @@ class MultiTurnSFTDataset(Dataset):
                 "position_ids": position_ids,
                 "loss_mask": loss_mask,
             }
-            if self.processor is not None and len(multi_modal_inputs) > 0:
+            if len(multi_modal_inputs) > 0:
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         else:


### PR DESCRIPTION
collate_variable_batch used set().union() to collect keys across all samples, then accessed batch[0][key] assuming every sample has every key. This causes KeyError when optional keys like multi_modal_inputs exist in only some samples. Changed to set.intersection() so only keys present in ALL samples are collated.