### PR TITLE
[perf, fsdp, trainer] feat: Skip training for zero-advantage responses to speed up RL.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+parameterized
 pytest
 pre-commit
 py-spy

--- a/tests/trainer/ppo/test_filter_zero_adv_on_cpu.py
+++ b/tests/trainer/ppo/test_filter_zero_adv_on_cpu.py
@@ -1,0 +1,386 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.trainer.ppo.metric_utils import (
+    KEY_NUM_SEQS_CORRECTION_FACTOR,
+    KEY_NUM_TOKENS_CORRECTION_FACTOR,
+    KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP,
+    ZERO_ADV_EPS,
+    ceildiv,
+    filter_zero_adv_batch,
+)
+
+EXPECTED_METRIC_KEYS = (
+    "actor/filter_zero_adv/kept_ratio",
+    "actor/filter_zero_adv/num_kept",
+    "actor/filter_zero_adv/num_nonzero",
+    "actor/filter_zero_adv/num_padded",
+    "actor/filter_zero_adv/num_total",
+)
+
+
+def _make_batch(num_nonzero, num_zero, seq_len, attention_lengths=None):
+    """Helper to construct a DataProto batch for filter_zero_adv_batch tests.
+
+    Args:
+        num_nonzero: Number of sequences with nonzero advantage.
+        num_zero: Number of sequences with zero advantage.
+        seq_len: Sequence length for all tensors.
+        attention_lengths: Optional tuple of attention lengths per sequence.
+            If None, all sequences have full attention.
+    """
+    bs = num_nonzero + num_zero
+    advantages = torch.zeros(bs, seq_len)
+    if num_nonzero > 0:
+        advantages[:num_nonzero] = torch.randn(num_nonzero, seq_len).abs() + 1.0
+    response_mask = torch.ones(bs, seq_len)
+
+    if attention_lengths is not None:
+        attention_mask = torch.zeros(bs, seq_len)
+        for i, length in enumerate(attention_lengths):
+            attention_mask[i, :length] = 1.0
+    else:
+        attention_mask = torch.ones(bs, seq_len)
+
+    td = TensorDict(
+        {
+            "advantages": advantages,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+        },
+        batch_size=(bs,),
+    )
+    return DataProto(batch=td)
+
+
+class TestCeildiv(unittest.TestCase):
+    @parameterized.expand(
+        (
+            (1, 1, 1),
+            (4, 2, 2),
+            (5, 2, 3),
+            (10, 3, 4),
+            (10, 4, 3),
+            (7, 1, 7),
+            (0, 5, 0),
+            (1, 5, 1),
+            (128, 128, 1),
+            (129, 128, 2),
+        )
+    )
+    def test_ceildiv(self, a, b, expected):
+        self.assertEqual(ceildiv(a, b), expected)
+
+
+class TestFilterZeroAdvBatch(unittest.TestCase):
+    """Tests for filter_zero_adv_batch in metric_utils.py."""
+
+    # ------------------------------------------------------------------ #
+    #  No-op: batch returned unchanged (select logic)
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            ("all_nonzero_dp2", 8, 0, 4, 2),
+            ("all_nonzero_dp4", 8, 0, 4, 4),
+            ("all_nonzero_dp8", 16, 0, 8, 8),
+        )
+    )
+    def test_filter_no_op_all_nonzero(self, _name, num_nonzero, num_zero, seq_len, dp_size):
+        """When all sequences have nonzero advantage, batch is returned unchanged."""
+        batch = _make_batch(num_nonzero, num_zero, seq_len)
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        bs = num_nonzero + num_zero
+        self.assertIs(filtered, batch)
+        self.assertEqual(sorted(metrics.keys()), list(EXPECTED_METRIC_KEYS))
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], bs)
+        self.assertAlmostEqual(metrics["actor/filter_zero_adv/kept_ratio"], 1.0)
+        self.assertNotIn(KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP, filtered.meta_info)
+
+    @parameterized.expand(
+        (
+            ("need_3_pad_have_1", 9, 1, 4, 4),
+            ("need_3_pad_have_2", 13, 2, 4, 8),
+            ("need_3_pad_have_3", 13, 3, 4, 8),
+            ("need_6_pad_have_6", 10, 6, 4, 8),
+            ("no_zeros_unaligned", 7, 0, 4, 4),
+        )
+    )
+    def test_filter_no_op_not_enough_zeros_to_pad(self, _name, num_nonzero, num_zero, seq_len, dp_size):
+        """When there aren't enough zero-adv samples for dp_size alignment, skip filtering."""
+        batch = _make_batch(num_nonzero, num_zero, seq_len)
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        bs = num_nonzero + num_zero
+        self.assertIs(filtered, batch)
+        self.assertEqual(sorted(metrics.keys()), list(EXPECTED_METRIC_KEYS))
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], bs)
+        self.assertAlmostEqual(metrics["actor/filter_zero_adv/kept_ratio"], 1.0)
+        self.assertNotIn(KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP, filtered.meta_info)
+
+    def test_filter_no_op_empty_response_mask(self):
+        """When original_num_tokens == 0, skip filtering."""
+        bs, seq_len, dp_size = 8, 4, 2
+        td = TensorDict(
+            {
+                "advantages": torch.zeros(bs, seq_len),
+                "attention_mask": torch.ones(bs, seq_len),
+                "response_mask": torch.zeros(bs, seq_len),
+            },
+            batch_size=(bs,),
+        )
+        batch = DataProto(batch=td)
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        self.assertIs(filtered, batch)
+        self.assertEqual(sorted(metrics.keys()), list(EXPECTED_METRIC_KEYS))
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], bs)
+        self.assertAlmostEqual(metrics["actor/filter_zero_adv/kept_ratio"], 1.0)
+        self.assertNotIn(KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP, filtered.meta_info)
+
+    # ------------------------------------------------------------------ #
+    #  Filtered: sequences are actually removed
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            # (name, num_nz, num_z, seq, dp, kept, padded, orig_bs_per_dp, seq_corr, token_corr)
+            ("6nz_4z_dp4", 6, 4, 4, 4, 8, 2, 3, 0.8, 0.8),
+            ("8nz_4z_dp4_aligned", 8, 4, 4, 4, 8, 0, 3, 2 / 3, 2 / 3),
+            ("3nz_7z_dp1", 3, 7, 4, 1, 3, 0, 10, 0.3, 0.3),
+            ("5nz_5z_dp2", 5, 5, 4, 2, 6, 1, 5, 0.6, 0.6),
+            ("4nz_12z_dp4", 4, 12, 8, 4, 4, 0, 4, 0.25, 0.25),
+            ("1nz_15z_dp4", 1, 15, 4, 4, 4, 3, 4, 0.25, 0.25),
+        )
+    )
+    def test_filtered_mixed(
+        self,
+        _name,
+        num_nonzero,
+        num_zero,
+        seq_len,
+        dp_size,
+        expected_kept,
+        expected_padded,
+        expected_original_bs_per_dp,
+        expected_seq_correction,
+        expected_token_correction,
+    ):
+        """Nonzero-adv sequences are kept, zero-adv removed (with dp_size padding)."""
+        batch = _make_batch(num_nonzero, num_zero, seq_len)
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        bs = num_nonzero + num_zero
+        # Metrics
+        self.assertEqual(sorted(metrics.keys()), list(EXPECTED_METRIC_KEYS))
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_nonzero"], num_nonzero)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], expected_kept)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_padded"], expected_padded)
+        self.assertAlmostEqual(metrics["actor/filter_zero_adv/kept_ratio"], expected_kept / bs)
+        self.assertEqual(filtered.batch["advantages"].shape[0], expected_kept)
+        # meta_info
+        self.assertEqual(filtered.meta_info[KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP], expected_original_bs_per_dp)
+        self.assertAlmostEqual(filtered.meta_info[KEY_NUM_SEQS_CORRECTION_FACTOR], expected_seq_correction)
+        self.assertAlmostEqual(
+            filtered.meta_info[KEY_NUM_TOKENS_CORRECTION_FACTOR], expected_token_correction, places=6
+        )
+
+    @parameterized.expand(
+        (
+            # (name, bs, seq, dp, kept, orig_bs_per_dp, seq_corr, token_corr)
+            ("16x8_dp4", 16, 8, 4, 4, 4, 0.25, 0.25),
+            ("8x4_dp2", 8, 4, 2, 2, 4, 0.25, 0.25),
+            ("32x4_dp8", 32, 4, 8, 8, 4, 0.25, 0.25),
+        )
+    )
+    def test_filtered_all_zero_keeps_dp_size(
+        self,
+        _name,
+        bs,
+        seq_len,
+        dp_size,
+        expected_kept,
+        expected_original_bs_per_dp,
+        expected_seq_correction,
+        expected_token_correction,
+    ):
+        """When all sequences have zero advantage, keep dp_size shortest samples."""
+        attention_lengths = tuple(range(1, bs + 1))
+        batch = _make_batch(0, bs, seq_len, attention_lengths=attention_lengths)
+
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        # Metrics
+        self.assertEqual(sorted(metrics.keys()), list(EXPECTED_METRIC_KEYS))
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_nonzero"], 0)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], expected_kept)
+        self.assertAlmostEqual(metrics["actor/filter_zero_adv/kept_ratio"], expected_kept / bs)
+        self.assertEqual(filtered.batch["advantages"].shape[0], expected_kept)
+        kept_lengths = filtered.batch["attention_mask"].sum(dim=-1)
+        self.assertTrue((kept_lengths <= dp_size).all())
+        # meta_info
+        self.assertEqual(filtered.meta_info[KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP], expected_original_bs_per_dp)
+        self.assertAlmostEqual(filtered.meta_info[KEY_NUM_SEQS_CORRECTION_FACTOR], expected_seq_correction)
+        self.assertAlmostEqual(
+            filtered.meta_info[KEY_NUM_TOKENS_CORRECTION_FACTOR], expected_token_correction, places=6
+        )
+
+    # ------------------------------------------------------------------ #
+    #  With ppo_mini_batch_size: align to dp_size * K
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            # (name, num_nz, num_z, seq, dp, mini_bs, kept, padded, orig_bs_per_dp)
+            ("128_dp8_mini32_k1", 90, 38, 4, 8, 32, 96, 6, 16),
+            ("128_dp8_mini4_k4", 90, 38, 4, 8, 4, 96, 6, 16),
+            ("64_dp4_mini8_k2", 40, 24, 4, 4, 8, 40, 0, 16),
+            ("32_dp4_mini4_k2", 20, 12, 4, 4, 4, 24, 4, 8),
+            ("32_dp4_mini2_few_nz", 3, 29, 4, 4, 2, 4, 1, 8),
+        )
+    )
+    def test_filtered_with_ppo_mini_batch_size(
+        self,
+        _name,
+        num_nonzero,
+        num_zero,
+        seq_len,
+        dp_size,
+        ppo_mini_batch_size,
+        expected_kept,
+        expected_padded,
+        expected_original_bs_per_dp,
+    ):
+        """With ppo_mini_batch_size, align to dp_size * K for even mini-batch distribution."""
+        batch = _make_batch(num_nonzero, num_zero, seq_len)
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size, ppo_mini_batch_size=ppo_mini_batch_size)
+
+        bs = num_nonzero + num_zero
+        self.assertEqual(metrics["actor/filter_zero_adv/num_total"], bs)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_nonzero"], num_nonzero)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], expected_kept)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_padded"], expected_padded)
+        self.assertEqual(filtered.batch["advantages"].shape[0], expected_kept)
+        self.assertEqual(filtered.meta_info[KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP], expected_original_bs_per_dp)
+        # Verify alignment: kept must be divisible by dp_size * align_opt_steps
+        bs_per_dp = ceildiv(bs, dp_size)
+        k_original = ceildiv(bs_per_dp, ppo_mini_batch_size)
+        align_opt_steps = min(k_original, max(1, ceildiv(num_nonzero, dp_size)))
+        self.assertEqual(expected_kept % (dp_size * align_opt_steps), 0)
+
+    @parameterized.expand(
+        (
+            # All zero with ppo_mini_batch_size: align to dp_size * K
+            # 32 total, dp=4, mini_bs=4 → bs_per_dp=8, K=2
+            # 0 nz → align_opt_steps=min(2, max(1, ceil(0/4)))=min(2,1)=1, align=4
+            ("32_dp4_mini4_all_zero", 32, 4, 4, 4),
+            # 16 total, dp=2, mini_bs=4 → bs_per_dp=8, K=2
+            # 0 nz → align_opt_steps=1, align=2
+            ("16_dp2_mini4_all_zero", 16, 4, 2, 4),
+        )
+    )
+    def test_filtered_all_zero_with_ppo_mini_batch_size(self, _name, bs, seq_len, dp_size, ppo_mini_batch_size):
+        """All-zero with ppo_mini_batch_size: align_opt_steps capped at 1, keep dp_size samples."""
+        attention_lengths = tuple(range(1, bs + 1))
+        batch = _make_batch(0, bs, seq_len, attention_lengths=attention_lengths)
+
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size, ppo_mini_batch_size=ppo_mini_batch_size)
+
+        # align_opt_steps = min(K, max(1, ceil(0/dp))) = 1, so align = dp_size
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], dp_size)
+        self.assertEqual(filtered.batch["advantages"].shape[0], dp_size)
+
+    # ------------------------------------------------------------------ #
+    #  Edge cases: eps threshold, response_mask masking
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            ("half_eps", ZERO_ADV_EPS * 0.5, 0),
+            ("just_below_eps", ZERO_ADV_EPS * 0.99, 0),
+            ("at_eps", ZERO_ADV_EPS, 8),  # >= check: exactly eps is nonzero
+            ("double_eps", ZERO_ADV_EPS * 2.0, 8),
+            ("well_above", 1e-4, 8),
+        )
+    )
+    def test_advantage_eps_threshold(self, _name, adv_value, expected_nonzero):
+        """Advantages are classified as zero/nonzero based on ZERO_ADV_EPS threshold."""
+        bs, seq_len, dp_size = 8, 4, 2
+        td = TensorDict(
+            {
+                "advantages": torch.full((bs, seq_len), adv_value),
+                "attention_mask": torch.ones(bs, seq_len),
+                "response_mask": torch.ones(bs, seq_len),
+            },
+            batch_size=(bs,),
+        )
+        batch = DataProto(batch=td)
+        _, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        self.assertEqual(metrics["actor/filter_zero_adv/num_nonzero"], expected_nonzero)
+
+    def test_response_mask_determines_zero_adv(self):
+        """Only response tokens matter for zero-adv detection (advantages * response_mask)."""
+        bs, seq_len, dp_size = 4, 8, 2
+        response_mask = torch.zeros(bs, seq_len)
+        response_mask[2:, 4:] = 1.0  # only last 2 sequences have response tokens
+        td = TensorDict(
+            {
+                "advantages": torch.ones(bs, seq_len) * 10.0,
+                "attention_mask": torch.ones(bs, seq_len),
+                "response_mask": response_mask,
+            },
+            batch_size=(bs,),
+        )
+        batch = DataProto(batch=td)
+        _, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        self.assertEqual(metrics["actor/filter_zero_adv/num_nonzero"], 2)
+
+    # ------------------------------------------------------------------ #
+    #  Padding selects shortest
+    # ------------------------------------------------------------------ #
+
+    def test_padding_selects_shortest_zero_adv(self):
+        """When padding is needed, the shortest zero-adv samples (by attention_mask) are chosen."""
+        seq_len, dp_size = 8, 4
+        # 5 nonzero (len=8 each) + 5 zero with varying attention lengths
+        zero_adv_lengths = (2, 6, 1, 4, 3)
+        attention_lengths = (8, 8, 8, 8, 8) + zero_adv_lengths
+        batch = _make_batch(5, 5, seq_len, attention_lengths=attention_lengths)
+
+        filtered, metrics = filter_zero_adv_batch(batch, dp_size)
+
+        # 5 → next multiple of 4 = 8, so 3 pads needed (shortest: len=1, 2, 3)
+        self.assertEqual(metrics["actor/filter_zero_adv/num_kept"], 8)
+        kept_attn_lengths = sorted(filtered.batch["attention_mask"].sum(dim=-1).tolist())
+        # 5 nonzero (len=8 each) + 3 shortest zero-adv pads (len=1, 2, 3)
+        self.assertEqual(kept_attn_lengths, [1.0, 2.0, 3.0, 8.0, 8.0, 8.0, 8.0, 8.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/trainer/ppo/test_filter_zero_adv_on_cpu.py
+++ b/tests/trainer/ppo/test_filter_zero_adv_on_cpu.py
@@ -26,6 +26,7 @@ from verl.trainer.ppo.metric_utils import (
     ZERO_ADV_EPS,
     ceildiv,
     filter_zero_adv_batch,
+    maybe_add_corrected_mfu,
 )
 
 EXPECTED_METRIC_KEYS = (
@@ -88,6 +89,55 @@ class TestCeildiv(unittest.TestCase):
     )
     def test_ceildiv(self, a, b, expected):
         self.assertEqual(ceildiv(a, b), expected)
+
+
+class TestMaybeAddCorrectedMfu(unittest.TestCase):
+    """Tests for maybe_add_corrected_mfu in metric_utils.py."""
+
+    @parameterized.expand(
+        (
+            ("absent", {}),
+            ("explicit_none", {KEY_NUM_TOKENS_CORRECTION_FACTOR: None}),
+        )
+    )
+    def test_no_correction(self, _name, meta_info):
+        """When correction factor is absent or None, no corrected metric is added."""
+        metrics = {"perf/mfu/actor": 0.25, "perf/mfu/critic": 0.10}
+        maybe_add_corrected_mfu(metrics, meta_info)
+        self.assertEqual(sorted(metrics.keys()), ["perf/mfu/actor", "perf/mfu/critic"])
+        self.assertAlmostEqual(metrics["perf/mfu/actor"], 0.25)
+        self.assertAlmostEqual(metrics["perf/mfu/critic"], 0.10)
+
+    @parameterized.expand(
+        (
+            ("full_batch", 1.0, 0.25, 0.25),
+            ("half_filtered", 0.5, 0.30, 0.15),
+            ("quarter_filtered", 0.25, 0.40, 0.10),
+            ("slight_filter", 0.8, 0.20, 0.16),
+            ("zero_mfu", 0.5, 0.0, 0.0),
+        )
+    )
+    def test_correction_applied(self, _name, token_correction, mfu, expected_corrected):
+        """Corrected MFU = original MFU * token_correction_factor; other keys unchanged."""
+        metrics = {"perf/mfu/actor": mfu, "perf/mfu/critic": 0.10, "loss": 1.5}
+        meta_info = {KEY_NUM_TOKENS_CORRECTION_FACTOR: token_correction}
+        maybe_add_corrected_mfu(metrics, meta_info)
+        self.assertEqual(
+            sorted(metrics.keys()), ["loss", "perf/mfu/actor", "perf/mfu/actor_corrected", "perf/mfu/critic"]
+        )
+        self.assertAlmostEqual(metrics["perf/mfu/actor_corrected"], expected_corrected, places=6)
+        self.assertAlmostEqual(metrics["perf/mfu/actor"], mfu)
+        self.assertAlmostEqual(metrics["perf/mfu/critic"], 0.10)
+        self.assertAlmostEqual(metrics["loss"], 1.5)
+
+    def test_correction_overwrites_existing(self):
+        """When perf/mfu/actor_corrected already exists, it is overwritten."""
+        metrics = {"perf/mfu/actor": 0.30, "perf/mfu/actor_corrected": 999.0}
+        meta_info = {KEY_NUM_TOKENS_CORRECTION_FACTOR: 0.5}
+        maybe_add_corrected_mfu(metrics, meta_info)
+        self.assertEqual(sorted(metrics.keys()), ["perf/mfu/actor", "perf/mfu/actor_corrected"])
+        self.assertAlmostEqual(metrics["perf/mfu/actor_corrected"], 0.15, places=6)
+        self.assertAlmostEqual(metrics["perf/mfu/actor"], 0.30)
 
 
 class TestFilterZeroAdvBatch(unittest.TestCase):

--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
+from parameterized import parameterized
 
 from verl.trainer.ppo.metric_utils import (
     bootstrap_metric,
@@ -540,6 +541,45 @@ class TestProcessValidationMetrics(unittest.TestCase):
 
         # For bootstrap with n=2, the majority vote could be either A or B
         # depending on the random sampling, so we don't check the exact value
+
+
+class TestZeroAdvMetrics(unittest.TestCase):
+    """Tests for zero-advantage metrics in compute_data_metrics."""
+
+    def _make_batch(self, advantages):
+        batch = MagicMock()
+        bs, seq = advantages.shape
+        batch.batch = {
+            "advantages": advantages,
+            "attention_mask": torch.ones((bs, seq * 2)),
+            "response_mask": torch.ones((bs, seq)),
+            "responses": torch.zeros((bs, seq)),
+            "returns": torch.ones((bs, seq)),
+            "token_level_rewards": torch.ones((bs, seq)),
+            "token_level_scores": torch.ones((bs, seq)),
+        }
+        return batch
+
+    @parameterized.expand(
+        (
+            # (name, advantages, expected_count, expected_ratio)
+            ("all_nonzero_2", ((0.1, 0.2), (0.3, 0.4)), 0, 0.0),
+            ("some_zero_2", ((0.0, 0.0), (0.3, 0.4)), 1, 0.5),
+            ("all_zero_2", ((0.0, 0.0), (0.0, 0.0)), 2, 1.0),
+            ("all_zero_1", ((0.0, 0.0),), 1, 1.0),
+            ("some_zero_3", ((0.0, 0.0), (0.3, 0.4), (0.5, 0.6)), 1, 1.0 / 3),
+            ("some_zero_4", ((0.0, 0.0), (0.0, 0.0), (0.3, 0.4), (0.5, 0.6)), 2, 0.5),
+            ("below_eps", ((1e-9, 1e-10), (0.3, 0.4)), 1, 0.5),
+            ("at_eps", ((1e-8, 0.0), (0.3, 0.4)), 0, 0.0),
+            ("above_eps", ((1e-7, 0.0), (0.3, 0.4)), 0, 0.0),
+        )
+    )
+    def test_zero_adv_count_and_ratio(self, _name, advantages, expected_count, expected_ratio):
+        batch = self._make_batch(torch.tensor(advantages))
+        metrics = compute_data_metrics(batch, use_critic=False)
+
+        self.assertEqual(metrics["critic/advantages/zero_adv_count"], expected_count)
+        self.assertAlmostEqual(metrics["critic/advantages/zero_adv_ratio"], expected_ratio)
 
 
 if __name__ == "__main__":

--- a/tests/trainer/ppo/test_split_then_filter_on_cpu.py
+++ b/tests/trainer/ppo/test_split_then_filter_on_cpu.py
@@ -1,0 +1,193 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.trainer.ppo.metric_utils import ZERO_ADV_EPS
+from verl.workers.actor.dp_actor import filter_zero_adv_micro_batch
+
+
+def _make_batch(advantages_1d, seq_len, response_lengths=None):
+    """Helper to construct a DataProto batch with explicit per-sample advantage magnitudes.
+
+    Args:
+        advantages_1d: 1D list/tensor of per-sample max advantage values.
+            Values < ZERO_ADV_EPS are treated as zero-adv by filter_zero_adv_micro_batch.
+        seq_len: Sequence length for all tensors.
+        response_lengths: Optional list of per-sample response token counts.
+            If None, all samples have full response_mask.
+    """
+    bs = len(advantages_1d)
+    advantages = torch.zeros(bs, seq_len)
+    for i, a in enumerate(advantages_1d):
+        advantages[i, :] = a
+
+    if response_lengths is not None:
+        response_mask = torch.zeros(bs, seq_len)
+        for i, rl in enumerate(response_lengths):
+            response_mask[i, :rl] = 1.0
+    else:
+        response_mask = torch.ones(bs, seq_len)
+
+    attention_mask = torch.ones(bs, seq_len)
+
+    td = TensorDict(
+        {
+            "advantages": advantages,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+        },
+        batch_size=(bs,),
+    )
+    return DataProto(batch=td)
+
+
+class TestFilterZeroAdvMicroBatch(unittest.TestCase):
+    """Tests for filter_zero_adv_micro_batch in dp_actor.py."""
+
+    # ------------------------------------------------------------------ #
+    #  All nonzero: no filtering, same object returned
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            # (name, advs, seq_len, resp_lengths, expected_orig_tok)
+            ("uniform_4", [1.0] * 4, 4, None, 16),
+            ("varied", [1.0, 2.0, 0.5, 3.0], 8, None, 32),
+            ("variable_resp", [1.0, 1.0], 10, [3, 7], 10),
+        )
+    )
+    def test_no_filter_all_nonzero(self, _name, advs, seq_len, resp_lengths, expected_orig_tok):
+        batch = _make_batch(advs, seq_len, response_lengths=resp_lengths)
+        filtered, num_nz, orig_sz, orig_tok = filter_zero_adv_micro_batch(batch)
+
+        self.assertIs(filtered, batch)
+        self.assertEqual(num_nz, len(advs))
+        self.assertEqual(orig_sz, len(advs))
+        self.assertEqual(orig_tok, expected_orig_tok)
+
+    # ------------------------------------------------------------------ #
+    #  Mixed: keeps only nonzero-adv samples
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            # (name, advs, seq_len, resp_lengths, expected_kept, expected_orig_tok,
+            #  expected_seq_corr, expected_tok_corr)
+            ("half_zero", [1.0, 0.0, 1.0, 0.0], 4, None, 2, 16, 0.5, 0.5),
+            ("one_zero", [1.0, 1.0, 1.0, 0.0], 4, None, 3, 16, 0.75, 0.75),
+            ("one_nonzero", [0.0, 0.0, 0.0, 1.0], 4, None, 1, 16, 0.25, 0.25),
+            ("variable_resp", [1.0, 0.0], 10, [8, 2], 1, 10, 0.5, 0.8),
+        )
+    )
+    def test_mixed_keeps_nonzero(
+        self, _name, advs, seq_len, resp_lengths, expected_kept, expected_orig_tok, expected_seq_corr, expected_tok_corr
+    ):
+        batch = _make_batch(advs, seq_len, response_lengths=resp_lengths)
+        filtered, num_nz, orig_sz, orig_tok = filter_zero_adv_micro_batch(batch)
+
+        self.assertEqual(len(filtered), expected_kept)
+        self.assertEqual(num_nz, expected_kept)
+        self.assertEqual(orig_sz, len(advs))
+        self.assertEqual(orig_tok, expected_orig_tok)
+        # All kept samples have nonzero advantage
+        response_mask = filtered.batch["response_mask"]
+        max_abs_adv = (filtered.batch["advantages"].abs() * response_mask).max(dim=-1).values
+        self.assertTrue((max_abs_adv >= ZERO_ADV_EPS).all())
+        # Correction factors
+        seq_corr = len(filtered) / orig_sz
+        filtered_tok = filtered.batch["response_mask"].sum().item()
+        tok_corr = filtered_tok / orig_tok
+        self.assertAlmostEqual(seq_corr, expected_seq_corr)
+        self.assertAlmostEqual(tok_corr, expected_tok_corr)
+
+    # ------------------------------------------------------------------ #
+    #  All zero: keeps 1 shortest sample
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            # (name, advs, seq_len, resp_lengths, attn_lengths, expected_orig_tok)
+            ("uniform_len", [0.0] * 4, 4, None, [4, 4, 4, 4], 16),
+            ("decreasing", [0.0] * 4, 8, None, [8, 6, 4, 2], 32),
+            ("increasing", [0.0] * 4, 8, None, [2, 4, 6, 8], 32),
+            ("variable_resp", [0.0] * 3, 10, [8, 2, 5], [10, 10, 10], 15),
+        )
+    )
+    def test_all_zero_keeps_shortest(self, _name, advs, seq_len, resp_lengths, attn_lengths, expected_orig_tok):
+        batch = _make_batch(advs, seq_len, response_lengths=resp_lengths)
+        for i, length in enumerate(attn_lengths):
+            batch.batch["attention_mask"][i, :] = 0.0
+            batch.batch["attention_mask"][i, :length] = 1.0
+
+        filtered, num_nz, orig_sz, orig_tok = filter_zero_adv_micro_batch(batch)
+
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(num_nz, 0)
+        self.assertEqual(orig_sz, len(advs))
+        self.assertEqual(orig_tok, expected_orig_tok)
+        actual_len = filtered.batch["attention_mask"].sum().item()
+        self.assertEqual(actual_len, min(attn_lengths))
+
+    # ------------------------------------------------------------------ #
+    #  Eps threshold
+    # ------------------------------------------------------------------ #
+
+    @parameterized.expand(
+        (
+            ("half_eps", ZERO_ADV_EPS * 0.5, 0),
+            ("just_below", ZERO_ADV_EPS * 0.99, 0),
+            ("at_eps", ZERO_ADV_EPS, 1),
+            ("double_eps", ZERO_ADV_EPS * 2.0, 1),
+        )
+    )
+    def test_eps_threshold(self, _name, adv_value, expected_nz_for_first):
+        advs = [adv_value, 1.0]  # second sample always nonzero
+        batch = _make_batch(advs, 4)
+        _, num_nz, _, _ = filter_zero_adv_micro_batch(batch)
+
+        self.assertEqual(num_nz, expected_nz_for_first + 1)  # +1 for the 1.0 sample
+
+    # ------------------------------------------------------------------ #
+    #  Meta_info isolation: filtered gets own dict
+    # ------------------------------------------------------------------ #
+
+    def test_meta_info_isolation(self):
+        batch = _make_batch([1.0, 0.0, 1.0, 0.0], 4)
+        batch.meta_info["shared_key"] = "original"
+
+        filtered, _, _, _ = filter_zero_adv_micro_batch(batch)
+
+        # Filtered is a new object.
+        self.assertIsNot(filtered, batch)
+        # Its own meta_info dict, same content.
+        self.assertIsNot(filtered.meta_info, batch.meta_info)
+        self.assertEqual(filtered.meta_info["shared_key"], "original")
+
+    def test_meta_info_not_copied_when_no_filter(self):
+        """When all nonzero, same object is returned."""
+        batch = _make_batch([1.0, 1.0], 4)
+        batch.meta_info["shared_key"] = "original"
+        filtered, _, _, _ = filter_zero_adv_micro_batch(batch)
+        self.assertIs(filtered, batch)
+        self.assertEqual(filtered.meta_info["shared_key"], "original")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -625,6 +625,9 @@ algorithm:
     kl_coef: 0.001
     horizon: 10000
     target_kl: 0.1
+  filter_zero_adv:
+    enable: false
+    match_loss_curve: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -628,6 +628,7 @@ algorithm:
   filter_zero_adv:
     enable: false
     match_loss_curve: true
+    match_mini_batch_data_split: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -657,6 +657,9 @@ algorithm:
     kl_coef: 0.001
     horizon: 10000
     target_kl: 0.1
+  filter_zero_adv:
+    enable: false
+    match_loss_curve: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -660,6 +660,7 @@ algorithm:
   filter_zero_adv:
     enable: false
     match_loss_curve: true
+    match_mini_batch_data_split: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -605,6 +605,7 @@ algorithm:
   filter_zero_adv:
     enable: false
     match_loss_curve: true
+    match_mini_batch_data_split: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -602,6 +602,9 @@ algorithm:
     kl_coef: 0.001
     horizon: 10000
     target_kl: 0.1
+  filter_zero_adv:
+    enable: false
+    match_loss_curve: true
   use_pf_ppo: false
   pf_ppo:
     reweight_method: pow

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 
 from verl.base_config import BaseConfig
 
-__all__ = ["AlgoConfig", "FilterGroupsConfig", "KLControlConfig", "RolloutCorrectionConfig"]
+__all__ = ["AlgoConfig", "FilterGroupsConfig", "FilterZeroAdvConfig", "KLControlConfig", "RolloutCorrectionConfig"]
 
 
 @dataclass
@@ -54,6 +54,22 @@ class FilterGroupsConfig(BaseConfig):
     enable: bool = False
     metric: Optional[str] = None
     max_num_gen_batches: int = 0
+
+
+@dataclass
+class FilterZeroAdvConfig(BaseConfig):
+    """Configuration for filter_zero_adv (skip zero-advantage responses in actor update).
+
+    Args:
+        enable (bool): Whether to enable filtering. Responses in all-same-reward groups
+            contribute no policy gradient; filtering them saves fwd/bwd compute.
+        match_loss_curve (bool): Whether to add ghost optimizer.step() calls to preserve
+            the same number of optimizer updates as unfiltered training, matching the
+            baseline convergence curve.
+    """
+
+    enable: bool = False
+    match_loss_curve: bool = True
 
 
 @dataclass
@@ -630,6 +646,8 @@ class AlgoConfig(BaseConfig):
         use_pf_ppo (bool): Whether to enable preference feedback PPO.
         pf_ppo (dict[str, Any]): Preference feedback PPO settings.
         filter_groups (Optional[FilterGroupsConfig]): Filter groups configuration, used in DAPO and Entropy
+        filter_zero_adv (FilterZeroAdvConfig): Configuration for skipping zero-advantage responses
+            in actor update. See FilterZeroAdvConfig for details.
         rollout_correction (Optional[RolloutCorrectionConfig]): Rollout Correction configuration.
             Addresses off-policy issues from policy mismatch, model staleness, and general distribution shifts.
 
@@ -658,6 +676,7 @@ class AlgoConfig(BaseConfig):
     use_pf_ppo: bool = False
     pf_ppo: dict[str, Any] = field(default_factory=dict)
     filter_groups: Optional[FilterGroupsConfig] = None
+    filter_zero_adv: FilterZeroAdvConfig = field(default_factory=FilterZeroAdvConfig)
     # Rollout Correction: corrects off-policy issues (policy mismatch, model staleness, distribution shifts)
     # Set to None to disable, use RolloutCorrectionConfig presets (e.g., .tis(), .mis()), or pass dict
     rollout_correction: Optional[RolloutCorrectionConfig] = None

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -66,10 +66,16 @@ class FilterZeroAdvConfig(BaseConfig):
         match_loss_curve (bool): Whether to add ghost optimizer.step() calls to preserve
             the same number of optimizer updates as unfiltered training, matching the
             baseline convergence curve.
+        match_mini_batch_data_split (bool): When True (and match_loss_curve=True), preserve
+            the baseline's mini-batch data assignment: split ALL data into K mini-batches
+            first (identical to baseline), then filter zero-adv within each mini-batch.
+            This is mathematically lossless (zero-adv = zero gradient) and ensures exact
+            convergence matching. No-op when match_loss_curve=False.
     """
 
     enable: bool = False
     match_loss_curve: bool = True
+    match_mini_batch_data_split: bool = True
 
 
 @dataclass

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -102,6 +102,16 @@ algorithm:
     # Target KL divergence (used for adaptive controller)
     target_kl: 0.1
 
+  # Skip zero-advantage responses in actor update to save compute.
+  # Responses in all-same-reward groups contribute no policy gradient.
+  filter_zero_adv:
+
+    # Whether to enable filtering
+    enable: False
+
+    # Whether to add ghost optimizer.step() to match baseline convergence curve
+    match_loss_curve: True
+
   # Whether to enable preference feedback PPO
   use_pf_ppo: False
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -112,6 +112,10 @@ algorithm:
     # Whether to add ghost optimizer.step() to match baseline convergence curve
     match_loss_curve: True
 
+    # Whether to preserve baseline's mini-batch data assignment (split-then-filter).
+    # Only effective when match_loss_curve is True. No-op when match_loss_curve is False.
+    match_mini_batch_data_split: True
+
   # Whether to enable preference feedback PPO
   use_pf_ppo: False
 

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -47,6 +47,11 @@ PolicyLossFn = Callable[
     tuple[torch.Tensor, dict[str, Any]],
 ]
 
+LOSS_AGG_SEQ_MEAN_TOKEN_MEAN = "seq-mean-token-mean"
+LOSS_AGG_SEQ_MEAN_TOKEN_SUM = "seq-mean-token-sum"
+LOSS_AGG_SEQ_MEAN_TOKEN_SUM_NORM = "seq-mean-token-sum-norm"
+LOSS_AGG_TOKEN_MEAN = "token-mean"
+
 POLICY_LOSS_REGISTRY: dict[str, PolicyLossFn] = {}
 
 
@@ -1165,13 +1170,13 @@ def agg_loss(
         loss: `a scalar torch.Tensor`
             aggregated loss
     """
-    if loss_agg_mode == "token-mean":
+    if loss_agg_mode == LOSS_AGG_TOKEN_MEAN:
         if batch_num_tokens is None:
             if dp_size > 1:
                 raise ValueError("(global) batch_num_tokens is required when dp_size > 1")
             batch_num_tokens = loss_mask.sum()
         loss = verl_F.masked_sum(loss_mat, loss_mask) / batch_num_tokens * dp_size
-    elif loss_agg_mode in ["seq-mean-token-sum", "seq-mean-token-sum-norm"]:
+    elif loss_agg_mode in (LOSS_AGG_SEQ_MEAN_TOKEN_SUM, LOSS_AGG_SEQ_MEAN_TOKEN_SUM_NORM):
         seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)  # token-sum
         seq_mask = (torch.sum(loss_mask, dim=-1) > 0).float()  # exclude fully masked sequences
         if global_batch_size is None:
@@ -1179,12 +1184,12 @@ def agg_loss(
                 raise ValueError("global_batch_size is required when dp_size > 1")
             global_batch_size = seq_mask.sum()
         loss = verl_F.masked_sum(seq_losses, seq_mask) / global_batch_size * dp_size  # seq-mean
-        if loss_agg_mode == "seq-mean-token-sum-norm":
+        if loss_agg_mode == LOSS_AGG_SEQ_MEAN_TOKEN_SUM_NORM:
             if loss_scale_factor is None:
                 horizon = loss_mask.shape[-1]
                 loss_scale_factor = horizon
             loss /= loss_scale_factor
-    elif loss_agg_mode == "seq-mean-token-mean":
+    elif loss_agg_mode == LOSS_AGG_SEQ_MEAN_TOKEN_MEAN:
         seq_mask = torch.sum(loss_mask, dim=-1)  # per-sequence token count
         seq_losses = torch.sum(loss_mat * loss_mask, dim=-1) / (seq_mask + 1e-8)  # token-mean
         seq_mask = (seq_mask > 0).float()  # exclude fully masked sequences

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -26,6 +26,8 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.utils.import_utils import deprecated
 
+ZERO_ADV_EPS = 1e-8
+
 
 @deprecated("verl.utils.metric.reduce_metrics")
 def reduce_metrics(metrics: dict[str, list[Any]]) -> dict[str, Any]:
@@ -136,6 +138,10 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
     valid_adv = torch.masked_select(advantages, response_mask)
     valid_returns = torch.masked_select(returns, response_mask)
 
+    # Per-response zero-advantage ratio: responses whose advantage is zero contribute no policy gradient.
+    max_abs_adv = (advantages.abs() * response_mask).max(dim=-1).values  # (bs,)
+    num_zero_adv = (max_abs_adv < ZERO_ADV_EPS).sum().item()
+    num_responses = max_abs_adv.numel()
     if use_critic:
         values = batch.batch["values"]
         valid_values = torch.masked_select(values, response_mask)
@@ -170,6 +176,8 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
         "critic/advantages/mean": torch.mean(valid_adv).detach().item(),
         "critic/advantages/max": torch.max(valid_adv).detach().item(),
         "critic/advantages/min": torch.min(valid_adv).detach().item(),
+        "critic/advantages/zero_adv_count": num_zero_adv,
+        "critic/advantages/zero_adv_ratio": num_zero_adv / num_responses if num_responses > 0 else 0.0,
         # returns
         "critic/returns/mean": torch.mean(valid_returns).detach().item(),
         "critic/returns/max": torch.max(valid_returns).detach().item(),

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -42,6 +42,21 @@ def ceildiv(a: int, b: int) -> int:
     return -(-a // b)
 
 
+def maybe_add_corrected_mfu(metrics: dict, meta_info: dict) -> None:
+    """Add corrected MFU metric when filter_zero_adv is active.
+
+    When filter_zero_adv is active, perf/mfu/actor is inflated: the FLOPS
+    numerator still reflects the original (unfiltered) token count while
+    time is reduced from processing fewer samples.  This adds
+    perf/mfu/actor_corrected, which scales MFU by
+    (filtered_tokens / original_tokens) to match the actual tokens
+    processed, roughly matching baseline MFU.
+    """
+    token_correction = meta_info.get(KEY_NUM_TOKENS_CORRECTION_FACTOR, None)
+    if token_correction is not None:
+        metrics["perf/mfu/actor_corrected"] = metrics["perf/mfu/actor"] * token_correction
+
+
 def _select_shortest(batch: DataProto, indices: torch.Tensor, k: int) -> list[int]:
     """Select the k shortest samples by attention_mask length from the given indices."""
     seq_lens = batch.batch[KEY_ATTENTION_MASK][indices].sum(dim=-1)

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -26,7 +26,119 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.utils.import_utils import deprecated
 
+KEY_ADVANTAGES = "advantages"
+KEY_ATTENTION_MASK = "attention_mask"
+KEY_FILTER_ZERO_ADV_CONFIG = "filter_zero_adv_config"
+KEY_NUM_SEQS_CORRECTION_FACTOR = "batch_num_seqs_correction_factor"
+KEY_NUM_TOKENS_CORRECTION_FACTOR = "batch_num_tokens_correction_factor"
+KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP = "original_batch_size_per_dp_group"
+KEY_RESPONSE_MASK = "response_mask"
+
+
 ZERO_ADV_EPS = 1e-8
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def _select_shortest(batch: DataProto, indices: torch.Tensor, k: int) -> list[int]:
+    """Select the k shortest samples by attention_mask length from the given indices."""
+    seq_lens = batch.batch[KEY_ATTENTION_MASK][indices].sum(dim=-1)
+    _, topk_idx = seq_lens.topk(k, largest=False)
+    return indices[topk_idx].tolist()
+
+
+def filter_zero_adv_batch(batch: DataProto, dp_size: int, ppo_mini_batch_size: int = 0) -> tuple[DataProto, dict]:
+    """Filter out zero-advantage responses to skip wasted actor compute.
+
+    Responses in all-same-reward groups have advantage≈0 and contribute no policy gradient.
+    Pads with shortest zero-adv samples to ensure divisibility by the alignment unit.
+
+    When ppo_mini_batch_size > 0, pads to dp_size * K (K = original mini-batch count)
+    so sequences distribute evenly across DP groups and mini-batches. Otherwise
+    pads to dp_size only.
+
+    When all samples have zero advantage, keeps alignment-unit shortest samples so the
+    optimizer/LR-scheduler still steps (gradients will be ~0).
+
+    Args:
+        batch: Full training batch with "advantages", "response_mask", "attention_mask".
+        dp_size: Data parallel size for alignment.
+        ppo_mini_batch_size: Mini-batch size for K computation. 0 = pad to dp_size only.
+
+    Returns:
+        (filtered_batch, metrics): filtered_batch always has ≥ dp_size samples.
+    """
+    response_mask = batch.batch[KEY_RESPONSE_MASK]
+    max_abs_adv = (batch.batch[KEY_ADVANTAGES].abs() * response_mask).max(dim=-1).values
+    num_total = max_abs_adv.numel()
+    bs_per_dp = ceildiv(num_total, dp_size)
+
+    _nonzero_mask = max_abs_adv >= ZERO_ADV_EPS
+    nonzero_indices = torch.where(_nonzero_mask)[0].tolist()
+    num_nonzero = len(nonzero_indices)
+
+    zero_idx_tensor = torch.where(~_nonzero_mask)[0]
+    num_zeros = zero_idx_tensor.numel()
+
+    # Alignment unit: dp_size * K when distributing evenly across mini-batches,
+    # otherwise dp_size only. Capped by num_nonzero to ensure each mini-batch
+    # gets at least one nonzero sample per DP group.
+    if ppo_mini_batch_size > 0:
+        k_original = ceildiv(bs_per_dp, ppo_mini_batch_size)
+        align_opt_steps = min(k_original, max(1, ceildiv(num_nonzero, dp_size)))
+    else:
+        align_opt_steps = 1
+    align = dp_size * align_opt_steps
+
+    original_num_tokens = response_mask.sum().item()
+    if original_num_tokens == 0:
+        # Empty batch: skip filtering.
+        selected = None
+    elif num_nonzero == 0:
+        # All zero-adv: keep align shortest for LR schedule continuity (~0 gradient).
+        selected = _select_shortest(batch, zero_idx_tensor, align)
+    else:
+        num_pad = (-num_nonzero) % align
+        if num_zeros <= num_pad:
+            # Not enough zero-adv samples to align — skip filtering, use full batch.
+            selected = None
+        elif num_pad > 0:
+            selected = nonzero_indices + _select_shortest(batch, zero_idx_tensor, num_pad)
+        else:
+            selected = nonzero_indices
+
+    if selected is None:
+        num_selected = num_total
+        filtered_batch = batch
+    else:
+        num_selected = len(selected)
+        assert num_selected != num_total, f"Filtering was a no-op but selected is not None: {num_selected=}"
+
+        filtered_batch = batch[selected]
+        filtered_batch.meta_info.update(
+            {
+                KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP: bs_per_dp,  # per-GPU (matches ppo_mini_batch_size)
+                # Loss normalization corrections: agg_loss divides by local token/seq count,
+                # but we need to normalize by the original (pre-filter) counts so the
+                # gradient magnitude matches the unfiltered baseline.
+                KEY_NUM_TOKENS_CORRECTION_FACTOR: (
+                    filtered_batch.batch[KEY_RESPONSE_MASK].sum().item() / original_num_tokens
+                ),
+                KEY_NUM_SEQS_CORRECTION_FACTOR: num_selected / num_total,
+            }
+        )
+    num_padded = num_selected - num_nonzero
+
+    metrics = {
+        "actor/filter_zero_adv/num_nonzero": num_nonzero,
+        "actor/filter_zero_adv/num_padded": num_padded,
+        "actor/filter_zero_adv/num_kept": num_selected,
+        "actor/filter_zero_adv/num_total": num_total,
+        "actor/filter_zero_adv/kept_ratio": num_selected / num_total if num_total > 0 else 0.0,
+    }
+    return filtered_batch, metrics
 
 
 @deprecated("verl.utils.metric.reduce_metrics")
@@ -107,13 +219,13 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
     sequence_score = batch.batch["token_level_scores"].sum(-1)
     sequence_reward = batch.batch["token_level_rewards"].sum(-1)
 
-    advantages = batch.batch["advantages"]
+    advantages = batch.batch[KEY_ADVANTAGES]
     returns = batch.batch["returns"]
 
     max_response_length = batch.batch["responses"].shape[-1]
 
     prompt_mask = batch.batch["attention_mask"][:, :-max_response_length].bool()
-    response_mask = batch.batch["response_mask"].bool()
+    response_mask = batch.batch[KEY_RESPONSE_MASK].bool()
 
     max_prompt_length = prompt_mask.size(-1)
 
@@ -352,7 +464,7 @@ def compute_variance_proxy_metrics(batch: DataProto, gradient_norm: float = None
         # Note: IS weight statistics and mismatch metrics are logged in ray_trainer.py
 
     # Get scalar advantages (mean over timesteps)
-    advantages = batch.batch["advantages"]
+    advantages = batch.batch[KEY_ADVANTAGES]
     # Compute mean advantage per trajectory using masked_mean
     advantages_scalar = verl_F.masked_mean(advantages, response_mask, axis=-1)
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1561,14 +1561,20 @@ class RayPPOTrainer:
                     # Keep the unfiltered batch for critic update and metrics; use filtered batch for actor.
                     actor_batch = batch
                     if self.config.algorithm.filter_zero_adv.enable:
-                        dp_size = self._get_dp_size(self.actor_rollout_wg, "actor")
-                        actor_batch, filter_metrics = filter_zero_adv_batch(
-                            batch,
-                            dp_size,
-                            ppo_mini_batch_size=self.config.actor_rollout_ref.actor.ppo_mini_batch_size,
-                        )
-                        actor_batch.meta_info[KEY_FILTER_ZERO_ADV_CONFIG] = self.config.algorithm.filter_zero_adv
-                        metrics.update(filter_metrics)
+                        fza_config = self.config.algorithm.filter_zero_adv
+                        if fza_config.match_loss_curve and fza_config.match_mini_batch_data_split:
+                            # Split-then-filter: send full batch to actor, filter within each mini-batch.
+                            # This preserves baseline's mini-batch data assignment for exact convergence match.
+                            pass
+                        else:
+                            dp_size = self._get_dp_size(self.actor_rollout_wg, "actor")
+                            actor_batch, filter_metrics = filter_zero_adv_batch(
+                                batch,
+                                dp_size,
+                                ppo_mini_batch_size=self.config.actor_rollout_ref.actor.ppo_mini_batch_size,
+                            )
+                            metrics.update(filter_metrics)
+                        actor_batch.meta_info[KEY_FILTER_ZERO_ADV_CONFIG] = fza_config
 
                     # update critic
                     if self.use_critic:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -44,10 +44,12 @@ from verl.trainer.distillation.losses import is_distillation_enabled
 from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
 from verl.trainer.ppo.metric_utils import (
+    KEY_FILTER_ZERO_ADV_CONFIG,
     compute_data_metrics,
     compute_throughout_metrics,
     compute_timing_metrics,
     compute_variance_proxy_metrics,
+    filter_zero_adv_batch,
     process_validation_metrics,
 )
 from verl.trainer.ppo.reward import extract_reward
@@ -1554,6 +1556,20 @@ class RayPPOTrainer:
                             config=self.config.algorithm,
                         )
 
+                    # Filter zero-advantage responses to skip wasted actor compute.
+                    # Responses in all-same-reward groups have advantage≈0 and contribute no policy gradient.
+                    # Keep the unfiltered batch for critic update and metrics; use filtered batch for actor.
+                    actor_batch = batch
+                    if self.config.algorithm.filter_zero_adv.enable:
+                        dp_size = self._get_dp_size(self.actor_rollout_wg, "actor")
+                        actor_batch, filter_metrics = filter_zero_adv_batch(
+                            batch,
+                            dp_size,
+                            ppo_mini_batch_size=self.config.actor_rollout_ref.actor.ppo_mini_batch_size,
+                        )
+                        actor_batch.meta_info[KEY_FILTER_ZERO_ADV_CONFIG] = self.config.algorithm.filter_zero_adv
+                        metrics.update(filter_metrics)
+
                     # update critic
                     if self.use_critic:
                         with marked_timer("update_critic", timing_raw, color="pink"):
@@ -1565,7 +1581,7 @@ class RayPPOTrainer:
                     if self.config.trainer.critic_warmup <= self.global_steps:
                         # update actor
                         with marked_timer("update_actor", timing_raw, color="red"):
-                            actor_output = self._update_actor(batch)
+                            actor_output = self._update_actor(actor_batch)
 
                         # Check if the ESI (Elastic Server Instance)/training plan is close to expiration.
                         esi_close_to_expiration = should_save_ckpt_esi(

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -50,6 +50,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
     filter_zero_adv_batch,
+    maybe_add_corrected_mfu,
     process_validation_metrics,
 )
 from verl.trainer.ppo.reward import extract_reward
@@ -1616,6 +1617,7 @@ class RayPPOTrainer:
                             self.checkpoint_manager.update_weights(self.global_steps)
 
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
+                        maybe_add_corrected_mfu(actor_output_metrics, actor_batch.meta_info)
                         metrics.update(actor_output_metrics)
 
                     # Log rollout generations if enabled

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -169,6 +169,24 @@ def validate_config(
     if config.algorithm.use_kl_in_reward and config.actor_rollout_ref.actor.use_kl_loss:
         print("NOTICE: You have both enabled in-reward kl and kl loss.")
 
+    if config.algorithm.filter_zero_adv.enable and (
+        config.actor_rollout_ref.actor.use_kl_loss and config.actor_rollout_ref.actor.kl_loss_coef != 0
+    ):
+        raise ValueError(
+            "algorithm.filter_zero_adv and actor KL loss (use_kl_loss=True, kl_loss_coef != 0)"
+            " cannot both be enabled — zero-adv samples still contribute to KL loss."
+        )
+    if config.algorithm.filter_zero_adv.enable and config.actor_rollout_ref.actor.entropy_coeff != 0:
+        raise ValueError(
+            "algorithm.filter_zero_adv and actor.entropy_coeff != 0 cannot both be True"
+            " — zero-adv samples still contribute non-zero entropy gradient."
+        )
+    if config.algorithm.filter_zero_adv.enable and config.actor_rollout_ref.actor.calculate_entropy:
+        print(
+            "WARNING: filter_zero_adv with calculate_entropy=True — actor/entropy metric"
+            " is computed on the filtered batch only, not the full batch."
+        )
+
     # critic
     if use_critic:
         critic_config = omega_conf_to_dataclass(config.critic)

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -29,10 +29,14 @@ import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.trainer.ppo.core_algos import LOSS_AGG_TOKEN_MEAN, agg_loss, get_policy_loss_fn, kl_penalty
 from verl.trainer.ppo.metric_utils import (
+    KEY_ADVANTAGES,
+    KEY_ATTENTION_MASK,
     KEY_FILTER_ZERO_ADV_CONFIG,
     KEY_NUM_SEQS_CORRECTION_FACTOR,
     KEY_NUM_TOKENS_CORRECTION_FACTOR,
     KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP,
+    KEY_RESPONSE_MASK,
+    ZERO_ADV_EPS,
     ceildiv,
 )
 from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
@@ -51,6 +55,48 @@ from verl.workers.config import ActorConfig
 __all__ = ["DataParallelPPOActor"]
 
 logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def filter_zero_adv_micro_batch(
+    micro_batch: DataProto,
+) -> tuple[DataProto, int, int, float]:
+    """Filter zero-adv samples from a single micro-batch.
+
+    Applied per-micro-batch after the baseline mini-batch → micro-batch split, so all
+    DP ranks have the same number of micro-batches (same number of backward calls).
+    This eliminates the FSDP deadlock risk of mini-batch-level filtering.
+
+    All-zero micro-batches keep their shortest sample (by attention_mask) so the
+    backward pass participates in FSDP collectives with ~0 gradient.
+
+    Returns:
+        (filtered_micro_batch, num_nonzero, original_size, original_tokens)
+    """
+    response_mask = micro_batch.batch[KEY_RESPONSE_MASK]
+    original_tokens = response_mask.sum().item()
+    max_abs_adv = (micro_batch.batch[KEY_ADVANTAGES].abs() * response_mask).max(dim=-1).values
+    nonzero_mask = max_abs_adv >= ZERO_ADV_EPS
+    nonzero_indices = torch.where(nonzero_mask)[0]
+
+    original_size = len(micro_batch)
+    num_nonzero = len(nonzero_indices)
+
+    if num_nonzero == original_size:
+        # All nonzero: no filtering needed.
+        return micro_batch, num_nonzero, original_size, original_tokens
+
+    if num_nonzero == 0:
+        # All zero-adv: keep 1 shortest sample for FSDP collective participation.
+        seq_lens = micro_batch.batch[KEY_ATTENTION_MASK].sum(dim=-1)
+        keep_indices = [seq_lens.argmin().item()]
+    else:
+        # Mixed: keep only nonzero-adv samples.
+        keep_indices = nonzero_indices.tolist()
+
+    filtered = micro_batch[keep_indices]
+    filtered.meta_info = dict(micro_batch.meta_info)  # own copy (splits share by ref)
+    return filtered, num_nonzero, original_size, original_tokens
 
 
 @GPUMemoryLogger(role="dp actor", logger=logger)
@@ -65,11 +111,27 @@ def _split_filter_zero_adv_mini_batches(
     """
     filter_zero_adv_config = data.meta_info.get(KEY_FILTER_ZERO_ADV_CONFIG, None)
     _filter_zero_adv = filter_zero_adv_config is not None and getattr(filter_zero_adv_config, "enable", False)
+    _match_loss_curve = _filter_zero_adv and getattr(filter_zero_adv_config, "match_loss_curve", False)
+    _match_mini_batch_data_split = _match_loss_curve and getattr(
+        filter_zero_adv_config, "match_mini_batch_data_split", False
+    )
+
+    if _match_mini_batch_data_split:
+        # Split-then-filter: data is the FULL (unfiltered) batch from trainer.
+        # Split into K mini-batches using ppo_mini_batch_size (identical to baseline).
+        # Filtering happens later at micro-batch level (in the training loop) to ensure
+        # all DP ranks have the same number of backward calls, preventing FSDP deadlock.
+        mini_batches = data.split(ppo_mini_batch_size)
+        metrics = {
+            "actor/num_mini_batches": len(mini_batches),
+            "actor/num_ghost_mini_batches": 0,
+        }
+        return mini_batches, True, True, 0, metrics
 
     # When filtering is a no-op (nothing removed), KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP
     # is not set — treat as if filter_zero_adv is off.
     filter_zero_adv = _filter_zero_adv and KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP in data.meta_info
-    match_loss_curve = filter_zero_adv and getattr(filter_zero_adv_config, "match_loss_curve", False)
+    match_loss_curve = filter_zero_adv and _match_loss_curve
 
     # Original per-DP-group batch size (before filter_zero_adv), for K computation.
     original_bs = data.meta_info.get(KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP, len(data))
@@ -93,9 +155,6 @@ def _split_filter_zero_adv_mini_batches(
         metrics["actor/num_ghost_mini_batches"] = num_ghost_opt_steps
 
     return mini_batches, filter_zero_adv, match_loss_curve, num_ghost_opt_steps, metrics
-
-
-logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 @deprecated("legacy worker implementation is deprecated and will be removed in v0.8.0")
@@ -604,6 +663,12 @@ class DataParallelPPOActor(BasePPOActor):
             data, self.config.ppo_mini_batch_size
         )
 
+        # Detect split-then-filter mode: filtering happens per-micro-batch in the loop below.
+        _fza_config = data.meta_info.get(KEY_FILTER_ZERO_ADV_CONFIG, None)
+        _filter_micro_batches = (
+            match_loss_curve and _fza_config is not None and getattr(_fza_config, "match_mini_batch_data_split", False)
+        )
+
         on_policy = len(mini_batches) == 1 and self.config.ppo_epochs == 1
 
         metrics = {
@@ -611,6 +676,9 @@ class DataParallelPPOActor(BasePPOActor):
             "actor/kl_loss": 0.0,
             **split_metrics,
         }
+        fza_total_nonzero = 0
+        fza_total_kept = 0
+        fza_total_count = 0
         for _ in range(self.config.ppo_epochs):
             for batch_idx, mini_batch in enumerate(mini_batches):
                 if self.config.use_dynamic_bsz:
@@ -631,6 +699,22 @@ class DataParallelPPOActor(BasePPOActor):
                         # mini-batch in the fewer-K path without extra correction.
                         self.gradient_accumulation = len(micro_batches)
 
+                # Per-micro-batch zero-adv filtering: same number of micro-batches
+                # on all DP ranks (no FSDP deadlock), each micro-batch just gets smaller.
+                original_micro_sizes = []
+                original_micro_tokens = []
+                if _filter_micro_batches:
+                    filtered = []
+                    for mb in micro_batches:
+                        f_mb, n_nz, orig_sz, orig_tok = filter_zero_adv_micro_batch(mb)
+                        filtered.append(f_mb)
+                        original_micro_sizes.append(orig_sz)
+                        original_micro_tokens.append(orig_tok)
+                        fza_total_nonzero += n_nz
+                        fza_total_kept += len(f_mb)
+                        fza_total_count += orig_sz
+                    micro_batches = filtered
+
                 self.actor_optimizer.zero_grad()
 
                 for micro_batch_idx, micro_batch in enumerate(micro_batches):
@@ -649,6 +733,7 @@ class DataParallelPPOActor(BasePPOActor):
                     # Weight each micro-batch so every sequence contributes
                     # 1/mini_bs to the gradient regardless of micro-batch size.
                     if self.config.use_dynamic_bsz:
+                        # #seqs is post-filter when filtering is active, which auto-corrects for removed za samples.
                         loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
                     else:
                         loss_scale_factor = 1 / self.gradient_accumulation
@@ -657,18 +742,34 @@ class DataParallelPPOActor(BasePPOActor):
                         # fewer-K: GA = len(micro_batches) naturally handles partial
                         # last mini-batch without extra correction.
 
-                    # Token-density correction for filter_zero_adv with token_mean:
-                    # loss_scale_factor already corrects for sample count, but token_mean
-                    # normalizes by total tokens. Removing zero-adv samples (often long
-                    # all-wrong responses) changes the avg tokens/seq, inflating the
-                    # per-sample gradient. Correct by the token-density ratio
-                    # (tokens_correction / seqs_correction) so the effective denominator
-                    # matches the original batch's token density.
-                    if match_loss_curve and loss_agg_mode == LOSS_AGG_TOKEN_MEAN:
-                        token_corr = data.meta_info.get(KEY_NUM_TOKENS_CORRECTION_FACTOR, 1.0)
-                        seq_corr = data.meta_info.get(KEY_NUM_SEQS_CORRECTION_FACTOR, 1.0)
-                        if seq_corr > 0:
-                            loss_scale_factor *= token_corr / seq_corr
+                    # Per-GA-step correction for zero-adv filtering.
+                    ga_loss_scale_factor = 1.0
+                    if _filter_micro_batches:
+                        if original_micro_sizes:
+                            orig_sz = original_micro_sizes[micro_batch_idx]
+                            filtered_sz = response_mask.shape[0]
+                            if filtered_sz < orig_sz:
+                                seq_corr = filtered_sz / orig_sz
+                                # use_dynamic_bsz: loss_scale_factor already reflects
+                                # filtered_sz, so seq correction is automatic.
+                                if not self.config.use_dynamic_bsz:
+                                    ga_loss_scale_factor *= seq_corr
+                                # Token-mean: additionally correct for token density.
+                                if loss_agg_mode == LOSS_AGG_TOKEN_MEAN:
+                                    orig_tok = original_micro_tokens[micro_batch_idx]
+                                    filtered_tok = response_mask.sum().item()
+                                    token_corr = filtered_tok / orig_tok if orig_tok > 0 else 1.0
+                                    ga_loss_scale_factor *= token_corr / seq_corr
+                    elif match_loss_curve:
+                        # Filter-then-split: for seq-mean modes, 2× nz content per micro-batch
+                        # × 0.5× fewer micro-batches cancel — no correction needed.
+                        # Token-mean needs correction for changed token denominator.
+                        if loss_agg_mode == LOSS_AGG_TOKEN_MEAN:
+                            seq_corr = mini_batch.meta_info.get(KEY_NUM_SEQS_CORRECTION_FACTOR, 1.0)
+                            if seq_corr > 0:
+                                token_corr = mini_batch.meta_info.get(KEY_NUM_TOKENS_CORRECTION_FACTOR, 1.0)
+                                ga_loss_scale_factor *= token_corr / seq_corr
+                    loss_scale_factor *= ga_loss_scale_factor
 
                     # all return: (bsz, response_length)
                     outputs = self._forward_micro_batch(
@@ -766,4 +867,15 @@ class DataParallelPPOActor(BasePPOActor):
                     append_to_dict(metrics, {"actor/grad_norm": grad_norm.detach().item()})
 
         self.actor_optimizer.zero_grad()
+
+        if _filter_micro_batches and fza_total_count > 0:
+            metrics.update(
+                {
+                    "actor/filter_zero_adv/num_nonzero": fza_total_nonzero,
+                    "actor/filter_zero_adv/num_kept": fza_total_kept,
+                    "actor/filter_zero_adv/num_total": fza_total_count,
+                    "actor/filter_zero_adv/kept_ratio": fza_total_kept / fza_total_count,
+                }
+            )
+
         return metrics

--- a/verl/workers/actor/dp_actor.py
+++ b/verl/workers/actor/dp_actor.py
@@ -27,7 +27,14 @@ from torch.distributed.tensor import DTensor
 
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
-from verl.trainer.ppo.core_algos import agg_loss, get_policy_loss_fn, kl_penalty
+from verl.trainer.ppo.core_algos import LOSS_AGG_TOKEN_MEAN, agg_loss, get_policy_loss_fn, kl_penalty
+from verl.trainer.ppo.metric_utils import (
+    KEY_FILTER_ZERO_ADV_CONFIG,
+    KEY_NUM_SEQS_CORRECTION_FACTOR,
+    KEY_NUM_TOKENS_CORRECTION_FACTOR,
+    KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP,
+    ceildiv,
+)
 from verl.utils.attention_utils import index_first_axis, pad_input, rearrange, unpad_input
 from verl.utils.device import get_device_id, get_device_name
 from verl.utils.fsdp_utils import FSDPModule, fsdp2_clip_grad_norm_
@@ -44,6 +51,50 @@ from verl.workers.config import ActorConfig
 __all__ = ["DataParallelPPOActor"]
 
 logger = logging.getLogger(__file__)
+
+
+@GPUMemoryLogger(role="dp actor", logger=logger)
+def _split_filter_zero_adv_mini_batches(
+    data: DataProto,
+    ppo_mini_batch_size: int,
+) -> tuple[list[DataProto], bool, bool, int, dict]:
+    """Split data into mini-batches, accounting for filter_zero_adv.
+
+    Returns:
+        (mini_batches, filter_zero_adv, match_loss_curve, num_ghost_opt_steps, metrics)
+    """
+    filter_zero_adv_config = data.meta_info.get(KEY_FILTER_ZERO_ADV_CONFIG, None)
+    _filter_zero_adv = filter_zero_adv_config is not None and getattr(filter_zero_adv_config, "enable", False)
+
+    # When filtering is a no-op (nothing removed), KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP
+    # is not set — treat as if filter_zero_adv is off.
+    filter_zero_adv = _filter_zero_adv and KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP in data.meta_info
+    match_loss_curve = filter_zero_adv and getattr(filter_zero_adv_config, "match_loss_curve", False)
+
+    # Original per-DP-group batch size (before filter_zero_adv), for K computation.
+    original_bs = data.meta_info.get(KEY_ORIGINAL_BATCH_SIZE_PER_DP_GROUP, len(data))
+
+    if match_loss_curve:
+        # Distribute filtered sequences evenly across K mini-batches
+        # (same K as baseline, capped by num_nonzero in filter_zero_adv_batch).
+        # Padding ensures divisibility by dp_size * K.
+        k_original = ceildiv(original_bs, ppo_mini_batch_size)
+        even_mini_batch_size = max(1, ceildiv(len(data), k_original))
+        mini_batches = data.split(even_mini_batch_size)
+    else:
+        mini_batches = data.split(ppo_mini_batch_size)
+
+    metrics = {"actor/num_mini_batches": len(mini_batches)}
+    num_ghost_opt_steps = 0
+    if _filter_zero_adv:
+        # How many fewer opt steps vs baseline (0 when match_loss_curve preserves K).
+        k_baseline = ceildiv(original_bs, ppo_mini_batch_size)
+        num_ghost_opt_steps = k_baseline - len(mini_batches)
+        metrics["actor/num_ghost_mini_batches"] = num_ghost_opt_steps
+
+    return mini_batches, filter_zero_adv, match_loss_curve, num_ghost_opt_steps, metrics
+
+
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
@@ -549,13 +600,16 @@ class DataParallelPPOActor(BasePPOActor):
 
         # Split to make minibatch iterator for updating the actor
         # See PPO paper for details. https://arxiv.org/abs/1707.06347
-        mini_batches = data.split(self.config.ppo_mini_batch_size)
+        mini_batches, _, match_loss_curve, num_ghost_opt_steps, split_metrics = _split_filter_zero_adv_mini_batches(
+            data, self.config.ppo_mini_batch_size
+        )
 
         on_policy = len(mini_batches) == 1 and self.config.ppo_epochs == 1
 
         metrics = {
             "actor/pg_loss": 0.0,
             "actor/kl_loss": 0.0,
+            **split_metrics,
         }
         for _ in range(self.config.ppo_epochs):
             for batch_idx, mini_batch in enumerate(mini_batches):
@@ -565,14 +619,21 @@ class DataParallelPPOActor(BasePPOActor):
                         mini_batch, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
                     )
                 else:
-                    self.gradient_accumulation = (
-                        self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
-                    )
                     micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)
+                    if match_loss_curve:
+                        # Use config GA so each sample weighs 1/ppo_mini_batch_size,
+                        # matching baseline per-sample gradient.
+                        self.gradient_accumulation = (
+                            self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
+                        )
+                    else:
+                        # Use actual micro-batch count: naturally handles partial last
+                        # mini-batch in the fewer-K path without extra correction.
+                        self.gradient_accumulation = len(micro_batches)
 
                 self.actor_optimizer.zero_grad()
 
-                for micro_batch in micro_batches:
+                for micro_batch_idx, micro_batch in enumerate(micro_batches):
                     micro_batch = micro_batch.to(get_device_id())
                     micro_batch_metrics = {}
                     model_inputs = {**micro_batch.batch, **micro_batch.non_tensor_batch, "pad_token_id": pad_token_id}
@@ -585,10 +646,29 @@ class DataParallelPPOActor(BasePPOActor):
 
                     calculate_entropy = self.config.calculate_entropy or (entropy_coeff != 0)
 
+                    # Weight each micro-batch so every sequence contributes
+                    # 1/mini_bs to the gradient regardless of micro-batch size.
                     if self.config.use_dynamic_bsz:
                         loss_scale_factor = response_mask.shape[0] / self.config.ppo_mini_batch_size
                     else:
                         loss_scale_factor = 1 / self.gradient_accumulation
+                        # match_loss_curve: each sample weighs 1/ppo_mini_batch_size
+                        # (config) via loss_scale_factor, matching baseline.
+                        # fewer-K: GA = len(micro_batches) naturally handles partial
+                        # last mini-batch without extra correction.
+
+                    # Token-density correction for filter_zero_adv with token_mean:
+                    # loss_scale_factor already corrects for sample count, but token_mean
+                    # normalizes by total tokens. Removing zero-adv samples (often long
+                    # all-wrong responses) changes the avg tokens/seq, inflating the
+                    # per-sample gradient. Correct by the token-density ratio
+                    # (tokens_correction / seqs_correction) so the effective denominator
+                    # matches the original batch's token density.
+                    if match_loss_curve and loss_agg_mode == LOSS_AGG_TOKEN_MEAN:
+                        token_corr = data.meta_info.get(KEY_NUM_TOKENS_CORRECTION_FACTOR, 1.0)
+                        seq_corr = data.meta_info.get(KEY_NUM_SEQS_CORRECTION_FACTOR, 1.0)
+                        if seq_corr > 0:
+                            loss_scale_factor *= token_corr / seq_corr
 
                     # all return: (bsz, response_length)
                     outputs = self._forward_micro_batch(
@@ -662,11 +742,8 @@ class DataParallelPPOActor(BasePPOActor):
                         metrics["actor/kl_loss"] += kl_loss.detach().item() * loss_scale_factor
                         micro_batch_metrics["actor/kl_coef"] = self.config.kl_loss_coef
 
-                    if self.config.use_dynamic_bsz:
-                        # relative to the dynamic bsz
-                        loss = policy_loss * loss_scale_factor
-                    else:
-                        loss = policy_loss * loss_scale_factor
+                    loss = policy_loss * loss_scale_factor
+
                     if self.scaler is not None:
                         self.scaler.scale(loss).backward()
                     else:
@@ -678,5 +755,15 @@ class DataParallelPPOActor(BasePPOActor):
                 grad_norm = self._optimizer_step()
                 mini_batch_metrics = {"actor/grad_norm": grad_norm.detach().item()}
                 append_to_dict(metrics, mini_batch_metrics)
+
+            # Ghost optimizer.step() with zero gradients to maintain K
+            # (the original number of optimizer steps per epoch).
+            # With match_loss_curve's even distribution, this is typically 0.
+            if match_loss_curve:
+                for _ in range(max(0, num_ghost_opt_steps)):
+                    self.actor_optimizer.zero_grad()
+                    grad_norm = self._optimizer_step()
+                    append_to_dict(metrics, {"actor/grad_norm": grad_norm.detach().item()})
+
         self.actor_optimizer.zero_grad()
         return metrics


### PR DESCRIPTION
### What does this PR do?

**SKIP** training for zero-advantage responses to speed up RL
- On top of #5770 

At high accuracy, less than `25%` samples have non-zero advantage (`critic/advantages/zero_adv_ratio`), and they don't contribute to the `pg_loss` at all. With `4` mini-batches:
1. It can train with the same `#mini-batches` as before, but with less `#samples`: `match_loss_curve = True`
    - This option is designed to match baseline as much as possible, including `num_ghost_opt_steps` opt steps when needed (Very unlikely)
2. It can be reduced into `1` single mini-batch: `match_loss_curve = False` 
    - This option is designed to train as fast as possible with the same `micro-bs` (static bs) or `tokens_per_gpu` (dynamic bs), faster than both baseline and `#1` option


Both options closely match baseline loss curve, and train faster due to the `skip`.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+zero+adv+is%3Aopen
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`


### Test


#### 1. `Qwen2.5 3B LoRA`: `2` epochs for `GSM8k`

Metrics comparison dropping noisy first `10` step and last `3` steps:
1. `timing_s/update_actor`
    - `avg`: `3.853 -> 2.278 (-40.9%)` or `1.7x` reduction
    - `std`: `0.183 -> 0.072 (-60.7%)` or `2.5x` reduction
2. `critic/rewards/mean`
    - `avg`: `0.909 -> 0.915`
8. `val-core/openai/gsm8k/acc/mean@1` 
    - `avg`: `0.855 -> 0.861`


```
sliuxl@c889f3b957d9 20:35 ~/qwen2d5 $ M=timing_s/update_actor; conda run -n et python ~/tb.py --files "sliuxl-mverl--qwen2d5_3b_inst--gsm8k/*/events*" --metric "$M"
2026-03-31 20:35:42,832 [tb.py:206] WARNING - Unknonw metric `timing_s/update_actor`!
2026-03-31 20:35:43,069 [tb.py:235] INFO - Set benchmark with index 0
2026-03-31 20:35:43,070 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13954-run-mverl-rl-0adv-05-j-01-ns01-tp01-bs16-pad0-base--20260331.152146/events.out.tfevents.1774996037.ip-10-4-145-27.2208577.0: (avg (std), med) = (  3.853 (  0.183),   3.814)  # timing_s/update_actor
2026-03-31 20:35:43,337 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13955-run-mverl-rl-0adv-05-j-02-ns01-tp01-bs16-pad0-rm-0adv-yes-mlc--20260331.152151/events.out.tfevents.1775000615.ip-10-4-145-27.2332233.0: (avg (std), med) = (  2.278 (  0.072),   2.254)  # timing_s/update_actor
2026-03-31 20:35:43,606 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13956-run-mverl-rl-0adv-05-j-03-ns01-tp01-bs16-pad0-rm-0adv-no-mlc--20260331.152156/events.out.tfevents.1775004996.ip-10-4-145-27.2451478.0: (avg (std), med) = (  1.652 (  0.473),   1.527)  # timing_s/update_actor

sliuxl@c889f3b957d9 19:56 ~/qwen2d5 $ M=critic/rewards/mean; conda run -n et python ~/tb.py --files "sliuxl-mverl--qwen2d5_3b_inst--gsm8k/*/events*" --metric "$M"
2026-03-31 19:57:02,837 [tb.py:206] WARNING - Unknonw metric `critic/rewards/mean`!
2026-03-31 19:57:03,085 [tb.py:235] INFO - Set benchmark with index 0
2026-03-31 19:57:03,086 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13954-run-mverl-rl-0adv-05-j-01-ns01-tp01-bs16-pad0-base--20260331.152146/events.out.tfevents.1774996037.ip-10-4-145-27.2208577.0: (avg (std), med) = (  0.909 (  0.028),   0.913)  # critic/rewards/mean
2026-03-31 19:57:03,348 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13955-run-mverl-rl-0adv-05-j-02-ns01-tp01-bs16-pad0-rm-0adv-yes-mlc--20260331.152151/events.out.tfevents.1775000615.ip-10-4-145-27.2332233.0: (avg (std), med) = (  0.915 (  0.026),   0.918)  # critic/rewards/mean
2026-03-31 19:57:03,630 [tb.py:264] INFO - [103/116] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13956-run-mverl-rl-0adv-05-j-03-ns01-tp01-bs16-pad0-rm-0adv-no-mlc--20260331.152156/events.out.tfevents.1775004996.ip-10-4-145-27.2451478.0: (avg (std), med) = (  0.904 (  0.027),   0.906)  # critic/rewards/mean


sliuxl@c889f3b957d9 20:35 ~/qwen2d5 $ M=val-core/openai/gsm8k/acc/mean@1; conda run -n et python ~/tb.py --files "sliuxl-mverl--qwen2d5_3b_inst--gsm8k/*/events*" --metric "$M"
2026-03-31 20:38:39,184 [tb.py:206] WARNING - Unknonw metric `val-core/openai/gsm8k/acc/mean@1`!
2026-03-31 20:38:39,432 [tb.py:235] INFO - Set benchmark with index 0
2026-03-31 20:38:39,434 [tb.py:264] INFO - [12/25] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13954-run-mverl-rl-0adv-05-j-01-ns01-tp01-bs16-pad0-base--20260331.152146/events.out.tfevents.1774996037.ip-10-4-145-27.2208577.0: (avg (std), med) = (  0.855 (  0.004),   0.857)  # val-core/openai/gsm8k/acc/mean@1
2026-03-31 20:38:39,695 [tb.py:264] INFO - [12/25] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13955-run-mverl-rl-0adv-05-j-02-ns01-tp01-bs16-pad0-rm-0adv-yes-mlc--20260331.152151/events.out.tfevents.1775000615.ip-10-4-145-27.2332233.0: (avg (std), med) = (  0.861 (  0.005),   0.863)  # val-core/openai/gsm8k/acc/mean@1
2026-03-31 20:38:39,972 [tb.py:264] INFO - [12/25] sliuxl-mverl--qwen2d5_3b_inst--gsm8k/verl_feature_config_pbtxt-dc7fdce1--13956-run-mverl-rl-0adv-05-j-03-ns01-tp01-bs16-pad0-rm-0adv-no-mlc--20260331.152156/events.out.tfevents.1775004996.ip-10-4-145-27.2451478.0: (avg (std), med) = (  0.859 (  0.004),   0.860)  # val-core/openai/gsm8k/acc/mean@1
```
 

<img width="1864" height="999" alt="Screenshot 2026-03-31 at 19 53 42" src="https://github.com/user-attachments/assets/90553dd5-27b2-428d-9372-eb45f1148e38" />


### Match Loss Curve

Based on loss agg mode:
1. `token-mean`: `tm`
2. `sequence-mean-token-mean`: `smtm`
3. `sequence-mean-token-sum`: `smts`
5. `sequence-mean-token-sum-norm`: `smtsn`
    - `0.5B`: **Slower** than baseline
    - `3B`: Matches with baseline

Notation: `#mini-batches` is `#optimizer-steps`
1. `mlcTmini`: `(match_loss_curve, match_data_split_mini_batch) = (True, True)`
   * Mathematically should be **equivalent to** baseline i.e. **LOSSLESS**: Preserve mini batch *and* micro-batch (grad accumulation) **data** split, and skip `0` adv samples in each grad accumulation on a GPU (Keep the shortest one when all `0` adv)
2. `mlcT`: `(match_loss_curve, match_data_split_mini_batch) = (True, False)`
   * Preserves `#mini-batches` (not data), but not `#micro-batches`: Slightly more efficient than `#1`
4. `mlcF`: `match_loss_curve = False`
   * It doesn't even try to preserve `#mini-batches`: Most efficient among the `3` options


#### 1. `(0.5B, tm)`
<img width="1711" height="909" alt="Screenshot 2026-04-09 at 17 14 10--0 5B--tm" src="https://github.com/user-attachments/assets/3225260b-2c8b-469f-9033-e54f15c3ff2f" />

#### 2. `(0.5B, smtm)`

<img width="1712" height="877" alt="Screenshot 2026-04-09 at 17 12 26--0 5B--smtm" src="https://github.com/user-attachments/assets/ef65d279-db85-4d86-85ee-d110c6565530" />

#### 3. `(0.5B, smts)`
<img width="1713" height="933" alt="Screenshot 2026-04-09 at 16 59 47--0 5B--smts-2x" src="https://github.com/user-attachments/assets/450053b8-9949-49d8-a114-caa03cf32e14" />


#### 4. `(0.5B, smtsn)`: Slower than baseline

<img width="1707" height="903" alt="Screenshot 2026-04-09 at 17 54 51--0 5B--smtsn--slower-than-baseline" src="https://github.com/user-attachments/assets/da768f74-bb11-4be3-89f9-b13950d063bd" />

#### 4.1 `(3B, smtsn)`
<img width="1686" height="885" alt="Screenshot 2026-04-09 at 18 31 51--03B--smtsn" src="https://github.com/user-attachments/assets/26d89a77-bee0-4a2b-9a22-dc6268abdcce" />


### API and Usage Example

Add to your RL config with `FSDP`:

```
    actor_rollout_ref.actor.entropy_coeff=0 \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.use_kl_loss=False \

    algorithm.filter_zero_adv.enable=True \
    algorithm.filter_zero_adv.match_loss_curve=True \
    algorithm.filter_zero_adv.match_mini_batch_data_split=True \

    trainer.use_legacy_worker_impl=auto \
```

**Known Limitation**
- Strict: To match baseline loss curve, it requires turning off both `entropy_loss` and `kl_loss`, currently hard coded to raise an `Exception` if it violates the condition
- When `kl_loss_coef` is sufficiently small, it's up to the user to turn on this feature: No longer lossless, while a good approximation by keeping KL divergence for `!0` adv samples


### Design & Code Changes

`dp_actor.py` has `3` `loss` components, when both `{#2, #3}` are off, we can skip `loss` completely as the `pg_loss` has `advantage` as a weight factor:
1. `policy_loss` $\propto$ `adv`
9. `entropy_loss`: By `(calculate_entropy: bool, entropy_coeff: float)`  and
10. `kl_loss`: By `(use_kl_loss: bool, kl_loss_coeff: float)`



### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
