### PR TITLE
[trainer, perf] feat: nest tensors by mask

### DIFF
--- a/tests/utils/test_nested_tensor_on_cpu.py
+++ b/tests/utils/test_nested_tensor_on_cpu.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.utils.nested_tensor import (
+    MaskNestingSpec,
+    mask_to_rle,
+    rle_to_mask,
+    unnest_tensor_by_rle,
+)
+
+
+def _unbind_nested(nt: torch.Tensor) -> list[torch.Tensor]:
+    """Unbind a nested tensor into a list of regular tensors."""
+    return list(nt.unbind())
+
+
+def _assert_rle_roundtrip(mask: torch.Tensor):
+    """Assert mask_to_rle -> rle_to_mask roundtrip, allowing trailing-False truncation.
+
+    ``rle_to_mask`` without ``shape`` infers ``seq_len`` as
+    ``max(offset + length)``, so trailing all-False columns from the original
+    mask are not preserved. This helper accounts for that by only comparing up
+    to the recovered width and verifying that any truncated columns were indeed
+    all-False.
+    """
+    offsets, lengths = mask_to_rle(mask)
+    recovered = rle_to_mask(offsets, lengths)
+    rec_cols = recovered.shape[1]
+    orig_cols = mask.shape[1]
+    assert torch.equal(recovered, mask[:, :rec_cols])
+    if rec_cols < orig_cols:
+        assert not mask[:, rec_cols:].any(), "Trailing columns contain True values but were lost"
+
+
+# ---------------------------------------------------------------------------
+# mask_to_rle
+# ---------------------------------------------------------------------------
+
+
+class TestMaskToRle:
+    def test_basic_example(self):
+        """Docstring example: mixed segments across two rows."""
+        mask = torch.tensor([[False, False, True, True, False], [False, True, True, False, True]])
+        offsets, lengths = mask_to_rle(mask)
+
+        off = _unbind_nested(offsets)
+        ln = _unbind_nested(lengths)
+
+        assert torch.equal(off[0], torch.tensor([2]))
+        assert torch.equal(off[1], torch.tensor([1, 4]))
+        assert torch.equal(ln[0], torch.tensor([2]))
+        assert torch.equal(ln[1], torch.tensor([2, 1]))
+
+    def test_all_true_row(self):
+        """Entirely True row produces a single full-width segment."""
+        mask = torch.ones(1, 6, dtype=torch.bool)
+        offsets, lengths = mask_to_rle(mask)
+
+        assert torch.equal(_unbind_nested(offsets)[0], torch.tensor([0]))
+        assert torch.equal(_unbind_nested(lengths)[0], torch.tensor([6]))
+
+    def test_all_false_row(self):
+        """Entirely False row produces zero segments."""
+        mask = torch.zeros(1, 4, dtype=torch.bool)
+        offsets, lengths = mask_to_rle(mask)
+
+        assert _unbind_nested(offsets)[0].numel() == 0
+        assert _unbind_nested(lengths)[0].numel() == 0
+
+    def test_alternating(self):
+        """Alternating True/False gives single-element segments."""
+        mask = torch.tensor([[True, False, True, False, True, False]])
+        offsets, lengths = mask_to_rle(mask)
+
+        assert torch.equal(_unbind_nested(offsets)[0], torch.tensor([0, 2, 4]))
+        assert torch.equal(_unbind_nested(lengths)[0], torch.tensor([1, 1, 1]))
+
+    def test_edges_true(self):
+        """Segments touching both edges of the row."""
+        mask = torch.tensor([[True, True, False, False, True]])
+        offsets, lengths = mask_to_rle(mask)
+
+        assert torch.equal(_unbind_nested(offsets)[0], torch.tensor([0, 4]))
+        assert torch.equal(_unbind_nested(lengths)[0], torch.tensor([2, 1]))
+
+    def test_multiple_rows_mixed(self):
+        """Rows with varying segment counts including an empty row."""
+        mask = torch.tensor(
+            [
+                [True, True, False, True],
+                [False, False, False, False],
+                [True, False, True, True],
+            ]
+        )
+        offsets, lengths = mask_to_rle(mask)
+        off = _unbind_nested(offsets)
+        ln = _unbind_nested(lengths)
+
+        assert torch.equal(off[0], torch.tensor([0, 3]))
+        assert torch.equal(ln[0], torch.tensor([2, 1]))
+        assert off[1].numel() == 0
+        assert ln[1].numel() == 0
+        assert torch.equal(off[2], torch.tensor([0, 2]))
+        assert torch.equal(ln[2], torch.tensor([1, 2]))
+
+    def test_rejects_1d(self):
+        with pytest.raises(AssertionError, match="Expected 2D mask"):
+            mask_to_rle(torch.tensor([True, False]))
+
+    def test_rejects_3d(self):
+        with pytest.raises(AssertionError, match="Expected 2D mask"):
+            mask_to_rle(torch.zeros(2, 3, 4, dtype=torch.bool))
+
+
+# ---------------------------------------------------------------------------
+# rle_to_mask
+# ---------------------------------------------------------------------------
+
+
+class TestRleToMask:
+    def test_roundtrip_basic(self):
+        """mask_to_rle -> rle_to_mask should recover the original mask."""
+        mask = torch.tensor([[False, False, True, True, False], [False, True, True, False, True]])
+        _assert_rle_roundtrip(mask)
+
+    def test_roundtrip_all_true(self):
+        mask = torch.ones(1, 5, dtype=torch.bool)
+        _assert_rle_roundtrip(mask)
+
+    def test_roundtrip_all_false(self):
+        """All-false mask: recovered mask has seq_len=0 without explicit shape."""
+        mask = torch.zeros(1, 3, dtype=torch.bool)
+        offsets, lengths = mask_to_rle(mask)
+        recovered = rle_to_mask(offsets, lengths)
+        assert recovered.shape == (1, 0)
+
+    def test_roundtrip_multiple_rows(self):
+        mask = torch.tensor(
+            [
+                [True, True, False, True],
+                [False, False, False, False],
+                [True, False, True, True],
+            ]
+        )
+        _assert_rle_roundtrip(mask)
+
+    def test_roundtrip_alternating(self):
+        mask = torch.tensor([[True, False, True, False, True, False]])
+        _assert_rle_roundtrip(mask)
+
+    def test_roundtrip_last_col_true(self):
+        """When the last column is True, recovered seq_len exactly matches."""
+        mask = torch.tensor([[True, False, False, True], [False, True, True, True]])
+        offsets, lengths = mask_to_rle(mask)
+        recovered = rle_to_mask(offsets, lengths)
+        assert torch.equal(recovered, mask)
+
+    def test_roundtrip_random(self):
+        """Fuzz-style: random boolean masks should roundtrip correctly."""
+        gen = torch.Generator().manual_seed(42)
+        for _ in range(10):
+            rows = torch.randint(1, 6, (1,), generator=gen).item()
+            cols = torch.randint(1, 20, (1,), generator=gen).item()
+            mask = torch.randint(0, 2, (rows, cols), dtype=torch.bool, generator=gen)
+            _assert_rle_roundtrip(mask)
+
+    # -- shape parameter tests -----------------------------------------------
+
+    def test_shape_exact_recovery(self):
+        """Passing the original shape recovers trailing-False columns."""
+        mask = torch.tensor([[True, False, True, False, True, False]])
+        offsets, lengths = mask_to_rle(mask)
+        recovered = rle_to_mask(offsets, lengths, shape=mask.shape)
+        assert torch.equal(recovered, mask)
+
+    def test_shape_all_false(self):
+        """All-false mask is fully recovered when shape is given."""
+        mask = torch.zeros(2, 5, dtype=torch.bool)
+        offsets, lengths = mask_to_rle(mask)
+        recovered = rle_to_mask(offsets, lengths, shape=mask.shape)
+        assert torch.equal(recovered, mask)
+
+    def test_shape_roundtrip_random(self):
+        """Fuzz-style: with shape, roundtrip always recovers the exact mask."""
+        gen = torch.Generator().manual_seed(77)
+        for _ in range(10):
+            rows = torch.randint(1, 6, (1,), generator=gen).item()
+            cols = torch.randint(1, 20, (1,), generator=gen).item()
+            mask = torch.randint(0, 2, (rows, cols), dtype=torch.bool, generator=gen)
+            offsets, lengths = mask_to_rle(mask)
+            recovered = rle_to_mask(offsets, lengths, shape=mask.shape)
+            assert torch.equal(recovered, mask), f"shape roundtrip failed for {mask.shape}"
+
+    def test_shape_batch_mismatch_raises(self):
+        """shape[0] != batch_size from offsets should raise."""
+        mask = torch.tensor([[True, False]])
+        offsets, lengths = mask_to_rle(mask)
+        with pytest.raises(AssertionError, match="does not match batch_size"):
+            rle_to_mask(offsets, lengths, shape=(3, 2))
+
+    def test_shape_as_torch_size(self):
+        """torch.Size should be accepted as shape."""
+        mask = torch.tensor([[True, True, False, False]])
+        offsets, lengths = mask_to_rle(mask)
+        recovered = rle_to_mask(offsets, lengths, shape=torch.Size([1, 4]))
+        assert torch.equal(recovered, mask)
+
+
+# ---------------------------------------------------------------------------
+# unnest_tensor_by_rle
+# ---------------------------------------------------------------------------
+
+
+class TestUnnestTensorByRle:
+    def _roundtrip(self, tensor: torch.Tensor, mask: torch.Tensor, pad_value: float = 0.0):
+        """Helper: masked_select -> unnest_tensor_by_rle should recover masked positions.
+
+        The recovered tensor may be narrower than the original when trailing
+        columns are all-False, because ``unnest_tensor_by_rle`` infers
+        ``seq_len`` from ``max(offset + length)``.
+        """
+        offsets, lengths = mask_to_rle(mask)
+        nested = torch.nested.masked_select(tensor, mask)
+        recovered = unnest_tensor_by_rle(nested, offsets, lengths, pad_value=pad_value)
+
+        rec_cols = recovered.shape[1]
+        orig_cols = mask.shape[1]
+        trimmed_mask = mask[:, :rec_cols]
+
+        # Masked positions within recovered range must match
+        assert torch.equal(recovered[trimmed_mask], tensor[:, :rec_cols][trimmed_mask])
+        # Non-masked positions must be filled with pad_value
+        assert (recovered[~trimmed_mask] == pad_value).all()
+        # Anything beyond recovered width must be all-False in original mask
+        if rec_cols < orig_cols:
+            assert not mask[:, rec_cols:].any()
+
+    def test_basic_1d_values(self):
+        """Basic 2D tensor with a simple mask."""
+        tensor = torch.arange(10).reshape(2, 5).float()
+        mask = torch.tensor([[False, False, True, True, False], [False, True, True, False, True]])
+        self._roundtrip(tensor, mask)
+
+    def test_all_true(self):
+        """All-true mask should recover the full tensor."""
+        tensor = torch.arange(8).reshape(2, 4).float()
+        mask = torch.ones(2, 4, dtype=torch.bool)
+        self._roundtrip(tensor, mask)
+
+    def test_all_false(self):
+        """All-false mask: output should be entirely pad_value."""
+        tensor = torch.arange(6).reshape(2, 3).float()
+        mask = torch.zeros(2, 3, dtype=torch.bool)
+
+        offsets, lengths = mask_to_rle(mask)
+        nested = torch.nested.masked_select(tensor, mask)
+        recovered = unnest_tensor_by_rle(nested, offsets, lengths, pad_value=-1.0)
+
+        # seq_len should be 0 when no segments exist, so output is (2, 0)
+        assert recovered.shape[0] == 2
+        assert recovered.shape[1] == 0
+
+    def test_custom_pad_value(self):
+        """Pad value should fill non-masked positions."""
+        tensor = torch.tensor([[10.0, 20.0, 30.0]])
+        mask = torch.tensor([[True, False, True]])
+        pad_value = -999.0
+        self._roundtrip(tensor, mask, pad_value=pad_value)
+
+    def test_mixed_empty_and_nonempty_rows(self):
+        """Rows with zero segments mixed with rows that have segments."""
+        tensor = torch.randn(3, 4)
+        mask = torch.tensor(
+            [
+                [True, True, False, False],
+                [False, False, False, False],
+                [False, True, True, False],
+            ]
+        )
+        self._roundtrip(tensor, mask)
+
+    def test_exact_recovery_when_last_col_true(self):
+        """When the last column has True in some row, recovered width matches exactly."""
+        tensor = torch.arange(12).reshape(3, 4).float()
+        mask = torch.tensor(
+            [
+                [True, False, False, True],
+                [False, True, False, False],
+                [True, True, True, True],
+            ]
+        )
+        offsets, lengths = mask_to_rle(mask)
+        nested = torch.nested.masked_select(tensor, mask)
+        recovered = unnest_tensor_by_rle(nested, offsets, lengths)
+        # Exact shape match since last column has True
+        assert recovered.shape == tensor.shape
+        assert torch.equal(recovered[mask], tensor[mask])
+        assert (recovered[~mask] == 0).all()
+
+    def test_random_roundtrip(self):
+        """Fuzz-style: random tensors and masks should roundtrip correctly."""
+        gen = torch.Generator().manual_seed(123)
+        for _ in range(10):
+            rows = torch.randint(1, 6, (1,), generator=gen).item()
+            cols = torch.randint(1, 15, (1,), generator=gen).item()
+            tensor = torch.randn(rows, cols, generator=gen)
+            mask = torch.randint(0, 2, (rows, cols), dtype=torch.bool, generator=gen)
+            if mask.any():
+                self._roundtrip(tensor, mask)
+
+
+# ---------------------------------------------------------------------------
+# MaskNestingSpec
+# ---------------------------------------------------------------------------
+
+
+class TestMaskNestingSpec:
+    def _make_td(self, batch_size: int, seq_len: int, *, seed: int = 0):
+        """Create a TensorDict with a mask and a few data fields.
+
+        Sets the first *and last* column to True so that ``rle_to_mask``
+        recovers the exact same ``seq_len`` (no trailing-False truncation).
+        """
+        gen = torch.Generator().manual_seed(seed)
+        mask = torch.randint(0, 2, (batch_size, seq_len), dtype=torch.bool, generator=gen)
+        mask[:, 0] = True
+        mask[:, -1] = True
+        td = TensorDict(
+            {
+                "response_mask": mask,
+                "values": torch.randn(batch_size, seq_len, generator=gen),
+                "logprobs": torch.randn(batch_size, seq_len, generator=gen),
+            },
+            batch_size=[batch_size],
+        )
+        return td, mask
+
+    def test_default_field_names(self):
+        """Offsets/lengths fields should default to <mask_field>_offsets/_lengths."""
+        spec = MaskNestingSpec(mask_field="response_mask", data_field_to_pad_value={"values": 0})
+        assert spec.offsets_field == "response_mask_offsets"
+        assert spec.lengths_field == "response_mask_lengths"
+
+    def test_custom_field_names(self):
+        spec = MaskNestingSpec(
+            mask_field="m",
+            offsets_field="my_off",
+            lengths_field="my_len",
+        )
+        assert spec.offsets_field == "my_off"
+        assert spec.lengths_field == "my_len"
+
+    def test_nest_removes_mask_adds_rle(self):
+        """After nesting, the mask field is removed and offsets/lengths are present."""
+        td, _ = self._make_td(2, 6)
+        spec = MaskNestingSpec(mask_field="response_mask", data_field_to_pad_value={"values": 0, "logprobs": 0})
+        spec.nest_in_td(td)
+
+        assert "response_mask" not in td.keys()
+        assert "response_mask_offsets" in td.keys()
+        assert "response_mask_lengths" in td.keys()
+        # Data fields should now be nested tensors
+        assert td["values"].is_nested
+        assert td["logprobs"].is_nested
+
+    def test_nest_unnest_roundtrip(self):
+        """nest_in_td followed by unnest_in_td should recover original data at masked positions."""
+        td, original_mask = self._make_td(3, 8, seed=7)
+        original_values = td["values"].clone()
+        original_logprobs = td["logprobs"].clone()
+
+        spec = MaskNestingSpec(mask_field="response_mask", data_field_to_pad_value={"values": 0, "logprobs": 0})
+        spec.nest_in_td(td)
+        spec.unnest_in_td(td)
+
+        # Mask should be recovered exactly (last column is True, so no truncation)
+        recovered_mask = td["response_mask"]
+        assert torch.equal(recovered_mask, original_mask)
+
+        # Data at masked positions should match
+        assert torch.equal(td["values"][original_mask], original_values[original_mask])
+        assert torch.equal(td["logprobs"][original_mask], original_logprobs[original_mask])
+
+        # Non-masked positions should be zero (default pad_value)
+        assert (td["values"][~original_mask] == 0).all()
+        assert (td["logprobs"][~original_mask] == 0).all()
+
+    def test_nest_unnest_no_data_fields(self):
+        """Spec with no data fields should still roundtrip the mask via RLE."""
+        td, original_mask = self._make_td(2, 5)
+        spec = MaskNestingSpec(mask_field="response_mask")
+
+        spec.nest_in_td(td)
+        assert "response_mask" not in td.keys()
+
+        spec.unnest_in_td(td)
+        assert torch.equal(td["response_mask"], original_mask)

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Amazon.com Inc and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,53 +14,109 @@
 # limitations under the License.
 import random
 
+import pytest
 import torch
 from tensordict import TensorDict
 
 from verl.workers.utils.padding import (
-    embeds_padding_2_no_padding,
-    left_right_2_no_padding,
-    no_padding_2_padding,
-    response_from_nested,
-    response_to_nested,
+    compress_batch_dtypes,
+    extract_response,
+    make_mask_nesting_specs,
+    nest_batch_by_mask,
+    prepare_response_slice,
+    prepare_unnest,
+    slice_response,
+    unnest,
+    unnest_batch_by_mask,
 )
 
+try:
+    from flash_attn.bert_padding import unpad_input as _  # noqa: F401
 
-def test_padding_conversion_with_log_probs():
-    """Test that log probability tensors remain in padded format after conversion
+    _has_flash_attn = True
+except ImportError:
+    _has_flash_attn = False
 
-    This test verifies the fix for the bug where ratio values were ~451,728 instead of ~1.0.
-    The key insight is that old_log_probs should STAY in padded format and be sliced
-    in the loss computation to match log_prob from model output, rather than being
-    converted to nested format.
+if _has_flash_attn:
+    from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
+
+requires_flash_attn = pytest.mark.skipif(not _has_flash_attn, reason="flash_attn not installed")
+
+# Token-ID pad value (stand-in for tokenizer.pad_token_id in production).
+_TEST_PAD_TOKEN_ID = 0
+
+
+def _nest(data):
+    """Test helper: build specs + nest in-place. Returns (data, specs).
+
+    Exercises the "pre-built specs" entry point of ``nest_batch`` so the
+    returned specs dict can be inspected by assertion-based tests. The
+    simpler ``nest_batch(data, pad_token_id=...)`` call is tested
+    separately via ``TestNestBatchSimple``.
     """
+    specs = make_mask_nesting_specs(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+    nest_batch_by_mask(data, specs)
+    return data, specs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_batch(prompt_lens, response_lens, max_seq_len, max_response_len):
+    """Helper to build a TensorDict with given prompt/response lengths."""
+    batch_size = len(prompt_lens)
+    input_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
+    attention_mask = torch.zeros(batch_size, max_seq_len)
+    response_mask = torch.zeros(batch_size, max_response_len)
+    position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1).clone()
+
+    for i in range(batch_size):
+        total_len = prompt_lens[i] + response_lens[i]
+        input_ids[i, :total_len] = torch.arange(1, total_len + 1)
+        attention_mask[i, :total_len] = 1
+        response_mask[i, : response_lens[i]] = 1
+
+    prompt_list = [input_ids[i, : prompt_lens[i]] for i in range(batch_size)]
+    response_list = [input_ids[i, prompt_lens[i] : prompt_lens[i] + response_lens[i]] for i in range(batch_size)]
+    prompts_nested = torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged)
+    responses_nested = torch.nested.as_nested_tensor(response_list, layout=torch.jagged)
+
+    return TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+            "prompts": prompts_nested,
+            "responses": responses_nested,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests requiring flash_attn (old path)
+# ---------------------------------------------------------------------------
+
+
+@requires_flash_attn
+def test_padding_conversion_with_log_probs():
+    """Test that log probability tensors remain in padded format after conversion (old path)."""
     batch_size = 4
     max_seq_len = 128
     max_response_len = 64
 
-    # Create test data with varying sequence lengths
     input_ids = torch.randint(0, 1000, (batch_size, max_seq_len))
-
-    # Create attention masks with different valid lengths per sample
     attention_mask = torch.zeros(batch_size, max_seq_len)
-    valid_lens = [100, 120, 90, 128]  # Different lengths for each batch item
+    valid_lens = [100, 120, 90, 128]
     for i, vlen in enumerate(valid_lens):
         attention_mask[i, :vlen] = 1
-
-    # Create response masks aligned with the end of each sequence
     response_mask = torch.zeros(batch_size, max_response_len)
-    response_lens = [50, 60, 45, 64]  # Different response lengths
+    response_lens = [50, 60, 45, 64]
     for i, rlen in enumerate(response_lens):
         response_mask[i, :rlen] = 1
-
-    # Create position IDs
     position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1)
-
-    # Add log probability tensors in padded format
-    old_log_probs = torch.randn(batch_size, max_seq_len)
-    ref_log_prob = torch.randn(batch_size, max_seq_len)
-    advantages = torch.randn(batch_size, max_response_len)
-    rollout_log_probs = torch.randn(batch_size, max_seq_len)
 
     data = TensorDict(
         {
@@ -67,87 +124,55 @@ def test_padding_conversion_with_log_probs():
             "attention_mask": attention_mask,
             "response_mask": response_mask,
             "position_ids": position_ids,
-            "old_log_probs": old_log_probs,
-            "ref_log_prob": ref_log_prob,
-            "advantages": advantages,
-            "rollout_log_probs": rollout_log_probs,
+            "old_log_probs": torch.randn(batch_size, max_seq_len),
+            "ref_log_prob": torch.randn(batch_size, max_seq_len),
+            "advantages": torch.randn(batch_size, max_response_len),
+            "rollout_log_probs": torch.randn(batch_size, max_seq_len),
         }
     )
-
-    # Convert to no-padding format
     data_converted = left_right_2_no_padding(data)
 
-    # Verify input_ids and position_ids are nested tensors
-    assert isinstance(data_converted["input_ids"], torch.Tensor)
     assert data_converted["input_ids"].is_nested
     assert data_converted["position_ids"].is_nested
-
-    # Verify log probs REMAIN in padded format (NOT converted to nested)
-    # They will be sliced in the loss computation to match log_prob format
-    assert isinstance(data_converted["old_log_probs"], torch.Tensor)
-    assert not data_converted["old_log_probs"].is_nested, "old_log_probs should remain in padded format"
-    assert not data_converted["ref_log_prob"].is_nested, "ref_log_prob should remain in padded format"
-    assert not data_converted["advantages"].is_nested, "advantages should remain in padded format"
-    assert not data_converted["rollout_log_probs"].is_nested, "rollout_log_probs should remain in padded format"
-
-    # Verify they maintain their original shapes
+    assert not data_converted["old_log_probs"].is_nested
+    assert not data_converted["ref_log_prob"].is_nested
+    assert not data_converted["advantages"].is_nested
     assert data_converted["old_log_probs"].shape == (batch_size, max_seq_len)
-    assert data_converted["ref_log_prob"].shape == (batch_size, max_seq_len)
-    assert data_converted["advantages"].shape == (batch_size, max_response_len)
-    assert data_converted["rollout_log_probs"].shape == (batch_size, max_seq_len)
-
-    # Verify that nested tensors (input_ids, position_ids) have correct number of elements per batch item
     for i, vlen in enumerate(valid_lens):
-        assert data_converted["input_ids"][i].numel() == vlen, (
-            f"Batch {i}: input_ids should have {vlen} elements, got {data_converted['input_ids'][i].numel()}"
-        )
+        assert data_converted["input_ids"][i].numel() == vlen
 
 
+@requires_flash_attn
 def test_padding_conversion_without_log_probs():
-    """Test that padding conversion works correctly when log prob tensors are not present"""
+    """Test that padding conversion works without log prob tensors (old path)."""
     batch_size = 4
     max_seq_len = 128
     max_response_len = 64
-
-    # Create minimal test data
-    input_ids = torch.randint(0, 1000, (batch_size, max_seq_len))
-    attention_mask = torch.ones(batch_size, max_seq_len)
-    response_mask = torch.ones(batch_size, max_response_len)
-    position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1)
-
     data = TensorDict(
         {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "response_mask": response_mask,
-            "position_ids": position_ids,
+            "input_ids": torch.randint(0, 1000, (batch_size, max_seq_len)),
+            "attention_mask": torch.ones(batch_size, max_seq_len),
+            "response_mask": torch.ones(batch_size, max_response_len),
+            "position_ids": torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1),
         }
     )
-
-    # Convert to no-padding format
     data_converted = left_right_2_no_padding(data)
-
-    # Verify basic conversion works
     assert data_converted["input_ids"].is_nested
     assert data_converted["position_ids"].is_nested
-    assert "old_log_probs" not in data_converted
-    assert "ref_log_prob" not in data_converted
 
 
+@requires_flash_attn
 def test_padding_roundtrip():
-    """Test that converting from padding to nested and back preserves values in the response region"""
+    """Test roundtrip via old path preserves response values."""
     batch_size = 2
     max_seq_len = 64
     max_response_len = 32
-    prompt_len = max_seq_len - max_response_len  # 32
+    prompt_len = 32
 
-    # Create simple test data with known values
     input_ids = torch.arange(1, max_seq_len + 1).unsqueeze(0).expand(batch_size, -1).clone()
     attention_mask = torch.ones(batch_size, max_seq_len)
     response_mask = torch.ones(batch_size, max_response_len)
     position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1)
-
-    # Create nested prompts and responses (required by no_padding_2_padding)
     prompt_list = [input_ids[i, :prompt_len] for i in range(batch_size)]
     response_list = [input_ids[i, prompt_len:] for i in range(batch_size)]
     prompts_nested = torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged)
@@ -163,90 +188,201 @@ def test_padding_roundtrip():
             "position_ids": position_ids,
         }
     )
-
-    # Convert to nested format
     data_nested = left_right_2_no_padding(data)
-
-    # Verify input_ids is nested
-    assert data_nested["input_ids"].is_nested
-
-    # Convert back to padding format
     recovered = no_padding_2_padding(data_nested["input_ids"], data_nested)
-
-    # Verify the shape is correct (response region only)
     assert recovered.shape == (batch_size, max_response_len)
-
-    # Verify values are correct (left-shifted by 1 for log_probs alignment)
-    # Response tokens are 33,34,...,64 -> left-shifted: 32,33,...,63
     expected = torch.arange(prompt_len, max_seq_len, dtype=torch.long).unsqueeze(0).expand(batch_size, -1)
     torch.testing.assert_close(recovered, expected)
 
 
+@requires_flash_attn
 def test_no_padding_2_padding_varying_lengths():
-    """Test no_padding_2_padding with varied prompt/response lengths."""
-    batch_size = 4
-    max_seq_len = 100
-    max_response_len = 50
-
+    """Test old roundtrip with varied prompt/response lengths."""
     prompt_lens = [10, 30, 5, 40]
     response_lens = [40, 20, 45, 10]
-
-    input_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
-    for i in range(batch_size):
-        total_len = prompt_lens[i] + response_lens[i]
-        input_ids[i, :total_len] = torch.arange(1, total_len + 1)
-
-    attention_mask = torch.zeros(batch_size, max_seq_len)
-    for i in range(batch_size):
-        attention_mask[i, : prompt_lens[i] + response_lens[i]] = 1
-
-    response_mask = torch.zeros(batch_size, max_response_len)
-    for i in range(batch_size):
-        response_mask[i, : response_lens[i]] = 1
-
-    position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1).clone()
-
-    prompt_list = [input_ids[i, : prompt_lens[i]] for i in range(batch_size)]
-    response_list = [input_ids[i, prompt_lens[i] : prompt_lens[i] + response_lens[i]] for i in range(batch_size)]
-
-    prompts_nested = torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged)
-    responses_nested = torch.nested.as_nested_tensor(response_list, layout=torch.jagged)
-
-    data = TensorDict(
-        {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-            "response_mask": response_mask,
-            "position_ids": position_ids,
-            "prompts": prompts_nested,
-            "responses": responses_nested,
-        }
-    )
-
+    data = _make_batch(prompt_lens, response_lens, max_seq_len=100, max_response_len=50)
     data_nested = left_right_2_no_padding(data)
-    input_ids_nested = data_nested["input_ids"]
-    log_probs_values = input_ids_nested.values().float()
-    log_probs_nested = torch.nested.nested_tensor_from_jagged(log_probs_values, offsets=input_ids_nested.offsets())
+    ids = data_nested["input_ids"]
+    output = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+    result = no_padding_2_padding(output, data_nested)
+    for i in range(4):
+        expected = torch.arange(prompt_lens[i], prompt_lens[i] + response_lens[i], dtype=torch.float)
+        torch.testing.assert_close(result[i, : response_lens[i]], expected, rtol=1e-5, atol=1e-6)
 
-    result_slice_response = no_padding_2_padding(log_probs_nested, data_nested)
 
-    # Verify no_padding_2_padding produces correct values (left-shifted by 1)
-    for i in range(batch_size):
-        resp_len = response_lens[i]
-        expected_start = prompt_lens[i]
-        expected_values = torch.arange(expected_start, expected_start + resp_len, dtype=torch.float)
-        torch.testing.assert_close(
-            result_slice_response[i, :resp_len],
-            expected_values,
-            rtol=1e-5,
-            atol=1e-6,
-            msg=f"Batch {i} (prompt_len={prompt_lens[i]}, resp_len={resp_len}): values incorrect",
+# ---------------------------------------------------------------------------
+# Tests for RLE path (no flash_attn dependency)
+# ---------------------------------------------------------------------------
+
+
+class TestCompressBatchDtypes:
+    """Tests for ``compress_batch_dtypes`` — orthogonal dtype pre-step."""
+
+    def test_routed_experts_compressed_when_in_range(self):
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["routed_experts"] = torch.randint(0, 8, (2, 30), dtype=torch.long)
+        compress_batch_dtypes(data)
+        assert data["routed_experts"].dtype == torch.uint8
+
+    def test_routed_experts_skipped_when_out_of_range(self):
+        """Values > 255 prevent the cast (would wrap around)."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["routed_experts"] = torch.full((2, 30), 300, dtype=torch.long)
+        compress_batch_dtypes(data)
+        # untouched: still int64
+        assert data["routed_experts"].dtype == torch.long
+
+    def test_routed_experts_skipped_on_negative_sentinel(self):
+        """Negative sentinels prevent the cast (would wrap to 255)."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        t = torch.randint(0, 8, (2, 30), dtype=torch.long)
+        t[0, 5] = -1
+        data["routed_experts"] = t
+        compress_batch_dtypes(data)
+        assert data["routed_experts"].dtype == torch.long
+
+    def test_already_compressed_is_noop(self):
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["routed_experts"] = torch.randint(0, 8, (2, 30), dtype=torch.uint8)
+        compress_batch_dtypes(data)
+        # unchanged (same tensor object not guaranteed, but dtype is)
+        assert data["routed_experts"].dtype == torch.uint8
+
+    def test_unknown_field_untouched(self):
+        """Fields not in KNOWN_FIELD_DTYPE_COMPRESSIONS are left alone."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        orig_input_ids_dtype = data["input_ids"].dtype
+        compress_batch_dtypes(data)
+        assert data["input_ids"].dtype == orig_input_ids_dtype
+
+
+class TestNestBatchFieldRouting:
+    """Tests for ``nest_batch`` field routing — nests every field in the registry."""
+
+    def test_all_seq_fields_nested(self):
+        """All fields paired with attention_mask become nested tensors."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["old_log_probs"] = torch.randn(2, 30)
+        data["ref_log_prob"] = torch.randn(2, 30)
+        data["rollout_log_probs"] = torch.randn(2, 30)
+
+        data, specs = _nest(data)
+
+        for key in ("input_ids", "position_ids", "old_log_probs", "ref_log_prob", "rollout_log_probs"):
+            assert data[key].is_nested, f"{key} should be nested"
+
+        seq_spec = specs["attention_mask"]
+        assert seq_spec.offsets_field in data
+        assert seq_spec.lengths_field in data
+
+    def test_resp_fields_nested(self):
+        """Fields paired with response_mask are nested."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["advantages"] = torch.randn(2, 15)
+        data["values"] = torch.randn(2, 15)
+
+        data, specs = _nest(data)
+
+        assert "response_mask" in specs
+        assert data["advantages"].is_nested, "advantages should be nested"
+        assert data["values"].is_nested, "values should be nested"
+
+        resp_spec = specs["response_mask"]
+        assert resp_spec.offsets_field in data
+        assert resp_spec.lengths_field in data
+
+    def test_already_nested_fields_untouched(self):
+        """Fields that are already nested (prompts, responses) are not re-nested."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        assert data["prompts"].is_nested  # pre-condition
+
+        data, specs = _nest(data)
+
+        assert data["prompts"].is_nested
+        assert data["responses"].is_nested
+
+    def test_3d_position_ids_auto_permuted(self):
+        """Raw multimodal 3-D ``(bs, heads, seq_len)`` position_ids is permuted to canonical form.
+
+        ``KNOWN_FIELD_PERMUTATIONS["position_ids"] = (0, 2, 1)`` tells
+        the library to swap dims 1 and 2 of any 3-D ``position_ids``
+        it sees. After nesting, each sample's position_ids is shaped
+        ``(valid_len, heads)`` — the expected canonical layout with
+        ``heads`` as a trailing feature dim.
+        """
+        batch_size = 2
+        max_seq_len = 30
+        max_response_len = 15
+        heads = 4
+
+        input_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
+        attention_mask = torch.zeros(batch_size, max_seq_len)
+        response_mask = torch.zeros(batch_size, max_response_len)
+        # Producer layout: (bs, heads, seq_len) — heads sits between
+        # the batch and sample-mask dims and must be permuted out.
+        position_ids = torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(batch_size, heads, -1).clone()
+
+        prompt_lens, response_lens = [10, 20], [15, 10]
+        for i in range(batch_size):
+            total = prompt_lens[i] + response_lens[i]
+            input_ids[i, :total] = torch.arange(1, total + 1)
+            attention_mask[i, :total] = 1
+            response_mask[i, : response_lens[i]] = 1
+
+        prompt_list = [input_ids[i, : prompt_lens[i]] for i in range(batch_size)]
+        response_list = [input_ids[i, prompt_lens[i] : prompt_lens[i] + response_lens[i]] for i in range(batch_size)]
+
+        data = TensorDict(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "response_mask": response_mask,
+                "position_ids": position_ids,
+                "prompts": torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged),
+                "responses": torch.nested.as_nested_tensor(response_list, layout=torch.jagged),
+            }
         )
-    print("All varied length tests passed")
+
+        data, _ = _nest(data)
+
+        assert data["position_ids"].is_nested
+        # Each sample should have (valid_len, heads) shape — trailing dim preserved
+        for i in range(batch_size):
+            valid_len = prompt_lens[i] + response_lens[i]
+            assert data["position_ids"][i].shape == (valid_len, heads)
+
+    def test_routed_experts_preserves_precompressed_dtype(self):
+        """nest_batch_by_mask preserves whatever dtype the caller passed in.
+
+        The dtype compression is now an orthogonal pre-step
+        (:func:`compress_batch_dtypes`) — this test asserts that
+        :func:`nest_batch_by_mask` does not secretly do it anymore.
+        """
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        # Caller chose to pre-compress to uint8.
+        data["routed_experts"] = torch.randint(0, 8, (2, 30), dtype=torch.uint8)
+
+        data, _ = _nest(data)
+
+        assert data["routed_experts"].is_nested
+        assert data["routed_experts"].dtype == torch.uint8
+
+    def test_nest_batch_by_mask_does_not_compress_dtype(self):
+        """int64 routed_experts stays int64 through nest_batch_by_mask alone."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["routed_experts"] = torch.randint(0, 8, (2, 30), dtype=torch.long)
+
+        data, _ = _nest(data)
+
+        assert data["routed_experts"].is_nested
+        # nest_batch_by_mask is a pure nesting op; it does not touch dtypes
+        assert data["routed_experts"].dtype == torch.long
 
 
 def test_embeds_padding_2_no_padding_varying_lengths():
     """Test that padding tokens are stripped correctly when sequences have different valid lengths."""
+    from verl.workers.utils.padding import embeds_padding_2_no_padding
+
     batch_size = 3
     max_seq_len = 20
     dim = 16
@@ -283,6 +419,8 @@ def test_embeds_padding_2_no_padding_varying_lengths():
 
 
 def test_response_from_nested():
+    from verl.workers.utils.padding import response_from_nested
+
     batch_size = 10
     log_probs = [torch.rand(random.randint(2, 100)) for _ in range(batch_size)]
     log_probs_nt = torch.nested.as_nested_tensor(
@@ -302,6 +440,8 @@ def test_response_from_nested():
 
 
 def test_response_to_nested():
+    from verl.workers.utils.padding import response_to_nested
+
     batch_size = 10
     log_probs = torch.rand(batch_size, 100)
     response_mask = [torch.ones(random.randint(1, log_probs[i].shape[0] - 1)) for i in range(batch_size)]
@@ -325,3 +465,708 @@ if __name__ == "__main__":
     test_response_from_nested()
     test_response_to_nested()
     print("All padding conversion tests passed!")
+
+
+class TestNestUnnestRoundtrip:
+    """Tests for ``nest_batch`` ↔ ``unnest_batch`` full round-trip."""
+
+    def test_seq_fields_roundtrip(self):
+        """seq-level fields survive nest → unnest at mask=True positions."""
+        prompt_lens = [10, 30, 5, 40]
+        response_lens = [40, 20, 45, 10]
+        max_seq_len = 100
+        max_response_len = 50
+
+        data = _make_batch(prompt_lens, response_lens, max_seq_len, max_response_len)
+        attn_mask = data["attention_mask"].bool()
+        # Zero out padding positions so round-trip is exact
+        data["position_ids"] = data["position_ids"] * attn_mask.long()
+        orig_input_ids = data["input_ids"].clone()
+        orig_position_ids = data["position_ids"].clone()
+
+        data, specs = _nest(data)
+
+        assert data["input_ids"].is_nested
+        assert data["position_ids"].is_nested
+
+        unnest_batch_by_mask(data, specs)
+
+        assert not data["input_ids"].is_nested
+        assert not data["position_ids"].is_nested
+        assert data["attention_mask"].shape == (4, max_seq_len)
+
+        torch.testing.assert_close(data["input_ids"], orig_input_ids)
+        torch.testing.assert_close(data["position_ids"], orig_position_ids)
+
+    def test_resp_fields_roundtrip(self):
+        """resp-level fields survive nest → unnest at mask=True positions."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        resp_mask = data["response_mask"].bool()
+        # Zero out padding positions so round-trip is exact
+        data["advantages"] = torch.randn(2, 15) * resp_mask.float()
+        data["values"] = torch.randn(2, 15) * resp_mask.float()
+        orig_adv = data["advantages"].clone()
+        orig_val = data["values"].clone()
+
+        data, specs = _nest(data)
+        assert data["advantages"].is_nested
+        assert data["values"].is_nested
+
+        unnest_batch_by_mask(data, specs)
+
+        assert not data["advantages"].is_nested
+        assert not data["values"].is_nested
+        torch.testing.assert_close(data["advantages"], orig_adv)
+        torch.testing.assert_close(data["values"], orig_val)
+        # response_mask restored
+        assert "response_mask" in data
+        assert data["response_mask"].shape == (2, 15)
+
+    def test_3d_position_ids_roundtrip(self):
+        """Raw 3-D ``(bs, heads, seq_len)`` position_ids round-trips.
+
+        The registered permutation in ``KNOWN_FIELD_PERMUTATIONS``
+        fires on the way in (producing the canonical
+        ``(bs, seq_len, heads)`` layout for nesting) and its inverse
+        fires on the way out, restoring the original shape exactly.
+        """
+        batch_size = 2
+        max_seq_len = 30
+        max_response_len = 15
+        heads = 4
+        prompt_lens, response_lens = [10, 20], [15, 10]
+
+        input_ids = torch.zeros(batch_size, max_seq_len, dtype=torch.long)
+        attention_mask = torch.zeros(batch_size, max_seq_len)
+        response_mask = torch.zeros(batch_size, max_response_len)
+        # Producer layout: (bs, heads, seq_len).
+        position_ids = torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(batch_size, heads, -1).clone()
+
+        for i in range(batch_size):
+            total = prompt_lens[i] + response_lens[i]
+            input_ids[i, :total] = torch.arange(1, total + 1)
+            attention_mask[i, :total] = 1
+            response_mask[i, : response_lens[i]] = 1
+
+        # Zero out padding positions so round-trip is exact (mask
+        # broadcasts across the heads axis at position 1).
+        position_ids = position_ids * attention_mask.unsqueeze(1).long()
+
+        prompt_list = [input_ids[i, : prompt_lens[i]] for i in range(batch_size)]
+        response_list = [input_ids[i, prompt_lens[i] : prompt_lens[i] + response_lens[i]] for i in range(batch_size)]
+
+        data = TensorDict(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "response_mask": response_mask,
+                "position_ids": position_ids.clone(),
+                "prompts": torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged),
+                "responses": torch.nested.as_nested_tensor(response_list, layout=torch.jagged),
+            }
+        )
+        orig_pos = position_ids.clone()
+
+        data, specs = _nest(data)
+        assert data["position_ids"].is_nested
+
+        unnest_batch_by_mask(data, specs)
+        assert not data["position_ids"].is_nested
+        assert data["position_ids"].shape == (batch_size, heads, max_seq_len)
+        torch.testing.assert_close(data["position_ids"], orig_pos)
+
+    def test_mixed_fields_roundtrip(self):
+        """A batch with seq-level + resp-level + already-nested fields round-trips."""
+        data = _make_batch([10, 30], [15, 10], 40, 15)
+        attn_mask = data["attention_mask"].bool()
+        resp_mask = data["response_mask"].bool()
+        # Zero out padding so round-trip is exact
+        data["old_log_probs"] = torch.randn(2, 40) * attn_mask.float()
+        data["advantages"] = torch.randn(2, 15) * resp_mask.float()
+        orig = {k: data[k].clone() for k in ("input_ids", "old_log_probs", "advantages")}
+
+        data, specs = _nest(data)
+        unnest_batch_by_mask(data, specs)
+
+        for key, orig_val in orig.items():
+            assert not data[key].is_nested, f"{key} should be dense after unnest"
+            torch.testing.assert_close(data[key], orig_val)
+
+
+class TestUnnest:
+    """Tests for the library layer: ``prepare_unnest`` + ``unnest``."""
+
+    def test_unnest_preserves_values_at_mask_positions(self):
+        """Unnested dense tensor holds nested values at the original mask=True positions."""
+        prompt_lens = [10, 20, 5]
+        response_lens = [15, 10, 25]
+        max_seq_len = 50
+        max_response_len = 30
+
+        data = _make_batch(prompt_lens, response_lens, max_seq_len, max_response_len)
+        # Capture attention_mask before nest_batch_by_mask pops it.
+        attn_mask = data["attention_mask"].clone().bool()
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        nested = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+
+        ctx = prepare_unnest(data)
+        dense = unnest(ctx, nested)
+
+        # Dense shape uses RLE-inferred seq_len (max(offset+length)), which
+        # for contiguous left-padding equals the largest total_len across rows.
+        assert dense.ndim == 2
+        assert dense.shape[0] == ctx.batch_size == len(prompt_lens)
+        assert dense.shape[1] == ctx.seq_len
+
+        # Every mask=True position carries its original input_id value (as float).
+        for i in range(len(prompt_lens)):
+            total = prompt_lens[i] + response_lens[i]
+            expected = torch.arange(1, total + 1, dtype=torch.float)
+            torch.testing.assert_close(dense[i, :total], expected)
+            # Pad positions should be zero-filled.
+            if total < dense.shape[1]:
+                assert torch.all(dense[i, total:] == 0.0)
+        # Sanity: dense width never exceeds the original attention_mask width.
+        assert dense.shape[1] <= attn_mask.shape[1]
+
+    def test_unnest_with_trailing_dims(self):
+        """Trailing feature dims (e.g. top-k) flow through unchanged."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        flat_vals = ids.values().float().unsqueeze(-1).expand(-1, 4).contiguous()
+        nested = torch.nested.nested_tensor_from_jagged(flat_vals, offsets=ids.offsets())
+
+        dense = unnest(prepare_unnest(data), nested)
+        assert dense.ndim == 3
+        assert dense.shape[0] == 2
+        assert dense.shape[-1] == 4
+
+    def test_ctx_reused_across_tensors(self):
+        """A single ``UnnestContext`` can scatter multiple nested tensors."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        a = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+        b = torch.nested.nested_tensor_from_jagged(ids.values().float() * 2.0, offsets=ids.offsets())
+
+        ctx = prepare_unnest(data)
+        dense_a = unnest(ctx, a)
+        dense_b = unnest(ctx, b)
+        # dense_b == 2 * dense_a at every position (zeros at pads hold trivially).
+        torch.testing.assert_close(dense_b, dense_a * 2.0)
+
+
+class TestSliceResponse:
+    """Tests for the PPO layer: ``prepare_response_slice`` + ``slice_response``."""
+
+    def test_slice_bounds_match_reference_left_shift(self):
+        """Slicer produces the PPO one-token left-shift of each response region."""
+        prompt_lens = [10, 25, 5]
+        response_lens = [20, 10, 30]
+        max_seq_len = 60
+        max_response_len = 35
+
+        data = _make_batch(prompt_lens, response_lens, max_seq_len, max_response_len)
+        data, _ = _nest(data)
+
+        # Build a dense tensor with known values via the library layer.
+        ids = data["input_ids"]
+        nested = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+        dense = unnest(prepare_unnest(data), nested)
+
+        slice_ctx = prepare_response_slice(data)
+        sliced = slice_response(slice_ctx, dense)
+        assert sliced.shape == (len(prompt_lens), max_response_len)
+        assert slice_ctx.max_response_len == max_response_len
+
+        # _make_batch assigns input_ids[i, :total_len] = 1..total_len, so
+        # position k carries value (k+1). The PPO left-shift means the
+        # slice at response pos t holds the token at (prompt_len + t - 1)
+        # zero-indexed → value (prompt_len + t).
+        for i in range(len(prompt_lens)):
+            r_len = response_lens[i]
+            p_len = prompt_lens[i]
+            expected = torch.arange(p_len, p_len + r_len, dtype=torch.float)
+            torch.testing.assert_close(sliced[i, :r_len], expected)
+            if r_len < max_response_len:
+                assert torch.all(sliced[i, r_len:] == 0.0)
+
+    def test_slice_preserves_trailing_dims(self):
+        """Trailing dims on the dense tensor are preserved by the slicer."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        flat_vals = ids.values().float().unsqueeze(-1).expand(-1, 3).contiguous()
+        nested = torch.nested.nested_tensor_from_jagged(flat_vals, offsets=ids.offsets())
+        dense = unnest(prepare_unnest(data), nested)
+
+        sliced = slice_response(prepare_response_slice(data), dense)
+        assert sliced.shape == (2, 15, 3)
+
+
+class TestResponseExtractionIntegration:
+    """End-to-end tests for the two-layer pipeline (``unnest`` + ``slice_response``)."""
+
+    def test_roundtrip_varying_lengths(self):
+        """Roundtrip with varied prompt/response lengths produces correct response slices."""
+        prompt_lens = [10, 30, 5, 40]
+        response_lens = [40, 20, 45, 10]
+        max_seq_len = 100
+        max_response_len = 50
+
+        data = _make_batch(prompt_lens, response_lens, max_seq_len, max_response_len)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        model_output = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+
+        unnest_ctx = prepare_unnest(data)
+        slice_ctx = prepare_response_slice(data)
+        result = slice_response(slice_ctx, unnest(unnest_ctx, model_output))
+        assert result.shape == (4, max_response_len)
+
+        # Response values are left-shifted by 1 for log_prob alignment.
+        for i in range(4):
+            r_len = response_lens[i]
+            expected = torch.arange(prompt_lens[i], prompt_lens[i] + r_len, dtype=torch.float)
+            torch.testing.assert_close(result[i, :r_len], expected, rtol=1e-5, atol=1e-6)
+
+    def test_roundtrip_uniform_lengths(self):
+        """Roundtrip with uniform lengths (no padding needed)."""
+        prompt_lens = [32] * 4
+        response_lens = [32] * 4
+
+        data = _make_batch(prompt_lens, response_lens, 64, 32)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        model_output = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+        result = slice_response(prepare_response_slice(data), unnest(prepare_unnest(data), model_output))
+
+        assert result.shape == (4, 32)
+        for i in range(4):
+            expected = torch.arange(32, 64, dtype=torch.float)
+            torch.testing.assert_close(result[i], expected, rtol=1e-5, atol=1e-6)
+
+    def test_roundtrip_with_trailing_dims(self):
+        """Model output with trailing dimensions (e.g. top-k logits) works."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        flat_vals = ids.values().float().unsqueeze(-1).expand(-1, 5)
+        model_output = torch.nested.nested_tensor_from_jagged(flat_vals, offsets=ids.offsets())
+
+        result = slice_response(prepare_response_slice(data), unnest(prepare_unnest(data), model_output))
+        assert result.shape == (2, 15, 5)
+
+
+class TestExtractResponseDispatch:
+    """Tests for ``extract_response`` — dispatches on batch nesting style.
+
+    Verifies that the same ``extract_response(data, tensor)`` call
+    handles new mask-nesting batches, and (with flash_attn) legacy
+    batches, so worker loss code stays transparent to
+    ``use_mask_nesting``.
+    """
+
+    def test_new_path_matches_manual_two_step(self):
+        """extract_response on a new-path batch == manual unnest + slice_response."""
+        data = _make_batch([10, 25, 5], [20, 10, 30], 60, 35)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        nested = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+
+        via_dispatch = extract_response(data, nested)
+        via_manual = slice_response(prepare_response_slice(data), unnest(prepare_unnest(data), nested))
+        torch.testing.assert_close(via_dispatch, via_manual)
+
+    def test_multiple_tensors_new_path(self):
+        """Calling extract_response per tensor produces consistent results."""
+        data = _make_batch([10, 20, 5], [15, 10, 25], 40, 25)
+        data, _ = _nest(data)
+
+        ids = data["input_ids"]
+        a = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+        b = torch.nested.nested_tensor_from_jagged(ids.values().float() * 2.0, offsets=ids.offsets())
+
+        result_a = extract_response(data, a)
+        result_b = extract_response(data, b)
+        torch.testing.assert_close(result_b, result_a * 2.0)
+
+
+@requires_flash_attn
+class TestExtractResponseDispatchLegacy:
+    """Legacy-path coverage for ``extract_response`` (requires flash_attn)."""
+
+    def test_legacy_path_matches_no_padding_2_padding(self):
+        """extract_response on a legacy batch == no_padding_2_padding."""
+        prompt_lens = [10, 30, 5, 40]
+        response_lens = [40, 20, 45, 10]
+
+        data = _make_batch(prompt_lens, response_lens, 100, 50)
+        data = left_right_2_no_padding(data)
+
+        ids = data["input_ids"]
+        model_output = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+
+        via_dispatch = extract_response(data, model_output)
+        via_direct = no_padding_2_padding(model_output, data)
+        torch.testing.assert_close(via_dispatch, via_direct)
+
+    def test_both_paths_produce_identical_output(self):
+        """The same extract_response call on legacy vs new batch → same result."""
+        prompt_lens = [10, 25, 5, 40]
+        response_lens = [20, 15, 35, 10]
+
+        data_legacy = _make_batch(prompt_lens, response_lens, 75, 35)
+        data_new = _make_batch(prompt_lens, response_lens, 75, 35)
+
+        data_legacy = left_right_2_no_padding(data_legacy)
+        data_new, _ = _nest(data_new)
+
+        legacy_ids = data_legacy["input_ids"]
+        new_ids = data_new["input_ids"]
+        legacy_output = torch.nested.nested_tensor_from_jagged(
+            legacy_ids.values().float(), offsets=legacy_ids.offsets()
+        )
+        new_output = torch.nested.nested_tensor_from_jagged(new_ids.values().float(), offsets=new_ids.offsets())
+
+        result_legacy = extract_response(data_legacy, legacy_output)
+        result_new = extract_response(data_new, new_output)
+        torch.testing.assert_close(result_legacy, result_new)
+
+
+class TestNestBatchSimple:
+    """Tests for the single-step ``nest_batch`` API (build-and-apply)."""
+
+    def test_simple_kwarg_path(self):
+        """nest_batch(data, pad_token_id=...) builds specs internally."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        nest_batch_by_mask(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        assert data["input_ids"].is_nested
+        assert data["position_ids"].is_nested
+
+    def test_unnest_without_specs_uses_stash(self):
+        """unnest_batch() with no specs retrieves them from the stash."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        attn_mask = data["attention_mask"].bool()
+        data["position_ids"] = data["position_ids"] * attn_mask.long()
+        orig_ids = data["input_ids"].clone()
+        orig_pos = data["position_ids"].clone()
+
+        nest_batch_by_mask(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        assert data["input_ids"].is_nested
+
+        unnest_batch_by_mask(data)  # no specs arg
+        assert not data["input_ids"].is_nested
+        torch.testing.assert_close(data["input_ids"], orig_ids)
+        torch.testing.assert_close(data["position_ids"], orig_pos)
+
+    def test_unnest_without_state_is_noop(self):
+        """unnest_batch on a never-nested TensorDict is a no-op, not a crash."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        # Don't nest. Calling unnest should return data unchanged.
+        result = unnest_batch_by_mask(data)
+        assert result is data
+        assert not data["input_ids"].is_nested
+
+    def test_field_to_mask_and_pad_custom_field(self):
+        """Declarative per-call custom field registration."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        # A fresh field the library has no knowledge of.
+        data["my_custom_scores"] = torch.ones(2, 15)
+        nest_batch_by_mask(
+            data,
+            pad_token_id=_TEST_PAD_TOKEN_ID,
+            field_to_mask_and_pad={"my_custom_scores": ("response_mask", 0.0)},
+        )
+        assert data["my_custom_scores"].is_nested
+
+    def test_dynamic_specs_mutation(self):
+        """Pre-built specs can be mutated before being passed to nest_batch."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        data["routed_experts"] = torch.randint(0, 8, (2, 30))
+
+        specs = make_mask_nesting_specs(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        # Opt out of nesting routed_experts for this call.
+        specs["attention_mask"].data_field_to_pad_value.pop("routed_experts", None)
+        nest_batch_by_mask(data, specs)
+
+        assert data["input_ids"].is_nested
+        # routed_experts was skipped, so it remains dense.
+        assert not data["routed_experts"].is_nested
+
+    def test_conflicting_specs_and_kwargs_raise(self):
+        """Passing both pre-built specs and build-from-scratch kwargs raises."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        specs = make_mask_nesting_specs(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        with pytest.raises(TypeError, match="pre-built"):
+            nest_batch_by_mask(data, specs, pad_token_id=1)
+
+
+class TestNestBatchDispatchCompat:
+    """Regression tests for the dispatch/collect path (chunk_tensordict → per-chunk consumer).
+
+    When a nested TensorDict is chunked for RPC dispatch to Ray workers,
+    each chunk inherits a reference to the stashed ``MaskNestingSpec``
+    dict — which carries the **original full-batch** ``mask_shape``.
+    Consumers that read ``mask_shape[-1]`` (seq dim) are fine; consumers
+    that read or allocate with ``mask_shape[0]`` would see the stale
+    full-batch dim instead of the per-chunk dim.
+    """
+
+    def _make_nested_batch(self, bs: int):
+        max_seq_len, max_response_len = 12, 6
+        input_ids = torch.zeros(bs, max_seq_len, dtype=torch.long)
+        attention_mask = torch.zeros(bs, max_seq_len)
+        response_mask = torch.zeros(bs, max_response_len)
+        advantages = torch.randn(bs, max_response_len)
+        for i in range(bs):
+            total = 8 + (i % 3)
+            input_ids[i, :total] = torch.arange(1, total + 1)
+            attention_mask[i, :total] = 1
+            response_mask[i, : 3 + i % 2] = 1
+        advantages = advantages * response_mask
+        prompt_list = [input_ids[i, :5] for i in range(bs)]
+        response_list = [input_ids[i, 5 : 5 + (3 + i % 2)] for i in range(bs)]
+        return TensorDict(
+            {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "response_mask": response_mask,
+                "advantages": advantages,
+                "prompts": torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged),
+                "responses": torch.nested.as_nested_tensor(response_list, layout=torch.jagged),
+            },
+            batch_size=[bs],
+        )
+
+    def test_chunked_per_chunk_unnest(self):
+        """unnest_batch_by_mask on a per-chunk TensorDict uses local batch dim.
+
+        Guards against a regression where ``MaskNestingSpec.unnest_in_td``
+        allocated the mask with the full-batch ``mask_shape``, leaving
+        extra rows of zeros on each chunk.
+        """
+        from verl.utils.tensordict_utils import chunk_tensordict
+
+        data = self._make_nested_batch(bs=4)
+        orig_ids = data["input_ids"].clone()
+        orig_adv = data["advantages"].clone()
+
+        nest_batch_by_mask(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        chunks = chunk_tensordict(data, chunks=2)
+
+        for i, chunk in enumerate(chunks):
+            # Each chunk has its own RLE offsets (2 rows) but the stashed
+            # specs still reference the full (4, seq_len) mask_shape.
+            unnest_batch_by_mask(chunk)
+            assert chunk["input_ids"].shape[0] == 2
+            assert chunk["attention_mask"].shape[0] == 2
+            assert chunk["advantages"].shape[0] == 2
+            expected_ids = orig_ids[i * 2 : (i + 1) * 2]
+            expected_adv = orig_adv[i * 2 : (i + 1) * 2]
+            torch.testing.assert_close(chunk["input_ids"], expected_ids)
+            torch.testing.assert_close(chunk["advantages"], expected_adv)
+
+    def test_chunked_per_chunk_response_extraction(self):
+        """unnest + slice_response work on a per-chunk TensorDict.
+
+        ``prepare_response_slice`` reads ``specs[...].mask_shape[-1]``
+        for ``max_response_len``; this guards the stale full-batch dim
+        in ``mask_shape`` from leaking into shape computations.
+        """
+        from verl.utils.tensordict_utils import chunk_tensordict
+
+        data = self._make_nested_batch(bs=4)
+        nest_batch_by_mask(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        chunks = chunk_tensordict(data, chunks=2)
+
+        for chunk in chunks:
+            ids = chunk["input_ids"]
+            model_out = torch.nested.nested_tensor_from_jagged(ids.values().float(), offsets=ids.offsets())
+            result = slice_response(prepare_response_slice(chunk), unnest(prepare_unnest(chunk), model_out))
+            # Shape must be (per-chunk bs, response_len) — NOT (full bs, ...)
+            assert result.shape[0] == 2
+            assert result.shape[1] == 6  # max_response_len from spec
+
+
+# ---------------------------------------------------------------------------
+# Trainer dispatch helper simulation
+# ---------------------------------------------------------------------------
+
+# These tests replicate the logic of
+# ``RayPPOTrainer._compress_batch`` / ``_decompress_batch`` inline —
+# avoiding the heavy Ray / vLLM imports required to instantiate a real
+# trainer. Since ``nest_batch_by_mask`` / ``unnest_batch_by_mask`` now
+# handle shape normalisation (and its reversal) internally, the
+# trainer helpers are reduced to thin wrappers that branch on
+# ``use_mask_nesting``. The sim helpers mirror that simplicity so
+# test failures surface drift from the real trainer implementation.
+
+
+def _sim_compress_batch(data: TensorDict, pad_token_id: int) -> TensorDict:
+    """Mirror of ``RayPPOTrainer._compress_batch`` (use_mask_nesting=True)."""
+    compress_batch_dtypes(data)
+    nest_batch_by_mask(data, pad_token_id=pad_token_id)
+    # Legacy worker-side ``loss_mask`` alias — see trainer-side TODO.
+    if "response_mask" in data:
+        data["loss_mask"] = data["response_mask"]
+    return data
+
+
+def _sim_decompress_batch(data: TensorDict) -> TensorDict:
+    """Mirror of ``RayPPOTrainer._decompress_batch`` (use_mask_nesting=True)."""
+    unnest_batch_by_mask(data)  # auto-retrieve specs + reverse permutations
+    data.pop("loss_mask", None)
+    return data
+
+
+class TestTrainerCompressBatch:
+    """Tests for trainer compress/decompress helpers — mostly verifying the library does the heavy lifting."""
+
+    def test_3d_position_ids_full_roundtrip(self):
+        """(bs, heads, seq_len) position_ids survive nest → unnest at mask=True positions."""
+        bs, heads, max_seq_len, max_response_len = 2, 4, 30, 15
+        prompt_lens, response_lens = [10, 20], [15, 10]
+
+        input_ids = torch.zeros(bs, max_seq_len, dtype=torch.long)
+        attention_mask = torch.zeros(bs, max_seq_len)
+        response_mask = torch.zeros(bs, max_response_len)
+        # Original multimodal layout: heads in the middle
+        position_ids = torch.arange(max_seq_len).unsqueeze(0).unsqueeze(0).expand(bs, heads, -1).clone()
+
+        for i in range(bs):
+            total = prompt_lens[i] + response_lens[i]
+            input_ids[i, :total] = torch.arange(1, total + 1)
+            attention_mask[i, :total] = 1
+            response_mask[i, : response_lens[i]] = 1
+        # Zero out padding positions so round-trip is exact
+        position_ids = position_ids * attention_mask.unsqueeze(1).long()
+
+        prompt_list = [input_ids[i, : prompt_lens[i]] for i in range(bs)]
+        response_list = [input_ids[i, prompt_lens[i] : prompt_lens[i] + response_lens[i]] for i in range(bs)]
+
+        data = TensorDict(
+            {
+                "input_ids": input_ids.clone(),
+                "attention_mask": attention_mask.clone(),
+                "response_mask": response_mask.clone(),
+                "position_ids": position_ids.clone(),
+                "prompts": torch.nested.as_nested_tensor(prompt_list, layout=torch.jagged),
+                "responses": torch.nested.as_nested_tensor(response_list, layout=torch.jagged),
+            }
+        )
+        orig_input_ids = input_ids.clone()
+        orig_pos = position_ids.clone()
+
+        _sim_compress_batch(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+
+        # Mid-state: everything nested, transpose flag stashed
+        assert data["input_ids"].is_nested
+        assert data["position_ids"].is_nested
+        # position_ids nested layout is (valid_len, heads) per sample
+        for i in range(bs):
+            valid_len = prompt_lens[i] + response_lens[i]
+            assert data["position_ids"][i].shape == (valid_len, heads)
+
+        _sim_decompress_batch(data)
+
+        # After unnest: dense tensors restored, position_ids back to (bs, heads, seq_len)
+        assert not data["input_ids"].is_nested
+        assert not data["position_ids"].is_nested
+        assert data["position_ids"].shape == (bs, heads, max_seq_len)
+        torch.testing.assert_close(data["input_ids"], orig_input_ids)
+        torch.testing.assert_close(data["position_ids"], orig_pos)
+
+    def test_2d_position_ids_full_roundtrip(self):
+        """2-D position_ids (single-head) flow: no transpose, regular round-trip."""
+        bs, max_seq_len, max_response_len = 2, 30, 15
+        data = _make_batch([10, 20], [15, 10], max_seq_len, max_response_len)
+        attn_mask = data["attention_mask"].bool()
+        data["position_ids"] = data["position_ids"] * attn_mask.long()
+
+        orig_input_ids = data["input_ids"].clone()
+        orig_pos = data["position_ids"].clone()
+
+        _sim_compress_batch(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        assert data["input_ids"].is_nested
+        assert data["position_ids"].is_nested
+
+        _sim_decompress_batch(data)
+        assert not data["input_ids"].is_nested
+        assert not data["position_ids"].is_nested
+        assert data["position_ids"].shape == (bs, max_seq_len)
+        torch.testing.assert_close(data["input_ids"], orig_input_ids)
+        torch.testing.assert_close(data["position_ids"], orig_pos)
+
+    def test_decompress_without_compress_is_noop(self):
+        """Calling _decompress_batch on a never-nested TensorDict is a no-op."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        orig_ids = data["input_ids"].clone()
+
+        # Skip nest; jump straight to unnest (no stashed state, no flag).
+        _sim_decompress_batch(data)
+
+        assert not data["input_ids"].is_nested
+        torch.testing.assert_close(data["input_ids"], orig_ids)
+
+    def test_loss_mask_alias_inference_path(self):
+        """_compress_batch re-exposes ``loss_mask`` when response_mask isn't popped.
+
+        Legacy convention: some worker loss code reads
+        ``data["loss_mask"]`` instead of ``data["response_mask"]``.
+        In inference-style flows (``_compute_values`` etc.) the batch
+        has no resp-level data fields, so ``response_mask`` is never
+        popped during nesting — the trainer then aliases it under
+        ``loss_mask`` post-nest.
+        """
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        # No resp-level data fields → response_mask stays in batch_td.
+        _sim_compress_batch(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        assert "loss_mask" in data
+        assert "response_mask" in data
+        # Both point to the same tensor (alias by reference).
+        assert data["loss_mask"] is data["response_mask"]
+
+    def test_loss_mask_alias_dropped_on_decompress(self):
+        """_decompress_batch cleans up the ``loss_mask`` alias."""
+        data = _make_batch([10, 20], [15, 10], 30, 15)
+        _sim_compress_batch(data, pad_token_id=_TEST_PAD_TOKEN_ID)
+        assert "loss_mask" in data
+        _sim_decompress_batch(data)
+        assert "loss_mask" not in data
+        assert "response_mask" in data
+
+
+@requires_flash_attn
+class TestNewVsLegacyEquivalence:
+    """Cross-validate ``nest_batch`` against the legacy flash_attn path."""
+
+    def test_roundtrip_equivalence(self):
+        """Both paths produce identical response extractions."""
+        prompt_lens = [10, 30, 5, 40]
+        response_lens = [40, 20, 45, 10]
+        data_old = _make_batch(prompt_lens, response_lens, 100, 50)
+        data_rle = _make_batch(prompt_lens, response_lens, 100, 50)
+
+        data_old = left_right_2_no_padding(data_old)
+        data_rle, rle_specs = _nest(data_rle)
+
+        old_ids = data_old["input_ids"]
+        old_output = torch.nested.nested_tensor_from_jagged(old_ids.values().float(), offsets=old_ids.offsets())
+        rle_ids = data_rle["input_ids"]
+        rle_output = torch.nested.nested_tensor_from_jagged(rle_ids.values().float(), offsets=rle_ids.offsets())
+
+        result_old = no_padding_2_padding(old_output, data_old)
+        result_rle = slice_response(prepare_response_slice(data_rle), unnest(prepare_unnest(data_rle), rle_output))
+
+        torch.testing.assert_close(result_old, result_rle)

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -28,6 +28,7 @@ from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy, Place
 from verl.protocol import DataProto, _padding_size_key
 from verl.single_controller.base import ClassWithInitArgs, ResourcePool, Worker, WorkerGroup
 from verl.single_controller.base.decorator import MAGIC_ATTR, Dispatch
+from verl.utils.debug import marked_timer
 from verl.utils.device import get_device_name, is_torch_npu_available
 from verl.utils.py_functional import temp_env_var
 
@@ -48,12 +49,24 @@ def get_random_string(length: int) -> str:
 def func_generator(self, method_name, dispatch_fn, collect_fn, execute_fn, blocking):
     class Functor:
         def __call__(this, *args, **kwargs):
-            args, kwargs = dispatch_fn(self, *args, **kwargs)
-            padding_count = kwargs.pop(_padding_size_key, 0)
-            output = execute_fn(method_name, *args, **kwargs)
-            if blocking:
-                output = ray.get(output)
-            output = collect_fn(self, output)
+            timing = getattr(self, "_wg_timing", None)
+            if timing is not None:
+                with marked_timer("wg_dispatch", timing), marked_timer(f"wg_dispatch/{method_name}", timing):
+                    args, kwargs = dispatch_fn(self, *args, **kwargs)
+                padding_count = kwargs.pop(_padding_size_key, 0)
+                with marked_timer("wg_execute", timing), marked_timer(f"wg_execute/{method_name}", timing):
+                    output = execute_fn(method_name, *args, **kwargs)
+                    if blocking:
+                        output = ray.get(output)
+                with marked_timer("wg_collect", timing), marked_timer(f"wg_collect/{method_name}", timing):
+                    output = collect_fn(self, output)
+            else:
+                args, kwargs = dispatch_fn(self, *args, **kwargs)
+                padding_count = kwargs.pop(_padding_size_key, 0)
+                output = execute_fn(method_name, *args, **kwargs)
+                if blocking:
+                    output = ray.get(output)
+                output = collect_fn(self, output)
             if padding_count > 0:
                 if isinstance(output, DataProto):
                     indices = [i for i in range(len(output))][:-padding_count]

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -831,6 +831,7 @@ trainer:
   save_freq: -1
   esi_redundant_time: 0
   resume_mode: auto
+  use_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -832,6 +832,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   use_mask_nesting: false
+  strict_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -768,6 +768,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   use_mask_nesting: false
+  strict_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -767,6 +767,7 @@ trainer:
   save_freq: -1
   esi_redundant_time: 0
   resume_mode: auto
+  use_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -789,6 +789,7 @@ trainer:
   save_freq: -1
   esi_redundant_time: 0
   resume_mode: auto
+  use_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -790,6 +790,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   use_mask_nesting: false
+  strict_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -745,6 +745,7 @@ trainer:
   esi_redundant_time: 0
   resume_mode: auto
   use_mask_nesting: false
+  strict_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -744,6 +744,7 @@ trainer:
   save_freq: -1
   esi_redundant_time: 0
   resume_mode: auto
+  use_mask_nesting: false
   resume_from_path: null
   val_before_train: true
   val_only: false

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -161,6 +161,9 @@ trainer:
   # "resume_path": resume from a user-defined path
   resume_mode: auto
 
+  # Use mask-driven RLE nesting instead of legacy left_right_2_no_padding
+  use_mask_nesting: False
+
   # Path to resume training from (only used when resume_mode is "resume_path")
   resume_from_path: null
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -164,6 +164,12 @@ trainer:
   # Use mask-driven RLE nesting instead of legacy left_right_2_no_padding
   use_mask_nesting: False
 
+  # When True (and use_mask_nesting is True), any tensor field in the batch
+  # that remains dense after nest_batch_by_mask raises a RuntimeError instead
+  # of just warning. Use in CI/dev to catch newly-added fields that silently
+  # bypass compression.
+  strict_mask_nesting: False
+
   # Path to resume training from (only used when resume_mode is "resume_path")
   resume_from_path: null
 

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -23,7 +23,7 @@ from verl.trainer.ppo.core_algos import agg_loss, get_policy_loss_fn, kl_penalty
 from verl.utils.metric import AggregationType, Metric
 from verl.workers.config import ActorConfig, DistillationConfig, DistillationLossConfig
 from verl.workers.utils.losses import ppo_loss
-from verl.workers.utils.padding import no_padding_2_padding
+from verl.workers.utils.padding import extract_response
 
 DistillationLossFn = Callable[
     [
@@ -255,7 +255,7 @@ def distillation_loss(
         policy_loss_fn = get_policy_loss_fn(loss_config.policy_loss_mode)
         for k, v in config.global_batch_info.items():
             loss_config.global_batch_info[k] = v
-        log_prob = no_padding_2_padding(model_output["log_probs"], data)
+        log_prob = extract_response(data, model_output["log_probs"])
         old_log_prob = data["old_log_probs"]
         rollout_is_weights = data.get("rollout_is_weights", None)
         distillation_loss, pg_metrics = policy_loss_fn(
@@ -294,10 +294,10 @@ def compute_forward_kl_topk(
     - distillation_losses: (bsz, resp_len)
     - distillation_metrics: Dictionary of metrics.
     """
-    # topk loss has been computed in logits processor
-    distillation_losses = no_padding_2_padding(model_output["distillation_losses"], data)
-    student_mass = no_padding_2_padding(model_output["student_mass"], data)
-    teacher_mass = no_padding_2_padding(model_output["teacher_mass"], data)
+    # topk loss has been computed in logits processor.
+    distillation_losses = extract_response(data, model_output["distillation_losses"])
+    student_mass = extract_response(data, model_output["student_mass"])
+    teacher_mass = extract_response(data, model_output["teacher_mass"])
     response_mask_bool = data["response_mask"].bool()
     assert distillation_losses.shape == student_mass.shape == teacher_mass.shape == response_mask_bool.shape
 
@@ -338,8 +338,8 @@ def compute_distillation_loss_reverse_kl_estimator(
     - distillation_losses: (bsz, resp_len)
     - distillation_metrics: Dictionary of metrics.
     """
-    student_log_probs = no_padding_2_padding(model_output["log_probs"], data)
-    teacher_log_probs = no_padding_2_padding(data["teacher_logprobs"], data).squeeze(-1)
+    student_log_probs = extract_response(data, model_output["log_probs"])
+    teacher_log_probs = extract_response(data, data["teacher_logprobs"]).squeeze(-1)
     response_mask_bool = data["response_mask"].bool()
     assert teacher_log_probs.shape == student_log_probs.shape == response_mask_bool.shape
 

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -301,13 +301,20 @@ def compute_timing_metrics(batch: DataProto, timing_raw: dict[str, float]) -> di
         **{name: num_overall_tokens for name in ["ref", "values", "adv", "update_critic", "update_actor"]},
     }
 
-    return {
-        **{f"timing_s/{name}": value for name, value in timing_raw.items()},
-        **{
-            f"timing_per_token_ms/{name}": timing_raw[name] * 1000 / num_tokens_of_section[name]
-            for name in set(num_tokens_of_section.keys()) & set(timing_raw.keys())
-        },
-    }
+    _DATA_IO_PREFIXES = ("compress", "decompress", "wg_dispatch", "wg_execute", "wg_collect")
+
+    metrics: dict[str, Any] = {}
+
+    for name, value in timing_raw.items():
+        if name.startswith(_DATA_IO_PREFIXES):
+            metrics[f"data_io/timing_s/{name}"] = value
+        else:
+            metrics[f"timing_s/{name}"] = value
+
+    for name in set(num_tokens_of_section.keys()) & set(timing_raw.keys()):
+        metrics[f"timing_per_token_ms/{name}"] = timing_raw[name] * 1000 / num_tokens_of_section[name]
+
+    return metrics
 
 
 def compute_throughout_metrics(batch: DataProto, timing_raw: dict[str, float], n_gpus: int) -> dict[str, Any]:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -322,6 +322,11 @@ class RayPPOTrainer:
         self.use_prefix_grouper = self.config.actor_rollout_ref.actor.get("use_prefix_grouper", False)
         self.use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
         self.use_mask_nesting = config.trainer.get("use_mask_nesting", False)
+        # When True, `_compress_batch` raises if any tensor field is not nested
+        # (i.e. missing from the registry) — guards against silent compression
+        # regressions when new fields are added. Defaults to False to preserve
+        # backward compatibility; warnings are still emitted.
+        self.strict_mask_nesting = config.trainer.get("strict_mask_nesting", False)
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
@@ -1159,6 +1164,13 @@ class RayPPOTrainer:
             )
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
+            # Derive `prompt_mask` from attention_mask's left half so the
+            # registry entry ``"prompts": ("prompt_mask", ...)`` can nest it.
+            # attention_mask is left-padded on the prompt side, so slicing up
+            # to `max_prompt_length` recovers exactly the prompt-axis mask.
+            if "prompts" in batch_td and "prompt_mask" not in batch_td and "attention_mask" in batch_td:
+                pm_len = batch_td["prompts"].shape[-1]
+                batch_td["prompt_mask"] = batch_td["attention_mask"][:, :pm_len].contiguous()
             # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
             if "response_mask" in batch_td:
                 batch_td["loss_mask"] = batch_td["response_mask"]
@@ -1167,6 +1179,7 @@ class RayPPOTrainer:
                 batch_td,
                 pad_token_id=self.tokenizer.pad_token_id,
                 field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
+                strict=self.strict_mask_nesting,
             )
             # Restore `response_mask` as a nested all-ones alias of `loss_mask`
             # so worker-side loss code (which still selects "response_mask")
@@ -1184,6 +1197,8 @@ class RayPPOTrainer:
         batch_td.pop("response_mask", None)
         unnest_batch_by_mask(batch_td)  # no-op if batch_td wasn't nested
         batch_td.pop("loss_mask", None)
+        # Drop the derived prompt_mask — original input didn't have it.
+        batch_td.pop("prompt_mask", None)
         return batch_td
 
     def _decompress_model_outputs(self, batch_td, tensors: dict):

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1149,6 +1149,14 @@ class RayPPOTrainer:
     def _compress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Compress a batch TensorDict for worker dispatch."""
         with marked_timer("compress", self._timing_raw):
+            # Record config-declared lengths so downstream consumers don't have
+            # to re-derive them from tensor shapes (which drift after nesting
+            # and worker chunking).
+            tu.assign_non_tensor(
+                batch_td,
+                max_prompt_length=self.config.data.max_prompt_length,
+                max_response_length=self.config.data.max_response_length,
+            )
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
             # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1160,12 +1160,20 @@ class RayPPOTrainer:
                 pad_token_id=self.tokenizer.pad_token_id,
                 field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
             )
+            # Restore `response_mask` as a nested all-ones alias of `loss_mask`
+            # so worker-side loss code (which still selects "response_mask")
+            # keeps working; `_decompress_batch` drops this alias before
+            # `unnest_batch_by_mask` rehydrates the real 2D mask.
+            if "loss_mask" in batch_td:
+                batch_td["response_mask"] = batch_td["loss_mask"]
         return batch_td
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""
         if not self.use_mask_nesting:
             return batch_td
+        # Drop the nested alias before unnest so it rehydrates the real 2D mask.
+        batch_td.pop("response_mask", None)
         unnest_batch_by_mask(batch_td)  # no-op if batch_td wasn't nested
         batch_td.pop("loss_mask", None)
         return batch_td

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1157,15 +1157,6 @@ class RayPPOTrainer:
                 max_prompt_length=self.config.data.max_prompt_length,
                 max_response_length=self.config.data.max_response_length,
             )
-            # One-shot payload-size instrumentation: for the first `_bench_compress`
-            # call, measure the same real batch through both the legacy dense path
-            # (left_right_2_no_padding) and the nested path (nest_batch_by_mask),
-            # report per-field bytes + cloudpickle size for direct comparison.
-            if not getattr(self, "_bench_compress_done", False):
-                try:
-                    self._bench_payload_sizes(batch_td)
-                finally:
-                    self._bench_compress_done = True
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
             # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
@@ -1184,105 +1175,6 @@ class RayPPOTrainer:
             if "loss_mask" in batch_td:
                 batch_td["response_mask"] = batch_td["loss_mask"]
         return batch_td
-
-    def _bench_payload_sizes(self, batch_td: TensorDict) -> None:
-        """One-shot instrumentation: pickle both code paths and report sizes."""
-        import io
-        import pickle
-
-        import cloudpickle
-
-        def _tensor_bytes(t):
-            if t.is_nested:
-                v = t.values()
-                o = t.offsets() if hasattr(t, "offsets") else None
-                b = v.numel() * v.element_size()
-                if o is not None:
-                    b += o.numel() * o.element_size()
-                return b
-            return t.numel() * t.element_size()
-
-        def _field_row(k, v):
-            if isinstance(v, torch.Tensor):
-                dtype = str(v.dtype).replace("torch.", "")
-                shape = tuple(v.shape)
-                nested = v.is_nested
-                nelem = v.values().numel() if v.is_nested else v.numel()
-                b = _tensor_bytes(v)
-                extra = f"values_numel={v.values().numel()}" if v.is_nested else ""
-                return (
-                    f"  {k:<30} nested={str(nested):<5} dtype={dtype:<10} "
-                    f"shape={str(shape):<28} nelem={nelem:<12} bytes={b / 1e6:>9.2f} MB  {extra}"
-                )
-            return f"  {k:<30} non-tensor type={type(v).__name__}"
-
-        def _td_total_bytes(td):
-            return sum(_tensor_bytes(v) for v in td.values() if isinstance(v, torch.Tensor))
-
-        def _pickle_bytes(td):
-            buf = io.BytesIO()
-            cloudpickle.dump(td, buf, protocol=pickle.HIGHEST_PROTOCOL)
-            return len(buf.getvalue())
-
-        print("=" * 90, flush=True)
-        print("PAYLOAD BENCH — one-shot measurement on real batch before _compress_batch", flush=True)
-        print("=" * 90, flush=True)
-
-        # Snapshot the real pre-compress batch for the legacy run (clone to a fresh TD
-        # so both paths see the exact same input).
-        src_items = {k: v for k, v in batch_td.items()}
-        orig_raw = _td_total_bytes(batch_td)
-        orig_pkl = _pickle_bytes(batch_td)
-        print(f"ORIGINAL DENSE (pre-compress, {len(list(batch_td.keys()))} keys):", flush=True)
-        for k in sorted(batch_td.keys()):
-            print(_field_row(k, batch_td.get(k)), flush=True)
-        print(f"  >>> total raw = {orig_raw / 1e6:.2f} MB,  cloudpickle = {orig_pkl / 1e6:.2f} MB", flush=True)
-
-        # Run legacy path on a clone
-        legacy_td = TensorDict(src_items, batch_size=batch_td.batch_size)
-        try:
-            legacy_td = left_right_2_no_padding(legacy_td)
-            legacy_raw = _td_total_bytes(legacy_td)
-            legacy_pkl = _pickle_bytes(legacy_td)
-            print(f"\nLEGACY (left_right_2_no_padding, {len(list(legacy_td.keys()))} keys):", flush=True)
-            for k in sorted(legacy_td.keys()):
-                print(_field_row(k, legacy_td.get(k)), flush=True)
-            print(f"  >>> total raw = {legacy_raw / 1e6:.2f} MB,  cloudpickle = {legacy_pkl / 1e6:.2f} MB", flush=True)
-        except Exception as e:
-            print(f"\nLEGACY path raised {type(e).__name__}: {e}", flush=True)
-            legacy_raw = legacy_pkl = -1
-
-        # Run nesting path on another clone
-        nest_td = TensorDict(src_items, batch_size=batch_td.batch_size)
-        try:
-            if "response_mask" in nest_td:
-                nest_td["loss_mask"] = nest_td["response_mask"]
-            compress_batch_dtypes(nest_td)
-            nest_batch_by_mask(
-                nest_td,
-                pad_token_id=self.tokenizer.pad_token_id,
-                field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
-            )
-            nest_raw = _td_total_bytes(nest_td)
-            nest_pkl = _pickle_bytes(nest_td)
-            print(f"\nNESTING (nest_batch_by_mask, {len(list(nest_td.keys()))} keys):", flush=True)
-            for k in sorted(nest_td.keys()):
-                print(_field_row(k, nest_td.get(k)), flush=True)
-            print(f"  >>> total raw = {nest_raw / 1e6:.2f} MB,  cloudpickle = {nest_pkl / 1e6:.2f} MB", flush=True)
-        except Exception as e:
-            print(f"\nNESTING path raised {type(e).__name__}: {e}", flush=True)
-            nest_raw = nest_pkl = -1
-
-        print("\n=== SUMMARY ===", flush=True)
-        print(f"  original dense  : raw {orig_raw / 1e6:10.2f} MB | pkl {orig_pkl / 1e6:10.2f} MB", flush=True)
-        print(f"  legacy          : raw {legacy_raw / 1e6:10.2f} MB | pkl {legacy_pkl / 1e6:10.2f} MB", flush=True)
-        print(f"  nesting         : raw {nest_raw / 1e6:10.2f} MB | pkl {nest_pkl / 1e6:10.2f} MB", flush=True)
-        if legacy_raw > 0 and nest_raw > 0:
-            print(
-                f"  ratio legacy/nesting:   raw {legacy_raw / nest_raw:.2f}x    pkl {legacy_pkl / nest_pkl:.2f}x",
-                flush=True,
-            )
-        print("=" * 90, flush=True)
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -29,6 +29,7 @@ from typing import Any, Optional
 import numpy as np
 import torch
 from omegaconf import OmegaConf, open_dict
+from tensordict import TensorDict
 from torch.utils.data import Dataset, Sampler
 from torchdata.stateful_dataloader import StatefulDataLoader
 from tqdm import tqdm
@@ -70,7 +71,13 @@ from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_
 from verl.utils.torch_functional import masked_mean
 from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.config import DistillationConfig, EngineConfig
-from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
+from verl.workers.utils.padding import (
+    compress_batch_dtypes,
+    extract_response,
+    left_right_2_no_padding,
+    nest_batch_by_mask,
+    unnest_batch_by_mask,
+)
 
 
 def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
@@ -314,6 +321,7 @@ class RayPPOTrainer:
 
         self.use_prefix_grouper = self.config.actor_rollout_ref.actor.get("use_prefix_grouper", False)
         self.use_legacy_worker_impl = config.trainer.get("use_legacy_worker_impl", "auto")
+        self.use_mask_nesting = config.trainer.get("use_mask_nesting", False)
 
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
@@ -1138,17 +1146,40 @@ class RayPPOTrainer:
         )
         metrics.update(global_balance_stats)
 
+    def _compress_batch(self, batch_td: TensorDict) -> TensorDict:
+        """Compress a batch TensorDict for worker dispatch."""
+        with marked_timer("compress", self._timing_raw):
+            if not self.use_mask_nesting:
+                return left_right_2_no_padding(batch_td)
+            compress_batch_dtypes(batch_td)
+            nest_batch_by_mask(batch_td, pad_token_id=self.tokenizer.pad_token_id)
+        # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
+        if "response_mask" in batch_td:
+            batch_td["loss_mask"] = batch_td["response_mask"]
+        return batch_td
+
+    def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
+        """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""
+        if not self.use_mask_nesting:
+            return batch_td
+        unnest_batch_by_mask(batch_td)  # no-op if batch_td wasn't nested
+        batch_td.pop("loss_mask", None)
+        return batch_td
+
+    def _decompress_model_outputs(self, batch_td, tensors: dict):
+        """Extract padded response slices from model outputs via :func:`extract_response`."""
+        with marked_timer("decompress", self._timing_raw):
+            return {key: extract_response(batch_td, t) for key, t in tensors.items()}
+
     def _compute_values(self, batch: DataProto) -> DataProto:
         if self.use_legacy_worker_impl == "disable":
             batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
+            batch_td = self._compress_batch(batch_td)
             tu.assign_non_tensor(batch_td, compute_loss=False)
             output = self.critic_wg.infer_batch(batch_td)
             output = output.get()
             values = tu.get(output, "values")
-            values = no_padding_2_padding(values, batch_td)
+            values = self._decompress_model_outputs(batch_td, {"values": values})["values"]
             values = tu.get_tensordict({"values": values.float()})
             values = DataProto.from_tensordict(values)
         else:
@@ -1157,11 +1188,8 @@ class RayPPOTrainer:
 
     def _compute_ref_log_prob(self, batch: DataProto) -> DataProto:
         if self.use_legacy_worker_impl == "disable":
-            # step 1: convert dataproto to tensordict.
             batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
+            batch_td = self._compress_batch(batch_td)
             metadata = {"calculate_entropy": False, "compute_loss": False}
             if self.ref_in_actor:
                 metadata["no_lora_adapter"] = True
@@ -1170,11 +1198,8 @@ class RayPPOTrainer:
                 output = self.actor_rollout_wg.compute_log_prob(batch_td)
             else:
                 output = self.ref_policy_wg.compute_ref_log_prob(batch_td)
-            # gather output
             log_probs = tu.get(output, "log_probs")
-            # step 4. No padding to padding
-            log_probs = no_padding_2_padding(log_probs, batch_td)
-            # step 5: rebuild a tensordict and convert to dataproto
+            log_probs = self._decompress_model_outputs(batch_td, {"log_probs": log_probs})["log_probs"]
             ref_log_prob = tu.get_tensordict({"ref_log_prob": log_probs.float()})
             ref_log_prob = DataProto.from_tensordict(ref_log_prob)
         else:
@@ -1184,24 +1209,19 @@ class RayPPOTrainer:
 
     def _compute_old_log_prob(self, batch: DataProto):
         if self.use_legacy_worker_impl == "disable":
-            # TODO: remove step 1, 2, 4 after we make the whole training tensordict and padding free
-            # step 1: convert dataproto to tensordict.
+            # TODO: drop the nest/unnest round-trip once training is fully padding-free
             batch_td = batch.to_tensordict()
-            # step 2: convert from padding to nopadding
-            batch_td = left_right_2_no_padding(batch_td)
-            # step 3: add meta info
+            batch_td = self._compress_batch(batch_td)
             tu.assign_non_tensor(batch_td, calculate_entropy=True, compute_loss=False)
             output = self.actor_rollout_wg.compute_log_prob(batch_td)
-            # gather output
             entropy = tu.get(output, "entropy")
             log_probs = tu.get(output, "log_probs")
             routed_experts = tu.get(output, "routed_experts")
 
             old_log_prob_mfu = tu.get(output, "metrics")["mfu"]
-            # step 4. No padding to padding
-            entropy = no_padding_2_padding(entropy, batch_td)
-            log_probs = no_padding_2_padding(log_probs, batch_td)
-            # step 5: rebuild a tensordict and convert to dataproto
+            unnested = self._decompress_model_outputs(batch_td, {"entropy": entropy, "log_probs": log_probs})
+            entropy = unnested["entropy"]
+            log_probs = unnested["log_probs"]
             if routed_experts is not None:
                 old_log_prob = tu.get_tensordict(
                     {"old_log_probs": log_probs.float(), "entropys": entropy.float(), "routed_experts": routed_experts}
@@ -1222,8 +1242,7 @@ class RayPPOTrainer:
         # update actor
         if self.use_legacy_worker_impl == "disable":
             batch_td = batch.to_tensordict()
-            # step 2: convert from padding to no-padding
-            batch_td = left_right_2_no_padding(batch_td)
+            batch_td = self._compress_batch(batch_td)
             calculate_entropy = self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
             distillation_use_topk = (
                 self.distillation_config.distillation_loss.loss_settings.use_topk
@@ -1260,8 +1279,7 @@ class RayPPOTrainer:
     def _update_critic(self, batch: DataProto) -> DataProto:
         if self.use_legacy_worker_impl == "disable":
             batch_td = batch.to_tensordict()
-            # step 2: convert from padding to no-padding
-            batch_td = left_right_2_no_padding(batch_td)
+            batch_td = self._compress_batch(batch_td)
             ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
             ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
             ppo_epochs = self.config.critic.ppo_epochs
@@ -1349,6 +1367,15 @@ class RayPPOTrainer:
                     self.actor_rollout_wg.async_calls_finalize_fn_exec(blocking=False)
                 metrics = {}
                 timing_raw = {}
+                self._timing_raw = timing_raw
+                all_wgs = (
+                    self.actor_rollout_wg,
+                    getattr(self, "critic_wg", None),
+                    getattr(self, "ref_policy_wg", None),
+                )
+                for wg in all_wgs:
+                    if wg is not None:
+                        wg._wg_timing = timing_raw
 
                 with marked_timer("start_profile", timing_raw):
                     self._start_profiling(

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1162,6 +1162,15 @@ class RayPPOTrainer:
                 max_prompt_length=self.config.data.max_prompt_length,
                 max_response_length=self.config.data.max_response_length,
             )
+            # One-shot payload-size instrumentation: for the first `_bench_compress`
+            # call, measure the same real batch through both the legacy dense path
+            # (left_right_2_no_padding) and the nested path (nest_batch_by_mask),
+            # report per-field bytes + cloudpickle size for direct comparison.
+            if not getattr(self, "_bench_compress_done", False):
+                try:
+                    self._bench_payload_sizes(batch_td)
+                finally:
+                    self._bench_compress_done = True
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
             # Derive `prompt_mask` from attention_mask's left half so the
@@ -1188,6 +1197,105 @@ class RayPPOTrainer:
             if "loss_mask" in batch_td:
                 batch_td["response_mask"] = batch_td["loss_mask"]
         return batch_td
+
+    def _bench_payload_sizes(self, batch_td: TensorDict) -> None:
+        """One-shot instrumentation: pickle both code paths and report sizes."""
+        import io
+        import pickle
+
+        import cloudpickle
+
+        def _tensor_bytes(t):
+            if t.is_nested:
+                v = t.values()
+                o = t.offsets() if hasattr(t, "offsets") else None
+                b = v.numel() * v.element_size()
+                if o is not None:
+                    b += o.numel() * o.element_size()
+                return b
+            return t.numel() * t.element_size()
+
+        def _field_row(k, v):
+            if isinstance(v, torch.Tensor):
+                dtype = str(v.dtype).replace("torch.", "")
+                shape = tuple(v.shape)
+                nested = v.is_nested
+                nelem = v.values().numel() if v.is_nested else v.numel()
+                b = _tensor_bytes(v)
+                extra = f"values_numel={v.values().numel()}" if v.is_nested else ""
+                return (
+                    f"  {k:<30} nested={str(nested):<5} dtype={dtype:<10} "
+                    f"shape={str(shape):<28} nelem={nelem:<12} bytes={b / 1e6:>9.2f} MB  {extra}"
+                )
+            return f"  {k:<30} non-tensor type={type(v).__name__}"
+
+        def _td_total_bytes(td):
+            return sum(_tensor_bytes(v) for v in td.values() if isinstance(v, torch.Tensor))
+
+        def _pickle_bytes(td):
+            buf = io.BytesIO()
+            cloudpickle.dump(td, buf, protocol=pickle.HIGHEST_PROTOCOL)
+            return len(buf.getvalue())
+
+        print("=" * 90, flush=True)
+        print("PAYLOAD BENCH — one-shot measurement on real batch before _compress_batch", flush=True)
+        print("=" * 90, flush=True)
+
+        # Snapshot the real pre-compress batch for the legacy run (clone to a fresh TD
+        # so both paths see the exact same input).
+        src_items = {k: v for k, v in batch_td.items()}
+        orig_raw = _td_total_bytes(batch_td)
+        orig_pkl = _pickle_bytes(batch_td)
+        print(f"ORIGINAL DENSE (pre-compress, {len(list(batch_td.keys()))} keys):", flush=True)
+        for k in sorted(batch_td.keys()):
+            print(_field_row(k, batch_td.get(k)), flush=True)
+        print(f"  >>> total raw = {orig_raw / 1e6:.2f} MB,  cloudpickle = {orig_pkl / 1e6:.2f} MB", flush=True)
+
+        # Run legacy path on a clone
+        legacy_td = TensorDict(src_items, batch_size=batch_td.batch_size)
+        try:
+            legacy_td = left_right_2_no_padding(legacy_td)
+            legacy_raw = _td_total_bytes(legacy_td)
+            legacy_pkl = _pickle_bytes(legacy_td)
+            print(f"\nLEGACY (left_right_2_no_padding, {len(list(legacy_td.keys()))} keys):", flush=True)
+            for k in sorted(legacy_td.keys()):
+                print(_field_row(k, legacy_td.get(k)), flush=True)
+            print(f"  >>> total raw = {legacy_raw / 1e6:.2f} MB,  cloudpickle = {legacy_pkl / 1e6:.2f} MB", flush=True)
+        except Exception as e:
+            print(f"\nLEGACY path raised {type(e).__name__}: {e}", flush=True)
+            legacy_raw = legacy_pkl = -1
+
+        # Run nesting path on another clone
+        nest_td = TensorDict(src_items, batch_size=batch_td.batch_size)
+        try:
+            if "response_mask" in nest_td:
+                nest_td["loss_mask"] = nest_td["response_mask"]
+            compress_batch_dtypes(nest_td)
+            nest_batch_by_mask(
+                nest_td,
+                pad_token_id=self.tokenizer.pad_token_id,
+                field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
+            )
+            nest_raw = _td_total_bytes(nest_td)
+            nest_pkl = _pickle_bytes(nest_td)
+            print(f"\nNESTING (nest_batch_by_mask, {len(list(nest_td.keys()))} keys):", flush=True)
+            for k in sorted(nest_td.keys()):
+                print(_field_row(k, nest_td.get(k)), flush=True)
+            print(f"  >>> total raw = {nest_raw / 1e6:.2f} MB,  cloudpickle = {nest_pkl / 1e6:.2f} MB", flush=True)
+        except Exception as e:
+            print(f"\nNESTING path raised {type(e).__name__}: {e}", flush=True)
+            nest_raw = nest_pkl = -1
+
+        print("\n=== SUMMARY ===", flush=True)
+        print(f"  original dense  : raw {orig_raw / 1e6:10.2f} MB | pkl {orig_pkl / 1e6:10.2f} MB", flush=True)
+        print(f"  legacy          : raw {legacy_raw / 1e6:10.2f} MB | pkl {legacy_pkl / 1e6:10.2f} MB", flush=True)
+        print(f"  nesting         : raw {nest_raw / 1e6:10.2f} MB | pkl {nest_pkl / 1e6:10.2f} MB", flush=True)
+        if legacy_raw > 0 and nest_raw > 0:
+            print(
+                f"  ratio legacy/nesting:   raw {legacy_raw / nest_raw:.2f}x    pkl {legacy_pkl / nest_pkl:.2f}x",
+                flush=True,
+            )
+        print("=" * 90, flush=True)
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1157,6 +1157,15 @@ class RayPPOTrainer:
                 max_prompt_length=self.config.data.max_prompt_length,
                 max_response_length=self.config.data.max_response_length,
             )
+            # One-shot payload-size instrumentation: for the first `_bench_compress`
+            # call, measure the same real batch through both the legacy dense path
+            # (left_right_2_no_padding) and the nested path (nest_batch_by_mask),
+            # report per-field bytes + cloudpickle size for direct comparison.
+            if not getattr(self, "_bench_compress_done", False):
+                try:
+                    self._bench_payload_sizes(batch_td)
+                finally:
+                    self._bench_compress_done = True
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
             # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
@@ -1175,6 +1184,105 @@ class RayPPOTrainer:
             if "loss_mask" in batch_td:
                 batch_td["response_mask"] = batch_td["loss_mask"]
         return batch_td
+
+    def _bench_payload_sizes(self, batch_td: TensorDict) -> None:
+        """One-shot instrumentation: pickle both code paths and report sizes."""
+        import io
+        import pickle
+
+        import cloudpickle
+
+        def _tensor_bytes(t):
+            if t.is_nested:
+                v = t.values()
+                o = t.offsets() if hasattr(t, "offsets") else None
+                b = v.numel() * v.element_size()
+                if o is not None:
+                    b += o.numel() * o.element_size()
+                return b
+            return t.numel() * t.element_size()
+
+        def _field_row(k, v):
+            if isinstance(v, torch.Tensor):
+                dtype = str(v.dtype).replace("torch.", "")
+                shape = tuple(v.shape)
+                nested = v.is_nested
+                nelem = v.values().numel() if v.is_nested else v.numel()
+                b = _tensor_bytes(v)
+                extra = f"values_numel={v.values().numel()}" if v.is_nested else ""
+                return (
+                    f"  {k:<30} nested={str(nested):<5} dtype={dtype:<10} "
+                    f"shape={str(shape):<28} nelem={nelem:<12} bytes={b / 1e6:>9.2f} MB  {extra}"
+                )
+            return f"  {k:<30} non-tensor type={type(v).__name__}"
+
+        def _td_total_bytes(td):
+            return sum(_tensor_bytes(v) for v in td.values() if isinstance(v, torch.Tensor))
+
+        def _pickle_bytes(td):
+            buf = io.BytesIO()
+            cloudpickle.dump(td, buf, protocol=pickle.HIGHEST_PROTOCOL)
+            return len(buf.getvalue())
+
+        print("=" * 90, flush=True)
+        print("PAYLOAD BENCH — one-shot measurement on real batch before _compress_batch", flush=True)
+        print("=" * 90, flush=True)
+
+        # Snapshot the real pre-compress batch for the legacy run (clone to a fresh TD
+        # so both paths see the exact same input).
+        src_items = {k: v for k, v in batch_td.items()}
+        orig_raw = _td_total_bytes(batch_td)
+        orig_pkl = _pickle_bytes(batch_td)
+        print(f"ORIGINAL DENSE (pre-compress, {len(list(batch_td.keys()))} keys):", flush=True)
+        for k in sorted(batch_td.keys()):
+            print(_field_row(k, batch_td.get(k)), flush=True)
+        print(f"  >>> total raw = {orig_raw / 1e6:.2f} MB,  cloudpickle = {orig_pkl / 1e6:.2f} MB", flush=True)
+
+        # Run legacy path on a clone
+        legacy_td = TensorDict(src_items, batch_size=batch_td.batch_size)
+        try:
+            legacy_td = left_right_2_no_padding(legacy_td)
+            legacy_raw = _td_total_bytes(legacy_td)
+            legacy_pkl = _pickle_bytes(legacy_td)
+            print(f"\nLEGACY (left_right_2_no_padding, {len(list(legacy_td.keys()))} keys):", flush=True)
+            for k in sorted(legacy_td.keys()):
+                print(_field_row(k, legacy_td.get(k)), flush=True)
+            print(f"  >>> total raw = {legacy_raw / 1e6:.2f} MB,  cloudpickle = {legacy_pkl / 1e6:.2f} MB", flush=True)
+        except Exception as e:
+            print(f"\nLEGACY path raised {type(e).__name__}: {e}", flush=True)
+            legacy_raw = legacy_pkl = -1
+
+        # Run nesting path on another clone
+        nest_td = TensorDict(src_items, batch_size=batch_td.batch_size)
+        try:
+            if "response_mask" in nest_td:
+                nest_td["loss_mask"] = nest_td["response_mask"]
+            compress_batch_dtypes(nest_td)
+            nest_batch_by_mask(
+                nest_td,
+                pad_token_id=self.tokenizer.pad_token_id,
+                field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
+            )
+            nest_raw = _td_total_bytes(nest_td)
+            nest_pkl = _pickle_bytes(nest_td)
+            print(f"\nNESTING (nest_batch_by_mask, {len(list(nest_td.keys()))} keys):", flush=True)
+            for k in sorted(nest_td.keys()):
+                print(_field_row(k, nest_td.get(k)), flush=True)
+            print(f"  >>> total raw = {nest_raw / 1e6:.2f} MB,  cloudpickle = {nest_pkl / 1e6:.2f} MB", flush=True)
+        except Exception as e:
+            print(f"\nNESTING path raised {type(e).__name__}: {e}", flush=True)
+            nest_raw = nest_pkl = -1
+
+        print("\n=== SUMMARY ===", flush=True)
+        print(f"  original dense  : raw {orig_raw / 1e6:10.2f} MB | pkl {orig_pkl / 1e6:10.2f} MB", flush=True)
+        print(f"  legacy          : raw {legacy_raw / 1e6:10.2f} MB | pkl {legacy_pkl / 1e6:10.2f} MB", flush=True)
+        print(f"  nesting         : raw {nest_raw / 1e6:10.2f} MB | pkl {nest_pkl / 1e6:10.2f} MB", flush=True)
+        if legacy_raw > 0 and nest_raw > 0:
+            print(
+                f"  ratio legacy/nesting:   raw {legacy_raw / nest_raw:.2f}x    pkl {legacy_pkl / nest_pkl:.2f}x",
+                flush=True,
+            )
+        print("=" * 90, flush=True)
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1151,11 +1151,15 @@ class RayPPOTrainer:
         with marked_timer("compress", self._timing_raw):
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
+            # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
+            if "response_mask" in batch_td:
+                batch_td["loss_mask"] = batch_td["response_mask"]
             compress_batch_dtypes(batch_td)
-            nest_batch_by_mask(batch_td, pad_token_id=self.tokenizer.pad_token_id)
-        # TODO: eliminate loss_mask alias once worker loss code reads response_mask directly.
-        if "response_mask" in batch_td:
-            batch_td["loss_mask"] = batch_td["response_mask"]
+            nest_batch_by_mask(
+                batch_td,
+                pad_token_id=self.tokenizer.pad_token_id,
+                field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
+            )
         return batch_td
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1162,15 +1162,6 @@ class RayPPOTrainer:
                 max_prompt_length=self.config.data.max_prompt_length,
                 max_response_length=self.config.data.max_response_length,
             )
-            # One-shot payload-size instrumentation: for the first `_bench_compress`
-            # call, measure the same real batch through both the legacy dense path
-            # (left_right_2_no_padding) and the nested path (nest_batch_by_mask),
-            # report per-field bytes + cloudpickle size for direct comparison.
-            if not getattr(self, "_bench_compress_done", False):
-                try:
-                    self._bench_payload_sizes(batch_td)
-                finally:
-                    self._bench_compress_done = True
             if not self.use_mask_nesting:
                 return left_right_2_no_padding(batch_td)
             # Derive `prompt_mask` from attention_mask's left half so the
@@ -1197,105 +1188,6 @@ class RayPPOTrainer:
             if "loss_mask" in batch_td:
                 batch_td["response_mask"] = batch_td["loss_mask"]
         return batch_td
-
-    def _bench_payload_sizes(self, batch_td: TensorDict) -> None:
-        """One-shot instrumentation: pickle both code paths and report sizes."""
-        import io
-        import pickle
-
-        import cloudpickle
-
-        def _tensor_bytes(t):
-            if t.is_nested:
-                v = t.values()
-                o = t.offsets() if hasattr(t, "offsets") else None
-                b = v.numel() * v.element_size()
-                if o is not None:
-                    b += o.numel() * o.element_size()
-                return b
-            return t.numel() * t.element_size()
-
-        def _field_row(k, v):
-            if isinstance(v, torch.Tensor):
-                dtype = str(v.dtype).replace("torch.", "")
-                shape = tuple(v.shape)
-                nested = v.is_nested
-                nelem = v.values().numel() if v.is_nested else v.numel()
-                b = _tensor_bytes(v)
-                extra = f"values_numel={v.values().numel()}" if v.is_nested else ""
-                return (
-                    f"  {k:<30} nested={str(nested):<5} dtype={dtype:<10} "
-                    f"shape={str(shape):<28} nelem={nelem:<12} bytes={b / 1e6:>9.2f} MB  {extra}"
-                )
-            return f"  {k:<30} non-tensor type={type(v).__name__}"
-
-        def _td_total_bytes(td):
-            return sum(_tensor_bytes(v) for v in td.values() if isinstance(v, torch.Tensor))
-
-        def _pickle_bytes(td):
-            buf = io.BytesIO()
-            cloudpickle.dump(td, buf, protocol=pickle.HIGHEST_PROTOCOL)
-            return len(buf.getvalue())
-
-        print("=" * 90, flush=True)
-        print("PAYLOAD BENCH — one-shot measurement on real batch before _compress_batch", flush=True)
-        print("=" * 90, flush=True)
-
-        # Snapshot the real pre-compress batch for the legacy run (clone to a fresh TD
-        # so both paths see the exact same input).
-        src_items = {k: v for k, v in batch_td.items()}
-        orig_raw = _td_total_bytes(batch_td)
-        orig_pkl = _pickle_bytes(batch_td)
-        print(f"ORIGINAL DENSE (pre-compress, {len(list(batch_td.keys()))} keys):", flush=True)
-        for k in sorted(batch_td.keys()):
-            print(_field_row(k, batch_td.get(k)), flush=True)
-        print(f"  >>> total raw = {orig_raw / 1e6:.2f} MB,  cloudpickle = {orig_pkl / 1e6:.2f} MB", flush=True)
-
-        # Run legacy path on a clone
-        legacy_td = TensorDict(src_items, batch_size=batch_td.batch_size)
-        try:
-            legacy_td = left_right_2_no_padding(legacy_td)
-            legacy_raw = _td_total_bytes(legacy_td)
-            legacy_pkl = _pickle_bytes(legacy_td)
-            print(f"\nLEGACY (left_right_2_no_padding, {len(list(legacy_td.keys()))} keys):", flush=True)
-            for k in sorted(legacy_td.keys()):
-                print(_field_row(k, legacy_td.get(k)), flush=True)
-            print(f"  >>> total raw = {legacy_raw / 1e6:.2f} MB,  cloudpickle = {legacy_pkl / 1e6:.2f} MB", flush=True)
-        except Exception as e:
-            print(f"\nLEGACY path raised {type(e).__name__}: {e}", flush=True)
-            legacy_raw = legacy_pkl = -1
-
-        # Run nesting path on another clone
-        nest_td = TensorDict(src_items, batch_size=batch_td.batch_size)
-        try:
-            if "response_mask" in nest_td:
-                nest_td["loss_mask"] = nest_td["response_mask"]
-            compress_batch_dtypes(nest_td)
-            nest_batch_by_mask(
-                nest_td,
-                pad_token_id=self.tokenizer.pad_token_id,
-                field_to_mask_and_pad={"loss_mask": ("response_mask", 0)},
-            )
-            nest_raw = _td_total_bytes(nest_td)
-            nest_pkl = _pickle_bytes(nest_td)
-            print(f"\nNESTING (nest_batch_by_mask, {len(list(nest_td.keys()))} keys):", flush=True)
-            for k in sorted(nest_td.keys()):
-                print(_field_row(k, nest_td.get(k)), flush=True)
-            print(f"  >>> total raw = {nest_raw / 1e6:.2f} MB,  cloudpickle = {nest_pkl / 1e6:.2f} MB", flush=True)
-        except Exception as e:
-            print(f"\nNESTING path raised {type(e).__name__}: {e}", flush=True)
-            nest_raw = nest_pkl = -1
-
-        print("\n=== SUMMARY ===", flush=True)
-        print(f"  original dense  : raw {orig_raw / 1e6:10.2f} MB | pkl {orig_pkl / 1e6:10.2f} MB", flush=True)
-        print(f"  legacy          : raw {legacy_raw / 1e6:10.2f} MB | pkl {legacy_pkl / 1e6:10.2f} MB", flush=True)
-        print(f"  nesting         : raw {nest_raw / 1e6:10.2f} MB | pkl {nest_pkl / 1e6:10.2f} MB", flush=True)
-        if legacy_raw > 0 and nest_raw > 0:
-            print(
-                f"  ratio legacy/nesting:   raw {legacy_raw / nest_raw:.2f}x    pkl {legacy_pkl / nest_pkl:.2f}x",
-                flush=True,
-            )
-        print("=" * 90, flush=True)
 
     def _decompress_batch(self, batch_td: TensorDict) -> TensorDict:
         """Inverse of :meth:`_compress_batch`. No-op in legacy mode."""

--- a/verl/utils/nested_tensor.py
+++ b/verl/utils/nested_tensor.py
@@ -1,0 +1,305 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for working with nested (jagged) tensors via Run-Length Encoding (RLE).
+
+Provides efficient compression and decompression of boolean masks by encoding
+contiguous ``True`` runs as (offset, length) pairs stored in PyTorch nested
+tensors.  This is useful for variable-length sequence packing and transport.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Sequence
+
+import torch
+
+if TYPE_CHECKING:
+    from tensordict import TensorDictBase
+
+
+def mask_to_rle(mask: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Encode a boolean mask into Run-Length Encoding (RLE) of the ``True`` runs along the last dimension.
+
+    RLE compresses a mask by recording only the start offset and length of each contiguous
+    run of ``True`` values, rather than storing every element. Each row in the batch may have
+    a different number of runs, so the results are returned as nested tensors.
+
+    Currently only supports a single batch dimension (i.e. 2D mask input).
+
+    Args:
+        mask (torch.Tensor): The boolean mask to encode. Shape: ``(batch_size, seq_len)``.
+    Returns:
+        offsets (torch.Tensor): Nested tensor of run start positions. Shape: ``(batch_size, j1)``.
+        lengths (torch.Tensor): Nested tensor of run lengths. Shape: ``(batch_size, j1)``.
+    Example:
+        >>> mask = torch.tensor(
+        ...     [[False, False, True, True, False],
+        ...      [False, True, True, False, True]])
+        >>> offsets, lengths = mask_to_rle(mask)
+        >>> print([component for component in offsets])
+        [tensor([2]), tensor([1, 4])]
+        >>> print([component for component in lengths])
+        [tensor([2]), tensor([2, 1])]
+
+    """
+    assert mask.ndim == 2, f"Expected 2D mask (batch_size, last_dim), got {mask.ndim}D with shape {mask.shape}"
+    last_dim = mask.shape[-1]
+    flat_mask = mask.reshape(-1, last_dim).bool()
+    num_rows = flat_mask.shape[0]
+
+    # Pad each row with False on both sides to detect transitions at boundaries
+    padded = torch.nn.functional.pad(flat_mask.int(), (1, 1), value=0)
+    diff = padded[:, 1:] - padded[:, :-1]
+
+    # Segment starts where diff == 1 (False -> True),
+    # segment ends where diff == -1 (True -> False)
+    start_rows, start_cols = (diff == 1).nonzero(as_tuple=True)
+    _, end_cols = (diff == -1).nonzero(as_tuple=True)
+
+    seg_lengths = end_cols - start_cols
+
+    # Group by row: count segments per row, then split into per-row tensors
+    counts = torch.bincount(start_rows, minlength=num_rows).tolist()
+    offsets = torch.nested.nested_tensor(list(torch.split(start_cols, counts)), layout=torch.jagged)
+    lengths = torch.nested.nested_tensor(list(torch.split(seg_lengths, counts)), layout=torch.jagged)
+    return offsets, lengths
+
+
+def _rle_scatter_indices(
+    offsets: torch.Tensor,
+    lengths: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    """Build vectorized scatter indices from nested RLE offsets/lengths.
+
+    Returns ``(row_indices, col_indices, flat_offsets_vals, seq_len)`` where
+    ``row_indices[k]`` and ``col_indices[k]`` identify the output position
+    for the k-th element across all rows/segments. ``seq_len`` is the
+    inferred output width (``max(offset + length)``).
+    """
+    flat_off = offsets.values()  # (total_segments,)
+    flat_len = lengths.values()  # (total_segments,)
+    device = flat_off.device
+
+    total_segments = flat_off.shape[0]
+    if total_segments == 0:
+        empty = torch.empty(0, dtype=torch.long, device=device)
+        return empty, empty, flat_off, 0
+
+    seq_len: int = (flat_off + flat_len).max().item()
+
+    # Segments-per-row from the jagged offsets buffer
+    nt_offsets = offsets._offsets  # (batch_size + 1,)
+    segs_per_row = nt_offsets[1:] - nt_offsets[:-1]  # (batch_size,)
+    batch_size = segs_per_row.shape[0]
+
+    total_elements = flat_len.sum().item()
+
+    # Map each element to its destination column:
+    #   dest_col[k] = flat_off[seg_of_k] + (k - seg_start_of_k)
+    seg_cumlen = flat_len.cumsum(0)
+    seg_starts = seg_cumlen - flat_len
+
+    within_seg = torch.arange(total_elements, device=device) - seg_starts.repeat_interleave(flat_len)
+    col_indices = flat_off.repeat_interleave(flat_len) + within_seg
+
+    # Map each element to its batch row
+    row_of_seg = torch.arange(batch_size, device=device).repeat_interleave(segs_per_row)
+    row_indices = row_of_seg.repeat_interleave(flat_len)
+
+    return row_indices, col_indices, flat_off, seq_len
+
+
+def rle_to_mask(
+    offsets: torch.Tensor,
+    lengths: torch.Tensor,
+    shape: Sequence[int, ...] | torch.Size | None = None,
+) -> torch.Tensor:
+    """
+    Decode a Run-Length Encoding (RLE) of the ``True`` runs along the last dimension into a boolean mask.
+
+    When ``shape`` is not provided the output ``seq_len`` is inferred as
+    ``max(offset + length)`` across all rows, so trailing all-False columns
+    from the original mask are not preserved. Pass the original mask shape
+    to recover the exact dimensions.
+
+    Args:
+        offsets (torch.Tensor): Nested tensor of run start positions. Shape: ``(batch_size, j1)``.
+        lengths (torch.Tensor): Nested tensor of run lengths. Shape: ``(batch_size, j1)``.
+        shape (Sequence[int, ...] | torch.Size | None): If given, the output mask
+            is created with this shape instead of inferring ``(batch_size, seq_len)``.
+            Must be compatible with ``batch_size`` from the offsets tensor.
+    Returns:
+        mask (torch.Tensor): Boolean mask. Shape: ``shape`` or ``(batch_size, seq_len)``.
+    """
+    assert offsets.ndim == 2, f"Expected 2D offsets (batch_size, j1), got {offsets.ndim}D with shape {offsets.shape}"
+    assert lengths.ndim == 2, f"Expected 2D lengths (batch_size, j1), got {lengths.ndim}D with shape {lengths.shape}"
+    batch_size = offsets.shape[0]
+
+    row_idx, col_idx, _, seq_len = _rle_scatter_indices(offsets, lengths)
+
+    if shape is not None:
+        assert shape[0] == batch_size, f"shape[0]={shape[0]} does not match batch_size={batch_size} from offsets"
+        mask = torch.zeros(shape, dtype=torch.bool)
+    else:
+        mask = torch.zeros(batch_size, seq_len, dtype=torch.bool)
+
+    if row_idx.numel() > 0:
+        mask[row_idx, col_idx] = True
+    return mask
+
+
+def unnest_tensor_by_rle(
+    tensor: torch.Tensor, offsets: torch.Tensor, lengths: torch.Tensor, pad_value: float = 0.0
+) -> torch.Tensor:
+    """
+    Unnest a nested tensor by the nested RLE of the mask.
+    Inversion of ``torch.nested.masked_select(tensor, mask)`` & ``offsets, lengths = mask_to_rle(mask)``.
+
+    Reconstructs a dense tensor from a nested tensor by placing each row's
+    elements back at the positions described by the RLE segments. Positions
+    not covered by any segment are filled with ``pad_value``.
+
+    Uses vectorized index computation with a single advanced-indexing scatter
+    instead of Python loops, so performance scales with tensor ops rather than
+    the number of segments.
+
+    Args:
+        tensor (torch.Tensor): Nested tensor produced by ``masked_select``.
+            Shape: ``(batch_size, j1, *trailing)``.
+        offsets (torch.Tensor): Nested tensor of run start positions from ``mask_to_rle``.
+            Shape: ``(batch_size, k1)``.
+        lengths (torch.Tensor): Nested tensor of run lengths from ``mask_to_rle``.
+            Shape: ``(batch_size, k1)``.
+        pad_value (float): Value to fill positions not covered by any segment. Default: ``0.0``.
+    Returns:
+        torch.Tensor: Dense tensor of shape ``(batch_size, seq_len, *trailing)``
+            where ``seq_len = max(offset + length)`` across all rows.
+    """
+    batch_size = tensor.shape[0]
+    row_idx, col_idx, _, seq_len = _rle_scatter_indices(offsets, lengths)
+
+    data_flat = tensor.values()  # (total_elements, *trailing)
+    trailing_shape = data_flat.shape[1:]
+
+    output = torch.full((batch_size, seq_len, *trailing_shape), pad_value, dtype=tensor.dtype, device=tensor.device)
+    if row_idx.numel() > 0:
+        output[row_idx, col_idx] = data_flat
+    return output
+
+
+@dataclass
+class MaskNestingSpec:
+    """Specification for nesting a group of data tensors with mask in a ``TensorDict``."""
+
+    mask_field: str
+    mask_shape: Sequence[int] | None = None
+    offsets_field: str | None = None
+    lengths_field: str | None = None
+    data_field_to_pad_value: dict[str, int | float | bool] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.offsets_field is None:
+            self.offsets_field = f"{self.mask_field}_offsets"
+        if self.lengths_field is None:
+            self.lengths_field = f"{self.mask_field}_lengths"
+
+    def nest_in_td(self, td: TensorDictBase) -> TensorDictBase:
+        """Nest every data field in *td* by the mask.
+
+        Each data tensor must have shape
+        ``(*batch_dims, *sample_mask_dims, *feature_dims)``, where
+        ``(*batch_dims, *sample_mask_dims) == mask.shape`` — the leading
+        dims are the outer batch (TensorDict ``batch_size``), the next dims
+        are what the per-sample mask actually selects over, and any
+        trailing ``feature_dims`` (e.g. multi-head, hidden) pass through
+        unchanged. This generalises ``torch.nested.masked_select`` which
+        only handles same-shape mask + data.
+        """
+        mask: torch.Tensor = td.pop(self.mask_field).bool()
+        if self.mask_shape is None:
+            self.mask_shape = mask.shape
+
+        # Per-row valid token counts → jagged offsets reused for every field.
+        # mask is 2-D (batch_size, seq_len); flatten leading dims if higher-D.
+        flat_mask = mask.reshape(mask.shape[0], -1)
+        counts = flat_mask.sum(dim=-1)
+        nt_offsets = torch.zeros(mask.shape[0] + 1, dtype=torch.long, device=mask.device)
+        nt_offsets[1:] = counts.cumsum(0)
+
+        for data_field in self.data_field_to_pad_value:
+            t = td[data_field]
+            assert t.shape[: mask.ndim] == mask.shape, (
+                f"data field {data_field!r} has shape {tuple(t.shape)}, "
+                f"expected leading dims to match mask shape {tuple(mask.shape)}"
+            )
+            # Fancy indexing broadcasts the mask over trailing dims, returning
+            # a tensor of shape (n_true, *batch_dims).
+            flat_values = t[mask]
+            td[data_field] = torch.nested.nested_tensor_from_jagged(flat_values, offsets=nt_offsets)
+
+        offsets, lengths = mask_to_rle(mask)
+        td[self.offsets_field] = offsets
+        td[self.lengths_field] = lengths
+
+        return td
+
+    def unnest_in_td(self, td: TensorDictBase) -> TensorDictBase:
+        """Inversion of ``nest_in_td``.
+
+        Computes the RLE scatter indices once and reuses them for every data
+        field and the mask, avoiding redundant work when multiple fields share
+        the same mask.
+
+        The batch dimension always comes from the live RLE offsets
+        (``offsets.shape[0]``), **not** from ``self.mask_shape[0]``. This
+        matters when the TensorDict has been chunked (e.g. per-worker
+        dispatch): the stashed ``mask_shape`` carries the **original**
+        full-batch dim, while the offsets have been split to the local
+        per-chunk batch. Only the trailing dims of ``mask_shape`` are
+        load-bearing — they let us preserve trailing all-False columns
+        that RLE inference alone would drop.
+        """
+        offsets = td.pop(self.offsets_field)
+        lengths = td.pop(self.lengths_field)
+
+        batch_size = offsets.shape[0]
+        row_idx, col_idx, _, seq_len = _rle_scatter_indices(offsets, lengths)
+
+        # Construct the local mask shape using:
+        #   - batch_size from offsets (per-chunk correct), and
+        #   - trailing dims from self.mask_shape if available (to honour
+        #     trailing all-False columns), else from RLE-inferred seq_len.
+        if self.mask_shape is not None:
+            local_mask_shape = (batch_size, *tuple(self.mask_shape)[1:])
+        else:
+            local_mask_shape = (batch_size, seq_len)
+        out_seq_len = local_mask_shape[-1]
+
+        for data_field, pad_value in self.data_field_to_pad_value.items():
+            nt = td[data_field]
+            data_flat = nt.values()  # (total_elements, *trailing)
+            trailing_shape = data_flat.shape[1:]
+            out = torch.full((batch_size, out_seq_len, *trailing_shape), pad_value, dtype=nt.dtype, device=nt.device)
+            if row_idx.numel() > 0:
+                out[row_idx, col_idx] = data_flat
+            td[data_field] = out
+
+        mask = torch.zeros(local_mask_shape, dtype=torch.bool)
+        if row_idx.numel() > 0:
+            mask[row_idx, col_idx] = True
+        td[self.mask_field] = mask
+        return td

--- a/verl/utils/nested_tensor.py
+++ b/verl/utils/nested_tensor.py
@@ -101,8 +101,8 @@ def _rle_scatter_indices(
 
     seq_len: int = (flat_off + flat_len).max().item()
 
-    # Segments-per-row from the jagged offsets buffer
-    nt_offsets = offsets._offsets  # (batch_size + 1,)
+    # Segments-per-row from the jagged offsets buffer (public API).
+    nt_offsets = offsets.offsets()  # (batch_size + 1,)
     segs_per_row = nt_offsets[1:] - nt_offsets[:-1]  # (batch_size,)
     batch_size = segs_per_row.shape[0]
 

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -23,7 +23,7 @@ from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.metric import AggregationType, Metric
 from verl.utils.torch_functional import masked_mean, masked_sum
 from verl.workers.config import ActorConfig, CriticConfig
-from verl.workers.utils.padding import no_padding_2_padding
+from verl.workers.utils.padding import extract_response
 
 
 def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
@@ -57,10 +57,11 @@ def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
 def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
     """Computes ppo loss from model output (log_prob, entropy, values, etc. ) and old_log_probs from data."""
-    log_prob = no_padding_2_padding(model_output["log_probs"], data)
+    # Dispatches on the batch's nesting style (legacy vs new) transparently.
+    log_prob = extract_response(data, model_output["log_probs"])
     entropy = model_output.get("entropy", None)
     if entropy is not None:
-        entropy = no_padding_2_padding(entropy, data)
+        entropy = extract_response(data, entropy)
 
     # global batch info for loss aggregation
     config.global_batch_info["dp_size"] = data["dp_size"]
@@ -157,7 +158,7 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     Returns:
         value loss
     """
-    vpreds = no_padding_2_padding(model_output["values"], data)  # (bsz, response_length)
+    vpreds = extract_response(data, model_output["values"])  # (bsz, response_length)
 
     # select fields and convert to padded tensor
     data = data.select("values", "returns", "response_mask").to_padded_tensor()

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -23,7 +23,7 @@ from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.metric import AggregationType, Metric
 from verl.utils.torch_functional import masked_mean, masked_sum
 from verl.workers.config import ActorConfig, CriticConfig
-from verl.workers.utils.padding import extract_response
+from verl.workers.utils.padding import extract_response, select_and_pad_to_response
 
 
 def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
@@ -90,7 +90,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         fields.append("rollout_is_weights")
     if "ref_log_prob" in data:
         fields.append("ref_log_prob")
-    data = data.select(*fields).to_padded_tensor()
+    data = select_and_pad_to_response(data, *fields)
 
     response_mask = data["response_mask"].to(bool)
     # compute policy loss
@@ -161,7 +161,7 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     vpreds = extract_response(data, model_output["values"])  # (bsz, response_length)
 
     # select fields and convert to padded tensor
-    data = data.select("values", "returns", "response_mask").to_padded_tensor()
+    data = select_and_pad_to_response(data, "values", "returns", "response_mask")
     values = data["values"]
     returns = data["returns"]
     response_mask = data["response_mask"].to(bool)

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -768,20 +768,24 @@ def prepare_response_slice(data: TensorDict) -> ResponseSliceContext:
         return None
 
     orig_seq_len = _orig_mask_len("attention_mask")
-    orig_response_len = _orig_mask_len("response_mask")
 
     prompt_ids = data["prompts"]
     response_ids = data["responses"]
     if prompt_ids.is_nested:
         prompt_lens = prompt_ids.offsets().diff()
         response_lens = response_ids.offsets().diff()
-        max_response_len = orig_response_len if orig_response_len is not None else response_lens.max().item()
     else:
         mask_shape = (batch_size, orig_seq_len) if orig_seq_len is not None else None
         attn_mask = rle_to_mask(offsets, lengths, shape=mask_shape)
         prompt_lens = attn_mask[:, : prompt_ids.shape[1]].sum(dim=1)
         response_lens = attn_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-        max_response_len = orig_response_len if orig_response_len is not None else response_ids.shape[1]
+    # Pad to the batch-local max so the resulting dense (bs, local_max) aligns
+    # with the per-micro-batch dimensions produced by
+    # ``TensorDict.to_padded_tensor()`` on response-axis nested fields
+    # (old_log_probs, advantages, ...). Using the spec-stashed full-batch
+    # ``orig_response_len`` here would leave extract_response's output wider
+    # than the rest and break downstream arithmetic in ppo_loss.
+    max_response_len = int(response_lens.max().item())
 
     rle_first_offsets = offsets.values()[offsets._offsets[:-1]]
     slice_bounds: list[tuple[int, int, int]] = []

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -279,13 +279,15 @@ KNOWN_FIELD_TO_MASK_AND_PAD: dict[str, tuple[str, int | float | DynamicPadValue]
     "input_ids": ("attention_mask", PAD_TOKEN_ID),
     "teacher_ids": ("attention_mask", PAD_TOKEN_ID),
     "position_ids": ("attention_mask", 0),
-    "old_log_probs": ("attention_mask", 0.0),
-    "ref_log_prob": ("attention_mask", 0.0),
-    "rollout_log_probs": ("attention_mask", 0.0),
-    "entropys": ("attention_mask", 0.0),
     "teacher_logprobs": ("attention_mask", 0.0),
     "routed_experts": ("attention_mask", 0),
     # paired with response_mask (response-only axis)
+    # log-prob / entropy fields are extracted via `extract_response` in
+    # `_decompress_model_outputs` and stored back as (bsz, max_response_len).
+    "old_log_probs": ("response_mask", 0.0),
+    "ref_log_prob": ("response_mask", 0.0),
+    "rollout_log_probs": ("response_mask", 0.0),
+    "entropys": ("response_mask", 0.0),
     "advantages": ("response_mask", 0.0),
     "returns": ("response_mask", 0.0),
     "values": ("response_mask", 0.0),

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -30,6 +30,7 @@ Two APIs coexist here:
 """
 
 import enum
+import warnings
 from dataclasses import dataclass
 
 import torch
@@ -281,9 +282,12 @@ KNOWN_FIELD_TO_MASK_AND_PAD: dict[str, tuple[str, int | float | DynamicPadValue]
     "position_ids": ("attention_mask", 0),
     "teacher_logprobs": ("attention_mask", 0.0),
     "routed_experts": ("attention_mask", 0),
+    # paired with prompt_mask (prompt-only axis, left-aligned = valid prompt tokens)
+    "prompts": ("prompt_mask", PAD_TOKEN_ID),
     # paired with response_mask (response-only axis)
     # log-prob / entropy fields are extracted via `extract_response` in
     # `_decompress_model_outputs` and stored back as (bsz, max_response_len).
+    "responses": ("response_mask", PAD_TOKEN_ID),
     "old_log_probs": ("response_mask", 0.0),
     "ref_log_prob": ("response_mask", 0.0),
     "rollout_log_probs": ("response_mask", 0.0),
@@ -520,6 +524,8 @@ def nest_batch_by_mask(
     *,
     pad_token_id: int | None = None,
     field_to_mask_and_pad: dict[str, tuple[str, int | float | bool | DynamicPadValue]] | None = None,
+    strict: bool = False,
+    ignore_dense_fields: set[str] | None = None,
 ) -> TensorDict:
     """Nest every eligible tensor field in *data* in place using mask-driven RLE.
 
@@ -568,6 +574,15 @@ def nest_batch_by_mask(
             ``field_to_mask_and_pad``.
         pad_token_id: Tokenizer pad token id (paths 1 & 2).
         field_to_mask_and_pad: Per-field overrides (path 2).
+        strict: If True, raise ``RuntimeError`` when any tensor field in
+            ``data`` is not nested by the time this function returns
+            (e.g. a field missing from the registry). Defaults to False,
+            in which case a ``warnings.warn`` is issued instead — useful
+            for catching un-registered new fields that silently bypass
+            compression and bloat worker dispatch.
+        ignore_dense_fields: Tensor field names that are expected to
+            remain dense and should be excluded from the post-nest
+            check (e.g. scalar-per-row fields, pre-computed buffers).
 
     Returns:
         The mutated TensorDict.
@@ -598,7 +613,72 @@ def nest_batch_by_mask(
     if permutations:
         tu.assign_non_tensor_data(data, _MASK_NESTING_PERMUTATIONS_KEY, permutations)
 
+    # Post-nest coverage check: any remaining dense tensor field is a
+    # missed compression opportunity (likely absent from the registry).
+    _check_nesting_coverage(data, strict=strict, ignore_dense_fields=ignore_dense_fields)
+
     return data
+
+
+# Tensor fields that are structurally expected to remain dense after nesting
+# (scalar-per-row tracking fields, RLE meta, etc.) — skip them in the coverage
+# check to avoid noisy warnings.
+_DEFAULT_IGNORE_DENSE = frozenset({"dummy_tensor"})
+
+
+def _check_nesting_coverage(
+    data: TensorDict,
+    *,
+    strict: bool,
+    ignore_dense_fields: set[str] | None,
+) -> None:
+    """Report any tensor field in *data* that wasn't nested.
+
+    Nested tensors (``is_nested``) and the RLE offsets/lengths emitted by
+    :meth:`MaskNestingSpec.nest_in_td` are expected; anything else that
+    survived as a dense tensor is flagged — either via ``warnings.warn``
+    or ``RuntimeError`` (when ``strict=True``).
+    """
+    ignore = set(_DEFAULT_IGNORE_DENSE)
+    if ignore_dense_fields:
+        ignore.update(ignore_dense_fields)
+
+    # Mask-spec artefacts (``{mask}_offsets`` / ``{mask}_lengths``) are
+    # the nested RLE products of nesting itself — exempt them.
+    specs = tu.get_non_tensor_data(data, _MASK_NESTING_SPECS_KEY, default={}) or {}
+    for spec in specs.values():
+        ignore.add(spec.offsets_field)
+        ignore.add(spec.lengths_field)
+
+    remaining: list[tuple[str, tuple[int, ...], torch.dtype, int]] = []
+    for key in list(data.keys()):
+        if key in ignore:
+            continue
+        value = data.get(key)
+        if not isinstance(value, torch.Tensor):
+            continue
+        if value.is_nested:
+            continue
+        remaining.append((key, tuple(value.shape), value.dtype, value.numel() * value.element_size()))
+
+    if not remaining:
+        return
+
+    total_bytes = sum(b for *_, b in remaining)
+    lines = [
+        f"nest_batch_by_mask: {len(remaining)} tensor field(s) remained dense "
+        f"after nesting (total {total_bytes / 1e6:.1f} MB). Each is a missed "
+        f"compression opportunity — either register it in "
+        f"KNOWN_FIELD_TO_MASK_AND_PAD, pass it via `field_to_mask_and_pad`, "
+        f"or add it to `ignore_dense_fields` if it is intentionally dense:",
+    ]
+    for name, shape, dtype, nbytes in remaining:
+        lines.append(f"  {name}: shape={shape} dtype={dtype} bytes={nbytes / 1e6:.2f} MB")
+    message = "\n".join(lines)
+
+    if strict:
+        raise RuntimeError(message)
+    warnings.warn(message, stacklevel=2)
 
 
 def response_from_nested(tensor: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -12,17 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Padding / nesting utilities for verl worker pipelines.
+
+Two APIs coexist here:
+
+* **Legacy** — :func:`left_right_2_no_padding` and
+  :func:`no_padding_2_padding`. Depend on ``flash_attn.unpad_input`` and
+  only nest ``input_ids`` / ``position_ids``. Still used when
+  ``RayPPOTrainer.use_mask_nesting`` is ``False`` (the current default).
+  Pending removal once the new API becomes the default and stabilises.
+
+* **Current** — :func:`nest_batch_by_mask` / :func:`unnest_batch_by_mask`
+  for the per-batch nest/unnest roundtrip, :func:`extract_response`
+  to slice response regions from model outputs (dispatches over both
+  styles). Backed by :class:`verl.utils.nested_tensor.MaskNestingSpec`.
+  Does not depend on ``flash_attn``.
+"""
+
+import enum
+from dataclasses import dataclass
+
 import torch
 import torch.nn.functional as F
 from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+from verl.utils.nested_tensor import (
+    MaskNestingSpec,
+    _rle_scatter_indices,
+    rle_to_mask,
+)
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     """
     Convert TensorDict from left-right padding to no-padding format.
+
+    .. note::
+        Legacy API kept for the ``use_mask_nesting=False`` code path.
+        New code should prefer :func:`nest_batch`.
 
     Args:
         data: TensorDict with "input_ids", "attention_mask", "response_mask", "position_ids"
@@ -72,7 +101,9 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
 
     routed_experts = data.get("routed_experts", None)
     if routed_experts is not None and not routed_experts.is_nested:
-        if routed_experts.max() <= 255:
+        # uint8 range is [0, 255]; guard against negative sentinels that would
+        # wrap-around on cast.
+        if routed_experts.min() >= 0 and routed_experts.max() <= 255:
             routed_experts = routed_experts.to(torch.uint8)
         routed_experts_rmpad = index_first_axis(routed_experts.unsqueeze(-1).flatten(0, 1), indices)
         routed_experts_nested = torch.nested.nested_tensor_from_jagged(
@@ -98,6 +129,10 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
 
 def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor:
     """Slice response from unpad model output.
+
+    .. note::
+        Legacy API kept for the ``use_mask_nesting=False`` code path.
+        New code should prefer :func:`unnest` + :func:`slice_response`.
 
     Args:
         tensor: a nested tensor or a tensor of shape (total_nnz,*),
@@ -183,6 +218,387 @@ def embeds_padding_2_no_padding(data: TensorDict) -> TensorDict:
     return data
 
 
+class DynamicPadValue(enum.Enum):
+    """Sentinel enum for pad values that must be resolved at nesting time.
+
+    Registry entries tagged with a member of this enum defer their pad
+    value to a caller-supplied kwarg of :func:`nest_batch_by_mask`. Each
+    member corresponds to a specific tokenizer-owned value so the
+    library can declare *what kind* of dynamic value a field needs
+    without hard-coding the value itself.
+
+    verl currently only uses :attr:`PAD_TOKEN_ID`. The enum leaves room
+    for additional dynamic kinds (``BOS_TOKEN_ID``, ``EOS_TOKEN_ID``,
+    ``MASK_TOKEN_ID``, …) without changing the resolution machinery —
+    each new kind is one enum member, one kwarg on
+    :func:`nest_batch_by_mask`, and one entry in the dynamic-resolver
+    dict inside :func:`make_mask_nesting_specs`.
+
+    **Single-tokenizer assumption**: verl assumes all token-ID fields
+    in a batch share the same tokenizer, so a single kwarg per
+    enum member drives every sentinel-tagged entry. If you need
+    per-field pad values (e.g. a distillation teacher with a different
+    tokenizer), override that field explicitly via
+    :func:`nest_batch_by_mask`'s ``field_to_mask_and_pad`` kwarg::
+
+        nest_batch_by_mask(
+            data,
+            pad_token_id=student_tok.pad_token_id,
+            field_to_mask_and_pad={
+                "teacher_ids": ("attention_mask", teacher_tok.pad_token_id),
+            },
+        )
+    """
+
+    PAD_TOKEN_ID = enum.auto()
+
+    def __repr__(self) -> str:
+        return self.name
+
+
+# Convenience alias for the common PAD_TOKEN_ID case — equivalent to
+# ``DynamicPadValue.PAD_TOKEN_ID`` but less verbose at call sites.
+PAD_TOKEN_ID = DynamicPadValue.PAD_TOKEN_ID
+
+
+# Per-field nesting registry for verl's PPO pipeline.
+#
+# Each entry maps a data field name to ``(mask_field, pad_value)``:
+# * ``mask_field`` — the name of the mask in the TensorDict that covers
+#   this field's ``(*batch_dims, *sample_mask_dims)``.
+# * ``pad_value`` — a literal value to fill at mask=False positions when
+#   unnesting, or :data:`PAD_TOKEN_ID` to signal "pull this from
+#   ``tokenizer.pad_token_id`` at spec-building time".
+#
+# Literal-pad fields have semantics that are stable across tokenizer /
+# model: they are either (a) always consumed alongside a mask that zeroes
+# out pad positions in loss/metric computations, or (b) semantically
+# neutral at 0 / 0.0.
+KNOWN_FIELD_TO_MASK_AND_PAD: dict[str, tuple[str, int | float | DynamicPadValue]] = {
+    # paired with attention_mask (full prompt+response axis)
+    "input_ids": ("attention_mask", PAD_TOKEN_ID),
+    "teacher_ids": ("attention_mask", PAD_TOKEN_ID),
+    "position_ids": ("attention_mask", 0),
+    "old_log_probs": ("attention_mask", 0.0),
+    "ref_log_prob": ("attention_mask", 0.0),
+    "rollout_log_probs": ("attention_mask", 0.0),
+    "entropys": ("attention_mask", 0.0),
+    "teacher_logprobs": ("attention_mask", 0.0),
+    "routed_experts": ("attention_mask", 0),
+    # paired with response_mask (response-only axis)
+    "advantages": ("response_mask", 0.0),
+    "returns": ("response_mask", 0.0),
+    "values": ("response_mask", 0.0),
+    "token_level_scores": ("response_mask", 0.0),
+    "token_level_rewards": ("response_mask", 0.0),
+    "rm_scores": ("response_mask", 0.0),
+    "rollout_is_weights": ("response_mask", 0.0),
+    "sum_pi_squared": ("response_mask", 0.0),
+}
+
+
+# ---------------------------------------------------------------------------
+# dtype compression
+# ---------------------------------------------------------------------------
+
+# Fields whose values fit a narrower dtype than the producer emitted
+# (memory / RPC bandwidth saving). Each entry maps a field name to
+# ``(target_dtype, valid_min, valid_max)``; :func:`compress_batch_dtypes`
+# casts only when the live tensor's actual range fits in ``[valid_min,
+# valid_max]`` — otherwise the cast would silently wrap around (most
+# commonly when a producer uses a negative sentinel).
+KNOWN_FIELD_DTYPE_COMPRESSIONS: dict[str, tuple[torch.dtype, int, int]] = {
+    # MoE routing indices in verl fit comfortably in uint8 (≤ 256 experts).
+    "routed_experts": (torch.uint8, 0, 255),
+}
+
+
+def compress_batch_dtypes(data: TensorDict) -> TensorDict:
+    """Cast eligible fields down to narrower dtypes in place.
+
+    Concerns orthogonal to mask nesting: this operation only rewrites
+    field dtypes where the live values fit a smaller type, to save
+    memory and RPC bandwidth. Call **before** :func:`nest_batch_by_mask`
+    — once a field is nested, its values are hidden behind a
+    ``NestedTensor`` and per-element range checks are more awkward.
+
+    Uses :data:`KNOWN_FIELD_DTYPE_COMPRESSIONS` as the registry of
+    eligible fields. Unlisted fields are left untouched. Already
+    nested fields and tensors whose range doesn't fit the target
+    dtype are silently skipped.
+
+    Args:
+        data: TensorDict to compress in-place.
+
+    Returns:
+        The mutated TensorDict.
+    """
+    for field, (target_dtype, valid_min, valid_max) in KNOWN_FIELD_DTYPE_COMPRESSIONS.items():
+        t = data.get(field, None)
+        if t is None or not isinstance(t, torch.Tensor) or t.is_nested:
+            continue
+        if t.dtype == target_dtype:
+            continue
+        if t.min() >= valid_min and t.max() <= valid_max:
+            data[field] = t.to(target_dtype)
+    return data
+
+
+def make_mask_nesting_specs(
+    data: TensorDict,
+    pad_token_id: int | None = None,
+    field_to_mask_and_pad: dict[str, tuple[str, int | float | bool | DynamicPadValue]] | None = None,
+) -> dict[str, MaskNestingSpec]:
+    """Build :class:`MaskNestingSpec` objects for a padded TensorDict.
+
+    Classification is **purely by data-field name**, resolved against two
+    sources merged in this order (later overrides earlier):
+
+    1. :data:`KNOWN_FIELD_TO_MASK_AND_PAD` — the library-owned registry.
+       Entries map ``field → (mask_field, pad_value)`` where ``pad_value``
+       is either a literal (fully static) or a :class:`DynamicPadValue`
+       member such as :data:`PAD_TOKEN_ID` (mask is known, pad value is
+       dynamic and resolved from the matching kwarg).
+    2. ``field_to_mask_and_pad`` — caller-supplied overrides, used for
+       custom user fields or to override a dynamic entry individually
+       (e.g. a distillation teacher with a different tokenizer:
+       ``{"teacher_ids": ("attention_mask", teacher_pad_id)}``).
+
+    Every :class:`DynamicPadValue` left unresolved after merging (i.e.
+    the caller did not pass the matching kwarg) causes that field to be
+    silently skipped — it is treated as "unknown" and left untouched.
+
+    Unknown field names are silently ignored.
+
+    The function groups data fields by their target mask and emits one
+    :class:`MaskNestingSpec` per mask. Tensor shape is only used as a
+    sanity check (``data.shape[: mask.ndim] == mask.shape``).
+
+    Each data tensor must have shape
+    ``(*batch_dims, *sample_mask_dims, *feature_dims)`` such that
+    ``(*batch_dims, *sample_mask_dims) == mask.shape``. The leading dims
+    must match the mask exactly; any trailing ``feature_dims`` (e.g.
+    multi-head) pass through untouched.
+
+    The returned specs are plain dataclasses — callers can freely mutate
+    ``data_field_to_pad_value`` on them (add, remove, or override entries)
+    before passing them to :func:`nest_batch`.
+
+    Args:
+        data: TensorDict containing the data and mask tensors.
+        pad_token_id: Tokenizer pad token id. Resolves every
+            :data:`PAD_TOKEN_ID` entry in the merged registry. A single
+            global value is applied to all token-ID fields — see
+            :class:`DynamicPadValue` for the rationale and how to opt
+            out per-field.
+        field_to_mask_and_pad: Caller-supplied per-field overrides,
+            ``{field: (mask_field, pad_value)}``. Use this for custom
+            user fields or to override a dynamic entry individually.
+
+    Returns:
+        ``{mask_field: MaskNestingSpec}`` — one entry per mask that has
+        at least one data field bound to it.
+    """
+    merged: dict[str, tuple[str, int | float | bool | DynamicPadValue]] = dict(KNOWN_FIELD_TO_MASK_AND_PAD)
+    if field_to_mask_and_pad:
+        merged.update(field_to_mask_and_pad)
+
+    # Dispatch table mapping each dynamic kind to its resolved value
+    # (or None if the caller didn't supply it). Extend this dict when
+    # adding new DynamicPadValue members.
+    dynamic_resolved: dict[DynamicPadValue, int | None] = {
+        DynamicPadValue.PAD_TOKEN_ID: pad_token_id,
+    }
+
+    # Group data fields by their target mask field.
+    fields_by_mask: dict[str, dict[str, int | float | bool]] = {}
+    for data_field in list(data.keys()):
+        if data_field not in merged:
+            continue  # unknown field, leave untouched
+        t = data.get(data_field, None)
+        if t is None or not isinstance(t, torch.Tensor) or t.is_nested:
+            continue
+
+        mask_field, pad_value = merged[data_field]
+
+        # Resolve dynamic pad values from the dispatch table. Silently
+        # skip the field if the caller did not supply the matching
+        # kwarg (treat as "unknown field").
+        if isinstance(pad_value, DynamicPadValue):
+            resolved = dynamic_resolved.get(pad_value)
+            if resolved is None:
+                continue
+            pad_value = resolved
+
+        assert mask_field in data, (
+            f"field {data_field!r} requires mask {mask_field!r} which is missing from the TensorDict"
+        )
+        mask_t = data[mask_field]
+        # Validate that the field's leading dims (after any registered
+        # permutation from KNOWN_FIELD_PERMUTATIONS) match the mask.
+        # nest_batch_by_mask will apply the permutation for real.
+        perm = _permutation_for_field(data_field, t.ndim)
+        canonical_shape = tuple(t.shape[p] for p in perm) if perm is not None else tuple(t.shape)
+        expected_prefix = tuple(mask_t.shape)
+        if canonical_shape[: len(expected_prefix)] != expected_prefix:
+            perm_hint = f" (after permutation {perm})" if perm is not None else ""
+            raise AssertionError(
+                f"field {data_field!r} has shape {tuple(t.shape)}{perm_hint}; "
+                f"expected leading (*batch_dims, *sample_mask_dims) to match "
+                f"mask {mask_field!r} shape {expected_prefix}. "
+                f"Hint: if this is a new layout that needs a permutation, "
+                f"add an entry to KNOWN_FIELD_PERMUTATIONS."
+            )
+        fields_by_mask.setdefault(mask_field, {})[data_field] = pad_value
+
+    specs: dict[str, MaskNestingSpec] = {}
+    for mask_field, fields in fields_by_mask.items():
+        specs[mask_field] = MaskNestingSpec(
+            mask_field=mask_field,
+            mask_shape=tuple(data[mask_field].shape),
+            data_field_to_pad_value=fields,
+        )
+    return specs
+
+
+# Non-tensor keys where `nest_batch_by_mask` stashes reversal state so
+# that `unnest_batch_by_mask` can fully reverse the operation without
+# the caller having to thread anything through themselves.
+_MASK_NESTING_SPECS_KEY = "_mask_nesting_specs"
+_MASK_NESTING_PERMUTATIONS_KEY = "_mask_nesting_permutations"
+
+
+# Per-field permutations that canonicalise a producer's layout into
+# ``(*batch_dims, *sample_mask_dims, *feature_dims)`` before nesting.
+#
+# Classification is **explicit by field name** — no shape inference
+# (same principle as :data:`KNOWN_FIELD_TO_MASK_AND_PAD`). Each entry
+# maps a field name to a ``torch.permute`` tuple that the library
+# applies iff the live tensor's rank matches the permutation's length.
+# This lets a single entry handle the common "sometimes multimodal,
+# sometimes not" case for ``position_ids``: 2-D ``(bs, seq_len)`` has
+# ``ndim == 2 != 3`` so the registered 3-D permutation is skipped;
+# 3-D ``(bs, heads, seq_len)`` matches and gets permuted to
+# ``(bs, seq_len, heads)``.
+#
+# ``unnest_batch_by_mask`` reads the same permutations from stashed
+# state and applies the inverse, so the round-trip is transparent to
+# downstream code.
+KNOWN_FIELD_PERMUTATIONS: dict[str, tuple[int, ...]] = {
+    # Multimodal position_ids: (bs, heads, seq_len) → (bs, seq_len, heads).
+    "position_ids": (0, 2, 1),
+}
+
+
+def _inverse_permutation(perm: tuple[int, ...]) -> tuple[int, ...]:
+    """Return the permutation that undoes *perm*."""
+    inv = [0] * len(perm)
+    for i, p in enumerate(perm):
+        inv[p] = i
+    return tuple(inv)
+
+
+def _permutation_for_field(field: str, ndim: int) -> tuple[int, ...] | None:
+    """Return the registered permutation for *field* if it applies to a rank-*ndim* tensor.
+
+    Returns ``None`` when the field is unlisted or the registered
+    permutation's length does not match ``ndim`` (e.g. a 3-D
+    ``position_ids`` permutation declared in the registry does not
+    apply to a 2-D text-only ``position_ids`` tensor).
+    """
+    perm = KNOWN_FIELD_PERMUTATIONS.get(field)
+    if perm is None or len(perm) != ndim:
+        return None
+    return perm
+
+
+def nest_batch_by_mask(
+    data: TensorDict,
+    specs: dict[str, MaskNestingSpec] | None = None,
+    *,
+    pad_token_id: int | None = None,
+    field_to_mask_and_pad: dict[str, tuple[str, int | float | bool | DynamicPadValue]] | None = None,
+) -> TensorDict:
+    """Nest every eligible tensor field in *data* in place using mask-driven RLE.
+
+    There are three ways to drive the nesting, listed from simplest to
+    most flexible:
+
+    1. **Simple** — let the library resolve specs from
+       :data:`KNOWN_FIELD_TO_MASK_AND_PAD` and the tokenizer's pad id::
+
+           nest_batch_by_mask(data, pad_token_id=tokenizer.pad_token_id)
+
+    2. **Declarative custom fields** — add or override entries via the
+       ``field_to_mask_and_pad`` kwarg::
+
+           nest_batch_by_mask(
+               data,
+               pad_token_id=tokenizer.pad_token_id,
+               field_to_mask_and_pad={"my_field": ("attention_mask", 0.0)},
+           )
+
+    3. **Dynamic / programmatic** — build specs with
+       :func:`make_mask_nesting_specs`, mutate them, and pass them back::
+
+           specs = make_mask_nesting_specs(data, pad_token_id=tok.pad_token_id)
+           specs["attention_mask"].data_field_to_pad_value.pop("routed_experts", None)
+           nest_batch_by_mask(data, specs=specs)
+
+    Before invoking ``spec.nest_in_td``, each tracked field whose
+    layout is registered in :data:`KNOWN_FIELD_PERMUTATIONS` is
+    permuted to the canonical
+    ``(*batch_dims, *sample_mask_dims, *feature_dims)`` form. This
+    transparently handles producers that emit a non-canonical layout
+    — most notably multimodal 3-D ``position_ids``
+    ``(bs, heads, seq_len)`` which is auto-permuted to
+    ``(bs, seq_len, heads)`` before nesting and permuted back by
+    :func:`unnest_batch_by_mask`.
+
+    The resolved specs and any permutations applied are stashed as
+    non-tensor data so :func:`unnest_batch_by_mask` can fully reverse
+    the operation without the caller re-threading anything.
+
+    Args:
+        data: TensorDict to nest in-place.
+        specs: Pre-built ``{mask_field: MaskNestingSpec}`` for path 3.
+            Mutually exclusive with ``pad_token_id`` /
+            ``field_to_mask_and_pad``.
+        pad_token_id: Tokenizer pad token id (paths 1 & 2).
+        field_to_mask_and_pad: Per-field overrides (path 2).
+
+    Returns:
+        The mutated TensorDict.
+    """
+    if specs is None:
+        specs = make_mask_nesting_specs(data, pad_token_id=pad_token_id, field_to_mask_and_pad=field_to_mask_and_pad)
+    elif pad_token_id is not None or field_to_mask_and_pad is not None:
+        raise TypeError(
+            "nest_batch_by_mask: pass either `specs` (pre-built) or the "
+            "`pad_token_id` / `field_to_mask_and_pad` kwargs, not both."
+        )
+
+    permutations: dict[str, tuple[int, ...]] = {}
+    for spec in specs.values():
+        for field in spec.data_field_to_pad_value:
+            t = data[field]
+            perm = _permutation_for_field(field, t.ndim)
+            if perm is not None:
+                data[field] = t.permute(perm).contiguous()
+                permutations[field] = perm
+
+    # Apply specs in a deterministic order (insertion order of the dict).
+    for spec in specs.values():
+        spec.nest_in_td(data)
+
+    # Stash reversal state.
+    tu.assign_non_tensor_data(data, _MASK_NESTING_SPECS_KEY, specs)
+    if permutations:
+        tu.assign_non_tensor_data(data, _MASK_NESTING_PERMUTATIONS_KEY, permutations)
+
+    return data
+
+
 def response_from_nested(tensor: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:
     """Extract response from nested model output.
 
@@ -219,3 +635,223 @@ def response_to_nested(tensor: torch.Tensor, response_mask: torch.Tensor) -> tor
         response_list.append(tensor[i, : response_lens[i]])
 
     return torch.nested.as_nested_tensor(response_list, layout=torch.jagged)
+
+
+def unnest_batch_by_mask(
+    data: TensorDict,
+    specs: dict[str, MaskNestingSpec] | None = None,
+) -> TensorDict:
+    """Inverse of :func:`nest_batch_by_mask`. Reconstruct padded fields in place.
+
+    When ``specs`` is not supplied, retrieves the ones that
+    :func:`nest_batch_by_mask` stashed under ``_mask_nesting_specs``.
+    If the TensorDict was never nested (key absent) this is a no-op.
+
+    Converts every nested tensor tracked by *specs* back to dense
+    padded form, restores the corresponding mask fields, and reverses
+    any shape-normalising permutations applied on the way in.
+    Trailing ``feature_dims`` (e.g. multi-head) are preserved
+    automatically by ``MaskNestingSpec.unnest_in_td``.
+
+    Args:
+        data: TensorDict previously transformed by :func:`nest_batch_by_mask`.
+        specs: Optional ``{mask_field: MaskNestingSpec}``. When ``None``,
+            retrieved from ``data``'s stashed state.
+
+    Returns:
+        The same TensorDict with dense padded tensors restored.
+    """
+    if specs is None:
+        specs = tu.get_non_tensor_data(data, _MASK_NESTING_SPECS_KEY, default=None)
+        if specs is None:
+            # Never nested — nothing to undo.
+            return data
+
+    for spec in specs.values():
+        spec.unnest_in_td(data)
+
+    # Reverse any shape-normalising permutations applied on the way in.
+    permutations = tu.get_non_tensor_data(data, _MASK_NESTING_PERMUTATIONS_KEY, default=None)
+    if permutations:
+        for field, perm in permutations.items():
+            inv = _inverse_permutation(perm)
+            data[field] = data[field].permute(inv).contiguous()
+
+    # Clean up stashed state.
+    data.pop(_MASK_NESTING_SPECS_KEY, None)
+    data.pop(_MASK_NESTING_PERMUTATIONS_KEY, None)
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: library-level nested → dense unnest
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UnnestContext:
+    """Precomputed scatter indices for :func:`unnest`."""
+
+    row_idx: torch.Tensor
+    col_idx: torch.Tensor
+    batch_size: int
+    seq_len: int
+
+
+def prepare_unnest(data: TensorDict) -> UnnestContext:
+    """Precompute scatter indices from a mask-nested TensorDict's RLE."""
+    offsets = data["attention_mask_offsets"]
+    lengths = data["attention_mask_lengths"]
+    row_idx, col_idx, _, seq_len = _rle_scatter_indices(offsets, lengths)
+    return UnnestContext(
+        row_idx=row_idx,
+        col_idx=col_idx,
+        batch_size=offsets.shape[0],
+        seq_len=int(seq_len),
+    )
+
+
+def unnest(ctx: UnnestContext, tensor: torch.Tensor) -> torch.Tensor:
+    """Scatter a nested tensor into a zero-filled dense ``(batch_size, seq_len, *trailing)``."""
+    data_flat = tensor.values() if tensor.is_nested else tensor
+    trailing_shape = data_flat.shape[1:]
+    dense = torch.full(
+        (ctx.batch_size, ctx.seq_len, *trailing_shape),
+        0.0,
+        dtype=tensor.dtype,
+        device=tensor.device,
+    )
+    if ctx.row_idx.numel() > 0:
+        dense[ctx.row_idx, ctx.col_idx] = data_flat
+    return dense
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: PPO-level response slicing from dense (bs, seq_len, *) tensors
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResponseSliceContext:
+    """Precomputed per-sample slice bounds for :func:`slice_response`.
+
+    Bounds bake in the PPO one-token left-shift.
+    """
+
+    slice_bounds: list[tuple[int, int, int]]  # one (resp_start, resp_end, pad_size) per sample
+    max_response_len: int
+
+
+def prepare_response_slice(data: TensorDict) -> ResponseSliceContext:
+    """Derive per-sample ``(resp_start, resp_end, pad_size)`` bounds from a mask-nested batch.
+
+    Uses ``prompts`` / ``responses`` for lengths and the RLE's first
+    offset per row for absolute positions. Original padded dimensions
+    are recovered from stashed :class:`MaskNestingSpec` when available,
+    falling back to live masks otherwise.
+    """
+    offsets = data["attention_mask_offsets"]
+    lengths = data["attention_mask_lengths"]
+    batch_size = offsets.shape[0]
+
+    # Prefer stashed spec for original dims; fall back to live mask.
+    specs = tu.get_non_tensor_data(data, _MASK_NESTING_SPECS_KEY, default={}) or {}
+
+    def _orig_mask_len(mask_field: str) -> int | None:
+        if mask_field in specs:
+            return specs[mask_field].mask_shape[-1]
+        if mask_field in data:
+            return data[mask_field].shape[-1]
+        return None
+
+    orig_seq_len = _orig_mask_len("attention_mask")
+    orig_response_len = _orig_mask_len("response_mask")
+
+    prompt_ids = data["prompts"]
+    response_ids = data["responses"]
+    if prompt_ids.is_nested:
+        prompt_lens = prompt_ids.offsets().diff()
+        response_lens = response_ids.offsets().diff()
+        max_response_len = orig_response_len if orig_response_len is not None else response_lens.max().item()
+    else:
+        mask_shape = (batch_size, orig_seq_len) if orig_seq_len is not None else None
+        attn_mask = rle_to_mask(offsets, lengths, shape=mask_shape)
+        prompt_lens = attn_mask[:, : prompt_ids.shape[1]].sum(dim=1)
+        response_lens = attn_mask[:, prompt_ids.shape[1] :].sum(dim=1)
+        max_response_len = orig_response_len if orig_response_len is not None else response_ids.shape[1]
+
+    rle_first_offsets = offsets.values()[offsets._offsets[:-1]]
+    slice_bounds: list[tuple[int, int, int]] = []
+    for i in range(batch_size):
+        abs_start = rle_first_offsets[i].item()
+        p_len = prompt_lens[i].item()
+        r_len = response_lens[i].item()
+        # left-shift by 1 for log_prob/value alignment
+        resp_start = abs_start + p_len - 1
+        resp_end = abs_start + p_len + r_len - 1
+        pad_size = max_response_len - r_len
+        slice_bounds.append((resp_start, resp_end, pad_size))
+
+    return ResponseSliceContext(slice_bounds=slice_bounds, max_response_len=int(max_response_len))
+
+
+def slice_response(ctx: ResponseSliceContext, dense: torch.Tensor) -> torch.Tensor:
+    """Slice the response region from a dense ``(bs, seq_len, *trailing)`` tensor."""
+    trailing_shape = dense.shape[2:]
+    skip_padding = (0, 0) * len(trailing_shape)
+    response_list = [
+        F.pad(dense[i, start:end], (*skip_padding, 0, pad)) for i, (start, end, pad) in enumerate(ctx.slice_bounds)
+    ]
+    return torch.stack(response_list, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# Dispatching layer: unified response extraction over both batch nesting styles
+# ---------------------------------------------------------------------------
+
+
+def extract_response(data: TensorDict, tensor: torch.Tensor) -> torch.Tensor:
+    """Extract the padded response region from a model output tensor.
+
+    Dispatches on batch nesting style: new path (``attention_mask_offsets``
+    present) runs :func:`unnest` → :func:`slice_response`; legacy path
+    slices the flat ``(total_nnz, *)`` values directly. Both apply the
+    PPO one-token left-shift and right-pad to ``max_response_len``.
+    """
+    if "attention_mask_offsets" in data:
+        return slice_response(prepare_response_slice(data), unnest(prepare_unnest(data), tensor))
+
+    # Legacy path — mirrors no_padding_2_padding inline.
+    values = tensor.values() if tensor.is_nested else tensor
+    prompt_ids = data["prompts"]
+    response_ids = data["responses"]
+    attention_mask = data["attention_mask"]
+
+    max_response_len = tu.get_non_tensor_data(data=data, key="max_response_len", default=-1)
+
+    if prompt_ids.is_nested:
+        prompt_lens = prompt_ids.offsets().diff()
+        response_lens = response_ids.offsets().diff()
+        if max_response_len < 0:
+            max_response_len = response_lens.max().item()
+    else:
+        assert not attention_mask.is_nested
+        prompt_lens = attention_mask[:, : prompt_ids.shape[1]].sum(dim=1)
+        response_lens = attention_mask[:, prompt_ids.shape[1] :].sum(dim=1)
+        max_response_len = response_ids.shape[1]
+
+    sequence_lens = prompt_lens + response_lens
+    sequence_offsets = sequence_lens.cumsum(dim=0)
+    assert sequence_offsets[-1].item() == values.shape[0]
+    assert not prompt_lens.eq(0).any(), (
+        f"flat_start = seq_offset - resp_len - 1 assumes prompt_len > 0. Got {prompt_lens}"
+    )
+
+    skip_padding = (0, 0) * (values.ndim - 1)
+    response_list = []
+    for resp_len, seq_offset in zip(response_lens, sequence_offsets, strict=True):
+        pad_size = max_response_len - resp_len
+        # left-shift by 1 for log_prob/value alignment
+        response_list.append(F.pad(values[seq_offset - resp_len - 1 : seq_offset - 1], (*skip_padding, 0, pad_size)))
+    return torch.stack(response_list, dim=0)

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -875,7 +875,15 @@ def prepare_response_slice(data: TensorDict) -> ResponseSliceContext:
     else:
         max_response_len = int(response_ids.shape[1])
 
-    rle_first_offsets = offsets.values()[offsets._offsets[:-1]]
+    # First column of the per-row RLE offsets. Uses the public ``offsets()``
+    # jagged-layout API instead of the private ``_offsets`` attribute, and
+    # guards against rows whose mask had zero True positions (which would
+    # otherwise pick up the next non-empty row's first segment).
+    row_offsets = offsets.offsets()
+    has_segments = row_offsets.diff() > 0
+    rle_first_offsets = torch.zeros(batch_size, dtype=torch.long, device=offsets.device)
+    if has_segments.any():
+        rle_first_offsets[has_segments] = offsets.values()[row_offsets[:-1][has_segments]]
     slice_bounds: list[tuple[int, int, int]] = []
     for i in range(batch_size):
         abs_start = rle_first_offsets[i].item()

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -768,20 +768,32 @@ def prepare_response_slice(data: TensorDict) -> ResponseSliceContext:
         return None
 
     orig_seq_len = _orig_mask_len("attention_mask")
-    orig_response_len = _orig_mask_len("response_mask")
+
+    # Canonical per-task max_response_length comes from the config (stashed on
+    # the batch by the trainer); fall back to the stashed mask_shape only if
+    # the config value wasn't recorded.
+    config_max_response_len = tu.get_non_tensor_data(data, "max_response_length", default=None)
+    spec_response_len = _orig_mask_len("response_mask")
 
     prompt_ids = data["prompts"]
     response_ids = data["responses"]
     if prompt_ids.is_nested:
         prompt_lens = prompt_ids.offsets().diff()
         response_lens = response_ids.offsets().diff()
-        max_response_len = orig_response_len if orig_response_len is not None else response_lens.max().item()
     else:
         mask_shape = (batch_size, orig_seq_len) if orig_seq_len is not None else None
         attn_mask = rle_to_mask(offsets, lengths, shape=mask_shape)
         prompt_lens = attn_mask[:, : prompt_ids.shape[1]].sum(dim=1)
         response_lens = attn_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-        max_response_len = orig_response_len if orig_response_len is not None else response_ids.shape[1]
+
+    if config_max_response_len is not None:
+        max_response_len = int(config_max_response_len)
+    elif spec_response_len is not None:
+        max_response_len = int(spec_response_len)
+    elif prompt_ids.is_nested:
+        max_response_len = int(response_lens.max().item())
+    else:
+        max_response_len = int(response_ids.shape[1])
 
     rle_first_offsets = offsets.values()[offsets._offsets[:-1]]
     slice_bounds: list[tuple[int, int, int]] = []
@@ -811,6 +823,37 @@ def slice_response(ctx: ResponseSliceContext, dense: torch.Tensor) -> torch.Tens
 # ---------------------------------------------------------------------------
 # Dispatching layer: unified response extraction over both batch nesting styles
 # ---------------------------------------------------------------------------
+
+
+def select_and_pad_to_response(data: TensorDict, *fields: str) -> TensorDict:
+    """Select nested response-axis fields and pad them to the canonical width.
+
+    :meth:`TensorDict.to_padded_tensor` pads jagged tensors to the
+    *per-micro-batch local* max along the response axis. That width can be
+    narrower than :func:`extract_response`'s output (which targets the
+    task-level ``max_response_length`` stashed on the batch by the trainer).
+    Any downstream arithmetic that mixes the two (e.g.
+    ``log_prob - old_log_prob`` in :func:`ppo_loss`) would then crash on
+    shape mismatch after worker chunking.
+
+    This helper right-pads every selected field's response dim up to that
+    canonical width so all response-axis tensors share one shape.
+    """
+    selected = data.select(*fields).to_padded_tensor()
+    max_response_length = tu.get_non_tensor_data(data, "max_response_length", default=None)
+    if max_response_length is None:
+        return selected
+    target = int(max_response_length)
+    for key in list(selected.keys()):
+        v = selected[key]
+        if not isinstance(v, torch.Tensor) or v.ndim < 2:
+            continue
+        gap = target - v.shape[1]
+        if gap <= 0:
+            continue
+        pad_dims = (0, 0) * (v.ndim - 2) + (0, gap)
+        selected[key] = F.pad(v, pad_dims)
+    return selected
 
 
 def extract_response(data: TensorDict, tensor: torch.Tensor) -> torch.Tensor:

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -768,24 +768,20 @@ def prepare_response_slice(data: TensorDict) -> ResponseSliceContext:
         return None
 
     orig_seq_len = _orig_mask_len("attention_mask")
+    orig_response_len = _orig_mask_len("response_mask")
 
     prompt_ids = data["prompts"]
     response_ids = data["responses"]
     if prompt_ids.is_nested:
         prompt_lens = prompt_ids.offsets().diff()
         response_lens = response_ids.offsets().diff()
+        max_response_len = orig_response_len if orig_response_len is not None else response_lens.max().item()
     else:
         mask_shape = (batch_size, orig_seq_len) if orig_seq_len is not None else None
         attn_mask = rle_to_mask(offsets, lengths, shape=mask_shape)
         prompt_lens = attn_mask[:, : prompt_ids.shape[1]].sum(dim=1)
         response_lens = attn_mask[:, prompt_ids.shape[1] :].sum(dim=1)
-    # Pad to the batch-local max so the resulting dense (bs, local_max) aligns
-    # with the per-micro-batch dimensions produced by
-    # ``TensorDict.to_padded_tensor()`` on response-axis nested fields
-    # (old_log_probs, advantages, ...). Using the spec-stashed full-batch
-    # ``orig_response_len`` here would leave extract_response's output wider
-    # than the rest and break downstream arithmetic in ppo_loss.
-    max_response_len = int(response_lens.max().item())
+        max_response_len = orig_response_len if orig_response_len is not None else response_ids.shape[1]
 
     rle_first_offsets = offsets.values()[offsets._offsets[:-1]]
     slice_bounds: list[tuple[int, int, int]] = []


### PR DESCRIPTION
### What does this PR do?

Make the `use_mask_nesting=True` path usable end-to-end and push its
dispatch payload compression close to the theoretical ceiling.

The base commit `b6e6562e feat: nested tensor utilities` landed the
library-level utilities (`nest_batch_by_mask` / `MaskNestingSpec` /
`extract_response`) but running with `trainer.use_mask_nesting=True`
crashed at the first `_compress_batch` call. This PR:

1. Fixes the bug chain blocking end-to-end execution of the nesting
   path (`loss_mask` / `response_mask` plumbing, response-axis shape
   mismatches).
2. Introduces a canonical `max_prompt_length` / `max_response_length`
   stashed on the batch so `extract_response` and
   `TensorDict.to_padded_tensor` agree on the response-axis width.
3. Extends `KNOWN_FIELD_TO_MASK_AND_PAD` with `prompts` / `responses`
   (which were silently staying dense and accounting for ~78% of
   post-nest wire bytes) by deriving a `prompt_mask` from
   `attention_mask[:, :max_prompt]` at compress time.
4. Adds a coverage check inside `nest_batch_by_mask` that reports (or,
   with `trainer.strict_mask_nesting=True`, raises on) any tensor
   field still dense after nesting.

No related issue; Slack / GH discussion on the feature commit
`b6e6562e` is the context. Duplicate search:
`gh pr list --repo verl-project/verl --state open --search "use_mask_nesting"`
/ `"nest_batch_by_mask"` returned none relevant.

### Checklist Before Starting

- [x] Search for similar PRs — none open that touch this path:
      `gh pr list --repo verl-project/verl --state open --search "use_mask_nesting"`
- [x] PR title follows `[{modules}] {type}: {description}`:
      `[trainer, perf] feat: make use_mask_nesting usable end-to-end, nest prompts/responses`
      (no `[BREAKING]` — defaults unchanged; new `trainer.strict_mask_nesting`
      defaults to `False`).

### Test

Not CI-testable in its full form (requires Ray + 16×A100 + vLLM
rollout). Validated on a live RL run: Qwen2.5-Math-7B, 2 nodes × 8×A100,
DAPO-Math-17k, `max_prompt_length=2048`, `max_response_length=14336`,
`train_prompt_bsz=512`, `rollout.n=16` (flat batch 8192), `adv=rloo`,
ULysses SP=4, FSDP=8, vLLM TP=1.

**Dispatch timings, steady-state averages over steps 2-4**:

| Metric | baseline<br>(`use_mask_nesting=False`) | first end-to-end-working nest<br>(pre-registry-fix) | **this PR** |
|---|---:|---:|---:|
| `wg_dispatch/actor_rollout_compute_log_prob` | 8.52 s | 4.67 s | **3.33 s** |
| `wg_dispatch/actor_rollout_update_actor` | 11.26 s | 5.40 s | **4.19 s** |
| combined dispatch | 19.78 s | 10.07 s | **7.52 s** |
| dispatch speedup vs baseline | 1× | 1.96× | **2.63×** |
| step total | 557.6 s | 557.1 s | **526.8 s** (−5.5%) |

Modelling dispatch as `T = α + β · bytes` solves to `α ≈ 6 s` (Ray RPC /
serialize fixed cost) + `β ≈ 14 s` (payload-proportional). The observed
2.63× corresponds to a back-solved payload compression ≈ **11.2×**,
against a ~11.9× theoretical ceiling from the batch's 8.4% valid-token
fill ratio. Coverage check reports no remaining dense tensor fields on
this task.

Training loss / grad-norm / MFU remain stable across observed steps
(step 4 throughput 1216 tok/s, actor MFU 39.5%, actor_infer MFU 60.6%).

Validation runs:

- Baseline (`use_mask_nesting=False`): job `fd2a521f2e3e80d0`, 100+
  steps completed — dispatch reference numbers.
- Pre-PR (nesting on, no fix): job `b09b7e4e0efee766` run_times=0 —
  crashes at `forward_backward_batch` with `KeyError('loss_mask')`.
- First end-to-end run (fixes only, no registry expansion):
  `b09b7e4e0efee766` run_times=13 — training proceeds, dispatch 1.96×.
- **With full PR**: forked job `23498c720a9d1e9c` — 4 training steps
  complete, dispatch **2.63×**, no warning, loss stable.

**Numerical equivalence vs baseline** (first 4 steps, same config fork,
same model init):

| step | baseline `critic/score/mean` | ours `critic/score/mean` | Δ |
|---:|---:|---:|---:|
| 1 | −0.9841 | −0.9849 | 8 × 10⁻⁴ |
| 2 | −0.9880 | −0.9856 | 2.4 × 10⁻³ |
| 3 | −0.9883 | −0.9863 | 2.0 × 10⁻³ |
| 4 | −0.9849 | −0.9849 | 0 |

`score/{max,min} = ±1` match exactly on all four steps; `entropy`,
`grad_norm`, `pg_loss`, `response_length/mean` all land in the same
distribution. The millidecimal-level drift on `score/mean` corresponds
to a few dozen of the 8192 samples flipping binary correctness — well
within vLLM rollout non-determinism (PagedAttention scheduling order
perturbs logits at ULP scale, which under `temperature=1.0` sampling
diverges trajectories even with identical prompts + model weights).
No evidence of systematic bias; consistent with nesting being purely
a transport-layer change.

Local checks:

```bash
pre-commit install
pre-commit run --all-files --show-diff-on-failure --color=always   # passes
```

CI unit tests still cover the utilities via the existing
`tests/utils/test_nested_tensor_on_cpu.py` /
`tests/utils/test_padding_on_cpu.py` from the base feature commit.

### API and Usage Example

No required user-facing changes. Defaults preserve existing behaviour.

Two new `trainer.*` knobs:

```yaml
trainer:
  use_mask_nesting: True          # existing; this PR makes it functional
  strict_mask_nesting: False      # NEW — set True in CI / dev to fail fast
                                  # when a new batch tensor field bypasses
                                  # nesting (i.e. absent from the registry).
```

Registry extension (library-side, no user action required):

```python
# verl/workers/utils/padding.py
KNOWN_FIELD_TO_MASK_AND_PAD = {
    ...
    "prompts":   ("prompt_mask",   PAD_TOKEN_ID),  # NEW — prompt_mask is
                                                   # derived from
                                                   # attention_mask[:, :max_prompt]
                                                   # in _compress_batch
    "responses": ("response_mask", PAD_TOKEN_ID),  # NEW
    # log-prob / entropy fields moved from ("attention_mask", ...) to
    # ("response_mask", ...) because _decompress_model_outputs stores
    # them as (bsz, max_response_len).
    "old_log_probs":     ("response_mask", 0.0),   # CHANGED
    "ref_log_prob":      ("response_mask", 0.0),   # CHANGED
    "rollout_log_probs": ("response_mask", 0.0),   # CHANGED
    "entropys":          ("response_mask", 0.0),   # CHANGED
    ...
}
```

New `nest_batch_by_mask` kwargs (both have backward-compatible defaults):

```python
nest_batch_by_mask(
    data,
    pad_token_id=tok.pad_token_id,
    # new, default False — raise instead of warn on un-nested tensor fields
    strict=False,
    # new, default None — names of tensor fields that are intentionally
    # expected to stay dense and should be excluded from the coverage check
    ignore_dense_fields={"my_scalar_field"},
)
```

New library helper used by `ppo_loss` / `value_loss`:

```python
from verl.workers.utils.padding import select_and_pad_to_response

# replaces  data.select(*fields).to_padded_tensor()
# and right-pads the response dim to the batch-stashed
# max_response_length so log_prob (from extract_response) and
# old_log_probs / advantages / response_mask all share the same width.
data = select_and_pad_to_response(data, "response_mask", "old_log_probs", "advantages")
```

### Design & Code Changes

#### Bug fixes required to execute `use_mask_nesting=True`

Each surfaced as the previous one was unblocked; cumulative in the
final diff.

- `_compress_batch`: alias `loss_mask = response_mask` **before**
  `nest_batch_by_mask` (and list `loss_mask` in
  `field_to_mask_and_pad`) so it becomes a nested all-ones jagged
  field. Workers' `forward_backward_batch` was hitting
  `KeyError('loss_mask')` because `nest_in_td` pops `response_mask`,
  making the old post-nest alias branch dead.
- `KNOWN_FIELD_TO_MASK_AND_PAD`: re-pair `old_log_probs` /
  `ref_log_prob` / `rollout_log_probs` / `entropys` with
  `response_mask`. `_decompress_model_outputs` stores them as
  `(bsz, max_response_len)`, so the shape-prefix assertion against
  `attention_mask` (`max_total`) was firing in `_update_actor`.
- `_compress_batch`: restore `response_mask` as a nested alias of
  `loss_mask` after nesting so worker-side `ppo_loss` / `value_loss`
  `data.select("response_mask", ...)` keeps working;
  `_decompress_batch` drops the alias before `unnest_batch_by_mask`.

#### Canonical max-length carried on the batch

Two independent code paths were deriving the response-axis output
width from tensor shapes and drifting after worker chunking:

- `extract_response` / `slice_response` padded to the nesting spec's
  stashed `mask_shape[-1]` (original full-batch max).
- `TensorDict.to_padded_tensor()` in loss fns padded to the
  per-micro-batch local max.

The two collided in `compute_policy_loss_vanilla`
(`log_prob - old_log_prob`: `(bs, 14336)` vs `(bs, 301)`). Fix:

- `_compress_batch` writes
  `config.data.{max_prompt_length, max_response_length}` onto the batch
  via `tu.assign_non_tensor`.
- `prepare_response_slice` reads the stashed value first, falls back
  to shape inference.
- New `select_and_pad_to_response` in `verl/workers/utils/padding.py`
  replaces `data.select(...).to_padded_tensor()` in `ppo_loss` /
  `value_loss` and right-pads each selected field's response dim up to
  the canonical width, so every response-axis arithmetic sees matching
  shapes regardless of chunking.

#### Coverage / strict mode

- `prompts` paired with a new `prompt_mask` (derived from
  `attention_mask[:, :max_prompt_length]` in `_compress_batch`, popped
  by `_decompress_batch` after unnest) and `responses` paired with
  `response_mask`.
- `nest_batch_by_mask` walks the TD once after nesting and reports any
  tensor field that stayed dense, excluding
  `_DEFAULT_IGNORE_DENSE = {"dummy_tensor"}` and spec-owned RLE
  offsets/lengths. Offenders are printed with `shape` / `dtype` /
  `bytes`.
- New `trainer.strict_mask_nesting` flag (default `False`): when
  `True`, the coverage check raises `RuntimeError` instead of warning.

#### Files touched

```
 verl/trainer/config/ppo_trainer.yaml               |  +9
 verl/trainer/config/_generated_ppo_*_trainer.yaml  |  +8 (autogen)
 verl/trainer/ppo/ray_trainer.py                    |  +40 −3
 verl/workers/utils/padding.py                      | +142 −12
 verl/workers/utils/losses.py                       |  +4 −3
```

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] `pre-commit run --all-files` passes.
- [ ] Add / Update documentation — not yet; the feature commit
      `b6e6562e` did not add user docs for `use_mask_nesting`; a
      follow-up doc PR will describe the switch and the new
      `strict_mask_nesting` flag once this lands.
- [ ] Add CI test — existing CPU tests in
      `tests/utils/test_nested_tensor_on_cpu.py` and
      `tests/utils/test_padding_on_cpu.py` continue to cover the
      library utilities. The end-to-end behaviour (training-step
      convergence with `use_mask_nesting=True`) requires a GPU-backed
      e2e test; I can extend
      `.github/workflows/e2e_ppo_trainer.yml` with a
      `use_mask_nesting=True` variant in a follow-up once reviewers
      are okay with the test-hour budget.
- [ ] `ci-request` Slack ping — will do after addressing review.
- [x] No `recipe` submodule change.

---

**AI-assisted**: written with Claude (Claude Opus 4.6 1M context, via
Claude Code). Every changed line was reviewed by the submitter and the
rationale was validated end-to-end on the running RL workload before
being committed. Commits carry
`Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
trailers.
