### PR TITLE
[trainer] fix: handle empty response_mask in calculate_debug_metrics

### DIFF
--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -98,6 +98,18 @@ def calculate_debug_metrics(data: DataProto) -> dict:
     actor_probs = torch.exp(actor_old_log_probs)
     rollout_probs = torch.exp(rollout_old_log_probs)
     response_mask_bool = response_mask.bool()
+
+    # check if there are any valid tokens before computing metrics
+    if not response_mask_bool.any():
+        logger.warning("response_mask is all False, returning default metrics")
+        return {
+            "training/rollout_probs_diff_valid": 0,
+            "training/rollout_probs_diff_max": float("nan"),
+            "training/rollout_probs_diff_mean": float("nan"),
+            "training/rollout_probs_diff_std": float("nan"),
+            "training/rollout_actor_probs_pearson_corr": float("nan"),
+        }
+
     pearson_corrcoef = pearson_correlation_coefficient(actor_probs, rollout_probs, response_mask_bool)
     rollout_probs_diff = calculate_log_prob_diff(actor_probs, rollout_probs, response_mask_bool)
     return {


### PR DESCRIPTION
### What does this PR do?

Fixes #5859

When `response_mask` is all `False` (e.g., in extreme rejection sampling scenarios), `calculate_debug_metrics` crashes with:
```
RuntimeError: The size of tensor a (4864) must match the size of tensor b (310002) at non-singleton dimension 1
```

### Checklist Before Starting

- [x] Search for similar PRs: 
  - https://github.com/volcengine/verl/pulls?q=is%3Apr+calculate_debug_metrics
  - Found related PRs #5229 and #4252 which add/modify metrics but don't fix this crash
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Existing unit tests pass. This is a defensive bug fix for an edge case.

### API and Usage Example

No API changes. The function signature remains the same:

```python
from verl.utils.debug.metrics import calculate_debug_metrics

# Normal case - works as before
metrics = calculate_debug_metrics(data)
# Returns: {'training/rollout_probs_diff_valid': 1, ...}

# Edge case - now handled gracefully instead of crashing
metrics = calculate_debug_metrics(data_with_all_false_mask)
# Returns: {'training/rollout_probs_diff_valid': 0, 'training/rollout_probs_diff_max': nan, ...}
```

### Design & Code Changes

**File changed:** `verl/utils/debug/metrics.py` (+12 lines)

**Root Cause:**
```python
# Line 58-60
def calculate_log_prob_diff(log_probs1, log_probs2, mask):
    full_diff = torch.abs(log_probs1 - log_probs2)  # RuntimeError when mask is all False!
    return torch.masked_select(full_diff, mask)
```

**Solution:** Add early return check at Line 102-111:
```python
    if not response_mask_bool.any():
        logger.warning("response_mask is all False, returning default metrics")
        return {
            "training/rollout_probs_diff_valid": 0,
            "training/rollout_probs_diff_max": float("nan"),
            "training/rollout_probs_diff_mean": float("nan"),
            "training/rollout_probs_diff_std": float("nan"),
            "training/rollout_actor_probs_pearson_corr": float("nan"),
        }
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)
- [x] Apply pre-commit checks (ruff check & format passed locally)
- [x] Add / Update documentation (N/A - internal bug fix)
- [x] Add unit or end-to-end test(s) (N/A - edge case, existing tests pass)
- [ ] Send a message in the `ci-request` channel (will do after CI passes)