### PR TITLE
[rollout] feat: chunk large tensors in bucketed weight transfer

### DIFF
--- a/tests/workers/rollout/rollout_vllm/test_bucketed_weight_transfer.py
+++ b/tests/workers/rollout/rollout_vllm/test_bucketed_weight_transfer.py
@@ -1,0 +1,83 @@
+import asyncio
+import multiprocessing as mp
+import os
+import uuid
+
+import torch
+
+from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver, BucketedWeightSender
+
+
+def run_sender(zmq_handle, original_weights):
+    # Set a tiny bucket size (1MB) to force chunking
+    sender = BucketedWeightSender(zmq_handle=zmq_handle, bucket_size_mb=1, use_shm=True)
+    
+    async def weight_gen():
+        for k, v in original_weights.items():
+            yield k, v
+            
+    asyncio.run(sender.async_send_weights(weight_gen()))
+
+
+def run_receiver(zmq_handle, original_weights, result_queue):
+    # Force use CPU
+    receiver = BucketedWeightReceiver(zmq_handle=zmq_handle, device=torch.device("cpu"), use_shm=True)
+    
+    received_weights = {}
+    
+    def on_received(weights):
+        for name, tensor in weights:
+            received_weights[name] = tensor.clone()
+            
+    receiver.receive_weights(on_received)
+    
+    all_matched = True
+    for name, orig_tensor in original_weights.items():
+        if name not in received_weights:
+            print(f"Missing tensor: {name}")
+            all_matched = False
+            continue
+            
+        recv_tensor = received_weights[name]
+        is_match = torch.allclose(orig_tensor, recv_tensor)
+        print(f"Tensor {name}: shape={orig_tensor.shape}, Match = {is_match}")
+        if not is_match:
+            all_matched = False
+            
+    result_queue.put(all_matched)
+
+
+def test_chunking_large_tensors():
+    unique_id = uuid.uuid4().hex
+    zmq_handle = f"ipc:///tmp/test-zmq-{unique_id}.sock"
+    
+    # 1MB bucket = 1048576 bytes ~ 262144 float32 numbers
+    test_weights = {
+        "small_1": torch.randn((128, 512), dtype=torch.float32),           # 0.25 MB, fits in 1 bucket
+        "large_1": torch.randn((5 * 128, 512), dtype=torch.float32),       # 1.25 MB, spans 2 buckets
+        "large_2": torch.ones((10 * 128, 512), dtype=torch.float32) * 5,   # 2.5 MB, spans 3 buckets
+        "small_2": torch.randn((64, 256), dtype=torch.float32),            # 0.06 MB, fits in bucket
+    }
+    
+    ctx = mp.get_context("spawn")
+    result_queue = ctx.Queue()
+    
+    p_sender = ctx.Process(target=run_sender, args=(zmq_handle, test_weights))
+    p_receiver = ctx.Process(target=run_receiver, args=(zmq_handle, test_weights, result_queue))
+    
+    p_receiver.start()
+    # give receiver a moment to bind/connect
+    import time
+    time.sleep(1)
+    p_sender.start()
+    
+    p_sender.join()
+    p_receiver.join()
+    
+    success = result_queue.get()
+    assert success, "Weight transfer failed to match original tensors."
+    print("All tests passed! Chunked weight transfer is successful.")
+
+
+if __name__ == "__main__":
+    test_chunking_large_tensors()

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -198,12 +198,16 @@ class BucketedWeightSender:
             self.socket = None
         del self.buffer
         self.buffer = None
+        
+        # Explicit python GC to collect any stray tensor views
+        # targeting the shared memory before closing it.
+        gc.collect()
+
         if self.shm is not None:
             self.shm.close()
             self.shm.unlink()
             del self.shm
             self.shm = None
-        gc.collect()
         get_torch_device().ipc_collect()
         get_torch_device().empty_cache()
 
@@ -251,48 +255,59 @@ class BucketedWeightReceiver:
             partial_tensors = {}
             while True:
                 metadata = self.socket.recv_pyobj()
-                weights = []
-                for name, meta in metadata["bucket_meta"].items():
-                    shape, dtype, offset = meta["shape"], meta["dtype"], meta["offset"]
-                    tensor_offset = meta.get("tensor_offset", 0)
-                    chunk_bytes = meta.get("chunk_bytes", dtype.itemsize * shape.numel())
-                    is_complete = meta.get("is_complete", True)
-                    
-                    chunk_tensor = self.buffer[offset : offset + chunk_bytes]
-                    full_size = dtype.itemsize * shape.numel()
-                    
-                    # Optimization: if the tensor is complete in one chunk, avoid extra allocation
-                    if is_complete and chunk_bytes == full_size:
-                        tensor = chunk_tensor.view(dtype=dtype).view(shape)
-                        if self.use_shm:
-                            tensor = tensor.to(self.device)
-                        weights.append((name, tensor))
-                        continue
-
-                    if name not in partial_tensors:
-                        # allocate an empty tensor on the target device
-                        partial_tensors[name] = torch.empty(shape, dtype=dtype, device=self.device)
-
-                    partial_1d = partial_tensors[name].view(-1).view(torch.uint8)
-                    if not self.use_shm:
-                        partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(chunk_tensor, non_blocking=True)
-                    else:
-                        t = chunk_tensor.to(self.device, non_blocking=True)
-                        partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(t)
-
-                    if is_complete:
-                        weights.append((name, partial_tensors.pop(name)))
-
-                if weights:
-                    on_bucket_received(weights)
-                    
-                get_torch_device().synchronize()
-                self.socket.send(b"")
-                del weights
+                self._process_bucket(metadata, partial_tensors, on_bucket_received)
                 if metadata["is_last"]:
                     break
         finally:
             self._cleanup()
+
+    def _process_bucket(self, metadata, partial_tensors, on_bucket_received):
+        """Process a single bucket in a separate method to ensure local variables 
+        (e.g., tensor views holding shm references) go out of scope immediately."""
+        weights = []
+        for name, meta in metadata["bucket_meta"].items():
+            shape, dtype, offset = meta["shape"], meta["dtype"], meta["offset"]
+            tensor_offset = meta.get("tensor_offset", 0)
+            chunk_bytes = meta.get("chunk_bytes", dtype.itemsize * shape.numel())
+            is_complete = meta.get("is_complete", True)
+            
+            chunk_tensor = self.buffer[offset : offset + chunk_bytes]
+            full_size = dtype.itemsize * shape.numel()
+            
+            # Optimization: if the tensor is complete in one chunk, avoid extra allocation
+            if is_complete and chunk_bytes == full_size:
+                tensor = chunk_tensor.view(dtype=dtype).view(shape)
+                if self.use_shm:
+                    tensor = tensor.to(self.device)
+                    # If device is CPU, `.to()` doesn't copy and still holds the shm buffer pointer.
+                    # Force clone to detatch shared memory in local/CPU testing mode.
+                    if tensor.device.type == "cpu":
+                        tensor = tensor.clone()
+                else: 
+                    tensor = tensor.clone()
+
+                weights.append((name, tensor))
+                continue
+
+            if name not in partial_tensors:
+                # allocate an empty tensor on the target device
+                partial_tensors[name] = torch.empty(shape, dtype=dtype, device=self.device)
+
+            partial_1d = partial_tensors[name].view(-1).view(torch.uint8)
+            if not self.use_shm:
+                partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(chunk_tensor, non_blocking=True)
+            else:
+                t = chunk_tensor.to(self.device, non_blocking=True)
+                partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(t)
+
+            if is_complete:
+                weights.append((name, partial_tensors.pop(name)))
+
+        if weights:
+            on_bucket_received(weights)
+            
+        get_torch_device().synchronize()
+        self.socket.send(b"")
 
     def _init_socket(self):
         """Initialize ZMQ REP socket and connect."""
@@ -325,10 +340,14 @@ class BucketedWeightReceiver:
         get_torch_device().synchronize()
         del self.buffer
         self.buffer = None
+        
+        # Explicit python GC to collect any stray tensor views
+        # targeting the shared memory before closing it.
+        gc.collect()
+
         if self.shm is not None:
             self.shm.close()
             del self.shm
             self.shm = None
-        gc.collect()
         get_torch_device().ipc_collect()
         get_torch_device().empty_cache()

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -117,34 +117,45 @@ class BucketedWeightSender:
             bucket_meta: dict[str, TensorMetadata] = {}
             # dtype = PrecisionType.to_dtype(self.config.dtype)
             async for name, weight in ensure_async_iterator(weights):
-                # model parameters are in fp32 full precision
-                # (vermouth1992) we should not force cast weight here because some parameters
-                # (such as moe gate) have to keep fp32 precision. If a weight is bf16 in the rollout side,
-                # the rollout should automatically cast on demand. However, this would incur a higher weight
-                # transfer volume.
-                # weight = weight.to(dtype, non_blocking=True)
+                weight_bytes = weight.view(-1).view(torch.uint8)
+                tensor_bytes = weight.nbytes
+                tensor_offset = 0
 
-                # fill the tensor bucket
-                if offset + weight.nbytes > self.bucket_size:
-                    get_torch_device().synchronize()
-                    self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
-                    self.socket.recv()
-                    bucket_meta = {}
-                    offset = 0
+                while tensor_offset < tensor_bytes:
+                    chunk_bytes = min(tensor_bytes - tensor_offset, self.bucket_size - offset)
+                    
+                    if chunk_bytes == 0:
+                        get_torch_device().synchronize()
+                        self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
+                        self.socket.recv()
+                        bucket_meta = {}
+                        offset = 0
+                        chunk_bytes = min(tensor_bytes - tensor_offset, self.bucket_size - offset)
 
-                # TODO: slice embedding layer weight into chunks
-                assert offset + weight.nbytes <= self.bucket_size, (
-                    f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
-                    f"Please increase rollout.update_weights_bucket_megabytes({self.bucket_size_mb} MB)."
-                )
-                bucket_meta[name] = {
-                    "name": name,
-                    "shape": weight.shape,
-                    "dtype": weight.dtype,
-                    "offset": offset,
-                }
-                self.buffer[offset : offset + weight.nbytes].copy_(weight.view(-1).view(torch.uint8), non_blocking=True)
-                offset += weight.nbytes
+                    bucket_meta[name] = {
+                        "name": name,
+                        "shape": weight.shape,
+                        "dtype": weight.dtype,
+                        "tensor_offset": tensor_offset,
+                        "offset": offset,
+                        "chunk_bytes": chunk_bytes,
+                        "is_complete": tensor_offset + chunk_bytes == tensor_bytes
+                    }
+                    
+                    self.buffer[offset : offset + chunk_bytes].copy_(
+                        weight_bytes[tensor_offset : tensor_offset + chunk_bytes], non_blocking=True
+                    )
+                    
+                    offset += chunk_bytes
+                    tensor_offset += chunk_bytes
+                    
+                    # If bucket is entirely full but tensor is not fully written, flush it
+                    if offset == self.bucket_size and tensor_offset < tensor_bytes:
+                        get_torch_device().synchronize()
+                        self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
+                        self.socket.recv()
+                        bucket_meta = {}
+                        offset = 0
 
             # send the last bucket
             get_torch_device().synchronize()
@@ -237,20 +248,47 @@ class BucketedWeightReceiver:
             self._init_buffer()
 
             # receive bucket and update weights
+            partial_tensors = {}
             while True:
                 metadata = self.socket.recv_pyobj()
-                weights, tensor = [], None
+                weights = []
                 for name, meta in metadata["bucket_meta"].items():
                     shape, dtype, offset = meta["shape"], meta["dtype"], meta["offset"]
-                    size = dtype.itemsize * shape.numel()
-                    tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
-                    if self.use_shm:
-                        tensor = tensor.to(self.device)
-                    weights.append((name, tensor))
-                on_bucket_received(weights)
+                    tensor_offset = meta.get("tensor_offset", 0)
+                    chunk_bytes = meta.get("chunk_bytes", dtype.itemsize * shape.numel())
+                    is_complete = meta.get("is_complete", True)
+                    
+                    chunk_tensor = self.buffer[offset : offset + chunk_bytes]
+                    full_size = dtype.itemsize * shape.numel()
+                    
+                    # Optimization: if the tensor is complete in one chunk, avoid extra allocation
+                    if is_complete and chunk_bytes == full_size:
+                        tensor = chunk_tensor.view(dtype=dtype).view(shape)
+                        if self.use_shm:
+                            tensor = tensor.to(self.device)
+                        weights.append((name, tensor))
+                        continue
+
+                    if name not in partial_tensors:
+                        # allocate an empty tensor on the target device
+                        partial_tensors[name] = torch.empty(shape, dtype=dtype, device=self.device)
+
+                    partial_1d = partial_tensors[name].view(-1).view(torch.uint8)
+                    if not self.use_shm:
+                        partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(chunk_tensor, non_blocking=True)
+                    else:
+                        t = chunk_tensor.to(self.device, non_blocking=True)
+                        partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(t)
+
+                    if is_complete:
+                        weights.append((name, partial_tensors.pop(name)))
+
+                if weights:
+                    on_bucket_received(weights)
+                    
                 get_torch_device().synchronize()
                 self.socket.send(b"")
-                del weights, tensor
+                del weights
                 if metadata["is_last"]:
                     break
         finally:

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -294,11 +294,7 @@ class BucketedWeightReceiver:
                 partial_tensors[name] = torch.empty(shape, dtype=dtype, device=self.device)
 
             partial_1d = partial_tensors[name].view(-1).view(torch.uint8)
-            if not self.use_shm:
-                partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(chunk_tensor, non_blocking=True)
-            else:
-                t = chunk_tensor.to(self.device, non_blocking=True)
-                partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(t)
+            partial_1d[tensor_offset : tensor_offset + chunk_bytes].copy_(chunk_tensor, non_blocking=True)
 
             if is_complete:
                 weights.append((name, partial_tensors.pop(name)))


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

This PR resolves an issue in the vLLM Rollout where the process crashes if a single model weight (Tensor) exceeds the pre-configured shared memory bucket limit (`update_weights_bucket_megabytes`). 
By introducing a **Chunked Weight Transfer** mechanism, the sender now automatically slices oversized tensors into multiple chunks to fit the bucket size, and the receiver caches and reassembles these chunks. This removes the restriction that forced users to manually increase the bucket size for large models.

Related Issue: Fixes #5836

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [is:pr is:open weight transfer bucket] No similar PRs found.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - Suggested PR title: `[vllm, rollout] fix: support chunked weight transfer for large tensors`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

Validated the correct chunking and reassembly of both small tensors and large tensors that span across multiple buckets via a new unit test. All tests passed successfully:

```bash
root@f228dd876cae:/workspace/verl_woo# python tests/workers/rollout/rollout_vllm/test_bucketed_weight_transfer.py 
Tensor small_1: shape=torch.Size([128, 512]), Match = True
Tensor large_1: shape=torch.Size([640, 512]), Match = True
Tensor large_2: shape=torch.Size([1280, 512]), Match = True
Tensor small_2: shape=torch.Size([64, 256]), Match = True
All tests passed! Chunked weight transfer is successful.