### PR TITLE
[tool, rollout, cfg] feat: per-instance tool environment for multi-turn agent loop

### DIFF
--- a/examples/sglang_multiturn/multi_env/README.md
+++ b/examples/sglang_multiturn/multi_env/README.md
@@ -1,0 +1,26 @@
+# Multi-Environment Tool-Use Example
+
+Demonstrates per-instance tool environment routing in `ToolAgentLoop`.
+
+Each dataset row carries `extra_info.tool_env_id` and `extra_info.db_path`.
+`ToolAgentLoop` resolves per-instance tools via a manifest and loads a
+per-instance shared DB automatically — no custom subclass needed.
+
+## Environments
+
+| env_id | tool | DB schema |
+|--------|------|-----------|
+| `inventory_store` | `check_stock` | `{"products": {"laptop": {"stock": 10, "price": 999.99}}}` |
+| `bank_account` | `check_balance` | `{"accounts": {"alice": {"balance": 5000.0}}}` |
+
+## Quick Start
+
+```bash
+# From project root:
+bash examples/sglang_multiturn/multi_env/run_multi_env_grpo.sh
+```
+
+## Key Files
+
+- `config/tool_env_manifest.yaml` — Maps `tool_env_id` → tool config path
+- `config/multi_env_grpo.yaml` — Training config with `tool_env_manifest_path` set

--- a/examples/sglang_multiturn/multi_env/config/multi_env_grpo.yaml
+++ b/examples/sglang_multiturn/multi_env/config/multi_env_grpo.yaml
@@ -1,0 +1,31 @@
+hydra:
+  searchpath:
+    - file://verl/trainer/config
+
+defaults:
+  - ppo_trainer
+  - _self_
+
+data:
+  max_prompt_length: 1024
+  max_response_length: 2048
+  train_batch_size: 64
+  return_raw_chat: True
+
+actor_rollout_ref:
+  hybrid_engine: True
+  rollout:
+    name: sglang
+    multi_turn:
+      enable: True
+      max_assistant_turns: 5
+      max_user_turns: 5
+      max_parallel_calls: 5
+      max_tool_response_length: 512
+      tool_response_truncate_side: right
+      # No global tool_config_path — tools are resolved per-instance
+      # via the manifest below.
+      tool_config_path: null
+      tool_env_manifest_path: ./config/tool_env_manifest.yaml
+    agent:
+      default_agent_loop: tool_agent

--- a/examples/sglang_multiturn/multi_env/config/tool_config/bank_tool_config.yaml
+++ b/examples/sglang_multiturn/multi_env/config/tool_config/bank_tool_config.yaml
@@ -1,0 +1,16 @@
+tools:
+  - class_name: "examples.sglang_multiturn.multi_env.envs.bank_tools.CheckBalanceTool"
+    config:
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "check_balance"
+        description: "Look up the current balance of a bank account."
+        parameters:
+          type: "object"
+          properties:
+            account_id:
+              type: "string"
+              description: "Account holder name (e.g. 'alice')."
+          required: ["account_id"]

--- a/examples/sglang_multiturn/multi_env/config/tool_config/inventory_tool_config.yaml
+++ b/examples/sglang_multiturn/multi_env/config/tool_config/inventory_tool_config.yaml
@@ -1,0 +1,16 @@
+tools:
+  - class_name: "examples.sglang_multiturn.multi_env.envs.inventory_tools.CheckStockTool"
+    config:
+      type: native
+    tool_schema:
+      type: "function"
+      function:
+        name: "check_stock"
+        description: "Look up the current stock and price of a product."
+        parameters:
+          type: "object"
+          properties:
+            product_name:
+              type: "string"
+              description: "Product name (e.g. 'laptop')."
+          required: ["product_name"]

--- a/examples/sglang_multiturn/multi_env/config/tool_env_manifest.yaml
+++ b/examples/sglang_multiturn/multi_env/config/tool_env_manifest.yaml
@@ -1,0 +1,9 @@
+# Tool environment manifest: maps tool_env_id -> tool config path.
+# Each dataset row's extra_info.tool_env_id is looked up here to
+# determine which tools to load for that particular trajectory.
+
+inventory_store:
+  tool_config_path: ./config/tool_config/inventory_tool_config.yaml
+
+bank_account:
+  tool_config_path: ./config/tool_config/bank_tool_config.yaml

--- a/examples/sglang_multiturn/multi_env/envs/__init__.py
+++ b/examples/sglang_multiturn/multi_env/envs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/sglang_multiturn/multi_env/envs/bank_tools.py
+++ b/examples/sglang_multiturn/multi_env/envs/bank_tools.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bank balance lookup tool — reads account info from a per-instance shared DB.
+
+DB schema: ``{"accounts": {"alice": {"balance": 5000.0}, ...}}``
+"""
+
+import json
+from typing import Any, Optional
+from uuid import uuid4
+
+from verl.tools.base_tool import BaseTool
+from verl.tools.schemas import OpenAIFunctionToolSchema, ToolResponse
+
+
+class CheckBalanceTool(BaseTool):
+    def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
+        super().__init__(config, tool_schema)
+        self._dbs: dict[str, dict] = {}
+
+    async def create(self, instance_id: Optional[str] = None, **kwargs) -> tuple[str, ToolResponse]:
+        instance_id = instance_id or str(uuid4())
+        self._dbs[instance_id] = kwargs.get("create_kwargs", {}).get("shared_db") or {"accounts": {}}
+        return instance_id, ToolResponse()
+
+    async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs) -> tuple[ToolResponse, float, dict]:
+        acct = parameters.get("account_id", "").strip().lower()
+        accounts = self._dbs[instance_id].get("accounts", {})
+        if acct not in accounts:
+            return ToolResponse(text=json.dumps({"error": f"'{acct}' not found"})), 0.0, {}
+        return ToolResponse(text=json.dumps({"account": acct, "balance": accounts[acct].get("balance", 0)})), 0.0, {}
+
+    async def release(self, instance_id: str, **kwargs) -> None:
+        self._dbs.pop(instance_id, None)

--- a/examples/sglang_multiturn/multi_env/envs/inventory_tools.py
+++ b/examples/sglang_multiturn/multi_env/envs/inventory_tools.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inventory lookup tool — reads product info from a per-instance shared DB.
+
+DB schema: ``{"products": {"laptop": {"stock": 10, "price": 999.99}, ...}}``
+"""
+
+import json
+from typing import Any, Optional
+from uuid import uuid4
+
+from verl.tools.base_tool import BaseTool
+from verl.tools.schemas import OpenAIFunctionToolSchema, ToolResponse
+
+
+class CheckStockTool(BaseTool):
+    def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
+        super().__init__(config, tool_schema)
+        self._dbs: dict[str, dict] = {}
+
+    async def create(self, instance_id: Optional[str] = None, **kwargs) -> tuple[str, ToolResponse]:
+        instance_id = instance_id or str(uuid4())
+        self._dbs[instance_id] = kwargs.get("create_kwargs", {}).get("shared_db") or {"products": {}}
+        return instance_id, ToolResponse()
+
+    async def execute(self, instance_id: str, parameters: dict[str, Any], **kwargs) -> tuple[ToolResponse, float, dict]:
+        name = parameters.get("product_name", "").strip().lower()
+        products = self._dbs[instance_id].get("products", {})
+        if name not in products:
+            return ToolResponse(text=json.dumps({"error": f"'{name}' not found"})), 0.0, {}
+        info = products[name]
+        result = {"product": name, "stock": info.get("stock", 0), "price": info.get("price", 0)}
+        return ToolResponse(text=json.dumps(result)), 0.0, {}
+
+    async def release(self, instance_id: str, **kwargs) -> None:
+        self._dbs.pop(instance_id, None)

--- a/examples/sglang_multiturn/multi_env/prepare_multi_env_dataset.py
+++ b/examples/sglang_multiturn/multi_env/prepare_multi_env_dataset.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env python3
+"""Generate train/val parquets for the multi-env tool-use example.
+
+Each row carries ``extra_info.tool_env_id`` and ``extra_info.db_path`` so that
+the ``MultiEnvToolAgentLoop`` can resolve per-instance tools and shared DB.
+
+Usage::
+
+    python prepare_multi_env_dataset.py --output_dir ./data
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+SCENARIOS = [
+    {
+        "data_source": "multi_env_demo/inventory",
+        "tool_env_id": "inventory_store",
+        "db_file": "inventory_001.json",
+        "system": "You are a shopping assistant with access to a check_stock tool.",
+        "user": "Is the laptop in stock? What's the price?",
+    },
+    {
+        "data_source": "multi_env_demo/inventory",
+        "tool_env_id": "inventory_store",
+        "db_file": "inventory_001.json",
+        "system": "You are a shopping assistant with access to a check_stock tool.",
+        "user": "How many phones do you have available?",
+    },
+    {
+        "data_source": "multi_env_demo/bank",
+        "tool_env_id": "bank_account",
+        "db_file": "bank_001.json",
+        "system": "You are a banking assistant with access to a check_balance tool.",
+        "user": "What is Alice's current balance?",
+    },
+    {
+        "data_source": "multi_env_demo/bank",
+        "tool_env_id": "bank_account",
+        "db_file": "bank_001.json",
+        "system": "You are a banking assistant with access to a check_balance tool.",
+        "user": "Check Bob's account balance for me.",
+    },
+]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output_dir", default="./data")
+    parser.add_argument("--db_dir", default="./sample_dbs")
+    args = parser.parse_args()
+
+    db_dir = str(Path(args.db_dir).resolve())
+    rows: list[dict] = []
+    for idx, s in enumerate(SCENARIOS):
+        rows.append(
+            {
+                "data_source": s["data_source"],
+                "prompt": json.dumps(
+                    [{"role": "system", "content": s["system"]}, {"role": "user", "content": s["user"]}],
+                    ensure_ascii=False,
+                ),
+                "ability": "tool_use",
+                "reward_model": json.dumps({"style": "rule", "ground_truth": ""}),
+                "extra_info": json.dumps(
+                    {"index": idx, "tool_env_id": s["tool_env_id"], "db_path": os.path.join(db_dir, s["db_file"])},
+                    ensure_ascii=False,
+                ),
+            }
+        )
+
+    train_rows, val_rows = rows[:-1], rows[-1:]
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    for split, split_rows in [("train", train_rows), ("val", val_rows)]:
+        table = pa.table({k: [r[k] for r in split_rows] for k in split_rows[0]})
+        path = os.path.join(args.output_dir, f"{split}.parquet")
+        pq.write_table(table, path)
+        print(f"Wrote {len(split_rows)} rows -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sglang_multiturn/multi_env/run_multi_env_grpo.sh
+++ b/examples/sglang_multiturn/multi_env/run_multi_env_grpo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Multi-environment tool-use GRPO training example.
+set -x
+ulimit -n 65535
+
+PROJECT_DIR="$(pwd)"
+EXAMPLE_DIR="$PROJECT_DIR/examples/sglang_multiturn/multi_env"
+
+# Step 1: Prepare dataset
+python3 "$EXAMPLE_DIR/prepare_multi_env_dataset.py" \
+    --output_dir "$EXAMPLE_DIR/data" \
+    --db_dir "$EXAMPLE_DIR/sample_dbs"
+
+# Step 2: Train
+python3 -m verl.trainer.main_ppo \
+    --config-path="$EXAMPLE_DIR/config" \
+    --config-name='multi_env_grpo' \
+    algorithm.adv_estimator=grpo \
+    data.train_files="$EXAMPLE_DIR/data/train.parquet" \
+    data.val_files="$EXAMPLE_DIR/data/val.parquet" \
+    actor_rollout_ref.model.path=Qwen/Qwen2.5-3B-Instruct \
+    actor_rollout_ref.rollout.multi_turn.tool_env_manifest_path="$EXAMPLE_DIR/config/tool_env_manifest.yaml" \
+    actor_rollout_ref.rollout.agent.default_agent_loop=tool_agent \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=1 \
+    trainer.total_epochs=5 \
+    "$@"

--- a/examples/sglang_multiturn/multi_env/sample_dbs/bank_001.json
+++ b/examples/sglang_multiturn/multi_env/sample_dbs/bank_001.json
@@ -1,0 +1,7 @@
+{
+  "accounts": {
+    "alice": {"balance": 5000.00},
+    "bob": {"balance": 3000.00},
+    "charlie": {"balance": 1500.00}
+  }
+}

--- a/examples/sglang_multiturn/multi_env/sample_dbs/inventory_001.json
+++ b/examples/sglang_multiturn/multi_env/sample_dbs/inventory_001.json
@@ -1,0 +1,8 @@
+{
+  "products": {
+    "laptop": {"stock": 10, "price": 999.99},
+    "phone": {"stock": 25, "price": 699.99},
+    "tablet": {"stock": 15, "price": 449.99},
+    "headphones": {"stock": 50, "price": 149.99}
+  }
+}

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 from uuid import uuid4
 
 import torch
+from omegaconf import OmegaConf
 from PIL import Image
 
 from verl.experimental.agent_loop.agent_loop import (
@@ -113,6 +114,12 @@ class ToolAgentLoop(AgentLoopBase):
         self.prompt_length = self.rollout_config.prompt_length
         self.response_length = self.rollout_config.response_length
 
+        # Per-instance tool environment support
+        self.tool_env_manifest_path = self.rollout_config.multi_turn.get("tool_env_manifest_path", None)
+        self._manifest_cache_path: str | None = None
+        self._manifest_cache: dict[str, dict[str, Any]] = {}
+        self._tool_env_cache: dict[str, tuple[dict[str, Any], list[dict[str, Any]]]] = {}
+
         # Initialize interactions from config file
         self.interaction_config_file = self.rollout_config.multi_turn.interaction_config_path
         if self.interaction_config_file:
@@ -160,6 +167,10 @@ class ToolAgentLoop(AgentLoopBase):
             interaction_kwargs=interaction_kwargs,
         )
 
+        # Per-instance setup hook (override in subclasses to inject
+        # per-instance tools, shared state, etc. into agent_data.extra_fields)
+        await self._setup_instance(agent_data, **kwargs)
+
         # State machine loop
         state = AgentState.PENDING
         while state != AgentState.TERMINATED:
@@ -200,11 +211,117 @@ class ToolAgentLoop(AgentLoopBase):
         output.extra_fields.update({"turn_scores": agent_data.turn_scores, "tool_rewards": agent_data.tool_rewards})
         return output
 
+    async def _setup_instance(self, agent_data: AgentData, **kwargs) -> None:
+        """Resolve per-instance tools and shared DB if extra_info provides them.
+
+        When ``extra_info`` contains ``tool_config_path`` or ``tool_env_id`` (with
+        a ``tool_env_manifest_path`` configured), this method loads the
+        corresponding tool set and stores it in ``agent_data.extra_fields`` so
+        that subsequent state-machine steps use per-instance tools.
+
+        An optional ``extra_info.db_path`` (JSON) is loaded and stored as
+        ``agent_data.extra_fields["shared_db"]`` for stateful tool environments.
+
+        Override in subclasses for further customization.
+        """
+        extra_info = kwargs.get("extra_info", {}) or {}
+
+        # --- Per-instance tool environment --------------------------------
+        active_tools, active_tool_schemas = self._resolve_active_tool_env(extra_info)
+        if active_tools is not self.tools:
+            agent_data.extra_fields["active_tools"] = active_tools
+            agent_data.extra_fields["active_tool_schemas"] = active_tool_schemas
+
+        # --- Per-instance shared DB ---------------------------------------
+        db_path = extra_info.get("db_path")
+        if isinstance(db_path, str) and db_path and os.path.exists(db_path):
+            try:
+                with open(db_path, encoding="utf-8") as f:
+                    agent_data.extra_fields["shared_db"] = json.load(f)
+            except Exception as e:
+                logger.warning("Failed to load shared DB from %s: %s", db_path, e)
+
+    def _resolve_active_tool_env(self, extra_info: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Determine the tool set for this particular request."""
+        direct_path = extra_info.get("tool_config_path")
+
+        if not direct_path:
+            tool_env_id = extra_info.get("tool_env_id")
+            if tool_env_id:
+                manifest = self._load_tool_env_manifest()
+                env_cfg = manifest.get(str(tool_env_id), {})
+                direct_path = env_cfg.get("tool_config_path")
+
+        if direct_path:
+            try:
+                return self._build_tools_from_config(direct_path)
+            except Exception as e:
+                logger.warning(
+                    "Failed to load tools from %s, falling back to defaults: %s",
+                    direct_path,
+                    e,
+                )
+
+        return self.tools, self.tool_schemas
+
+    def _load_tool_env_manifest(self) -> dict[str, dict[str, Any]]:
+        """Load and cache the tool environment manifest YAML."""
+        if not self.tool_env_manifest_path:
+            return {}
+        resolved = os.path.expanduser(self.tool_env_manifest_path)
+        if self._manifest_cache_path == resolved and self._manifest_cache:
+            return self._manifest_cache
+        if not os.path.exists(resolved):
+            logger.warning("tool_env_manifest_path does not exist: %s", resolved)
+            self._manifest_cache_path = resolved
+            self._manifest_cache = {}
+            return {}
+        try:
+            loaded = OmegaConf.load(resolved)
+            raw = OmegaConf.to_container(loaded, resolve=True)
+            self._manifest_cache = self._normalize_manifest(raw)
+        except Exception as e:
+            logger.warning("Failed to load tool env manifest %s: %s", resolved, e)
+            self._manifest_cache = {}
+        self._manifest_cache_path = resolved
+        return self._manifest_cache
+
+    @staticmethod
+    def _normalize_manifest(raw: Any) -> dict[str, dict[str, Any]]:
+        """Accept both dict-style and list-style manifests."""
+        if raw is None:
+            return {}
+        if isinstance(raw, dict):
+            if "environments" in raw and isinstance(raw["environments"], list):
+                return {str(env["id"]): env for env in raw["environments"] if isinstance(env, dict) and "id" in env}
+            return {str(k): v for k, v in raw.items() if isinstance(v, dict)}
+        return {}
+
+    def _build_tools_from_config(self, tool_config_path: str) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Build tool map and schemas from a config file, with caching."""
+        resolved = os.path.expanduser(tool_config_path)
+        if resolved in self._tool_env_cache:
+            return self._tool_env_cache[resolved]
+        tool_list = initialize_tools_from_config(resolved)
+        tool_map = {tool.name: tool for tool in tool_list}
+        tool_schemas = [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True) for tool in tool_list]
+        self._tool_env_cache[resolved] = (tool_map, tool_schemas)
+        return tool_map, tool_schemas
+
+    def _get_active_tools(self, agent_data: AgentData) -> dict[str, Any]:
+        """Return the tool map for the current instance."""
+        return agent_data.extra_fields.get("active_tools", self.tools)
+
+    def _get_active_tool_schemas(self, agent_data: AgentData) -> list[dict[str, Any]]:
+        """Return the tool schemas for the current instance."""
+        return agent_data.extra_fields.get("active_tool_schemas", self.tool_schemas)
+
     async def _handle_pending_state(self, agent_data: AgentData, sampling_params: dict[str, Any]) -> AgentState:
         """Handle the pending state: prepare the prompt and start generation."""
+        active_tool_schemas = self._get_active_tool_schemas(agent_data)
         prompt_ids = await self.apply_chat_template(
             agent_data.messages,
-            tools=self.tool_schemas,
+            tools=active_tool_schemas,
             images=agent_data.image_data,
             videos=agent_data.video_data,
         )
@@ -259,7 +376,8 @@ class ToolAgentLoop(AgentLoopBase):
             return AgentState.TERMINATED
 
         # Extract tool calls
-        tools = [tool.tool_schema for tool in self.tools.values()]
+        active_tools = self._get_active_tools(agent_data)
+        tools = [tool.tool_schema for tool in active_tools.values()]
         _, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
 
         # Handle interaction if needed
@@ -427,9 +545,15 @@ class ToolAgentLoop(AgentLoopBase):
             # TODO: append malformed tool_call to the prompt: invalid function name or arguments
             tool_name = tool_call.name
             tool_args = json.loads(tool_call.arguments)
-            tool = self.tools[tool_name]
+            active_tools = self._get_active_tools(agent_data)
+            tool = active_tools[tool_name]
             kwargs = tools_kwargs.get(tool_name, {})
-            instance_id, _ = await tool.create(create_kwargs=kwargs.get("create_kwargs", {}))
+            create_kwargs = dict(kwargs.get("create_kwargs", {}))
+            # Inject shared state (e.g. per-instance DB) into tool creation
+            shared_db = agent_data.extra_fields.get("shared_db")
+            if shared_db is not None:
+                create_kwargs.setdefault("shared_db", shared_db)
+            instance_id, _ = await tool.create(create_kwargs=create_kwargs)
             tool_execution_response, tool_reward, res = await tool.execute(
                 instance_id, tool_args, agent_data=agent_data
             )

--- a/verl/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl/trainer/config/_generated_diffusion_trainer.yaml
@@ -281,6 +281,7 @@ actor_rollout_ref:
       enable: false
       max_assistant_turns: null
       tool_config_path: null
+      tool_env_manifest_path: null
       max_user_turns: null
       max_parallel_calls: 1
       max_tool_response_length: 256

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -301,6 +301,7 @@ actor_rollout_ref:
       enable: false
       max_assistant_turns: null
       tool_config_path: null
+      tool_env_manifest_path: null
       max_user_turns: null
       max_parallel_calls: 1
       max_tool_response_length: 256

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -268,6 +268,7 @@ actor_rollout_ref:
       enable: false
       max_assistant_turns: null
       tool_config_path: null
+      tool_env_manifest_path: null
       max_user_turns: null
       max_parallel_calls: 1
       max_tool_response_length: 256

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -277,6 +277,7 @@ actor_rollout_ref:
       enable: false
       max_assistant_turns: null
       tool_config_path: null
+      tool_env_manifest_path: null
       max_user_turns: null
       max_parallel_calls: 1
       max_tool_response_length: 256

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -247,6 +247,7 @@ actor_rollout_ref:
       enable: false
       max_assistant_turns: null
       tool_config_path: null
+      tool_env_manifest_path: null
       max_user_turns: null
       max_parallel_calls: 1
       max_tool_response_length: 256

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -176,6 +176,9 @@ multi_turn:
   # null for no tool
   tool_config_path: null
 
+  # null for no per-instance tool env manifest
+  tool_env_manifest_path: null
+
   # null for no limit (default max_length // 3)
   max_user_turns: null
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -77,6 +77,7 @@ class MultiTurnConfig(BaseConfig):
     enable: bool = False
     max_assistant_turns: Optional[int] = None
     tool_config_path: Optional[str] = None
+    tool_env_manifest_path: Optional[str] = None
     max_user_turns: Optional[int] = None
     max_parallel_calls: int = 1
     max_tool_response_length: int = 256


### PR DESCRIPTION
### What does this PR do?

Add **per-instance tool environment** support to `ToolAgentLoop`, allowing each dataset row to use a different tool set and stateful DB during multi-turn rollouts — without requiring any custom subclass.

**Motivation**: In real-world agent training, different scenarios need different tools (e.g., inventory queries vs. bank balance checks) and different state (e.g., per-store databases). Currently, all rows in a batch share the same tool configuration. This PR enables heterogeneous tool environments via dataset-level configuration.

**How it works**:
1. Dataset rows carry `extra_info.tool_env_id` and `extra_info.db_path`
2. `ToolAgentLoop._setup_instance()` resolves tools via a manifest YAML and loads the shared DB
3. Per-instance tools and schemas are cached and injected into the state machine (PENDING → GENERATING → PROCESSING_TOOLS)
4. Users only need manifest YAML + dataset `extra_info` — zero Python code required

### API and Usage Example

**Config** — add `tool_env_manifest_path` to the rollout multi-turn config:
```yaml
# In your training config
actor_rollout_ref:
  rollout:
    multi_turn:
      tool_env_manifest_path: config/tool_env_manifest.yaml
```

**Manifest YAML** — maps `tool_env_id` to tool configs:
```yaml
# tool_env_manifest.yaml
tool_envs:
  inventory_env:
    tool_config_path: config/tool_config/inventory_tool_config.yaml
  bank_env:
    tool_config_path: config/tool_config/bank_tool_config.yaml
```

**Dataset** — each row carries per-instance info in `extra_info`:
```python
extra_info = {
    "tool_env_id": "inventory_env",   # selects tool set from manifest
    "db_path": "sample_dbs/inv.json", # per-instance stateful DB
}
```

No subclass or custom Python code needed.

### Design & Code Changes

**Core (3 files modified)**:
- `verl/experimental/agent_loop/tool_agent_loop.py` (+132/-4):
  - `_setup_instance()`: reads `tool_env_id` / `db_path` from `extra_info`, resolves manifest, builds tools, loads shared DB
  - `_get_active_tools()` / `_get_active_tool_schemas()`: per-instance tool access with fallback to global tools
  - `_resolve_active_tool_env()`, `_load_tool_env_manifest()`, `_normalize_manifest()`, `_build_tools_from_config()`: manifest resolution and caching
  - `_handle_pending_state()`, `_handle_generating_state()`, `_call_tool()`: updated to use per-instance tools/schemas
- `verl/workers/config/rollout.py` (+1): `tool_env_manifest_path: Optional[str] = None` in `MultiTurnConfig`
- `verl/trainer/config/rollout/rollout.yaml` (+3): `tool_env_manifest_path: null` default

**Example (new directory, ~300 lines)**:
- `examples/sglang_multiturn/multi_env/`: complete working example with inventory/bank tool environments, dataset prep script, training config, sample DBs, run script, and README

**Data flow**:
```
Dataset Row → extra_info.tool_env_id + extra_info.db_path
  ↓
_setup_instance()
├── tool_env_id → manifest → tool_config_path → tools (cached per config)
├── db_path → JSON → extra_fields["shared_db"]
└── extra_fields["active_tools"] / ["active_tool_schemas"]
  ↓
State machine (unchanged): PENDING → GENERATING → PROCESSING_TOOLS → TERMINATED
```
### Test

- `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` — all 12 hooks passed
- `ruff check` and `ruff format --check` passed on all changed files
- `py_compile` passed on all changed Python files