### PR TITLE
[doc] feat: add Claude Code skills for add-dataset, add-reward, add-trainer

### DIFF
--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -21,7 +21,7 @@ veRL datasets follow a two-step pattern:
 
 1. **Preprocessing script** (`examples/data_preprocess/<name>.py`) — run once offline to
    convert raw data into parquet files with a fixed schema
-2. **`RLDataset`** (`verl/utils/dataset/rl_dataset.py`) — runtime dataset class that
+2. **`RLHFDataset`** (`verl/utils/dataset/rl_dataset.py`) — runtime dataset class that
    reads the parquet files; you usually do NOT need to modify this
 
 ## Required Schema

--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: add-dataset
+description: Guide for adding a new dataset to veRL. Use when user wants to preprocess or integrate a new RL training dataset.
+---
+
+# Add Dataset
+
+Add a new dataset for RL training in veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I add a dataset?"
+- User wants to preprocess a new dataset for GRPO/PPO training
+- User mentions creating a data preprocessing script
+
+## Overview
+
+veRL datasets follow a two-step pattern:
+
+1. **Preprocessing script** (`examples/data_preprocess/<name>.py`) — run once offline to
+   convert raw data into parquet files with a fixed schema
+2. **`RLDataset`** (`verl/utils/dataset/rl_dataset.py`) — runtime dataset class that
+   reads the parquet files; you usually do NOT need to modify this
+
+## Required Schema
+
+Every preprocessed sample must contain these fields:
+
+```python
+{
+    "data_source": str,          # Identifies the reward function to use, e.g. "gsm8k"
+    "prompt": list[dict],        # Chat messages, e.g. [{"role": "user", "content": "..."}]
+    "ability": str,              # Task category, e.g. "math", "coding", "qa"
+    "reward_model": {
+        "style": "rule",         # "rule" for compute_score, "model" for reward model
+        "ground_truth": str,     # Ground truth answer (used by compute_score)
+    },
+    "extra_info": {
+        "split": str,            # "train" or "test"
+        "index": int,            # Sample index for reproducibility
+    },
+}
+```
+
+## Step-by-Step Guide
+
+### Step 1: Create Preprocessing Script
+
+Create `examples/data_preprocess/<name>.py`:
+
+```python
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import argparse
+import os
+
+import datasets
+from verl.utils.hdfs_io import copy, makedirs
+
+data_source = "<name>"     # Must match key in default_compute_score
+
+SYSTEM_PROMPT = "You are a helpful assistant."  # Optional
+
+
+def make_map_fn(split: str):
+    def process_fn(example: dict, idx: int) -> dict:
+        # Build the prompt as a chat template
+        question = example["question"]  # adapt to your dataset fields
+        answer = str(example["answer"])
+
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+
+        return {
+            "data_source": data_source,
+            "prompt": messages,
+            "ability": "math",          # change as appropriate
+            "reward_model": {
+                "style": "rule",
+                "ground_truth": answer,
+            },
+            "extra_info": {
+                "split": split,
+                "index": idx,
+            },
+        }
+
+    return process_fn
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_dir", default="~/data/<name>")
+    parser.add_argument("--hdfs_dir", default=None)
+    args = parser.parse_args()
+
+    local_dir = os.path.expanduser(args.local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+
+    # Load from HuggingFace hub or local path
+    dataset = datasets.load_dataset("<hf_dataset_id>")
+
+    for split in ["train", "test"]:
+        if split not in dataset:
+            continue
+        processed = dataset[split].map(
+            function=make_map_fn(split),
+            with_indices=True,
+            remove_columns=dataset[split].column_names,
+        )
+        output_path = os.path.join(local_dir, f"{split}.parquet")
+        processed.to_parquet(output_path)
+        print(f"Saved {len(processed)} samples to {output_path}")
+
+    if args.hdfs_dir:
+        makedirs(args.hdfs_dir)
+        copy(src=local_dir, dst=args.hdfs_dir)
+```
+
+### Step 2: Run Preprocessing
+
+```bash
+python examples/data_preprocess/<name>.py --local_dir ~/data/<name>
+```
+
+### Step 3: Update Training Config
+
+Point the trainer to your new dataset:
+
+```bash
+# In your run script or YAML config:
+data.train_files=~/data/<name>/train.parquet
+data.val_files=~/data/<name>/test.parquet
+data.train_data_sources=<name>    # optional, for filtering
+```
+
+### Step 4: Register Reward Function
+
+Make sure `verl/utils/reward_score/__init__.py` handles your `data_source`:
+
+```python
+elif data_source == "<name>":
+    from verl.utils.reward_score.<name> import compute_score
+    return compute_score(solution_str, ground_truth)
+```
+
+See the `/add-reward` skill for details.
+
+## Reference Implementations
+
+| Dataset      | File                                          | Notes                          |
+| ------------ | --------------------------------------------- | ------------------------------ |
+| GSM8K        | `examples/data_preprocess/gsm8k.py`           | Math QA baseline               |
+| MATH         | `examples/data_preprocess/math_dataset.py`    | Competition math               |
+| Geo3K        | `examples/data_preprocess/geo3k.py`           | Geometry                       |
+| Multi-turn   | `verl/utils/dataset/multiturn_sft_dataset.py` | SFT with multi-turn dialogues  |
+
+## Key Requirements
+
+1. **Fixed schema**: All required fields must be present (see above)
+2. **Parquet format**: veRL's `RLDataset` expects `.parquet` files
+3. **data_source matches**: Must align with your reward function's dispatch key
+4. **Prompt as chat messages**: Use list-of-dicts format, not a raw string
+
+## Common Mistakes
+
+- ❌ Missing `reward_model.ground_truth` field (reward manager will crash)
+- ❌ Prompt as a raw string instead of chat message list
+- ❌ `data_source` mismatch with reward function
+- ❌ Forgetting to remove original dataset columns after `map()`
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-dataset/SKILL.md
+
+## How to Update
+- When RLDataset schema changes: update Required Schema section
+- When new reference datasets added: update table
+================================================================================
+-->

--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -164,7 +164,7 @@ See the `/add-reward` skill for details.
 ## Key Requirements
 
 1. **Fixed schema**: All required fields must be present (see above)
-2. **Parquet format**: veRL's `RLDataset` expects `.parquet` files
+2. **Parquet format**: veRL's `RLHFDataset` expects `.parquet` files
 3. **data_source matches**: Must align with your reward function's dispatch key
 4. **Prompt as chat messages**: Use list-of-dicts format, not a raw string
 
@@ -182,7 +182,7 @@ See the `/add-reward` skill for details.
 Location: .agents/skills/add-dataset/SKILL.md
 
 ## How to Update
-- When RLDataset schema changes: update Required Schema section
+- When RLHFDataset schema changes: update Required Schema section
 - When new reference datasets added: update table
 ================================================================================
 -->

--- a/.agents/skills/add-reward/SKILL.md
+++ b/.agents/skills/add-reward/SKILL.md
@@ -87,7 +87,7 @@ Update `verl/utils/reward_score/__init__.py` to include your new data source:
 ```python
 from verl.utils.reward_score.<name> import compute_score as <name>_compute_score
 
-def default_compute_score(data_source, solution_str, ground_truth, extra_info=None):
+def default_compute_score(data_source, solution_str, ground_truth, extra_info=None, **kwargs):
     # ... existing cases ...
     elif data_source == "<your_dataset_name>":
         return <name>_compute_score(solution_str, ground_truth)

--- a/.agents/skills/add-reward/SKILL.md
+++ b/.agents/skills/add-reward/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: add-reward
+description: Guide for adding a new reward function to veRL. Use when user wants to create a reward (compute_score) function.
+---
+
+# Add Reward
+
+Add a new reward function to veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I add a reward function?"
+- User wants to implement custom reward scoring
+- User mentions `compute_score` or reward verification
+
+## Overview
+
+veRL separates reward functions into two layers:
+
+1. **`compute_score` function** (`verl/utils/reward_score/<name>.py`) — pure Python,
+   takes decoded strings and returns a float score
+2. **`RewardManager`** (`verl/workers/reward_manager/`) — wraps compute_score, handles
+   batching, decoding, and DataProto interface
+
+For most use cases, you only need to implement a `compute_score` function and register
+it. A custom `RewardManager` is only needed for advanced use cases (e.g., remote reward
+models, PRIME).
+
+## Step-by-Step Guide
+
+### Step 1: Create the compute_score Function
+
+Create `verl/utils/reward_score/<name>.py`:
+
+```python
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+import re
+from typing import Any
+
+
+def compute_score(solution_str: str, ground_truth: Any) -> float:
+    """Compute reward score for a single completion.
+
+    Args:
+        solution_str: Decoded model output string (prompt + completion).
+        ground_truth: Ground truth answer from the dataset.
+
+    Returns:
+        Float score, typically in [0.0, 1.0].
+    """
+    try:
+        answer = _extract_answer(solution_str)
+        if answer is not None and _is_correct(answer, str(ground_truth)):
+            return 1.0
+        return 0.0
+    except Exception:
+        return 0.0
+
+
+def _extract_answer(solution_str: str) -> str | None:
+    """Extract answer from model output. Customize this logic."""
+    # Example: extract content from \boxed{}
+    match = re.search(r"\\boxed\{([^}]+)\}", solution_str)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _is_correct(predicted: str, ground_truth: str) -> bool:
+    """Check if the predicted answer matches ground truth."""
+    return predicted.strip() == ground_truth.strip()
+```
+
+### Step 2: Register in default_compute_score
+
+Update `verl/utils/reward_score/__init__.py` to include your new data source:
+
+```python
+from verl.utils.reward_score.<name> import compute_score as <name>_compute_score
+
+def default_compute_score(data_source, solution_str, ground_truth, extra_info=None):
+    # ... existing cases ...
+    elif data_source == "<your_dataset_name>":
+        return <name>_compute_score(solution_str, ground_truth)
+    else:
+        raise NotImplementedError(f"Unknown data_source: {data_source}")
+```
+
+### Step 3: Set data_source in Dataset Preprocessing
+
+In your data preprocessing script, set the `data_source` field to match:
+
+```python
+# In data_preprocess/<name>.py
+data_source = "<your_dataset_name>"
+
+def make_map_fn(split):
+    def process_fn(example, idx):
+        return {
+            "data_source": data_source,
+            "prompt": [...],           # list of chat messages
+            "ability": "math",         # task category
+            "reward_model": {
+                "style": "rule",
+                "ground_truth": example["answer"],
+            },
+            "extra_info": {...},
+        }
+    return process_fn
+```
+
+### Step 4: Wire into Training Config
+
+In your training script (e.g., `examples/grpo_trainer/run_qwen2-7b_math.sh`):
+
+```bash
+# Use NaiveRewardManager (default) with your compute_score
+reward_model.reward_manager=naive
+```
+
+Or in the Python trainer config:
+
+```python
+# Trainer will call NaiveRewardManager which calls default_compute_score
+# which dispatches to your function based on data_source
+```
+
+### Step 5 (Optional): Custom RewardManager
+
+Only needed if `NaiveRewardManager` is insufficient (e.g., remote reward model,
+process-level rewards like PRIME). Subclass `AbstractRewardManager`:
+
+```python
+from verl.workers.reward_manager import register
+from verl.workers.reward_manager.abstract import AbstractRewardManager
+from verl import DataProto
+import torch
+
+
+@register("<name>")
+class MyRewardManager(AbstractRewardManager):
+    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source", **kwargs):
+        self.tokenizer = tokenizer
+        self.num_examine = num_examine
+        self.compute_score = compute_score
+
+    def __call__(self, data: DataProto, return_dict: bool = False) -> torch.Tensor:
+        # Decode responses, call compute_score, return reward tensor
+        ...
+```
+
+Then reference it in config: `reward_model.reward_manager=<name>`
+
+## Reference Implementations
+
+| Reward        | File                                     | Description                   |
+| ------------- | ---------------------------------------- | ----------------------------- |
+| GSM8K         | `verl/utils/reward_score/gsm8k.py`       | Math answer extraction        |
+| Math general  | `verl/utils/reward_score/math_reward.py` | LaTeX boxed answer matching   |
+| Geo3K         | `verl/utils/reward_score/geo3k.py`       | Geometry answer verification  |
+| PRIME         | `verl/workers/reward_manager/prime.py`   | Process reward model          |
+| DAPO          | `verl/workers/reward_manager/dapo.py`    | DAPO-style reward shaping     |
+
+## Key Requirements
+
+1. **Return float**: `compute_score` returns a single float per sample
+2. **No side effects**: Function must be deterministic and stateless
+3. **Handle exceptions**: Return `0.0` on error, do not raise
+4. **data_source matches**: The string in dataset must match the dispatch key in `__init__.py`
+
+## Common Mistakes
+
+- ❌ Raising exceptions inside `compute_score` (causes worker crash)
+- ❌ `data_source` mismatch between dataset and `default_compute_score`
+- ❌ Returning a tensor instead of a float
+- ❌ Assuming solution_str contains only the completion (it includes the prompt too)
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-reward/SKILL.md
+
+## How to Update
+- When reward_score API changes: update Step 1 signature
+- When RewardManager API changes: update Step 5
+- When new reference implementations added: update table
+================================================================================
+-->

--- a/.agents/skills/add-reward/SKILL.md
+++ b/.agents/skills/add-reward/SKILL.md
@@ -17,16 +17,27 @@ This skill is triggered when:
 
 ## Overview
 
-veRL separates reward functions into two layers:
+Reward computation runs through **Reward Loop**
+(`verl/experimental/reward_loop/`), the default reward implementation. A
+`RewardLoopManager` launches `reward.num_workers` `RewardLoopWorker` actors across
+the cluster; each worker owns one `RewardManager` and scores samples concurrently
+with `asyncio`. The pre-Reward-Loop implementation under
+`verl/workers/reward_manager/` is still shipped for backward compatibility (see
+the `legacy_reward_impl` config group), but new reward code should target Reward
+Loop.
 
-1. **`compute_score` function** (`verl/utils/reward_score/<name>.py`) — pure Python,
-   takes decoded strings and returns a float score
-2. **`RewardManager`** (`verl/workers/reward_manager/`) — wraps compute_score, handles
-   batching, decoding, and DataProto interface
+There are two layers:
 
-For most use cases, you only need to implement a `compute_score` function and register
-it. A custom `RewardManager` is only needed for advanced use cases (e.g., remote reward
-models, PRIME).
+1. **`compute_score` function** — pure Python, takes decoded strings and returns
+   a float (or a dict carrying a `score` key). It may be **sync or async**; the
+   type is detected automatically and sync functions run in an executor.
+2. **`RewardManager`** (`verl/experimental/reward_loop/reward_manager/`) — wraps
+   `compute_score` and implements `async run_single(data) -> dict`, handling
+   decoding and the DataProto interface.
+
+For most use cases you only need a `compute_score` function. A custom
+`RewardManager` is only needed for advanced cases (rate-limited APIs, remote
+CPU-heavy verifiers, reward models).
 
 ## Step-by-Step Guide
 
@@ -47,15 +58,19 @@ import re
 from typing import Any
 
 
-def compute_score(solution_str: str, ground_truth: Any) -> float:
+def compute_score(data_source: str, solution_str: str, ground_truth: Any, extra_info=None) -> float:
     """Compute reward score for a single completion.
 
     Args:
-        solution_str: Decoded model output string (prompt + completion).
+        data_source: Dataset identifier carried on the sample.
+        solution_str: Decoded model response (the completion only, special tokens stripped).
         ground_truth: Ground truth answer from the dataset.
+        extra_info: Per-sample dict; Reward Loop also injects `num_turns` and
+            `rollout_reward_scores`.
 
     Returns:
-        Float score, typically in [0.0, 1.0].
+        Float score, typically in [0.0, 1.0]. A dict with a `score` key is also
+        accepted; its remaining keys are surfaced as `reward_extra_info`.
     """
     try:
         answer = _extract_answer(solution_str)
@@ -80,19 +95,39 @@ def _is_correct(predicted: str, ground_truth: str) -> bool:
     return predicted.strip() == ground_truth.strip()
 ```
 
-### Step 2: Register in default_compute_score
+Use `async def compute_score(...)` when scoring involves external API calls or
+sandboxed execution — the worker awaits it directly instead of occupying an
+executor thread, which is significantly more efficient under concurrency.
 
-Update `verl/utils/reward_score/__init__.py` to include your new data source:
+### Step 2: Make the Function Reachable
+
+Two options.
+
+**Option A (no core edit, preferred for project-specific rewards)** — point the
+config at your file:
+
+```bash
+reward.custom_reward_function.path=/path/to/my_reward.py \
+reward.custom_reward_function.name=compute_score
+```
+
+The custom function replaces the default dispatch entirely for every sample.
+
+**Option B (contributing a dataset reward upstream)** — register in
+`verl/utils/reward_score/__init__.py` so `default_compute_score` dispatches on
+`data_source`:
+
+Add an import and one dispatch branch. Leave the existing
+`default_compute_score` signature untouched — it carries extra parameters
+(`sandbox_fusion_url`, `concurrent_semaphore`, `memory_limit_mb`, `**kwargs`) that
+callers rely on:
 
 ```python
 from verl.utils.reward_score.<name> import compute_score as <name>_compute_score
 
-def default_compute_score(data_source, solution_str, ground_truth, extra_info=None, **kwargs):
-    # ... existing cases ...
+# inside default_compute_score, alongside the existing branches:
     elif data_source == "<your_dataset_name>":
         return <name>_compute_score(solution_str, ground_truth)
-    else:
-        raise NotImplementedError(f"Unknown data_source: {data_source}")
 ```
 
 ### Step 3: Set data_source in Dataset Preprocessing
@@ -120,69 +155,70 @@ def make_map_fn(split):
 
 ### Step 4: Wire into Training Config
 
-In your training script (e.g., `examples/grpo_trainer/run_qwen2-7b_math.sh`):
+Reward settings live under the `reward` config group
+(`verl/trainer/config/reward/reward.yaml`):
 
 ```bash
-# Use NaiveRewardManager (default) with your compute_score
-reward_model.reward_manager=naive
+reward.reward_manager.name=naive \
+reward.num_workers=8
 ```
 
-Or in the Python trainer config:
-
-```python
-# Trainer will call NaiveRewardManager which calls default_compute_score
-# which dispatches to your function based on data_source
-```
+`reward.num_workers` sets how many reward workers are launched; raise it when
+reward computation, not rollout, is the bottleneck.
 
 ### Step 5 (Optional): Custom RewardManager
 
-Only needed if `NaiveRewardManager` is insufficient (e.g., remote reward model,
-process-level rewards like PRIME). Subclass `AbstractRewardManager`:
+Only needed when the built-in managers are insufficient. Subclass
+`RewardManagerBase` and implement the async `run_single`:
 
 ```python
-from verl.workers.reward_manager import register
-from verl.workers.reward_manager.abstract import AbstractRewardManager
 from verl import DataProto
-import torch
+from verl.experimental.reward_loop.reward_manager import register
+from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
 
 
 @register("<name>")
-class MyRewardManager(AbstractRewardManager):
-    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source", **kwargs):
-        self.tokenizer = tokenizer
-        self.num_examine = num_examine
-        self.compute_score = compute_score
+class MyRewardManager(RewardManagerBase):
+    def __init__(self, config, tokenizer, compute_score, **kwargs):
+        super().__init__(config, tokenizer, compute_score)
 
-    def __call__(self, data: DataProto, return_dict: bool = False) -> torch.Tensor:
-        # Decode responses, call compute_score, return reward tensor
-        ...
+    async def run_single(self, data: DataProto) -> dict:
+        data_item = data[-1]  # multi-output trajectories: score the last sequence
+        # Decode the response, call compute_score, and return the score dict.
+        return {"reward_score": score, "reward_extra_info": {}}
 ```
 
-Then reference it in config: `reward_model.reward_manager=<name>`
+Then reference it in config: `reward.reward_manager.name=<name>`.
 
 ## Reference Implementations
 
-| Reward        | File                                     | Description                   |
-| ------------- | ---------------------------------------- | ----------------------------- |
-| GSM8K         | `verl/utils/reward_score/gsm8k.py`       | Math answer extraction        |
-| Math general  | `verl/utils/reward_score/math_reward.py` | LaTeX boxed answer matching   |
-| Geo3K         | `verl/utils/reward_score/geo3k.py`       | Geometry answer verification  |
-| PRIME         | `verl/workers/reward_manager/prime.py`   | Process reward model          |
-| DAPO          | `verl/workers/reward_manager/dapo.py`    | DAPO-style reward shaping     |
+| Reward        | File                                                          | Description                          |
+| ------------- | ------------------------------------------------------------- | ------------------------------------ |
+| GSM8K         | `verl/utils/reward_score/gsm8k.py`                             | Math answer extraction               |
+| Math general  | `verl/utils/reward_score/math_reward.py`                       | LaTeX boxed answer matching          |
+| Geo3K         | `verl/utils/reward_score/geo3k.py`                             | Geometry answer verification         |
+| naive         | `verl/experimental/reward_loop/reward_manager/naive.py`        | Default manager, sync or async score |
+| dapo          | `verl/experimental/reward_loop/reward_manager/dapo.py`         | Overlong reward penalty              |
+| limited       | `verl/experimental/reward_loop/reward_manager/limited.py`      | Caps concurrency for rate-limited APIs |
+| remote        | `verl/experimental/reward_loop/reward_manager/remote.py`       | Separate process for CPU-heavy verifiers |
 
 ## Key Requirements
 
-1. **Return float**: `compute_score` returns a single float per sample
+1. **Return a float or a score dict**: `compute_score` returns one float per
+   sample, or a dict whose `score` key holds it
 2. **No side effects**: Function must be deterministic and stateless
 3. **Handle exceptions**: Return `0.0` on error, do not raise
-4. **data_source matches**: The string in dataset must match the dispatch key in `__init__.py`
+4. **data_source matches**: The string in the dataset must match the dispatch key
+   in `__init__.py` (Option B only)
 
 ## Common Mistakes
 
 - ❌ Raising exceptions inside `compute_score` (causes worker crash)
 - ❌ `data_source` mismatch between dataset and `default_compute_score`
 - ❌ Returning a tensor instead of a float
-- ❌ Assuming solution_str contains only the completion (it includes the prompt too)
+- ❌ Blocking calls (`requests`, `time.sleep`) inside an `async def compute_score`,
+  which stalls every other sample on that worker
+- ❌ Targeting the legacy `verl/workers/reward_manager/` registry for new managers
 
 <!--
 ================================================================================
@@ -192,7 +228,8 @@ Location: .agents/skills/add-reward/SKILL.md
 
 ## How to Update
 - When reward_score API changes: update Step 1 signature
-- When RewardManager API changes: update Step 5
+- When the Reward Loop RewardManager API changes: update Step 5
+- When the reward config group changes: update Step 2 / Step 4 keys
 - When new reference implementations added: update table
 ================================================================================
 -->

--- a/.agents/skills/add-trainer/SKILL.md
+++ b/.agents/skills/add-trainer/SKILL.md
@@ -61,47 +61,52 @@ examples/<name>_trainer/
 
 ### Step 3: Implement the Trainer Class
 
+**Option A — new advantage estimator (recommended for most cases)**
+
+Advantage computation is handled by a standalone `compute_advantage()` function in
+`ray_trainer.py`, not a method. The correct extension point is `register_adv_est`:
+
 ```python
 # examples/<name>_trainer/<name>_trainer.py
-import torch
-from omegaconf import DictConfig
-from verl import DataProto
-from verl.trainer.ppo.ray_trainer import RayPPOTrainer  # or write from scratch
+from verl.trainer.ppo.core_algos import register_adv_est
 
+
+@register_adv_est("<name>")
+def compute_<name>_advantage(token_level_rewards, response_mask, config, **kwargs):
+    """Custom advantage estimator for <name>.
+
+    Args:
+        token_level_rewards: shape [bs, resp_len]
+        response_mask:        shape [bs, resp_len]
+        config:               trainer OmegaConf config
+
+    Returns:
+        advantages: shape [bs, resp_len]
+        returns:    shape [bs, resp_len]
+    """
+    # ... your advantage logic
+    return advantages, returns
+```
+
+**Option B — structural trainer changes**
+
+Only subclass `RayPPOTrainer` if you need to change the overall training loop
+(e.g., add a second optimizer step, change data flow). Override `fit()` directly:
+
+```python
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer
 
 class MyTrainer(RayPPOTrainer):
-    """My custom RL trainer."""
-
-    def _compute_advantage(self, data: DataProto) -> DataProto:
-        """Override advantage computation for your algorithm."""
-        rewards = data.batch["token_level_scores"]  # shape: [bs, seqlen]
-        # ... your advantage computation
-        data.batch["advantages"] = advantages
-        data.batch["returns"] = returns
-        return data
-
     def fit(self):
-        """Main training loop."""
-        for epoch in range(self.config.trainer.total_epochs):
-            for batch_dict in self.train_dataloader:
-                # 1. Generate rollouts
-                data: DataProto = self.actor_rollout_ref.generate_sequences(batch_dict)
-
-                # 2. Compute rewards
-                reward_tensor = self.reward_fn(data)
-                data.batch["token_level_scores"] = reward_tensor
-
-                # 3. Compute advantages (your algorithm logic here)
-                data = self._compute_advantage(data)
-
-                # 4. Update actor
-                actor_output = self.actor_rollout_ref.update_actor(data)
-
-                # 5. Log metrics
-                self._log_metrics(actor_output)
+        for batch_dict in self.train_dataloader:
+            data = self.actor_rollout_ref.generate_sequences(batch_dict)
+            # ... custom loop logic
 ```
 
 ### Step 4: Write Run Script
+
+**Option A** — custom advantage estimator: import your module first so
+`@register_adv_est` executes, then call the standard entry point:
 
 ```bash
 #!/bin/bash
@@ -109,8 +114,12 @@ class MyTrainer(RayPPOTrainer):
 
 set -x
 
-python3 -m verl.trainer.main_ppo \
-    algorithm.adv_estimator=grpo \
+python3 -c "
+import examples.<name>_trainer.<name>_trainer  # registers the estimator
+from verl.trainer.main_ppo import main
+main()
+" -- \
+    algorithm.adv_estimator=<name> \
     data.train_files=$HOME/data/gsm8k/train.parquet \
     data.val_files=$HOME/data/gsm8k/test.parquet \
     data.train_batch_size=256 \

--- a/.agents/skills/add-trainer/SKILL.md
+++ b/.agents/skills/add-trainer/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: add-trainer
+description: Guide for adding a new RL trainer recipe to veRL. Use when user wants to implement a new algorithm or training recipe.
+---
+
+# Add Trainer
+
+Add a new RL training recipe (algorithm variant) to veRL.
+
+## When to Use
+
+This skill is triggered when:
+
+- User asks "how do I implement a new algorithm?"
+- User wants to add a new trainer on top of veRL's worker infrastructure
+- User mentions creating a new `recipe/` entry or trainer script
+
+## Overview
+
+veRL follows a **single-controller + Ray workers** architecture:
+
+```
+Your Trainer Script (controller, CPU node)
+    │
+    ├── ActorRolloutRefWorker  (Ray remote, GPU)  — generates rollouts + computes logprobs
+    ├── CriticWorker           (Ray remote, GPU)  — value estimates (PPO only)
+    ├── RewardModelWorker      (Ray remote, GPU)  — optional RM scoring
+    └── RewardManager          (inline)           — rule-based reward scoring
+```
+
+The controller drives the training loop by calling `.generate_sequences()`,
+`.compute_ref_log_prob()`, `.update_actor()`, etc. on remote workers via Ray.
+
+For a new algorithm, you typically:
+1. Write a trainer class (controller logic)
+2. Reuse existing workers or subclass them
+3. Add a run script with the config
+
+## Step-by-Step Guide
+
+### Step 1: Study a Reference Trainer
+
+Start by reading the simplest existing trainer that resembles your target algorithm:
+
+| Algorithm | File                                      |
+| --------- | ----------------------------------------- |
+| GRPO      | `verl/trainer/ppo/ray_trainer.py`         |
+| RLOO      | `examples/rloo_trainer/`                  |
+| REINFORCE++| `examples/reinforce_plus_plus_trainer/`  |
+| DAPO      | `examples/dapo/`                          |
+| ReMax     | `examples/remax_trainer/`                 |
+
+### Step 2: Create Trainer Directory
+
+```
+examples/<name>_trainer/
+├── __init__.py
+├── <name>_trainer.py      # Main trainer class
+└── run_qwen2-7b.sh        # Example run script
+```
+
+### Step 3: Implement the Trainer Class
+
+```python
+# examples/<name>_trainer/<name>_trainer.py
+import torch
+from omegaconf import DictConfig
+from verl import DataProto
+from verl.trainer.ppo.ray_trainer import RayPPOTrainer  # or write from scratch
+
+
+class MyTrainer(RayPPOTrainer):
+    """My custom RL trainer."""
+
+    def _compute_advantage(self, data: DataProto) -> DataProto:
+        """Override advantage computation for your algorithm."""
+        rewards = data.batch["token_level_scores"]  # shape: [bs, seqlen]
+        # ... your advantage computation
+        data.batch["advantages"] = advantages
+        data.batch["returns"] = returns
+        return data
+
+    def fit(self):
+        """Main training loop."""
+        for epoch in range(self.config.trainer.total_epochs):
+            for batch_dict in self.train_dataloader:
+                # 1. Generate rollouts
+                data: DataProto = self.actor_rollout_ref.generate_sequences(batch_dict)
+
+                # 2. Compute rewards
+                reward_tensor = self.reward_fn(data)
+                data.batch["token_level_scores"] = reward_tensor
+
+                # 3. Compute advantages (your algorithm logic here)
+                data = self._compute_advantage(data)
+
+                # 4. Update actor
+                actor_output = self.actor_rollout_ref.update_actor(data)
+
+                # 5. Log metrics
+                self._log_metrics(actor_output)
+```
+
+### Step 4: Write Run Script
+
+```bash
+#!/bin/bash
+# examples/<name>_trainer/run_qwen2-7b.sh
+
+set -x
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=256 \
+    data.max_prompt_length=512 \
+    data.max_response_length=512 \
+    actor_rollout_ref.model.path=Qwen/Qwen2-7B-Instruct \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    reward_model.reward_manager=naive \
+    trainer.total_epochs=15 \
+    trainer.project_name=<name>_trainer \
+    trainer.experiment_name=qwen2-7b-gsm8k
+```
+
+### Step 5: Key DataProto Fields
+
+`DataProto` is veRL's data container. Common fields in the batch:
+
+| Field                      | Shape              | Description                            |
+| -------------------------- | ------------------ | -------------------------------------- |
+| `input_ids`                | `[bs, seqlen]`     | Prompt + response token IDs            |
+| `attention_mask`           | `[bs, seqlen]`     | 1 for real tokens, 0 for padding       |
+| `position_ids`             | `[bs, seqlen]`     | Position indices                       |
+| `responses`                | `[bs, resp_len]`   | Response token IDs only                |
+| `response_mask`            | `[bs, resp_len]`   | 1 for response tokens                  |
+| `token_level_scores`       | `[bs, resp_len]`   | Per-token rewards from reward manager  |
+| `advantages`               | `[bs, resp_len]`   | Computed advantages                    |
+| `returns`                  | `[bs, resp_len]`   | Computed returns                       |
+| `old_log_probs`            | `[bs, resp_len]`   | Log probs from rollout policy          |
+| `ref_log_prob`             | `[bs, resp_len]`   | Log probs from reference policy        |
+
+### Step 6: Core Algorithm Utilities
+
+veRL provides registered advantage estimators and policy loss functions:
+
+```python
+from verl.trainer.ppo.core_algos import get_adv_estimator_fn, register_adv_est
+
+# Use built-in estimators: "gae", "grpo", "reinforce", "rloo", "remax"
+adv_fn = get_adv_estimator_fn("grpo")
+advantages, returns = adv_fn(token_level_rewards, response_mask, config)
+
+# Register your own estimator
+@register_adv_est("my_estimator")
+def my_estimator(token_level_rewards, response_mask, config, **kwargs):
+    ...
+    return advantages, returns
+```
+
+## Key Requirements
+
+1. **Ray-based**: Workers must be Ray remote actors
+2. **DataProto**: Use DataProto as the data exchange format between controller and workers
+3. **OmegaConf config**: Use Hydra/OmegaConf for configuration
+4. **No hardcoded paths**: All paths via config
+
+## Common Mistakes
+
+- ❌ Modifying `DataProto.batch` tensors in-place without `.clone()` when needed
+- ❌ Forgetting to apply `response_mask` when computing per-token losses
+- ❌ Mixing up `token_level_scores` (raw rewards) vs `advantages` (normalized)
+- ❌ Calling blocking Ray ops inside a loop without `.get()` at the right time
+
+<!--
+================================================================================
+                            MAINTAINER GUIDE
+================================================================================
+Location: .agents/skills/add-trainer/SKILL.md
+
+## How to Update
+- When DataProto fields change: update Step 5 table
+- When core_algos API changes: update Step 6
+- When new reference trainers added: update Step 1 table
+================================================================================
+-->

--- a/.agents/skills/add-trainer/SKILL.md
+++ b/.agents/skills/add-trainer/SKILL.md
@@ -129,7 +129,7 @@ main()
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
-    reward_model.reward_manager=naive \
+    reward.reward_manager.name=naive \
     trainer.total_epochs=15 \
     trainer.project_name=<name>_trainer \
     trainer.experiment_name=qwen2-7b-gsm8k


### PR DESCRIPTION
### What does this PR do?

Adds three Claude Code skills for the most common veRL contribution patterns. Split out from #5843 per review from @tongyx361.

Each file under `.agents/skills/` is read by Claude Code when the user invokes the corresponding slash command. No runtime behavior is affected.

| Skill | Slash command | Purpose |
|---|---|---|
| `add-dataset` | `/add-dataset` | Preprocess + integrate a new RL training dataset |
| `add-reward` | `/add-reward` | Implement a `compute_score` reward function |
| `add-trainer` | `/add-trainer` | Add a new algorithm / trainer recipe |

---

### Usage examples

#### `/add-dataset` — adding AQuA-RAT

**Prompt:** `/add-dataset` I want to add the `openai/aqua_rat` multiple-choice math dataset.

**Claude generates** `examples/data_preprocess/aqua_rat.py`:

```python
data_source = "openai/aqua_rat"

def make_map_fn(split: str):
    def process_fn(example: dict, idx: int) -> dict:
        options_str = "\n".join(example["options"])
        content = f"{example['question']}\n\nOptions:\n{options_str}"
        return {
            "data_source": data_source,
            "prompt": [
                {"role": "system", "content": "Think step by step, then select the correct option (A-E)."},
                {"role": "user", "content": content},
            ],
            "ability": "math",
            "reward_model": {"style": "rule", "ground_truth": example["correct"]},
            "extra_info": {"split": split, "index": idx},
        }
    return process_fn
```

The skill correctly applied the required schema (`data_source`, `prompt`, `reward_model.ground_truth`) and matched the dataset field names.

---

#### `/add-reward` — multiple-choice answer extraction

**Prompt:** `/add-reward` for `openai/aqua_rat` — extract the chosen option letter (A–E).

**Claude generates** `verl/utils/reward_score/aqua_rat.py`:

```python
import re

def compute_score(solution_str: str, ground_truth: str) -> float:
    matches = re.findall(r'\b([A-E])\b', solution_str.split("assistant")[-1])
    if matches and matches[-1] == ground_truth.strip().upper():
        return 1.0
    return 0.0
```

And registers it in `verl/utils/reward_score/__init__.py`:

```python
elif data_source == "openai/aqua_rat":
    from . import aqua_rat
    res = aqua_rat.compute_score(solution_str, ground_truth)
```

The skill correctly followed the no-exceptions, return-float contract and matched the `data_source` key from the preprocessing step.

---

#### `/add-trainer` — GRPO with clipped advantages

**Prompt:** `/add-trainer` I want a GRPO variant that clips advantages to `[-clip, clip]` before the policy update.

**Claude generates** `examples/grpo_clip_trainer/grpo_clip_trainer.py`:

```python
from verl.trainer.ppo.ray_trainer import RayPPOTrainer
from verl.trainer.ppo.core_algos import register_adv_est

@register_adv_est("grpo_clip")
def grpo_clip_estimator(token_level_rewards, response_mask, config, **kwargs):
    advantages, returns = _grpo_base(token_level_rewards, response_mask, config)
    clip = config.algorithm.get("advantage_clip", 5.0)
    advantages = advantages.clamp(-clip, clip)
    return advantages, returns

class GRPOClipTrainer(RayPPOTrainer):
    pass  # uses grpo_clip via config: algorithm.adv_estimator=grpo_clip
```

The skill correctly identified `register_adv_est` as the extension point and showed how to wire the config key through.

---

### Checklist

- [x] No runtime changes — `.agents/skills/` files only
- [x] Splits out part of #5843
- [x] Usage examples verified against actual veRL code structure

### Related
- Remaining skills will follow in separate PRs: `add-unit-tests`, `review-pr`, `create-pr`, `commit-conventions`, `debug-distributed`, upgrade skills