### PR TITLE
[fully_async]fix: terminated training when streaming_generation raise exception

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -572,8 +572,8 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             # Send a finish signal
             await self.message_queue_client.put_sample(sample=None)
 
-        async with self.lock:
-            self.running = False
+            async with self.lock:
+                self.running = False
 
     async def fit(self):
         """


### PR DESCRIPTION
### What does this PR do?

In fully async training, when `_streaming_generation_main` raise exception in `processor_task`, this [block](https://github.com/verl-project/verl/blob/main/verl/experimental/fully_async_policy/fully_async_rollouter.py#L575]) block wouldn't be executed, cause `monitor_task` never stop. 

Simply move it into `finally` block would sovel this problem.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

