### PR TITLE
[training_utils] fix: mrope position_ids preprocess bug fix

### DIFF
--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -890,6 +890,6 @@ def maybe_fix_3d_position_ids(data: TensorDict):
                 # offsets.shape: [wrong](0, 4, 8, ...)           -> [correct](0, seq_len, 2 * seq_len, ...)
                 # values.shape : [wrong](4 * batch_num, seq_len) -> [correct](4, batch_num * seq_len)
                 offsets = torch.arange(0, (batch_num + 1) * seq_len, seq_len, dtype=offsets.dtype)
-                values = values.view(batch_num, 4, -1).transpose(0, 1).flatten(1)
+                values = values.contiguous().view(batch_num, 4, -1).transpose(0, 1).flatten(1)
 
             data["position_ids"] = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets, jagged_dim=2)

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -889,7 +889,7 @@ def maybe_fix_3d_position_ids(data: TensorDict):
                 # when same seq_len for all batch_num, there is wrong offsets and values
                 # offsets.shape: [wrong](0, 4, 8, ...)           -> [correct](0, seq_len, 2 * seq_len, ...)
                 # values.shape : [wrong](4 * batch_num, seq_len) -> [correct](4, batch_num * seq_len)
-                offsets = torch.arange(0, (batch_num + 1) * seq_len, seq_len, dtype=torch.int32)
+                offsets = torch.arange(0, (batch_num + 1) * seq_len, seq_len, dtype=offsets.dtype)
                 values = values.view(batch_num, 4, -1).transpose(0, 1).flatten(1)
 
             data["position_ids"] = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets, jagged_dim=2)

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -880,4 +880,16 @@ def maybe_fix_3d_position_ids(data: TensorDict):
     # will incur indexing error for ragged tensor. This only happens when using 3D position ids in VLMs.
     # This is likely a bug in tensordict. As a workaround, we manually set _ragged_index.
     if "position_ids" in data.keys() and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
-        data["position_ids"]._ragged_idx = 2
+        batch_num, _, seq_len = data["position_ids"].shape
+        if isinstance(seq_len, int):
+            # change mrope position_ids shape from (batch_num, jx, seq_len) to (batch_num, 4, jx)
+            offsets = data["position_ids"].offsets()
+            values = data["position_ids"].values()
+            if values.shape[0] != 4:
+                # when same seq_len for all batch_num, there is wrong offsets and values
+                # offsets.shape: [wrong](0, 4, 8, ...)           -> [correct](0, seq_len, 2 * seq_len, ...)
+                # values.shape : [wrong](4 * batch_num, seq_len) -> [correct](4, batch_num * seq_len)
+                offsets = torch.arange(0, (batch_num + 1) * seq_len, seq_len, dtype=torch.int32)
+                values = values.view(batch_num, 4, -1).transpose(0, 1).flatten(1)
+
+            data["position_ids"] = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets, jagged_dim=2)


### PR DESCRIPTION
### What does this PR do?

This is a coner case.

During model debugging, an error :
`RuntimeError: split_with_sizes expects split_sizes to sum exactly to 1091 (input tensor's size at dimension 1), but got split_sizes=[4]`

This error is triggered under the following specific conditions:

* Using mrope (VL model)
* Input in bsnd format (non-pack mode)
* Engine worker
* Small global batch size (GBS) — each dp is assigned only 1 or 2 mini-batches per step

In non-pack mode, verl utilizes `torch.nested_tensor`. The standard shape of `position_idx` is `(b, s)`, whereas for mrope, it is `(b, 4, s)`. When initializing a `nested_tensor`, the framework automatically designates a single distinct dimension as the variable dimension (only one variable dimension is permitted). 

When `b = 1`, there are no varying dimensions across samples, so the second dimension (`[4]`) is automatically set as the variable dimension (i.e., dim=1). The same issue arises when `b` is small and the sequence lengths (`s`) of multiple samples are identical.

Additionally, in the `maybe_fix_3d_position_ids` method, the internal attribute `_ragged_idx` — which specifies the split dimension — is hardcoded to 2 (corresponding to variable dimension dim=1) to accommodate mrope scenarios. This hardcoding conflicts with the variable dimension automatically assigned during `nested_tensor` initialization, leading to an error when executing `unbind()`.

In summary, hardcoding `_ragged_idx` is a makeshift solution. It forcibly switches the variable dimension to dim=2 without modifying the actual variable dimension determined during `nested_tensor` creation. While this works for most batch configurations, it triggers the aforementioned error under the specific conditions outlined.

To resolve this issue, this PR reconstructs the shape of `position_ids` for all mrope scenarios using `torch.nested.nested_tensor_from_jagged`, replacing the previous approach of only modifying `_ragged_idx`.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

You can validate this issue by follow codes:
```python
import torch

def nt_solution(nt):
    batch_num, _, seq_len = nt.shape
    if isinstance(seq_len, int):      
        offset = torch.arange(0, (batch_num + 1) * seq_len, seq_len, dtype=torch.int32)
        values = nt.values().view(batch_num, 4, -1).transpose(0, 1).flatten(1)
        print(f">>>>> offset: {offset}")
        print(f">>>>> values.shape: {values.shape}")
        nt = torch.nested.nested_tensor_from_jagged(values, offsets=offset, jagged_dim=2)
        return nt

def reshape_nt():
    a = torch.randn(4, 17)
    b = torch.randn(4, 17)

    nt = torch.nested.as_nested_tensor([a, b], layout=torch.jagged)

    print(f">>>>> orig nt: {nt}")

    nt = nt_solution(nt)

    print(f">>>>> processed nt: {nt}")
    nt._ragged_idx = 2

    ut = nt.unbind()
    print(f">>>>> len(ut): {len(ut)}")

if __name__ == "__main__":
    reshape_nt()

# >>>>> orig nt: NestedTensor(size=(2, j1, 17), offsets=tensor([0, 4, 8]), contiguous=True)
# >>>>> offset: tensor([ 0, 17, 34], dtype=torch.int32)
# >>>>> values.shape: torch.Size([4, 34])
# >>>>> processed nt: NestedTensor(size=(2, 4, j2), offsets=tensor([ 0, 17, 34], dtype=torch.int32), contiguous=True)
# >>>>> len(ut): 2
```

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
