### PR TITLE
fix: use configured param_dtype in forward_step autocast instead of hardcoded bf16

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -339,6 +339,7 @@ class FSDPEngine(BaseEngine):
             buffer_dtype = torch.float32
 
         mixed_precision = MixedPrecision(param_dtype=param_dtype, reduce_dtype=reduce_dtype, buffer_dtype=buffer_dtype)
+        self._autocast_dtype = param_dtype
 
         auto_wrap_policy = get_fsdp_wrap_policy(
             module=module,
@@ -1139,7 +1140,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         micro_batch = micro_batch.to(get_device_id())
         model_inputs, output_args = self.prepare_model_inputs(micro_batch=micro_batch)
 
-        with torch.autocast(device_type=device_name, dtype=torch.bfloat16):
+        with torch.autocast(device_type=device_name, dtype=self._autocast_dtype):
             raw_output = self.module(
                 **model_inputs,
                 use_cache=False,


### PR DESCRIPTION
## Summary

Fixes #5932.

`forward_step()` hardcodes `torch.autocast(dtype=torch.bfloat16)`, ignoring the `mixed_precision.param_dtype` already resolved from engine config earlier in the same class. This means setting `param_dtype=fp16` or disabling mixed precision has no effect on the forward execution path.

## Changes

1. Store `param_dtype` as `self._autocast_dtype` after resolving mixed precision config (line ~341)
2. Use `self._autocast_dtype` in `forward_step()`'s autocast context instead of hardcoded `torch.bfloat16`

1 file changed: `verl/workers/engine/fsdp/transformer_impl.py`

## Not a duplicate

Checked open PRs — no existing PR addresses this. #3243 is about CLI override not being accepted; this is about forward execution ignoring the resolved value.

## AI assistance disclosure

AI assistance was used. The fix is minimal (2 lines) and straightforward.