### PR TITLE
[fully_async, ckpt, rollout, trainer, tool, cfg] fix: ROCm async training compatibility for AMD MI300X

### DIFF
--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -118,6 +118,8 @@ class NCCLCheckpointEngine(CheckpointEngine):
         self.group_name = group_name
         self.rebuild_group = rebuild_group
         self.rollout_dtype = rollout_dtype
+        self.send_buf = None
+        self.recv_buf = None
 
         # start zeromq server for broadcasting bucket tensor metadata
         self.is_master = is_master
@@ -126,13 +128,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
             self._start_zmq_server()
 
     def prepare(self) -> MasterMetadata:
-        # For master process, use cupy instead of torch to avoid memory register error
-        # when `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
-        if self.is_master:
-            self.send_buf = cp.zeros(self.bucket_size, dtype=cp.uint8)
-            self.recv_buf = cp.zeros(self.bucket_size, dtype=cp.uint8)
-        else:
+        if self.send_buf is None:
             self.send_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="cuda")
+        if self.recv_buf is None:
             self.recv_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="cuda")
 
         return MasterMetadata(zmq_ip=self.ip, zmq_port=self.listen_port) if self.is_master else None
@@ -144,11 +142,6 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 collective.destroy_collective_group(self.group_name)
             self.rank = None
             self.world_size = None
-
-        self.send_buf = None
-        self.recv_buf = None
-
-        torch.cuda.empty_cache()
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
@@ -274,7 +267,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 "dtype": weight.dtype,
                 "offset": offset,
             }
-            send_buf[offset : offset + weight.nbytes] = cp.asarray(weight.view(-1).view(torch.uint8))
+            send_buf[offset : offset + weight.nbytes] = weight.view(-1).view(torch.uint8)
             offset += weight.nbytes
 
         # broadcast last bucket

--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
@@ -1,6 +1,6 @@
 hydra:
   searchpath:
-    - file://verl/trainer/config
+    - pkg://verl.trainer.config
 
 defaults:
   - ppo_trainer

--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -90,7 +90,7 @@ def init_execution_pool(
     if mode == PoolMode.ThreadMode:
         return (
             ray.remote(ExecutionWorker)
-            .options(max_concurrency=num_workers)
+            .options(name="sandbox-execution-pool", get_if_exists=True, max_concurrency=num_workers)
             .remote(enable_global_rate_limit=enable_global_rate_limit, rate_limit=rate_limit)
         )
     else:

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -31,6 +31,7 @@ PPO_RAY_RUNTIME_ENV = {
         # https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/maintenref/envvar/envref_07_0143.html
         "HCCL_HOST_SOCKET_PORT_RANGE": "auto",
         "HCCL_NPU_SOCKET_PORT_RANGE": "auto",
+        "HSA_NO_SCRATCH_RECLAIM": "1",
     },
 }
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -422,7 +422,7 @@ class RayPPOTrainer:
         lines = []
         for i in range(n):
             entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
+            lines.append(json.dumps(entry, ensure_ascii=False, default=str))
 
         with open(filename, "w") as f:
             f.write("\n".join(lines) + "\n")

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -32,7 +32,7 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
 from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_device_name, is_npu_available, set_expandable_segments
+from verl.utils.device import get_device_name, get_torch_device, is_npu_available, set_expandable_segments
 from verl.utils.distributed import initialize_global_process_group_ray, set_numa_affinity
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.import_utils import import_external_libs
@@ -674,7 +674,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # 0. send_weights only for async training with disaggregated trainer and rollout
         if self.config.rollout.checkpoint_engine.backend != "naive":
             per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
-            await self.checkpoint_engine.send_weights(per_tensor_param)
+            per_tensor_param = list(per_tensor_param)
+            get_torch_device().synchronize()
+            await self.checkpoint_engine.send_weights(iter(per_tensor_param))
             return
 
         set_expandable_segments(False)

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -155,11 +155,23 @@ class BucketedWeightSender:
 
     def _init_socket(self):
         """Initialize ZMQ REQ socket and bind."""
+        if self.zmq_handle.startswith("ipc://"):
+            ipc_path = self.zmq_handle[len("ipc://") :]
+            try:
+                os.remove(ipc_path)
+            except FileNotFoundError:
+                pass
         self.socket = self.zmq_context.socket(zmq.REQ)
         self.socket.bind(self.zmq_handle)
 
     def _init_buffer(self):
-        """build communication buffer"""
+        """build communication buffer, reuse if already allocated"""
+        if self.buffer is not None and not self.use_shm:
+            handle = reduce_tensor(self.buffer)
+            self.socket.send_pyobj(handle)
+            self.socket.recv()
+            return
+
         buffer, shm = None, None
         if not self.use_shm:
             buffer = torch.empty(self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}")
@@ -181,17 +193,22 @@ class BucketedWeightSender:
         self.shm = shm
 
     def _cleanup(self):
-        """clean up"""
+        """clean up socket but keep buffer for reuse"""
         if self.socket is not None:
             self.socket.close()
             self.socket = None
-        del self.buffer
-        self.buffer = None
+        if self.zmq_handle.startswith("ipc://"):
+            ipc_path = self.zmq_handle[len("ipc://") :]
+            try:
+                os.remove(ipc_path)
+            except FileNotFoundError:
+                pass
         if self.shm is not None:
             self.shm.close()
             self.shm.unlink()
             del self.shm
             self.shm = None
+            self.buffer = None
         gc.collect()
         get_torch_device().ipc_collect()
         get_torch_device().empty_cache()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -265,9 +265,7 @@ class vLLMColocateWorkerExtension:
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication."""
-        if not hasattr(self, "device_uuid") or not self.device_uuid:
-            self.device_uuid = get_device_uuid(self.device.index)
-        return f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        return f"ipc:///tmp/rl-colocate-zmq-rank-{self.local_rank}.sock"
 
 
 class vLLMOmniColocateWorkerExtension(_OmniWorkerBase):
@@ -331,9 +329,7 @@ class vLLMOmniColocateWorkerExtension(_OmniWorkerBase):
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication."""
-        if not hasattr(self, "device_uuid") or not self.device_uuid:
-            self.device_uuid = get_device_uuid(self.device.index)
-        return f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        return f"ipc:///tmp/rl-colocate-zmq-rank-{self.local_rank}.sock"
 
 
 class SuppressSignalInThread:

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -95,7 +95,7 @@ class ServerAdapter(BaseRollout):
             self.sleep_level = VLLM_SLEEP_LEVEL
 
         self.device_uuid = get_device_uuid(get_device_id())
-        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-rank-{rank % local_world_size}.sock"
 
         self.use_shm = not is_support_ipc()
         if self.use_shm:
@@ -163,13 +163,14 @@ class ServerAdapter(BaseRollout):
             kwargs={**kwargs, "use_shm": self.use_shm},
         )
 
-        bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
-        sender = BucketedWeightSender(
-            zmq_handle=self.zmq_handle,
-            bucket_size_mb=bucket_size_mb,
-            use_shm=self.use_shm,
-        )
-        await sender.async_send_weights(weights)
+        if not hasattr(self, "_weight_sender") or self._weight_sender is None:
+            bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
+            self._weight_sender = BucketedWeightSender(
+                zmq_handle=self.zmq_handle,
+                bucket_size_mb=bucket_size_mb,
+                use_shm=self.use_shm,
+            )
+        await self._weight_sender.async_send_weights(weights)
 
         if future is not None:
             await future


### PR DESCRIPTION
### What does this PR do?

Fix multiple issues that prevent fully async FSDP2 training from working on AMD ROCm platforms (MI300X series).

**Environment:**
- AMD Instinct MI3xx (8× GPU, 192 GB HBM each), ROCm 7.2.0, PyTorch 2.10.0+rocm7.2.0, vLLM v0.19.1rc0
- Cross-validated on NVIDIA H20 with CUDA, vLLM 0.18.2 (latest verl main + this patch): no regression observed up to step 86, where a pre-existing bug (`AttributeError: 'list' object has no attribute 'dim'` in `agent_loop.py:696`) is hit — this bug exists with or without this patch and is unrelated to these changes.

**Training curves (MI3xx vs H20) and training script**

[dapo_7b_fully_async.sh](https://github.com/user-attachments/files/26700697/dapo_7b_fully_async.sh)
<img width="2234" height="1181" alt="qwen2 5_7b_fully_async" src="https://github.com/user-attachments/assets/03d72c65-a9a4-4596-be92-4245074c5bdb" />

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+rocm+async
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Validated by full async FSDP2 DAPO/GRPO RL + ReTool training on AMD MI3xx:
- 250+ global steps completed, 60+ weight synchronization cycles without OOM or deadlock
- Cross-validated on NVIDIA H20: training runs normally with this patch applied (no regression)
  - H20 (CUDA) cross-validation note:

Applied this patch on latest verl main (commit 9b54564f) + vLLM 0.18.2 on NVIDIA H20. Training ran normally up to step 86 / global_step 344, where a pre-existing bug in agent_loop.py:698 is hit:

File "verl/experimental/agent_loop/agent_loop.py", line 698, in _agent_loop_postprocess
    if response_mask_output["input_ids"].dim() == 1:
AttributeError: 'list' object has no attribute 'dim'
This is caused by tokenizer.pad() returning a Python list instead of a torch.Tensor for response_mask in certain edge cases, even with return_tensors="pt". This bug exists on the current main branch with or without this patch — it is not introduced by any changes in this PR. The file agent_loop.py is not modified in this PR.

MI3xx (ROCm 7.2): 250+ global steps, 60+ weight syncs completed without OOM or deadlock. The same agent_loop.py bug was also encountered on MI3xx at a later step, confirming it is platform-independent.

### API and Usage Example

No API changes. All fixes are internal implementation details.

### Design & Code Changes

1. **NCCL checkpoint engine: unify buffers to torch tensors** (`nccl_checkpoint_engine.py`)
   - Replace `cupy` buffers with `torch.zeros` to fix HIP stream synchronization issues on ROCm
   - Remove `cp.asarray()` conversion in `send_weights`
   - Persist buffers across calls to prevent HIP memory fragmentation OOM (see #9)

2. **Add `HSA_NO_SCRATCH_RECLAIM` env var** (`constants_ppo.py`)
   - Required by AMD RCCL on MI300X; without it, FSDP initialization fails with `ncclSystemError`

3. **Fix `numpy.bool_` JSON serialization** (`ray_trainer.py`)
   - Add `default=str` fallback for `json.dumps` since numpy 2.x `bool_` is no longer a Python `bool` subclass

4. **Materialize generator before `send_weights`** (`engine_workers.py`)
   - `get_per_tensor_param()` returns a generator containing `full_tensor()` calls that trigger FSDP `all_gather`
   - Lazy consumption causes rank-misaligned collective calls → deadlock
   - Fix: `list()` to materialize + `torch.cuda.synchronize()` before sending

5. **ZMQ IPC handle: use rank instead of GPU UUID** (`vllm_rollout.py`, `utils.py`)
   - On ROCm, `CheckpointEngineWorker` and vLLM worker see different GPU UUIDs due to different `CUDA_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES` settings
   - Use deterministic rank number instead

6. **Clean up stale ZMQ IPC socket files** (`bucketed_weight_transfer.py`)
   - Remove leftover `/tmp/rl-colocate-zmq-rank-*.sock` files before `bind()` and after `close()` to prevent `Address already in use` on restart

7. **Fix Hydra searchpath** (`fully_async_ppo_trainer.yaml`)
   - Use `pkg://verl.trainer.config` instead of `file://verl/trainer/config` for editable installs

8. **Sandbox Ray actor reuse** (`sandbox_fusion_tools.py`)
   - Add `name` and `get_if_exists=True` to prevent duplicate `ExecutionWorker` actor creation

9. **Persist weight sync buffers to prevent OOM** (`nccl_checkpoint_engine.py`, `vllm_rollout.py`, `bucketed_weight_transfer.py`)
   - On ROCm/HIP, `torch.cuda.empty_cache()` does not effectively return physical memory to the system
   - Repeated alloc/free of large buffers (NCCL 4 GB + IPC 2 GB) causes HIP memory fragmentation → OOM after ~10 weight sync cycles
   - Fix: allocate once and reuse across sync iterations

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). The official documents will be compiled after the merger.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: These fixes target ROCm-specific runtime behavior (HIP memory management, RCCL env vars, GPU UUID mismatch) that cannot be reproduced in CI without AMD GPU hardware.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
