### PR TITLE
[trainer] fix: serialize numpy rollout metadata in rollout_data_dir dumps

### DIFF
--- a/tests/trainer/ppo/test_ray_trainer_rollout_dump_json_on_cpu.py
+++ b/tests/trainer/ppo/test_ray_trainer_rollout_dump_json_on_cpu.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+RAY_TRAINER_PATH = Path(__file__).resolve().parents[3] / "verl/trainer/ppo/ray_trainer.py"
+
+
+def _load_rollout_dump_helper():
+    source = RAY_TRAINER_PATH.read_text()
+    module = ast.parse(source, filename=str(RAY_TRAINER_PATH))
+    selected = [
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "_jsonify_rollout_value"
+    ]
+    helper_module = ast.Module(body=selected, type_ignores=[])
+    namespace = {"np": np}
+    exec(compile(helper_module, filename=str(RAY_TRAINER_PATH), mode="exec"), namespace)
+    return namespace["_jsonify_rollout_value"]
+
+
+def _load_dump_generations():
+    source = RAY_TRAINER_PATH.read_text()
+    module = ast.parse(source, filename=str(RAY_TRAINER_PATH))
+    helper_nodes = [
+        node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "_jsonify_rollout_value"
+    ]
+    dump_node = None
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "RayPPOTrainer":
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef) and child.name == "_dump_generations":
+                    dump_node = child
+                    break
+    assert dump_node is not None
+    helper_module = ast.Module(body=[*helper_nodes, dump_node], type_ignores=[])
+    namespace = {"np": np, "json": json, "os": os}
+    exec(compile(helper_module, filename=str(RAY_TRAINER_PATH), mode="exec"), namespace)
+    return namespace["_dump_generations"]
+
+
+def test_jsonify_rollout_value_converts_numpy_bool_scalar():
+    jsonify_rollout_value = _load_rollout_dump_helper()
+
+    value = jsonify_rollout_value(np.bool_(True))
+
+    assert value is True
+    assert isinstance(value, bool)
+
+
+def test_jsonify_rollout_value_converts_nested_numpy_values():
+    jsonify_rollout_value = _load_rollout_dump_helper()
+
+    value = jsonify_rollout_value(
+        {
+            "keep": np.bool_(False),
+            "scores": np.array([np.float32(1.5), np.float32(2.5)]),
+            "nested": [np.int64(3), {"ok": np.bool_(True)}],
+        }
+    )
+
+    assert value == {
+        "keep": False,
+        "scores": [1.5, 2.5],
+        "nested": [3, {"ok": True}],
+    }
+
+
+def test_jsonify_rollout_value_produces_json_serializable_entry():
+    jsonify_rollout_value = _load_rollout_dump_helper()
+
+    entry = {
+        "reward_flags": np.bool_(True),
+        "metadata": {"accepted": np.bool_(False), "shape": np.array([1, 2])},
+    }
+
+    serialized = json.dumps(jsonify_rollout_value(entry), ensure_ascii=False)
+
+    assert json.loads(serialized) == {
+        "reward_flags": True,
+        "metadata": {"accepted": False, "shape": [1, 2]},
+    }
+
+
+def test_dump_generations_writes_jsonl_with_numpy_bool_entries():
+    dump_generations = _load_dump_generations()
+
+    class DummyTrainer:
+        global_steps = 7
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dump_generations(
+            DummyTrainer(),
+            inputs=["prompt"],
+            outputs=["answer"],
+            gts=["gt"],
+            scores=[1.0],
+            reward_extra_infos_dict={
+                "accepted": [np.bool_(True)],
+                "nested": [{"keep": np.bool_(False), "shape": np.array([1, 2])}],
+            },
+            dump_path=tmpdir,
+        )
+
+        payload = Path(tmpdir, "7.jsonl").read_text().strip()
+
+    assert json.loads(payload) == {
+        "input": "prompt",
+        "output": "answer",
+        "gts": "gt",
+        "score": 1.0,
+        "step": 7,
+        "accepted": True,
+        "nested": {"keep": False, "shape": [1, 2]},
+    }

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -74,6 +74,20 @@ from verl.workers.config import DistillationConfig, FSDPEngineConfig, McoreEngin
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
 
+def _jsonify_rollout_value(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {k: _jsonify_rollout_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_jsonify_rollout_value(v) for v in value]
+    if isinstance(value, tuple):
+        return [_jsonify_rollout_value(v) for v in value]
+    return value
+
+
 def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
     """Apply KL penalty to the token-level rewards.
 
@@ -422,7 +436,7 @@ class RayPPOTrainer:
 
         lines = []
         for i in range(n):
-            entry = {k: v[i] for k, v in base_data.items()}
+            entry = {k: _jsonify_rollout_value(v[i]) for k, v in base_data.items()}
             lines.append(json.dumps(entry, ensure_ascii=False))
 
         with open(filename, "w") as f:


### PR DESCRIPTION
### What does this PR do?

Fixes `trainer.rollout_data_dir` JSON dumping when rollout metadata contains numpy scalars such as `numpy.bool_`.

The rollout dumper previously passed per-sample entries directly into `json.dumps(...)`, which raises `TypeError: Object of type bool_ is not JSON serializable` for numpy scalar values.

This PR adds a small recursive normalizer in the rollout dump path to convert:
- numpy scalars to native Python scalars
- numpy arrays to lists
- nested dict/list/tuple containers recursively

### Test

Validated with:

```bash
PYTHONPATH=/hy-tmp/verl-submit pytest -q tests/trainer/ppo/test_ray_trainer_rollout_dump_json_on_cpu.py
```

The added CPU tests cover:
- `numpy.bool_` scalar conversion
- nested numpy scalar / ndarray conversion
- `_dump_generations` writing a real JSONL payload with numpy-backed metadata
