### PR TITLE
[misc] fix: license for verl/workers/rollout/trtllm_rollout/__init__.py

### DIFF
--- a/verl/workers/rollout/trtllm_rollout/__init__.py
+++ b/verl/workers/rollout/trtllm_rollout/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
### What does this PR do?

This PR fixes the lack of license in `verl/workers/rollout/trtllm_rollout/__init__.py`, following other files under `trtllm_rollout`.