### PR TITLE
[megatron, ckpt] fix: handle None param_data in get_megatron_module_device when use_distributed_optimizer=False

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -1347,6 +1347,12 @@ def get_megatron_module_device(models: list[Any]) -> str:
             return "cpu"
 
     buffer = model_chunk.buffers[0]
+    if buffer.param_data is None:
+        # use_distributed_optimizer=False: no flat param buffer, check module params directly
+        try:
+            return next(model_chunk.module.parameters()).device.type
+        except StopIteration:
+            return "cpu"
     if buffer.param_data.storage().size() == 0:
         return "cpu"
     else:


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in `get_megatron_module_device` during checkpoint saving when `use_distributed_optimizer=False`.

When `use_distributed_optimizer=False`, Megatron's `ParamAndGradBuffer.param_data` is intentionally set to `None` (no flat param buffer is allocated since the distributed optimizer does not need it). The original code unconditionally called `buffer.param_data.storage()`, causing:

```
AttributeError: 'NoneType' object has no attribute 'storage'
```

This crash happens at the very start of `save_checkpoint`, before any data is written, so the checkpoint is never saved.

**Trigger condition:** `use_distributed_optimizer=False` + checkpoint saving. This combination arises in certain expert/pipeline parallel configs where the distributed optimizer is incompatible with the NCCL communication groups, e.g. PP=4, EP=2, TP=2, ETP=2 with `vanilla_mbridge=True`.

### Checklist Before Starting

- [x] Search for similar PRs. No existing fix found for this specific issue.

### Test

Verified on Qwen3.5-35B-A3B with the following config:

```
engine.tensor_model_parallel_size=2
engine.pipeline_model_parallel_size=4
engine.expert_model_parallel_size=2
engine.expert_tensor_parallel_size=2
engine.use_distributed_optimizer=False
engine.use_mbridge=True
engine.vanilla_mbridge=True
```

Checkpoint saves successfully at the configured `save_freq` step.

### Design & Code Changes

`get_megatron_module_device` now handles `param_data is None` by falling back to checking the device of the actual module parameters:

```python
# Before
buffer = model_chunk.buffers[0]
if buffer.param_data.storage().size() == 0:  # crash when param_data is None
    return 'cpu'

# After
buffer = model_chunk.buffers[0]
if buffer.param_data is None:
    # use_distributed_optimizer=False: no flat param buffer, check module params directly
    try:
        return next(model_chunk.module.parameters()).device.type
    except StopIteration:
        return 'cpu'
if buffer.param_data.storage().size() == 0:
    return 'cpu'
```

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s). Not feasible for this fix as it requires a specific multi-node parallel config to reproduce.