### PR TITLE
[trainer,algo] feat: Support On-Policy Distillation in `main_ppo_sync`

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -232,6 +232,14 @@ class AgentLoopOutput(BaseModel):
             rm_scores[-1] = reward_score
             output["rm_scores"] = rm_scores
 
+        teacher_ids, teacher_logprobs = (
+            output["extra_fields"].pop("teacher_ids", None),
+            output["extra_fields"].pop("teacher_logprobs", None),
+        )
+        if teacher_ids is not None:
+            output["teacher_ids"] = teacher_ids
+        if teacher_logprobs is not None:
+            output["teacher_logprobs"] = teacher_logprobs
         return output
 
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1089,8 +1089,6 @@ class AgentLoopManager:
         await instance._initialize_llm_servers()
         await instance._init_global_load_balancer()
         await instance._init_agent_loop_workers()
-        if instance.stream_teacher_with_rollout:
-            await instance.teacher_model_manager.wake_up()
         return instance
 
     async def _initialize_llm_servers(self):
@@ -1191,6 +1189,8 @@ class AgentLoopManager:
         Returns:
             DataProto: Output batch.
         """
+        if self.stream_teacher_with_rollout:
+            await self.teacher_model_manager.wake_up()
         chunkes = prompts.chunk(len(self.agent_loop_workers))
         outputs = await asyncio.gather(
             *[
@@ -1198,7 +1198,8 @@ class AgentLoopManager:
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
             ]
         )
-
+        if self.stream_teacher_with_rollout:
+            await self.teacher_model_manager.sleep()
         output = DataProto.concat(outputs)
 
         # calculate performance metrics

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1089,6 +1089,8 @@ class AgentLoopManager:
         await instance._initialize_llm_servers()
         await instance._init_global_load_balancer()
         await instance._init_agent_loop_workers()
+        if instance.stream_teacher_with_rollout:
+            await instance.teacher_model_manager.wake_up()
         return instance
 
     async def _initialize_llm_servers(self):
@@ -1189,8 +1191,6 @@ class AgentLoopManager:
         Returns:
             DataProto: Output batch.
         """
-        if self.stream_teacher_with_rollout:
-            await self.teacher_model_manager.wake_up()
         chunkes = prompts.chunk(len(self.agent_loop_workers))
         outputs = await asyncio.gather(
             *[
@@ -1198,8 +1198,7 @@ class AgentLoopManager:
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=True)
             ]
         )
-        if self.stream_teacher_with_rollout:
-            await self.teacher_model_manager.sleep()
+
         output = DataProto.concat(outputs)
 
         # calculate performance metrics

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -25,6 +25,7 @@ from verl.experimental.agent_loop import AsyncLLMServerManager
 from verl.protocol import DataProto
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.transferqueue_utils import tqbridge
 from verl.workers.config import DistillationConfig, DistillationLossConfig
 
 
@@ -125,18 +126,35 @@ class AsyncTeacherLLMServerManager(AsyncLLMServerManager):
         assert teacher_ids.shape[0] == teacher_logprobs.shape[0] == len(sequence_ids)
         return teacher_ids, teacher_logprobs
 
-    async def compute_teacher_logprobs_batch(self, data: DataProto) -> DataProto:
+    @tqbridge()
+    async def compute_teacher_logprobs_batch(self, data: DataProto | TensorDict) -> DataProto | TensorDict:
         """Compute teacher log probabilities for a batch of prompt-response pairs."""
+        use_tensordict = isinstance(data, TensorDict)
+        if use_tensordict:
+            prompt_width = int(max(data["prompts"].offsets()[1:] - data["prompts"].offsets()[:-1]))
+            response_width = int(max(data["responses"].offsets()[1:] - data["responses"].offsets()[:-1]))
+            data = DataProto.from_tensordict(data)
+        else:
+            prompt_width = data.batch["prompts"].shape[1]
+            response_width = data.batch["responses"].shape[1]
+
         multi_modal_data_batch = data.non_tensor_batch.get("teacher_multi_modal_data")
         tasks = []
         lengths = []
-        prompt_width = data.batch["prompts"].shape[1]
-        response_width = data.batch["responses"].shape[1]
 
         # Compute logprobs for each sample in the batch
         for i in range(len(data)):
-            item = data[i : i + 1]
-            sequence_ids, prompt_length, response_length = _unpad_teacher_inputs(item)
+            if not use_tensordict:
+                item = data[i : i + 1]
+                sequence_ids, prompt_length, response_length = _unpad_teacher_inputs(item)
+            else:
+                item = data[i]
+                sequence_ids, prompt_length, response_length = (
+                    normalize_token_ids(item.batch["input_ids"]),
+                    len(item.batch["prompts"]),
+                    len(item.batch["responses"]),
+                )
+
             multi_modal_data = None if multi_modal_data_batch is None else multi_modal_data_batch[i]
             lengths.append((prompt_length, response_length))
             tasks.append(
@@ -149,27 +167,43 @@ class AsyncTeacherLLMServerManager(AsyncLLMServerManager):
             )
         outputs = await asyncio.gather(*tasks)
 
-        # Pad the teacher logprobs and ids
-        padded_teacher_ids = []
-        padded_teacher_logprobs = []
-        for (teacher_ids, teacher_logprobs), (prompt_length, response_length) in zip(outputs, lengths, strict=True):
-            padded_ids, padded_logprobs = _pad_teacher_outputs(
-                teacher_ids,
-                teacher_logprobs,
-                prompt_width=prompt_width,
-                response_width=response_width,
-                prompt_length=prompt_length,
-                response_length=response_length,
-                pad_token_id=self.pad_token_id,
-            )
-            padded_teacher_ids.append(padded_ids)
-            padded_teacher_logprobs.append(padded_logprobs)
+        if not use_tensordict:
+            # Pad the teacher logprobs and ids
+            padded_teacher_ids = []
+            padded_teacher_logprobs = []
+            for (teacher_ids, teacher_logprobs), (prompt_length, response_length) in zip(outputs, lengths, strict=True):
+                padded_ids, padded_logprobs = _pad_teacher_outputs(
+                    teacher_ids,
+                    teacher_logprobs,
+                    prompt_width=prompt_width,
+                    response_width=response_width,
+                    prompt_length=prompt_length,
+                    response_length=response_length,
+                    pad_token_id=self.pad_token_id,
+                )
+                padded_teacher_ids.append(padded_ids)
+                padded_teacher_logprobs.append(padded_logprobs)
 
-        batch = TensorDict(
-            {
-                "teacher_ids": torch.cat(padded_teacher_ids),
-                "teacher_logprobs": torch.cat(padded_teacher_logprobs),
-            },
-            batch_size=len(data),
-        )
-        return DataProto(batch=batch)
+            batch = TensorDict(
+                {
+                    "teacher_ids": torch.cat(padded_teacher_ids),
+                    "teacher_logprobs": torch.cat(padded_teacher_logprobs),
+                },
+                batch_size=len(data),
+            )
+            return DataProto(batch=batch)
+        else:
+            all_teacher_ids = []
+            all_teacher_logprobs = []
+            for teacher_ids, teacher_logprobs in outputs:
+                all_teacher_ids.append(teacher_ids)
+                all_teacher_logprobs.append(teacher_logprobs)
+
+            batch = TensorDict(
+                {
+                    "teacher_ids": torch.nested.as_nested_tensor(all_teacher_ids, layout=torch.jagged),
+                    "teacher_logprobs": torch.nested.as_nested_tensor(all_teacher_logprobs, layout=torch.jagged),
+                },
+                batch_size=len(data),
+            )
+            return batch

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -25,7 +25,6 @@ from verl.experimental.agent_loop import AsyncLLMServerManager
 from verl.protocol import DataProto
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.tokenizer import normalize_token_ids
-from verl.utils.transferqueue_utils import tqbridge
 from verl.workers.config import DistillationConfig, DistillationLossConfig
 
 
@@ -126,35 +125,18 @@ class AsyncTeacherLLMServerManager(AsyncLLMServerManager):
         assert teacher_ids.shape[0] == teacher_logprobs.shape[0] == len(sequence_ids)
         return teacher_ids, teacher_logprobs
 
-    @tqbridge()
-    async def compute_teacher_logprobs_batch(self, data: DataProto | TensorDict) -> DataProto | TensorDict:
+    async def compute_teacher_logprobs_batch(self, data: DataProto) -> DataProto:
         """Compute teacher log probabilities for a batch of prompt-response pairs."""
-        use_tensordict = isinstance(data, TensorDict)
-        if use_tensordict:
-            prompt_width = int(max(data["prompts"].offsets()[1:] - data["prompts"].offsets()[:-1]))
-            response_width = int(max(data["responses"].offsets()[1:] - data["responses"].offsets()[:-1]))
-            data = DataProto.from_tensordict(data)
-        else:
-            prompt_width = data.batch["prompts"].shape[1]
-            response_width = data.batch["responses"].shape[1]
-
         multi_modal_data_batch = data.non_tensor_batch.get("teacher_multi_modal_data")
         tasks = []
         lengths = []
+        prompt_width = data.batch["prompts"].shape[1]
+        response_width = data.batch["responses"].shape[1]
 
         # Compute logprobs for each sample in the batch
         for i in range(len(data)):
-            if not use_tensordict:
-                item = data[i : i + 1]
-                sequence_ids, prompt_length, response_length = _unpad_teacher_inputs(item)
-            else:
-                item = data[i]
-                sequence_ids, prompt_length, response_length = (
-                    normalize_token_ids(item.batch["input_ids"]),
-                    len(item.batch["prompts"]),
-                    len(item.batch["responses"]),
-                )
-
+            item = data[i : i + 1]
+            sequence_ids, prompt_length, response_length = _unpad_teacher_inputs(item)
             multi_modal_data = None if multi_modal_data_batch is None else multi_modal_data_batch[i]
             lengths.append((prompt_length, response_length))
             tasks.append(
@@ -167,43 +149,27 @@ class AsyncTeacherLLMServerManager(AsyncLLMServerManager):
             )
         outputs = await asyncio.gather(*tasks)
 
-        if not use_tensordict:
-            # Pad the teacher logprobs and ids
-            padded_teacher_ids = []
-            padded_teacher_logprobs = []
-            for (teacher_ids, teacher_logprobs), (prompt_length, response_length) in zip(outputs, lengths, strict=True):
-                padded_ids, padded_logprobs = _pad_teacher_outputs(
-                    teacher_ids,
-                    teacher_logprobs,
-                    prompt_width=prompt_width,
-                    response_width=response_width,
-                    prompt_length=prompt_length,
-                    response_length=response_length,
-                    pad_token_id=self.pad_token_id,
-                )
-                padded_teacher_ids.append(padded_ids)
-                padded_teacher_logprobs.append(padded_logprobs)
-
-            batch = TensorDict(
-                {
-                    "teacher_ids": torch.cat(padded_teacher_ids),
-                    "teacher_logprobs": torch.cat(padded_teacher_logprobs),
-                },
-                batch_size=len(data),
+        # Pad the teacher logprobs and ids
+        padded_teacher_ids = []
+        padded_teacher_logprobs = []
+        for (teacher_ids, teacher_logprobs), (prompt_length, response_length) in zip(outputs, lengths, strict=True):
+            padded_ids, padded_logprobs = _pad_teacher_outputs(
+                teacher_ids,
+                teacher_logprobs,
+                prompt_width=prompt_width,
+                response_width=response_width,
+                prompt_length=prompt_length,
+                response_length=response_length,
+                pad_token_id=self.pad_token_id,
             )
-            return DataProto(batch=batch)
-        else:
-            all_teacher_ids = []
-            all_teacher_logprobs = []
-            for teacher_ids, teacher_logprobs in outputs:
-                all_teacher_ids.append(teacher_ids)
-                all_teacher_logprobs.append(teacher_logprobs)
+            padded_teacher_ids.append(padded_ids)
+            padded_teacher_logprobs.append(padded_logprobs)
 
-            batch = TensorDict(
-                {
-                    "teacher_ids": torch.nested.as_nested_tensor(all_teacher_ids, layout=torch.jagged),
-                    "teacher_logprobs": torch.nested.as_nested_tensor(all_teacher_logprobs, layout=torch.jagged),
-                },
-                batch_size=len(data),
-            )
-            return batch
+        batch = TensorDict(
+            {
+                "teacher_ids": torch.cat(padded_teacher_ids),
+                "teacher_logprobs": torch.cat(padded_teacher_logprobs),
+            },
+            batch_size=len(data),
+        )
+        return DataProto(batch=batch)

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -110,7 +110,10 @@ def compute_distillation_loss_range(
     distillation_losses: torch.Tensor, response_mask: torch.Tensor
 ) -> dict[str, Metric]:
     """Compute min and max distillation loss over valid response tokens."""
-    distillation_losses_response = distillation_losses[response_mask.bool()]
+    if response_mask.is_nested:
+        distillation_losses_response = distillation_losses[response_mask.bool().to_padded_tensor(False)]
+    else:
+        distillation_losses_response = distillation_losses[response_mask.bool()]
     return {
         "distillation/loss_min": Metric(AggregationType.MIN, distillation_losses_response.min()),
         "distillation/loss_max": Metric(AggregationType.MAX, distillation_losses_response.max()),
@@ -257,6 +260,10 @@ def distillation_loss(
             loss_config.global_batch_info[k] = v
         log_prob = no_padding_2_padding(model_output["log_probs"], data)
         old_log_prob = data["old_log_probs"]
+        if old_log_prob.is_nested:
+            old_log_prob = data["old_log_probs"].to_padded_tensor(0.0)
+        if response_mask.is_nested:
+            response_mask = response_mask.to_padded_tensor(False)
         rollout_is_weights = data.get("rollout_is_weights", None)
         distillation_loss, pg_metrics = policy_loss_fn(
             old_log_prob=old_log_prob,
@@ -271,6 +278,8 @@ def distillation_loss(
         distillation_metrics.update(pg_metrics)
     else:
         # Directly backpropagate distillation loss as a supervised loss, as in https://arxiv.org/abs/2306.13649.
+        if response_mask.is_nested:
+            response_mask = response_mask.to_padded_tensor(False)
         distillation_loss = agg_loss(
             loss_mat=distillation_losses,
             loss_mask=response_mask,
@@ -298,7 +307,10 @@ def compute_forward_kl_topk(
     distillation_losses = no_padding_2_padding(model_output["distillation_losses"], data)
     student_mass = no_padding_2_padding(model_output["student_mass"], data)
     teacher_mass = no_padding_2_padding(model_output["teacher_mass"], data)
-    response_mask_bool = data["response_mask"].bool()
+    if data["response_mask"].is_nested:
+        response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
+    else:
+        response_mask_bool = data["response_mask"].bool()
     assert distillation_losses.shape == student_mass.shape == teacher_mass.shape == response_mask_bool.shape
 
     # Log amount of mass in the top-k log probabilities for both student and teacher.
@@ -340,7 +352,10 @@ def compute_distillation_loss_reverse_kl_estimator(
     """
     student_log_probs = no_padding_2_padding(model_output["log_probs"], data)
     teacher_log_probs = no_padding_2_padding(data["teacher_logprobs"], data).squeeze(-1)
-    response_mask_bool = data["response_mask"].bool()
+    if data["response_mask"].is_nested:
+        response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
+    else:
+        response_mask_bool = data["response_mask"].bool()
     assert teacher_log_probs.shape == student_log_probs.shape == response_mask_bool.shape
 
     loss_config: DistillationLossConfig = distillation_config.distillation_loss

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -461,7 +461,7 @@ class AgentLoopManagerTQ(AgentLoopManager):
         await instance._initialize_llm_servers()
         await instance._init_global_load_balancer()
         await instance._init_agent_loop_workers()
-        if instance.stream_teacher_with_rollout:
+        if teacher_model_manager is not None:
             await instance.teacher_model_manager.wake_up()
         return instance
 
@@ -843,16 +843,6 @@ class PPOTrainer:
         )
         with open(local_latest_checkpointed_iteration, "w") as f:
             f.write(str(self.global_steps))
-
-    def _should_compute_teacher_colocate(self, batch: KVBatchMeta) -> bool:
-        return self.use_teacher_policy and not self.distillation_config.teacher_model.enable_resource_pool
-
-    def _compute_teacher_colocate(self, batch: KVBatchMeta) -> KVBatchMeta:
-        """Compute teacher logprobs after rollout when teacher and student are colocated."""
-        assert self.teacher_model_manager is not None, "TeacherModelManager is None"
-        teacher_batch = self.teacher_model_manager.compute_logprobs(batch)
-
-        return teacher_batch
 
     def _validate(self) -> dict[str, float]:
         # Lists to collect samples for the table
@@ -1431,43 +1421,38 @@ class PPOTrainer:
         batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
         self.checkpoint_manager.sleep_replicas()
 
-        # 3. [OPTIONAL] compute teacher logprobs
-        if self._should_compute_teacher_colocate(batch):
-            with marked_timer("teacher", timing_raw, color="cyan"):
-                batch = self._compute_teacher_colocate(batch)
-
-        # 4. [OPTIONAL] compute reward score with colocated reward model
+        # 3. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
             with marked_timer("reward", timing_raw, color="yellow"):
                 batch = self._compute_reward_colocate(batch)
 
-        # 5. balance batch across data parallel groups
+        # 4. balance batch across data parallel groups
         self._balance_batch(batch, metrics=metrics)
 
-        # 6. compute old_log_prob
+        # 5. compute old_log_prob
         with marked_timer("old_log_prob", timing_raw, color="blue"):
             batch = self._compute_old_log_prob(batch, metrics=metrics)
 
-        # 7. [OPTIONAL] compute ref_log_prob
+        # 6. [OPTIONAL] compute ref_log_prob
         if self.use_reference_policy:
             with marked_timer("ref", timing_raw, color="olive"):
                 batch = self._compute_ref_log_prob(batch, metrics=metrics)
 
-        # 8. [OPTIONAL] compute critic values
+        # 7. [OPTIONAL] compute critic values
         if self.use_critic:
             with marked_timer("values", timing_raw, color="cyan"):
                 batch = self._compute_values(batch, metrics=metrics)
 
-        # 9. compute advantage and return
+        # 8. compute advantage and return
         with marked_timer("adv", timing_raw, color="brown"):
             batch = self._compute_advantage(batch, metrics=metrics)
 
-        # 10. [OPTIONAL] update critic
+        # 9. [OPTIONAL] update critic
         if self.use_critic:
             with marked_timer("update_critic", timing_raw, color="pink"):
                 batch = self._update_critic(batch, metrics=metrics)
 
-        # 11. update actor
+        # 10. update actor
         if self.config.trainer.critic_warmup <= self.global_steps:
             with marked_timer("update_actor", timing_raw, color="red"):
                 batch = self._update_actor(batch, metrics=metrics)
@@ -1500,18 +1485,6 @@ class TaskRunner:
             self.role_worker_mapping[Role.Critic] = ray.remote(TrainingWorker)
             self.mapping[Role.Critic] = "global_pool"
 
-    def add_teacher_model_resource_pool(self, config):
-        """Add teacher model worker if enabled."""
-        from verl.trainer.ppo.ray_trainer import Role
-
-        if is_distillation_enabled(config.get("distillation")):
-            # we do not use teacher model workers, so we only register teacher model in resource pool
-            # without registering a teacher model worker in role-worker mapping
-            if config.distillation.teacher_model.enable_resource_pool:
-                self.mapping[Role.TeacherModel] = "teacher_pool"
-            else:
-                self.mapping[Role.TeacherModel] = "global_pool"
-
     def init_resource_pool_mgr(self, config):
         """Initialize resource pool manager."""
 
@@ -1538,19 +1511,21 @@ class TaskRunner:
 
         distillation_config = config.get("distillation")
         if is_distillation_enabled(distillation_config):
-            if distillation_config.teacher_model.enable_resource_pool:
-                if distillation_config.teacher_model.n_gpus_per_node <= 0:
-                    raise ValueError("config.distillation.teacher_model.n_gpus_per_node must be greater than 0")
-                if distillation_config.teacher_model.nnodes <= 0:
-                    raise ValueError("config.distillation.teacher_model.nnodes must be greater than 0")
+            if not distillation_config.teacher_model.enable_resource_pool:
+                raise ValueError(
+                    "Only support using dedicated resource_pool for teacher_model! Please set "
+                    "`distillation.teacher_model.enable_resource_pool=True`"
+                )
+            if distillation_config.teacher_model.n_gpus_per_node <= 0:
+                raise ValueError("config.distillation.teacher_model.n_gpus_per_node must be greater than 0")
+            if distillation_config.teacher_model.nnodes <= 0:
+                raise ValueError("config.distillation.teacher_model.nnodes must be greater than 0")
 
-                teacher_pool = [
-                    distillation_config.teacher_model.n_gpus_per_node
-                ] * distillation_config.teacher_model.nnodes
-                resource_pool_spec["teacher_pool"] = teacher_pool
-            else:
-                distillation_config.teacher_model.nnodes = config.trainer.nnodes
-                distillation_config.teacher_model.n_gpus_per_node = config.trainer.n_gpus_per_node
+            teacher_pool = [
+                distillation_config.teacher_model.n_gpus_per_node
+            ] * distillation_config.teacher_model.nnodes
+            resource_pool_spec["teacher_pool"] = teacher_pool
+            self.mapping[Role.TeacherModel] = "teacher_pool"
 
         self.resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
 
@@ -1563,7 +1538,6 @@ class TaskRunner:
 
         self.add_actor_rollout_worker(config)
         self.add_critic_worker(config)
-        self.add_teacher_model_resource_pool(config)
         self.init_resource_pool_mgr(config)
 
         trainer = PPOTrainer(

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -61,6 +61,7 @@ from verl.single_controller.ray import (
     ResourcePoolManager,
     create_colocated_worker_cls,
 )
+from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.main_ppo import create_rl_dataset, create_rl_sampler, run_ppo
 from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import agg_loss
@@ -90,7 +91,7 @@ from verl.utils.ray_utils import auto_await
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.tensordict_utils import list_of_dict_to_tensordict
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
-from verl.workers.config import CriticConfig
+from verl.workers.config import CriticConfig, DistillationConfig
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
 from verl.workers.utils.losses import value_loss
 from verl.workers.utils.padding import response_from_nested, response_to_nested
@@ -372,6 +373,14 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             kwargs=kwargs,
         )
 
+        # TODO: Support output:list[AgentLoopOutput]
+        await self._compute_teacher_logprobs(
+            output,
+            prompt_ids=output.prompt_ids,
+            response_ids=output.response_ids,
+            validate=validate,
+        )
+
         if final_output.reward_score is not None:
             for output in outputs[:-1]:
                 output.reward_score = final_output.reward_score
@@ -454,7 +463,8 @@ class AgentLoopManagerTQ(AgentLoopManager):
         await instance._init_agent_loop_workers()
         return instance
 
-    def generate_sequences(self, prompts: TensorDict) -> None:
+    @auto_await
+    async def generate_sequences(self, prompts: TensorDict) -> None:
         """
         Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
         into TransferQueue once an agent loop finished.
@@ -462,6 +472,9 @@ class AgentLoopManagerTQ(AgentLoopManager):
         Args:
             prompts (TensorDict): Input batch from train or validation dataset.
         """
+        if self.stream_teacher_with_rollout:
+            await self.teacher_model_manager.wake_up()
+
         # mark prompts as pending in replay buffer
         global_steps = prompts["global_steps"]
         partition_id = "train" if "validate" not in prompts else "val"
@@ -475,6 +488,11 @@ class AgentLoopManagerTQ(AgentLoopManager):
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=False)
             ]
         )
+
+        # Ignore teacher model sleep because the above ray.get only makesure all the tasks were dispatched,
+        # not completed.
+        # if self.stream_teacher_with_rollout:
+        #     await self.teacher_model_manager.sleep()
 
 
 # ======================================= USER SECTION END =======================================
@@ -593,6 +611,7 @@ class PPOTrainer:
         actor_rollout_cls = RayClassWithInitArgs(
             cls=self.role_worker_mapping[actor_role],
             config=self.config.actor_rollout_ref,
+            distillation_config=self.config.get("distillation"),
             role=str(actor_role),
         )
         self.resource_pool_to_cls[actor_rollout_resource_pool][str(actor_role)] = actor_rollout_cls
@@ -631,6 +650,8 @@ class PPOTrainer:
         logger.info(f"worker group kwargs: {wg_kwargs}")
 
         for resource_pool, class_dict in self.resource_pool_to_cls.items():
+            if not class_dict:
+                continue
             worker_dict_cls = create_colocated_worker_cls(class_dict=class_dict)
             wg_dict = RayWorkerGroup(
                 resource_pool=resource_pool,
@@ -674,16 +695,19 @@ class PPOTrainer:
         )
         logger.info("reward loop manager initialized")
 
-        # TODO: Support OPD
+        # 8. initialize teacher loop manager
         if self.use_teacher_policy:
-            logger.info("OPD is not supported in `main_ppo_sync.py` yet.")
-            self.teacher_model_manager = None
-            self.distillation_config = None
+            teacher_resource_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
+            self.teacher_model_manager = TeacherModelManager(
+                config=self.config.distillation,
+                resource_pool=teacher_resource_pool,
+            )
+            self.distillation_config: DistillationConfig = omega_conf_to_dataclass(self.config.distillation)
         else:
             self.teacher_model_manager = None
             self.distillation_config = None
 
-        # 8. initialize agent loop manager
+        # 9. initialize agent loop manager
         manager_class_fqn = self.config.actor_rollout_ref.rollout.get("agent", {}).get("agent_loop_manager_class")
         if manager_class_fqn:
             agent_loop_manager_cls = load_class_from_fqn(manager_class_fqn, "AgentLoopManager")
@@ -699,7 +723,7 @@ class PPOTrainer:
         )
         logger.info("agent loop manager initialized")
 
-        # 9. initialize checkpoint engine manager
+        # 10. initialize checkpoint engine manager
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
         self.checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
@@ -826,6 +850,16 @@ class PPOTrainer:
         )
         with open(local_latest_checkpointed_iteration, "w") as f:
             f.write(str(self.global_steps))
+
+    def _should_compute_teacher_colocate(self, batch: KVBatchMeta) -> bool:
+        return self.use_teacher_policy and not self.distillation_config.teacher_model.enable_resource_pool
+
+    def _compute_teacher_colocate(self, batch: KVBatchMeta) -> KVBatchMeta:
+        """Compute teacher logprobs after rollout when teacher and student are colocated."""
+        assert self.teacher_model_manager is not None, "TeacherModelManager is None"
+        teacher_batch = self.teacher_model_manager.compute_logprobs(batch)
+
+        return teacher_batch
 
     def _validate(self) -> dict[str, float]:
         # Lists to collect samples for the table
@@ -1038,7 +1072,13 @@ class PPOTrainer:
             return
 
         # 1. compute log probs
-        batch.extra_info.update({"calculate_entropy": True, "compute_loss": False})
+        batch.extra_info.update(
+            {
+                "calculate_entropy": True,
+                "compute_loss": False,
+                "temperature": self.config.actor_rollout_ref.rollout.temperature,
+            }
+        )
         output: KVBatchMeta = self.actor_rollout_wg.compute_log_prob(batch)
         assert len(output) == len(batch)
 
@@ -1054,7 +1094,7 @@ class PPOTrainer:
         data["old_log_probs"] = response_from_nested(data.pop("log_probs"), data["response_mask"])
         data["entropy"] = response_from_nested(data.pop("entropy"), data["response_mask"])
         t_start = time.time()
-        tq.kv_batch_put(
+        batch = tq.kv_batch_put(
             keys=batch.keys, partition_id=batch.partition_id, fields=data.select("old_log_probs", "entropy")
         )
         t_end = time.time()
@@ -1085,7 +1125,11 @@ class PPOTrainer:
     def _compute_ref_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the reference log prob of the batch."""
         # 1. compute log probs
-        metadata = {"calculate_entropy": False, "compute_loss": False}
+        metadata = {
+            "calculate_entropy": False,
+            "compute_loss": False,
+            "temperature": self.config.actor_rollout_ref.rollout.temperature,
+        }
         if self.ref_in_actor:
             metadata["no_lora_adapter"] = True
         batch.extra_info.update(metadata)
@@ -1191,7 +1235,7 @@ class PPOTrainer:
             output[field] = response_to_nested(data.batch[field], response_mask)
         output = TensorDict(output, batch_size=len(batch))
         t_start = time.time()
-        tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=output)
+        batch = tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=output)
         t_end = time.time()
         print(f"[DEBUG] _compute_advantage time to put data: {t_end - t_start:.2f}", flush=True)
 
@@ -1226,13 +1270,20 @@ class PPOTrainer:
         calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
             self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
         )
+        distillation_use_topk = (
+            self.distillation_config.distillation_loss.loss_settings.use_topk
+            if is_distillation_enabled(self.config.get("distillation"))
+            else False
+        )
         extra_info = {
             "calculate_entropy": calculate_entropy,
+            "distillation_use_topk": distillation_use_topk,
             "global_batch_size": ppo_mini_batch_size,
             "mini_batch_size": ppo_mini_batch_size,
             "epochs": self.config.actor_rollout_ref.actor.ppo_epochs,
             "seed": self.config.actor_rollout_ref.actor.data_loader_seed,
             "dataloader_kwargs": {"shuffle": self.config.actor_rollout_ref.actor.shuffle},
+            "temperature": self.config.actor_rollout_ref.rollout.temperature,
         }
         batch.extra_info.update(extra_info)
 
@@ -1387,38 +1438,43 @@ class PPOTrainer:
         batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
         self.checkpoint_manager.sleep_replicas()
 
-        # 3. [OPTIONAL] compute reward score with colocated reward model
+        # 3. [OPTIONAL] compute teacher logprobs
+        if self._should_compute_teacher_colocate(batch):
+            with marked_timer("teacher", timing_raw, color="cyan"):
+                batch = self._compute_teacher_colocate(batch)
+
+        # 4. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
             with marked_timer("reward", timing_raw, color="yellow"):
                 batch = self._compute_reward_colocate(batch)
 
-        # 4. balance batch across data parallel groups
+        # 5. balance batch across data parallel groups
         self._balance_batch(batch, metrics=metrics)
 
-        # 5. compute old_log_prob
+        # 6. compute old_log_prob
         with marked_timer("old_log_prob", timing_raw, color="blue"):
             batch = self._compute_old_log_prob(batch, metrics=metrics)
 
-        # 6. [OPTIONAL] compute ref_log_prob
+        # 7. [OPTIONAL] compute ref_log_prob
         if self.use_reference_policy:
             with marked_timer("ref", timing_raw, color="olive"):
                 batch = self._compute_ref_log_prob(batch, metrics=metrics)
 
-        # 7. [OPTIONAL] compute critic values
+        # 8. [OPTIONAL] compute critic values
         if self.use_critic:
             with marked_timer("values", timing_raw, color="cyan"):
                 batch = self._compute_values(batch, metrics=metrics)
 
-        # 8. compute advantage and return
+        # 9. compute advantage and return
         with marked_timer("adv", timing_raw, color="brown"):
             batch = self._compute_advantage(batch, metrics=metrics)
 
-        # 9. [OPTIONAL] update critic
+        # 10. [OPTIONAL] update critic
         if self.use_critic:
             with marked_timer("update_critic", timing_raw, color="pink"):
                 batch = self._update_critic(batch, metrics=metrics)
 
-        # 10. update actor
+        # 11. update actor
         if self.config.trainer.critic_warmup <= self.global_steps:
             with marked_timer("update_actor", timing_raw, color="red"):
                 batch = self._update_actor(batch, metrics=metrics)
@@ -1451,6 +1507,18 @@ class TaskRunner:
             self.role_worker_mapping[Role.Critic] = ray.remote(TrainingWorker)
             self.mapping[Role.Critic] = "global_pool"
 
+    def add_teacher_model_resource_pool(self, config):
+        """Add teacher model worker if enabled."""
+        from verl.trainer.ppo.ray_trainer import Role
+
+        if is_distillation_enabled(config.get("distillation")):
+            # we do not use teacher model workers, so we only register teacher model in resource pool
+            # without registering a teacher model worker in role-worker mapping
+            if config.distillation.teacher_model.enable_resource_pool:
+                self.mapping[Role.TeacherModel] = "teacher_pool"
+            else:
+                self.mapping[Role.TeacherModel] = "global_pool"
+
     def init_resource_pool_mgr(self, config):
         """Initialize resource pool manager."""
 
@@ -1475,6 +1543,22 @@ class TaskRunner:
             config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
             self.mapping[Role.RewardModel] = "global_pool"
 
+        distillation_config = config.get("distillation")
+        if is_distillation_enabled(distillation_config):
+            if distillation_config.teacher_model.enable_resource_pool:
+                if distillation_config.teacher_model.n_gpus_per_node <= 0:
+                    raise ValueError("config.distillation.teacher_model.n_gpus_per_node must be greater than 0")
+                if distillation_config.teacher_model.nnodes <= 0:
+                    raise ValueError("config.distillation.teacher_model.nnodes must be greater than 0")
+
+                teacher_pool = [
+                    distillation_config.teacher_model.n_gpus_per_node
+                ] * distillation_config.teacher_model.nnodes
+                resource_pool_spec["teacher_pool"] = teacher_pool
+            else:
+                distillation_config.teacher_model.nnodes = config.trainer.nnodes
+                distillation_config.teacher_model.n_gpus_per_node = config.trainer.n_gpus_per_node
+
         self.resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
 
     def run(self, config):
@@ -1486,6 +1570,7 @@ class TaskRunner:
 
         self.add_actor_rollout_worker(config)
         self.add_critic_worker(config)
+        self.add_teacher_model_resource_pool(config)
         self.init_resource_pool_mgr(config)
 
         trainer = PPOTrainer(

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -461,10 +461,11 @@ class AgentLoopManagerTQ(AgentLoopManager):
         await instance._initialize_llm_servers()
         await instance._init_global_load_balancer()
         await instance._init_agent_loop_workers()
+        if instance.stream_teacher_with_rollout:
+            await instance.teacher_model_manager.wake_up()
         return instance
 
-    @auto_await
-    async def generate_sequences(self, prompts: TensorDict) -> None:
+    def generate_sequences(self, prompts: TensorDict) -> None:
         """
         Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
         into TransferQueue once an agent loop finished.
@@ -472,9 +473,6 @@ class AgentLoopManagerTQ(AgentLoopManager):
         Args:
             prompts (TensorDict): Input batch from train or validation dataset.
         """
-        if self.stream_teacher_with_rollout:
-            await self.teacher_model_manager.wake_up()
-
         # mark prompts as pending in replay buffer
         global_steps = prompts["global_steps"]
         partition_id = "train" if "validate" not in prompts else "val"
@@ -488,11 +486,6 @@ class AgentLoopManagerTQ(AgentLoopManager):
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=False)
             ]
         )
-
-        # Ignore teacher model sleep because the above ray.get only makesure all the tasks were dispatched,
-        # not completed.
-        # if self.stream_teacher_with_rollout:
-        #     await self.teacher_model_manager.sleep()
 
 
 # ======================================= USER SECTION END =======================================

--- a/verl/utils/transferqueue_utils.py
+++ b/verl/utils/transferqueue_utils.py
@@ -100,15 +100,17 @@ def _run_async_in_temp_loop(async_func: Callable[..., Any], *args, **kwargs) -> 
 
 def _find_meta(*args, **kwargs):
     for arg in args:
-        if isinstance(arg, BatchMeta):
+        if isinstance(arg, BatchMeta | KVBatchMeta):
             return arg
     for v in kwargs.values():
-        if isinstance(v, BatchMeta):
+        if isinstance(v, BatchMeta | KVBatchMeta):
             return v
     return None
 
 
-async def _async_meta_to_realdata(meta: BatchMeta) -> TensorDict:
+async def _async_meta_to_realdata(meta: BatchMeta | KVBatchMeta) -> TensorDict:
+    if isinstance(meta, KVBatchMeta):
+        meta = await async_kv_batch_meta2batch_meta(meta)
     meta_info = copy.deepcopy(meta.extra_info)
     if meta.size == 0:
         empty_td = TensorDict({}, batch_size=(0,))
@@ -314,7 +316,8 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
     # TODO: move to the top
     from verl.single_controller.base.decorator import _check_dispatch_mode
 
-    _check_dispatch_mode(dispatch_mode)
+    if dispatch_mode is not None:
+        _check_dispatch_mode(dispatch_mode)
 
     def decorator(func):
         pid = os.getpid()
@@ -329,9 +332,16 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
                 if not TQ_INITIALIZED:
                     tq.init()
                     TQ_INITIALIZED = True
+
+                is_kv_batch_meta = isinstance(batch_meta, KVBatchMeta)
+                if is_kv_batch_meta:
+                    tags = batch_meta.tags
+                    batch_meta = kv_batch_meta2batch_meta(batch_meta)
                 t1 = time.time()
-                args = [_meta_to_realdata(arg) if isinstance(arg, BatchMeta) else arg for arg in args]
-                kwargs = {k: _meta_to_realdata(v) if isinstance(v, BatchMeta) else v for k, v in kwargs.items()}
+                args = [_meta_to_realdata(arg) if isinstance(arg, BatchMeta | KVBatchMeta) else arg for arg in args]
+                kwargs = {
+                    k: _meta_to_realdata(v) if isinstance(v, BatchMeta | KVBatchMeta) else v for k, v in kwargs.items()
+                }
                 t2 = time.time()
                 logger.info(
                     f"Task {func.__name__} (pid={pid}) is getting len_samples={batch_meta.size}, cost time: {t2 - t1}"
@@ -347,9 +357,15 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
                         )
                         put_data = True
 
-                need_collect = _compute_need_collect(dispatch_mode, args)
+                if dispatch_mode is not None:
+                    need_collect = _compute_need_collect(dispatch_mode, args)
+                else:
+                    need_collect = True
                 if put_data and need_collect:
                     updated_meta = _update_meta_with_output(output, batch_meta, func.__name__)
+                    if is_kv_batch_meta:
+                        updated_meta = batch_meta2kv_batch_meta(updated_meta)
+                        updated_meta.tags = tags
                     return updated_meta
                 return _postprocess_common(output, put_data, need_collect)
 
@@ -363,10 +379,20 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
                 if not TQ_INITIALIZED:
                     tq.init()
                     TQ_INITIALIZED = True
+
+                is_kv_batch_meta = isinstance(batch_meta, KVBatchMeta)
+                if is_kv_batch_meta:
+                    tags = batch_meta.tags
+                    batch_meta = await async_kv_batch_meta2batch_meta(batch_meta)
+
                 t1 = time.time()
-                args = [await _async_meta_to_realdata(arg) if isinstance(arg, BatchMeta) else arg for arg in args]
+                args = [
+                    await _async_meta_to_realdata(arg) if isinstance(arg, BatchMeta | KVBatchMeta) else arg
+                    for arg in args
+                ]
                 kwargs = {
-                    k: await _async_meta_to_realdata(v) if isinstance(v, BatchMeta) else v for k, v in kwargs.items()
+                    k: await _async_meta_to_realdata(v) if isinstance(v, BatchMeta | KVBatchMeta) else v
+                    for k, v in kwargs.items()
                 }
                 t2 = time.time()
                 logger.info(
@@ -383,9 +409,15 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
                         )
                         put_data = True
 
-                need_collect = _compute_need_collect(dispatch_mode, args)
+                if dispatch_mode is not None:
+                    need_collect = _compute_need_collect(dispatch_mode, args)
+                else:
+                    need_collect = True
                 if put_data and need_collect:
                     updated_meta = await _async_update_meta_with_output(output, batch_meta, func.__name__)
+                    if is_kv_batch_meta:
+                        updated_meta = await async_batch_meta2kv_batch_meta(updated_meta)
+                        updated_meta.tags = tags
                     return updated_meta
                 return _postprocess_common(output, put_data, need_collect)
 


### PR DESCRIPTION
### What does this PR do?

Support #5041 in `main_ppo_sync.py`.

> Note: only support `distillation.teacher_model.enable_resource_pool=True`, as colocated teacher will not be maintenanced in the future.

Test runs were performed for two settings:

- USE_POLICY_GRADIENT=False & DISTILLATION_LOSS_MODE='forward_kl_topk'
- USE_POLICY_GRADIENT=True & DISTILLATION_LOSS_MODE='k3'

<img width="1365" height="792" alt="image" src="https://github.com/user-attachments/assets/1aae7cb1-02a3-4ae9-82af-4bcc66243bc3" />
<img width="683" height="372" alt="image" src="https://github.com/user-attachments/assets/955eb824-40f4-46f1-8b05-df1fa174c0ce" />

### Scripts
```bash
#!/usr/bin/env bash
set -xeuo pipefail

############################ Quick Config ############################

ROLLOUT_NAME="vllm" # sglang or vllm

FAMILY="Qwen"
STUDENT_MODEL=Qwen3-0.6B
TEACHER_MODEL=Qwen3-VL-8B-Instruct

# Exp1
USE_POLICY_GRADIENT=False
DISTILLATION_LOSS_MODE="forward_kl_topk"

# Exp2
# USE_POLICY_GRADIENT=True
# DISTILLATION_LOSS_MODE="k3"

USE_FUSED_KERNELS=False


DISTILLATION_LOSS_MAX_CLAMP=10.0
DISTILLATION_LOG_PROB_MIN_CLAMP=-10.0

PROJECT_NAME='verl_on_policy_distillation_example_gsm8k'

MAX_PROMPT=256
MAX_RESPONSE_LENGTH=512
MAX_NUM_TOKENS=$(( MAX_PROMPT + MAX_RESPONSE_LENGTH + 1 ))
TRAIN_PROMPT_BSZ=128
STUDENT_MICRO_BATCH_SIZE_PER_GPU=2
STUDENT_MAX_TOKEN_LEN_PER_GPU=$(( STUDENT_MICRO_BATCH_SIZE_PER_GPU * (MAX_PROMPT + MAX_RESPONSE_LENGTH) ))
USE_DYNAMIC_BSZ=True

STUDENT_WORLD_SIZE=8

TEACHER_WORLD_SIZE=8

SP=1

EXP_NAME="fsdp/student-${STUDENT_MODEL}/teacher-${TEACHER_MODEL}/loss-${DISTILLATION_LOSS_MODE}/pg-${USE_POLICY_GRADIENT}"

ENFORCE_EAGER=True # true for faster debugging

############################ Paths ############################

gsm8k_train_path=/datasets/gsm8k/train.parquet
gsm8k_test_path=/datasets/gsm8k/test.parquet

TRAIN_FILES="['$gsm8k_train_path']"
TEST_FILES="['$gsm8k_test_path']"

############################ Parameter Groups ############################

DATA=(
    data.train_files="$TRAIN_FILES"
    data.val_files="$TEST_FILES"
    data.max_prompt_length=$MAX_PROMPT
    data.max_response_length=$MAX_RESPONSE_LENGTH
    data.train_batch_size=$TRAIN_PROMPT_BSZ
    data.filter_overlong_prompts=True
    data.truncation='error'
    data.shuffle=False
)

MODEL=(
    actor_rollout_ref.model.path="/models/Qwen3-0.6B"
    actor_rollout_ref.model.enable_gradient_checkpointing=True
    actor_rollout_ref.model.use_remove_padding=True
    actor_rollout_ref.model.use_fused_kernels=$USE_FUSED_KERNELS
    actor_rollout_ref.actor.use_torch_compile=True
    actor_rollout_ref.rollout.enforce_eager=$ENFORCE_EAGER
)

DISTILLATION=(
    distillation.enabled=True
    distillation.num_workers=8
    distillation.teacher_model.enable_resource_pool=True
    distillation.teacher_model.n_gpus_per_node=$TEACHER_WORLD_SIZE
    distillation.teacher_model.nnodes=1
    distillation.teacher_model.model_path="/models/Qwen3-VL-8B-Instruct"
    distillation.teacher_model.inference.tensor_model_parallel_size=2
    distillation.teacher_model.inference.name=$ROLLOUT_NAME
    distillation.teacher_model.inference.gpu_memory_utilization=0.6
    distillation.teacher_model.inference.enforce_eager=$ENFORCE_EAGER
    distillation.teacher_model.inference.max_model_len=$MAX_NUM_TOKENS
    distillation.teacher_model.inference.max_num_batched_tokens=$MAX_NUM_TOKENS
    distillation.teacher_model.inference.max_num_seqs=$MAX_NUM_TOKENS
    distillation.distillation_loss.loss_mode=$DISTILLATION_LOSS_MODE
    distillation.distillation_loss.topk=64
    distillation.distillation_loss.use_task_rewards=False
    distillation.distillation_loss.use_policy_gradient=$USE_POLICY_GRADIENT
    distillation.distillation_loss.loss_max_clamp=$DISTILLATION_LOSS_MAX_CLAMP
    distillation.distillation_loss.log_prob_min_clamp=$DISTILLATION_LOG_PROB_MIN_CLAMP
)

STUDENT=(
    actor_rollout_ref.actor.optim.lr=1e-6
    actor_rollout_ref.actor.ppo_mini_batch_size=$TRAIN_PROMPT_BSZ
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$STUDENT_MICRO_BATCH_SIZE_PER_GPU
    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$STUDENT_MAX_TOKEN_LEN_PER_GPU
    actor_rollout_ref.actor.use_dynamic_bsz=$USE_DYNAMIC_BSZ
    actor_rollout_ref.actor.fsdp_config.param_offload=True
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True
    actor_rollout_ref.actor.ulysses_sequence_parallel_size=$SP
)

ROLLOUT=(
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=$STUDENT_MICRO_BATCH_SIZE_PER_GPU
    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=$STUDENT_MAX_TOKEN_LEN_PER_GPU
    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=$USE_DYNAMIC_BSZ
    actor_rollout_ref.rollout.tensor_model_parallel_size=1
    actor_rollout_ref.rollout.name=$ROLLOUT_NAME
    actor_rollout_ref.rollout.gpu_memory_utilization=0.6
    actor_rollout_ref.rollout.calculate_log_probs=False
    actor_rollout_ref.rollout.max_model_len=$MAX_NUM_TOKENS
    actor_rollout_ref.rollout.max_num_batched_tokens=$MAX_NUM_TOKENS
    actor_rollout_ref.rollout.max_num_seqs=$MAX_NUM_TOKENS
    actor_rollout_ref.rollout.n=1
)

ALGORITHM=(
    algorithm.adv_estimator=grpo
    algorithm.use_kl_in_reward=False
)

TRAINER=(
    trainer.logger='["console"]'
    trainer.project_name=$PROJECT_NAME
    trainer.experiment_name=$EXP_NAME
    trainer.n_gpus_per_node=$STUDENT_WORLD_SIZE
    trainer.nnodes=1
    trainer.save_freq=200
    trainer.test_freq=5
    trainer.total_epochs=15
    trainer.val_before_train=False
    trainer.use_legacy_worker_impl=disable
    trainer.resume_mode=disable
    trainer.log_val_generations=5
)



############################ Launch ############################

python3 -m verl.trainer.main_ppo_sync \
    --config-path=config \
    --config-name='ppo_trainer.yaml' \
    "${DATA[@]}" \
    "${ALGORITHM[@]}" \
    "${MODEL[@]}" \
    "${DISTILLATION[@]}" \
    "${ROLLOUT[@]}" \
    "${STUDENT[@]}" \
    "${TRAINER[@]}" \
    $@ 2>&1 | tee "with_tq_OPD.log"
```

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
