### PR TITLE
[ckpt] chore: Checkpoint Save & Resume for Async Training on Ascend NPUs

### DIFF
--- a/docs/ascend_tutorial/quick_start/ascend_checkpoint_save_and_resume_tips.md
+++ b/docs/ascend_tutorial/quick_start/ascend_checkpoint_save_and_resume_tips.md
@@ -1,0 +1,85 @@
+Apply changes to MindSpeed if you need to save and resume checkpoints in async training
+
+### a:
+In `/MindSpeed/mindspeed/core/megatron_basic/megatron_basic.py`, at **line 184**
+
+Replce 
+
+```python
+        self.optimizer.dummy_step()
+```
+
+with 
+
+```python
+            # Patched: bypass HybridDeviceOptimizer.dummy_step() which uses NPU streams
+            # Instead, step each sub-optimizer directly to init optimizer states
+            for sub_opt in self.optimizer.sub_optimizers:
+                for group in sub_opt.param_groups:
+                    for param in group["params"]:
+                        if param.numel() == 0:
+                            continue
+                        param.grad = torch.randn_like(param)
+                sub_opt.step()
+                sub_opt.zero_grad()
+```
+
+### b:
+
+In `/MindSpeed/mindspeed/core/megatron_basic/megatron_basic.py`, at **line 260** 
+
+Replace
+
+```python
+                            return torch.empty(
+                                (elements_count,), dtype=torch.float32, device=torch.cuda.current_device()
+                            )
+```
+
+with 
+
+```python
+                            return torch.empty(
+                                (elements_count,), dtype=torch.float32, device=("cpu" if isinstance(self.optimizer, HybridDeviceOptimizer) else torch.cuda.current_device())
+                            )
+```
+
+
+### c:
+
+In `/MindSpeed/mindspeed/core/megatron_basic/megatron_basic.py`, at **line 290** 
+
+replace 
+```python
+       steps = list(
+            set([g["step"] for g in state_dict["optimizer"]["param_groups"] if "step" in g])
+        )
+```
+
+with 
+
+```python
+        steps = list(
+            set([g["step"] for g in state_dict["optimizer"]["param_groups"] if "step" in g and g["step"] is not None])
+        )
+```
+
+### d:
+
+In the training scripts. set the following parameters. Note that param offload should be enabled.
+
+
+```bash 
+export HCCL_CONNECT_TIMEOUT=1800
+export HCCL_EXEC_TIMEOUT=1800
+    actor_rollout_ref.actor.megatron.dist_ckpt_optim_fully_reshardable=False \
+    trainer.save_freq=10 \
+    actor_rollout_ref.actor.megatron.param_offload=True \
+    actor_rollout_ref.actor.megatron.optimizer_offload=True \
+    actor_rollout_ref.actor.megatron.grad_offload=True \
+    actor_rollout_ref.ref.megatron.param_offload=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=1 \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True \
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=True \
+ ```

--- a/docs/ascend_tutorial/quick_start/ascend_checkpoint_save_and_resume_tips.md
+++ b/docs/ascend_tutorial/quick_start/ascend_checkpoint_save_and_resume_tips.md
@@ -1,9 +1,13 @@
+# Checkpoint Save and Resume Tips on Ascend NPU
+
+Last updated: 06/01/2026
+
 Apply changes to MindSpeed if you need to save and resume checkpoints in async training
 
 ### a:
 In `/MindSpeed/mindspeed/core/megatron_basic/megatron_basic.py`, at **line 184**
 
-Replce 
+Replace 
 
 ```python
         self.optimizer.dummy_step()
@@ -49,7 +53,7 @@ with
 
 In `/MindSpeed/mindspeed/core/megatron_basic/megatron_basic.py`, at **line 290** 
 
-replace 
+Replace 
 ```python
        steps = list(
             set([g["step"] for g in state_dict["optimizer"]["param_groups"] if "step" in g])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ verl is fast with:
    ascend_tutorial/quick_start/ascend_quick_start.rst
    ascend_tutorial/quick_start/dockerfile_build_guidance.rst
    ascend_tutorial/quick_start/ascend_sglang_quick_start.rst
+   ascend_tutorial/quick_start/ascend_checkpoint_save_and_resume_tips.md
    ascend_tutorial/features/ascend_consistency.rst
    ascend_tutorial/features/ascend_backend_features.md
    ascend_tutorial/profiling/ascend_profiling_zh.rst

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -334,12 +334,12 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 megatron_config.distrib_optim_fully_reshardable_mem_efficient
             )
             if dist_ckpt_optim_fully_reshardable:
-                metadata["distrib_optim_sharding_type"] = "fully_reshardable"
+                metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
                 metadata["distrib_optim_fully_reshardable_mem_efficient"] = (
                     distrib_optim_fully_reshardable_mem_efficient
                 )
             else:
-                metadata["distrib_optim_sharding_type"] = "dp_reshardable"
+                metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
 
         metadata["singleton_local_shards"] = False
         metadata["chained_optim_avoid_prefix"] = True
@@ -421,6 +421,11 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             # For backward compatibility
             sharded_sd_metadata = None
         else:
+           try:
+                from mindspeed.core.optimizer.adamw import AdamW as MindSpeedAdamW
+                torch.serialization.add_safe_globals([MindSpeedAdamW])
+            except ImportError:
+                pass
             sharded_sd_metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
         if sharded_sd_metadata is None:
             if self.use_distributed_optimizer:

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -31,7 +31,7 @@ from packaging import version
 from transformers import GenerationConfig
 
 from verl.models.weight_loader_registry import get_weight_saver
-from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.device import get_device_name, get_torch_device, is_npu_available
 from verl.utils.fs import is_non_local, local_mkdir_safe
 from verl.utils.logger import log_with_rank
 from verl.utils.megatron.dist_checkpointing import load_dist_checkpointing, save_dist_checkpointing
@@ -444,12 +444,13 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             # For backward compatibility
             sharded_sd_metadata = None
         else:
-            try:
-                from mindspeed.core.optimizer.adamw import AdamW as MindSpeedAdamW
+            if is_npu_available:
+                try:
+                    from mindspeed.core.optimizer.adamw import AdamW as MindSpeedAdamW
 
-                torch.serialization.add_safe_globals([MindSpeedAdamW])
-            except Exception:
-                pass
+                    torch.serialization.add_safe_globals([MindSpeedAdamW])
+                except Exception:
+                    pass
             sharded_sd_metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
         if sharded_sd_metadata is None:
             if self.use_distributed_optimizer:

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -287,7 +287,30 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.14.0/megatron/core/optimizer/distrib_optimizer.py#L1109-L1123
                 if mcore_ge_014:
                     sharded_state_dict_kwargs["metadata"] = base_metadata
-            optimizer_sharded_states = self.optimizer.sharded_state_dict(state_dict, **sharded_state_dict_kwargs)
+            try:
+                optimizer_sharded_states = self.optimizer.sharded_state_dict(state_dict, **sharded_state_dict_kwargs)
+            except NotImplementedError as e:
+                # Some Megatron-LM builds (e.g. MindSpeed on Ascend NPUs) only implement
+                # "fully_sharded_model_space". Fall back to it when the configured sharding type
+                # is rejected so save/resume still succeeds.
+                requested = base_metadata.get("distrib_optim_sharding_type") if base_metadata else None
+                if (
+                    "Unknown sharding_type" in str(e)
+                    and base_metadata is not None
+                    and requested != "fully_sharded_model_space"
+                ):
+                    logger.warning(
+                        "Optimizer rejected sharding_type=%r (%s); retrying with 'fully_sharded_model_space'.",
+                        requested,
+                        e,
+                    )
+                    base_metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
+                    base_metadata.pop("distrib_optim_fully_reshardable_mem_efficient", None)
+                    optimizer_sharded_states = self.optimizer.sharded_state_dict(
+                        state_dict, **sharded_state_dict_kwargs
+                    )
+                else:
+                    raise
             state_dict["optimizer"] = optimizer_sharded_states
 
             if self.lr_scheduler is not None:
@@ -334,12 +357,12 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 megatron_config.distrib_optim_fully_reshardable_mem_efficient
             )
             if dist_ckpt_optim_fully_reshardable:
-                metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
+                metadata["distrib_optim_sharding_type"] = "fully_reshardable"
                 metadata["distrib_optim_fully_reshardable_mem_efficient"] = (
                     distrib_optim_fully_reshardable_mem_efficient
                 )
             else:
-                metadata["distrib_optim_sharding_type"] = "fully_sharded_model_space"
+                metadata["distrib_optim_sharding_type"] = "dp_reshardable"
 
         metadata["singleton_local_shards"] = False
         metadata["chained_optim_avoid_prefix"] = True
@@ -421,10 +444,11 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             # For backward compatibility
             sharded_sd_metadata = None
         else:
-           try:
+            try:
                 from mindspeed.core.optimizer.adamw import AdamW as MindSpeedAdamW
+
                 torch.serialization.add_safe_globals([MindSpeedAdamW])
-            except ImportError:
+            except Exception:
                 pass
             sharded_sd_metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
         if sharded_sd_metadata is None:


### PR DESCRIPTION
### What does this PR do?


This PR addresses the problem in checkpoint saving and resuming on async training on Ascend NPUs.  Fixes a `NotImplementedError` raised in `distrib_optimizer.py` when attempting to save checkpoints during fully async training on Ascend NPUs. The error was triggered by an unsupported `sharding_type: fully_reshardable` passed to the distributed optimizer's `sharded_state_dict` method.

This PR implements proper checkpoint save and resume logic in the Megatron-based async training pipeline for Ascend NPU environments, ensuring `sharding_type` is handled correctly and checkpoint state dicts can be generated, saved, and restored without error.

**Root cause:** `MegatronCheckpointManager.generate_state_dict` passed `fully_reshardable` as the sharding type to `DistributedOptimizer.sharded_state_dict`, which had no handling for this value on the Ascend code path.

**Changes:**
- Handle `fully_reshardable` sharding type in the checkpoint manager for Ascend NPU compatibility
- Enable end-to-end checkpoint save and resume in the `FullyAsyncTrainer` on Ascend
- We also provide the modifications that should be applied in mindpeed in a .md file.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
