### PR TITLE
[megatron] fix: correct CP>1 batch_num_tokens aggregation in engine path

### DIFF
--- a/tests/workers/engine/run_megatron_engine_cp_loss_norm.sh
+++ b/tests/workers/engine/run_megatron_engine_cp_loss_norm.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Megatron engine loss normalization — CP>1 smoke test.
+#
+# Validates that batch_num_tokens is all-reduced over DP×CP (not just DP)
+# in the modern engine path (MegatronEngine.forward_backward_batch).
+#
+# Default: 1 node × 8 GPUs  (TP=1, PP=2, CP=2, DP=2)
+#
+# Usage:
+#   bash tests/workers/engine/run_megatron_engine_cp_loss_norm.sh
+#
+# Override parallelism:
+#   NPROC_PER_NODE=4 ACTOR_PP=1 ACTOR_CP=2 \
+#       bash tests/workers/engine/run_megatron_engine_cp_loss_norm.sh
+#
+# Environment variables:
+#   NPROC_PER_NODE   — GPUs per node            (default: 8)
+#   ACTOR_TP         — tensor parallelism       (default: 1)
+#   ACTOR_PP         — pipeline parallelism     (default: 2)
+#   ACTOR_CP         — context parallelism      (default: 2)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+ACTOR_TP="${ACTOR_TP:-1}"
+ACTOR_PP="${ACTOR_PP:-2}"
+ACTOR_CP="${ACTOR_CP:-2}"
+
+WORLD_SIZE=$((NPROC_PER_NODE))
+DP_SIZE=$((WORLD_SIZE / (ACTOR_TP * ACTOR_PP * ACTOR_CP)))
+
+echo "=== Megatron Engine CP loss normalization test ==="
+echo "  ${NPROC_PER_NODE} GPUs: TP=${ACTOR_TP} PP=${ACTOR_PP} CP=${ACTOR_CP} DP=${DP_SIZE}"
+echo "=================================================="
+
+export ACTOR_PP ACTOR_TP ACTOR_CP
+
+torchrun \
+    --standalone \
+    --nnodes=1 \
+    --nproc-per-node="$NPROC_PER_NODE" \
+    "${SCRIPT_DIR}/test_special_megatron_engine_cp_loss_norm.py"

--- a/tests/workers/engine/test_special_megatron_engine_cp_loss_norm.py
+++ b/tests/workers/engine/test_special_megatron_engine_cp_loss_norm.py
@@ -1,0 +1,221 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Megatron engine path: batch_num_tokens correctness with CP > 1.
+
+Verifies that MegatronEngine.forward_backward_batch all-reduces
+batch_num_tokens over the DP×CP group (with_context_parallel=True),
+not just the pure DP group.  When CP > 1 each CP rank holds only 1/CP
+of the sequence, so using the pure DP group would undercount tokens by
+a factor of CP, inflating gradients by the same factor.
+
+Usage::
+
+    torchrun --standalone --nnodes=1 --nproc-per-node=8 \
+        tests/workers/engine/test_special_megatron_engine_cp_loss_norm.py
+"""
+
+import os
+
+import megatron.core.parallel_state as mpu
+import torch
+import torch.distributed as dist
+
+from verl.utils.distributed import destroy_global_process_group, initialize_global_process_group
+
+ACTOR_TP = int(os.environ.get("ACTOR_TP", 1))
+ACTOR_PP = int(os.environ.get("ACTOR_PP", 2))
+ACTOR_CP = int(os.environ.get("ACTOR_CP", 2))
+
+MINI_BATCH_SIZE = int(os.environ.get("MINI_BATCH_SIZE", 4))
+RESPONSE_LEN = int(os.environ.get("RESPONSE_LEN", 16))
+SEED = 42
+
+
+class TestBatchNumTokensCPGroup:
+    """batch_num_tokens must be all-reduced over DP×CP for correct loss normalization."""
+
+    def __init__(self):
+        self.local_rank, self.rank, self.world_size = initialize_global_process_group()
+        mpu.initialize_model_parallel(
+            tensor_model_parallel_size=ACTOR_TP,
+            pipeline_model_parallel_size=ACTOR_PP,
+            context_parallel_size=ACTOR_CP,
+        )
+        from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+
+        model_parallel_cuda_manual_seed(SEED)
+
+        self.dp_size = mpu.get_data_parallel_world_size()
+        self.cp_size = mpu.get_context_parallel_world_size()
+        self.dp_cp_size = mpu.get_data_parallel_world_size(with_context_parallel=True)
+        self.device = torch.device(f"cuda:{self.local_rank}")
+
+        if self.rank == 0:
+            print(
+                f"[INFO] Parallel config: TP={ACTOR_TP} PP={ACTOR_PP} CP={ACTOR_CP} "
+                f"DP={self.dp_size} world={self.world_size}"
+            )
+
+    def shutdown(self):
+        destroy_global_process_group()
+
+    # ------------------------------------------------------------------
+    # Test 1: DP×CP all-reduce gives correct global token count
+    # ------------------------------------------------------------------
+    def test_dp_cp_allreduce_gives_global_token_count(self):
+        """All-reducing local token counts over DP×CP must yield the true
+        global total.  This is the group that forward_backward_batch must use."""
+
+        if self.rank == 0:
+            print("[TEST 1] DP×CP all-reduce gives correct global token count")
+
+        tokens_per_cp_rank = MINI_BATCH_SIZE * RESPONSE_LEN // self.cp_size
+        local_tokens = torch.tensor(tokens_per_cp_rank, dtype=torch.float32, device=self.device)
+
+        expected_global = float(self.dp_size * self.cp_size * tokens_per_cp_rank)
+
+        bnt = local_tokens.clone()
+        dist.all_reduce(
+            bnt,
+            op=dist.ReduceOp.SUM,
+            group=mpu.get_data_parallel_group(with_context_parallel=True),
+        )
+
+        if self.rank == 0:
+            print(f"  local tokens/rank    = {tokens_per_cp_rank}")
+            print(f"  DP×CP all-reduce     = {bnt.item()}")
+            print(f"  expected global total = {expected_global}")
+
+        assert bnt.item() == expected_global, f"DP×CP all-reduce gave {bnt.item()}, expected {expected_global}"
+
+        # Sanity: pure DP group gives a different (smaller) result when CP > 1
+        if self.cp_size > 1:
+            bnt_dp_only = local_tokens.clone()
+            dist.all_reduce(
+                bnt_dp_only,
+                op=dist.ReduceOp.SUM,
+                group=mpu.get_data_parallel_group(),
+            )
+            assert bnt_dp_only.item() < expected_global, (
+                f"Sanity check: pure DP all-reduce should be smaller than global "
+                f"total when CP > 1, got {bnt_dp_only.item()} vs {expected_global}"
+            )
+            if self.rank == 0:
+                print(f"  (sanity: pure DP all-reduce = {bnt_dp_only.item()}, which is {self.cp_size}× too small)")
+
+        if self.rank == 0:
+            print("[PASS] test_dp_cp_allreduce_gives_global_token_count\n")
+
+    # ------------------------------------------------------------------
+    # Test 2: agg_loss is correct with DP×CP batch_num_tokens
+    # ------------------------------------------------------------------
+    def test_agg_loss_with_correct_bnt(self):
+        """agg_loss with DP×CP batch_num_tokens must produce the correct
+        token-mean loss (= local_sum / global_tokens * dp_size)."""
+
+        if self.rank == 0:
+            print("[TEST 2] agg_loss correctness with DP×CP batch_num_tokens")
+
+        from verl.trainer.ppo.core_algos import agg_loss
+
+        tokens_per_cp_rank = MINI_BATCH_SIZE * RESPONSE_LEN // self.cp_size
+        expected_global_tokens = float(self.dp_size * self.cp_size * tokens_per_cp_rank)
+
+        torch.manual_seed(SEED)
+        loss_mat = torch.randn(MINI_BATCH_SIZE, RESPONSE_LEN // self.cp_size, device=self.device)
+        loss_mask = torch.ones_like(loss_mat, dtype=torch.bool)
+        local_masked_sum = loss_mat.sum().item()
+
+        loss = agg_loss(
+            loss_mat=loss_mat,
+            loss_mask=loss_mask,
+            loss_agg_mode="token-mean",
+            dp_size=self.dp_size,
+            batch_num_tokens=int(expected_global_tokens),
+        )
+
+        expected_loss = local_masked_sum / expected_global_tokens * self.dp_size
+
+        if self.rank == 0:
+            print(f"  local_sum           = {local_masked_sum:.6f}")
+            print(f"  global_tokens       = {expected_global_tokens}")
+            print(f"  dp_size             = {self.dp_size}")
+            print(f"  agg_loss result     = {loss.item():.6f}")
+            print(f"  expected            = {expected_loss:.6f}")
+
+        torch.testing.assert_close(
+            loss,
+            torch.tensor(expected_loss, device=self.device),
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+        if self.rank == 0:
+            print("[PASS] test_agg_loss_with_correct_bnt\n")
+
+    # ------------------------------------------------------------------
+    # Test 3: engine forward_backward_batch uses DP×CP group
+    # ------------------------------------------------------------------
+    def test_engine_uses_dp_cp_group(self):
+        """MegatronEngine.forward_backward_batch must all-reduce batch_num_tokens
+        over the DP×CP group (with_context_parallel=True)."""
+
+        if self.rank == 0:
+            print("[TEST 3] engine forward_backward_batch must use DP×CP group")
+
+        import inspect
+
+        from verl.workers.engine.megatron.transformer_impl import MegatronEngine
+
+        src = inspect.getsource(MegatronEngine.forward_backward_batch)
+
+        uses_cp_group = "with_context_parallel=True" in src
+
+        if self.rank == 0:
+            if uses_cp_group:
+                print("  forward_backward_batch uses with_context_parallel — correct")
+            else:
+                print("  forward_backward_batch does NOT use with_context_parallel")
+
+        assert uses_cp_group, (
+            "MegatronEngine.forward_backward_batch all-reduces batch_num_tokens "
+            "over mpu.get_data_parallel_group() (pure DP, without CP). "
+            "When CP > 1 this gives a token count that is CP× too small. "
+            "Fix: use mpu.get_data_parallel_group(with_context_parallel=True)."
+        )
+
+        if self.rank == 0:
+            print("[PASS] test_engine_uses_dp_cp_group\n")
+
+
+if __name__ == "__main__":
+    assert int(os.environ.get("WORLD_SIZE", 1)) > 1, (
+        "This test must run in distributed mode with torchrun. "
+        f"Need at least {ACTOR_TP * ACTOR_PP * ACTOR_CP} GPUs "
+        f"(TP={ACTOR_TP} × PP={ACTOR_PP} × CP={ACTOR_CP})."
+    )
+
+    test = TestBatchNumTokensCPGroup()
+    try:
+        test.test_dp_cp_allreduce_gives_global_token_count()
+        test.test_agg_loss_with_correct_bnt()
+        test.test_engine_uses_dp_cp_group()
+
+        if test.rank == 0:
+            print("=" * 60)
+            print("ALL TESTS PASSED")
+            print("=" * 60)
+    finally:
+        test.shutdown()

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -584,9 +584,14 @@ class MegatronEngine(BaseEngine):
         tu.assign_non_tensor(data, sp_size=self.engine_config.context_parallel_size)
 
         # compute num_tokens in global batch for loss normalization
+        # Must all-reduce over DP×CP (with_context_parallel=True) because each
+        # CP rank holds only a 1/CP slice of the sequence.  Using the pure DP
+        # group would undercount tokens by a factor of CP.
         batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
         torch.distributed.all_reduce(
-            batch_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.get_data_parallel_group()
+            batch_num_tokens,
+            op=torch.distributed.ReduceOp.SUM,
+            group=mpu.get_data_parallel_group(with_context_parallel=True),
         )
         tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens.item())
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())

--- a/verl/workers/rollout/trtllm_rollout/__init__.py
+++ b/verl/workers/rollout/trtllm_rollout/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## Summary

This PR fixes a correctness bug in the **Megatron engine path** when `context_parallel_size > 1`.

In `MegatronEngine.forward_backward_batch()`, `batch_num_tokens` is used as the denominator for `loss_agg_mode="token-mean"` normalization. When context parallelism is enabled, each CP rank only owns a **1/CP slice of the sequence**, so `batch_num_tokens` must be aggregated over the **DP×CP group**, not the pure DP group.

Using the pure DP group undercounts valid tokens by a factor of `CP`, which makes token-mean loss normalization incorrect in the engine path for `CP > 1`.

This PR fixes that by reducing `batch_num_tokens` over:

```python
mpu.get_data_parallel_group(with_context_parallel=True)
```

while intentionally keeping `dp_size` equal to **pure DP**.

Closes #5983 
Related to #4852  
Potentially related to #1332

---

## Problem

The Megatron engine path computes:
- `batch_num_tokens`
- `dp_size`

and passes them into downstream loss aggregation.

For `loss_agg_mode="token-mean"`, the intended semantics are:

- `batch_num_tokens` = true valid-token count for the full shard participating in the token-mean denominator
- `dp_size` = pure data parallel size

This is correct for standard DP/TP/PP layouts. However, when `context_parallel_size > 1`, the sequence is partitioned across CP ranks, so each rank only sees a fraction of the valid tokens.

If `batch_num_tokens` is reduced over the **pure DP group**, the token count is smaller than the true global token count by a factor of `CP`. That leads to incorrect normalization and over-scaled loss values.

In practice, for `CP > 1`, the current behavior effectively computes:

```text
batch_num_tokens ≈ true_tokens / CP
```

which makes `token-mean` normalization wrong by construction.

---

## Root cause

The denominator used for token-mean aggregation is gathered over the wrong communication group.

For token counting:
- **incorrect** group: pure DP
- **correct** group: DP×CP

This distinction matters because CP partitions the sequence itself. Each CP rank contributes only a partial token view, so token counting must include the context-parallel dimension.

At the same time, `dp_size` must remain **pure DP**, because `agg_loss(..., loss_agg_mode="token-mean")` expects DP scaling semantics there, not DP×CP scaling.

So the correct combination is:
- `batch_num_tokens`: reduce over **DP×CP**
- `dp_size`: keep as **pure DP**

---

## Fix

This PR changes the `batch_num_tokens` all-reduce in `MegatronEngine.forward_backward_batch()` from the pure DP group to the CP-aware DP×CP group:

```python
torch.distributed.all_reduce(
    batch_num_tokens,
    op=torch.distributed.ReduceOp.SUM,
    group=mpu.get_data_parallel_group(with_context_parallel=True),
)
```

and keeps:

```python
dp_size = self.get_data_parallel_size()
```

unchanged.

This is intentionally a **minimal production change**:
- no refactors
- no algorithm changes
- no changes to non-CP paths
- no changes to user-facing configuration

It only corrects the communication group used for token counting.

---

## Why this fix is correct

When `CP > 1`, each CP rank holds only a partial sequence slice. That means the true token-mean denominator must include all valid tokens across the CP dimension.

Reducing `batch_num_tokens` over DP×CP restores exactly that behavior.

The fix also preserves the existing and intended `agg_loss(...)` contract:
- `batch_num_tokens` reflects the full valid-token count
- `dp_size` reflects pure DP only

That makes the Megatron engine path consistent with the expected semantics of `loss_agg_mode="token-mean"`.

---

## Validation

This PR adds focused distributed coverage for the CP>1 case.

### `tests/workers/engine/test_special_megatron_engine_cp_loss_norm.py`

This test is intentionally narrow and checks three things:

1. **DP×CP token aggregation is the correct denominator**
   - verifies that all-reducing over DP×CP yields the true global token count
   - verifies that pure-DP reduction is too small when `CP > 1`

2. **`agg_loss(..., loss_agg_mode="token-mean")` behaves correctly once the denominator is correct**
   - validates the expected normalization math directly

3. **The engine path uses the CP-aware group in `forward_backward_batch()`**
   - acts as a regression marker for the exact CP-specific behavior fixed in this PR

### `tests/workers/engine/run_megatron_engine_cp_loss_norm.sh`

A simple manual smoke script is included to make the reproducer easy to run under `torchrun`.

The script is intentionally lightweight and targeted at this exact bug, so reviewers and future contributors can validate the behavior without needing a full training recipe or model checkpoint.

---

## Why this PR is useful for upstream

This is a **small correctness fix** in an actively maintained path:
- it affects the **modern Megatron engine path**
- it is directly relevant to users running with `context_parallel_size > 1`
- it improves loss-normalization correctness rather than changing behavior for unrelated configurations

It also complements existing engine-path normalization discussions such as #4852 by adding a focused fix and targeted coverage for a specific CP-related failure mode.

In short, this PR:
- fixes a real normalization bug
- keeps the production diff minimal
- adds narrowly scoped regression coverage for the exact issue being fixed

---

## Scope

This PR is intentionally limited to:
- the Megatron **engine path**
- `CP > 1` token-count normalization
- focused distributed validation

It does **not** include:
- legacy worker changes
- FSDP changes
- rollout changes
- unrelated refactors
- broad Megatron behavior changes outside the token-count aggregation path

---

## Local validation

The following were used during validation:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always

# manual smoke
bash tests/workers/engine/run_megatron_engine_cp_loss_norm.sh

# direct distributed run
torchrun --standalone --nnodes=1 --nproc_per_node=8 \
  tests/workers/engine/test_special_megatron_engine_cp_loss_norm.py
```

I can narrow or reshape the validation further if maintainers prefer a different test style for engine-path special tests.
