### PR TITLE
[reward] fix: restore timeout in math_verify via ProcessPoolExecutor

### DIFF
--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
 import threading
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -19,6 +20,10 @@ from concurrent.futures import TimeoutError as FuturesTimeoutError
 try:
     from math_verify.errors import TimeoutException
 except ImportError:
+
+    class TimeoutException(Exception):
+        pass
+
     print("To use Math-Verify, please install it first by running `pip install math-verify`.")
 
 _pool = None
@@ -30,7 +35,7 @@ def _get_pool():
     if _pool is None:
         with _pool_lock:
             if _pool is None:
-                _pool = ProcessPoolExecutor(max_workers=4)
+                _pool = ProcessPoolExecutor(max_workers=4, mp_context=multiprocessing.get_context("spawn"))
     return _pool
 
 
@@ -57,6 +62,6 @@ def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0
         ret_score = future.result(timeout=timeout)
     except (FuturesTimeoutError, TimeoutException):
         ret_score = timeout_score
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Error in math_verify compute_score: {e}")
     return ret_score


### PR DESCRIPTION
### What does this PR do?

Follow-up to #5635. That PR fixed the `signal.alarm()` crash by disabling all timeouts (`parsing_timeout=None`, `timeout_seconds=None`). However, this causes the reward worker to **hang indefinitely** on adversarial or complex model outputs that trigger pathological parsing in `math_verify`.

This PR restores timeout protection by running `math_verify` in a subprocess via `ProcessPoolExecutor`, where `signal.alarm()` works normally (each subprocess has its own main thread). An outer `future.result(timeout=30)` provides a fallback guarantee.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+math_verify+signal
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated on Qwen2.5-3B-Instruct GRPO training with MATH500 val set on 4-node cluster:

- **Before fix** (#5635 with `parsing_timeout=None`): Training hangs at step 2 — a single `math_verify` call blocks the `RewardLoopWorker` indefinitely. All GPUs idle.
- **After fix**: Training runs continuously. Problematic inputs are killed after 30s timeout and scored as 0.

### API and Usage Example

No API changes — same `compute_score(model_output, ground_truth)` signature. New optional `timeout` parameter (default 30s).

### Design & Code Changes

1. Run `parse()` + `verify()` in a subprocess via `ProcessPoolExecutor` — `signal.alarm()` works in each subprocess's main thread
2. Enforce outer timeout with `future.result(timeout=30)` as fallback
3. Lazy-initialized process pool (4 workers) with thread-safe singleton pattern
4. Import `math_verify` inside subprocess function to avoid pickling issues

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs) — no doc changes needed.
- [ ] Add unit or end-to-end test(s) — validated via training experiment.