### PR TITLE
[tool] feat: add Daytona sandbox backend for tool calling

### DIFF
--- a/docs/sglang_multiturn/multiturn.rst
+++ b/docs/sglang_multiturn/multiturn.rst
@@ -31,15 +31,16 @@ For custom environment interaction tools, you can implement your own tools based
         tool_schema:
 
 You may refer to GSM8KTool_example_configuration_, which is one example of the tool configurations. Its implementation can be found in gsm8k_tool.py_.
+For a remote Python code execution backend, refer to ``examples/sglang_multiturn/config/tool_config/daytona_tool_config.yaml``.
 
-Finally, set the ``tools_config_file`` in your rollout config:
+Finally, set the ``tool_config_path`` in your rollout config:
 
 .. code-block:: yaml
 
     actor_rollout_ref:
         rollout:
-            tool_kwargs:
-                tools_config_file: <path_to_tool_yaml_file>
+            multi_turn:
+                tool_config_path: <path_to_tool_yaml_file>
 
 This allows integration of customized tool behaviors during actor rollout steps.
 

--- a/docs/start/install.rst
+++ b/docs/start/install.rst
@@ -95,6 +95,7 @@ After pulling the desired Docker image and installing desired inference and trai
     git clone https://github.com/volcengine/verl && cd verl
     pip3 install -e ".[vllm]"
     pip3 install -e ".[sglang]"
+    pip3 install -e ".[daytona]"
 
 
 Install from custom environment

--- a/examples/sglang_multiturn/README.md
+++ b/examples/sglang_multiturn/README.md
@@ -35,4 +35,5 @@ bash examples/sglang_multiturn/run_qwen2.5-3b_gsm8k_multiturn_4xgpu.sh
 
 - The rollout supports multi-turn conversations with tool-calling capabilities.
 - Current tools are used for GSM8K answer evaluation.
-- Future versions may extend to search and code interpreter tools.
+- For remote Python code execution, export your `DAYTONA_*` credentials and use `examples/sglang_multiturn/config/tool_config/daytona_tool_config.yaml`. `examples/sglang_multiturn/config/retool_multiturn_daytona_grpo.yaml` shows the full GRPO wiring.
+- To benchmark Daytona against Sandbox Fusion through the real veRL tool lifecycle, run `python3 scripts/benchmark_daytona_tool.py --backend daytona` or `--backend both` after setting `SANDBOX_FUSION_URL` for the Sandbox Fusion comparison.

--- a/examples/sglang_multiturn/config/retool_multiturn_daytona_grpo.yaml
+++ b/examples/sglang_multiturn/config/retool_multiturn_daytona_grpo.yaml
@@ -1,0 +1,22 @@
+hydra:
+  searchpath:
+    - file://verl/trainer/config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+data:
+  max_prompt_length: 1024
+  max_response_length: 1024
+  train_batch_size: 256
+  return_raw_chat: True
+
+actor_rollout_ref:
+  hybrid_engine: True
+  rollout:
+    name: sglang
+    multi_turn:
+      enable: True
+      max_assistant_turns: 5
+      tool_config_path: "./config/tool_config/daytona_tool_config.yaml"

--- a/examples/sglang_multiturn/config/tool_config/daytona_tool_config.yaml
+++ b/examples/sglang_multiturn/config/tool_config/daytona_tool_config.yaml
@@ -1,0 +1,25 @@
+tools:
+  - class_name: "verl.tools.daytona_sandbox_tool.DaytonaSandboxTool"
+    config:
+      rate_limit: 32
+      enable_global_rate_limit: true
+      create_timeout: 60
+      default_timeout: 30
+      delete_timeout: 60
+      auto_stop_interval: 15
+      auto_delete_interval: 30
+      name_prefix: "verl-daytona"
+      language: "python"
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "code_interpreter"
+        description: "A tool for executing Python code in a Daytona sandbox."
+        parameters:
+          type: "object"
+          properties:
+            code:
+              type: "string"
+              description: "The Python code to execute."
+          required: ["code"]

--- a/scripts/benchmark_daytona_tool.py
+++ b/scripts/benchmark_daytona_tool.py
@@ -1,0 +1,549 @@
+# Copyright 2025 Individual Contributor: Muhammad Hashmi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark the Daytona sandbox tool: setup cost and execution latency."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import platform
+import statistics
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from verl.tools.schemas import (
+    OpenAIFunctionParametersSchema,
+    OpenAIFunctionPropertySchema,
+    OpenAIFunctionSchema,
+    OpenAIFunctionToolSchema,
+)
+
+DEFAULT_CONCURRENCY = [1, 4, 8]
+DEFAULT_WARMUPS = 3
+DEFAULT_ITERATIONS = 20
+
+
+def build_code_interpreter_schema() -> OpenAIFunctionToolSchema:
+    """Return the code interpreter schema used by the benchmarked tool."""
+    return OpenAIFunctionToolSchema(
+        type="function",
+        function=OpenAIFunctionSchema(
+            name="code_interpreter",
+            description="A tool for executing Python code.",
+            parameters=OpenAIFunctionParametersSchema(
+                type="object",
+                properties={
+                    "code": OpenAIFunctionPropertySchema(
+                        type="string",
+                        description="The Python code to execute.",
+                    )
+                },
+                required=["code"],
+            ),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """Describe one benchmark scenario."""
+
+    name: str
+    label: str
+    code: str
+    expected_substring: str | None
+    expects_error: bool = False
+
+
+SCENARIOS = [
+    Scenario(
+        name="simple_stdout",
+        label="Executing print(2+2) — minimal round-trip latency",
+        code="print(2 + 2)",
+        expected_substring="4",
+    ),
+    Scenario(
+        name="cpu_bound_stdout",
+        label="Executing sum(i*i for 20k iterations) — CPU-bound compute",
+        code=("total = 0\nfor i in range(20000):\n    total += i * i\nprint(total)\n"),
+        expected_substring="2666466670000",
+    ),
+    Scenario(
+        name="runtime_error",
+        label="Executing raise ValueError — error propagation",
+        code="raise ValueError('boom from benchmark')",
+        expected_substring="ValueError",
+        expects_error=True,
+    ),
+]
+
+
+def percentile(values: list[float], pct: float) -> float:
+    """Return a simple percentile for a non-empty sorted sample."""
+    if not values:
+        raise ValueError("percentile() requires at least one value")
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * pct)
+    return ordered[index]
+
+
+def build_daytona_config(args: argparse.Namespace) -> dict[str, Any]:
+    """Build the Daytona tool configuration for benchmarking."""
+    config = {
+        "type": "native",
+        "rate_limit": max(args.concurrency),
+        "enable_global_rate_limit": True,
+        "create_timeout": args.create_timeout,
+        "default_timeout": args.default_timeout,
+        "delete_timeout": args.delete_timeout,
+        "auto_stop_interval": args.auto_stop_interval,
+        "auto_delete_interval": args.auto_delete_interval,
+        "name_prefix": "verl-daytona-bench",
+        "language": "python",
+    }
+
+    for key, value in {
+        "snapshot": args.daytona_snapshot,
+        "api_url": args.daytona_api_url,
+        "target": args.daytona_target,
+        "organization_id": args.daytona_organization_id,
+    }.items():
+        if value is not None:
+            config[key] = value
+
+    return config
+
+
+def ensure_output_dir(output_root: Path) -> Path:
+    """Create a timestamped benchmark output directory."""
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = output_root / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+
+def check_daytona_credentials() -> None:
+    """Fail fast if Daytona credentials are missing."""
+    if not os.environ.get("DAYTONA_API_KEY") and not os.environ.get("DAYTONA_JWT_TOKEN"):
+        raise SystemExit("DAYTONA_API_KEY (or DAYTONA_JWT_TOKEN) is not set. Export it before running the benchmark.")
+
+
+def make_tool(args: argparse.Namespace):
+    """Instantiate the Daytona tool backend."""
+    from verl.tools.daytona_sandbox_tool import DaytonaSandboxTool
+
+    return DaytonaSandboxTool(build_daytona_config(args), build_code_interpreter_schema())
+
+
+# -- Phase 1: Sandbox setup --------------------------------------------------
+
+
+async def _create_one(tool) -> tuple[str, float]:
+    """Create a single sandbox and return (instance_id, elapsed_seconds)."""
+    t0 = perf_counter()
+    instance_id, _ = await tool.create()
+    return instance_id, perf_counter() - t0
+
+
+async def measure_setup(tool, count: int) -> dict[str, Any]:
+    """Create `count` sandboxes in parallel, measuring each creation time.
+
+    Returns a dict with per-sandbox timings, total wall time, and the list
+    of instance_ids for use in subsequent phases.
+
+    On partial failure, cleans up any successfully created sandboxes before
+    re-raising.
+    """
+    total_start = perf_counter()
+
+    results = await asyncio.gather(
+        *[_create_one(tool) for _ in range(count)],
+        return_exceptions=True,
+    )
+
+    total_wall = perf_counter() - total_start
+
+    # Separate successes from failures.
+    succeeded = [(iid, t) for r in results if not isinstance(r, BaseException) for iid, t in [r]]
+    failures = [r for r in results if isinstance(r, BaseException)]
+
+    if failures:
+        # Clean up whatever was created before propagating the error.
+        created_ids = [iid for iid, _ in succeeded]
+        if created_ids:
+            print(f"\n  Setup failed — cleaning up {len(created_ids)} sandboxes that were created...")
+            await _force_cleanup(tool, created_ids)
+        raise failures[0]
+
+    instance_ids = [iid for iid, _ in succeeded]
+    create_times = [t for _, t in succeeded]
+
+    return {
+        "sandbox_count": count,
+        "create_times_s": create_times,
+        "p50_create_s": percentile(create_times, 0.50),
+        "p95_create_s": percentile(create_times, 0.95),
+        "max_create_s": max(create_times),
+        "mean_create_s": statistics.fmean(create_times),
+        "total_wall_s": total_wall,
+        "instance_ids": instance_ids,
+    }
+
+
+async def _force_cleanup(tool, instance_ids: list[str]) -> None:
+    """Best-effort cleanup of sandboxes. Logs but does not raise on individual failures."""
+    results = await asyncio.gather(
+        *[_release_one(tool, iid) for iid in instance_ids],
+        return_exceptions=True,
+    )
+    failed = sum(1 for r in results if r.get("error"))
+    if failed:
+        print(f"  Warning: {failed}/{len(instance_ids)} sandboxes failed to release during cleanup")
+    else:
+        print(f"  Cleaned up {len(instance_ids)} sandboxes")
+
+
+# -- Phase 2: Execution latency (sandboxes already running) ------------------
+
+
+async def run_single_execution(tool, instance_id: str, scenario: Scenario, timeout: int) -> dict[str, Any]:
+    """Execute one code snippet on an existing sandbox and measure latency."""
+    started_at = perf_counter()
+
+    try:
+        response, _, metrics = await tool.execute(instance_id, {"code": scenario.code, "timeout": timeout})
+    except Exception as exc:
+        ended_at = perf_counter()
+        return {
+            "latency_s": ended_at - started_at,
+            "success": False,
+            "error": str(exc),
+            "response_text": "",
+            "metrics": {},
+        }
+
+    ended_at = perf_counter()
+    metrics = metrics or {}
+    response_text = response.text or ""
+    has_error_signal = "had_error" in metrics
+    had_error = bool(metrics.get("had_error"))
+
+    if scenario.expects_error:
+        success = scenario.expected_substring in response_text
+        if has_error_signal:
+            success = success and had_error
+    else:
+        success = scenario.expected_substring in response_text
+        if has_error_signal:
+            success = success and not had_error
+
+    return {
+        "latency_s": ended_at - started_at,
+        "success": success,
+        "error": None,
+        "response_text": response_text,
+        "metrics": metrics,
+    }
+
+
+async def measure_execution(
+    tool,
+    instance_ids: list[str],
+    scenario: Scenario,
+    concurrency: int,
+    warmups: int,
+    iterations: int,
+    timeout: int,
+) -> dict[str, Any]:
+    """Measure execution latency on pre-created sandboxes.
+
+    Distributes work round-robin across `concurrency` sandboxes from the pool.
+    """
+    pool = instance_ids[:concurrency]
+    measured_calls = []
+    total_measured_time = 0.0
+
+    for phase_name, batch_count in (("warmup", warmups), ("measured", iterations)):
+        for _ in range(batch_count):
+            batch_start = perf_counter()
+
+            # Round-robin: each concurrent task gets its own sandbox from the pool.
+            tasks = [run_single_execution(tool, pool[i % len(pool)], scenario, timeout) for i in range(concurrency)]
+            results = await asyncio.gather(*tasks)
+
+            batch_duration = perf_counter() - batch_start
+
+            if phase_name == "measured":
+                total_measured_time += batch_duration
+                measured_calls.extend(results)
+
+    latencies = [c["latency_s"] for c in measured_calls]
+    successes = sum(1 for c in measured_calls if c["success"])
+
+    return {
+        "scenario": scenario.name,
+        "concurrency": concurrency,
+        "measured_call_count": len(measured_calls),
+        "success_count": successes,
+        "failure_count": len(measured_calls) - successes,
+        "p50_latency_s": percentile(latencies, 0.50),
+        "p95_latency_s": percentile(latencies, 0.95),
+        "max_latency_s": max(latencies),
+        "mean_latency_s": statistics.fmean(latencies),
+        "throughput_calls_per_s": len(measured_calls) / total_measured_time if total_measured_time else 0.0,
+    }
+
+
+# -- Phase 3: Teardown -------------------------------------------------------
+
+
+async def _release_one(tool, instance_id: str) -> dict[str, Any]:
+    """Release a single sandbox and record the outcome."""
+    t0 = perf_counter()
+    try:
+        await tool.release(instance_id)
+    except Exception as exc:
+        return {
+            "instance_id": instance_id,
+            "elapsed_s": perf_counter() - t0,
+            "error": str(exc),
+        }
+
+    return {
+        "instance_id": instance_id,
+        "elapsed_s": perf_counter() - t0,
+        "error": None,
+    }
+
+
+async def measure_teardown(tool, instance_ids: list[str]) -> dict[str, Any]:
+    """Release all sandboxes in parallel and measure total teardown time."""
+    total_start = perf_counter()
+
+    release_results = await asyncio.gather(*[_release_one(tool, iid) for iid in instance_ids])
+
+    total_wall = perf_counter() - total_start
+    failures = [result for result in release_results if result["error"] is not None]
+    if failures:
+        failure_summary = ", ".join(f"{item['instance_id']}: {item['error']}" for item in failures[:3])
+        raise RuntimeError(f"Failed to release {len(failures)} sandboxes: {failure_summary}")
+
+    release_times = [result["elapsed_s"] for result in release_results]
+
+    return {
+        "sandbox_count": len(instance_ids),
+        "release_times_s": release_times,
+        "mean_release_s": statistics.fmean(release_times) if release_times else 0.0,
+        "total_wall_s": total_wall,
+    }
+
+
+# -- Reporting ----------------------------------------------------------------
+
+
+def build_terminal_summary(summary: dict[str, Any]) -> str:
+    """Render a fixed-width aligned terminal summary."""
+    lines = []
+
+    headers = ["Scenario", "Conc", "p50 (s)", "p95 (s)", "Thru (c/s)", "OK", "Fail"]
+    widths = [16, 5, 8, 8, 10, 6, 4]
+
+    ok_rows = [r for r in summary["results"] if r.get("status") == "ok"]
+    if not ok_rows:
+        return ""
+
+    def fmt_row(vals: list[str]) -> str:
+        return "  ".join(v.rjust(w) for v, w in zip(vals, widths, strict=False))
+
+    lines.append("")
+    lines.append(fmt_row(headers))
+    lines.append("  ".join("-" * w for w in widths))
+
+    for row in ok_rows:
+        lines.append(
+            fmt_row(
+                [
+                    row["scenario"],
+                    str(row["concurrency"]),
+                    f"{row['p50_latency_s']:.4f}",
+                    f"{row['p95_latency_s']:.4f}",
+                    f"{row['throughput_calls_per_s']:.2f}",
+                    str(row["success_count"]),
+                    str(row["failure_count"]),
+                ]
+            )
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def write_json(path: Path, payload: Any) -> None:
+    """Write JSON with stable indentation."""
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n")
+
+
+def write_csv(path: Path, result_rows: list[dict[str, Any]]) -> None:
+    """Write a flat CSV of benchmark results."""
+    import csv
+
+    fieldnames = [
+        "scenario",
+        "concurrency",
+        "p50_s",
+        "p95_s",
+        "max_s",
+        "mean_s",
+        "throughput_calls_per_s",
+        "success_count",
+        "failure_count",
+    ]
+
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in result_rows:
+            if row.get("status") != "ok":
+                continue
+            writer.writerow(
+                {
+                    "scenario": row["scenario"],
+                    "concurrency": row["concurrency"],
+                    "p50_s": f"{row['p50_latency_s']:.4f}",
+                    "p95_s": f"{row['p95_latency_s']:.4f}",
+                    "max_s": f"{row['max_latency_s']:.4f}",
+                    "mean_s": f"{row['mean_latency_s']:.4f}",
+                    "throughput_calls_per_s": f"{row['throughput_calls_per_s']:.2f}",
+                    "success_count": row["success_count"],
+                    "failure_count": row["failure_count"],
+                }
+            )
+
+
+# -- Main orchestrator --------------------------------------------------------
+
+
+async def run_benchmarks(args: argparse.Namespace) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    """Run all benchmarks: setup, execution, teardown."""
+    max_concurrency = max(args.concurrency)
+    result_rows: list[dict[str, Any]] = []
+    setup_result: dict[str, Any] | None = None
+
+    tool = make_tool(args)
+
+    # Phase 1: Create sandboxes up front.
+    instance_ids: list[str] = []
+    print(f"\n{'=' * 60}")
+    print(f"  SETUP — Creating {max_concurrency} sandboxes")
+    print(f"{'=' * 60}")
+    try:
+        setup = await measure_setup(tool, max_concurrency)
+        instance_ids = setup.pop("instance_ids")
+        print(
+            f"  {max_concurrency} sandboxes created in {setup['total_wall_s']:.2f}s (p50={setup['p50_create_s']:.3f}s)"
+        )
+
+        # Phase 2: Measure execution latency at each concurrency level.
+        for scenario in SCENARIOS:
+            print(f"\n{'=' * 60}")
+            print(f"  {scenario.label}")
+            print(f"{'=' * 60}")
+            for concurrency in args.concurrency:
+                print(f"  concurrency={concurrency}...", end=" ", flush=True)
+                result = await measure_execution(
+                    tool,
+                    instance_ids,
+                    scenario,
+                    concurrency,
+                    args.warmups,
+                    args.iterations,
+                    args.default_timeout,
+                )
+                result["status"] = "ok"
+                result_rows.append(result)
+                ok = result["success_count"]
+                fail = result["failure_count"]
+                print(
+                    f"p50={result['p50_latency_s']:.3f}s  "
+                    f"throughput={result['throughput_calls_per_s']:.1f}/s  {ok}/{ok + fail} ok"
+                )
+    finally:
+        # Always clean up whatever sandboxes were created, even on failure.
+        if instance_ids:
+            print(f"\n{'=' * 60}")
+            print(f"  TEARDOWN — Releasing {len(instance_ids)} sandboxes")
+            print(f"{'=' * 60}")
+            teardown = await measure_teardown(tool, instance_ids)
+            print(f"  {len(instance_ids)} sandboxes released in {teardown['total_wall_s']:.2f}s")
+            setup_result = {"setup": setup, "teardown": teardown}
+        await tool.close()
+
+    return result_rows, setup_result
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse benchmark CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", default="outputs/daytona")
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        nargs="+",
+        default=DEFAULT_CONCURRENCY,
+        help="Concurrent tool calls per batch. Sandboxes are pre-created for the max level.",
+    )
+    parser.add_argument("--warmups", type=int, default=DEFAULT_WARMUPS)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--default-timeout", type=int, default=30)
+    parser.add_argument("--create-timeout", type=int, default=60)
+    parser.add_argument("--delete-timeout", type=int, default=60)
+    parser.add_argument("--auto-stop-interval", type=int, default=15)
+    parser.add_argument("--auto-delete-interval", type=int, default=30)
+    parser.add_argument("--daytona-api-url", default=None)
+    parser.add_argument("--daytona-target", default=None)
+    parser.add_argument("--daytona-organization-id", default=None)
+    parser.add_argument("--daytona-snapshot", default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the benchmark and save the artifact bundle locally."""
+    args = parse_args()
+    check_daytona_credentials()
+    output_dir = ensure_output_dir(Path(args.output_root))
+
+    result_rows, setup_result = asyncio.run(run_benchmarks(args))
+
+    summary = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "host": platform.platform(),
+        "python_version": platform.python_version(),
+        "results": result_rows,
+        "setup_result": setup_result,
+    }
+
+    write_json(output_dir / "summary.json", summary)
+    write_csv(output_dir / "results.csv", result_rows)
+
+    print(f"\nSaved benchmark artifacts to {output_dir}")
+    print(build_terminal_summary(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ SGLANG_REQUIRES = [
 ]
 TRL_REQUIRES = ["trl<=0.9.6"]
 MCORE_REQUIRES = ["mbridge"]
+DAYTONA_REQUIRES = ["daytona>=0.158.0,<0.159.0"]
 
 extras_require = {
     "test": TEST_REQUIRES,
@@ -70,6 +71,7 @@ extras_require = {
     "trl": TRL_REQUIRES,
     "mcore": MCORE_REQUIRES,
     "trtllm": TRTLLM_REQUIRES,
+    "daytona": DAYTONA_REQUIRES,
 }
 
 

--- a/verl/tools/daytona_sandbox_tool.py
+++ b/verl/tools/daytona_sandbox_tool.py
@@ -1,0 +1,254 @@
+# Copyright 2025 Individual Contributor: Muhammad Hashmi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Daytona-backed code interpreter tool for multi-turn rollout."""
+
+import asyncio
+import logging
+import os
+from typing import Any, Optional
+from uuid import uuid4
+
+from verl.utils.rollout_trace import rollout_trace_op
+
+from .base_tool import BaseTool
+from .schemas import (
+    OpenAIFunctionParametersSchema,
+    OpenAIFunctionPropertySchema,
+    OpenAIFunctionSchema,
+    OpenAIFunctionToolSchema,
+    ToolResponse,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def _build_code_interpreter_schema() -> OpenAIFunctionToolSchema:
+    """Return the default OpenAI tool schema for code execution."""
+    return OpenAIFunctionToolSchema(
+        type="function",
+        function=OpenAIFunctionSchema(
+            name="code_interpreter",
+            description="A tool for executing Python code in a Daytona sandbox.",
+            parameters=OpenAIFunctionParametersSchema(
+                type="object",
+                properties={
+                    "code": OpenAIFunctionPropertySchema(
+                        type="string",
+                        description="The Python code to execute.",
+                    )
+                },
+                required=["code"],
+            ),
+        ),
+    )
+
+
+def _load_async_daytona_sdk():
+    """Import the async Daytona SDK lazily so the backend stays optional."""
+    try:
+        from daytona import AsyncDaytona, CreateSandboxFromSnapshotParams, DaytonaConfig
+    except ImportError as exc:
+        raise ImportError(
+            "DaytonaSandboxTool requires the optional 'daytona' dependency. "
+            "Install it with `pip install -e '.[daytona]'` or `pip install 'daytona>=0.158.0,<0.159.0'`."
+        ) from exc
+
+    return AsyncDaytona, DaytonaConfig, CreateSandboxFromSnapshotParams
+
+
+def _resolve_daytona_auth(config: dict[str, Any]) -> dict[str, str]:
+    """Resolve Daytona auth from config or environment."""
+    api_key = config.get("api_key") or os.getenv("DAYTONA_API_KEY")
+    jwt_token = config.get("jwt_token") or os.getenv("DAYTONA_JWT_TOKEN")
+
+    if not api_key and not jwt_token:
+        raise ValueError("DaytonaSandboxTool requires DAYTONA_API_KEY or DAYTONA_JWT_TOKEN")
+
+    auth = {}
+    if api_key:
+        auth["api_key"] = api_key
+    if jwt_token:
+        auth["jwt_token"] = jwt_token
+    return auth
+
+
+class DaytonaSandboxTool(BaseTool):
+    """A tool for executing Python code in Daytona cloud sandboxes.
+
+    Each rollout trajectory gets its own isolated Daytona sandbox. ``create``
+    provisions that sandbox once and stores it under the trajectory's
+    ``instance_id``. Subsequent ``execute`` calls reuse the same sandbox, so
+    state inside the container persists across tool invocations within the same
+    trajectory. ``release`` deletes the remote sandbox and clears the local
+    bookkeeping for that instance.
+
+    The tool keeps a single async Daytona client and optionally applies a
+    global semaphore so sandbox creation, code execution, and deletion can be
+    throttled across concurrent trajectories. Execution outputs are accumulated
+    per instance and returned later from ``calc_reward``.
+
+    - ``get_openai_tool_schema``: return the OpenAI function schema exposed to the model.
+    - ``create``: create and register a sandbox for one trajectory.
+    - ``execute``: run Python code in the trajectory's existing sandbox.
+    - ``calc_reward``: return the collected outputs for that trajectory.
+    - ``release``: delete the sandbox and drop local tool state.
+    """
+
+    def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema | None):
+        tool_schema = tool_schema or _build_code_interpreter_schema()
+        super().__init__(config, tool_schema)
+
+        AsyncDaytona, DaytonaConfig, CreateSandboxFromSnapshotParams = _load_async_daytona_sdk()
+
+        auth_config = _resolve_daytona_auth(config)
+        self._create_sandbox_params_cls = CreateSandboxFromSnapshotParams
+
+        # Build the async Daytona client.
+        client_config = {}
+        for key in ("api_key", "api_url", "target", "jwt_token", "organization_id"):
+            value = {**config, **auth_config}.get(key)
+            if value is not None:
+                client_config[key] = value
+
+        if client_config:
+            self._daytona = AsyncDaytona(DaytonaConfig(**client_config))
+        else:
+            self._daytona = AsyncDaytona()
+
+        self._sandboxes: dict[str, Any] = {}
+        self._instance_dict: dict[str, dict] = {}
+
+        # Config.
+        self.rate_limit = config.get("rate_limit", 32)
+        self.default_timeout = config.get("default_timeout", 30)
+        self._create_timeout = config.get("create_timeout", 60)
+        self._delete_timeout = config.get("delete_timeout", 60)
+        self._auto_stop_interval = config.get("auto_stop_interval", 15)
+        self._auto_delete_interval = config.get("auto_delete_interval", 30)
+        self._name_prefix = config.get("name_prefix", "verl-daytona")
+        self._base_labels = dict(config.get("labels") or {})
+        self._snapshot = config.get("snapshot")
+        self._language = config.get("language", "python")
+        self._env_vars = dict(config.get("env_vars") or {})
+
+        if self._language != "python":
+            raise ValueError("DaytonaSandboxTool currently supports only language='python'")
+
+        self._semaphore = asyncio.Semaphore(self.rate_limit) if config.get("enable_global_rate_limit", True) else None
+
+        logger.info(
+            "Initialized DaytonaSandboxTool with rate_limit=%s default_timeout=%s",
+            self.rate_limit,
+            self.default_timeout,
+        )
+
+    def get_openai_tool_schema(self) -> OpenAIFunctionToolSchema:
+        """Return the OpenAI tool schema."""
+        return self.tool_schema
+
+    async def _rate_limited(self, coro):
+        """Await a coroutine under the rate limiter."""
+        if self._semaphore is None:
+            return await coro
+        async with self._semaphore:
+            return await coro
+
+    async def create(self, instance_id: Optional[str] = None, **kwargs) -> tuple[str, ToolResponse]:
+        """Create a Daytona sandbox for one rollout trajectory.
+
+        Spins up an isolated cloud sandbox. The sandbox persists until
+        ``release`` is called for this instance_id.
+        """
+        if instance_id is None:
+            instance_id = str(uuid4())
+
+        labels = {
+            **self._base_labels,
+            "framework": "verl",
+            "backend": "daytona",
+            "tool": self.name,
+            "instance_id": instance_id,
+        }
+        params = self._create_sandbox_params_cls(
+            name=f"{self._name_prefix}-{instance_id[:8]}",
+            language=self._language,
+            snapshot=self._snapshot,
+            env_vars=self._env_vars or None,
+            labels=labels,
+            auto_stop_interval=self._auto_stop_interval,
+            auto_delete_interval=self._auto_delete_interval,
+        )
+
+        sandbox = await self._rate_limited(self._daytona.create(params, timeout=self._create_timeout))
+        self._sandboxes[instance_id] = sandbox
+        self._instance_dict[instance_id] = {"reward": []}
+        return instance_id, ToolResponse()
+
+    @rollout_trace_op
+    async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs) -> tuple[ToolResponse, float, dict]:
+        """Execute Python code inside the existing Daytona sandbox.
+
+        Sends the code to the sandbox's code interpreter and returns combined
+        stdout/stderr as the tool response.  Structured error details (name,
+        value, traceback) are included in the metrics dict when execution fails.
+        """
+        code = parameters.get("code", "")
+        timeout = parameters.get("timeout", self.default_timeout)
+        envs = parameters.get("envs")
+        language = parameters.get("language")
+
+        if language is not None and language != "python":
+            raise ValueError("DaytonaSandboxTool only supports Python code execution")
+
+        if not isinstance(code, str):
+            code = str(code)
+
+        if envs is not None and not isinstance(envs, dict):
+            raise ValueError("envs must be a dictionary of string environment variables")
+
+        sandbox = self._sandboxes[instance_id]
+        result = await self._rate_limited(sandbox.code_interpreter.run_code(code, timeout=timeout, envs=envs))
+
+        output = result.stdout + result.stderr
+        if result.error is not None:
+            error_text = f"{result.error.name}: {result.error.value}"
+            if result.error.traceback:
+                error_text = f"{error_text}\n{result.error.traceback}"
+            output = f"{output.rstrip()}\n{error_text}".strip()
+
+        self._instance_dict[instance_id]["reward"].append(output)
+
+        metrics = {
+            "sandbox_id": sandbox.id,
+            "stdout_chars": len(result.stdout),
+            "stderr_chars": len(result.stderr),
+            "had_error": result.error is not None,
+            "error_name": None if result.error is None else result.error.name,
+        }
+        return ToolResponse(text=output), 0.0, metrics
+
+    async def calc_reward(self, instance_id: str, **kwargs) -> list[str]:
+        """Return the collected tool outputs for the trajectory."""
+        return self._instance_dict[instance_id]["reward"]
+
+    async def release(self, instance_id: str, **kwargs) -> None:
+        """Delete the Daytona sandbox and clean up local state for this trajectory."""
+        sandbox = self._sandboxes.pop(instance_id)
+        await self._rate_limited(sandbox.delete(timeout=self._delete_timeout))
+        del self._instance_dict[instance_id]
+
+    async def close(self) -> None:
+        """Close the underlying Daytona client and its HTTP session."""
+        await self._daytona.close()


### PR DESCRIPTION
### What does this PR do?

Adds Daytona as an alternative cloud sandbox backend for rollout-time tool calling.

Related: #2873, [bytedance/SandboxFusion#33](https://github.com/bytedance/SandboxFusion/issues/33)

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [tool daytona](https://github.com/volcengine/verl/pulls?q=is%3Apr+daytona)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Benchmark run with 250 concurrent sandboxes from macOS arm64 over ethernet to Daytona cloud (full network round-trip):

| Metric | Value |
|---|---|
| 250 sandboxes created (parallel) | 0.88s wall |
| p50 latency (concurrency=1) | 407ms |
| p50 latency (concurrency=250) | 1.13s |
| Peak throughput (250 concurrent) | 174 calls/s |
| Success rate (15,000+ calls) | 99.9% |

```
        Scenario   Conc   p50 (s)   p95 (s)  Thru (c/s)      OK  Fail
----------------  -----  --------  --------  ----------  ------  ----
   simple_stdout      1    0.4071    0.4212        2.45      20     0
   simple_stdout      4    0.4319    0.6744        6.00      80     0
   simple_stdout      8    0.4655    0.6980       11.56     160     0
   simple_stdout     16    0.5237    0.7619       20.72     320     0
   simple_stdout     32    0.5645    0.8144       38.25     640     0
   simple_stdout     64    0.6658    0.9117       67.98    1278     2
   simple_stdout    128    0.8264    1.1036      109.87    2559     1
   simple_stdout    250    1.1665    1.4546      168.47    4996     4
cpu_bound_stdout      1    0.4118    0.4276        2.43      20     0
cpu_bound_stdout      4    0.4283    0.6695        6.05      80     0
cpu_bound_stdout      8    0.4673    0.6986       11.46     160     0
cpu_bound_stdout     16    0.5030    0.7369       21.47     320     0
cpu_bound_stdout     32    0.5468    0.8014       39.23     640     0
cpu_bound_stdout     64    0.6592    0.9140       68.89    1280     0
cpu_bound_stdout    128    0.8491    1.1287      114.11    2560     0
cpu_bound_stdout    250    1.1324    1.4013      174.17    5000     0
   runtime_error      1    0.4110    0.4242        2.43      20     0
   runtime_error      4    0.4416    0.6871        5.90      80     0
   runtime_error      8    0.4694    0.6958       11.50     160     0
   runtime_error     16    0.5035    0.7489       21.23     320     0
   runtime_error     32    0.5431    0.7848       39.44     639     1
   runtime_error     64    0.6422    0.8862       70.19    1280     0
   runtime_error    128    0.8206    1.0988      112.29    2559     1
   runtime_error    250    1.1902    1.4462      168.16    4997     3
```

### API and Usage Example

```bash
pip install -e ".[daytona]"
export DAYTONA_API_KEY="..."
```

```yaml
# tool_config/daytona_tool_config.yaml
tools:
  code_interpreter:
    class_name: "verl.tools.daytona_sandbox_tool.DaytonaSandboxTool"
    config:
      rate_limit: 32
      create_timeout: 60
      default_timeout: 30
```

Set `tools_config_file` to `daytona_tool_config.yaml` in your rollout config. No other code changes needed.

### Design & Code Changes

- **`verl/tools/daytona_sandbox_tool.py`** — `DaytonaSandboxTool` implementing `BaseTool`. One isolated sandbox per trajectory, using `AsyncDaytona` with `asyncio.Semaphore` for rate limiting.
- **`scripts/benchmark_daytona_tool.py`** — Benchmark measuring setup, execution latency, and throughput at configurable concurrency levels. Cleans up sandboxes on any failure. Outputs JSON + CSV.
- **YAML configs** — `daytona_tool_config.yaml` and `retool_multiturn_daytona_grpo.yaml` for the sglang multi-turn example.
- **`setup.py`** — Optional `daytona` extra.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Daytona requires API credentials and cloud sandbox provisioning — not suitable for CI. Validated via benchmark script.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.