### PR TITLE
[Worker] fix: pass dp_group to legacy worker prepare_dynamic_batch calls

### DIFF
--- a/tests/utils/test_reduce_metrics_jagged.py
+++ b/tests/utils/test_reduce_metrics_jagged.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Tests for reduce_metrics handling of jagged (nested) metric lists.
+
+When legacy workers call prepare_dynamic_batch without dp_group, different
+DP ranks can produce different numbers of micro-batches.  The resulting
+metric dicts then contain jagged lists (e.g. [[1.0, 2.0], [3.0]]) instead
+of flat lists.  Before the fix, calling np.mean / np.max / np.min on such
+a structure would raise:
+    ValueError: setting an array element with a sequence
+
+These tests verify the defensive _flatten_metric_values helper and the
+updated reduce_metrics function handle this case correctly.
+"""
+
+import math
+
+import pytest
+
+from verl.utils.metric.utils import Metric, _flatten_metric_values, reduce_metrics
+
+# ---------------------------------------------------------------------------
+# _flatten_metric_values
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenMetricValues:
+    """Tests for the _flatten_metric_values helper."""
+
+    def test_flat_list_unchanged(self):
+        """A flat list of scalars should be returned as-is."""
+        values = [1.0, 2.0, 3.0]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0]
+
+    def test_jagged_list(self):
+        """A jagged nested list should be flattened to scalars."""
+        values = [[1.0, 2.0], [3.0]]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0]
+
+    def test_uniform_nested_list(self):
+        """A uniformly nested list should also be flattened."""
+        values = [[1.0, 2.0], [3.0, 4.0]]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_deeply_nested(self):
+        """Deeply nested structures should be recursively flattened."""
+        values = [[[1.0], [2.0, 3.0]], [4.0]]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_empty_list(self):
+        """An empty list should return an empty list."""
+        assert _flatten_metric_values([]) == []
+
+    def test_mixed_scalars_and_lists(self):
+        """A mix of scalars and sub-lists should be flattened correctly."""
+        values = [1.0, [2.0, 3.0], 4.0]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_tuples_flattened(self):
+        """Tuples should also be recursively flattened."""
+        values = [(1.0, 2.0), (3.0,)]
+        assert _flatten_metric_values(values) == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# reduce_metrics with jagged lists
+# ---------------------------------------------------------------------------
+
+
+class TestReduceMetricsJagged:
+    """Tests that reduce_metrics handles jagged nested lists without crashing."""
+
+    def test_mean_jagged(self):
+        """Mean over a jagged list should flatten first, then compute."""
+        metrics = {"loss": [[1.0, 2.0], [3.0]]}
+        result = reduce_metrics(metrics)
+        assert result["loss"] == pytest.approx(2.0)
+
+    def test_max_jagged(self):
+        """Max over a jagged list (key contains 'max')."""
+        metrics = {"max_reward": [[5.0, 8.0], [6.0]]}
+        result = reduce_metrics(metrics)
+        assert result["max_reward"] == pytest.approx(8.0)
+
+    def test_min_jagged(self):
+        """Min over a jagged list (key contains 'min')."""
+        metrics = {"min_error": [[0.3, 0.1], [0.2]]}
+        result = reduce_metrics(metrics)
+        assert result["min_error"] == pytest.approx(0.1)
+
+    def test_flat_list_still_works(self):
+        """Flat lists should continue to work as before (regression check)."""
+        metrics = {
+            "loss": [1.0, 2.0, 3.0],
+            "max_reward": [5.0, 8.0, 6.0],
+            "min_error": [0.1, 0.05, 0.2],
+        }
+        result = reduce_metrics(metrics)
+        assert result["loss"] == pytest.approx(2.0)
+        assert result["max_reward"] == pytest.approx(8.0)
+        assert result["min_error"] == pytest.approx(0.05)
+
+    def test_single_value(self):
+        """Single-element list should still work."""
+        metrics = {"loss": [42.0]}
+        result = reduce_metrics(metrics)
+        assert result["loss"] == pytest.approx(42.0)
+
+    def test_empty_list_returns_nan(self):
+        """Empty list should produce NaN (existing behavior)."""
+        metrics = {"loss": []}
+        result = reduce_metrics(metrics)
+        assert math.isnan(result["loss"])
+
+    def test_metric_object_not_affected(self):
+        """Metric objects should still use their own aggregate method."""
+        metric = Metric(aggregation="mean")
+        metric.extend([1.0, 2.0, 3.0])
+        metrics = {"custom": metric, "loss": [[1.0], [2.0, 3.0]]}
+        result = reduce_metrics(metrics)
+        assert result["custom"] == pytest.approx(2.0)
+        assert result["loss"] == pytest.approx(2.0)
+
+    def test_deeply_nested_jagged(self):
+        """Deeply nested jagged lists should be handled gracefully."""
+        metrics = {"loss": [[[1.0, 2.0], [3.0]], [4.0, 5.0]]}
+        result = reduce_metrics(metrics)
+        assert result["loss"] == pytest.approx(3.0)

--- a/verl/experimental/vla/dp_rob.py
+++ b/verl/experimental/vla/dp_rob.py
@@ -204,7 +204,9 @@ class RobDataParallelPPOActor(BasePPOActor):
 
         if use_dynamic_bsz:
             max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
-            micro_batches, batch_idx_list = prepare_dynamic_batch(data, max_token_len=max_token_len)
+            micro_batches, batch_idx_list = prepare_dynamic_batch(
+                data, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+            )
         else:
             micro_batches = data.split(micro_batch_size)
 
@@ -256,7 +258,9 @@ class RobDataParallelPPOActor(BasePPOActor):
         for batch_idx, mini_batch in enumerate(mini_batches):
             if self.config.use_dynamic_bsz:
                 max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
-                micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                micro_batches, _ = prepare_dynamic_batch(
+                    mini_batch, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+                )
             else:
                 self.gradient_accumulation = self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu
                 micro_batches = mini_batch.split(self.config.ppo_micro_batch_size_per_gpu)

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -22,6 +22,29 @@ import numpy as np
 import torch
 
 
+def _flatten_metric_values(values: list[Any]) -> list[Any]:
+    """Flatten potentially nested metric values into a 1-D list of scalars.
+
+    When DP ranks produce different numbers of micro-batches (e.g. because
+    ``prepare_dynamic_batch`` was called without ``dp_group``), the collected
+    metric lists can become *jagged* -- a list whose elements are themselves
+    lists of different lengths.  Passing such a structure directly to
+    ``np.mean`` / ``np.max`` / ``np.min`` raises ``ValueError: setting an
+    array element with a sequence``.
+
+    This helper recursively flattens any nested lists / tuples so that the
+    downstream NumPy reduction always receives a plain 1-D sequence of
+    scalars.
+    """
+    flat: list[Any] = []
+    for v in values:
+        if isinstance(v, (list, tuple)):
+            flat.extend(_flatten_metric_values(v))
+        else:
+            flat.append(v)
+    return flat
+
+
 def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, Any]:
     """
     Reduces a dictionary of metric lists by computing the mean, max, or min of each list.
@@ -49,12 +72,14 @@ def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, 
     for key, val in metrics.items():
         if isinstance(val, Metric):
             metrics[key] = val.aggregate()
-        elif "max" in key:
-            metrics[key] = np.max(val)
-        elif "min" in key:
-            metrics[key] = np.min(val)
         else:
-            metrics[key] = np.mean(val)
+            val = _flatten_metric_values(val)
+            if "max" in key:
+                metrics[key] = np.max(val)
+            elif "min" in key:
+                metrics[key] = np.min(val)
+            else:
+                metrics[key] = np.mean(val)
     return metrics
 
 

--- a/verl/workers/critic/dp_critic.py
+++ b/verl/workers/critic/dp_critic.py
@@ -166,7 +166,9 @@ class DataParallelPPOCritic(BasePPOCritic):
 
         if use_dynamic_bsz:
             max_token_len = data.meta_info["max_token_len"] * self.ulysses_sequence_parallel_size
-            micro_batches, batch_idx_list = prepare_dynamic_batch(data, max_token_len=max_token_len)
+            micro_batches, batch_idx_list = prepare_dynamic_batch(
+                data, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+            )
         else:
             micro_batches = data.split(micro_batch_size)
 
@@ -210,7 +212,9 @@ class DataParallelPPOCritic(BasePPOCritic):
             for batch_idx, mini_batch in enumerate(mini_batches):
                 if self.config.use_dynamic_bsz:
                     max_token_len = self.config.ppo_max_token_len_per_gpu * self.ulysses_sequence_parallel_size
-                    micro_batches, _ = prepare_dynamic_batch(mini_batch, max_token_len=max_token_len)
+                    micro_batches, _ = prepare_dynamic_batch(
+                        mini_batch, max_token_len=max_token_len, dp_group=torch.distributed.group.WORLD
+                    )
                 else:
                     self.gradient_accumulation = (
                         self.config.ppo_mini_batch_size // self.config.ppo_micro_batch_size_per_gpu


### PR DESCRIPTION
## Summary

Fix `reduce_metrics` crash when legacy workers (`dp_critic`, `dp_rob`) use dynamic batching (`use_dynamic_bsz=True`) with DP > 1.

**Root cause:** `prepare_dynamic_batch` calls in `dp_critic.py` and `dp_rob.py` were missing the `dp_group` parameter. Without it, the `all_reduce(MAX)` sync in `rearrange_micro_batches` is skipped, causing each DP rank to independently compute different micro-batch counts. The resulting jagged metric lists then crash `np.mean()` with `ValueError: setting an array element with a sequence`.

**Fix:**
- Pass `dp_group=torch.distributed.group.WORLD` to all 4 affected `prepare_dynamic_batch` call sites (matching the pattern used by engine workers and `dp_actor.py` after PR #5591)
- Add `_flatten_metric_values()` defensive helper in `reduce_metrics()` to gracefully handle any remaining jagged inputs

**Files changed:**
- `verl/workers/critic/dp_critic.py` — 2 call sites
- `verl/experimental/vla/dp_rob.py` — 2 call sites
- `verl/utils/metric/utils.py` — defensive flatten
- `tests/utils/test_reduce_metrics_jagged.py` — 15 new tests

<details>
<summary>Test output (After — 15 passed)</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-9.0.2, pluggy-1.6.0 -- /ssd1/jianglidang/workspace/myenv-verl/bin/python
cachedir: .pytest_cache
rootdir: /ssd1/jianglidang/workspace/verl
configfile: pyproject.toml
plugins: hydra-core-1.3.2, anyio-4.13.0, rerunfailures-16.1, asyncio-1.3.0
asyncio: mode=strict, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... collected 15 items

tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_flat_list_unchanged PASSED [  6%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_jagged_list PASSED [ 13%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_uniform_nested_list PASSED [ 20%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_deeply_nested PASSED [ 26%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_empty_list PASSED [ 33%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_mixed_scalars_and_lists PASSED [ 40%]
tests/utils/test_reduce_metrics_jagged.py::TestFlattenMetricValues::test_tuples_flattened PASSED [ 46%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_mean_jagged PASSED [ 53%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_max_jagged PASSED [ 60%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_min_jagged PASSED [ 66%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_flat_list_still_works PASSED [ 73%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_single_value PASSED [ 80%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_empty_list_returns_nan PASSED [ 86%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_metric_object_not_affected PASSED [ 93%]
tests/utils/test_reduce_metrics_jagged.py::TestReduceMetricsJagged::test_deeply_nested_jagged PASSED [100%]

======================== 15 passed, 3 warnings in 3.50s ========================
```

</details>

## Checklist Before Starting

- [x] Search for similar PRs — no existing PR for #5421
- [x] This PR is not duplicating an existing PR
- [x] AI assistance was used (Claude Code)

Closes #5421