### PR TITLE
[fully_async] fix: Add Mindspeed Patch for Async Training on Ascend NPUs

### DIFF
--- a/verl/experimental/fully_async_policy/shell/geo3k_qwen3vl_30b_megatron_6_2_npu_async.sh
+++ b/verl/experimental/fully_async_policy/shell/geo3k_qwen3vl_30b_megatron_6_2_npu_async.sh
@@ -1,0 +1,156 @@
+set -x
+ENGINE=${1:-vllm}
+export CUDA_DEVICE_MAX_CONNECTIONS=1 
+export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+export HYDRA_FULL_ERROR=1
+export VLLM_ASCEND_ENABLE_NZ=0
+export VLLM_USE_V1=1
+
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+export VLLM_ALLREDUCE_USE_SYMM_MEM=0
+export HYDRA_FULL_ERROR=1
+export VLLM_ASCEND_ENABLE_NZ=0
+
+HF_MODEL_PATH=/home/model/Qwen3-VL-30B-A3B-Instruct
+
+train_path=/data/geo3k/train.parquet
+test_path=/data/geo3k/test.parquet
+
+rollout_mode="async"
+rollout_name="vllm" # sglang or vllm
+if [ "$rollout_mode" = "async" ]; then
+    export VLLM_USE_V1=1
+    return_raw_chat="True"
+fi
+
+train_prompt_bsz=0
+gen_prompt_bsz=1
+n_resp_per_prompt=4
+total_rollout_steps=$(((64*160)))
+test_freq=10
+require_batches=1
+partial_rollout=True
+total_epochs=200
+PROJECT_NAME='ASYNC_training'
+
+####################### with negative KL uncomment
+EXP_NAME='qwen3_vl_3b_megatron_async'
+enable_chunked_prefill=False
+train_prompt_mini_bsz=16
+staleness_threshold=0
+trigger_parameter_sync_step=4
+max_prompt_length=$((1024))
+max_response_length=$((1024 * 16))
+use_dynamic_bsz=True
+actor_ppo_max_token_len=$(((max_prompt_length + max_response_length)))
+infer_ppo_max_token_len=$(((max_prompt_length + max_response_length)))
+NNODES=${NNODES:-2}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-16}
+n_gpus_rollout=12
+n_gpus_training=$((NGPUS_PER_NODE - n_gpus_rollout))
+GEN_TP=${GEN_TP:-4}
+CP=${CP:-1}
+TP=${TP:-4}
+PP=${PP:-2}
+EP=${EP:-4}
+ETP=${ETP:-1}
+use_kl_loss=False
+loss_mode=geo_mean
+clip_ratio=0.4
+
+
+
+python -m verl.experimental.fully_async_policy.fully_async_main \
+    --config-path=config \
+    --config-name='fully_async_ppo_megatron_trainer.yaml'\
+    algorithm.adv_estimator=grpo \
+    data.train_files="$train_path" \
+    data.val_files="$test_path" \
+    data.train_batch_size=${train_prompt_bsz} \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio} \
+    data.gen_batch_size=${gen_prompt_bsz} \
+    data.return_raw_chat=${return_raw_chat} \
+    actor_rollout_ref.model.path=$HF_MODEL_PATH \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_decay_steps=51200 \
+    actor_rollout_ref.hybrid_engine=False \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=$PP \
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=$TP \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.context_parallel_size=${CP} \
+    actor_rollout_ref.actor.megatron.context_parallel_size=$CP \
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=$EP \
+    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=$ETP \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=0.01 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$GEN_TP \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.name=$ENGINE \
+    actor_rollout_ref.rollout.mode=${rollout_mode} \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.disable_mm_preprocessor_cache=True \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.megatron.use_mbridge=True \
+    actor_rollout_ref.actor.megatron.param_offload=True \
+    actor_rollout_ref.actor.megatron.optimizer_offload=True \
+    actor_rollout_ref.actor.megatron.grad_offload=True \
+    actor_rollout_ref.ref.megatron.param_offload=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=1 \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_router_dtype=fp32 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.gradient_accumulation_fusion=False \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_permute_fusion=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.apply_rope_fusion=False \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=True \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_aux_loss_coeff=0.01 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_z_loss_coeff=0.001 \
+    +actor_rollout_ref.actor.megatron.override_transformer_config.fp8=False \
+    actor_rollout_ref.actor.megatron.use_dist_checkpointing=False \
+    actor_rollout_ref.ref.megatron.use_dist_checkpointing=False \
+    algorithm.use_kl_in_reward=False \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console", "tensorboard"]' \
+    trainer.project_name=${PROJECT_NAME} \
+    trainer.experiment_name=$EXP_NAME \
+    trainer.test_freq="${test_freq}" \
+    trainer.total_epochs="${total_epochs}" \
+    trainer.val_before_train=False \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=auto \
+    trainer.nnodes="${NNODES}" \
+    trainer.n_gpus_per_node="${n_gpus_training}" \
+    rollout.nnodes="${NNODES}" \
+    rollout.n_gpus_per_node="${n_gpus_rollout}" \
+    rollout.total_rollout_steps="${total_rollout_steps}" \
+    trainer.test_freq="${test_freq}" \
+    trainer.device=npu \
+    actor_rollout_ref.rollout.enable_chunked_prefill=${enable_chunked_prefill} \
+    async_training.staleness_threshold="${staleness_threshold}" \
+    async_training.trigger_parameter_sync_step="${trigger_parameter_sync_step}" \
+    async_training.require_batches="${require_batches}" \
+    async_training.partial_rollout="${partial_rollout}" 2>&1 | tee "./logs/${PROJECT_NAME}/run_${EXP_NAME}.log"

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -15,6 +15,7 @@
 
 import logging
 import os
+from typing import Callable
 
 from omegaconf import DictConfig
 
@@ -87,11 +88,11 @@ class DetachActorWorker(ActorRolloutRefWorker):
         return self._strategy_handlers
 
     @property
-    def copy_handler(self):
+    def copy_handler(self) -> Callable:
         return self._get_strategy_handlers()[0]
 
     @property
-    def restore_handler(self):
+    def restore_handler(self) -> Callable:
         return self._get_strategy_handlers()[1]
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -89,10 +89,12 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
     @property
     def copy_handler(self) -> Callable:
+        """Get the copy handler for the strategy."""
         return self._get_strategy_handlers()[0]
 
     @property
     def restore_handler(self) -> Callable:
+        """Get the restore handler for the strategy."""
         return self._get_strategy_handlers()[1]
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -51,7 +51,6 @@ class DetachActorWorker(ActorRolloutRefWorker):
         """
         ActorRolloutRefWorker.__init__(self, config, role)
         self._strategy_handlers = None
-        self.copy_handler, self.restore_handler = self._get_strategy_handlers()
 
     def _get_strategy_handlers(self):
         """
@@ -86,6 +85,14 @@ class DetachActorWorker(ActorRolloutRefWorker):
             raise NotImplementedError(f"Unsupported strategy: {strategy}")
 
         return self._strategy_handlers
+
+    @property
+    def copy_handler(self):
+        return self._get_strategy_handlers()[0]
+
+    @property
+    def restore_handler(self):
+        return self._get_strategy_handlers()[1]
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
     def save_model_to_cpu(self, n):

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -53,11 +53,6 @@ from verl.workers.config import (
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
 from verl.workers.utils.losses import diffusion_loss, ppo_loss
 
-try:
-    from verl.workers.engine.mindspeed.transformer_impl import repatch
-except ImportError:
-    repatch = None
-
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
@@ -499,10 +494,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     def init_model(self):
         model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model)
 
-        if repatch is not None:
-            # NPU MindSpeed patch, will be refactored with MindSpeedEngine.
-            repatch(self.config.actor.megatron.get("override_transformer_config", {}))
-        
         # 1. build reference model
         if "ref" in self.role:
             # TODO: align ref config with actor config

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -53,6 +53,11 @@ from verl.workers.config import (
 from verl.workers.rollout.base import BaseRollout, get_rollout_class
 from verl.workers.utils.losses import diffusion_loss, ppo_loss
 
+try:
+    from verl.workers.engine.mindspeed.transformer_impl import repatch
+except ImportError:
+    repatch = None
+
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
@@ -494,6 +499,10 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     def init_model(self):
         model_config: HFModelConfig = omega_conf_to_dataclass(self.config.model)
 
+        if repatch is not None:
+            # NPU MindSpeed patch, will be refactored with MindSpeedEngine.
+            repatch(self.config.actor.megatron.get("override_transformer_config", {}))
+        
         # 1. build reference model
         if "ref" in self.role:
             # TODO: align ref config with actor config


### PR DESCRIPTION
### What does this PR do?

The MindSpeed patch for Megatron was not being applied in the `fully_async` training path, causing `torch_npu`-related errors when training on Ascend NPUs. This PR addressed this issue. We also provide an example script for training Qwen3-VL-30B-megatron in a fully async setting on ascend npus. 

### Fix
Ensured the MindSpeed patch is applied correctly regardless of the training mode, so `fully_async` training now works as expected on Ascend NPUs.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
