### PR TITLE
fix: flatten multi-component position_ids to 1D for nested tensor compatibility

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -904,8 +904,13 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
             if pad_mode == DatasetPadMode.NO_PADDING:
                 input_ids_rmpad = input_ids.values().unsqueeze(0)  # (1, total_nnz)
-                if position_ids.dim() == 3:
-                    position_ids_rmpad = position_ids.values().unsqueeze(1)  # (4, 1, total_nnz)
+                num_pos_components = tu.get_non_tensor_data(data=micro_batch, key="num_pos_components", default=0)
+                if num_pos_components > 0:
+                    # position_ids stored as flattened 1D nested tensor: (total_nnz * num_components,)
+                    # reshape to (num_components, 1, total_nnz)
+                    flat_pos = position_ids.values()  # (total_nnz * num_components,)
+                    total_nnz = flat_pos.shape[0] // num_pos_components
+                    position_ids_rmpad = flat_pos.view(total_nnz, num_pos_components).T.unsqueeze(1)
                 else:
                     position_ids_rmpad = position_ids.values().unsqueeze(0)  # (1, total_nnz)
             else:
@@ -976,10 +981,13 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     input_ids, padding=pad_token_id, output_size=(batch_size, max_seq_len)
                 )
 
-                if position_ids.dim() == 3:
+                num_pos_components = tu.get_non_tensor_data(data=micro_batch, key="num_pos_components", default=0)
+                if num_pos_components > 0:
+                    # position_ids stored as flattened 1D nested: each sample has (seq_len * num_components,)
+                    # pad to (batch, max_seq_len * num_components), then reshape to (num_components, batch, max_seq_len)
                     position_ids = torch.nested.to_padded_tensor(
-                        position_ids, padding=0, output_size=(batch_size, 4, max_seq_len)
-                    ).transpose(0, 1)  # (4, batch_size, max_seq_len)
+                        position_ids, padding=0, output_size=(batch_size, max_seq_len * num_pos_components)
+                    ).view(batch_size, max_seq_len, num_pos_components).permute(2, 0, 1)
                 else:
                     position_ids = torch.nested.to_padded_tensor(
                         position_ids, padding=0, output_size=(batch_size, max_seq_len)

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -56,15 +56,21 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     input_ids_nested = torch.nested.nested_tensor_from_jagged(input_ids_rmpad.squeeze(-1), offsets=cu_seqlens)
 
     position_ids_list = []
+    num_pos_components = 0  # 0 means 1D position_ids, >0 means multi-component (e.g. 4 for Qwen3.5/Qwen2-VL)
     for i in range(attention_mask.shape[0]):
         curr_mask = attention_mask[i].bool()
         curr_pos_ids = position_ids[i]
         if curr_pos_ids.dim() == 1:  # (seq_len,)
             valid_ids = curr_pos_ids[curr_mask]
-        else:  # (4, seq_len)
-            valid_ids = curr_pos_ids[:, curr_mask]
+        else:  # (num_components, seq_len) — flatten to 1D for nested tensor compatibility
+            # 3D jagged nested tensors have broken unbind() and to_padded_tensor() in PyTorch
+            # (see pytorch/pytorch#153238), so we flatten to 1D and reshape back in prepare_model_inputs
+            num_pos_components = curr_pos_ids.shape[0]
+            valid_ids = curr_pos_ids[:, curr_mask].T.contiguous().flatten()  # (valid_len * num_components,)
         position_ids_list.append(valid_ids)
     position_ids_nested = torch.nested.as_nested_tensor(position_ids_list, layout=torch.jagged)
+    if num_pos_components > 0:
+        tu.assign_non_tensor_data(data, "num_pos_components", num_pos_components)
 
     data["input_ids"] = input_ids_nested
     data["position_ids"] = position_ids_nested


### PR DESCRIPTION
## Summary

Fixes a crash when training models with multi-dimensional RoPE position_ids (e.g. Qwen3.5's 4-component `(text, height, width, temporal)`, Qwen2-VL) on the FSDP `engine_workers.py` path (`use_legacy_worker_impl=disable`).

Related: #5772 (same class of bug on the Megatron/mbridge path)

## Problem

`left_right_2_no_padding()` in `padding.py` creates per-sample position_ids of shape `(num_components, valid_len)` and passes them directly to `torch.nested.as_nested_tensor(..., layout=torch.jagged)`.

Jagged layout treats **dim 0** as the ragged dimension, so it interprets `num_components` (e.g. 4) as ragged instead of `seq_len`. The resulting nested tensor has shape `[batch, *(ragged=4), seq_len]` instead of the intended `[batch, *(ragged=seq_len), num_components]`.

Downstream in `transformer_impl.py`, `to_padded_tensor()` produces incorrect shapes → crash in `apply_rotary_pos_emb`.

Transposing to `(valid_len, num_components)` before nesting doesn't work either, because 3D jagged nested tensors have broken `unbind()` and `to_padded_tensor()` in PyTorch (see [pytorch/pytorch#153238](https://github.com/pytorch/pytorch/issues/153238)).

## Fix

Flatten multi-component position_ids to 1D `(seq_len * num_components,)` before creating the nested tensor, keeping it purely 2D jagged. Store `num_pos_components` as non-tensor metadata. Reshape back to `(num_components, batch, seq_len)` in `prepare_model_inputs`.

### Changes

**`verl/workers/utils/padding.py`** — `left_right_2_no_padding()`:
- Flatten `(num_components, valid_len)` → `(valid_len * num_components,)` via `.T.contiguous().flatten()`
- Store `num_pos_components` in non-tensor metadata via `tu.assign_non_tensor_data`

**`verl/workers/engine/fsdp/transformer_impl.py`** — `prepare_model_inputs()`:
- **NO_PADDING path**: `.view(total_nnz, num_components).T.unsqueeze(1)` → `(num_components, 1, total_nnz)`
- **Padded path**: `to_padded_tensor(..., output_size=(batch, max_seq_len * num_components)).view(batch, max_seq_len, num_components).permute(2, 0, 1)` → `(num_components, batch, max_seq_len)`

## Affected models

Any model with multi-dimensional RoPE on the FSDP `engine_workers.py` path:
- Qwen3.5 (4-component: text + 3D spatial)
- Qwen2-VL (3-component mRoPE)
- Other VLMs with multi-component position_ids

## Test plan

- [x] Qwen3.5-0.8B, FSDP2, `use_legacy_worker_impl=disable`: 3 GRPO training steps + validation pass. Previously crashed with RoPE shape mismatch.
- [ ] Qwen2-VL (not tested, same position_ids format — should work)