### PR TITLE
[doc, misc] chore: add Claude Code skills and CLAUDE.md for AI-assisted development

### DIFF
--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: add-dataset
+description: Guide for adding a new dataset to veRL. Use when user wants to preprocess or integrate a new RL training dataset.
+---
+
+# Add Dataset
+
+Add a new dataset for RL training in veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I add a dataset?"
+- User wants to preprocess a new dataset for GRPO/PPO training
+- User mentions creating a data preprocessing script
+
+## Overview
+
+veRL datasets follow a two-step pattern:
+
+1. **Preprocessing script** (`examples/data_preprocess/<name>.py`) — run once offline to
+   convert raw data into parquet files with a fixed schema
+2. **`RLDataset`** (`verl/utils/dataset/rl_dataset.py`) — runtime dataset class that
+   reads the parquet files; you usually do NOT need to modify this
+
+## Required Schema
+
+Every preprocessed sample must contain these fields:
+
+```python
+{
+    "data_source": str,          # Identifies the reward function to use, e.g. "gsm8k"
+    "prompt": list[dict],        # Chat messages, e.g. [{"role": "user", "content": "..."}]
+    "ability": str,              # Task category, e.g. "math", "coding", "qa"
+    "reward_model": {
+        "style": "rule",         # "rule" for compute_score, "model" for reward model
+        "ground_truth": str,     # Ground truth answer (used by compute_score)
+    },
+    "extra_info": {
+        "split": str,            # "train" or "test"
+        "index": int,            # Sample index for reproducibility
+    },
+}
+```
+
+## Step-by-Step Guide
+
+### Step 1: Create Preprocessing Script
+
+Create `examples/data_preprocess/<name>.py`:
+
+```python
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import argparse
+import os
+
+import datasets
+from verl.utils.hdfs_io import copy, makedirs
+
+data_source = "<name>"     # Must match key in default_compute_score
+
+SYSTEM_PROMPT = "You are a helpful assistant."  # Optional
+
+
+def make_map_fn(split: str):
+    def process_fn(example: dict, idx: int) -> dict:
+        # Build the prompt as a chat template
+        question = example["question"]  # adapt to your dataset fields
+        answer = str(example["answer"])
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+
+        return {
+            "data_source": data_source,
+            "prompt": messages,
+            "ability": "math",          # change as appropriate
+            "reward_model": {
+                "style": "rule",
+                "ground_truth": answer,
+            },
+            "extra_info": {
+                "split": split,
+                "index": idx,
+            },
+        }
+
+    return process_fn
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_dir", default="~/data/<name>")
+    parser.add_argument("--hdfs_dir", default=None)
+    args = parser.parse_args()
+
+    local_dir = os.path.expanduser(args.local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+
+    # Load from HuggingFace hub or local path
+    dataset = datasets.load_dataset("<hf_dataset_id>")
+
+    for split in ["train", "test"]:
+        if split not in dataset:
+            continue
+        processed = dataset[split].map(
+            function=make_map_fn(split),
+            with_indices=True,
+            remove_columns=dataset[split].column_names,
+        )
+        output_path = os.path.join(local_dir, f"{split}.parquet")
+        processed.to_parquet(output_path)
+        print(f"Saved {len(processed)} samples to {output_path}")
+
+    if args.hdfs_dir:
+        makedirs(args.hdfs_dir)
+        copy(src=local_dir, dst=args.hdfs_dir)
+```
+
+### Step 2: Run Preprocessing
+
+```bash
+python examples/data_preprocess/<name>.py --local_dir ~/data/<name>
+```
+
+### Step 3: Update Training Config
+
+Point the trainer to your new dataset:
+
+```bash
+# In your run script or YAML config:
+data.train_files=~/data/<name>/train.parquet
+data.val_files=~/data/<name>/test.parquet
+data.train_data_sources=<name>    # optional, for filtering
+```
+
+### Step 4: Register Reward Function
+
+Make sure `verl/utils/reward_score/__init__.py` handles your `data_source`:
+
+```python
+elif data_source == "<name>":
+    from verl.utils.reward_score.<name> import compute_score
+    return compute_score(solution_str, ground_truth)
+```
+
+See the `/add-reward` skill for details.
+
+## Reference Implementations
+
+| Dataset      | File                                          | Notes                          |
+| ------------ | --------------------------------------------- | ------------------------------ |
+| GSM8K        | `examples/data_preprocess/gsm8k.py`           | Math QA baseline               |
+| MATH         | `examples/data_preprocess/math_dataset.py`    | Competition math               |
+| Geo3K        | `examples/data_preprocess/geo3k.py`           | Geometry                       |
+| Multi-turn   | `verl/utils/dataset/multiturn_sft_dataset.py` | SFT with multi-turn dialogues  |
+
+## Key Requirements
+
+1. **Fixed schema**: All required fields must be present (see above)
+2. **Parquet format**: veRL's `RLDataset` expects `.parquet` files
+3. **data_source matches**: Must align with your reward function's dispatch key
+4. **Prompt as chat messages**: Use list-of-dicts format, not a raw string
+
+## Common Mistakes
+
+- ❌ Missing `reward_model.ground_truth` field (reward manager will crash)
+- ❌ Prompt as a raw string instead of chat message list
+- ❌ `data_source` mismatch with reward function
+- ❌ Forgetting to remove original dataset columns after `map()`
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-dataset/SKILL.md
+
+## How to Update
+- When RLDataset schema changes: update Required Schema section
+- When new reference datasets added: update table
+================================================================================
+-->

--- a/.agents/skills/add-reward/SKILL.md
+++ b/.agents/skills/add-reward/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: add-reward
+description: Guide for adding a new reward function to veRL. Use when user wants to create a reward (compute_score) function.
+---
+
+# Add Reward
+
+Add a new reward function to veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I add a reward function?"
+- User wants to implement custom reward scoring
+- User mentions `compute_score` or reward verification
+
+## Overview
+
+veRL separates reward functions into two layers:
+
+1. **`compute_score` function** (`verl/utils/reward_score/<name>.py`) — pure Python,
+   takes decoded strings and returns a float score
+2. **`RewardManager`** (`verl/workers/reward_manager/`) — wraps compute_score, handles
+   batching, decoding, and DataProto interface
+
+For most use cases, you only need to implement a `compute_score` function and register
+it. A custom `RewardManager` is only needed for advanced use cases (e.g., remote reward
+models, PRIME).
+
+## Step-by-Step Guide
+
+### Step 1: Create the compute_score Function
+
+Create `verl/utils/reward_score/<name>.py`:
+
+```python
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import re
+from typing import Any
+
+
+def compute_score(solution_str: str, ground_truth: Any) -> float:
+    """Compute reward score for a single completion.
+
+    Args:
+        solution_str: Decoded model output string (prompt + completion).
+        ground_truth: Ground truth answer from the dataset.
+
+    Returns:
+        Float score, typically in [0.0, 1.0].
+    """
+    try:
+        answer = _extract_answer(solution_str)
+        if answer is not None and _is_correct(answer, str(ground_truth)):
+            return 1.0
+        return 0.0
+    except Exception:
+        return 0.0
+
+
+def _extract_answer(solution_str: str) -> str | None:
+    """Extract answer from model output. Customize this logic."""
+    # Example: extract content from \boxed{}
+    match = re.search(r"\\boxed\{([^}]+)\}", solution_str)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _is_correct(predicted: str, ground_truth: str) -> bool:
+    """Check if the predicted answer matches ground truth."""
+    return predicted.strip() == ground_truth.strip()
+```
+
+### Step 2: Register in default_compute_score
+
+Update `verl/utils/reward_score/__init__.py` to include your new data source:
+
+```python
+from verl.utils.reward_score.<name> import compute_score as <name>_compute_score
+
+def default_compute_score(data_source, solution_str, ground_truth, extra_info=None):
+    # ... existing cases ...
+    elif data_source == "<your_dataset_name>":
+        return <name>_compute_score(solution_str, ground_truth)
+    else:
+        raise NotImplementedError(f"Unknown data_source: {data_source}")
+```
+
+### Step 3: Set data_source in Dataset Preprocessing
+
+In your data preprocessing script, set the `data_source` field to match:
+
+```python
+# In data_preprocess/<name>.py
+data_source = "<your_dataset_name>"
+
+def make_map_fn(split):
+    def process_fn(example, idx):
+        return {
+            "data_source": data_source,
+            "prompt": [...],           # list of chat messages
+            "ability": "math",         # task category
+            "reward_model": {
+                "style": "rule",
+                "ground_truth": example["answer"],
+            },
+            "extra_info": {...},
+        }
+    return process_fn
+```
+
+### Step 4: Wire into Training Config
+
+In your training script (e.g., `examples/grpo_trainer/run_qwen2-7b_math.sh`):
+
+```bash
+# Use NaiveRewardManager (default) with your compute_score
+reward_model.reward_manager=naive
+```
+
+Or in the Python trainer config:
+
+```python
+# Trainer will call NaiveRewardManager which calls default_compute_score
+# which dispatches to your function based on data_source
+```
+
+### Step 5 (Optional): Custom RewardManager
+
+Only needed if `NaiveRewardManager` is insufficient (e.g., remote reward model,
+process-level rewards like PRIME). Subclass `AbstractRewardManager`:
+
+```python
+from verl.workers.reward_manager import register
+from verl.workers.reward_manager.abstract import AbstractRewardManager
+from verl import DataProto
+import torch
+
+
+@register("<name>")
+class MyRewardManager(AbstractRewardManager):
+    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source", **kwargs):
+        self.tokenizer = tokenizer
+        self.num_examine = num_examine
+        self.compute_score = compute_score
+
+    def __call__(self, data: DataProto, return_dict: bool = False) -> torch.Tensor:
+        # Decode responses, call compute_score, return reward tensor
+        ...
+```
+
+Then reference it in config: `reward_model.reward_manager=<name>`
+
+## Reference Implementations
+
+| Reward        | File                                     | Description                   |
+| ------------- | ---------------------------------------- | ----------------------------- |
+| GSM8K         | `verl/utils/reward_score/gsm8k.py`       | Math answer extraction        |
+| Math general  | `verl/utils/reward_score/math_reward.py` | LaTeX boxed answer matching   |
+| Geo3K         | `verl/utils/reward_score/geo3k.py`       | Geometry answer verification  |
+| PRIME         | `verl/workers/reward_manager/prime.py`   | Process reward model          |
+| DAPO          | `verl/workers/reward_manager/dapo.py`    | DAPO-style reward shaping     |
+
+## Key Requirements
+
+1. **Return float**: `compute_score` returns a single float per sample
+2. **No side effects**: Function must be deterministic and stateless
+3. **Handle exceptions**: Return `0.0` on error, do not raise
+4. **data_source matches**: The string in dataset must match the dispatch key in `__init__.py`
+
+## Common Mistakes
+
+- ❌ Raising exceptions inside `compute_score` (causes worker crash)
+- ❌ `data_source` mismatch between dataset and `default_compute_score`
+- ❌ Returning a tensor instead of a float
+- ❌ Assuming solution_str contains only the completion (it includes the prompt too)
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-reward/SKILL.md
+
+## How to Update
+- When reward_score API changes: update Step 1 signature
+- When RewardManager API changes: update Step 5
+- When new reference implementations added: update table
+================================================================================
+-->

--- a/.agents/skills/add-trainer/SKILL.md
+++ b/.agents/skills/add-trainer/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: add-trainer
+description: Guide for adding a new RL trainer recipe to veRL. Use when user wants to implement a new algorithm or training recipe.
+---
+
+# Add Trainer
+
+Add a new RL training recipe (algorithm variant) to veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I implement a new algorithm?"
+- User wants to add a new trainer on top of veRL's worker infrastructure
+- User mentions creating a new `recipe/` entry or trainer script
+
+## Overview
+
+veRL follows a **single-controller + Ray workers** architecture:
+
+```
+Your Trainer Script (controller, CPU node)
+    │
+    ├── ActorRolloutRefWorker  (Ray remote, GPU)  — generates rollouts + computes logprobs
+    ├── CriticWorker           (Ray remote, GPU)  — value estimates (PPO only)
+    ├── RewardModelWorker      (Ray remote, GPU)  — optional RM scoring
+    └── RewardManager          (inline)           — rule-based reward scoring
+```
+
+The controller drives the training loop by calling `.generate_sequences()`,
+`.compute_ref_log_prob()`, `.update_actor()`, etc. on remote workers via Ray.
+
+For a new algorithm, you typically:
+1. Write a trainer class (controller logic)
+2. Reuse existing workers or subclass them
+3. Add a run script with the config
+
+## Step-by-Step Guide
+
+### Step 1: Study a Reference Trainer
+
+Start by reading the simplest existing trainer that resembles your target algorithm:
+
+| Algorithm | File                                      |
+| --------- | ----------------------------------------- |
+| GRPO      | `verl/trainer/ppo/ray_trainer.py`         |
+| RLOO      | `examples/rloo_trainer/`                  |
+| REINFORCE++| `examples/reinforce_plus_plus_trainer/`  |
+| DAPO      | `examples/dapo/`                          |
+| ReMax     | `examples/remax_trainer/`                 |
+
+### Step 2: Create Trainer Directory
+
+```
+examples/<name>_trainer/
+├── __init__.py
+├── <name>_trainer.py      # Main trainer class
+└── run_qwen2-7b.sh        # Example run script
+```
+
+### Step 3: Implement the Trainer Class
+
+```python
+# examples/<name>_trainer/<name>_trainer.py
+import torch
+from omegaconf import DictConfig
+from verl import DataProto
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer  # or write from scratch
+
+
+class MyTrainer(RayPPOTrainer):
+    """My custom RL trainer."""
+
+    def _compute_advantage(self, data: DataProto) -> DataProto:
+        """Override advantage computation for your algorithm."""
+        rewards = data.batch["token_level_scores"]  # shape: [bs, seqlen]
+        # ... your advantage computation
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
+        return data
+
+    def fit(self):
+        """Main training loop."""
+        for epoch in range(self.config.trainer.total_epochs):
+            for batch_dict in self.train_dataloader:
+                # 1. Generate rollouts
+                data: DataProto = self.actor_rollout_ref.generate_sequences(batch_dict)
+
+                # 2. Compute rewards
+                reward_tensor = self.reward_fn(data)
+                data.batch["token_level_scores"] = reward_tensor
+
+                # 3. Compute advantages (your algorithm logic here)
+                data = self._compute_advantage(data)
+
+                # 4. Update actor
+                actor_output = self.actor_rollout_ref.update_actor(data)
+
+                # 5. Log metrics
+                self._log_metrics(actor_output)
+```
+
+### Step 4: Write Run Script
+
+```bash
+#!/bin/bash
+# examples/<name>_trainer/run_qwen2-7b.sh
+
+set -x
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=256 \
+    data.max_prompt_length=512 \
+    data.max_response_length=512 \
+    actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    reward_model.reward_manager=naive \
+    trainer.total_epochs=15 \
+    trainer.project_name=<name>_trainer \
+    trainer.experiment_name=qwen2-7b-gsm8k
+```
+
+### Step 5: Key DataProto Fields
+
+`DataProto` is veRL's data container. Common fields in the batch:
+
+| Field                      | Shape              | Description                            |
+| -------------------------- | ------------------ | -------------------------------------- |
+| `input_ids`                | `[bs, seqlen]`     | Prompt + response token IDs            |
+| `attention_mask`           | `[bs, seqlen]`     | 1 for real tokens, 0 for padding       |
+| `position_ids`             | `[bs, seqlen]`     | Position indices                       |
+| `responses`                | `[bs, resp_len]`   | Response token IDs only                |
+| `response_mask`            | `[bs, resp_len]`   | 1 for response tokens                  |
+| `token_level_scores`       | `[bs, resp_len]`   | Per-token rewards from reward manager  |
+| `advantages`               | `[bs, resp_len]`   | Computed advantages                    |
+| `returns`                  | `[bs, resp_len]`   | Computed returns                       |
+| `old_log_probs`            | `[bs, resp_len]`   | Log probs from rollout policy          |
+| `ref_log_prob`             | `[bs, resp_len]`   | Log probs from reference policy        |
+
+### Step 6: Core Algorithm Utilities
+
+veRL provides registered advantage estimators and policy loss functions:
+
+```python
+from verl.trainer.ppo.core_algos import get_adv_estimator_fn, register_adv_est
+
+# Use built-in estimators: "gae", "grpo", "reinforce", "rloo", "remax"
+adv_fn = get_adv_estimator_fn("grpo")
+advantages, returns = adv_fn(token_level_rewards, response_mask, config)
+
+# Register your own estimator
+@register_adv_est("my_estimator")
+def my_estimator(token_level_rewards, response_mask, config, **kwargs):
+    ...
+    return advantages, returns
+```
+
+## Key Requirements
+
+1. **Ray-based**: Workers must be Ray remote actors
+2. **DataProto**: Use DataProto as the data exchange format between controller and workers
+3. **OmegaConf config**: Use Hydra/OmegaConf for configuration
+4. **No hardcoded paths**: All paths via config
+
+## Common Mistakes
+
+- ❌ Modifying `DataProto.batch` tensors in-place without `.clone()` when needed
+- ❌ Forgetting to apply `response_mask` when computing per-token losses
+- ❌ Mixing up `token_level_scores` (raw rewards) vs `advantages` (normalized)
+- ❌ Calling blocking Ray ops inside a loop without `.get()` at the right time
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-trainer/SKILL.md
+
+## How to Update
+- When DataProto fields change: update Step 5 table
+- When core_algos API changes: update Step 6
+- When new reference trainers added: update Step 1 table
+================================================================================
+-->

--- a/.agents/skills/add-unit-tests/SKILL.md
+++ b/.agents/skills/add-unit-tests/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: add-unit-tests
+description: Guide for adding unit tests to veRL. Use when user wants to add tests for new functionality or increase test coverage.
+---
+
+# Add Unit Tests
+
+Add unit tests to veRL following the project's testing conventions.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I add tests?"
+- User wants to increase test coverage
+- User needs to write tests for new functionality
+
+## Step-by-Step Guide
+
+### Step 1: Understand Test Categories
+
+| Category              | Location                     | How It Runs              | Trigger                      |
+| --------------------- | ---------------------------- | ------------------------ | ---------------------------- |
+| **CPU unit tests**    | `tests/**/test_*_on_cpu.py`  | `pytest` on CPU          | `cpu_unit_tests.yml`         |
+| **GPU unit tests**    | `tests/**/test_*.py`         | `pytest` on GPU          | `gpu_unit_tests.yml`         |
+| **Distributed tests** | `tests/special_distributed/` | Multi-GPU pytest         | Separate CI workflow         |
+| **E2E tests**         | `tests/special_e2e/`         | Full training run        | `e2e_*.yml`                  |
+| **Sanity tests**      | `tests/special_sanity/`      | Quick smoke tests        | Always triggered             |
+
+**Naming rules:**
+- CPU-only tests: filename must end with `_on_cpu.py`
+- Default tests run on GPU — skip gracefully if CUDA unavailable
+- Follow the directory structure matching the source: `tests/trainer/` for `verl/trainer/`
+
+### Step 2: Create the Test File
+
+```python
+# tests/<namespace>/test_<module>_on_cpu.py  (CPU)
+# tests/<namespace>/test_<module>.py          (GPU)
+
+import pytest
+import torch
+
+from verl.<namespace>.<module> import MyClass
+```
+
+### Step 3: Write Test Functions
+
+Follow the Arrange-Act-Assert pattern, with descriptive names:
+
+```python
+def test_compute_score_correct_answer_returns_one():
+    """compute_score returns 1.0 when model output matches ground truth."""
+    # Arrange
+    solution = "The answer is \\boxed{42}"
+    ground_truth = "42"
+
+    # Act
+    score = compute_score(solution, ground_truth)
+
+    # Assert
+    assert score == 1.0
+
+
+def test_compute_score_wrong_answer_returns_zero():
+    solution = "The answer is \\boxed{99}"
+    score = compute_score(solution, "42")
+    assert score == 0.0
+
+
+def test_compute_score_exception_returns_zero():
+    """compute_score must not raise; return 0.0 on malformed input."""
+    score = compute_score(None, "42")  # type: ignore
+    assert score == 0.0
+```
+
+### Step 4: GPU / CUDA Guards
+
+Always skip gracefully when GPU is not available:
+
+```python
+import torch
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="CUDA not available")
+def test_gpu_forward_pass():
+    model = MyModel().cuda()
+    x = torch.randn(2, 16, device="cuda")
+    out = model(x)
+    assert out.shape == (2, 16)
+```
+
+### Step 5: Tensor Assertions
+
+Use `torch.testing.assert_close` instead of bare `assert`:
+
+```python
+import torch
+
+def test_advantage_normalization():
+    rewards = torch.tensor([1.0, 0.0, 1.0, 0.0])
+    mask = torch.ones_like(rewards)
+    adv = normalize_advantages(rewards, mask)
+
+    # Prefer assert_close over .equal() — gives useful diff on failure
+    torch.testing.assert_close(adv.mean(), torch.tensor(0.0), atol=1e-5, rtol=0)
+    torch.testing.assert_close(adv.std(), torch.tensor(1.0), atol=1e-5, rtol=0)
+```
+
+### Step 6: DataProto Tests
+
+When testing code that uses `DataProto`:
+
+```python
+from verl import DataProto
+import torch
+
+def make_dummy_batch(batch_size=4, seq_len=16):
+    return DataProto.from_dict({
+        "input_ids": torch.randint(0, 1000, (batch_size, seq_len)),
+        "attention_mask": torch.ones(batch_size, seq_len, dtype=torch.long),
+        "responses": torch.randint(0, 1000, (batch_size, 8)),
+        "response_mask": torch.ones(batch_size, 8, dtype=torch.long),
+    })
+
+
+def test_reward_manager_output_shape():
+    data = make_dummy_batch()
+    manager = NaiveRewardManager(tokenizer=mock_tokenizer, num_examine=0)
+    reward = manager(data)
+    assert reward.shape == (4, 8)  # [batch_size, response_len]
+```
+
+### Step 7: Parametrize for Multiple Cases
+
+```python
+@pytest.mark.parametrize("batch_size,seq_len", [(1, 8), (4, 16), (8, 32)])
+def test_seqlen_balancing(batch_size, seq_len):
+    seqlens = [seq_len] * batch_size
+    result = balance_sequences(seqlens, n_gpus=2)
+    assert len(result) == 2
+```
+
+### Step 8: CI Registration
+
+After writing your test:
+
+1. **CPU test** (`test_*_on_cpu.py`): automatically picked up by `cpu_unit_tests.yml`
+2. **GPU test** (`test_*.py`): automatically picked up by `gpu_unit_tests.yml`
+3. **If your test is slow or requires special hardware**: manually exclude it in the
+   relevant CI yamls per `tests/README.md` instructions
+
+## Reference Implementations
+
+| File                                      | Description                               |
+| ----------------------------------------- | ----------------------------------------- |
+| `tests/test_protocol_on_cpu.py`           | DataProto CPU tests (good starting point) |
+| `tests/test_base_config_on_cpu.py`        | Config dataclass tests                    |
+| `tests/trainer/`                          | Trainer unit tests                        |
+| `tests/workers/`                          | Worker unit tests                         |
+| `tests/utils/`                            | Utility function tests                    |
+| `tests/special_distributed/`             | Multi-GPU distributed tests               |
+
+## Common Mistakes
+
+- ❌ GPU test without `@pytest.mark.skipif(not CUDA_AVAILABLE, ...)` guard
+- ❌ `assert tensor.equal(other)` — use `torch.testing.assert_close` instead
+- ❌ Missing `_on_cpu.py` suffix for CPU-only tests (they'll be scheduled on GPU nodes)
+- ❌ Raising inside `compute_score` under test — always test the 0.0-on-error path
+- ❌ Forgetting to exclude slow/special tests from `cpu_unit_tests.yml` / `gpu_unit_tests.yml`
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-unit-tests/SKILL.md
+
+## How to Update
+- When test layout changes: update Step 1 table
+- When DataProto schema changes: update Step 6 helper
+- When CI yamls renamed: update Step 8
+================================================================================
+-->

--- a/.agents/skills/commit-conventions/SKILL.md
+++ b/.agents/skills/commit-conventions/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: commit-conventions
+description: veRL commit message conventions. Load on every git commit to enforce Conventional Commits format.
+---
+
+# Commit Conventions
+
+veRL follows the **Conventional Commits** specification.
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer]
+```
+
+- **Subject**: ≤72 chars, imperative mood ("add", "fix", not "added", "fixes")
+- **Body**: explain *why*, not *what*; wrap at 72 chars
+- **Footer**: reference issues (`Closes #123`, `Fixes #456`)
+
+## Types
+
+| Type       | When to Use                                              |
+| ---------- | -------------------------------------------------------- |
+| `feat`     | New feature or algorithm                                 |
+| `fix`      | Bug fix                                                  |
+| `perf`     | Performance improvement (no behavior change)             |
+| `refactor` | Code restructuring (no feature/fix)                      |
+| `docs`     | Documentation only                                       |
+| `test`     | Adding or fixing tests                                   |
+| `chore`    | Build, CI, dependencies, tooling                         |
+| `revert`   | Reverting a previous commit                              |
+
+## Scopes (inferred from file paths)
+
+| Scope        | Paths                                           |
+| ------------ | ----------------------------------------------- |
+| `trainer`    | `verl/trainer/`                                 |
+| `workers`    | `verl/workers/`                                 |
+| `reward`     | `verl/utils/reward_score/`, `workers/reward_manager/` |
+| `dataset`    | `verl/utils/dataset/`                           |
+| `rollout`    | `verl/workers/rollout/`                         |
+| `actor`      | `verl/workers/actor/`                           |
+| `critic`     | `verl/workers/critic/`                          |
+| `fsdp`       | `verl/workers/fsdp_workers.py`, `verl/utils/fsdp_utils.py` |
+| `megatron`   | `verl/workers/megatron_workers.py`, `verl/utils/megatron/` |
+| `vllm`       | `verl/utils/vllm/`                              |
+| `sglang`     | `verl/utils/sglang/`                            |
+| `protocol`   | `verl/protocol.py`                              |
+| `recipe`     | `recipe/`                                       |
+| `examples`   | `examples/`                                     |
+| `ci`         | `.github/`                                      |
+
+## Examples
+
+```
+feat(reward): add process-level reward scoring for code tasks
+
+fix(trainer): fix NaN loss when response_mask is all zeros
+
+perf(rollout): reduce memory copies during sequence packing
+
+docs(recipe): add DAPO recipe README with benchmark results
+
+chore(ci): update torch version to 2.5.1 in test matrix
+```
+
+## PR Workflow (upstream contribution)
+
+When submitting to `verl-project/verl`, always branch from `upstream/main`:
+
+```bash
+git fetch upstream main
+git checkout -b feat/my-feature upstream/main
+# ... make changes ...
+git add <specific files>
+git commit -m "feat(scope): description"
+git push origin feat/my-feature
+gh pr create --repo verl-project/verl --head <your-fork>:feat/my-feature --base main
+```
+
+Verify diff before opening PR:
+```bash
+git diff upstream/main  # must only contain intended changes
+```
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/commit-conventions/SKILL.md
+Loaded: automatically on every git commit
+
+## How to Update
+- Add scopes when new major directories are added
+- Keep type list stable (Conventional Commits spec)
+================================================================================
+-->

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: create-pr
+description: Rebase onto upstream/main, squash local commits, generate a Conventional Commit message, and create or update the GitHub pull request to verl-project/verl.
+---
+
+# Create Pull Request
+
+Use this skill when the user asks to create or update a PR for the current branch.
+
+## Inputs
+
+- Optional `--draft`
+- Optional `--base <branch>` (default: `main`)
+
+## Preconditions
+
+1. Verify the current branch is not `main` or `master`.
+2. Check for uncommitted changes with `git status --short`.
+3. Ensure `gh` is available (`gh auth status`).
+4. If uncommitted changes exist, stop and ask the user to commit or stash them first.
+
+## Workflow
+
+### Step 1: Check for an Existing PR
+
+```bash
+gh pr view --json number,title,url,state,isDraft
+```
+
+If a PR already exists, tell the user before rewriting history or force-pushing.
+
+### Step 2: Fetch and Rebase onto Upstream
+
+veRL PRs target `verl-project/verl`, not a personal fork's main:
+
+```bash
+git fetch upstream main
+git rebase upstream/main
+```
+
+- If rebase conflicts occur, abort and stop:
+  ```bash
+  git rebase --abort
+  ```
+- Tell the user which files conflicted and ask them to resolve manually.
+
+### Step 3: Squash into One Commit
+
+```bash
+git reset --soft upstream/main
+```
+
+Load `commit-conventions` skill before generating the commit message.
+
+**veRL PR title format** (enforced by CI `check-pr-title.yml`):
+
+```
+[{modules}] {type}: {description}
+```
+
+- `{modules}`: e.g. `fsdp`, `megatron`, `vllm`, `sglang`, `trainer`, `algo`, `reward`,
+  `data`, `recipe`, `doc`, `ci` — separate multiple with `,`
+- `{type}`: `feat`, `fix`, `refactor`, `chore`, `test`
+- If any API breaks (CLI args, config keys, function signatures): prepend `[BREAKING]`
+- Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`
+
+Keep the subject imperative and under ~72 characters.
+
+### Step 4: Generate PR Body
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`. Fill in:
+
+- **What does this PR do?** — concise overview, link related issues/PRs
+- **Test** — experiment results or CI test commands; if no CI coverage, explain why
+- **API and Usage Example** — code snippet if API changes
+- **Design & Code Changes** — high-level design for complex PRs
+
+**Checklist to verify before submitting:**
+
+- [ ] `pre-commit run --all-files` passes
+- [ ] Docs updated if behavior changes (`docs/`)
+- [ ] Unit or e2e test added (or explanation why not)
+- [ ] If `recipe/` submodule changed: `git submodule update --remote`
+
+### Step 5: Push and Create or Update PR
+
+```bash
+# First push (or after rebase that rewrites history)
+git push origin <branch>          # or --force-with-lease if rebased
+
+# Create PR targeting upstream
+gh pr create \
+  --repo verl-project/verl \
+  --head <your-fork>:<branch> \
+  --base main \
+  --title "[modules] type: description" \
+  --body "$(cat <<'EOF'
+### What does this PR do?
+...
+
+### Test
+...
+
+### Checklist Before Submitting
+- [ ] pre-commit passes
+- [ ] Docs updated
+- [ ] Tests added
+EOF
+)"
+```
+
+To update an existing PR:
+```bash
+gh pr edit <number> --title "..." --body "..."
+```
+
+## Guardrails
+
+- Never create a PR from `main` or `master`
+- Never silently force-push over an existing PR branch — confirm first
+- Never bypass `commit-conventions` for the squashed commit
+- PR title must match `[{modules}] {type}: {description}` — CI will reject otherwise
+- Verify `git diff upstream/main` only contains intended changes before pushing
+
+## Output
+
+Report:
+
+- Base branch used (`upstream/main`)
+- Final squashed commit message
+- PR title (must match veRL format)
+- PR URL if creation/update succeeded
+- Any steps skipped or requiring user follow-up
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/create-pr/SKILL.md
+
+## How to Update
+- When PR template changes: update Step 4 body template
+- When CI title format changes: update Step 3 format rules
+================================================================================
+-->

--- a/.agents/skills/debug-distributed/SKILL.md
+++ b/.agents/skills/debug-distributed/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: debug-distributed
+description: Guide for debugging distributed training issues in veRL. Use when encountering hangs, OOM, wrong results, or Ray errors.
+---
+
+# Debug Distributed Training
+
+Diagnose and fix distributed training issues in veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- Training hangs or deadlocks
+- OOM (out of memory) errors
+- Wrong/NaN loss or reward values
+- Ray worker crashes or connection errors
+- NCCL / collective communication errors
+- HybridEngine resharding failures
+
+---
+
+## Category 1: Hangs / Deadlocks
+
+### Symptoms
+- Training stuck with no output, no error
+- `ray.get()` never returns
+
+### Checklist
+
+1. **NCCL barrier mismatch** — all ranks must call the same collectives in the same
+   order. Add rank-0 logging before each collective to confirm all ranks reach it.
+
+2. **Ray actor deadlock** — check if a remote call is waiting on a result that itself
+   waits on another remote call (circular dependency).
+
+3. **Rollout never returns** — vLLM/SGLang engine stuck. Check inference worker logs:
+   ```bash
+   ray logs actor --id <actor_id>
+   ```
+
+4. **Uneven data across ranks** — padding or sequence balancing issue causes one rank
+   to have 0 samples. Check `seqlen_balancing.py`.
+
+5. **Enable NCCL debug**:
+   ```bash
+   export NCCL_DEBUG=INFO
+   export NCCL_DEBUG_SUBSYS=ALL
+   ```
+
+---
+
+## Category 2: OOM (Out of Memory)
+
+### Common Causes & Fixes
+
+| Cause | Fix |
+|-------|-----|
+| Too large `max_response_length` | Reduce `data.max_response_length` |
+| vLLM `gpu_memory_utilization` too high | Lower `actor_rollout_ref.rollout.gpu_memory_utilization` (e.g., 0.4) |
+| Gradient accumulation accumulates too much | Reduce `actor.ppo_mini_batch_size` |
+| HybridEngine holds two copies during resharding | Use `offload_params=True` |
+| Sequence packing increases effective batch size | Lower `data.train_batch_size` |
+
+### Quick Debug
+
+```python
+# Add to your trainer to track memory
+import torch
+print(f"[Rank {rank}] GPU memory: {torch.cuda.memory_allocated()/1e9:.2f}GB allocated, "
+      f"{torch.cuda.memory_reserved()/1e9:.2f}GB reserved")
+```
+
+---
+
+## Category 3: NaN / Wrong Loss or Reward
+
+### Checklist
+
+1. **Reward always 0** — `data_source` mismatch. Verify:
+   ```python
+   # Print data_source values in your dataset
+   print(batch.non_tensor_batch["data_source"])
+   ```
+
+2. **NaN in loss** — often caused by:
+   - Log prob of 0-probability tokens (numerical underflow)
+   - `response_mask` is all zeros for some samples
+   - Advantage normalization dividing by zero std
+
+   ```python
+   # Check advantage stats
+   adv = data.batch["advantages"]
+   mask = data.batch["response_mask"]
+   print(f"adv mean={adv[mask.bool()].mean():.4f}, std={adv[mask.bool()].std():.4f}")
+   ```
+
+3. **Importance ratio explodes** — old_log_probs and new log_probs misaligned.
+   Check that attention_mask and position_ids match between rollout and training.
+
+4. **Reward NaN** — exception in `compute_score` returning `float('nan')`.
+   Add explicit exception handling returning `0.0`.
+
+5. **ref_log_prob mismatch** — reference model not loaded correctly. Verify with:
+   ```bash
+   actor_rollout_ref.ref.log=True  # Enable ref logprob logging
+   ```
+
+---
+
+## Category 4: Ray Worker Crashes
+
+### Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `RayActorError` | Worker process died | Check worker logs for root cause |
+| `OutOfMemoryError` in Ray | Ray object store full | Increase `object_store_memory` in `runtime_env.yaml` |
+| `ActorDiedError` during resharding | HybridEngine crash | Check NCCL version compatibility |
+| `ConnectionRefusedError` | Head node not reachable | Check `ray start --head` is running |
+
+### Get Worker Logs
+
+```bash
+# List all actors
+ray list actors
+
+# Get logs for a specific actor
+ray logs actor --id <actor_id>
+
+# Stream logs in real time
+ray logs actor --id <actor_id> --follow
+```
+
+---
+
+## Category 5: HybridEngine Resharding Issues
+
+veRL's HybridEngine transitions weights between training (FSDP/Megatron) and inference
+(vLLM/SGLang) sharding. Failures here are usually:
+
+1. **TP size mismatch** — training TP and rollout TP must be compatible.
+   Check `actor_rollout_ref.actor.model_parallel_size` vs
+   `actor_rollout_ref.rollout.tensor_model_parallel_size`.
+
+2. **Weight name mismatch after conversion** — add logging in the sharding manager:
+   ```python
+   # verl/workers/sharding_manager/
+   # Add: print(list(state_dict.keys())[:10])
+   ```
+
+3. **CUDA device mismatch** — ensure training and rollout workers are on the same GPU
+   set when using collocated placement.
+
+---
+
+## General Debug Tips
+
+```python
+# 1. Isolate to single GPU first
+trainer.n_gpus_per_node=1 trainer.nnodes=1
+
+# 2. Reduce batch size to minimum
+data.train_batch_size=4
+
+# 3. Enable verbose Ray logging
+import logging
+logging.getLogger("ray").setLevel(logging.DEBUG)
+
+# 4. Use veRL's built-in profiler
+trainer.profile=True
+
+# 5. Print DataProto shapes at key points
+for k, v in data.batch.items():
+    print(f"  {k}: {v.shape} {v.dtype}")
+```
+
+## Key Log Locations
+
+| Component | Log location |
+|-----------|-------------|
+| Ray workers | `ray logs actor --id <id>` |
+| vLLM engine | Actor log, search `[vLLM]` prefix |
+| SGLang engine | Actor log, search `[SGLang]` prefix |
+| NCCL | `NCCL_DEBUG=INFO` output |
+| Training metrics | WandB / stdout based on `trainer.logger` |
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/debug-distributed/SKILL.md
+
+## How to Update
+- When new common error patterns emerge: add to the relevant category
+- When Ray API changes: update log commands
+================================================================================
+-->

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: review-pr
+description: Read-only pull request review for veRL with risk analysis and targeted checklists.
+---
+
+# Review Pull Request
+
+Use this skill when the user asks for a PR review of the current branch or a specific PR.
+
+## Inputs
+
+- Optional PR number (defaults to current branch's PR)
+- Optional `--quick` to stop after the change analysis phase
+
+## Hard Rules
+
+- **Stay read-only.** Do not edit files, commit, push, rebase, or change GitHub state.
+- Do not run build, install, or test commands that mutate the environment.
+- Use `gh` for PR metadata and `git diff` for content.
+
+## Workflow
+
+### Phase 1: Resolve PR Context
+
+```bash
+gh pr view [<number>] --json number,title,body,state,isDraft,files,baseRefName,headRefName
+```
+
+- If no PR exists or it is closed, stop and report clearly.
+- Record: branch name, changed files, PR title format compliance.
+
+**veRL PR title format check** (enforced by CI):
+
+```
+[{modules}] {type}: {description}
+```
+
+Flag if title doesn't match this pattern.
+
+### Phase 2: Change Analysis
+
+Classify changed files into risk areas:
+
+| Risk Area | Paths | Risk Level |
+|-----------|-------|------------|
+| Protocol / DataProto | `verl/protocol.py` | CRITICAL |
+| HybridEngine / sharding | `verl/workers/sharding_manager/` | CRITICAL |
+| Core algorithm (loss, advantage) | `verl/trainer/ppo/core_algos.py` | HIGH |
+| Workers (actor, critic, rollout) | `verl/workers/actor/`, `critic/`, `rollout/` | HIGH |
+| Reward manager | `verl/workers/reward_manager/` | HIGH |
+| vLLM / SGLang integration | `verl/utils/vllm/`, `verl/utils/sglang/` | HIGH |
+| Trainer orchestration | `verl/trainer/` | MEDIUM |
+| Dataset / reward_score | `verl/utils/dataset/`, `verl/utils/reward_score/` | MEDIUM |
+| Config / base_config | `verl/base_config.py`, `verl/workers/config/` | MEDIUM |
+| Examples / recipes | `examples/`, `recipe/` | LOW |
+| Docs | `docs/` | LOW |
+| CI | `.github/workflows/` | LOW |
+
+Build a `CHANGE_ANALYSIS_REPORT`:
+- Detected risk areas
+- Highest risk level: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`
+- Affected files
+- Likely failure modes
+
+If `--quick`, return the report and stop.
+
+### Phase 3: Review Planning
+
+Select review passes based on risk areas. Always include at least one general logic pass.
+Split by risk area, not by file count.
+
+### Phase 4: Execute Review Passes
+
+For each risk area, check the following:
+
+#### CRITICAL: Protocol / DataProto changes
+- Does `DataProto` schema change break downstream workers?
+- Are all `.batch`, `.non_tensor_batch`, `.meta_info` accesses updated consistently?
+- Does the change affect checkpoint compatibility?
+
+#### CRITICAL: HybridEngine / Sharding
+- Are training TP and rollout TP sizes still compatible?
+- Is NCCL group initialization correct across all placement strategies?
+- Is memory released properly between training and inference phases?
+
+#### HIGH: Algorithm (core_algos.py)
+- Is `response_mask` applied correctly before loss/advantage computation?
+- Is advantage normalization level (`batch` vs `group`) consistent with the algorithm?
+- Are importance ratios clipped correctly (old_log_probs alignment with new_log_probs)?
+- Does NaN propagation from `log(0)` get handled?
+
+#### HIGH: Workers
+- Are Ray remote calls properly awaited (`.remote()` + `ray.get()`)?
+- Is GPU memory released between rollout and training phases?
+- Are collective ops (all_reduce, broadcast) called on matching ranks?
+
+#### HIGH: vLLM / SGLang integration
+- Do imported vLLM symbols still exist at the pinned version (`requirements.txt`)?
+- Are try/except fallbacks for version-specific imports still correct?
+- Is `SamplingParams` usage compatible with the pinned vLLM version?
+
+#### MEDIUM: Reward / Dataset
+- Does `compute_score` handle exceptions and return `0.0` (never raise)?
+- Does `data_source` in preprocessed dataset match the dispatch key in `__init__.py`?
+- Are all required DataProto fields present in dataset output?
+
+#### MEDIUM: Config changes
+- Does renaming a config field break existing YAML run scripts in `examples/`?
+- Is backward compatibility handled or `[BREAKING]` added to PR title?
+
+### Phase 5: Final Report
+
+```markdown
+CHANGE_ANALYSIS_REPORT:
+- risk_level: CRITICAL | HIGH | MEDIUM | LOW
+- detected_risk_areas: [...]
+- affected_files: [...]
+- likely_failure_modes: [...]
+
+Findings (ordered by severity)
+1. [CRITICAL] Title — path:line
+   - Problem: ...
+   - Fix: ...
+
+2. [HIGH] ...
+
+Open Questions
+- ...
+
+Residual Risk
+- ...
+
+PR Format Check
+- Title compliant: yes/no
+- pre-commit: (can't verify, remind reviewer)
+- Tests added: yes/no (based on diff)
+- Docs updated: yes/no (based on diff)
+```
+
+## What to Ignore
+
+- Pure style nits already caught by pre-commit (ruff, isort)
+- Issues outside the changed scope unless the PR makes them worse
+- Speculative concerns with no concrete trigger in the diff
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/review-pr/SKILL.md
+
+## How to Update
+- When new high-risk modules added: update Phase 2 risk table
+- When PR title format changes (check-pr-title.yml): update Phase 1
+================================================================================
+-->

--- a/.agents/skills/upgrade-megatron-core/SKILL.md
+++ b/.agents/skills/upgrade-megatron-core/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: upgrade-megatron-core
+description: Upgrade Megatron-Core in veRL by auditing affected APIs, cross-referencing upstream sources, and updating call sites.
+---
+
+# Upgrade Megatron-Core
+
+Upgrade the pinned Megatron-Core version in veRL and update all affected call sites.
+
+## Usage
+
+```
+Target Megatron-Core version: $VERSION
+```
+
+`$VERSION`: target version tag, e.g. `core_v0.17.0`, `core_r0.12.0`, or a commit SHA.
+If omitted, check current pinned version in the Dockerfile and validate compatibility.
+
+## Prerequisites — Clone Upstream Sources
+
+veRL depends on both **Megatron-LM** and **mbridge** (the HF↔MCore weight conversion
+layer). Both must be audited when upgrading.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MCORE_DIR="${REPO_ROOT}/Megatron-LM"
+MBRIDGE_DIR="${REPO_ROOT}/mbridge-src"
+
+# Validate VERSION
+if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "Error: Invalid version format"; exit 1
+fi
+
+# Clone Megatron-LM
+if [ ! -d "$MCORE_DIR" ]; then
+  git clone --depth 1 --branch "${VERSION}" https://github.com/NVIDIA/Megatron-LM.git "$MCORE_DIR"
+else
+  cd "$MCORE_DIR" && git fetch origin && git checkout "${VERSION}" && cd -
+fi
+
+# Clone mbridge (check current version from docker/Dockerfile.stable.vllm)
+MBRIDGE_VERSION=$(grep "megatron.bridge\|mbridge" docker/Dockerfile.stable.vllm | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ ! -d "$MBRIDGE_DIR" ]; then
+  git clone --depth 1 https://github.com/NVIDIA-NeMo/Megatron-Bridge.git "$MBRIDGE_DIR"
+fi
+```
+
+If cloning fails, stop and report to the user.
+
+**Relevant upstream source paths:**
+
+```
+Megatron-LM/megatron/core/
+  parallel_state.py
+  distributed/
+  optimizer/
+  optimizer_param_scheduler.py
+  pipeline_parallel/schedules.py
+  pipeline_parallel/utils.py
+  transformer/transformer_config.py
+  transformer/transformer_layer.py
+  transformer/enums.py
+  transformer/moe/moe_utils.py
+  transformer/moe/token_dispatcher.py
+  transformer/moe/router.py
+  transformer/multi_latent_attention.py
+  transformer/multi_token_prediction.py
+  models/gpt/gpt_model.py
+  models/gpt/gpt_layer_specs.py
+  models/gpt/moe_module_specs.py
+  models/common/model_chunk_schedule_plan.py
+  dist_checkpointing/serialization.py
+  dist_checkpointing/strategies/fully_parallel.py
+  dist_checkpointing/strategies/async_utils.py
+  dist_checkpointing/strategies/filesystem_async.py
+  packed_seq_params.py
+  utils.py
+  inference/contexts.py
+  fusions/fused_cross_entropy.py
+  extensions/transformer_engine.py
+```
+
+---
+
+## Affected Files in veRL
+
+### Primary — Core Model Layer
+
+| File | Key Megatron APIs |
+|------|------------------|
+| `verl/models/mcore/patch.py` | `parallel_state`, `tensor_parallel`, `multi_latent_attention`, `dist_checkpointing.strategies.*`, monkey-patches megatron internals |
+| `verl/models/mcore/model_initializer.py` | `GPTModel`, `get_gpt_decoder_block_spec`, `get_gpt_mtp_block_spec`, `TEColumnParallelLinear`, `TERowParallelLinear`, `MLPSubmodules`, `get_vit_layer_with_transformer_engine_spec` |
+| `verl/models/mcore/model_forward_fused.py` | `parallel_state`, `GPTModel`, `PackedSeqParams`, `gather_from_sequence_parallel_region`, `make_viewless_tensor`, `deprecate_inference_params`, `BaseInferenceContext`, `config_logger` |
+| `verl/models/mcore/model_forward_1f1b_overlap.py` | `TransformerModelChunkSchedulePlan`, `GPTModel`, `make_viewless_tensor`, `gather_from_sequence_parallel_region`, `MultiTokenPredictionLayer` |
+| `verl/models/mcore/mtp_patch.py` | `GPTModel`, `MultiTokenPredictionLayer`, `roll_tensor`, `make_viewless_tensor`, `unwrap_model`, `parallel_state` |
+| `verl/models/mcore/config_converter.py` | `parallel_state`, `TransformerConfig`, `MLATransformerConfig`, `set_experimental_flag`, `AttnBackend` |
+| `verl/models/mcore/bridge.py` | `parallel_state`, `tensor_parallel`, `megatron.bridge.AutoBridge`, `AutoMapping`, `CanonicalLoRA`, `DoRA`, `LoRA`, `VLMLoRA` |
+| `verl/models/mcore/loader.py` | `mpu`, `DistributedDataParallel`, `Float16Module` |
+
+### Primary — Workers
+
+| File | Key Megatron APIs |
+|------|------------------|
+| `verl/workers/megatron_workers.py` | `parallel_state`, `tensor_parallel`, `AttnBackend`, `dist_checkpointing.strategies.base.async_calls` |
+| `verl/utils/megatron_utils.py` | Broad megatron utils; `LayerType`, `finalize_model_grads` |
+
+### Primary — Utilities
+
+| File | Key Megatron APIs |
+|------|------------------|
+| `verl/utils/megatron/dist_checkpointing.py` | `dist_checkpointing`, `mpu`, `ShardedObjectHistoryRecorder`, `FullyParallelSaveStrategy`, `FullyParallelLoadStrategy` |
+| `verl/utils/megatron/optimizer.py` | `OptimizerConfig`, `get_megatron_optimizer`, `OptimizerParamScheduler` |
+| `verl/utils/megatron/pipeline_parallel.py` | `parallel_state` |
+| `verl/utils/megatron/tensor_parallel.py` | `parallel_state`, `tensor_parallel`, `ModelParallelConfig` |
+| `verl/utils/megatron/router_replay_patch.py` | `moe_utils`, `MoEAlltoAllTokenDispatcher`, `TopKRouter`, `TransformerConfig` |
+| `verl/utils/megatron/router_replay_utils.py` | `parallel_state`, `get_schedule_table`, `gather/scatter_to_sequence_parallel_region`, `TransformerConfig`, `get_transformer_layer_offset`, `is_vp_first_stage`, `is_vp_last_stage`, `LayerType` |
+| `verl/utils/checkpoint/megatron_checkpoint_manager.py` | `dist_checkpointing`, `mpu`, `tensor_parallel`, `ShardedObject`, `AttnBackend`, `megatron.bridge.training.checkpointing`, `async_calls` |
+| `verl/trainer/distillation/megatron/losses.py` | `fused_cross_entropy`, `get_tensor_model_parallel_group`, `VocabUtility` |
+
+### Secondary — Model Merger
+
+| File | Key Megatron APIs |
+|------|------------------|
+| `verl/model_merger/megatron_model_merger.py` | `mpu`, `ModelType`, `model_parallel_cuda_manual_seed` |
+
+### Version / Docker
+
+| File | Usage |
+|------|-------|
+| `docker/Dockerfile.stable.vllm` | `pip install git+...Megatron-LM.git@core_v0.X.Y` |
+| `docker/verl*/Dockerfile.app.*` | May also pin Megatron version |
+
+---
+
+## Audit Workflow
+
+### Step 1: Identify Current Pinned Version
+
+```bash
+grep -i "Megatron-LM\|megatron" docker/Dockerfile.stable.vllm | grep "pip install"
+```
+
+### Step 2: Enumerate All Megatron Imports
+
+```bash
+grep -rn "from megatron\|import megatron" verl/ --include="*.py" | grep -v "__pycache__"
+```
+
+### Step 3: Cross-Reference Each Symbol
+
+For each import, verify in `Megatron-LM/`:
+- Does the module path still exist?
+- Has the class/function signature changed?
+- Has anything been moved or renamed?
+
+**Highest-churn symbols to always check:**
+
+| Symbol | Why It Changes Often |
+|--------|----------------------|
+| `TransformerConfig` | New fields added nearly every release |
+| `MLATransformerConfig` | MLA (Multi-Latent Attention) is experimental |
+| `PackedSeqParams` | Sequence packing format evolves |
+| `get_gpt_decoder_block_spec` / `get_gpt_mtp_block_spec` | Layer spec signatures change |
+| `FullyParallelSaveStrategy` / `FullyParallelLoadStrategy` | Distributed checkpointing API evolves |
+| `async_calls` | Async checkpoint internals are fragile |
+| `MoEAlltoAllTokenDispatcher` | MoE dispatcher is frequently refactored |
+| `get_schedule_table` | PP schedule API changes with new schedules |
+| `AttnBackend` | New backends added, old ones deprecated |
+
+### Step 4: Audit patch.py Carefully
+
+`verl/models/mcore/patch.py` monkey-patches Megatron internals. These break silently:
+
+```bash
+# See what is being patched
+grep -n "= " verl/models/mcore/patch.py | grep -v "^#" | head -30
+```
+
+For each patched attribute:
+- Verify the patched object still exists in `Megatron-LM/`
+- Verify its internal structure hasn't changed
+- If the upstream bug is fixed at `$VERSION`, consider removing the patch
+
+### Step 5: Audit MoE Router Replay Patches
+
+`router_replay_patch.py` and `router_replay_utils.py` patch MoE token dispatching
+internals that change frequently:
+
+```bash
+grep -n "from megatron" verl/utils/megatron/router_replay_patch.py
+grep -n "from megatron" verl/utils/megatron/router_replay_utils.py
+```
+
+Verify `MoEAlltoAllTokenDispatcher`, `TopKRouter`, and `get_schedule_table` signatures.
+
+### Step 6: Audit mbridge (megatron.bridge)
+
+`verl/models/mcore/bridge.py` uses mbridge for HF↔MCore weight conversion. mbridge
+version must be compatible with the new Megatron-Core version:
+
+```bash
+grep -n "megatron.bridge" verl/models/mcore/bridge.py
+grep -n "megatron.bridge" verl/utils/checkpoint/megatron_checkpoint_manager.py
+```
+
+Check `mbridge-src/` for:
+- `AutoBridge`, `AutoMapping` signatures
+- `CanonicalLoRA`, `LoRA`, `VLMLoRA`, `DoRA` interfaces
+- `apply_peft_adapter_filter_to_state_dict` in `training/checkpointing`
+
+### Step 7: Update Version Pin
+
+```bash
+# Update Dockerfile
+sed -i "s|Megatron-LM.git@core_v[0-9.]*|Megatron-LM.git@${VERSION}|" docker/Dockerfile.stable.vllm
+
+# Check other Dockerfiles
+grep -rl "Megatron-LM" docker/ | xargs grep -l "pip install"
+```
+
+### Step 8: Run Validation
+
+```bash
+# CPU import checks
+python -c "
+from verl.models.mcore import config_converter
+from verl.utils.megatron import optimizer, pipeline_parallel
+print('Megatron imports OK')
+"
+
+# CPU unit tests
+pytest tests/test_*_on_cpu.py -x
+
+# If GPU available, run megatron-specific tests
+pytest tests/ -k "megatron" -x
+```
+
+---
+
+## Common Breaking Patterns
+
+| Pattern | What to Check |
+|---------|---------------|
+| `TransformerConfig` new required fields | Config constructor calls in `config_converter.py` |
+| `PackedSeqParams` field renames | All usages in `model_forward_fused.py` |
+| Checkpointing strategy API | `FullyParallelSaveStrategy/LoadStrategy` constructor args |
+| `get_gpt_decoder_block_spec` signature | `model_initializer.py` call site |
+| MoE dispatcher refactor | `router_replay_patch.py` internal hooks |
+| `parallel_state` function renames | All `mpu.*` usages across workers |
+| `AttnBackend` enum values | `config_converter.py`, `megatron_workers.py` |
+| MTP API changes | `mtp_patch.py` — `MultiTokenPredictionLayer`, `roll_tensor` |
+| `async_calls` internals | `megatron_checkpoint_manager.py` async checkpoint path |
+
+---
+
+## Output
+
+Report:
+
+1. Current pinned version vs target version
+2. Table of changed/broken imports with fix applied
+3. Patches in `patch.py` / `router_replay_patch.py` that need updating or removal
+4. mbridge compatibility status
+5. Files modified
+6. Validation commands run and their results
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/upgrade-megatron-core/SKILL.md
+
+## How to Update
+- When new megatron imports added to verl: update Affected Files tables
+- When new common breaking patterns emerge: update the patterns table
+- When mbridge repo URL changes: update Prerequisites section
+================================================================================
+-->

--- a/.agents/skills/upgrade-sglang/SKILL.md
+++ b/.agents/skills/upgrade-sglang/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: upgrade-sglang
+description: Upgrade SGLang in veRL by auditing affected call sites, cross-referencing upstream source, and updating for compatibility.
+---
+
+# Upgrade SGLang
+
+Upgrade the pinned SGLang version in veRL and update all affected call sites.
+
+## Usage
+
+```
+Target SGLang version: $VERSION
+```
+
+`$VERSION`: target SGLang version tag, e.g. `v0.5.3`, `0.6.0`. If omitted, check
+current pinned version in `requirements_sglang.txt` and validate compatibility.
+
+## Prerequisites — Clone Upstream Source
+
+```bash
+SGLANG_DIR="$(git rev-parse --show-toplevel)/sglang-src"
+# Validate VERSION to prevent command injection
+if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "Error: Invalid version format"; exit 1
+fi
+if [ ! -d "$SGLANG_DIR" ]; then
+  git clone --depth 1 --branch "${VERSION}" https://github.com/sgl-project/sglang.git "$SGLANG_DIR"
+else
+  cd "$SGLANG_DIR" && git fetch origin && git checkout "${VERSION}" && cd -
+fi
+```
+
+If cloning fails, stop and report to the user.
+
+---
+
+## Affected Files in veRL
+
+### Primary — Most Likely to Break
+
+| File | SGLang APIs Used |
+|------|-----------------|
+| `verl/workers/rollout/sglang_rollout/async_sglang_server.py` | `sglang.srt.entrypoints.engine`, `http_server` (`launch_server`, `add_api_routes`, etc.), `io_struct` (GenerateReqInput, BatchStrOut, BatchEmbeddingOut, etc.), `tokenizer_manager.ServerStatus`, `utils.common.add_prometheus_middleware`, `layers.moe.routed_experts_capturer.extract_routed_experts_from_meta_info` |
+| `verl/workers/rollout/sglang_rollout/sglang_rollout.py` | `sglang.srt.entrypoints.engine`, `server_args.ServerArgs`, `srt.utils` (kill_process_tree, etc.), `weight_sync.utils._preprocess_tensor_for_update_weights`, `weight_sync.utils.update_weights`, `io_struct.LoadLoRAAdapterFromTensorsReqInput` |
+| `verl/workers/rollout/sglang_rollout/http_server_engine.py` | `entrypoints.EngineBase.EngineBase`, `http_server.launch_server`, `io_struct.UpdateWeightsFromTensorReqInput`, `server_args.ServerArgs`, `utils.kill_process_tree` |
+
+### Secondary — Utilities
+
+| File | SGLang APIs Used |
+|------|-----------------|
+| `verl/utils/sglang/sglang_fp8_utils.py` | Commented-out: `distributed.device_communicators.pynccl.PyNcclCommunicator`, `distributed.utils.statelessprocessgroup` — verify if re-enabled |
+| `verl/experimental/reward_loop/router/inner_sglang_router.py` | Internal router using SGLang HTTP API |
+
+### Version / Docker
+
+| File | Usage |
+|------|-------|
+| `requirements_sglang.txt` | Pinned version: `sglang[all]==X.Y.Z` |
+| `docker/Dockerfile.stable.sglang` | Docker image SGLang version |
+| `docker/verl*/Dockerfile.app.sglang*` | Versioned Docker images |
+
+---
+
+## Audit Workflow
+
+### Step 1: Identify Current Pinned Version
+
+```bash
+cat requirements_sglang.txt | grep sglang
+```
+
+### Step 2: Enumerate All SGLang Imports
+
+```bash
+grep -rn "from sglang\|import sglang" verl/ --include="*.py" | grep -v "__pycache__"
+```
+
+### Step 3: Cross-Reference Against Upstream Source
+
+For each imported symbol, verify it still exists at `$VERSION` in `sglang-src/`:
+
+**Key symbols to always check:**
+
+| Symbol | Upstream Source Path |
+|--------|----------------------|
+| `ServerArgs` | `sglang-src/python/sglang/srt/server_args.py` |
+| `EngineBase` | `sglang-src/python/sglang/srt/entrypoints/EngineBase.py` |
+| `launch_server` | `sglang-src/python/sglang/srt/entrypoints/http_server.py` |
+| `UpdateWeightsFromTensorReqInput` | `sglang-src/python/sglang/srt/managers/io_struct.py` |
+| `LoadLoRAAdapterFromTensorsReqInput` | `sglang-src/python/sglang/srt/managers/io_struct.py` |
+| `GenerateReqInput` | `sglang-src/python/sglang/srt/managers/io_struct.py` |
+| `ServerStatus` | `sglang-src/python/sglang/srt/managers/tokenizer_manager.py` |
+| `update_weights` | `sglang-src/python/sglang/srt/weight_sync/utils.py` |
+| `_preprocess_tensor_for_update_weights` | `sglang-src/python/sglang/srt/weight_sync/utils.py` |
+| `kill_process_tree` | `sglang-src/python/sglang/srt/utils/__init__.py` or `utils.py` |
+| `add_prometheus_middleware` | `sglang-src/python/sglang/srt/utils/common.py` |
+| `extract_routed_experts_from_meta_info` | `sglang-src/python/sglang/srt/layers/moe/routed_experts_capturer.py` |
+
+For each symbol, check:
+- Does it still exist at this path?
+- Has the class/function signature changed?
+- Has the module been moved or renamed?
+
+### Step 4: io_struct Is Especially Fragile
+
+`sglang.srt.managers.io_struct` changes frequently between releases. Fully audit all
+symbols imported from it:
+
+```bash
+grep -n "from sglang.srt.managers.io_struct" verl/ -r --include="*.py"
+```
+
+For each symbol, verify its class definition, field names, and `__init__` signature in
+`sglang-src/python/sglang/srt/managers/io_struct.py`.
+
+### Step 5: weight_sync API
+
+The weight synchronization API (`weight_sync/utils.py`) is veRL's critical path for
+updating rollout weights after each training step. Any signature change here will break
+the HybridEngine weight sync:
+
+```bash
+# Check current usage
+grep -n "update_weights\|_preprocess_tensor" verl/workers/rollout/sglang_rollout/sglang_rollout.py
+```
+
+Verify against upstream that function signatures and expected tensor formats are
+unchanged.
+
+### Step 6: EngineBase Interface
+
+`EngineBase` is subclassed in `http_server_engine.py`. If the base class interface
+changes (new abstract methods, changed signatures), the subclass must be updated:
+
+```bash
+# Check current subclass
+grep -n "class\|def " verl/workers/rollout/sglang_rollout/http_server_engine.py | head -20
+```
+
+### Step 7: Update Version Pin
+
+```bash
+# Update requirements_sglang.txt
+sed -i "s/sglang\[all\]==[0-9.]*/sglang[all]==$VERSION/" requirements_sglang.txt
+
+# Check Docker files that may also pin sglang
+grep -rl "sglang" docker/ | grep Dockerfile
+```
+
+### Step 8: Run Validation
+
+```bash
+# Check imports resolve (CPU, no GPU needed)
+python -c "
+import sys
+sys.path.insert(0, '.')
+# Test that sglang can be imported
+import sglang
+print('sglang version:', sglang.__version__)
+"
+
+# Run CPU unit tests
+pytest tests/test_*_on_cpu.py -x
+
+# If GPU available, run sglang-specific tests
+pytest tests/ -k "sglang" -x
+```
+
+---
+
+## Common Breaking Patterns Across SGLang Versions
+
+| Pattern | What to Check |
+|---------|---------------|
+| `io_struct` field renames | `GenerateReqInput`, `UpdateWeightsFromTensorReqInput` field names change between versions |
+| `weight_sync` module reorganization | `update_weights` moved between submodules |
+| `EngineBase` new abstract methods | Subclass `http_server_engine.py` may need new methods |
+| `ServerArgs` new required fields | New arguments added to `ServerArgs.__init__` |
+| `kill_process_tree` location | Moved between `srt.utils` and `srt.utils.common` across versions |
+| `ServerStatus` enum values | New status values or renamed values in tokenizer_manager |
+| MoE routed experts API | `extract_routed_experts_from_meta_info` signature changes with MoE updates |
+| Prometheus middleware location | `add_prometheus_middleware` sometimes moved or renamed |
+
+---
+
+## Output
+
+Report:
+
+1. Current pinned version vs target version
+2. Table of changed/broken imports with fix applied
+3. `io_struct` fields that changed
+4. `weight_sync` API changes if any
+5. Files modified
+6. Validation commands run and their results
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/upgrade-sglang/SKILL.md
+
+## How to Update
+- When new sglang imports added to verl: update Affected Files table
+- When new common breaking patterns emerge: update the patterns table
+- When sglang repo structure changes: update upstream source paths in Step 3
+================================================================================
+-->

--- a/.agents/skills/upgrade-vllm/SKILL.md
+++ b/.agents/skills/upgrade-vllm/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: upgrade-vllm
+description: Upgrade vLLM in veRL by auditing affected call sites, cross-referencing upstream source, and updating for compatibility.
+---
+
+# Upgrade vLLM
+
+Upgrade the pinned vLLM version in veRL and update all affected call sites.
+
+## Usage
+
+```
+Target vLLM version: $VERSION
+```
+
+`$VERSION`: target vLLM version tag, e.g. `v0.9.0`, `0.8.5`. If omitted, check current
+pinned version in `requirements.txt` and validate compatibility.
+
+## Prerequisites — Clone Upstream Source
+
+Cross-reference API signatures against the target version:
+
+```bash
+VLLM_DIR="$(git rev-parse --show-toplevel)/vllm-src"
+# Validate VERSION to prevent command injection
+if [[ ! "$VERSION" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  echo "Error: Invalid version format"; exit 1
+fi
+if [ ! -d "$VLLM_DIR" ]; then
+  git clone --depth 1 --branch "${VERSION}" https://github.com/vllm-project/vllm.git "$VLLM_DIR"
+else
+  cd "$VLLM_DIR" && git fetch origin && git checkout "${VERSION}" && cd -
+fi
+```
+
+If cloning fails, stop and report to the user.
+
+---
+
+## Affected Files in veRL
+
+### Primary — Most Likely to Break
+
+| File | vLLM APIs Used |
+|------|----------------|
+| `verl/workers/rollout/vllm_rollout/vllm_async_server.py` | `SamplingParams`, `AsyncEngineArgs`, `build_app`, `init_app_state`, `run_headless`, `TokensPrompt`, `LoRARequest`, `RequestOutput`, `UsageContext`, `AsyncLLM`, `FlexibleArgumentParser`, `FinishReason` |
+| `verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py` | Similar to above, multimodal variant |
+| `verl/workers/rollout/vllm_rollout/utils.py` | vLLM utility imports |
+| `verl/utils/vllm/utils.py` | `LoRAModel`, `LoRARequest`, `get_adapter_absolute_path`, `LRUCacheWorkerLoRAManager`, `PEFTHelper` |
+| `verl/utils/vllm/patch.py` | vLLM internal patches |
+| `verl/utils/vllm/vllm_fp8_utils.py` | vLLM FP8 internals |
+| `verl/workers/sharding_manager/` | vLLM weight resharding hooks |
+
+### Secondary — Config / Version Tracking
+
+| File | Usage |
+|------|-------|
+| `requirements.txt` | Pinned version: `# vllm==X.Y.Z` |
+| `requirements-cuda.txt` | May also pin vllm |
+| `docker/Dockerfile.stable.vllm` | Docker image vllm version |
+
+---
+
+## Audit Workflow
+
+### Step 1: Identify Current Pinned Version
+
+```bash
+grep -i vllm requirements.txt requirements-cuda.txt 2>/dev/null
+```
+
+### Step 2: Enumerate All vLLM Imports
+
+```bash
+grep -rn "from vllm\|import vllm" verl/ --include="*.py" | grep -v "__pycache__"
+```
+
+For each import, note the module path and symbol name.
+
+### Step 3: Cross-Reference Against Upstream Source
+
+For each imported symbol, verify in `vllm-src/`:
+
+**Key symbols to always check:**
+
+| Symbol | Upstream Source Path |
+|--------|----------------------|
+| `SamplingParams` | `vllm-src/vllm/sampling_params.py` |
+| `AsyncEngineArgs` | `vllm-src/vllm/engine/arg_utils.py` |
+| `build_app` | `vllm-src/vllm/entrypoints/openai/api_server.py` |
+| `init_app_state` | `vllm-src/vllm/entrypoints/openai/api_server.py` |
+| `run_headless` | `vllm-src/vllm/entrypoints/cli/serve.py` |
+| `TokensPrompt` | `vllm-src/vllm/inputs/__init__.py` |
+| `LoRARequest` | `vllm-src/vllm/lora/request.py` |
+| `RequestOutput` | `vllm-src/vllm/outputs.py` |
+| `AsyncLLM` | `vllm-src/vllm/v1/engine/async_llm.py` |
+| `FinishReason` | `vllm-src/vllm/v1/engine/__init__.py` |
+| `FlexibleArgumentParser` | `vllm-src/vllm/utils/argparse_utils.py` or `vllm/utils.py` |
+| `LoRAModel` | `vllm-src/vllm/lora/lora_model.py` or `vllm/lora/models.py` |
+| `PEFTHelper` | `vllm-src/vllm/lora/peft_helper.py` |
+| `LRUCacheWorkerLoRAManager` | `vllm-src/vllm/lora/worker_manager.py` |
+| `UsageContext` | `vllm-src/vllm/usage/usage_lib.py` |
+
+For each symbol, check:
+- Does it still exist at this path?
+- Has the class/function signature changed?
+- Has the module been moved or renamed?
+
+### Step 4: Handle try/except Version Fallbacks
+
+veRL already has several try/except blocks for cross-version compatibility, e.g.:
+
+```python
+try:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+except ImportError:
+    from vllm.utils import FlexibleArgumentParser
+```
+
+For each such block:
+1. Check which branch is correct at `$VERSION`
+2. If only one branch is now valid, simplify to a direct import
+3. If neither branch is valid, update both
+
+### Step 5: Check Internal Patch Compatibility
+
+`verl/utils/vllm/patch.py` monkey-patches vLLM internals. These are the most fragile:
+
+```bash
+cat verl/utils/vllm/patch.py
+```
+
+For each patched attribute/method:
+- Verify the patched object still exists in `vllm-src/`
+- Verify its signature hasn't changed
+- If the upstream bug is fixed, consider removing the patch
+
+### Step 6: Update Version Pin
+
+```bash
+# Update requirements.txt
+sed -i "s/# vllm==.*/# vllm==$VERSION/" requirements.txt
+
+# Update Docker images if applicable
+grep -l "vllm" docker/Dockerfile.stable.vllm
+```
+
+### Step 7: Run Validation
+
+```bash
+# Check imports resolve (CPU, no GPU needed)
+python -c "from verl.utils.vllm.utils import *; print('OK')"
+
+# Run CPU unit tests
+pytest tests/test_*_on_cpu.py -x
+
+# If GPU available, run vllm-specific tests
+pytest tests/ -k "vllm" -x
+```
+
+---
+
+## Common Breaking Patterns Across vLLM Versions
+
+| Pattern | What to Check |
+|---------|---------------|
+| Module reorganization | `from vllm.X import Y` → `from vllm.A.B import Y` |
+| `FlexibleArgumentParser` moved | Between `vllm.utils` and `vllm.utils.argparse_utils` |
+| `LoRAModel` renamed | Between `lora.lora_model` and `lora.models` |
+| `FinishReason` added/moved | In `vllm.v1.engine` |
+| `init_app_state` signature change | New required params in OpenAI server |
+| `AsyncLLM` API change | `v1` engine interface evolves frequently |
+| `SamplingParams` new fields | Often adds new sampling options |
+
+---
+
+## Output
+
+Report:
+
+1. Current pinned version vs target version
+2. Table of changed/broken imports with fix applied
+3. Patches in `patch.py` that need updating or removal
+4. Files modified
+5. Validation commands run and their results
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/upgrade-vllm/SKILL.md
+
+## How to Update
+- When new vllm imports added to verl: update Affected Files table
+- When new common breaking patterns emerge: update the patterns table
+================================================================================
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,125 @@
+# CLAUDE.md - veRL
+
+## WHAT: Project Overview
+
+veRL (Volcano Engine Reinforcement Learning) is a flexible, efficient, production-ready
+RL training library for LLMs, initiated by ByteDance Seed.
+
+**Tech Stack**: Python 3.10+ | PyTorch | FSDP / Megatron-LM | vLLM / SGLang | Ray
+
+**Core Directories**:
+
+- `verl/` - Core package
+  - `trainer/` - PPO trainer, core algorithm utilities (advantage estimators, policy loss)
+  - `workers/` - Ray remote workers (actor, critic, rollout, reward_manager, sharding_manager)
+  - `utils/` - Shared utilities
+    - `reward_score/` - `compute_score` functions (one per task/dataset)
+    - `dataset/` - `RLDataset` and preprocessing utilities
+    - `vllm/`, `sglang/` - Inference engine integration
+    - `megatron/`, `fsdp_utils.py` - Training backend utilities
+  - `protocol.py` - `DataProto`: the core data container between controller and workers
+  - `models/` - Model registry and weight loaders
+- `examples/` - Trainer recipes and data preprocessing scripts
+  - `data_preprocess/` - Dataset conversion scripts (raw → parquet)
+  - `grpo_trainer/`, `ppo_trainer/`, `dapo/`, `rloo_trainer/`, etc. - Algorithm recipes
+- `recipe/` - Community-contributed training recipes (git submodule)
+- `tests/` - Unit and integration tests
+
+## WHY: Purpose
+
+- Efficient RL training for LLM post-training (RLHF, RLVR) at scale
+- HybridEngine: same GPU pool for training (FSDP/Megatron) and inference (vLLM/SGLang)
+  — eliminates memory redundancy during weight sync
+- Modular: reward functions, datasets, and trainer logic are independently extensible
+
+## HOW: Core Commands
+
+```bash
+# Install dependencies
+pip install -e ".[gpu]"
+# or with uv:
+uv pip install -e ".[gpu]"
+
+# Preprocess a dataset (run once offline)
+python examples/data_preprocess/gsm8k.py --local_dir ~/data/gsm8k
+
+# Launch training (local single-node)
+bash examples/grpo_trainer/run_qwen2-7b_math.sh
+
+# Run tests
+pytest tests/
+
+# Format and lint
+pre-commit run --all-files
+```
+
+## Boundaries
+
+### Constraints
+
+- Designed for multi-GPU / multi-node Ray clusters
+- Integration tests require GPUs; explain skips when unavailable
+- `recipe/` is a git submodule — run `git submodule update --init --recursive` first
+
+### Always Do
+
+- Read relevant files before modifying code
+- Follow existing code patterns in the same module
+- Add `compute_score` to `verl/utils/reward_score/__init__.py` dispatch table when
+  adding a new reward function
+- Set `data_source` in preprocessed dataset to match the reward dispatch key
+
+### Ask First
+
+- Modifying `verl/protocol.py` (`DataProto` schema changes affect all workers)
+- Adding new dependencies
+- Changing worker placement or Ray resource allocation logic
+- Renaming public APIs used in `examples/`
+
+### Never Do
+
+- Hardcode file paths or cluster-specific endpoints
+- Skip pre-commit hooks
+- Use wildcard imports (`from x import *`)
+- Raise exceptions inside `compute_score` (return `0.0` instead)
+
+## PR Workflow (contributing to upstream)
+
+Every upstream PR **must branch from `upstream/main`**, not local `main`:
+
+```bash
+git fetch upstream main
+git checkout -b feat/xxx upstream/main
+# make targeted changes
+git add <specific files>
+git commit -m "feat(scope): description"
+git push origin feat/xxx
+gh pr create --repo verl-project/verl --head <your-fork>:feat/xxx --base main
+```
+
+Verify diff before opening: `git diff upstream/main`
+
+## Progressive Disclosure: Skills
+
+| Task                    | Skill                  |
+| ----------------------- | ---------------------- |
+| Add reward function     | `/add-reward`          |
+| Add dataset             | `/add-dataset`         |
+| Add new trainer/recipe  | `/add-trainer`         |
+| Add unit tests          | `/add-unit-tests`      |
+| Debug distributed issue | `/debug-distributed`   |
+| Create / update PR      | `/create-pr`           |
+| Review a PR             | `/review-pr`           |
+| Upgrade vLLM version    | `/upgrade-vllm`        |
+| Upgrade SGLang version  | `/upgrade-sglang`      |
+| Upgrade Megatron-Core   | `/upgrade-megatron-core` |
+| Commit message format   | `/commit-conventions`  |
+
+Skills live in `.agents/skills/`.
+
+## Git Workflow
+
+- **Commits**: Conventional Commits (`feat:`, `fix:`, `docs:`), ≤72 chars subject,
+  imperative voice, reasoning in body
+- **Squash**: Squash WIP commits before opening PR
+- **PR requirements**: Run pre-commit, document test coverage, note hardware limitations


### PR DESCRIPTION
### What does this PR do?

Add project-specific Claude Code configuration to help AI assistants work more effectively within veRL's codebase. This includes a CLAUDE.md project overview and 11 guided development skills under .agents/skills/.

These files are only read by Claude Code and do not affect veRL runtime behavior.

### Checklist Before Starting

- [x] Search for similar PRs: no existing Claude Code configuration found in veRL

### Test

No runtime changes -- configuration files only, not imported by veRL.

### Design & Code Changes

- CLAUDE.md: project overview, directories, commands, PR workflow, skill index
- .agents/skills/add-reward: compute_score and RewardManager guide
- .agents/skills/add-dataset: dataset preprocessing (raw to parquet) guide
- .agents/skills/add-trainer: Ray worker trainer/recipe guide
- .agents/skills/add-unit-tests: CPU/GPU test conventions and CI registration
- .agents/skills/debug-distributed: hangs, OOM, NaN, Ray crashes, HybridEngine
- .agents/skills/commit-conventions: veRL module scopes and PR title format
- .agents/skills/create-pr: upstream/main branching and title format enforcement
- .agents/skills/review-pr: risk-based review (DataProto, HybridEngine as CRITICAL)
- .agents/skills/upgrade-vllm: vLLM call site audit for rollout workers
- .agents/skills/upgrade-sglang: SGLang io_struct, weight_sync, EngineBase audit
- .agents/skills/upgrade-megatron-core: patch.py, MoE router replay, mbridge audit

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] pre-commit not applicable (markdown only)
- [x] No tests needed (configuration files only)