### PR TITLE
[chat_template]: handle system message in apply_chat_template fall…

### DIFF
--- a/tests/utils/test_chat_template_on_cpu.py
+++ b/tests/utils/test_chat_template_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.utils.tokenizer.chat_template import apply_chat_template
+
+
+def _text_of(message):
+    content = message["content"]
+    if isinstance(content, list):
+        return "".join(part.get("text", "") for part in content)
+    return content
+
+
+class StrictTokenizer:
+    """Chat template with the Qwen3.5 constraints that trigger the fallback path.
+
+    * at least one user message is required,
+    * a system message must come first,
+    * only the *last* assistant message keeps its ``reasoning_content``,
+      like Qwen3 / DeepSeek-R1 templates do.
+    """
+
+    def render(self, messages, add_generation_prompt=False, tools=None):
+        rendered = ""
+        if tools:
+            rendered += f"<|tools|>{','.join(tools)}"
+        for i, message in enumerate(messages):
+            role = message["role"]
+            rendered += f"<|{role}|>"
+            if role == "assistant" and i == len(messages) - 1 and message.get("reasoning_content"):
+                rendered += f"<think>{message['reasoning_content']}</think>"
+            rendered += _text_of(message)
+        if add_generation_prompt:
+            rendered += "<|assistant|>"
+        return rendered
+
+    def apply_chat_template(
+        self, messages, tokenize=True, add_generation_prompt=True, tools=None, return_dict=False, **kwargs
+    ):
+        if not any(m["role"] == "user" for m in messages):
+            raise ValueError("chat template requires at least one user message")
+        if any(m["role"] == "system" for m in messages[1:]):
+            raise ValueError("System message must be at the beginning.")
+        text = self.render(messages, add_generation_prompt=add_generation_prompt, tools=tools)
+        if not tokenize:
+            return text
+        return [ord(c) for c in text]
+
+
+@pytest.fixture
+def tokenizer():
+    return StrictTokenizer()
+
+
+def _expected(tokenizer, messages, add_generation_prompt, tools=None, tokenize=False):
+    text = tokenizer.render(messages, add_generation_prompt=add_generation_prompt, tools=tools)
+    return [ord(c) for c in text] if tokenize else text
+
+
+@pytest.mark.parametrize("add_generation_prompt", [False, True])
+@pytest.mark.parametrize("tokenize", [False, True])
+def test_single_system_message(tokenizer, add_generation_prompt, tokenize):
+    """A lone system message must not raise, and must not carry a dummy user."""
+    messages = [{"role": "system", "content": "you are a helpful assistant"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=tokenize, add_generation_prompt=add_generation_prompt)
+    assert got == _expected(tokenizer, messages, add_generation_prompt, tokenize=tokenize)
+
+
+def test_system_message_keeps_tools(tokenizer):
+    messages = [{"role": "system", "content": "sys"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False, tools=["get_time"])
+    assert got == _expected(tokenizer, messages, False, tools=["get_time"])
+
+
+@pytest.mark.parametrize("tokenize", [False, True])
+def test_trailing_assistant_keeps_reasoning_content(tokenizer, tokenize):
+    """The dummy user must not shift the last assistant message out of last place."""
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "hello", "reasoning_content": "thinking hard"},
+    ]
+    got = apply_chat_template(tokenizer, messages, tokenize=tokenize, add_generation_prompt=False)
+    expected = _expected(tokenizer, messages, False, tokenize=tokenize)
+    assert got == expected
+    if not tokenize:
+        assert "<think>thinking hard</think>" in got
+
+
+def test_no_system_message_uses_prefix_path(tokenizer):
+    """Messages without a system prefix keep the original prepend-and-strip behaviour."""
+    messages = [{"role": "assistant", "content": "hello", "reasoning_content": "why"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=False)
+    assert got == _expected(tokenizer, messages, False)
+
+
+def test_no_fallback_when_template_accepts_messages(tokenizer):
+    messages = [{"role": "user", "content": "hi"}]
+    got = apply_chat_template(tokenizer, messages, tokenize=False, add_generation_prompt=True)
+    assert got == _expected(tokenizer, messages, True)

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -173,8 +173,76 @@ def apply_chat_template(
             **kwargs,
         )
     except Exception:
-        # Qwen3.5 apply_chat_template needs messages with at least one user message
+        # Qwen3.5 apply_chat_template needs messages with at least one user message.
+        # A leading system block must stay first, so the dummy user cannot be prepended
+        # in that case. It is not appended either: templates that keep the reasoning
+        # content of the *last* assistant message only (Qwen3, DeepSeek-R1, ...) would
+        # drop it once another message follows. Instead the dummy user is inserted right
+        # after the leading system block and its span is cut back out of the middle of
+        # the output, which keeps both the system message first and the last assistant
+        # message last.
         dummy_user_message = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
+        num_leading_system = 0
+        while num_leading_system < len(messages) and messages[num_leading_system].get("role") == "system":
+            num_leading_system += 1
+
+        if num_leading_system:
+            head = list(messages[:num_leading_system])
+            tail = list(messages[num_leading_system:])
+            # The difference trick gives the length of one dummy-user span; subtracting it
+            # from the head+dummy rendering gives the length of the head block itself.
+            one_user = processor.apply_chat_template(
+                head + dummy_user_message,
+                tokenize=tokenize,
+                add_generation_prompt=False,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+            two_users = processor.apply_chat_template(
+                head + dummy_user_message * 2,
+                tokenize=tokenize,
+                add_generation_prompt=False,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+            output = processor.apply_chat_template(
+                head + dummy_user_message + tail,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+                tools=tools,
+                return_dict=return_dict,
+                **kwargs,
+            )
+
+            if not tokenize:  # tokenize=False
+                user_len = len(two_users) - len(one_user)
+                head_len = len(one_user) - user_len
+                return output[:head_len] + output[head_len + user_len :]
+            elif not return_dict:  # tokenize=True and return_dict=False
+                if isinstance(output[0], list):  # transformers>=5
+                    assert len(output) == 1, "output must be a list[int] or list[list[int]]"
+                    one_user = one_user[0]
+                    two_users = two_users[0]
+                    output = output[0]
+                user_len = len(two_users) - len(one_user)
+                head_len = len(one_user) - user_len
+                return output[:head_len] + output[head_len + user_len :]
+            else:  # tokenize=True and return_dict=True and return_tensors="pt"
+                import torch
+
+                one_user = dict(one_user)
+                two_users = dict(two_users)
+                output = dict(output)
+                user_len = two_users["input_ids"].shape[1] - one_user["input_ids"].shape[1]
+                head_len = one_user["input_ids"].shape[1] - user_len
+                for key in ("input_ids", "attention_mask", "mm_token_type_ids"):
+                    if key not in output:
+                        continue
+                    output[key] = torch.cat([output[key][:, :head_len], output[key][:, head_len + user_len :]], dim=1)
+                return output
+
         dummy_user_prefix = processor.apply_chat_template(
             dummy_user_message,
             tokenize=tokenize,


### PR DESCRIPTION
The existing fallback for models like Qwen3.5 that require at least one user message unconditionally prepends a dummy user message before the real messages:

    apply_template([dummy_user] + messages)

This works for user/assistant messages, but fails when the single message being processed is a system message, because Qwen3.5's chat template enforces two constraints:
  1. At least one user message must be present.
  2. System message must appear first.

The fallback satisfies (1) but violates (2), raising:
    TemplateError: System message must be at the beginning.

Reproduce: run multiturn SFT with a dataset where some conversations have a system message and some do not. verl tokenizes each message individually via _process_single_message; when a system message is processed alone, the fallback inserts dummy_user before it, breaking the template constraint.

Fix: detect whether the messages list contains a system role. If so, append the dummy user *after* the real messages instead, and strip the dummy suffix from the output using the length-difference trick (len(two_users) - len(one_user)) to recover the pure system tokens. The original prefix-stripping path is preserved for all non-system cases.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
