### PR TITLE
[dataset] fix: keep video payload intact when filtering overlong prompts

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -16,12 +16,11 @@ import os
 
 import pytest
 import torch
+from datasets import Dataset
 from omegaconf import OmegaConf
 from PIL import Image
 from torch.utils.data import DataLoader
 
-from verl import DataProto
-from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
 
 
@@ -34,6 +33,9 @@ def get_gsm8k_data():
 
 
 def test_rl_dataset():
+    from verl import DataProto
+    from verl.utils import hf_tokenizer
+
     tokenizer = hf_tokenizer(os.path.expanduser("~/models/deepseek-ai/deepseek-coder-1.3b-instruct"))
     local_path = get_gsm8k_data()
     config = OmegaConf.create(
@@ -65,6 +67,8 @@ def test_rl_dataset():
 
 
 def test_rl_dataset_with_max_samples():
+    from verl.utils import hf_tokenizer
+
     tokenizer = hf_tokenizer(os.path.expanduser("~/models/deepseek-ai/deepseek-coder-1.3b-instruct"))
     local_path = get_gsm8k_data()
     config = OmegaConf.create(
@@ -81,6 +85,9 @@ def test_rl_dataset_with_max_samples():
 
 
 def test_image_rl_data():
+    from verl import DataProto
+    from verl.utils import hf_processor, hf_tokenizer
+
     tokenizer = hf_tokenizer(os.path.expanduser("~/models/Qwen/Qwen2-VL-2B-Instruct"))
     processor = hf_processor(os.path.expanduser("~/models/Qwen/Qwen2-VL-2B-Instruct"))
     config = OmegaConf.create(
@@ -164,6 +171,9 @@ def video_data_file():
 
 
 def test_video_rl_data(video_data_file):
+    from verl import DataProto
+    from verl.utils import hf_processor, hf_tokenizer
+
     tokenizer = hf_tokenizer(os.path.expanduser("~/models/Qwen/Qwen2-VL-2B-Instruct"))
     processor = hf_processor(os.path.expanduser("~/models/Qwen/Qwen2-VL-2B-Instruct"))
     config = OmegaConf.create(
@@ -195,3 +205,57 @@ def test_video_rl_data(video_data_file):
     assert "images" not in data_proto.non_tensor_batch
 
     print("raw_prompt", data_proto.non_tensor_batch["raw_prompt"][0])
+
+
+def test_maybe_filter_out_long_prompts_keeps_video_payload(monkeypatch):
+    class FakeProcessor:
+        def __init__(self):
+            self.tokenizer = self
+
+        def apply_chat_template(self, messages, add_generation_prompt, tokenize, **kwargs):
+            assert messages[0]["content"][0]["type"] == "video"
+            return "prompt"
+
+        def __call__(self, text, images=None, videos=None, videos_kwargs=None):
+            assert images is None
+            assert videos is not None
+            assert len(videos) == 1
+            assert videos[0].shape == (2, 3, 4, 4)
+            return {"input_ids": [[1, 2, 3]]}
+
+    def fake_process_video(video, image_patch_size, return_video_metadata):
+        assert video["video"] == "demo.mp4"
+        assert return_video_metadata is True
+        return torch.ones(2, 3, 4, 4), {"fps": 2}
+
+    monkeypatch.setattr("verl.utils.dataset.vision_utils.process_video", fake_process_video)
+
+    dataset = RLHFDataset.__new__(RLHFDataset)
+    dataset.prompt_key = "prompt"
+    dataset.image_key = "images"
+    dataset.video_key = "videos"
+    dataset.image_patch_size = 14
+    dataset.max_prompt_length = 16
+    dataset.filter_overlong_prompts = True
+    dataset.num_workers = None
+    dataset.processor = FakeProcessor()
+    dataset.tokenizer = None
+    dataset.tool_schemas = None
+    dataset.apply_chat_template_kwargs = {}
+
+    row = {
+        "prompt": [{"role": "user", "content": "<video>Describe the clip."}],
+        "videos": [{"video": "demo.mp4"}],
+        "data_source": "unit-test",
+    }
+    dataframe = Dataset.from_list([row])
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert len(filtered) == 1
+    kept_row = filtered[0]
+    assert kept_row["videos"] == [{"video": "demo.mp4"}]
+
+    raw_prompt = dataset._build_messages(kept_row)
+    assert raw_prompt[0]["content"][0]["type"] == "video"
+    assert kept_row["videos"] == [{"video": "demo.mp4"}]

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -312,10 +312,11 @@ class RLHFDataset(Dataset):
         Returns:
             messages: List of messages with replaced placeholder.
         """
-        messages: list = example[self.prompt_key]
-        # When concatenating image and video datasets, pop will return None for image or video sample
-        images = example.pop(self.image_key, None) or []
-        videos = example.pop(self.video_key, None) or []
+        # Work on copies so prompt filtering and item access do not mutate the original dataset row.
+        messages: list = copy.deepcopy(example[self.prompt_key])
+        # When concatenating image and video datasets, image/video may be missing on some rows.
+        images = example.get(self.image_key) or []
+        videos = example.get(self.video_key) or []
 
         image_offset, video_offset = 0, 0
         for message in messages:
@@ -338,6 +339,7 @@ class RLHFDataset(Dataset):
                         image = image.convert("RGB")
                         content_list.append({"type": "image", "image": image})
                     elif isinstance(image, dict):
+                        image = dict(image)
                         if "bytes" in image:
                             image["image"] = Image.open(BytesIO(image["bytes"]))
                         content_list.append({"type": "image", **image})
@@ -346,7 +348,7 @@ class RLHFDataset(Dataset):
                     image_offset += 1
                 elif segment == "<video>":
                     assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
-                    content_list.append({"type": "video", **videos[video_offset]})
+                    content_list.append({"type": "video", **dict(videos[video_offset])})
                     video_offset += 1
                 else:
                     content_list.append({"type": "text", "text": segment})


### PR DESCRIPTION
## Summary

Fix a regression in `RLHFDataset` where `_build_messages()` mutated the input row by popping `images` / `videos`.

When `filter_overlong_prompts=True`, prompt-length filtering calls `_build_messages(doc)` before multimodal processing. For video samples this could remove `videos` from the row, causing the later processor call to receive `videos=None`.

## Changes

- make `_build_messages()` operate on copies instead of mutating the dataset row
- copy image/video dict payloads before assembling multimodal content
- add a regression test covering video samples in `maybe_filter_out_long_prompts()`

## Validation

```bash
PYTHONPATH=/hy-tmp/verl-submit pytest -q tests/utils/dataset/test_rl_dataset_on_cpu.py -k keeps_video_payload
```
