### PR TITLE
[fully_async] feat: enable fully async to log_val_generations

### DIFF
--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -45,6 +45,7 @@ class ValidateMetrics:
 
     timing_raw: dict[str, Any]
     metrics: Optional[dict[str, Any]] = None
+    val_generations: Optional[list[tuple]] = None
 
 
 def prepare_single_generation_data(batch_dict, config) -> DataProto:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -260,12 +260,36 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             self.step_start_time = time.time()
         return timing_raw
 
+    def _maybe_log_val_generations(self, inputs, outputs, scores):
+        """Capture validation generations to send back to trainer instead of logging directly.
+
+        The rollouter process does not have an active wandb session, so we capture the
+        sampled generations and return them via ValidateMetrics to the trainer for logging.
+        """
+        generations_to_log = self.config.trainer.log_val_generations
+        if generations_to_log == 0:
+            self._captured_val_generations = []
+            return
+
+        samples = list(zip(inputs, outputs, scores, strict=True))
+        samples.sort(key=lambda x: x[0])
+
+        rng = np.random.RandomState(42)
+        rng.shuffle(samples)
+
+        self._captured_val_generations = samples[:generations_to_log]
+
     def do_validate(self) -> ValidateMetrics:
         """Run validation and return metrics"""
         timing_raw = {}
+        self._captured_val_generations = []
         with marked_timer("rollouter/validate_time", timing_raw, color="green"):
             val_metrics: dict = self._validate()
-        return ValidateMetrics(timing_raw=timing_raw, metrics=val_metrics)
+        return ValidateMetrics(
+            timing_raw=timing_raw,
+            metrics=val_metrics,
+            val_generations=self._captured_val_generations,
+        )
 
     async def save_checkpoint(self, local_global_step_folder: str):
         # WARNING!: Due to the asynchronous nature, there are some in-flight samples

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -39,7 +39,7 @@ from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
-from verl.utils.tracking import Tracking
+from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,10 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             experiment_name=self.config.trainer.experiment_name,
             default_backend=self.config.trainer.logger,
             config=OmegaConf.to_container(self.config, resolve=True),
+        )
+        self.validation_generations_logger = ValidationGenerationsLogger(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
         )
 
         # ==================== fully async config ====================
@@ -532,6 +536,28 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         )
         self.metrics_aggregator.reset()
 
+    def _maybe_log_val_generations(self, inputs, outputs, scores):
+        """Capture validation generations for deferred logging in _fit_validate.
+
+        When use_trainer_do_validate=True, the trainer also runs _validate(True) which
+        calls this method. We capture instead of logging immediately so that we can
+        merge with rollouter-side generations and log once with the correct step.
+        """
+        generations_to_log = self.config.trainer.log_val_generations
+        if generations_to_log == 0:
+            self._captured_val_generations = []
+            return
+
+        import numpy as np
+
+        samples = list(zip(inputs, outputs, scores, strict=True))
+        samples.sort(key=lambda x: x[0])
+
+        rng = np.random.RandomState(42)
+        rng.shuffle(samples)
+
+        self._captured_val_generations = samples[:generations_to_log]
+
     async def _validate_process(self):
         """Run trainer-side validation using async rollout manager"""
         if self.config.async_training.use_trainer_do_validate:
@@ -573,6 +599,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         val_future = self.rollouter.do_validate.remote()
 
         # Run trainer-side validation
+        self._captured_val_generations = []
         train_val_metrics = await self._validate_process()
 
         # Wait for rollouter validation result and log
@@ -595,6 +622,23 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
                     f"Validation metrics: {val_metrics.metrics}"
                 )
         self.logger.log(data=val_metrics.timing_raw, step=self.current_param_version)
+
+        # Merge and log validation generations from rollouter (and trainer if applicable)
+        generations_to_log = self.config.trainer.log_val_generations
+        if generations_to_log > 0:
+            import numpy as np
+
+            all_generations = list(self._captured_val_generations)
+            if val_metrics.val_generations:
+                all_generations.extend(val_metrics.val_generations)
+            if all_generations:
+                all_generations.sort(key=lambda x: x[0])
+                rng = np.random.RandomState(42)
+                rng.shuffle(all_generations)
+                all_generations = all_generations[:generations_to_log]
+                self.validation_generations_logger.log(
+                    self.config.trainer.logger, all_generations, self.current_param_version
+                )
 
     def _fit_save_checkpoint(self, force=False):
         if self.current_param_version == self.last_ckpt_version:


### PR DESCRIPTION
### What does this PR do?

> Enable log_val_generations in fully async training

1. `FullyAsyncRollouter` does validation in fully async training but it does not initialize wandb, so `_maybe_log_val_generations` fails.
2. If `use_trainer_do_validate=True` and `log_val_generations > 0`, AttributeError is raised.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
