### PR TITLE
[veomni] feat: add DeepSeek-V3 to MOE_PARAM_HANDERS

### DIFF
--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -108,4 +108,5 @@ def _map_moe_params_qwen3_moe(name, tensor):
 
 MOE_PARAM_HANDERS = {
     "qwen3_moe": _map_moe_params_qwen3_moe,
+    "deepseek_v3": _map_moe_params_qwen3_moe,
 }


### PR DESCRIPTION
### What does this PR do?

Add `deepseek_v3` entry to `MOE_PARAM_HANDERS` mapping in `verl/workers/engine/veomni/utils.py`, reusing the existing `_map_moe_params_qwen3_moe` handler since DeepSeek-V3 shares the same MoE parameter mapping logic as Qwen3-MoE.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+deepseek_v3+moe
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

This is a configuration-level change (adding a key to a dictionary mapping). The mapping reuses an existing, tested handler function (`_map_moe_params_qwen3_moe`). No new logic is introduced.

### API and Usage Example

No API changes. DeepSeek-V3 MoE models will now be automatically handled by the veomni engine during parameter mapping.

### Design & Code Changes

- Added `"deepseek_v3": _map_moe_params_qwen3_moe` to the `MOE_PARAM_HANDERS` dict in `verl/workers/engine/veomni/utils.py`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (N/A - no doc changes needed for this config addition)
- [ ] Add unit or end-to-end test(s). Not feasible: this is a single-line dictionary entry addition reusing an existing handler; no new logic to test.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference. (N/A)