### PR TITLE
[model, fsdp] fix: Fix modeling_qwen2_5_vl missing attribute 'Qwen2RMSNorm'

### DIFF
--- a/verl/models/transformers/npu_patch.py
+++ b/verl/models/transformers/npu_patch.py
@@ -316,7 +316,11 @@ modeling_qwen2.Qwen2MLP.forward = silu_forward_npu
 modeling_qwen2.apply_rotary_pos_emb = apply_rotary_pos_emb_npu
 
 # Patches for Qwen2.5-VL Model
-modeling_qwen2_5_vl.Qwen2RMSNorm.forward = rms_norm_forward_npu
+from transformers import __version__ as transformers_version
+if transformers_version <= "5.1.0":
+    modeling_qwen2_5_vl.Qwen2RMSNorm.forward = rms_norm_forward_npu
+else:
+    modeling_qwen2_5_vl.Qwen2_5_VLRMSNorm.forward = rms_norm_forward_npu
 modeling_qwen2_5_vl.Qwen2_5_VLMLP.forward = silu_forward_npu
 
 # Patches for Qwen3 Model

--- a/verl/models/transformers/npu_patch.py
+++ b/verl/models/transformers/npu_patch.py
@@ -316,8 +316,7 @@ modeling_qwen2.Qwen2MLP.forward = silu_forward_npu
 modeling_qwen2.apply_rotary_pos_emb = apply_rotary_pos_emb_npu
 
 # Patches for Qwen2.5-VL Model
-from transformers import __version__ as transformers_version
-if transformers_version <= "5.1.0":
+if hasattr(modeling_qwen2_5_vl, "Qwen2RMSNorm"):
     modeling_qwen2_5_vl.Qwen2RMSNorm.forward = rms_norm_forward_npu
 else:
     modeling_qwen2_5_vl.Qwen2_5_VLRMSNorm.forward = rms_norm_forward_npu


### PR DESCRIPTION
### What does this PR do?

This PR adds version checking for transformers and resolves issue #5788 by fixing the error modeling_qwen2_5_vl has no attribute 'Qwen2RMSNorm'.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

bug-reproduce
![img_v3_0210i_25326aea-d7ad-49eb-b95a-d25106a37bfg](https://github.com/user-attachments/assets/7c8034d7-36ad-4c46-a995-2310a250f7fb)

verified
<img width="2408" height="1364" alt="image" src="https://github.com/user-attachments/assets/9f24700a-012d-4f40-a3d6-e4950d9ef0e2" />
transformers==5.3.0
<img width="2764" height="1088" alt="image" src="https://github.com/user-attachments/assets/5cf1c44c-27bb-4d4a-a8bb-175f2bac9f66" />
transformers==4.57.0
<img width="2784" height="1364" alt="image" src="https://github.com/user-attachments/assets/409f4be7-0c72-4696-93a7-06ff1f6b4cd4" />




### API and Usage Example

N/A

### Design & Code Changes
 
N/A

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
