### PR TITLE
[perf] feat: simplify precision_debugger config behavior and docs

### DIFF
--- a/docs/ascend_tutorial/profiling/precision_debugger.md
+++ b/docs/ascend_tutorial/profiling/precision_debugger.md
@@ -1,25 +1,31 @@
 # Precision Debugger (msprobe) in verl
 
-Last updated: 03/28/2026.
+Last updated: 04/13/2026.
 
 This guide explains how to collect precision data in verl using the
 `msprobe` PrecisionDebugger.
 
 ## Prerequisites
 
-* Install `msprobe` in the training environment.
+* Install `msprobe` in the training environment:
+
+```bash
+pip install mindstudio-probe
+```
+
 * Prepare a `config.json` for msprobe (see examples below).
-* Enable profiler for the roles you want to collect. PrecisionDebugger only
-  runs on roles whose `profiler.enable=True` and whose rank matches
-  `profiler.ranks`.
+* Enable profiler for the roles you want to collect.
+
+Reference:
+* `https://gitcode.com/Ascend/msprobe.git`
 
 ## Configuration
 
 PrecisionDebugger is integrated through verl's unified profiler interface.
-You configure it in two places:
+Use a minimal two-part setup:
 
-* **Global profiling control** via `global_profiler` in the trainer config.
-* **Role profiling control** via each role's `profiler` block.
+* `global_profiler` selects the tool and config file.
+* role `profiler.enable=True` turns on profiling for that role.
 
 ### Global profiling control
 
@@ -30,14 +36,11 @@ configure the msprobe-specific options under `global_tool_config`.
 global_profiler:
   tool: precision_debugger
   steps: [1, 2, 5]
-  save_path: "outputs/profile" # optional, not used by msprobe
+  save_path: "outputs/profile"
   global_tool_config:
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: True
       config_path: /path/to/config.json
-      data_dir: outputs/precision_debug
-      steps: [1, 2, 5]
       stages:
         - actor_update
         - actor_compute_log_prob
@@ -50,12 +53,10 @@ global_profiler:
 
 Notes:
 
-* `steps` in `global_profiler` controls the step window for start/stop.
-* `precision_debugger.steps` provides an extra filter. If both are set,
-  the intersection is applied.
-* `data_dir` is the root directory for dumps. The actual path is
-  `{data_dir}/step_{global_step}/{stage}`.
-* `save_path` is ignored by msprobe.
+* `global_profiler.steps` is the only step filter for PrecisionDebugger.
+* Dumps are written under `global_profiler.save_path`.
+* Actual dump path is `{global_profiler.save_path}/step_{global_step}/{stage}`.
+* Do not set `dump_path` in `config.json`; output path is controlled by verl.
 
 ### Role profiling control
 
@@ -66,29 +67,13 @@ actor_rollout_ref:
   actor:
     profiler:
       enable: True
-      all_ranks: False
-      ranks: [0]
   ref:
     profiler:
       enable: True
-      all_ranks: False
-      ranks: [0]
 critic:
   profiler:
     enable: True
-    all_ranks: False
-    ranks: [0]
 ```
-
-If you want to provide an explicit per-role msprobe config, add
-`profiler.tool_config.precision_debugger` for each enabled role. In practice,
-the most important fields are:
-
-* `config_path`
-* `data_dir`
-* `steps`
-* `stages`
-* `strict`
 
 ## Supported stages
 
@@ -112,14 +97,13 @@ run, the most common useful combinations are:
   `actor_compute_log_prob`, `ref_compute_log_prob`, `compute_values`,
   `critic_update`, `actor_update`
 
-## msprobe config.json examples
+## msprobe config.json common examples
 
-Example for `task: statistics`:
+### `statistics` mode
 
 ```json
 {
   "task": "statistics",
-  "dump_path": "/home/data_dump",
   "rank": [],
   "step": [],
   "level": "L1",
@@ -134,12 +118,11 @@ Example for `task: statistics`:
 }
 ```
 
-Example for `task: tensor`:
+### `tensor` mode
 
 ```json
 {
   "task": "tensor",
-  "dump_path": "/home/data_dump",
   "rank": [],
   "step": [],
   "level": "L1",
@@ -157,8 +140,8 @@ Example for `task: tensor`:
 
 ## Minimal example
 
-The following example enables PrecisionDebugger on steps `1` and `2` for rank
-`0`:
+The following example enables PrecisionDebugger on steps `1` and `2`.
+If you need rank filtering, configure it only in msprobe `config.json`.
 
 ```yaml
 global_profiler:
@@ -167,10 +150,7 @@ global_profiler:
   global_tool_config:
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: True
       config_path: /path/to/dump_config.json
-      data_dir: outputs/precision_debug
-      steps: [1, 2]
       stages:
         - actor_compute_log_prob
         - ref_compute_log_prob
@@ -181,11 +161,29 @@ actor_rollout_ref:
   actor:
     profiler:
       enable: True
-      ranks: [0]
   ref:
     profiler:
       enable: True
-      ranks: [0]
+```
+
+## Minimal CLI example
+
+Use only the required flags:
+
+```bash
+python3 -m verl.trainer.main_ppo \
+  global_profiler.tool=precision_debugger \
+  global_profiler.steps='[1,2]' \
+  global_profiler.save_path=outputs/profile \
+  +global_profiler.global_tool_config.precision_debugger.config_path=/path/to/config.json \
+  actor_rollout_ref.actor.profiler.enable=True \
+  actor_rollout_ref.ref.profiler.enable=True
+```
+
+Optional stage filter:
+
+```bash
++global_profiler.global_tool_config.precision_debugger.stages='[actor_compute_log_prob,ref_compute_log_prob,actor_update]'
 ```
 
 ## Output layout
@@ -196,7 +194,7 @@ Inside each stage directory, msprobe creates its own `step*/rank*` layout.
 Example:
 
 ```text
-outputs/precision_debug/
+outputs/profile/
   step_1/
     actor_compute_log_prob/step0/rank0/dump.json
     actor_update/step0/rank0/dump.json
@@ -336,6 +334,17 @@ documentation for compare and visualization commands.
 * Because dump cost is high, prefer collecting a small number of representative
   steps first, then narrow the stage set if necessary.
 
+## Quality checklist
+
+Use this checklist to verify your setup is complete and reproducible:
+
+* `global_profiler.tool=precision_debugger`
+* `global_profiler.steps` includes the target step
+* `+global_profiler.global_tool_config.precision_debugger.config_path=...` is set
+* role `profiler.enable=True` is set for the stages you need
+* `msprobe` is importable in the runtime environment
+* output exists under `{global_profiler.save_path}/step_<global_step>/<stage>/...`
+
 ## Troubleshooting
 
 ### No dump directory is generated
@@ -345,7 +354,6 @@ Check:
 * `global_profiler.tool=precision_debugger`
 * `global_profiler.steps` contains the target step
 * role profiler is enabled for the target role
-* current rank is included in `profiler.ranks`
 * msprobe is installed in the training environment
 
 ### `PrecisionDebugger model not resolved`

--- a/verl/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl/trainer/config/_generated_diffusion_trainer.yaml
@@ -126,6 +126,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -181,6 +187,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -339,6 +351,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+          steps: null
+          stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+          strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false
@@ -517,6 +535,12 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+      precision_debugger:
+        _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+        config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+        steps: null
+        stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+        strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   forward_micro_batch_size: ${oc.select:.ppo_micro_batch_size,null}
   forward_micro_batch_size_per_gpu: ${oc.select:.ppo_micro_batch_size_per_gpu,null}
   ulysses_sequence_parallel_size: 1

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -146,6 +146,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -195,6 +201,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -359,6 +371,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+          steps: null
+          stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+          strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false
@@ -591,6 +609,12 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+      precision_debugger:
+        _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+        config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+        steps: null
+        stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+        strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   nccl_timeout: 600
   load_weight: true
   model:
@@ -873,9 +897,7 @@ global_profiler:
       kw_args: {}
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: false
       config_path: null
-      data_dir: outputs/precision_debug
       steps: null
       stages: null
       strict: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -117,6 +117,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -207,6 +213,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -326,6 +338,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+          steps: null
+          stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+          strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false
@@ -529,6 +547,12 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+      precision_debugger:
+        _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+        config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+        steps: null
+        stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+        strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   model:
     _target_: verl.workers.config.HFModelConfig
     path: ~/models/deepseek-llm-7b-chat
@@ -809,9 +833,7 @@ global_profiler:
       kw_args: {}
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: false
       config_path: null
-      data_dir: outputs/precision_debug
       steps: null
       stages: null
       strict: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -126,6 +126,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -181,6 +187,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -335,6 +347,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+          steps: null
+          stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+          strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false
@@ -547,6 +565,12 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+      precision_debugger:
+        _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+        config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+        steps: null
+        stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+        strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   forward_micro_batch_size: ${oc.select:.ppo_micro_batch_size,null}
   forward_micro_batch_size_per_gpu: ${oc.select:.ppo_micro_batch_size_per_gpu,null}
   ulysses_sequence_parallel_size: 1
@@ -831,9 +855,7 @@ global_profiler:
       kw_args: {}
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: false
       config_path: null
-      data_dir: outputs/precision_debug
       steps: null
       stages: null
       strict: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -115,6 +115,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -163,6 +169,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchMemoryToolConfig
           trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
           stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+          steps: null
+          stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+          strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
     router_replay:
       _target_: verl.workers.config.RouterReplayConfig
       mode: disabled
@@ -305,6 +317,12 @@ actor_rollout_ref:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.contents,[]}
           discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
+        precision_debugger:
+          _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+          config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+          steps: null
+          stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+          strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
     prometheus:
       _target_: verl.workers.config.PrometheusConfig
       enable: false
@@ -506,6 +524,12 @@ critic:
         _target_: verl.utils.profiler.config.TorchMemoryToolConfig
         trace_alloc_max_entries: ${oc.select:global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries,100000}
         stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+      precision_debugger:
+        _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+        config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+        steps: null
+        stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+        strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   model:
     _target_: verl.workers.config.HFModelConfig
     path: ~/models/deepseek-llm-7b-chat
@@ -786,9 +810,7 @@ global_profiler:
       kw_args: {}
     precision_debugger:
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
-      enable: false
       config_path: null
-      data_dir: outputs/precision_debug
       steps: null
       stages: null
       strict: false

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -240,6 +240,26 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+    # msprobe precision debugger config
+    precision_debugger:
+
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+
+      # Path to msprobe config json
+      config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+
+      # Deprecated and ignored. Use global_profiler.steps.
+      steps: null
+
+      # Profile stages
+      # Supported stages: actor_update, actor_compute_log_prob, ref_compute_log_prob,
+      # compute_values, critic_update, compute_rm_score
+      stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+
+      # Whether to fail on unknown stage or missing msprobe
+      strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
+
 # Router replay configuration for MoE models
 router_replay:
 

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -159,4 +159,24 @@ profiler:
 
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
+
+    # msprobe precision debugger config
+    precision_debugger:
+
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+
+      # Path to msprobe config json
+      config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+
+      # Deprecated and ignored. Use global_profiler.steps.
+      steps: null
+
+      # Profile stages
+      # Supported stages: actor_update, actor_compute_log_prob, ref_compute_log_prob,
+      # compute_values, critic_update, compute_rm_score
+      stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+
+      # Whether to fail on unknown stage or missing msprobe
+      strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
       

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -297,16 +297,10 @@ global_profiler:
       # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
       _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
 
-      # Enable msprobe precision debugger
-      enable: False
-
       # Path to msprobe config json
       config_path: null
 
-      # Data directory for msprobe dumps
-      data_dir: "outputs/precision_debug"
-
-      # Profile steps
+      # Deprecated and ignored. Use global_profiler.steps.
       steps: null
 
       # Profile stages

--- a/verl/trainer/config/profiler/profiler.yaml
+++ b/verl/trainer/config/profiler/profiler.yaml
@@ -76,17 +76,11 @@ tool_config:
     # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
     _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
 
-    # Enable msprobe precision debugger
-    enable: ${oc.select:global_profiler.global_tool_config.precision_debugger.enable,False}
-
     # Path to msprobe config json
     config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
 
-    # Data directory for msprobe dumps
-    data_dir: ${oc.select:global_profiler.global_tool_config.precision_debugger.data_dir,"outputs/precision_debug"}
-
-    # Profile steps
-    steps: ${oc.select:global_profiler.global_tool_config.precision_debugger.steps,null}
+    # Deprecated and ignored. Use global_profiler.steps.
+    steps: null
 
     # Profile stages
     stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}

--- a/verl/trainer/config/ref/ref.yaml
+++ b/verl/trainer/config/ref/ref.yaml
@@ -100,6 +100,26 @@ profiler:
       # Stack trace depth for memory allocations
       stack_depth: ${oc.select:global_profiler.global_tool_config.torch_memory.stack_depth,32}
 
+    # msprobe precision debugger config
+    precision_debugger:
+
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+
+      # Path to msprobe config json
+      config_path: ${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}
+
+      # Deprecated and ignored. Use global_profiler.steps.
+      steps: null
+
+      # Profile stages
+      # Supported stages: actor_update, actor_compute_log_prob, ref_compute_log_prob,
+      # compute_values, critic_update, compute_rm_score
+      stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
+
+      # Whether to fail on unknown stage or missing msprobe
+      strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
+
 # Router replay configuration for MoE models
 router_replay:
 

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -397,6 +397,26 @@ profiler:
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.torch.discrete,false}
 
+    # msprobe precision debugger config
+    precision_debugger:
+
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl.utils.profiler.config.PrecisionDebuggerToolConfig
+
+      # Path to msprobe config json
+      config_path: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.config_path,${oc.select:global_profiler.global_tool_config.precision_debugger.config_path,null}}
+
+      # Deprecated and ignored. Use global_profiler.steps.
+      steps: null
+
+      # Profile stages
+      # Supported stages: actor_update, actor_compute_log_prob, ref_compute_log_prob,
+      # compute_values, critic_update, compute_rm_score
+      stages: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.stages,${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}}
+
+      # Whether to fail on unknown stage or missing msprobe
+      strict: ${oc.select:actor_rollout_ref.actor.profiler.tool_config.precision_debugger.strict,${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}}
+
 # prometheus configuration for vllm/sglang server mode
 prometheus:
 

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -84,9 +84,9 @@ class PrecisionDebuggerToolConfig(BaseConfig):
     """Precision debugger tool config (msprobe)."""
 
     name: str = "precision_debugger"
-    enable: bool = False
     config_path: Optional[str] = None
-    data_dir: str = "outputs/precision_debug"
+    # Deprecated: precision_debugger no longer maintains an independent step filter.
+    # Collection window is controlled by global_profiler.steps.
     steps: Optional[list[int]] = None
     # Supported stages:
     # actor_update, actor_compute_log_prob, ref_compute_log_prob,
@@ -95,10 +95,8 @@ class PrecisionDebuggerToolConfig(BaseConfig):
     strict: bool = False
 
     def __post_init__(self) -> None:
-        assert isinstance(self.enable, bool), f"enable must be bool, got {type(self.enable)}"
         if self.config_path is not None:
             assert isinstance(self.config_path, str), f"config_path must be str, got {type(self.config_path)}"
-        assert isinstance(self.data_dir, str), f"data_dir must be str, got {type(self.data_dir)}"
         if self.steps is not None:
             assert isinstance(self.steps, list), f"steps must be list[int], got {type(self.steps)}"
         if self.stages is not None:

--- a/verl/utils/profiler/precision_debugger_profile.py
+++ b/verl/utils/profiler/precision_debugger_profile.py
@@ -68,14 +68,19 @@ _SKIP_STAGES = {"rollout_generate"}
 class PrecisionDebuggerProfiler:
     """Minimal msprobe PrecisionDebugger integration."""
 
-    def __init__(self, precision_cfg, rank: Optional[int] = None):
+    def __init__(self, precision_cfg, rank: Optional[int] = None, save_path: Optional[str] = None):
         self.rank = rank
         self.precision_cfg = self._normalize_config(precision_cfg)
-        self._enabled = bool(self.precision_cfg.enable)
         self._available = is_msprobe_available()
         self._debugger = None
         self._stages = self._normalize_stages(self.precision_cfg.stages)
         self._current_global_step = None
+        self._dump_root = save_path or "outputs/profile"
+        if self.precision_cfg.steps is not None:
+            logger.warning(
+                "`precision_debugger.steps` is deprecated and ignored. "
+                "Use `global_profiler.steps` to control profiling steps."
+            )
 
     @staticmethod
     def _normalize_config(precision_cfg) -> PrecisionDebuggerToolConfig:
@@ -149,8 +154,6 @@ class PrecisionDebuggerProfiler:
         return self._current_global_step
 
     def _should_collect(self, stage: str, global_step: Optional[int]) -> bool:
-        if not self._enabled:
-            return False
         if stage in _SKIP_STAGES:
             return False
         if stage not in _STAGE_TO_ROLE:
@@ -161,9 +164,6 @@ class PrecisionDebuggerProfiler:
             return False
         if self._stages is not None and stage not in self._stages:
             return False
-        if self.precision_cfg.steps is not None and global_step is not None:
-            if int(global_step) not in set(self.precision_cfg.steps):
-                return False
         return True
 
     def start(self, stage: Optional[str] = None, global_step: Optional[int] = None, model=None, **kwargs) -> bool:
@@ -181,7 +181,7 @@ class PrecisionDebuggerProfiler:
             if self.precision_cfg.strict:
                 raise ImportError("msprobe is not available but precision_debugger.strict is True")
             return False
-        if not self.precision_cfg.config_path or not self.precision_cfg.data_dir:
+        if not self.precision_cfg.config_path or not self._dump_root:
             return False
         if not self._is_valid_model(model):
             msg = f"PrecisionDebugger model not resolved for stage '{stage}'"
@@ -194,7 +194,7 @@ class PrecisionDebuggerProfiler:
             from msprobe.pytorch import PrecisionDebugger
 
             step_tag = f"step_{global_step}" if global_step is not None else "step_unknown"
-            dump_path = os.path.join(self.precision_cfg.data_dir, step_tag, stage)
+            dump_path = os.path.join(self._dump_root, step_tag, stage)
             os.makedirs(dump_path, exist_ok=True)
 
             if self._debugger is None:

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -108,6 +108,11 @@ class DistProfiler:
             # default rank 0 if enabled but ranks unspecified
             self._this_rank = (rank == 0) if self._enable else False
 
+        # precision_debugger delegates rank filtering to msprobe config.json.
+        # Keep verl-side rank gate open when profiler is enabled.
+        if self._tool == "precision_debugger" and self._enable:
+            self._this_rank = True
+
         # TorchMemoryProfiler currently do not support discrete mode.
         self._discrete = getattr(tool_config, "discrete", False) if tool_config else False
 
@@ -129,7 +134,7 @@ class DistProfiler:
         elif self._tool == "precision_debugger":
             from .precision_debugger_profile import PrecisionDebuggerProfiler as _Precision
 
-            self._impl = _Precision(precision_cfg=tool_config, rank=rank)
+            self._impl = _Precision(precision_cfg=tool_config, rank=rank, save_path=config.save_path)
         else:
             # Fallback to a no-op impl
             self._impl = _NoOpProfiler()


### PR DESCRIPTION
## Summary
This PR aligns and simplifies PrecisionDebugger integration and documentation.

### Changes
- Align PrecisionDebugger profiling behavior with global profiler controls.
- Simplify precision_debugger config behavior and usage guidance.
- Improve PrecisionDebugger docs with practical msprobe `config.json` examples (`statistics` and `tensor`) and simple CLI enablement examples.

## Why this is not duplicate work
- Checked existing open PRs for this head/base and did not find an existing open PR from `Tjh-UKN:main` to `verl-project/verl:main`.

## Tests run
- `python -m py_compile verl/utils/profiler/config.py verl/utils/profiler/profile.py verl/utils/profiler/precision_debugger_profile.py`
- Result: pass

fix #5985 

## Test Result
tree /data01/tjh/verl/outputs/precision_debug_SIMP/step_1/
/data01/tjh/verl/outputs/precision_debug_SIMP/step_1/
├── actor_compute_log_prob
│   └── step0
│       ├── rank0
│       │   └── dump.json
│       └── rank1
│           └── dump.json
├── actor_update
│   └── step0
│       ├── rank0
│       │   └── dump.json
│       └── rank1
│           └── dump.json
└── ref_compute_log_prob
    └── step0
        ├── rank0
        │   └── dump.json
        └── rank1
            └── dump.json

12 directories, 6 files