### PR TITLE
[rollout, vllm, ckpt] fix: auto-adjust update_weights_bucket_megabytes based on embedding weight size

### DIFF
--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -26,6 +26,7 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.ray_utils import auto_await
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig, RolloutConfig
 from verl.workers.rollout import BaseRollout, RolloutReplica, get_rollout_class
+from verl.workers.rollout.utils import get_minimum_bucket_size_mb
 
 
 class TensorMeta(TypedDict):
@@ -265,7 +266,12 @@ class CheckpointEngineWorker(Worker):
 
         self.server_adapter: BaseRollout = server_adapter
         backend = self.rollout_config.checkpoint_engine.backend
-        bucket_size = self.rollout_config.checkpoint_engine.update_weights_bucket_megabytes << 20
+        # Auto-adjust bucket size based on embedding weight size
+        self.bucket_size_mb = get_minimum_bucket_size_mb(
+            hf_config=self.model_config.hf_config,
+            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+        )
+        bucket_size = self.bucket_size_mb << 20
         engine_kwargs = self.rollout_config.checkpoint_engine.engine_kwargs.get(backend, {})
         # If custom_backend_module is set, import it so plugins can register
         # in CheckpointEngineRegistry before the backend is instantiated.

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -271,10 +271,10 @@ class CheckpointEngineWorker(Worker):
         if hf_config is not None:
             self.bucket_size_mb = get_minimum_bucket_size_mb(
                 hf_config=hf_config,
-                current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+                current_bucket_size_mb=self.rollout_config.checkpoint_engine.update_weights_bucket_megabytes,
             )
         else:
-            self.bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
+            self.bucket_size_mb = self.rollout_config.checkpoint_engine.update_weights_bucket_megabytes
 
         bucket_size = self.bucket_size_mb << 20
         engine_kwargs = self.rollout_config.checkpoint_engine.engine_kwargs.get(backend, {})

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -266,11 +266,16 @@ class CheckpointEngineWorker(Worker):
 
         self.server_adapter: BaseRollout = server_adapter
         backend = self.rollout_config.checkpoint_engine.backend
-        # Auto-adjust bucket size based on embedding weight size
-        self.bucket_size_mb = get_minimum_bucket_size_mb(
-            hf_config=self.model_config.hf_config,
-            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
-        )
+        hf_config = self.model_config.hf_config if isinstance(self.model_config, HFModelConfig) else None
+
+        if hf_config is not None:
+            self.bucket_size_mb = get_minimum_bucket_size_mb(
+                hf_config=hf_config,
+                current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+            )
+        else:
+            self.bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
+
         bucket_size = self.bucket_size_mb << 20
         engine_kwargs = self.rollout_config.checkpoint_engine.engine_kwargs.get(backend, {})
         # If custom_backend_module is set, import it so plugins can register

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -51,6 +51,7 @@ from verl.workers.config import (
     TrainingWorkerConfig,
 )
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
+from verl.workers.rollout.utils import get_minimum_bucket_size_mb
 from verl.workers.utils.losses import ppo_loss
 
 logger = logging.getLogger(__file__)
@@ -613,7 +614,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         if "actor" in self.role:
             checkpoint_engine_config = omega_conf_to_dataclass(self.config.rollout.checkpoint_engine)
             backend = checkpoint_engine_config.backend
-            bucket_size = checkpoint_engine_config.update_weights_bucket_megabytes << 20
+            # Auto-adjust bucket size based on embedding weight size
+            bucket_size_mb = get_minimum_bucket_size_mb(
+                hf_config=model_config,
+                current_bucket_size_mb=checkpoint_engine_config.update_weights_bucket_megabytes,
+            )
+            bucket_size = bucket_size_mb << 20
             engine_kwargs = checkpoint_engine_config.engine_kwargs.get(backend, {})
             # If custom_backend_module is set, import it so plugins can register
             # in CheckpointEngineRegistry before the backend is instantiated.

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -616,7 +616,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             backend = checkpoint_engine_config.backend
             # Auto-adjust bucket size based on embedding weight size
             bucket_size_mb = get_minimum_bucket_size_mb(
-                hf_config=model_config,
+                hf_config=model_config.hf_config,
                 current_bucket_size_mb=checkpoint_engine_config.update_weights_bucket_megabytes,
             )
             bucket_size = bucket_size_mb << 20

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -45,6 +45,7 @@ from verl.workers.rollout.sglang_rollout.utils import (
     SGLANG_LORA_NAME,
     get_named_tensor_buckets,
 )
+from verl.workers.rollout.utils import get_minimum_bucket_size_mb
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -124,6 +125,12 @@ class ServerAdapter(BaseRollout):
             fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
             self.model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         self._engine: AsyncHttpServerAdapter = None
+
+        # Auto-adjust bucket size based on embedding weight size
+        self.bucket_size_mb = get_minimum_bucket_size_mb(
+            hf_config=self.model_config.hf_config,
+            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+        )
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])
@@ -240,7 +247,7 @@ class ServerAdapter(BaseRollout):
                 # send http request
                 await self._engine.load_lora_adapter_from_tensor(req)
         else:
-            update_weights_bucket_bytes = int(self.config.checkpoint_engine.update_weights_bucket_megabytes) << 20
+            update_weights_bucket_bytes = int(self.bucket_size_mb) << 20
             if self.config.get("quantization", None) == "fp8":
                 from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper
 

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -126,11 +126,17 @@ class ServerAdapter(BaseRollout):
             self.model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         self._engine: AsyncHttpServerAdapter = None
 
-        # Auto-adjust bucket size based on embedding weight size
-        self.bucket_size_mb = get_minimum_bucket_size_mb(
-            hf_config=self.model_config.hf_config,
-            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
-        )
+        # model_config may not be HFModelConfig (e.g. DiffusionModelConfig or plain DictConfig),
+        # in that case skip auto-adjustment and use the configured value directly.
+        hf_config = self.model_config.hf_config if isinstance(self.model_config, HFModelConfig) else None
+
+        if hf_config is not None:
+            self.bucket_size_mb = get_minimum_bucket_size_mb(
+                hf_config=hf_config,
+                current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+            )
+        else:
+            self.bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])

--- a/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
@@ -301,11 +301,17 @@ class ServerAdapter(BaseRollout):
             fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
             model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         super().__init__(config, model_config, device_mesh)
-        # Auto-adjust bucket size based on embedding weight size
-        self.bucket_size_mb = get_minimum_bucket_size_mb(
-            hf_config=self.model_config.hf_config,
-            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
-        )
+        # model_config may not be HFModelConfig (e.g. DiffusionModelConfig or plain DictConfig),
+        # in that case skip auto-adjustment and use the configured value directly.
+        hf_config = self.model_config.hf_config if isinstance(self.model_config, HFModelConfig) else None
+
+        if hf_config is not None:
+            self.bucket_size_mb = get_minimum_bucket_size_mb(
+                hf_config=hf_config,
+                current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+            )
+        else:
+            self.bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
         self._adapter = None
         self.hybrid_device_mesh = None
         self.gpu_id = None

--- a/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_rollout.py
@@ -42,7 +42,7 @@ from verl.utils.device import get_torch_device
 from verl.utils.net_utils import is_valid_ipv6_address
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
-from verl.workers.rollout.utils import ensure_async_iterator
+from verl.workers.rollout.utils import ensure_async_iterator, get_minimum_bucket_size_mb
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -301,6 +301,11 @@ class ServerAdapter(BaseRollout):
             fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
             model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         super().__init__(config, model_config, device_mesh)
+        # Auto-adjust bucket size based on embedding weight size
+        self.bucket_size_mb = get_minimum_bucket_size_mb(
+            hf_config=self.model_config.hf_config,
+            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+        )
         self._adapter = None
         self.hybrid_device_mesh = None
         self.gpu_id = None
@@ -440,7 +445,7 @@ class ServerAdapter(BaseRollout):
         if self.is_leader_rank:
             await self._init_server_adapter()
 
-        total_available_bytes = int(self.config.checkpoint_engine.update_weights_bucket_megabytes) * 1024 * 1024
+        total_available_bytes = int(self.bucket_size_mb) * 1024 * 1024
 
         if self.config.get("quantization", None) == "fp8":
             from verl.utils.trtllm.trtllm_fp8_utils import TRTLLMFP8QuantizerHelper

--- a/verl/workers/rollout/utils.py
+++ b/verl/workers/rollout/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import logging
+import math
 
 import numpy as np
 import uvicorn
@@ -31,6 +32,52 @@ def get_max_position_embeddings(hf_config) -> int:
     if max_len is None:
         raise ValueError("max_position_embeddings not found in HFModelConfig!")
     return int(max_len)
+
+
+def get_minimum_bucket_size_mb(hf_config, current_bucket_size_mb: int) -> int:
+    """
+    Calculate the minimum required bucket size in MB based on the embedding weight size.
+
+    The embedding weight (embed_tokens) is typically the largest single weight tensor
+    in a model. The bucket size must be larger than any single weight tensor to avoid
+    AssertionError during weight transfer.
+
+    For multimodal models (e.g. Qwen3-VL), vocab_size and hidden_size may be nested
+    under text_config instead of the top-level config.
+
+    Args:
+        hf_config: HuggingFace model config object.
+        current_bucket_size_mb: Current bucket size in MB.
+
+    Returns:
+        Adjusted bucket size in MB, guaranteed to fit the embedding weight.
+    """
+    # For multimodal models, vocab_size/hidden_size may be in text_config
+    text_config = getattr(hf_config, "text_config", None)
+    if text_config is not None:
+        vocab_size = getattr(text_config, "vocab_size", 0)
+        hidden_size = getattr(text_config, "hidden_size", 0)
+    else:
+        vocab_size = getattr(hf_config, "vocab_size", 0)
+        hidden_size = getattr(hf_config, "hidden_size", 0)
+
+    if not (vocab_size and hidden_size):
+        return current_bucket_size_mb
+
+    # embed_tokens: [vocab_size, hidden_size] in float32 = 4 bytes
+    embed_size_mb = math.ceil(vocab_size * hidden_size * 4 / 1024 / 1024)
+
+    if embed_size_mb <= current_bucket_size_mb:
+        return current_bucket_size_mb
+
+    # round up to next 512MB boundary
+    recommended_mb = (embed_size_mb // 512 + 1) * 512
+    logger.warning(
+        f"Embedding weight size ({embed_size_mb} MB) exceeds "
+        f"update_weights_bucket_megabytes ({current_bucket_size_mb} MB), "
+        f"automatically increasing to {recommended_mb} MB."
+    )
+    return recommended_mb
 
 
 class _UvicornServerAutoPort(uvicorn.Server):

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -41,6 +41,7 @@ from verl.third_party.vllm import VLLM_SLEEP_LEVEL, get_version
 from verl.utils.device import get_device_id, is_support_ipc
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.base import BaseRollout
+from verl.workers.rollout.utils import get_minimum_bucket_size_mb
 from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightSender
 from verl.workers.rollout.vllm_rollout.utils import get_device_uuid
 
@@ -73,6 +74,11 @@ class ServerAdapter(BaseRollout):
     ):
         super().__init__(config, model_config, device_mesh)
         self.server_handle: ray.actor.ActorHandle = None
+        # Auto-adjust bucket size based on embedding weight size
+        self.bucket_size_mb = get_minimum_bucket_size_mb(
+            hf_config=self.model_config.hf_config,
+            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+        )
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])
@@ -163,10 +169,9 @@ class ServerAdapter(BaseRollout):
             kwargs={**kwargs, "use_shm": self.use_shm},
         )
 
-        bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
         sender = BucketedWeightSender(
             zmq_handle=self.zmq_handle,
-            bucket_size_mb=bucket_size_mb,
+            bucket_size_mb=self.bucket_size_mb,
             use_shm=self.use_shm,
         )
         await sender.async_send_weights(weights)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -74,11 +74,17 @@ class ServerAdapter(BaseRollout):
     ):
         super().__init__(config, model_config, device_mesh)
         self.server_handle: ray.actor.ActorHandle = None
-        # Auto-adjust bucket size based on embedding weight size
-        self.bucket_size_mb = get_minimum_bucket_size_mb(
-            hf_config=self.model_config.hf_config,
-            current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
-        )
+        # model_config may not be HFModelConfig (e.g. DiffusionModelConfig or plain DictConfig),
+        # in that case skip auto-adjustment and use the configured value directly.
+        hf_config = self.model_config.hf_config if isinstance(self.model_config, HFModelConfig) else None
+
+        if hf_config is not None:
+            self.bucket_size_mb = get_minimum_bucket_size_mb(
+                hf_config=hf_config,
+                current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
+            )
+        else:
+            self.bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
 
         rank = int(os.environ["RANK"])
         local_world_size = int(os.environ["RAY_LOCAL_WORLD_SIZE"])


### PR DESCRIPTION
------

### What does this PR do?

Auto-adjust `update_weights_bucket_megabytes` at runtime based on the model's embedding 
weight size, so that training no longer fails with an `AssertionError` when the embedding 
weight exceeds the default bucket size (2048 MB). This fix supports both standard LLMs 
(top-level `vocab_size`/`hidden_size`) and multimodal VLMs (nested under `text_config`).

Fixes #5952

### Checklist Before Starting
- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pulls?q=update_weights_bucket_megabytes
  - https://github.com/verl-project/verl/pulls?q=bucket+size+embedding
- [x] Format the PR title as `[{modules}] {type}: {description}`
  - Title: `[rollout, ckpt] fix: auto-adjust update_weights_bucket_megabytes based on embedding weight size`
  - Modules: `rollout`, `ckpt`
  - Type: `fix`
  - No `[BREAKING]` needed — this is an internal runtime adjustment, users do not need to change their launch scripts

### Test

This fix targets weight transfer initialization and requires a full training environment 
to validate end-to-end, which cannot be covered by the existing CI.

Manual verification was conducted with the following setup:
- Model: Qwen3-VL-8B-Instruct
- Script: `examples/grpo_trainer/run_qwen3_vl-8b_npu.sh`
- Hardware: Ascend NPU, 4 nodes × 8 devices

|        | Before fix                                                   | After fix                                                    |
| ------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
| Result | ❌ `AssertionError: Weight model.language_model.embed_tokens.weight is too large to fit in the bucket` | ✅ Training starts normally, bucket size auto-adjusted to 2560 MB |

The following warning log is emitted when the auto-adjustment is triggered:

```markdown
[Rank 14 | Local Rank 0] WARNING [verl.checkpoint_engine.base:71] => Embedding weight size (2374 MB) exceeds update_weights_bucket_megabytes (2048 MB), automatically increasing to 2560 MB. [repeated 15x across cluster]
```

CI coverage is not feasible for this change because:
- It requires a multimodal model and dataset environment not available in CI
- The fix is a simple runtime size check with no algorithmic change

### API and Usage Example

No API changes. This fix is fully transparent to users — no modifications to launch 
scripts or configs are required.

verl will automatically emit a warning and adjust the bucket size internally when the 
embedding weight exceeds the current bucket size:

```
[Rank 14 | Local Rank 0] WARNING [verl.checkpoint_engine.base:71] => Embedding weight size (2374 MB) exceeds update_weights_bucket_megabytes (2048 MB), automatically increasing to 2560 MB.
```

Users can still manually override the value if needed:

```
actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=4096
```

In this case, if the manually specified value is already larger than the embedding weight size, no adjustment will be made and no warning will be emitted.

### Design & Code Changes

**Root cause:** The default bucket size (2048 MB) is insufficient for large VL models whose `embed_tokens.weight` (e.g. Qwen3-VL-8B: shape `[151936, 4096]` in float32 ≈ 2.38 GB) exceeds the limit, causing an `AssertionError` in `bucketed_weight_transfer.py` at training startup. The assert exists because the current implementation does not support splitting a single tensor across multiple buckets (noted as a TODO in the code).

**Changes:**

1. New helper function `get_minimum_bucket_size_mb`in verl/workers/rollout/utils.py:
   - Reads `vocab_size` and `hidden_size` from `hf_config`
   - For multimodal models (e.g. Qwen3-VL), falls back to `text_config` if top-level fields are absent
   - Only adjusts when necessary, rounds up to the next 512 MB boundary for safety margin

```python
def get_minimum_bucket_size_mb(hf_config, current_bucket_size_mb: int) -> int:
    text_config = getattr(hf_config, "text_config", None)
    if text_config is not None:
        vocab_size = getattr(text_config, "vocab_size", 0)
        hidden_size = getattr(text_config, "hidden_size", 0)
    else:
        vocab_size = getattr(hf_config, "vocab_size", 0)
        hidden_size = getattr(hf_config, "hidden_size", 0)

    if not (vocab_size and hidden_size):
        return current_bucket_size_mb

    embed_size_mb = math.ceil(vocab_size * hidden_size * 4 / 1024 / 1024)
    if embed_size_mb <= current_bucket_size_mb:
        return current_bucket_size_mb

    recommended_mb = (embed_size_mb // 512 + 1) * 512
    logger.warning(
        f"Embedding weight size ({embed_size_mb} MB) exceeds "
        f"update_weights_bucket_megabytes ({current_bucket_size_mb} MB), "
        f"automatically increasing to {recommended_mb} MB."
    )
    return recommended_mb
```

2. **`ServerAdapter.__init__`** in `verl/workers/rollout/vllm_rollout/vllm_rollout.py` calls the helper and stores the adjusted value as an instance variable:

```python
# Auto-adjust bucket size based on embedding weight size
from verl.checkpoint_engine.base import get_minimum_bucket_size_mb
self.bucket_size_mb = get_minimum_bucket_size_mb(
    hf_config=self.model_config.hf_config,
    current_bucket_size_mb=self.config.checkpoint_engine.update_weights_bucket_megabytes,
)
```

Then `update_weights` reads `self.bucket_size_mb` directly when constructing `BucketedWeightSender`:

```python
sender = BucketedWeightSender(
    zmq_handle=self.zmq_handle,
    bucket_size_mb=self.bucket_size_mb,
    use_shm=self.use_shm,
)
```

**Key design decisions:**

- Function defined in `verl/workers/rollout/utils.py` where bucket logic lives, keeping it cohesive
- Reads from already-loaded `hf_config`, no extra file I/O
- Handles both LLM (top-level config) and VLM (`text_config` nested) correctly
- Only adjusts when necessary, respects user-specified values larger than the embedding size
- No changes to example scripts or user launch configs

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This fix requires a full multimodal training environment (large VL model + dataset) which is not available in CI. Manual end-to-end verification has been conducted as described in the Test section above.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [x] Not related to the `recipe` submodule, no submodule update needed.