### PR TITLE
[vllm, fsdp] fix: apply FSDP buffer updates during rollout weight sync

### DIFF
--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -1,0 +1,244 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_weight_update_utils():
+    module_path = _REPO_ROOT / "verl/workers/rollout/vllm_rollout/weight_update_utils.py"
+    spec = importlib.util.spec_from_file_location("weight_update_utils", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_weight_update_utils = _load_weight_update_utils()
+apply_buffer_updates = _weight_update_utils.apply_buffer_updates
+split_buffer_updates = _weight_update_utils.split_buffer_updates
+
+
+def _load_vllm_rollout_utils():
+    """Load vllm_rollout/utils.py with heavyweight deps stubbed.
+
+    Injected ``sys.modules`` entries are restored afterwards so the fakes do not
+    leak into other tests; the loaded module keeps working since it binds the
+    names it needs at import time.
+    """
+    module_name = "verl.workers.rollout.vllm_rollout.utils"
+    module_path = _REPO_ROOT / "verl/workers/rollout/vllm_rollout/utils.py"
+
+    fake_outputs = types.ModuleType("vllm.outputs")
+
+    class _FakeRequestOutput:
+        pass
+
+    fake_outputs.RequestOutput = _FakeRequestOutput
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.outputs = fake_outputs
+
+    fake_vllm_third_party = types.ModuleType("verl.third_party.vllm")
+    fake_vllm_third_party.VLLM_SLEEP_LEVEL = 1
+    fake_vllm_third_party.get_version = lambda pkg: "0.8.0"
+
+    fake_vllm_utils = types.ModuleType("verl.utils.vllm")
+
+    class _FakeTensorLoRARequest:
+        pass
+
+    class _FakeVLLMHijack:
+        @staticmethod
+        def hijack():
+            return None
+
+    fake_vllm_utils.TensorLoRARequest = _FakeTensorLoRARequest
+    fake_vllm_utils.VLLMHijack = _FakeVLLMHijack
+
+    fake_vllm_patch = types.ModuleType("verl.utils.vllm.patch")
+    fake_vllm_patch.patch_vllm_moe_model_weight_loader = lambda model: None
+
+    fake_vllm_fp8 = types.ModuleType("verl.utils.vllm.vllm_fp8_utils")
+    fake_vllm_fp8.apply_vllm_fp8_patches = lambda: None
+    fake_vllm_fp8.is_fp8_model = lambda config: False
+    fake_vllm_fp8.load_quanted_weights = lambda weights, runner, is_drafter=False: weights
+
+    fake_platform = types.ModuleType("verl.plugin.platform")
+    fake_platform.get_platform = lambda: None
+
+    fakes = {
+        "vllm": fake_vllm,
+        "vllm.outputs": fake_outputs,
+        "verl.third_party.vllm": fake_vllm_third_party,
+        "verl.utils.vllm": fake_vllm_utils,
+        "verl.utils.vllm.patch": fake_vllm_patch,
+        "verl.utils.vllm.vllm_fp8_utils": fake_vllm_fp8,
+        "verl.plugin.platform": fake_platform,
+        "verl.workers.rollout.vllm_rollout.weight_update_utils": _weight_update_utils,
+    }
+
+    saved = {name: sys.modules.get(name) for name in fakes}
+    try:
+        sys.modules.update(fakes)
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec is not None and spec.loader is not None
+        spec.loader.exec_module(module)
+    finally:
+        for name, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prev
+    return module
+
+
+_vllm_rollout_utils = _load_vllm_rollout_utils()
+vLLMColocateWorkerExtension = _vllm_rollout_utils.vLLMColocateWorkerExtension
+
+
+class _ToyBlock(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 4, bias=False)
+        self.register_buffer("e_score_correction_bias", torch.zeros(4, dtype=torch.float32))
+
+
+class _ToyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = torch.nn.Module()
+        self.model.layers = torch.nn.ModuleList([_ToyBlock()])
+
+
+class _FakeVllmConfig:
+    def __init__(self, speculative_config=None):
+        self.speculative_config = speculative_config
+
+
+class _FakeModelRunner:
+    def __init__(self, inner_model, speculative_config=None):
+        self.model = inner_model
+        self.vllm_config = _FakeVllmConfig(speculative_config=speculative_config)
+
+
+def test_split_buffer_updates_routes_registered_buffers():
+    model = _ToyModel()
+    weights = [
+        ("model.layers.0.linear.weight", torch.ones(4, 4, dtype=torch.float32)),
+        ("model.layers.0.e_score_correction_bias", torch.arange(4, dtype=torch.float32)),
+    ]
+
+    param_updates, buffer_updates, named_buffers = split_buffer_updates(model, weights)
+
+    assert [name for name, _ in param_updates] == ["model.layers.0.linear.weight"]
+    assert [name for name, _ in buffer_updates] == ["model.layers.0.e_score_correction_bias"]
+    assert "model.layers.0.e_score_correction_bias" in named_buffers
+
+
+def test_apply_buffer_updates_copies_buffer_values():
+    model = _ToyModel()
+    updates = [("model.layers.0.e_score_correction_bias", torch.arange(4, dtype=torch.float32) + 1)]
+
+    loaded = apply_buffer_updates(model, updates)
+
+    assert loaded == 1
+    torch.testing.assert_close(
+        model.model.layers[0].e_score_correction_bias, torch.tensor([1, 2, 3, 4], dtype=torch.float32)
+    )
+
+
+def test_apply_buffer_updates_ignores_non_buffer_weights():
+    model = _ToyModel()
+    weights = [("model.layers.0.linear.weight", torch.ones(4, 4, dtype=torch.float32))]
+
+    loaded = apply_buffer_updates(model, weights)
+
+    assert loaded == 0
+    assert torch.count_nonzero(model.model.layers[0].e_score_correction_bias) == 0
+
+
+def test_vllm_update_weights_loads_params_and_buffers():
+    model = _ToyModel()
+    loaded_param_names = []
+    apply_named_buffers = []
+
+    def _fake_load_weights(weights):
+        loaded_param_names.extend(name for name, _ in weights)
+
+    model.load_weights = _fake_load_weights
+
+    original_apply_buffer_updates = _vllm_rollout_utils.apply_buffer_updates
+
+    def _spy_apply_buffer_updates(inner_model, buffer_updates, named_buffers=None):
+        apply_named_buffers.append(named_buffers)
+        return original_apply_buffer_updates(inner_model, buffer_updates, named_buffers=named_buffers)
+
+    _vllm_rollout_utils.apply_buffer_updates = _spy_apply_buffer_updates
+
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(model)
+
+    weights = [
+        ("model.layers.0.linear.weight", torch.ones(4, 4, dtype=torch.float32)),
+        ("model.layers.0.e_score_correction_bias", torch.arange(4, dtype=torch.float32) + 5),
+    ]
+
+    try:
+        worker._update_weights(weights, peft_config=None, base_sync_done=False)
+    finally:
+        _vllm_rollout_utils.apply_buffer_updates = original_apply_buffer_updates
+
+    assert loaded_param_names == ["model.layers.0.linear.weight"]
+    assert apply_named_buffers and apply_named_buffers[0] is not None
+    torch.testing.assert_close(
+        model.model.layers[0].e_score_correction_bias, torch.tensor([5, 6, 7, 8], dtype=torch.float32)
+    )
+
+
+def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
+    """When an MTP drafter is synced, its registered buffers must be updated too."""
+    main_model = _ToyModel()
+    drafter_model = _ToyModel()
+    main_model.load_weights = lambda weights: None
+    drafter_model.load_weights = lambda weights: None
+
+    class _SpecConfig:
+        method = "mtp"
+        draft_model_config = object()
+
+    class _Drafter:
+        def __init__(self, m):
+            self.model = m
+
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(main_model, speculative_config=_SpecConfig())
+    worker.model_runner.drafter = _Drafter(drafter_model)
+
+    weights = [
+        ("model.layers.0.linear.weight", torch.ones(4, 4, dtype=torch.float32)),
+        ("model.layers.0.e_score_correction_bias", torch.arange(4, dtype=torch.float32) + 5),
+    ]
+
+    worker._update_weights(weights, peft_config=None, base_sync_done=False)
+
+    expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
+    torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
+    torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -29,6 +29,7 @@ from verl.utils.device import is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
+from verl.workers.rollout.vllm_rollout.weight_update_utils import apply_buffer_updates, split_buffer_updates
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -263,6 +264,18 @@ class vLLMColocateWorkerExtension:
             for model, model_config in self._iter_all_models_with_config():
                 process_weights_after_loading(model, model_config, self.device)
 
+    def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
+        """Apply buffer updates to the main model and any synced MTP drafter.
+
+        The main model (yielded first) reuses the prebuilt ``named_buffers`` map;
+        the drafter builds its own. Returns buffers applied to the main model.
+        """
+        models = list(self._iter_all_models())
+        loaded = apply_buffer_updates(models[0], buffer_updates, named_buffers=main_named_buffers)
+        for model in models[1:]:
+            apply_buffer_updates(model, buffer_updates)
+        return loaded
+
     def _update_weights(self, weights: list[tuple[str, torch.Tensor]], peft_config: dict, base_sync_done: bool):
         if peft_config and base_sync_done:
             weights = dict(weights)
@@ -276,20 +289,29 @@ class vLLMColocateWorkerExtension:
             self.add_lora(lora_request)
             logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
         else:
+            param_updates, buffer_updates, named_buffers = split_buffer_updates(self.model_runner.model, weights)
             # Add the FP8 related logic here as sharding manager has been deprecated.
             # Check if FP8 quantization is enabled and apply appropriate weight loading
             if is_fp8_model(self.model_runner.vllm_config):
                 logger.info(f"FP8 model detected (async): {self.model_runner.vllm_config.quant_config}")
                 # Convert bf16 weights to fp8 format before loading
-                loaded_params = load_quanted_weights(weights, self.model_runner)
-                logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
+                loaded_params = load_quanted_weights(param_updates, self.model_runner) if param_updates else []
                 # Keep the draft model in sync when present.
-                if self._use_mtp_drafter_weight_sync():
-                    load_quanted_weights(weights, self.model_runner, is_drafter=True)
+                if self._use_mtp_drafter_weight_sync() and param_updates:
+                    load_quanted_weights(param_updates, self.model_runner, is_drafter=True)
+                loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
+                logger.info(
+                    f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}, loaded_buffers: {loaded_buffers}"
+                )
             else:
-                logger.info("Loading standard weights (non-FP8, async)")
-                for model in self._iter_all_models():
-                    model.load_weights(weights)
+                if param_updates:
+                    for model in self._iter_all_models():
+                        model.load_weights(param_updates)
+                loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
+                logger.info(
+                    f"Loading standard weights (non-FP8, async), "
+                    f"loaded_params: {len(param_updates)}, loaded_buffers: {loaded_buffers}"
+                )
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication.

--- a/verl/workers/rollout/vllm_rollout/weight_update_utils.py
+++ b/verl/workers/rollout/vllm_rollout/weight_update_utils.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+WeightUpdate = tuple[str, torch.Tensor]
+
+
+def split_buffer_updates(
+    model: torch.nn.Module, weights: list[WeightUpdate]
+) -> tuple[list[WeightUpdate], list[WeightUpdate], dict[str, torch.Tensor]]:
+    """Split incoming weight updates into parameter and buffer updates.
+
+    Returns the parameter updates, the buffer updates, and the model's
+    ``named_buffers`` map so callers can reuse it without re-iterating.
+    """
+    named_buffers = dict(model.named_buffers())
+    param_updates, buffer_updates = [], []
+    for name, tensor in weights:
+        if name in named_buffers:
+            buffer_updates.append((name, tensor))
+        else:
+            param_updates.append((name, tensor))
+    return param_updates, buffer_updates, named_buffers
+
+
+@torch.no_grad()
+def apply_buffer_updates(
+    model: torch.nn.Module,
+    buffer_updates: list[WeightUpdate],
+    named_buffers: dict[str, torch.Tensor] | None = None,
+) -> int:
+    """Copy updated buffer tensors into the target model in-place."""
+    if not buffer_updates:
+        return 0
+
+    if named_buffers is None:
+        named_buffers = dict(model.named_buffers())
+    loaded = 0
+    for name, tensor in buffer_updates:
+        if name not in named_buffers:
+            continue
+
+        target = named_buffers[name]
+        if target.shape != tensor.shape:
+            raise ValueError(
+                f"Buffer shape mismatch for {name}: expected {tuple(target.shape)}, got {tuple(tensor.shape)}"
+            )
+
+        source = tensor.to(device=target.device, dtype=target.dtype, non_blocking=False)
+        target.copy_(source, non_blocking=False)
+        loaded += 1
+
+    return loaded


### PR DESCRIPTION
## Summary

Fix FSDP-to-rollout weight sync for models whose registered buffers are updated during training.

The existing rollout update path applies parameter updates through `load_weights(...)`, but registered buffers from the FSDP state dict can be missed. This may cause rollout/training mismatch for models that rely on mutable buffers such as `e_score_correction_bias`.

## Changes

- split incoming rollout weight updates into parameter updates and buffer updates
- keep parameter loading on the existing `load_weights(...)` path
- apply registered buffer updates explicitly in-place on the rollout model
- add CPU tests covering buffer routing and rollout-side update behavior

## Validation

```bash
PYTHONPATH=/hy-tmp/verl-submit pytest -q tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
```
