### PR TITLE
[cfg] fix: sync strategy from ActorConfig/CriticConfig to EngineConfig

### DIFF
--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -305,6 +305,10 @@ class FSDPActorConfig(ActorConfig):
         """Validate FSDP actor configuration parameters."""
         super().__post_init__()
         self.engine = self.fsdp_config
+        # Sync strategy to engine config so engine_workers can pick the right FSDP version.
+        # EngineConfig.strategy defaults to None, so without this, engine_workers.py always
+        # falls back to FSDP1 even when actor.strategy="fsdp2".
+        object.__setattr__(self.engine, "strategy", self.strategy)
 
         # backward compatibility
         if self.ulysses_sequence_parallel_size > 1:

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -197,6 +197,10 @@ class FSDPCriticConfig(CriticConfig):
         """Validate FSDP critic configuration parameters."""
         super().__post_init__()
         self.engine = self.fsdp
+        # Sync strategy to engine config so engine_workers can pick the right FSDP version.
+        # EngineConfig.strategy defaults to None, so without this, engine_workers.py always
+        # falls back to FSDP1 even when critic.strategy="fsdp2".
+        object.__setattr__(self.engine, "strategy", self.strategy)
 
         if self.strategy in {"fsdp", "fsdp2"}:
             if self.ulysses_sequence_parallel_size > 1:


### PR DESCRIPTION
## Summary

`FSDPActorConfig.__post_init__` and `FSDPCriticConfig.__post_init__` set `self.engine = self.fsdp_config` but never sync `self.strategy` to `self.engine.strategy`. Since `EngineConfig.strategy` defaults to `None`, `engine_workers.py:162` always passes `None` as the backend to `EngineRegistry.new()`, which falls back to FSDP1 regardless of the user's `actor.strategy` setting.

This causes crashes for models that require FSDP2, such as Qwen3.5 and other models with multi-dimensional RoPE `position_ids`, where FSDP1's parameter wrapping breaks `apply_rotary_pos_emb` with shape mismatches.

## Repro

1. Set `actor.strategy=fsdp2` with `use_legacy_worker_impl=disable` (new `engine_workers.py` path)
2. Train any model
3. `engine_workers.py` reads `engine_config.strategy` → gets `None` → defaults to FSDP1
4. For models with multi-dimensional position_ids (Qwen3.5, Qwen3-VL), FSDP1 wrapping breaks `apply_rotary_pos_emb`

## Fix

Sync `strategy` from the actor/critic config to the engine config in `__post_init__`:

```python
object.__setattr__(self.engine, "strategy", self.strategy)
```

Uses `object.__setattr__` because `BaseConfig` has frozen field logic that prevents normal attribute assignment.

## Affected configs

- `FSDPActorConfig` (`verl/workers/config/actor.py`)
- `FSDPCriticConfig` (`verl/workers/config/critic.py`)

Note: `McoreActorConfig`, `VeOmniActorConfig`, `TorchTitanActorConfig` are not affected because their engine configs have matching hardcoded `strategy` defaults.

## Impact

Affects all FSDP2 training using the new `engine_workers.py` path (`use_legacy_worker_impl=disable`). The legacy worker path is unaffected because it doesn't read `engine_config.strategy`.

## Test plan

- [x] Verified `engine_config.strategy == "fsdp2"` when `actor.strategy = "fsdp2"` with `use_legacy_worker_impl=disable`
- [x] Trained Qwen3.5-0.8B with `strategy=fsdp2` + `use_legacy_worker_impl=disable` — FSDP2 correctly applied, 3 training steps completed
- [x] Confirmed `strategy=fsdp` (default) is unchanged