### PR TITLE
[trainer] feat: add group reward std and gradient SNR metrics to compute_data_metrics

### DIFF
--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -222,6 +222,20 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
         metrics["tool_call_counts/max"] = tool_call_counts.max()
         metrics["tool_call_counts/mean"] = tool_call_counts.mean()
 
+    if "uid" in batch.non_tensor_batch:
+        uids = batch.non_tensor_batch["uid"]
+        scores_np = sequence_score.detach().cpu().numpy()
+
+        id2scores = defaultdict(list)
+        for i, uid in enumerate(uids):
+            id2scores[uid].append(scores_np[i])
+
+        group_stds = [np.std(v) for v in id2scores.values() if len(v) > 1]
+        if group_stds:
+            metrics["critic/group_reward/std_mean"] = float(np.mean(group_stds))
+            metrics["critic/group_reward/std_max"]  = float(np.max(group_stds))
+            metrics["critic/group_reward/std_min"]  = float(np.min(group_stds))
+
     return metrics
 
 
@@ -411,6 +425,11 @@ def compute_variance_proxy_metrics(batch: DataProto, gradient_norm: float = None
             # Component metrics for debugging
             "variance_proxy/expected_a_squared": expected_a_squared.detach().item(),
             "variance_proxy/expected_w": expected_w.detach().item(),
+            "variance_proxy/snr": (
+                proxy1_signal_strength / (proxy3_pure_noise + 1e-8)
+                if proxy1_signal_strength is not None and proxy3_pure_noise is not None and proxy3_pure_noise > 0
+                else 0.0
+            ),
         }
     )
 

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -223,14 +223,14 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
         metrics["tool_call_counts/mean"] = tool_call_counts.mean()
 
     if "uid" in batch.non_tensor_batch:
-        uids = batch.non_tensor_batch["uid"]
-        scores_np = sequence_score.detach().cpu().numpy()
+        uids = batch.non_tensor_batch["uid"][non_aborted_mask.cpu().numpy()]
+        rewards_np = non_aborted_sequence_reward.detach().cpu().numpy()
 
-        id2scores = defaultdict(list)
+        id2rewards = defaultdict(list)
         for i, uid in enumerate(uids):
-            id2scores[uid].append(scores_np[i])
+            id2rewards[uid].append(rewards_np[i])
 
-        group_stds = [np.std(v) for v in id2scores.values() if len(v) > 1]
+        group_stds = [np.std(v) for v in id2rewards.values() if len(v) > 1]
         if group_stds:
             metrics["critic/group_reward/std_mean"] = float(np.mean(group_stds))
             metrics["critic/group_reward/std_max"]  = float(np.max(group_stds))


### PR DESCRIPTION
### What does this PR do?

Adds three lightweight diagnostic metrics to `verl/trainer/ppo/metric_utils.py` to help monitor training health without any additional forward passes.

**`critic/advantages/std`**
Standard deviation of advantages over valid response tokens in the current batch. Complements the existing `mean/max/min` and makes it easier to monitor advantage distribution spread. A value near zero indicates advantage collapse.

**`critic/group_reward/std_mean` / `std_max` / `std_min`**
Per-group reward standard deviation across all prompt groups in the batch. In GRPO, each prompt has `n` sampled responses — this metric reflects how much rewards vary within each group. A near-zero value indicates reward signal collapse (all responses score similarly), which is a common silent failure mode that existing metrics do not directly capture.

**`variance_proxy/snr`**
Signal-to-noise ratio of the policy gradient, computed as `proxy1_signal_strength / (proxy3_pure_noise + eps)`. Requires `calculate_sum_pi_squared=True`. Provides a single scalar summarizing gradient quality instead of requiring users to manually divide `proxy1` by `proxy3`.

### Motivation

These metrics are zero-overhead (no extra forward passes) and directly observable in TensorBoard/WandB. They diagnose three common RL training failure modes:

| Failure mode | Metric |
|---|---|
| Reward collapse | `critic/group_reward/std_mean` → 0 |
| Gradient noise explosion | `variance_proxy/snr` drops |
| Advantage distribution degeneration | `critic/advantages/std` → 0 or diverges |

### Checklist Before Starting

- [x] Search for similar PRs. No overlapping PRs found. The closest is #5770 which adds `reward_extra_info` metrics — a different direction (user-defined reward fields) with no conflict.
- [x] Format the PR title as `[{modules}] {type}: {description}`
- [x] `{type}` is `feat`

### Test

Verified on Qwen2.5-1.5B-Instruct + GSM8K, 1× A800 80G, 52 training steps.

`critic/group_reward/std_mean` drops from ~0.28 to ~0.12 as the model learns to consistently solve easier problems, confirming the metric captures reward signal convergence as expected.

<img width="1347" height="427" alt="image" src="https://github.com/user-attachments/assets/ae9e93f7-0875-4c58-bdfe-d4d3662903e2" />