### PR TITLE
[megatron, ckpt] refactor: optimize mcore ckpt manager impl, checkpoint yaml config APIs

### DIFF
--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -3,7 +3,7 @@
 Using Checkpoints to Support Fault Tolerance Training
 =====================================================
 
-Last updated: 04/20/2026.
+Last updated: 04/23/2026.
 
 There could be training errors or machine failure during the whole RLHF training process, 
 so it is recommended to enable checkpoints to minimize your loss.
@@ -59,19 +59,81 @@ So the inner checkpoint structure of **FSDP** is like:
 
 All model shards, optimizers and extra states are stored together, in a sharded and distributed way.
 
-While **Megatron** current checkpoint structure is:
+While **Megatron** current checkpoint structure (layout schema v2) is:
 
 .. code::
 
     checkpoints/${trainer.project_name}/${trainer.experiment_name}
     ├── global_steps_${i}
     │   ├── actor
-    │   │   ├── huggingface     # HF config + tokenizer; also contains the HF model weights when mbridge is enabled and ``model`` (or ``hf_model``) is in save_contents
-    │   │   └── dist_ckpt       # optimizer + rng_state always; model shards only when mbridge is disabled
-    │   └── critic
-    │   │   ├── huggingface
-    │   │   └── dist_ckpt
+    │   │   ├── ckpt_contents.json       # manifest mapping each saved content (model, optimizer, …) to its on-disk path; see "Locating saved contents" below
+    │   │   ├── transformer_config.json  # serialised Megatron TransformerConfig (written when ``extra`` is in save_contents)
+    │   │   ├── model
+    │   │   │   ├── huggingface          # HF weights + config + tokenizer (written when mbridge is enabled and ``model`` / ``hf_model`` is in save_contents)
+    │   │   │   └── dist_ckpt            # Megatron model shards when mbridge is disabled, or PEFT adapter shards when mbridge is enabled
+    │   │   ├── optimizer
+    │   │   │   └── dist_ckpt            # optimizer + lr_scheduler shards (written when ``optimizer`` is in save_contents)
+    │   │   └── extra
+    │   │       └── dist_ckpt            # rng_state shards (written when ``extra`` is in save_contents)
+    │   └── critic                       # same layout as actor
     └── latest_checkpointed_iteration.txt
+
+.. note::
+
+    **Migrating pre-v2 checkpoints.** Older verl releases produced a flatter
+    layout with a single root-level ``dist_ckpt/`` directory (containing the
+    optimizer, rng, and optionally model shards) and a root-level
+    ``huggingface/`` directory.  The v2 loader rejects that layout at
+    ``load_checkpoint`` time with a clear error.  Convert an old checkpoint
+    in place with::
+
+        python scripts/migrate_megatron_checkpoint_layout.py \
+            --checkpoint /path/to/global_step_N/actor
+
+    or migrate every step under a run with
+    ``--checkpoint-root /path/to/run --all-steps``.  The migration defaults
+    to hardlinking the old ``dist_ckpt`` data into the new
+    ``model/optimizer/extra`` subdirectories, so it is fast and does not
+    duplicate disk usage.
+
+.. tip::
+
+    **Locating saved contents.** Every Megatron checkpoint directory contains a
+    ``ckpt_contents.json`` manifest at its root. To find where a specific piece of
+    the checkpoint lives (HF weights, optimizer shards, tokenizer, PEFT adapters,
+    …), open ``ckpt_contents.json`` and look up the logical name under the
+    ``contents`` map — each entry has a ``path`` field (relative to the checkpoint
+    directory) and a ``format`` field. The manifest is written last during the
+    save, so its presence also indicates a fully-complete checkpoint. A typical
+    manifest looks like:
+
+    .. code:: json
+
+        {
+          "schema_version": 2,
+          "framework": "megatron",
+          "role": "actor",
+          "arch": "Qwen3ForCausalLM",
+          "global_step": 100,
+          "world_size": 8,
+          "backend": {"use_mbridge": true, "use_dist_checkpointing": false, "peft": false},
+          "save_contents": ["model", "optimizer", "extra"],
+          "contents": {
+            "model":              {"path": "model/huggingface",    "format": "huggingface", "backend": "mbridge"},
+            "optimizer":          {"path": "optimizer/dist_ckpt",  "format": "megatron_dist_checkpoint"},
+            "lr_scheduler":       {"path": "optimizer/dist_ckpt",  "format": "megatron_dist_checkpoint", "key": "lr_scheduler"},
+            "rng_state":          {"path": "extra/dist_ckpt",      "format": "megatron_dist_checkpoint", "key": "rng_state"},
+            "transformer_config": {"path": "transformer_config.json", "format": "json"},
+            "hf_config":          {"path": "model/huggingface",    "format": "huggingface"},
+            "tokenizer":          {"path": "model/huggingface",    "format": "huggingface"}
+          },
+          "directories": {
+            "model/huggingface":   "HuggingFace-format artifacts written via mbridge: model weights, config.json, …",
+            "optimizer/dist_ckpt": "Megatron dist_checkpointing shards for the optimizer state …",
+            "extra/dist_ckpt":     "Megatron dist_checkpointing shards for extra state (rng_state)."
+          },
+          "saved_any_dist_ckpt": true
+        }
 
 Megatron Checkpoint Manager Backends
 ------------------------------------
@@ -80,17 +142,18 @@ The Megatron checkpoint manager supports two model-weight backends, controlled b
 ``actor_rollout_ref.actor.megatron.use_mbridge`` (and the symmetric ``critic`` / ``ref`` keys):
 
 - **mbridge (default, ``use_mbridge=True``)** -- model weights are saved/loaded in HuggingFace
-  format under ``global_step_${i}/${role}/huggingface/`` via `mbridge
+  format under ``global_step_${i}/${role}/model/huggingface/`` via `mbridge
   <https://github.com/ISEEKYAN/mbridge>`_ or `Megatron-Bridge
   <https://github.com/NVIDIA-NeMo/Megatron-Bridge>`_ (selected via ``vanilla_mbridge``).
   No conversion step is needed after training to obtain an HF model.
 
 - **dist_checkpoint (``use_mbridge=False``)** -- model weights are saved using Megatron's native
-  ``dist_checkpointing`` (sharded across ranks) under ``global_step_${i}/${role}/dist_ckpt/``,
-  alongside the optimizer and RNG states.
+  ``dist_checkpointing`` (sharded across ranks) under
+  ``global_step_${i}/${role}/model/dist_ckpt/``.
 
-Optimizer, LR-scheduler and RNG (``extra``) state always go through ``dist_checkpointing``
-regardless of which model backend is used; only the model weights pick a backend.
+Optimizer + LR-scheduler (``optimizer/dist_ckpt/``) and RNG state (``extra/dist_ckpt/``) always
+go through ``dist_checkpointing`` into their own sibling directories, regardless of which model
+backend is used; only the model weights pick a backend.
 
 The legacy alias ``actor_rollout_ref.actor.megatron.use_dist_checkpointing=True`` is still
 accepted by both the engine config and the checkpoint manager, and is translated to
@@ -111,39 +174,41 @@ and ``save_contents`` entry is resolved:
 
 In tabular form:
 
-+----------------------+----------------+----------------------------------------------------------------+
-| Backend              | save_contents  | Behaviour                                                      |
-+======================+================+================================================================+
-| ``mbridge`` (default)| ``model``      | Save HF model via mbridge into ``huggingface/``.               |
-+----------------------+----------------+----------------------------------------------------------------+
-| ``mbridge``          | ``hf_model``   | Save HF model via mbridge into ``huggingface/``.               |
-+----------------------+----------------+----------------------------------------------------------------+
-| ``mbridge``          | both           | Same HF model is saved **once** (deduplicated).                |
-+----------------------+----------------+----------------------------------------------------------------+
-| ``dist_checkpoint``  | ``model``      | Save sharded model into ``dist_ckpt/`` via Megatron's          |
-|                      |                | ``dist_checkpointing``.                                        |
-+----------------------+----------------+----------------------------------------------------------------+
-| ``dist_checkpoint``  | ``hf_model``   | **Error** -- ``hf_model`` is only supported by ``mbridge``.    |
-+----------------------+----------------+----------------------------------------------------------------+
-| both disabled        | any            | **Error** -- at least one backend must be enabled.             |
-+----------------------+----------------+----------------------------------------------------------------+
++----------------------+----------------+-----------------------------------------------------------------+
+| Backend              | save_contents  | Behaviour                                                       |
++======================+================+=================================================================+
+| ``mbridge`` (default)| ``model``      | Save HF model via mbridge into ``model/huggingface/``.          |
++----------------------+----------------+-----------------------------------------------------------------+
+| ``mbridge``          | ``hf_model``   | Save HF model via mbridge into ``model/huggingface/``.          |
++----------------------+----------------+-----------------------------------------------------------------+
+| ``mbridge``          | both           | Same HF model is saved **once** (deduplicated).                 |
++----------------------+----------------+-----------------------------------------------------------------+
+| ``dist_checkpoint``  | ``model``      | Save sharded model into ``model/dist_ckpt/`` via Megatron's     |
+|                      |                | ``dist_checkpointing``.                                         |
++----------------------+----------------+-----------------------------------------------------------------+
+| ``dist_checkpoint``  | ``hf_model``   | **Error** -- ``hf_model`` is only supported by ``mbridge``.     |
++----------------------+----------------+-----------------------------------------------------------------+
+| both disabled        | any            | **Error** -- at least one backend must be enabled.              |
++----------------------+----------------+-----------------------------------------------------------------+
 
 In all rows above, ``optimizer`` and ``extra`` (when listed in ``save_contents``) are saved through
-``dist_checkpointing`` into ``dist_ckpt/``. PEFT/LoRA adapter shards are also written into
-``dist_ckpt/`` even with the mbridge backend, because mbridge handles only base-model weights.
+``dist_checkpointing`` into their own directories -- ``optimizer/dist_ckpt/`` and
+``extra/dist_ckpt/``.  PEFT/LoRA adapter shards are written into ``model/dist_ckpt/`` even with
+the mbridge backend (because mbridge handles only base-model weights), sitting next to the
+mbridge-produced ``model/huggingface/`` tree.
 
 Recommended Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - **Default / production**: keep ``use_mbridge=True`` and use ``save_contents=['model',
-  'optimizer', 'extra']``. The ``huggingface/`` folder produced by mbridge can be loaded
+  'optimizer', 'extra']``. The ``model/huggingface/`` folder produced by mbridge can be loaded
   directly by HuggingFace Transformers without any further conversion step.
 - **HuggingFace-only export**: ``save_contents=['hf_model']`` (mbridge required). Useful when
   you only need a deployable HF checkpoint and not a resumable training state.
 - **Pure Megatron sharded model**: ``use_mbridge=False`` together with
-  ``save_contents=['model', 'optimizer', 'extra']``. The model goes into ``dist_ckpt/`` and you
-  can later run ``python -m verl.model_merger merge --backend megatron ...`` (see below) to
-  produce an HF checkpoint.
+  ``save_contents=['model', 'optimizer', 'extra']``. The model goes into ``model/dist_ckpt/``
+  and you can later run ``python -m verl.model_merger merge --backend megatron ...`` (see
+  below) to produce an HF checkpoint.
 
 Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------

--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -3,7 +3,7 @@
 Using Checkpoints to Support Fault Tolerance Training
 =====================================================
 
-Last updated: 03/22/2026.
+Last updated: 04/20/2026.
 
 There could be training errors or machine failure during the whole RLHF training process, 
 so it is recommended to enable checkpoints to minimize your loss.
@@ -12,10 +12,24 @@ The API Interface has already been listed in :ref:`config-explain-page`,
 and we will not repeat them. But there are still some technique details
 we hope to clarify.
 
+The ``checkpoint.save_contents`` / ``checkpoint.load_contents`` field accepts any combination of
+``model``, ``optimizer``, ``extra`` and ``hf_model``. The semantics are aligned between FSDP and
+Megatron:
+
+- ``model`` -- the framework-native model state. For **FSDP** this is the per-rank sharded state;
+  for **Megatron** this is either the HuggingFace state (when mbridge is enabled) or the
+  Megatron ``dist_checkpointing`` shards (when mbridge is disabled).
+- ``optimizer`` -- the optimizer state (sharded for both FSDP and Megatron).
+- ``extra`` -- LR scheduler state, RNG states, and (for Megatron) the serialised
+  ``TransformerConfig``.
+- ``hf_model`` -- the full model in HuggingFace format. **Megatron requires mbridge to be
+  enabled when ``hf_model`` is in ``save_contents``** -- with mbridge, ``model`` and ``hf_model``
+  produce the same HF checkpoint and are deduplicated (saved only once).
+
 .. note:: 
 
-    Notice that the ``checkpoint.contents`` field has no effect to FSDP checkpoint except ``hf_model``, 
-    the other 3 fields are binded together to save and load. We recommend to include ``model``, ``optimizer`` and ``extra`` all.
+    For FSDP, ``checkpoint.save_contents`` other than ``hf_model`` are binded together to save and
+    load. We recommend to include ``model``, ``optimizer`` and ``extra`` all.
 
 Checkpoint Saving Directory Structure
 -------------------------------------
@@ -52,12 +66,84 @@ While **Megatron** current checkpoint structure is:
     checkpoints/${trainer.project_name}/${trainer.experiment_name}
     ├── global_steps_${i}
     │   ├── actor
-    │   │   ├── huggingface     # default save config and tokenizer, save huggingface model if include ``hf_mode`` in checkpoint.contents
-    │   │   └── dist_ckpt       # save sharded model/optimizer/rng_states, naming the same as Megatron
+    │   │   ├── huggingface     # HF config + tokenizer; also contains the HF model weights when mbridge is enabled and ``model`` (or ``hf_model``) is in save_contents
+    │   │   └── dist_ckpt       # optimizer + rng_state always; model shards only when mbridge is disabled
     │   └── critic
     │   │   ├── huggingface
     │   │   └── dist_ckpt
     └── latest_checkpointed_iteration.txt
+
+Megatron Checkpoint Manager Backends
+------------------------------------
+
+The Megatron checkpoint manager supports two model-weight backends, controlled by
+``actor_rollout_ref.actor.megatron.use_mbridge`` (and the symmetric ``critic`` / ``ref`` keys):
+
+- **mbridge (default, ``use_mbridge=True``)** -- model weights are saved/loaded in HuggingFace
+  format under ``global_step_${i}/${role}/huggingface/`` via `mbridge
+  <https://github.com/ISEEKYAN/mbridge>`_ or `Megatron-Bridge
+  <https://github.com/NVIDIA-NeMo/Megatron-Bridge>`_ (selected via ``vanilla_mbridge``).
+  No conversion step is needed after training to obtain an HF model.
+
+- **dist_checkpoint (``use_mbridge=False``)** -- model weights are saved using Megatron's native
+  ``dist_checkpointing`` (sharded across ranks) under ``global_step_${i}/${role}/dist_ckpt/``,
+  alongside the optimizer and RNG states.
+
+Optimizer, LR-scheduler and RNG (``extra``) state always go through ``dist_checkpointing``
+regardless of which model backend is used; only the model weights pick a backend.
+
+The legacy alias ``actor_rollout_ref.actor.megatron.use_dist_checkpointing=True`` is still
+accepted by both the engine config and the checkpoint manager, and is translated to
+``use_mbridge=False`` internally. New configurations should prefer ``use_mbridge``.
+
+.. note::
+
+    The combination ``use_mbridge=False`` together with ``use_dist_checkpointing=False``
+    is **not supported** -- at least one model-weight backend must be enabled.
+
+The diagram below (from `RFC #5630
+<https://github.com/verl-project/verl/issues/5630>`_) summarises how each combination of backend
+and ``save_contents`` entry is resolved:
+
+.. image:: https://github.com/user-attachments/assets/6036822e-9d8a-4c1f-bbcc-a15dcb584c1b
+   :alt: Megatron checkpoint manager backend × save_contents behaviour
+   :align: center
+
+In tabular form:
+
++----------------------+----------------+----------------------------------------------------------------+
+| Backend              | save_contents  | Behaviour                                                      |
++======================+================+================================================================+
+| ``mbridge`` (default)| ``model``      | Save HF model via mbridge into ``huggingface/``.               |
++----------------------+----------------+----------------------------------------------------------------+
+| ``mbridge``          | ``hf_model``   | Save HF model via mbridge into ``huggingface/``.               |
++----------------------+----------------+----------------------------------------------------------------+
+| ``mbridge``          | both           | Same HF model is saved **once** (deduplicated).                |
++----------------------+----------------+----------------------------------------------------------------+
+| ``dist_checkpoint``  | ``model``      | Save sharded model into ``dist_ckpt/`` via Megatron's          |
+|                      |                | ``dist_checkpointing``.                                        |
++----------------------+----------------+----------------------------------------------------------------+
+| ``dist_checkpoint``  | ``hf_model``   | **Error** -- ``hf_model`` is only supported by ``mbridge``.    |
++----------------------+----------------+----------------------------------------------------------------+
+| both disabled        | any            | **Error** -- at least one backend must be enabled.             |
++----------------------+----------------+----------------------------------------------------------------+
+
+In all rows above, ``optimizer`` and ``extra`` (when listed in ``save_contents``) are saved through
+``dist_checkpointing`` into ``dist_ckpt/``. PEFT/LoRA adapter shards are also written into
+``dist_ckpt/`` even with the mbridge backend, because mbridge handles only base-model weights.
+
+Recommended Configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Default / production**: keep ``use_mbridge=True`` and use ``save_contents=['model',
+  'optimizer', 'extra']``. The ``huggingface/`` folder produced by mbridge can be loaded
+  directly by HuggingFace Transformers without any further conversion step.
+- **HuggingFace-only export**: ``save_contents=['hf_model']`` (mbridge required). Useful when
+  you only need a deployable HF checkpoint and not a resumable training state.
+- **Pure Megatron sharded model**: ``use_mbridge=False`` together with
+  ``save_contents=['model', 'optimizer', 'extra']``. The model goes into ``dist_ckpt/`` and you
+  can later run ``python -m verl.model_merger merge --backend megatron ...`` (see below) to
+  produce an HF checkpoint.
 
 Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------
@@ -167,22 +253,3 @@ No need to convert the model to Megatron dist-checkpoint format.
 
     This may increase CPU memory usage and lead to OOM issues for large models.
     We recommend using the default dp-reshardable format in most cases.
-
-
-Original Checkpoint Utils
--------------------------
-
-Original Checkpoint Utils refer to original checkpoint implementation in ``verl/models/[model]/megatron/checkpoint_utils``.
-
-We only need ``[model]_loader.py`` in original checkpoint utils now, since we get rid of storing ``hf_model`` every time (which is not recommended for large model training, try only saving sharded models if you can).
-
-.. note:: 
-
-    Note that ``[model]_loader`` only support environments where **storage clusters are able to connect with every calculation nodes**. 
-    Because it utilizes **sharded load way to minimize the loading checkpoint overhead**. 
-    Every rank loads its own data from ``state_dict`` which can be accessed by all of them.
-    While there is also no need to broadcast among DP ranks, since the saved state_dict is only produced by DP rank 0.
-
-    For users who can **only place the huggingface model on one device**, we keep the original costly implementation in ``[model]_loader_deprecated``. In this implementation, rank 0 broadcast all weights to each tp and pp rank, and then dp rank 0 broadcast to all dp ranks. There may be at risks of OOM.
-
-    To use deprecated loader, change the import package of ``load_state_dict_to_megatron_llama``.

--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -17,14 +17,21 @@ The ``checkpoint.save_contents`` / ``checkpoint.load_contents`` field accepts an
 Megatron:
 
 - ``model`` -- the framework-native model state. For **FSDP** this is the per-rank sharded state;
-  for **Megatron** this is either the HuggingFace state (when mbridge is enabled) or the
-  Megatron ``dist_checkpointing`` shards (when mbridge is disabled).
+  for **Megatron** this follows whether the engine provides a mbridge ``bridge`` and
+  ``use_dist_checkpointing``: HF weights under ``model/huggingface/`` when the HF path is active,
+  Megatron shards under ``model/dist_ckpt/`` when ``use_dist_checkpointing=True``, or **both**
+  when a ``bridge`` is present and dist shards are also enabled for the ``model`` slot.
 - ``optimizer`` -- the optimizer state (sharded for both FSDP and Megatron).
 - ``extra`` -- LR scheduler state, RNG states, and (for Megatron) the serialised
   ``TransformerConfig``.
-- ``hf_model`` -- the full model in HuggingFace format. **Megatron requires mbridge to be
-  enabled when ``hf_model`` is in ``save_contents``** -- with mbridge, ``model`` and ``hf_model``
-  produce the same HF checkpoint and are deduplicated (saved only once).
+- ``hf_model`` -- the full model in HuggingFace format. **Megatron requires a non-``None`` mbridge
+  ``bridge``** (the checkpoint manager checks ``bridge``, not a separate flag) whenever ``hf_model``
+  appears in ``save_contents`` or ``load_contents``. In practice the engine supplies the bridge when
+  mbridge is enabled (``use_mbridge=True`` in YAML). If the checkpoint also uses
+  ``use_dist_checkpointing=True`` for the ``model`` slot, HF export (``model/huggingface/``) is
+  written **in addition to** Megatron shards under ``model/dist_ckpt/``. When only the HF ``model``
+  path is used (no dist shards for weights), ``model`` and ``hf_model`` refer to the same HF tree
+  and are deduplicated (saved once).
 
 .. note:: 
 
@@ -69,8 +76,8 @@ While **Megatron** current checkpoint structure (layout schema v2) is:
     │   │   ├── ckpt_contents.json       # manifest mapping each saved content (model, optimizer, …) to its on-disk path; see "Locating saved contents" below
     │   │   ├── transformer_config.json  # serialised Megatron TransformerConfig (written when ``extra`` is in save_contents)
     │   │   ├── model
-    │   │   │   ├── huggingface          # HF weights + config + tokenizer (written when mbridge is enabled and ``model`` / ``hf_model`` is in save_contents)
-    │   │   │   └── dist_ckpt            # Megatron model shards when mbridge is disabled, or PEFT adapter shards when mbridge is enabled
+    │   │   │   ├── huggingface          # HF weights + config + tokenizer (mbridge ``bridge`` + ``model`` / ``hf_model`` in save_contents)
+    │   │   │   └── dist_ckpt            # Megatron model shards when ``use_dist_checkpointing``; PEFT adapter shards may live here with mbridge
     │   │   ├── optimizer
     │   │   │   └── dist_ckpt            # optimizer + lr_scheduler shards (written when ``optimizer`` is in save_contents)
     │   │   └── extra
@@ -116,7 +123,7 @@ While **Megatron** current checkpoint structure (layout schema v2) is:
           "arch": "Qwen3ForCausalLM",
           "global_step": 100,
           "world_size": 8,
-          "backend": {"use_mbridge": true, "use_dist_checkpointing": false, "peft": false},
+          "backend": {"has_bridge": true, "use_dist_checkpointing": false, "peft": false},
           "save_contents": ["model", "optimizer", "extra"],
           "contents": {
             "model":              {"path": "model/huggingface",    "format": "huggingface", "backend": "mbridge"},
@@ -138,31 +145,30 @@ While **Megatron** current checkpoint structure (layout schema v2) is:
 Megatron Checkpoint Manager Backends
 ------------------------------------
 
-The Megatron checkpoint manager supports two model-weight backends, controlled by
-``actor_rollout_ref.actor.megatron.use_mbridge`` (and the symmetric ``critic`` / ``ref`` keys):
+Megatron model weights are controlled by two booleans on
+``actor_rollout_ref.actor.megatron`` (and the symmetric ``critic`` / ``ref`` keys):
 
-- **mbridge (default, ``use_mbridge=True``)** -- model weights are saved/loaded in HuggingFace
-  format under ``global_step_${i}/${role}/model/huggingface/`` via `mbridge
-  <https://github.com/ISEEKYAN/mbridge>`_ or `Megatron-Bridge
-  <https://github.com/NVIDIA-NeMo/Megatron-Bridge>`_ (selected via ``vanilla_mbridge``).
-  No conversion step is needed after training to obtain an HF model.
+- **``use_mbridge`` (default ``True``)** -- when enabled, the Megatron engine builds the mbridge /
+  Megatron-Bridge instance passed into ``MegatronCheckpointManager`` as ``bridge``, which is
+  **required** for HuggingFace-format model weights under
+  ``global_step_${i}/${role}/model/huggingface/``. The manager itself only checks ``bridge is not
+  None`` for ``hf_model`` (and other HF model paths).
 
-- **dist_checkpoint (``use_mbridge=False``)** -- model weights are saved using Megatron's native
-  ``dist_checkpointing`` (sharded across ranks) under
-  ``global_step_${i}/${role}/model/dist_ckpt/``.
+- **``use_dist_checkpointing``** -- when ``True``, Megatron ``dist_checkpointing`` shards for the
+  ``model`` slot are written/read under ``global_step_${i}/${role}/model/dist_ckpt/``.
+
+The two flags are **independent**: both may be ``True`` to persist resume-friendly shards **and**
+an HF tree in the same step. Setting ``use_mbridge=False`` disables HF export/load via mbridge;
+``use_dist_checkpointing=False`` disables Megatron model shards for the ``model`` slot (unless
+PEFT still needs adapter shards under ``model/dist_ckpt/``).
 
 Optimizer + LR-scheduler (``optimizer/dist_ckpt/``) and RNG state (``extra/dist_ckpt/``) always
-go through ``dist_checkpointing`` into their own sibling directories, regardless of which model
-backend is used; only the model weights pick a backend.
-
-The legacy alias ``actor_rollout_ref.actor.megatron.use_dist_checkpointing=True`` is still
-accepted by both the engine config and the checkpoint manager, and is translated to
-``use_mbridge=False`` internally. New configurations should prefer ``use_mbridge``.
+go through ``dist_checkpointing`` into their own sibling directories.
 
 .. note::
 
-    The combination ``use_mbridge=False`` together with ``use_dist_checkpointing=False``
-    is **not supported** -- at least one model-weight backend must be enabled.
+    Prefer tuning ``use_mbridge`` and ``use_dist_checkpointing`` explicitly. Avoid relying on
+    informal equivalences between the two; hybrid checkpoints need both enabled.
 
 The diagram below (from `RFC #5630
 <https://github.com/verl-project/verl/issues/5630>`_) summarises how each combination of backend
@@ -174,22 +180,25 @@ and ``save_contents`` entry is resolved:
 
 In tabular form:
 
-+----------------------+----------------+-----------------------------------------------------------------+
-| Backend              | save_contents  | Behaviour                                                       |
-+======================+================+=================================================================+
-| ``mbridge`` (default)| ``model``      | Save HF model via mbridge into ``model/huggingface/``.          |
-+----------------------+----------------+-----------------------------------------------------------------+
-| ``mbridge``          | ``hf_model``   | Save HF model via mbridge into ``model/huggingface/``.          |
-+----------------------+----------------+-----------------------------------------------------------------+
-| ``mbridge``          | both           | Same HF model is saved **once** (deduplicated).                 |
-+----------------------+----------------+-----------------------------------------------------------------+
-| ``dist_checkpoint``  | ``model``      | Save sharded model into ``model/dist_ckpt/`` via Megatron's     |
-|                      |                | ``dist_checkpointing``.                                         |
-+----------------------+----------------+-----------------------------------------------------------------+
-| ``dist_checkpoint``  | ``hf_model``   | **Error** -- ``hf_model`` is only supported by ``mbridge``.     |
-+----------------------+----------------+-----------------------------------------------------------------+
-| both disabled        | any            | **Error** -- at least one backend must be enabled.              |
-+----------------------+----------------+-----------------------------------------------------------------+
++-----------------------------+----------------+----------------------------------------------------------+
+| Flags (mbridge / dist_ckpt) | save_contents  | Behaviour                                                |
++=============================+================+==========================================================+
+| mbridge only                | ``model``      | HF weights under ``model/huggingface/``.                 |
++-----------------------------+----------------+----------------------------------------------------------+
+| mbridge only                | ``hf_model``   | Same (HF tree); ``model`` / ``hf_model`` deduplicated.   |
++-----------------------------+----------------+----------------------------------------------------------+
+| mbridge only                | both           | Same HF checkpoint saved **once** (deduplicated).       |
++-----------------------------+----------------+----------------------------------------------------------+
+| dist_ckpt only              | ``model``      | Sharded weights under ``model/dist_ckpt/``.              |
++-----------------------------+----------------+----------------------------------------------------------+
+| dist_ckpt only              | ``hf_model``   | **Error** -- ``hf_model`` needs a ``bridge`` (enable mbridge in engine). |
++-----------------------------+----------------+----------------------------------------------------------+
+| mbridge + dist_ckpt         | ``model``      | Sharded weights under ``model/dist_ckpt/`` only (no HF  |
+|                             |                | weight export unless ``hf_model`` is also listed).     |
++-----------------------------+----------------+----------------------------------------------------------+
+| mbridge + dist_ckpt         | ``model`` +    | Megatron shards **and** HF export (two on-disk trees).   |
+|                             | ``hf_model``   |                                                          |
++-----------------------------+----------------+----------------------------------------------------------+
 
 In all rows above, ``optimizer`` and ``extra`` (when listed in ``save_contents``) are saved through
 ``dist_checkpointing`` into their own directories -- ``optimizer/dist_ckpt/`` and
@@ -205,10 +214,14 @@ Recommended Configurations
   directly by HuggingFace Transformers without any further conversion step.
 - **HuggingFace-only export**: ``save_contents=['hf_model']`` (mbridge required). Useful when
   you only need a deployable HF checkpoint and not a resumable training state.
-- **Pure Megatron sharded model**: ``use_mbridge=False`` together with
-  ``save_contents=['model', 'optimizer', 'extra']``. The model goes into ``model/dist_ckpt/``
-  and you can later run ``python -m verl.model_merger merge --backend megatron ...`` (see
-  below) to produce an HF checkpoint.
+- **Pure Megatron sharded model**: ``use_mbridge=False`` and ``use_dist_checkpointing=True``
+  with ``save_contents=['model', 'optimizer', 'extra']``. The model goes into ``model/dist_ckpt/``.
+  You can later run ``python -m verl.model_merger merge --backend megatron ...`` (see below) to
+  produce an HF checkpoint.
+
+- **Hybrid (resume + HF export)**: ``use_mbridge=True``, ``use_dist_checkpointing=True``, and
+  e.g. ``save_contents=['model', 'hf_model', 'optimizer', 'extra']`` to write both
+  ``model/dist_ckpt/`` and ``model/huggingface/`` in one step.
 
 Convert FSDP and Megatron Checkpoints to HuggingFace Format Model
 -----------------------------------------------------------------

--- a/docs/advance/checkpoint.rst
+++ b/docs/advance/checkpoint.rst
@@ -187,14 +187,15 @@ In tabular form:
 +-----------------------------+----------------+----------------------------------------------------------+
 | mbridge only                | ``hf_model``   | Same (HF tree); ``model`` / ``hf_model`` deduplicated.   |
 +-----------------------------+----------------+----------------------------------------------------------+
-| mbridge only                | both           | Same HF checkpoint saved **once** (deduplicated).       |
+| mbridge only                | both           | Same HF checkpoint saved **once** (deduplicated).        |
 +-----------------------------+----------------+----------------------------------------------------------+
 | dist_ckpt only              | ``model``      | Sharded weights under ``model/dist_ckpt/``.              |
 +-----------------------------+----------------+----------------------------------------------------------+
-| dist_ckpt only              | ``hf_model``   | **Error** -- ``hf_model`` needs a ``bridge`` (enable mbridge in engine). |
+| dist_ckpt only              | ``hf_model``   | **Error** -- ``hf_model`` needs a ``bridge``             |
+|                             |                | (enable mbridge in engine).                              |
 +-----------------------------+----------------+----------------------------------------------------------+
-| mbridge + dist_ckpt         | ``model``      | Sharded weights under ``model/dist_ckpt/`` only (no HF  |
-|                             |                | weight export unless ``hf_model`` is also listed).     |
+| mbridge + dist_ckpt         | ``model``      | Sharded weights under ``model/dist_ckpt/`` only (no HF   |
+|                             |                | weight export unless ``hf_model`` is also listed).       |
 +-----------------------------+----------------+----------------------------------------------------------+
 | mbridge + dist_ckpt         | ``model`` +    | Megatron shards **and** HF export (two on-disk trees).   |
 |                             | ``hf_model``   |                                                          |

--- a/docs/ascend_tutorial/feature_support/ascend_backend_features.md
+++ b/docs/ascend_tutorial/feature_support/ascend_backend_features.md
@@ -248,7 +248,7 @@ class MindSpeedFeature:
 | verl参数 | 简介|
 | --- | --- |
 | `actor_rollout_ref.actor.megatron.optimizer_offload` |是否卸载模型优化器到CPU，默认值为False|
-| `actor_rollout_ref.actor.megatron.use_mbridge` |是否使用mbridge进行权重转换；为 True（默认）时模型权重以HuggingFace 格式通过 mbridge 保存/加载，且 `save_contents` 中的 `model` 与 `hf_model` 会去重只保存一次；为 False 时使用 Megatron `dist_checkpointing` 保存模型分片，此时 `save_contents` 不允许包含 `hf_model`|
+| `actor_rollout_ref.actor.megatron.use_mbridge` |是否启用 mbridge：为 True（默认）时 engine 会构造 `bridge` 并交给 checkpoint manager，从而可读写 `model/huggingface/`；`save_contents` / `load_contents` 含 `hf_model` 时 manager 要求 `bridge` 非空（通常即此项为 True）。可与 `use_dist_checkpointing` 同时开启，在同一 checkpoint 中同时写入 HF 树与 `model/dist_ckpt/` 分片。为 False 时一般无 `hf_model`；仅 `model` 槽位走 `dist_checkpointing` 时需配合 `use_dist_checkpointing=True`|
 | `actor_rollout_ref.actor.megatron.param_offload` |是否卸载模型权重到CPU，默认值为False|
 | `actor_rollout_ref.actor.megatron.tensor_model_parallel_size` | 张量并行大小；默认值为1。|
 | `actor_rollout_ref.actor.megatron.pipeline_model_parallel_size`  |流水并行大小，默认值为1|
@@ -264,7 +264,7 @@ class MindSpeedFeature:
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity` |重新计算激活的粒度，可选项为'full', 'selective' and 'none'。其中full代表重新计算整个transformer layer，selective代表只计算transformer layer中的核心注意力部分。默认为'none'。|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method` |该参数需将recompute_granularity设置为'full'才生效，可选项为'uniform', 'block'。默认为None。|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers` |该参数需将recompute_granularity设置为'full'才生效，默认为None。若recompute_method设置为uniform，该参数含义为每个均匀划分的重新计算单元的transformer layers数量。例如你可以指定为--recompute_granularity full --recompute_method uniform --recompute_num_layers 4。recompute_num_layers越大，显存占用越小，计算成本越大。注意：当前进程中的模型层数需能被recompute_num_layers整除。默认为None。|
-| `actor_rollout_ref.actor.megatron.use_dist_checkpointing` |`use_mbridge` 的旧版别名，等价于 `use_mbridge=not use_dist_checkpointing`，默认值为 False。新配置请直接使用 `use_mbridge`|
+| `actor_rollout_ref.actor.megatron.use_dist_checkpointing` |为 True 时，`model` 槽位使用 Megatron `dist_checkpointing` 分片（`model/dist_ckpt/`）。与 `use_mbridge` 独立：两者可同时为 True 以保存/加载分片 + HF 导出。默认 False|
 | `actor_rollout_ref.actor.megatron.dist_checkpointing_path` |分布式权重路径，默认值为null|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn` |是否使用Flash Attention，默认值为true|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.use_fused_rotary_pos_emb` |是否使用融合旋转位置编码，默认值为False|

--- a/docs/ascend_tutorial/feature_support/ascend_backend_features.md
+++ b/docs/ascend_tutorial/feature_support/ascend_backend_features.md
@@ -248,7 +248,7 @@ class MindSpeedFeature:
 | verl参数 | 简介|
 | --- | --- |
 | `actor_rollout_ref.actor.megatron.optimizer_offload` |是否卸载模型优化器到CPU，默认值为False|
-| `actor_rollout_ref.actor.megatron.use_mbridge` |是否使用mbridge进行权重转换|
+| `actor_rollout_ref.actor.megatron.use_mbridge` |是否使用mbridge进行权重转换；为 True（默认）时模型权重以HuggingFace 格式通过 mbridge 保存/加载，且 `save_contents` 中的 `model` 与 `hf_model` 会去重只保存一次；为 False 时使用 Megatron `dist_checkpointing` 保存模型分片，此时 `save_contents` 不允许包含 `hf_model`|
 | `actor_rollout_ref.actor.megatron.param_offload` |是否卸载模型权重到CPU，默认值为False|
 | `actor_rollout_ref.actor.megatron.tensor_model_parallel_size` | 张量并行大小；默认值为1。|
 | `actor_rollout_ref.actor.megatron.pipeline_model_parallel_size`  |流水并行大小，默认值为1|
@@ -264,7 +264,7 @@ class MindSpeedFeature:
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity` |重新计算激活的粒度，可选项为'full', 'selective' and 'none'。其中full代表重新计算整个transformer layer，selective代表只计算transformer layer中的核心注意力部分。默认为'none'。|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method` |该参数需将recompute_granularity设置为'full'才生效，可选项为'uniform', 'block'。默认为None。|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers` |该参数需将recompute_granularity设置为'full'才生效，默认为None。若recompute_method设置为uniform，该参数含义为每个均匀划分的重新计算单元的transformer layers数量。例如你可以指定为--recompute_granularity full --recompute_method uniform --recompute_num_layers 4。recompute_num_layers越大，显存占用越小，计算成本越大。注意：当前进程中的模型层数需能被recompute_num_layers整除。默认为None。|
-| `actor_rollout_ref.actor.megatron.use_dist_checkpointing` |是否使用分布式权重，默认值为False|
+| `actor_rollout_ref.actor.megatron.use_dist_checkpointing` |`use_mbridge` 的旧版别名，等价于 `use_mbridge=not use_dist_checkpointing`，默认值为 False。新配置请直接使用 `use_mbridge`|
 | `actor_rollout_ref.actor.megatron.dist_checkpointing_path` |分布式权重路径，默认值为null|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn` |是否使用Flash Attention，默认值为true|
 | `actor_rollout_ref.actor.megatron.override_transformer_config.use_fused_rotary_pos_emb` |是否使用融合旋转位置编码，默认值为False|

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -336,10 +336,10 @@ Actor/Rollout/Reference Policy
     (``actor.megatron.use_mbridge``):
 
     - With ``use_mbridge=True`` (default): both ``model`` and ``hf_model`` save the full model
-      in HuggingFace format under ``${ckpt_path}/huggingface/`` via mbridge; if both are
+      in HuggingFace format under ``${ckpt_path}/model/huggingface/`` via mbridge; if both are
       listed, the model is saved once (deduplicated).
     - With ``use_mbridge=False``: ``model`` saves Megatron sharded weights via
-      ``dist_checkpointing`` under ``${ckpt_path}/dist_ckpt/``; ``hf_model`` is **not**
+      ``dist_checkpointing`` under ``${ckpt_path}/model/dist_ckpt/``; ``hf_model`` is **not**
       supported in this mode -- use ``python -m verl.model_merger merge --backend megatron``
       to convert sharded checkpoints to HF format after training.
 

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -158,7 +158,11 @@ Actor/Rollout/Reference Policy
         fsdp_size: -1
       checkpoint:
         # What to include in saved checkpoints
-        # with 'hf_model' you can save whole model as hf format, now only use sharded model checkpoint to save space
+        # 'hf_model' saves the full model in HuggingFace format. For Megatron this requires
+        # actor.megatron.use_mbridge=True (the default); 'model' and 'hf_model' then produce
+        # the same HF checkpoint and are deduplicated (saved once). With mbridge disabled,
+        # only the sharded 'model' is supported -- use verl.model_merger after training to
+        # convert it to HF format.
         save_contents: ['model', 'optimizer', 'extra']
         # For more flexibility, you can specify the contents to load from the checkpoint.
         load_contents: ${actor_rollout_ref.actor.checkpoint.save_contents}
@@ -324,9 +328,23 @@ Actor/Rollout/Reference Policy
 
 - ``actor_rollout_ref.actor.checkpoint``: The configurations of checkpoint function in actor
 
-  - ``save_contents``: The contents to save in the checkpoint. By default, we save model, optimizer and extra information in the checkpoint.
-    The extra information includes Rng states currently, FSDP supported lr_scheduler, and Megatron opt_param_scheduler will coming soon.
-    We do not store hf_model in checkpoint by default, but we provide a tool in ``scripts/model_merge.py`` to convert checkpoint format to hf format.
+  - ``save_contents``: The contents to save in the checkpoint. Accepts any subset of
+    ``model``, ``optimizer``, ``extra`` and ``hf_model``. Default is
+    ``['model', 'optimizer', 'extra']``. The extra information includes RNG states (and the
+    LR scheduler for FSDP, the ``opt_param_scheduler`` for Megatron).
+    For Megatron, the meaning of ``model`` depends on the active backend
+    (``actor.megatron.use_mbridge``):
+
+    - With ``use_mbridge=True`` (default): both ``model`` and ``hf_model`` save the full model
+      in HuggingFace format under ``${ckpt_path}/huggingface/`` via mbridge; if both are
+      listed, the model is saved once (deduplicated).
+    - With ``use_mbridge=False``: ``model`` saves Megatron sharded weights via
+      ``dist_checkpointing`` under ``${ckpt_path}/dist_ckpt/``; ``hf_model`` is **not**
+      supported in this mode -- use ``python -m verl.model_merger merge --backend megatron``
+      to convert sharded checkpoints to HF format after training.
+
+    For FSDP, ``hf_model`` saves the full HF model on rank 0 in addition to the sharded
+    ``model`` shards.
 
   - ``load_contents``: The contents to load in the checkpoint, you can specify different checkpoint loading contents. By default, it is the same with ``save_checkpoint``.
 

--- a/docs/perf/best_practices.rst
+++ b/docs/perf/best_practices.rst
@@ -109,8 +109,16 @@ Parameter Reference
   - ``actor_rollout_ref.model.path``:
     Path to the actor checkpoint in HuggingFace-compatible format.
   - ``actor_rollout_ref.actor.megatron.use_mbridge``:
-    Enable mbridge format conversion when the model was trained with Megatron. Use the latest mbridge release: https://github.com/ISEEKYAN/mbridge.
-    Now it must be True.
+    Selects the model-weight backend for the Megatron checkpoint manager. With ``True``
+    (default), model weights are saved/loaded in HuggingFace format via `mbridge
+    <https://github.com/ISEEKYAN/mbridge>`_ and ``hf_model`` in ``save_contents`` is
+    deduplicated against ``model``. With ``False``, model weights go through Megatron's
+    native ``dist_checkpointing`` and ``hf_model`` in ``save_contents`` is rejected
+    (use ``verl.model_merger`` after training instead). Optimizer / LR-scheduler / RNG
+    states always go through ``dist_checkpointing`` regardless of this flag.
+    The legacy alias ``actor_rollout_ref.actor.megatron.use_dist_checkpointing=True``
+    still works and is equivalent to ``use_mbridge=False``.
+    See :ref:`checkpoint-page` for the full save/load behaviour matrix.
   - ``actor_rollout_ref.actor.megatron.vanilla_mbridge``:
     If set to True, use mbridge, else use Megatron-Bridge https://github.com/NVIDIA-NeMo/Megatron-Bridge.
     Now it is True by default. and it will defaultly be set to False in the future(v0.8).

--- a/scripts/legacy_model_merger.py
+++ b/scripts/legacy_model_merger.py
@@ -103,10 +103,15 @@ class BaseModelMerger(ABC):
             )
             self.hf_model_config_path = config.hf_model_path
 
-        # Auto-detect huggingface subdirectory if it exists
-        huggingface_subdir = os.path.join(self.hf_model_config_path, "huggingface")
-        if os.path.isdir(huggingface_subdir):
-            self.hf_model_config_path = huggingface_subdir
+        # Auto-detect the huggingface subdirectory.  v2 Megatron layout
+        # nests it under model/huggingface; v1 (FSDP or pre-refactor
+        # Megatron) places it directly under the checkpoint root.
+        v2_subdir = os.path.join(self.hf_model_config_path, "model", "huggingface")
+        v1_subdir = os.path.join(self.hf_model_config_path, "huggingface")
+        if os.path.isdir(v2_subdir):
+            self.hf_model_config_path = v2_subdir
+        elif os.path.isdir(v1_subdir):
+            self.hf_model_config_path = v1_subdir
 
         self.model_config = AutoConfig.from_pretrained(self.hf_model_config_path)
 

--- a/scripts/megatron_merge_lora.py
+++ b/scripts/megatron_merge_lora.py
@@ -33,7 +33,6 @@ from omegaconf import OmegaConf
 
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup
-from verl.utils.megatron_utils import get_hf_model_checkpoint_path
 from verl.workers.engine_workers import ActorRolloutRefWorker
 
 os.environ["NCCL_DEBUG"] = "WARN"
@@ -117,8 +116,13 @@ def main_task(config):
     )
     worker.init_model()
 
+    # ``adapter_path`` points at the model/dist_ckpt/ tree that holds the
+    # PEFT adapter shards.  The merged HF weights are written as the sibling
+    # huggingface/ subtree inside the same model/ directory.
     adapter_path = config.actor_rollout_ref.model.lora.adapter_path
-    hf_ckpt_path = get_hf_model_checkpoint_path(os.path.dirname(adapter_path))
+    model_dir = os.path.dirname(os.path.normpath(adapter_path))
+    hf_ckpt_path = os.path.join(model_dir, "huggingface")
+    os.makedirs(hf_ckpt_path, exist_ok=True)
     worker.save_merged_weights(hf_ckpt_path)
 
 

--- a/scripts/migrate_megatron_checkpoint_layout.py
+++ b/scripts/migrate_megatron_checkpoint_layout.py
@@ -1,0 +1,248 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Migrate a pre-v2 Megatron checkpoint to the v2 split layout.
+
+Old layout (schema v1, produced by verl <= the previous release)::
+
+    <checkpoint>/
+    ├── dist_ckpt/                  # optimizer + rng + (maybe) model shards
+    ├── huggingface/                # mbridge HF tree (optional)
+    ├── transformer_config.json     # optional
+    └── ckpt_contents.json          # optional
+
+New layout (schema v2, produced by current verl)::
+
+    <checkpoint>/
+    ├── model/
+    │   ├── dist_ckpt/              # model shards (mbridge off / PEFT)
+    │   └── huggingface/            # mbridge HF tree
+    ├── optimizer/dist_ckpt/        # optimizer + lr_scheduler
+    ├── extra/dist_ckpt/            # rng_state
+    ├── transformer_config.json
+    └── ckpt_contents.json
+
+Why the migration is cheap
+--------------------------
+
+The old ``dist_ckpt/`` tree is a single torch_dist archive that may hold
+optimizer, rng, and (optionally) model/peft shards mixed together.
+Megatron's ``dist_checkpointing.load`` is key-driven: it only reads
+entries whose key matches the sharded state dict handed to it, and
+ignores unexpected keys by default.  That means we can satisfy the new
+loader's per-subtree expectations simply by *pointing* all three new
+``dist_ckpt/`` targets at the same physical data.
+
+The script therefore defaults to using hardlinks (same filesystem
+only), falling back to symlinks.  ``--copy`` forces a full copy if you
+need three independent physical trees (uses ~3x disk space).
+
+Typical usage
+-------------
+
+    # In-place migration of a single checkpoint directory:
+    python scripts/migrate_megatron_checkpoint_layout.py \
+        --checkpoint /path/to/checkpoints/run/global_step_100/actor
+
+    # Migrate every actor/critic subdirectory under a run:
+    python scripts/migrate_megatron_checkpoint_layout.py \
+        --checkpoint-root /path/to/checkpoints/run --all-steps
+
+The script is idempotent: running it again on an already-migrated
+checkpoint is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def _is_v2_layout(ckpt_dir: Path) -> bool:
+    return any((ckpt_dir / sub).is_dir() for sub in ("model", "optimizer", "extra"))
+
+
+def _is_legacy_layout(ckpt_dir: Path) -> bool:
+    return (ckpt_dir / "dist_ckpt").is_dir() or (ckpt_dir / "huggingface").is_dir()
+
+
+def _link_tree(src: Path, dst: Path, mode: str) -> None:
+    """Create ``dst`` as a hardlinked / symlinked / copied mirror of ``src``.
+
+    ``mode`` is one of ``"hardlink"``, ``"symlink"``, ``"copy"``.  Hardlink
+    falls back to symlink on cross-filesystem errors; symlink creates a
+    single directory symlink (cheap, but requires the symlink to stay
+    valid for the lifetime of the checkpoint).
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if mode == "symlink":
+        if dst.exists() or dst.is_symlink():
+            return
+        os.symlink(src.resolve(), dst)
+        return
+    if mode == "copy":
+        if dst.exists():
+            return
+        shutil.copytree(src, dst)
+        return
+    # hardlink: replicate directory structure and hardlink each file.
+    dst.mkdir(parents=True, exist_ok=True)
+    for root, _dirs, files in os.walk(src):
+        rel = Path(root).relative_to(src)
+        target_dir = dst / rel
+        target_dir.mkdir(parents=True, exist_ok=True)
+        for fname in files:
+            src_file = Path(root) / fname
+            tgt_file = target_dir / fname
+            if tgt_file.exists():
+                continue
+            try:
+                os.link(src_file, tgt_file)
+            except OSError:
+                shutil.copy2(src_file, tgt_file)
+
+
+def _move(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
+
+
+def migrate_one(ckpt_dir: Path, *, dry_run: bool, mode: str) -> str:
+    """Return a short status string for reporting."""
+    if _is_v2_layout(ckpt_dir):
+        return "skipped (already v2)"
+    if not _is_legacy_layout(ckpt_dir):
+        return "skipped (no recognised layout)"
+
+    legacy_dist = ckpt_dir / "dist_ckpt"
+    legacy_hf = ckpt_dir / "huggingface"
+
+    new_model = ckpt_dir / "model"
+    new_optim = ckpt_dir / "optimizer"
+    new_extra = ckpt_dir / "extra"
+    new_model_dist = new_model / "dist_ckpt"
+    new_model_hf = new_model / "huggingface"
+    new_optim_dist = new_optim / "dist_ckpt"
+    new_extra_dist = new_extra / "dist_ckpt"
+
+    actions: list[str] = []
+
+    if legacy_dist.is_dir():
+        actions.append(f"{mode}: {legacy_dist} -> {new_optim_dist}")
+        actions.append(f"{mode}: {legacy_dist} -> {new_extra_dist}")
+        actions.append(f"{mode}: {legacy_dist} -> {new_model_dist}")
+    if legacy_hf.is_dir():
+        actions.append(f"move: {legacy_hf} -> {new_model_hf}")
+
+    if dry_run:
+        for a in actions:
+            print(f"  would {a}")
+        return "planned"
+
+    if legacy_dist.is_dir():
+        _link_tree(legacy_dist, new_optim_dist, mode)
+        _link_tree(legacy_dist, new_extra_dist, mode)
+        # Model tree only needed if there's a chance the training produced
+        # model shards in the mixed dist_ckpt (dist_ckpt backend or PEFT).
+        # We always create it so the loader can satisfy should_load_model;
+        # unused keys are ignored by dist_checkpointing.
+        _link_tree(legacy_dist, new_model_dist, mode)
+    if legacy_hf.is_dir():
+        new_model.mkdir(parents=True, exist_ok=True)
+        _move(legacy_hf, new_model_hf)
+
+    # Remove the original dist_ckpt/ root entry only when we materialised
+    # independent copies; otherwise it's still referenced by the mirrors.
+    if mode == "copy" and legacy_dist.is_dir():
+        shutil.rmtree(legacy_dist)
+
+    return "migrated"
+
+
+def iter_checkpoint_dirs(root: Path) -> list[Path]:
+    """Yield every leaf checkpoint directory under ``root``.
+
+    A "leaf" is any directory that looks like a Megatron role directory —
+    i.e. it contains a ``dist_ckpt`` or ``huggingface`` subdir (legacy) or
+    a ``model`` subdir (v2, already migrated).
+    """
+    out: list[Path] = []
+    for dirpath, dirnames, _files in os.walk(root):
+        p = Path(dirpath)
+        if _is_legacy_layout(p) or _is_v2_layout(p):
+            out.append(p)
+            # don't descend further into an identified checkpoint
+            dirnames[:] = []
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--checkpoint", type=Path, help="Migrate a single role directory (e.g. .../global_step_N/actor).")
+    src.add_argument(
+        "--checkpoint-root",
+        type=Path,
+        help="Scan the given directory and migrate every role subdirectory found.",
+    )
+    parser.add_argument(
+        "--all-steps",
+        action="store_true",
+        help="With --checkpoint-root: recurse into every global_step_*/role/ directory.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions and exit.")
+    parser.add_argument(
+        "--mode",
+        choices=("hardlink", "symlink", "copy"),
+        default="hardlink",
+        help=(
+            "How to point the new dist_ckpt subtrees at the old data. "
+            "hardlink is cheapest and safe when the migration stays on one filesystem; "
+            "copy duplicates the data (~3x disk use)."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.checkpoint is not None:
+        targets = [args.checkpoint]
+    else:
+        if not args.all_steps:
+            parser.error("--checkpoint-root requires --all-steps")
+        targets = iter_checkpoint_dirs(args.checkpoint_root)
+
+    if not targets:
+        print("No checkpoint directories found.", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for t in targets:
+        if not t.is_dir():
+            print(f"[skip] {t}: not a directory")
+            continue
+        print(f"[{t}]")
+        try:
+            status = migrate_one(t, dry_run=args.dry_run, mode=args.mode)
+            print(f"  {status}")
+        except Exception as exc:  # pragma: no cover - migration tool
+            failures += 1
+            print(f"  FAILED: {exc}", file=sys.stderr)
+
+    return 0 if failures == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
+++ b/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
@@ -1,0 +1,566 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for MegatronCheckpointManager.
+
+These tests verify the __init__ flag resolution, builder composition,
+save_checkpoint / load_checkpoint dispatch, and edge cases.
+
+Uses real megatron.core with gloo backend on a single CPU process.
+"""
+
+import os
+import shutil
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.core import parallel_state as mpu
+
+from verl.trainer.config import CheckpointConfig
+from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
+
+# ---------------------------------------------------------------------------
+# Session-scoped: initialize torch.distributed + megatron parallel state once
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _init_distributed():
+    """Initialize gloo process group and megatron parallel state for the
+    entire test session (single process, world_size=1, CPU only)."""
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29599")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+
+    if not dist.is_initialized():
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+
+    if not mpu.model_parallel_is_initialized():
+        mpu.initialize_model_parallel(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+    yield
+
+    mpu.destroy_model_parallel()
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MegatronSub:
+    dist_ckpt_optim_fully_reshardable = False
+    distrib_optim_fully_reshardable_mem_efficient = False
+
+
+class _RoleCfg:
+    megatron = _MegatronSub()
+
+
+class _MinimalModel:
+    path = "/tmp/fake_model"
+
+
+class _MinimalConfig:
+    """Minimal stand-in for the trainer config object."""
+
+    model = _MinimalModel()
+    actor = _RoleCfg()
+
+
+def _make_mock_model():
+    """A mock model list (VPP length 1) with a working sharded_state_dict.
+
+    ``_build_model_sharded_state_dict`` does ``if hasattr(model, "module"): model = model.module``
+    (mirroring Megatron DDP unwrapping).  A bare ``MagicMock()`` auto-creates
+    ``model.module`` on access, so we explicitly delete it to prevent the
+    unwrap from redirecting to a different mock.
+    """
+    model = MagicMock()
+    del model.module
+    model.sharded_state_dict.return_value = {"layer.weight": MagicMock()}
+    return [model]
+
+
+def _make_manager(
+    save_contents=None,
+    load_contents=None,
+    use_mbridge=True,
+    bridge="auto",
+    peft_cls=None,
+    use_dist_checkpointing=None,
+    use_distributed_optimizer=False,
+):
+    if save_contents is None:
+        save_contents = ["model", "optimizer", "extra"]
+    if load_contents is None:
+        load_contents = ["model", "optimizer", "extra"]
+
+    ckpt_config = CheckpointConfig(
+        save_contents=list(save_contents),
+        load_contents=list(load_contents),
+        async_save=False,
+    )
+
+    model = _make_mock_model()
+    optimizer = MagicMock()
+    optimizer.sharded_state_dict.return_value = {"step": 1, "param_state": MagicMock()}
+    lr_scheduler = MagicMock()
+    lr_scheduler.state_dict.return_value = {"last_epoch": 10}
+
+    if bridge == "auto":
+        bridge = MagicMock() if use_mbridge else None
+
+    return MegatronCheckpointManager(
+        config=_MinimalConfig(),
+        checkpoint_config=ckpt_config,
+        model_config=MagicMock(),
+        transformer_config=MagicMock(spec=[]),
+        role="actor",
+        model=model,
+        arch="GPTForCausalLM",
+        hf_config=MagicMock(),
+        param_dtype=torch.float16,
+        share_embeddings_and_output_weights=False,
+        processing_class=MagicMock(),
+        optimizer=optimizer,
+        optimizer_scheduler=lr_scheduler,
+        use_distributed_optimizer=use_distributed_optimizer,
+        use_mbridge=use_mbridge,
+        bridge=bridge,
+        peft_cls=peft_cls,
+        use_dist_checkpointing=use_dist_checkpointing,
+    )
+
+
+# ===========================================================================
+# Tests: __init__ flag resolution
+# ===========================================================================
+
+
+class TestInitFlagResolution:
+    def test_mbridge_default_flags(self):
+        mgr = _make_manager(save_contents=["model", "optimizer", "extra"])
+        assert mgr.use_mbridge is True
+        assert mgr.use_dist_checkpointing is False
+        assert mgr._save_model_via_mbridge is True
+        assert mgr._save_model_via_dist_ckpt is False
+        assert mgr._save_peft_adapters_in_dist_ckpt is False
+
+    def test_dist_ckpt_flags(self):
+        mgr = _make_manager(save_contents=["model", "optimizer", "extra"], use_mbridge=False)
+        assert mgr.use_mbridge is False
+        assert mgr.use_dist_checkpointing is True
+        assert mgr._save_model_via_mbridge is False
+        assert mgr._save_model_via_dist_ckpt is True
+
+    def test_legacy_use_dist_checkpointing_translates(self):
+        mgr = _make_manager(save_contents=["model"], use_mbridge=True, use_dist_checkpointing=True)
+        assert mgr.use_mbridge is False
+        assert mgr.use_dist_checkpointing is True
+
+    def test_mbridge_requires_bridge_instance(self):
+        with pytest.raises(ValueError, match="use_mbridge=True requires a bridge"):
+            _make_manager(use_mbridge=True, bridge=None)
+
+    def test_hf_model_without_mbridge_raises(self):
+        with pytest.raises(ValueError, match="hf_model.*mbridge"):
+            _make_manager(save_contents=["hf_model"], use_mbridge=False)
+
+    def test_mbridge_model_and_hf_model_deduplicated(self):
+        mgr = _make_manager(save_contents=["model", "hf_model"])
+        assert mgr._save_model_via_mbridge is True
+        assert mgr._save_model_via_dist_ckpt is False
+
+    def test_mbridge_hf_model_only(self):
+        mgr = _make_manager(save_contents=["hf_model"])
+        assert mgr._save_model_via_mbridge is True
+
+    def test_peft_with_mbridge(self):
+        mgr = _make_manager(save_contents=["model", "optimizer"], peft_cls=MagicMock())
+        assert mgr._save_peft_adapters_in_dist_ckpt is True
+        assert mgr._load_model_via_mbridge is False
+        assert mgr._load_model_via_dist_ckpt is True
+
+    def test_load_flags_mbridge(self):
+        mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
+        assert mgr._load_model_via_mbridge is True
+        assert mgr._load_model_via_dist_ckpt is False
+
+    def test_load_flags_dist_ckpt(self):
+        mgr = _make_manager(load_contents=["model", "optimizer", "extra"], use_mbridge=False)
+        assert mgr._load_model_via_mbridge is False
+        assert mgr._load_model_via_dist_ckpt is True
+
+    def test_no_model_in_save_contents(self):
+        mgr = _make_manager(save_contents=["optimizer", "extra"])
+        assert mgr._save_model_via_mbridge is False
+        assert mgr._save_model_via_dist_ckpt is False
+
+
+# ===========================================================================
+# Tests: builder composition
+# ===========================================================================
+
+
+class TestBuilders:
+    def test_build_model_sharded_state_dict(self):
+        mgr = _make_manager()
+        result = mgr._build_model_sharded_state_dict(metadata={})
+        assert "model" in result
+        mgr.model[0].sharded_state_dict.assert_called_once()
+
+    def test_build_model_sharded_state_dict_vpp(self):
+        mgr = _make_manager()
+        second_model = MagicMock()
+        second_model.sharded_state_dict.return_value = {"layer2.weight": MagicMock()}
+        mgr.model.append(second_model)
+
+        result = mgr._build_model_sharded_state_dict(metadata={})
+        assert "model0" in result
+        assert "model1" in result
+
+    def test_build_optimizer_state_dict(self):
+        mgr = _make_manager()
+        model_sd = mgr._build_model_sharded_state_dict(metadata={})
+        result = mgr._build_optimizer_state_dict(model_sd, metadata={})
+        assert "optimizer" in result
+        mgr.optimizer.sharded_state_dict.assert_called_once()
+
+    def test_build_optimizer_includes_lr_scheduler(self):
+        mgr = _make_manager()
+        model_sd = mgr._build_model_sharded_state_dict(metadata={})
+        result = mgr._build_optimizer_state_dict(model_sd, metadata={})
+        assert "lr_scheduler" in result
+        assert result["lr_scheduler"]["last_epoch"] == 10
+
+    def test_build_optimizer_no_lr_scheduler(self):
+        mgr = _make_manager()
+        mgr.lr_scheduler = None
+        model_sd = mgr._build_model_sharded_state_dict(metadata={})
+        result = mgr._build_optimizer_state_dict(model_sd, metadata={})
+        assert "optimizer" in result
+        assert "lr_scheduler" not in result
+
+    def test_build_extra_state_dict(self):
+        mgr = _make_manager()
+        result = mgr._build_extra_state_dict()
+        assert "rng_state" in result
+
+
+# ===========================================================================
+# Tests: save_checkpoint dispatch
+# ===========================================================================
+
+
+class TestSaveCheckpointDispatch:
+    @pytest.fixture(autouse=True)
+    def _tmpdir(self):
+        self.test_dir = tempfile.mkdtemp()
+        yield
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _save_path(self, step=0):
+        return os.path.join(self.test_dir, f"global_step_{step}")
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_mbridge_optimizer_extra_goes_through_dist_ckpt(self, mock_save_dc):
+        """With mbridge, optimizer + extra go through dist_checkpointing; model via bridge."""
+        mgr = _make_manager(save_contents=["model", "optimizer", "extra"])
+        with patch.object(mgr, "_save_transformer_config"):
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_called_once()
+        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
+        assert "optimizer" in saved_sd
+        assert "rng_state" in saved_sd
+        assert "model" not in saved_sd
+        mgr.bridge.save_weights.assert_called_once()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_mbridge_model_only_no_dist_ckpt(self, mock_save_dc):
+        """With mbridge and save_contents=['model'], dist_checkpointing is not called."""
+        mgr = _make_manager(save_contents=["model"])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_not_called()
+        mgr.bridge.save_weights.assert_called_once()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_optimizer_only_without_model(self, mock_save_dc):
+        """save_contents=['optimizer'] saves optimizer via dist_ckpt, no model persisted."""
+        mgr = _make_manager(save_contents=["optimizer"])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_called_once()
+        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
+        assert "optimizer" in saved_sd
+        assert "model" not in saved_sd
+        mgr.bridge.save_weights.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_extra_only(self, mock_save_dc):
+        """save_contents=['extra'] saves only RNG states; model sharded SD not built."""
+        mgr = _make_manager(save_contents=["extra"])
+        with patch.object(mgr, "_save_transformer_config"):
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_called_once()
+        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
+        assert "rng_state" in saved_sd
+        assert "optimizer" not in saved_sd
+        assert "model" not in saved_sd
+        mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_dist_ckpt_backend_includes_model(self, mock_save_dc):
+        """With dist_ckpt backend, model shards go into dist_checkpoint."""
+        mgr = _make_manager(save_contents=["model", "optimizer", "extra"], use_mbridge=False)
+        with patch.object(mgr, "_save_transformer_config"):
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_called_once()
+        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
+        assert "model" in saved_sd
+        assert "optimizer" in saved_sd
+        assert "rng_state" in saved_sd
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_hf_model_with_mbridge_deduplicates(self, mock_save_dc):
+        """save_contents=['model', 'hf_model'] with mbridge saves model once via bridge."""
+        mgr = _make_manager(save_contents=["model", "hf_model"])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mgr.bridge.save_weights.assert_called_once()
+        mock_save_dc.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_peft_adapters_in_dist_ckpt(self, mock_save_dc):
+        """PEFT adapter shards go into dist_checkpoint even with mbridge."""
+        mgr = _make_manager(save_contents=["model", "optimizer"], peft_cls=MagicMock())
+
+        with patch.object(mgr, "_maybe_filter_peft_state_dict", side_effect=lambda sd: sd):
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_called_once()
+        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
+        assert "optimizer" in saved_sd
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_empty_save_contents(self, mock_save_dc):
+        """Empty save_contents should not trigger any saving."""
+        mgr = _make_manager(save_contents=[])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mock_save_dc.assert_not_called()
+        mgr.bridge.save_weights.assert_not_called()
+
+
+# ===========================================================================
+# Tests: load_checkpoint dispatch
+# ===========================================================================
+
+_PATCH_LOAD_META = "megatron.core.dist_checkpointing.load_content_metadata"
+
+
+class TestLoadCheckpointDispatch:
+    @pytest.fixture(autouse=True)
+    def _tmpdir(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.ckpt_path = os.path.join(self.test_dir, "global_step_1")
+        os.makedirs(os.path.join(self.ckpt_path, "dist_ckpt"), exist_ok=True)
+        yield
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_mbridge_load_model_via_bridge(self, mock_load_dc, _mock_meta):
+        """With mbridge, model loads via bridge; optimizer/extra via dist_ckpt."""
+        mock_load_dc.return_value = {
+            "optimizer": {"step": 1},
+            "lr_scheduler": {"last_epoch": 5},
+            "rng_state": [{"random_rng_state": None}],
+        }
+        mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
+
+        with patch.object(mgr, "_load_model_via_bridge") as mock_bridge_load, patch.object(mgr, "load_rng_states"):
+            mgr.load_checkpoint(self.ckpt_path)
+            mock_bridge_load.assert_called_once()
+
+        mock_load_dc.assert_called_once()
+        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
+        assert "optimizer" in loaded_sd
+        assert "rng_state" in loaded_sd
+        assert "model" not in loaded_sd
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_dist_ckpt_load_model_from_dist_ckpt(self, mock_load_dc, _mock_meta):
+        """With dist_ckpt backend, model loads from dist_checkpoint."""
+        mock_load_dc.return_value = {
+            "model": {"layer.weight": torch.zeros(1)},
+            "optimizer": {"step": 1},
+            "rng_state": [{"random_rng_state": None}],
+        }
+        mgr = _make_manager(load_contents=["model", "optimizer", "extra"], use_mbridge=False)
+
+        with patch.object(mgr, "load_rng_states"):
+            mgr.load_checkpoint(self.ckpt_path)
+
+        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
+        assert "model" in loaded_sd
+        assert "optimizer" in loaded_sd
+        mgr.model[0].load_state_dict.assert_called_once()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_optimizer_only(self, mock_load_dc, _mock_meta):
+        """load_contents=['optimizer'] loads only optimizer via dist_ckpt."""
+        mock_load_dc.return_value = {"optimizer": {"step": 1}}
+        mgr = _make_manager(load_contents=["optimizer"])
+        mgr.load_checkpoint(self.ckpt_path)
+
+        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
+        assert "optimizer" in loaded_sd
+        assert "model" not in loaded_sd
+        assert "rng_state" not in loaded_sd
+        mgr.optimizer.load_state_dict.assert_called_once()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_extra_only(self, mock_load_dc, _mock_meta):
+        """load_contents=['extra'] loads only RNG states; model SD not built."""
+        mock_load_dc.return_value = {"rng_state": [{"random_rng_state": None}]}
+        mgr = _make_manager(load_contents=["extra"])
+
+        with patch.object(mgr, "load_rng_states"):
+            mgr.load_checkpoint(self.ckpt_path)
+
+        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
+        assert "rng_state" in loaded_sd
+        assert "optimizer" not in loaded_sd
+        assert "model" not in loaded_sd
+        mgr.model[0].sharded_state_dict.assert_not_called()
+
+
+# ===========================================================================
+# Tests: save_checkpoint side effects (HF config, transformer config)
+# ===========================================================================
+
+
+class TestSaveCheckpointSideEffects:
+    @pytest.fixture(autouse=True)
+    def _tmpdir(self):
+        self.test_dir = tempfile.mkdtemp()
+        yield
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def _save_path(self, step=0):
+        return os.path.join(self.test_dir, f"global_step_{step}")
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_hf_config_saved_with_mbridge(self, mock_save_dc):
+        mgr = _make_manager(save_contents=["model"])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mgr.hf_config.save_pretrained.assert_called_once()
+        mgr.processing_class.save_pretrained.assert_called_once()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_hf_config_not_saved_without_model(self, mock_save_dc):
+        mgr = _make_manager(save_contents=["optimizer"])
+        mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mgr.hf_config.save_pretrained.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_transformer_config_saved_with_extra(self, mock_save_dc):
+        mgr = _make_manager(save_contents=["extra"])
+        with patch.object(mgr, "_save_transformer_config") as mock_tc:
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+            mock_tc.assert_called_once()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_transformer_config_not_saved_without_extra(self, mock_save_dc):
+        mgr = _make_manager(save_contents=["model"])
+        with patch.object(mgr, "_save_transformer_config") as mock_tc:
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+            mock_tc.assert_not_called()
+
+
+# ===========================================================================
+# Tests: model sharded state dict is NOT built when unnecessary
+# ===========================================================================
+
+
+class TestModelShardedStateDictNotBuiltUnnecessarily:
+    @pytest.fixture(autouse=True)
+    def _tmpdir(self):
+        self.test_dir = tempfile.mkdtemp()
+        yield
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_extra_only_does_not_build_model_sd(self, mock_save_dc):
+        mgr = _make_manager(save_contents=["extra"])
+        with patch.object(mgr, "_save_transformer_config"):
+            mgr.save_checkpoint(os.path.join(self.test_dir, "step_1"), global_step=1)
+        mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_model_only_mbridge_does_not_build_model_sd(self, mock_save_dc):
+        """mbridge model save uses bridge.save_weights, not model.sharded_state_dict."""
+        mgr = _make_manager(save_contents=["model"])
+        mgr.save_checkpoint(os.path.join(self.test_dir, "step_1"), global_step=1)
+        mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_optimizer_does_build_model_sd(self, mock_save_dc):
+        """Optimizer save needs model sharded SD as metadata input."""
+        mgr = _make_manager(save_contents=["optimizer"])
+        mgr.save_checkpoint(os.path.join(self.test_dir, "step_1"), global_step=1)
+        mgr.model[0].sharded_state_dict.assert_called_once()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_extra_only_does_not_build_model_sd(self, mock_load_dc, _mock_meta):
+        mock_load_dc.return_value = {"rng_state": [{"random_rng_state": None}]}
+        mgr = _make_manager(load_contents=["extra"])
+        ckpt_path = os.path.join(self.test_dir, "step_1")
+        os.makedirs(os.path.join(ckpt_path, "dist_ckpt"), exist_ok=True)
+
+        with patch.object(mgr, "load_rng_states"):
+            mgr.load_checkpoint(ckpt_path)
+        mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_optimizer_builds_model_sd(self, mock_load_dc, _mock_meta):
+        """Loading optimizer needs model sharded SD as metadata input."""
+        mock_load_dc.return_value = {"optimizer": {"step": 1}}
+        mgr = _make_manager(load_contents=["optimizer"])
+        ckpt_path = os.path.join(self.test_dir, "step_1")
+        os.makedirs(os.path.join(ckpt_path, "dist_ckpt"), exist_ok=True)
+
+        mgr.load_checkpoint(ckpt_path)
+        mgr.model[0].sharded_state_dict.assert_called_once()

--- a/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
+++ b/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
@@ -128,7 +128,9 @@ def _make_manager(
     lr_scheduler.state_dict.return_value = {"last_epoch": 10}
 
     if bridge == "auto":
-        bridge = None if use_dist_checkpointing else MagicMock()
+        save_c = list(save_contents)
+        would_save_hf = "hf_model" in save_c or ("model" in save_c and not use_dist_checkpointing)
+        bridge = MagicMock() if would_save_hf else (None if use_dist_checkpointing else MagicMock())
 
     return MegatronCheckpointManager(
         config=_MinimalConfig(),
@@ -199,9 +201,17 @@ class TestInitFlagResolution:
         with pytest.raises(ValueError, match="HF-format model weights require"):
             _make_manager(use_dist_checkpointing=False, bridge=None)
 
-    def test_hf_model_without_hf_path_raises(self):
+    def test_hf_model_requires_bridge(self):
         with pytest.raises(ValueError, match="'hf_model'"):
-            _make_manager(save_contents=["hf_model"], use_dist_checkpointing=True)
+            _make_manager(save_contents=["hf_model"], bridge=None)
+
+    def test_hf_model_with_dist_ckpt_when_mbridge(self):
+        mgr = _make_manager(
+            save_contents=["model", "hf_model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
+        assert mgr.should_save_hf_model is True
+        assert mgr.should_save_dist_ckpt_model is True
 
 
 # ===========================================================================
@@ -355,6 +365,21 @@ class TestSaveCheckpointDispatch:
 
         mgr.bridge.save_weights.assert_called_once()
         mock_save_dc.assert_not_called()
+
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
+    def test_hf_model_and_dist_ckpt_saves_both(self, mock_save_dc):
+        """With mbridge + dist_checkpointing, ``model`` and ``hf_model`` write shards and HF tree."""
+        mgr = _make_manager(
+            save_contents=["model", "hf_model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
+        with patch.object(mgr, "_save_transformer_config"):
+            mgr.save_checkpoint(self._save_path(), global_step=1)
+
+        mgr.bridge.save_weights.assert_called_once()
+        mock_save_dc.assert_called()
+        calls = _collect_save_calls(mock_save_dc)
+        assert "model" in calls and "optimizer" in calls and "extra" in calls
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
     def test_peft_adapters_under_model_subdir(self, mock_save_dc):

--- a/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
+++ b/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
@@ -105,10 +105,9 @@ def _make_mock_model():
 def _make_manager(
     save_contents=None,
     load_contents=None,
-    use_mbridge=True,
+    use_dist_checkpointing=False,
     bridge="auto",
     peft_cls=None,
-    use_dist_checkpointing=None,
     use_distributed_optimizer=False,
 ):
     if save_contents is None:
@@ -129,7 +128,7 @@ def _make_manager(
     lr_scheduler.state_dict.return_value = {"last_epoch": 10}
 
     if bridge == "auto":
-        bridge = MagicMock() if use_mbridge else None
+        bridge = None if use_dist_checkpointing else MagicMock()
 
     return MegatronCheckpointManager(
         config=_MinimalConfig(),
@@ -146,10 +145,9 @@ def _make_manager(
         optimizer=optimizer,
         optimizer_scheduler=lr_scheduler,
         use_distributed_optimizer=use_distributed_optimizer,
-        use_mbridge=use_mbridge,
+        use_dist_checkpointing=use_dist_checkpointing,
         bridge=bridge,
         peft_cls=peft_cls,
-        use_dist_checkpointing=use_dist_checkpointing,
     )
 
 
@@ -159,63 +157,51 @@ def _make_manager(
 
 
 class TestInitFlagResolution:
-    def test_mbridge_default_flags(self):
+    def test_hf_path_default(self):
         mgr = _make_manager(save_contents=["model", "optimizer", "extra"])
-        assert mgr.use_mbridge is True
         assert mgr.use_dist_checkpointing is False
-        assert mgr._save_model_via_mbridge is True
-        assert mgr._save_model_via_dist_ckpt is False
-        assert mgr._save_peft_adapters_in_dist_ckpt is False
+        assert mgr.should_save_hf_model is True
+        assert mgr.should_save_dist_ckpt_model is False
 
-    def test_dist_ckpt_flags(self):
-        mgr = _make_manager(save_contents=["model", "optimizer", "extra"], use_mbridge=False)
-        assert mgr.use_mbridge is False
+    def test_dist_ckpt_path(self):
+        mgr = _make_manager(
+            save_contents=["model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
         assert mgr.use_dist_checkpointing is True
-        assert mgr._save_model_via_mbridge is False
-        assert mgr._save_model_via_dist_ckpt is True
+        assert mgr.should_save_hf_model is False
+        assert mgr.should_save_dist_ckpt_model is True
 
-    def test_legacy_use_dist_checkpointing_translates(self):
-        mgr = _make_manager(save_contents=["model"], use_mbridge=True, use_dist_checkpointing=True)
-        assert mgr.use_mbridge is False
-        assert mgr.use_dist_checkpointing is True
-
-    def test_mbridge_requires_bridge_instance(self):
-        with pytest.raises(ValueError, match="use_mbridge=True requires a bridge"):
-            _make_manager(use_mbridge=True, bridge=None)
-
-    def test_hf_model_without_mbridge_raises(self):
-        with pytest.raises(ValueError, match="hf_model.*mbridge"):
-            _make_manager(save_contents=["hf_model"], use_mbridge=False)
-
-    def test_mbridge_model_and_hf_model_deduplicated(self):
-        mgr = _make_manager(save_contents=["model", "hf_model"])
-        assert mgr._save_model_via_mbridge is True
-        assert mgr._save_model_via_dist_ckpt is False
-
-    def test_mbridge_hf_model_only(self):
+    def test_hf_model_only_in_save_contents(self):
         mgr = _make_manager(save_contents=["hf_model"])
-        assert mgr._save_model_via_mbridge is True
-
-    def test_peft_with_mbridge(self):
-        mgr = _make_manager(save_contents=["model", "optimizer"], peft_cls=MagicMock())
-        assert mgr._save_peft_adapters_in_dist_ckpt is True
-        assert mgr._load_model_via_mbridge is False
-        assert mgr._load_model_via_dist_ckpt is True
-
-    def test_load_flags_mbridge(self):
-        mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
-        assert mgr._load_model_via_mbridge is True
-        assert mgr._load_model_via_dist_ckpt is False
-
-    def test_load_flags_dist_ckpt(self):
-        mgr = _make_manager(load_contents=["model", "optimizer", "extra"], use_mbridge=False)
-        assert mgr._load_model_via_mbridge is False
-        assert mgr._load_model_via_dist_ckpt is True
+        assert mgr.should_save_hf_model is True
+        assert mgr.should_save_dist_ckpt_model is False
 
     def test_no_model_in_save_contents(self):
         mgr = _make_manager(save_contents=["optimizer", "extra"])
-        assert mgr._save_model_via_mbridge is False
-        assert mgr._save_model_via_dist_ckpt is False
+        assert mgr.should_save_hf_model is False
+        assert mgr.should_save_dist_ckpt_model is False
+
+    def test_load_flags_hf_path(self):
+        mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
+        assert mgr.should_load_hf_model is True
+        assert mgr.should_load_dist_ckpt_model is False
+
+    def test_load_dist_ckpt_path(self):
+        mgr = _make_manager(
+            load_contents=["model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
+        assert mgr.should_load_hf_model is False
+        assert mgr.should_load_dist_ckpt_model is True
+
+    def test_hf_path_requires_bridge_instance(self):
+        with pytest.raises(ValueError, match="HF-format model weights require"):
+            _make_manager(use_dist_checkpointing=False, bridge=None)
+
+    def test_hf_model_without_hf_path_raises(self):
+        with pytest.raises(ValueError, match="'hf_model'"):
+            _make_manager(save_contents=["hf_model"], use_dist_checkpointing=True)
 
 
 # ===========================================================================
@@ -348,7 +334,10 @@ class TestSaveCheckpointDispatch:
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
     def test_dist_ckpt_backend_splits_into_three(self, mock_save_dc):
         """With dist_ckpt backend, model/optimizer/extra go to three separate directories."""
-        mgr = _make_manager(save_contents=["model", "optimizer", "extra"], use_mbridge=False)
+        mgr = _make_manager(
+            save_contents=["model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
         with patch.object(mgr, "_save_transformer_config"):
             mgr.save_checkpoint(self._save_path(), global_step=1)
 
@@ -435,8 +424,8 @@ class TestLoadCheckpointDispatch:
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
-    def test_mbridge_load_model_via_bridge(self, mock_load_dc, _mock_meta):
-        """With mbridge: model loads via bridge; optimizer/extra come from separate dist_ckpt dirs."""
+    def test_hf_weight_load_model_via_bridge(self, mock_load_dc, _mock_meta):
+        """On the HF path: model loads via bridge; optimizer/extra come from separate dist_ckpt dirs."""
         _make_v2_layout(self.ckpt_path, "optimizer", "extra")
 
         def fake_load(sharded_state_dict, ckpt_dir):
@@ -449,7 +438,10 @@ class TestLoadCheckpointDispatch:
         mock_load_dc.side_effect = fake_load
         mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
 
-        with patch.object(mgr, "_load_model_via_bridge") as mock_bridge_load, patch.object(mgr, "load_rng_states"):
+        with (
+            patch.object(mgr, "_load_model_as_hf_via_bridge") as mock_bridge_load,
+            patch.object(mgr, "load_rng_states"),
+        ):
             mgr.load_checkpoint(self.ckpt_path)
             mock_bridge_load.assert_called_once()
 
@@ -475,7 +467,10 @@ class TestLoadCheckpointDispatch:
             return {}
 
         mock_load_dc.side_effect = fake_load
-        mgr = _make_manager(load_contents=["model", "optimizer", "extra"], use_mbridge=False)
+        mgr = _make_manager(
+            load_contents=["model", "optimizer", "extra"],
+            use_dist_checkpointing=True,
+        )
 
         with patch.object(mgr, "load_rng_states"):
             mgr.load_checkpoint(self.ckpt_path)

--- a/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
+++ b/tests/utils/ckpt/test_megatron_checkpoint_manager_on_cpu.py
@@ -273,6 +273,19 @@ class TestBuilders:
 # ===========================================================================
 
 
+def _collect_save_calls(mock_save_dc):
+    """Return {relative_subdir: sharded_state_dict} for each save_dist_checkpointing call."""
+    out = {}
+    for call in mock_save_dc.call_args_list:
+        kwargs = call.kwargs
+        # Path format:   <root>/global_step_N/{model|optimizer|extra}/dist_ckpt
+        ckpt_path = kwargs["ckpt_path"]
+        normalized = os.path.normpath(ckpt_path)
+        subdir = os.path.basename(os.path.dirname(normalized))
+        out[subdir] = kwargs["sharded_state_dict"]
+    return out
+
+
 class TestSaveCheckpointDispatch:
     @pytest.fixture(autouse=True)
     def _tmpdir(self):
@@ -284,17 +297,18 @@ class TestSaveCheckpointDispatch:
         return os.path.join(self.test_dir, f"global_step_{step}")
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
-    def test_mbridge_optimizer_extra_goes_through_dist_ckpt(self, mock_save_dc):
-        """With mbridge, optimizer + extra go through dist_checkpointing; model via bridge."""
+    def test_mbridge_split_optimizer_extra(self, mock_save_dc):
+        """With mbridge, optimizer and extra go to SEPARATE dist_ckpt directories; model via bridge."""
         mgr = _make_manager(save_contents=["model", "optimizer", "extra"])
         with patch.object(mgr, "_save_transformer_config"):
             mgr.save_checkpoint(self._save_path(), global_step=1)
 
-        mock_save_dc.assert_called_once()
-        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
-        assert "optimizer" in saved_sd
-        assert "rng_state" in saved_sd
-        assert "model" not in saved_sd
+        calls = _collect_save_calls(mock_save_dc)
+        assert set(calls) == {"optimizer", "extra"}
+        assert "optimizer" in calls["optimizer"]
+        assert "rng_state" in calls["extra"]
+        # model must NOT be in any dist_ckpt tree (it lives under model/huggingface/)
+        assert all("model" not in sd for sd in calls.values())
         mgr.bridge.save_weights.assert_called_once()
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
@@ -307,43 +321,42 @@ class TestSaveCheckpointDispatch:
         mgr.bridge.save_weights.assert_called_once()
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
-    def test_optimizer_only_without_model(self, mock_save_dc):
-        """save_contents=['optimizer'] saves optimizer via dist_ckpt, no model persisted."""
+    def test_optimizer_only_writes_only_optimizer_subdir(self, mock_save_dc):
+        """save_contents=['optimizer'] writes ONLY the optimizer/ subtree."""
         mgr = _make_manager(save_contents=["optimizer"])
         mgr.save_checkpoint(self._save_path(), global_step=1)
 
-        mock_save_dc.assert_called_once()
-        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
-        assert "optimizer" in saved_sd
-        assert "model" not in saved_sd
+        calls = _collect_save_calls(mock_save_dc)
+        assert set(calls) == {"optimizer"}
+        assert "optimizer" in calls["optimizer"]
+        assert "model" not in calls["optimizer"]
         mgr.bridge.save_weights.assert_not_called()
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
     def test_extra_only(self, mock_save_dc):
-        """save_contents=['extra'] saves only RNG states; model sharded SD not built."""
+        """save_contents=['extra'] writes ONLY the extra/ subtree; model sharded SD not built."""
         mgr = _make_manager(save_contents=["extra"])
         with patch.object(mgr, "_save_transformer_config"):
             mgr.save_checkpoint(self._save_path(), global_step=1)
 
-        mock_save_dc.assert_called_once()
-        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
-        assert "rng_state" in saved_sd
-        assert "optimizer" not in saved_sd
-        assert "model" not in saved_sd
+        calls = _collect_save_calls(mock_save_dc)
+        assert set(calls) == {"extra"}
+        assert "rng_state" in calls["extra"]
+        assert "optimizer" not in calls["extra"]
         mgr.model[0].sharded_state_dict.assert_not_called()
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
-    def test_dist_ckpt_backend_includes_model(self, mock_save_dc):
-        """With dist_ckpt backend, model shards go into dist_checkpoint."""
+    def test_dist_ckpt_backend_splits_into_three(self, mock_save_dc):
+        """With dist_ckpt backend, model/optimizer/extra go to three separate directories."""
         mgr = _make_manager(save_contents=["model", "optimizer", "extra"], use_mbridge=False)
         with patch.object(mgr, "_save_transformer_config"):
             mgr.save_checkpoint(self._save_path(), global_step=1)
 
-        mock_save_dc.assert_called_once()
-        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
-        assert "model" in saved_sd
-        assert "optimizer" in saved_sd
-        assert "rng_state" in saved_sd
+        calls = _collect_save_calls(mock_save_dc)
+        assert set(calls) == {"model", "optimizer", "extra"}
+        assert "model" in calls["model"]
+        assert "optimizer" in calls["optimizer"]
+        assert "rng_state" in calls["extra"]
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
     def test_hf_model_with_mbridge_deduplicates(self, mock_save_dc):
@@ -355,16 +368,17 @@ class TestSaveCheckpointDispatch:
         mock_save_dc.assert_not_called()
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
-    def test_peft_adapters_in_dist_ckpt(self, mock_save_dc):
-        """PEFT adapter shards go into dist_checkpoint even with mbridge."""
+    def test_peft_adapters_under_model_subdir(self, mock_save_dc):
+        """PEFT adapter shards live under model/dist_ckpt/ even with mbridge; optimizer stays separate."""
         mgr = _make_manager(save_contents=["model", "optimizer"], peft_cls=MagicMock())
 
         with patch.object(mgr, "_maybe_filter_peft_state_dict", side_effect=lambda sd: sd):
             mgr.save_checkpoint(self._save_path(), global_step=1)
 
-        mock_save_dc.assert_called_once()
-        saved_sd = mock_save_dc.call_args[1]["sharded_state_dict"]
-        assert "optimizer" in saved_sd
+        calls = _collect_save_calls(mock_save_dc)
+        assert "model" in calls
+        assert "optimizer" in calls
+        assert "optimizer" in calls["optimizer"]
 
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.save_dist_checkpointing", return_value=None)
     def test_empty_save_contents(self, mock_save_dc):
@@ -383,84 +397,141 @@ class TestSaveCheckpointDispatch:
 _PATCH_LOAD_META = "megatron.core.dist_checkpointing.load_content_metadata"
 
 
+def _make_v2_layout(ckpt_path: str, *subdirs: str) -> None:
+    """Create the v2 split layout with the given subdirs non-empty.
+
+    ``subdirs`` is a subset of ``{"model", "optimizer", "extra"}``.  For each,
+    we create ``<ckpt_path>/<sub>/dist_ckpt`` and put a sentinel file in it so
+    ``_has_checkpoint_files`` returns True.
+    """
+    for sub in subdirs:
+        dpath = os.path.join(ckpt_path, sub, "dist_ckpt")
+        os.makedirs(dpath, exist_ok=True)
+        # dist_checkpointing writes arbitrary per-shard files; a dummy
+        # sentinel is enough for our in-repo _has_checkpoint_files gate.
+        sentinel = os.path.join(dpath, "common.pt")
+        with open(sentinel, "w") as f:
+            f.write("")
+
+
+def _load_calls_by_subdir(mock_load_dc):
+    """Return {subdir: sharded_state_dict} from load_dist_checkpointing invocations."""
+    out = {}
+    for call in mock_load_dc.call_args_list:
+        kwargs = call.kwargs
+        subdir = os.path.basename(os.path.dirname(os.path.normpath(kwargs["ckpt_dir"])))
+        out[subdir] = kwargs["sharded_state_dict"]
+    return out
+
+
 class TestLoadCheckpointDispatch:
     @pytest.fixture(autouse=True)
     def _tmpdir(self):
         self.test_dir = tempfile.mkdtemp()
         self.ckpt_path = os.path.join(self.test_dir, "global_step_1")
-        os.makedirs(os.path.join(self.ckpt_path, "dist_ckpt"), exist_ok=True)
+        os.makedirs(self.ckpt_path, exist_ok=True)
         yield
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
     def test_mbridge_load_model_via_bridge(self, mock_load_dc, _mock_meta):
-        """With mbridge, model loads via bridge; optimizer/extra via dist_ckpt."""
-        mock_load_dc.return_value = {
-            "optimizer": {"step": 1},
-            "lr_scheduler": {"last_epoch": 5},
-            "rng_state": [{"random_rng_state": None}],
-        }
+        """With mbridge: model loads via bridge; optimizer/extra come from separate dist_ckpt dirs."""
+        _make_v2_layout(self.ckpt_path, "optimizer", "extra")
+
+        def fake_load(sharded_state_dict, ckpt_dir):
+            if "optimizer" in sharded_state_dict:
+                return {"optimizer": {"step": 1}, "lr_scheduler": {"last_epoch": 5}}
+            if "rng_state" in sharded_state_dict:
+                return {"rng_state": [{"random_rng_state": None}]}
+            return {}
+
+        mock_load_dc.side_effect = fake_load
         mgr = _make_manager(load_contents=["model", "optimizer", "extra"])
 
         with patch.object(mgr, "_load_model_via_bridge") as mock_bridge_load, patch.object(mgr, "load_rng_states"):
             mgr.load_checkpoint(self.ckpt_path)
             mock_bridge_load.assert_called_once()
 
-        mock_load_dc.assert_called_once()
-        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
-        assert "optimizer" in loaded_sd
-        assert "rng_state" in loaded_sd
-        assert "model" not in loaded_sd
+        calls = _load_calls_by_subdir(mock_load_dc)
+        assert set(calls) == {"optimizer", "extra"}
+        assert "optimizer" in calls["optimizer"]
+        assert "rng_state" in calls["extra"]
+        assert "model" not in calls["optimizer"]
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
-    def test_dist_ckpt_load_model_from_dist_ckpt(self, mock_load_dc, _mock_meta):
-        """With dist_ckpt backend, model loads from dist_checkpoint."""
-        mock_load_dc.return_value = {
-            "model": {"layer.weight": torch.zeros(1)},
-            "optimizer": {"step": 1},
-            "rng_state": [{"random_rng_state": None}],
-        }
+    def test_dist_ckpt_load_model_from_each_subdir(self, mock_load_dc, _mock_meta):
+        """With dist_ckpt backend, all three subtrees are loaded independently."""
+        _make_v2_layout(self.ckpt_path, "model", "optimizer", "extra")
+
+        def fake_load(sharded_state_dict, ckpt_dir):
+            if "model" in sharded_state_dict:
+                return {"model": {"layer.weight": torch.zeros(1)}}
+            if "optimizer" in sharded_state_dict:
+                return {"optimizer": {"step": 1}}
+            if "rng_state" in sharded_state_dict:
+                return {"rng_state": [{"random_rng_state": None}]}
+            return {}
+
+        mock_load_dc.side_effect = fake_load
         mgr = _make_manager(load_contents=["model", "optimizer", "extra"], use_mbridge=False)
 
         with patch.object(mgr, "load_rng_states"):
             mgr.load_checkpoint(self.ckpt_path)
 
-        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
-        assert "model" in loaded_sd
-        assert "optimizer" in loaded_sd
+        calls = _load_calls_by_subdir(mock_load_dc)
+        assert set(calls) == {"model", "optimizer", "extra"}
+        assert "model" in calls["model"]
+        assert "optimizer" in calls["optimizer"]
+        assert "rng_state" in calls["extra"]
         mgr.model[0].load_state_dict.assert_called_once()
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
     def test_load_optimizer_only(self, mock_load_dc, _mock_meta):
-        """load_contents=['optimizer'] loads only optimizer via dist_ckpt."""
+        """load_contents=['optimizer'] touches only the optimizer subtree."""
+        _make_v2_layout(self.ckpt_path, "optimizer")
         mock_load_dc.return_value = {"optimizer": {"step": 1}}
         mgr = _make_manager(load_contents=["optimizer"])
         mgr.load_checkpoint(self.ckpt_path)
 
-        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
-        assert "optimizer" in loaded_sd
-        assert "model" not in loaded_sd
-        assert "rng_state" not in loaded_sd
+        calls = _load_calls_by_subdir(mock_load_dc)
+        assert set(calls) == {"optimizer"}
+        assert "optimizer" in calls["optimizer"]
+        assert "rng_state" not in calls["optimizer"]
         mgr.optimizer.load_state_dict.assert_called_once()
 
     @patch(_PATCH_LOAD_META, return_value=None)
     @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
     def test_load_extra_only(self, mock_load_dc, _mock_meta):
-        """load_contents=['extra'] loads only RNG states; model SD not built."""
+        """load_contents=['extra'] loads only RNG states from the extra subtree."""
+        _make_v2_layout(self.ckpt_path, "extra")
         mock_load_dc.return_value = {"rng_state": [{"random_rng_state": None}]}
         mgr = _make_manager(load_contents=["extra"])
 
         with patch.object(mgr, "load_rng_states"):
             mgr.load_checkpoint(self.ckpt_path)
 
-        loaded_sd = mock_load_dc.call_args[1]["sharded_state_dict"]
-        assert "rng_state" in loaded_sd
-        assert "optimizer" not in loaded_sd
-        assert "model" not in loaded_sd
+        calls = _load_calls_by_subdir(mock_load_dc)
+        assert set(calls) == {"extra"}
+        assert "rng_state" in calls["extra"]
         mgr.model[0].sharded_state_dict.assert_not_called()
+
+    @patch(_PATCH_LOAD_META, return_value=None)
+    @patch("verl.utils.checkpoint.megatron_checkpoint_manager.load_dist_checkpointing")
+    def test_load_rejects_legacy_layout(self, mock_load_dc, _mock_meta):
+        """Loading a pre-v2 checkpoint (bare dist_ckpt/ or huggingface/ at root) must fail fast."""
+        # Legacy layout: dist_ckpt/ directly at the root, NO model/optimizer/extra.
+        legacy_dir = os.path.join(self.ckpt_path, "dist_ckpt")
+        os.makedirs(legacy_dir, exist_ok=True)
+        with open(os.path.join(legacy_dir, "common.pt"), "w") as f:
+            f.write("")
+
+        mgr = _make_manager(load_contents=["optimizer"])
+        with pytest.raises(RuntimeError, match="deprecated Megatron checkpoint layout"):
+            mgr.load_checkpoint(self.ckpt_path)
+        mock_load_dc.assert_not_called()
 
 
 # ===========================================================================
@@ -547,7 +618,7 @@ class TestModelShardedStateDictNotBuiltUnnecessarily:
         mock_load_dc.return_value = {"rng_state": [{"random_rng_state": None}]}
         mgr = _make_manager(load_contents=["extra"])
         ckpt_path = os.path.join(self.test_dir, "step_1")
-        os.makedirs(os.path.join(ckpt_path, "dist_ckpt"), exist_ok=True)
+        _make_v2_layout(ckpt_path, "extra")
 
         with patch.object(mgr, "load_rng_states"):
             mgr.load_checkpoint(ckpt_path)
@@ -560,7 +631,7 @@ class TestModelShardedStateDictNotBuiltUnnecessarily:
         mock_load_dc.return_value = {"optimizer": {"step": 1}}
         mgr = _make_manager(load_contents=["optimizer"])
         ckpt_path = os.path.join(self.test_dir, "step_1")
-        os.makedirs(os.path.join(ckpt_path, "dist_ckpt"), exist_ok=True)
+        _make_v2_layout(ckpt_path, "optimizer")
 
         mgr.load_checkpoint(ckpt_path)
         mgr.model[0].sharded_state_dict.assert_called_once()

--- a/tests/workers/config/test_critic_config_on_cpu.py
+++ b/tests/workers/config/test_critic_config_on_cpu.py
@@ -63,7 +63,6 @@ class TestCriticConfig:
             "get",
             "nccl_timeout",
             "megatron",
-            "load_weight",
         ]
         for attr in expected_attrs:
             assert hasattr(megatron_config_obj, attr), f"Missing attribute: {attr}"
@@ -146,7 +145,7 @@ class TestCriticConfig:
                 setattr(critic_config, field_name, "modified_value")
 
         megatron_config = McoreCriticConfig(ppo_micro_batch_size_per_gpu=1, optim=McoreOptimizerConfig(lr=0.1))
-        megatron_frozen_fields = ["nccl_timeout", "load_weight", "data_loader_seed"]
+        megatron_frozen_fields = ["nccl_timeout", "data_loader_seed"]
 
         for field_name in megatron_frozen_fields:
             with pytest.raises((AttributeError, TypeError, ValueError)):

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -122,6 +122,21 @@ class ModelMergerConfig:
             self.private = False
 
 
+def _default_hf_model_config_path(backend: str, local_dir: str) -> str:
+    """Return the default path to HuggingFace config/tokenizer artifacts.
+
+    - FSDP: ``<local_dir>/huggingface`` (unchanged, single-tree layout).
+    - Megatron (v2 layout): ``<local_dir>/model/huggingface`` — the HF tree
+      is nested under ``model/`` alongside the optional ``model/dist_ckpt/``
+      shards.  Checkpoints produced before the v2 refactor will therefore
+      not resolve here; run ``scripts/migrate_megatron_checkpoint_layout.py``
+      first.
+    """
+    if backend == "megatron":
+        return os.path.join(local_dir, "model", "huggingface")
+    return os.path.join(local_dir, "huggingface")
+
+
 def generate_config_from_args(args: argparse.Namespace) -> ModelMergerConfig:
     common_config_args = {
         "operation": args.operation,
@@ -130,7 +145,7 @@ def generate_config_from_args(args: argparse.Namespace) -> ModelMergerConfig:
         "trust_remote_code": args.trust_remote_code,
         "is_value_model": args.is_value_model,
         "local_dir": args.local_dir,
-        "hf_model_config_path": os.path.join(args.local_dir, "huggingface"),
+        "hf_model_config_path": _default_hf_model_config_path(args.backend, args.local_dir),
         "use_cpu_initialization": args.use_cpu_initialization,
     }
 

--- a/verl/model_merger/megatron_model_merger.py
+++ b/verl/model_merger/megatron_model_merger.py
@@ -489,9 +489,9 @@ class MegatronModelMerger(BaseModelMerger):
                 tokenizer.save_pretrained(self.config.target_dir)
 
     def merge_and_save(self):
-        from verl.utils.megatron_utils import get_dist_checkpoint_path
+        from verl.utils.megatron_utils import get_model_dist_checkpoint_path
 
-        model_ckpt_path = get_dist_checkpoint_path(self.config.local_dir)
+        model_ckpt_path = get_model_dist_checkpoint_path(self.config.local_dir)
 
         model_state_dict = self._load_state_dicts(model_ckpt_path)
         merged_state_dict = self._merge_state_dicts(model_state_dict)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -114,15 +114,15 @@ actor_rollout_ref:
     shuffle: false
     data_loader_seed: 42
     checkpoint:
-      _target_: verl.trainer.config.CheckpointConfig
+      _target_: verl.workers.config.McoreCheckpointConfig
       save_contents:
       - model
       - optimizer
       - extra
       load_contents: ${.save_contents}
       async_save: false
-      mbridge_config: {}
       strict: true
+      mbridge_config: {}
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
@@ -170,7 +170,6 @@ actor_rollout_ref:
       - re:.*mlp.gate$
       activation_observer: static_minmax
       quantization_config_path: null
-    load_weight: true
   ref:
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: megatron
@@ -261,7 +260,6 @@ actor_rollout_ref:
         activation_observer: null
         quantization_config_path: null
     _target_: verl.workers.config.McoreActorConfig
-    load_weight: true
   rollout:
     _target_: verl.workers.config.RolloutConfig
     name: ???
@@ -587,7 +585,7 @@ critic:
   cliprange_value: 0.5
   loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
   checkpoint:
-    _target_: verl.trainer.config.CheckpointConfig
+    _target_: verl.workers.config.McoreCheckpointConfig
     save_contents:
     - model
     - optimizer
@@ -627,7 +625,6 @@ critic:
         stages: ${oc.select:global_profiler.global_tool_config.precision_debugger.stages,null}
         strict: ${oc.select:global_profiler.global_tool_config.precision_debugger.strict,False}
   nccl_timeout: 600
-  load_weight: true
   model:
     _target_: verl.workers.config.HFModelConfig
     path: ~/models/deepseek-llm-7b-chat

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -91,7 +91,6 @@ actor_rollout_ref:
       - extra
       load_contents: ${.save_contents}
       async_save: false
-      mbridge_config: {}
       strict: true
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
@@ -529,7 +528,6 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
-    mbridge_config: {}
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -100,7 +100,6 @@ actor_rollout_ref:
       - extra
       load_contents: ${.save_contents}
       async_save: false
-      mbridge_config: {}
       strict: true
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
@@ -545,7 +544,6 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
-    mbridge_config: {}
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -98,7 +98,6 @@ actor_rollout_ref:
       - extra
       load_contents: ${.save_contents}
       async_save: false
-      mbridge_config: {}
       strict: true
     use_fused_kernels: ${oc.select:actor_rollout_ref.model.use_fused_kernels,false}
     profiler:
@@ -534,7 +533,6 @@ critic:
     - extra
     load_contents: ${.save_contents}
     async_save: false
-    mbridge_config: {}
   profiler:
     _target_: verl.utils.profiler.ProfilerConfig
     tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -136,13 +136,6 @@ checkpoint:
 
   # Whether to save checkpoints asynchronously. Only effective for Megatron as of now.
   async_save: False
-  
-  # Mbridge config extension.
-  # when vanilla_mbridge=True, and your filesystem is a distributed filesystem,(which means you write a file in node A
-  # and you can read the file in node B immediately)
-  # set `mbridge_config.distributed_filesystem=True` and `mbridge_config.memory_efficient=True` to 
-  # speed up the checkpoint saving by 10x speed.
-  mbridge_config: {}
 
   # Whether to perform strict validation during weight export
   strict: True

--- a/verl/trainer/config/actor/megatron_actor.yaml
+++ b/verl/trainer/config/actor/megatron_actor.yaml
@@ -15,4 +15,16 @@ _target_: verl.workers.config.McoreActorConfig
 
 strategy: megatron
 
-load_weight: True
+# Megatron-specific checkpoint overrides: swap the base CheckpointConfig for
+# McoreCheckpointConfig so ``mbridge_config`` is available.
+checkpoint:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.McoreCheckpointConfig
+
+  # Mbridge config extension.
+  # when vanilla_mbridge=True, and your filesystem is a distributed filesystem,(which means you write a file in node A
+  # and you can read the file in node B immediately)
+  # set `mbridge_config.distributed_filesystem=True` and `mbridge_config.memory_efficient=True` to
+  # speed up the checkpoint saving by 10x speed.
+  mbridge_config: {}

--- a/verl/trainer/config/actor/mindspeed_actor.yaml
+++ b/verl/trainer/config/actor/mindspeed_actor.yaml
@@ -15,4 +15,13 @@ _target_: verl.workers.config.MindSpeedActorConfig
 
 strategy: mindspeed
 
-load_weight: True
+# MindSpeed checkpoint overrides: swap the base CheckpointConfig for
+# MindSpeedCheckpointConfig which inherits ``mbridge_config`` from
+# McoreCheckpointConfig (MindSpeed reuses the Megatron checkpoint manager).
+checkpoint:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.MindSpeedCheckpointConfig
+
+  # Mbridge config extension.
+  mbridge_config: {}

--- a/verl/trainer/config/config.py
+++ b/verl/trainer/config/config.py
@@ -26,6 +26,10 @@ class CheckpointConfig(BaseConfig):
 
     The inheritance from BaseConfig provides omegaconf.DictConfig-like interface for a dataclass config.
 
+    Backend-specific knobs (e.g. mbridge options for Megatron) live on subclasses
+    under ``verl/workers/config/checkpoint.py``. Keep this base class limited to
+    fields every backend understands.
+
     Args:
         save_contents (list[str]): What to include in saved checkpoints.
             Options: 'model', 'optimizer', 'extra', 'hf_model'.
@@ -37,7 +41,6 @@ class CheckpointConfig(BaseConfig):
     save_contents: list[str] = field(default_factory=lambda: ["model", "optimizer", "extra"])
     load_contents: list[str] = field(default_factory=lambda: ["model", "optimizer", "extra"])
     async_save: bool = False
-    mbridge_config: dict[str, Any] = field(default_factory=dict)
     strict: bool = True
 
 

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -79,9 +79,6 @@ checkpoint:
   # Whether to save checkpoints asynchronously. Only effective for Megatron as of now.
   async_save: False
 
-  # Mbridge config extension.
-  mbridge_config: {}
-
 # profile the critic model in `update_critic`
 profiler:
 

--- a/verl/trainer/config/critic/megatron_critic.yaml
+++ b/verl/trainer/config/critic/megatron_critic.yaml
@@ -21,8 +21,15 @@ strategy: megatron
 # seconds, default is 10 minutes for torch, you can set it to a larger value if you have long-running operations like 32B or 72B model using megatron
 nccl_timeout: 600
 
-# Whether to load initial weights
-load_weight: True
-
 # seed for data loader
 data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
+
+# Megatron-specific checkpoint overrides: swap the base CheckpointConfig for
+# McoreCheckpointConfig so ``mbridge_config`` is available.
+checkpoint:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.McoreCheckpointConfig
+
+  # Mbridge config extension.
+  mbridge_config: {}

--- a/verl/trainer/config/critic/mindspeed_critic.yaml
+++ b/verl/trainer/config/critic/mindspeed_critic.yaml
@@ -23,8 +23,16 @@ strategy: mindspeed
 # seconds, default is 10 minutes for torch, you can set it to a larger value if you have long-running operations like 32B or 72B model using megatron
 nccl_timeout: 600
 
-# Whether to load initial weights
-load_weight: True
-
 # seed for data loader
 data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
+
+# MindSpeed checkpoint overrides: swap the base CheckpointConfig for
+# MindSpeedCheckpointConfig which inherits ``mbridge_config`` from
+# McoreCheckpointConfig (MindSpeed reuses the Megatron checkpoint manager).
+checkpoint:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.MindSpeedCheckpointConfig
+
+  # Mbridge config extension.
+  mbridge_config: {}

--- a/verl/trainer/config/ref/megatron_ref.yaml
+++ b/verl/trainer/config/ref/megatron_ref.yaml
@@ -26,5 +26,3 @@ megatron:
   expert_tensor_parallel_size: ${oc.select:actor_rollout_ref.actor.megatron.expert_tensor_parallel_size,null}
   param_offload: ${oc.select:actor_rollout_ref.actor.megatron.param_offload,False}
   forward_only: True
-
-load_weight: True

--- a/verl/trainer/config/ref/mindspeed_ref.yaml
+++ b/verl/trainer/config/ref/mindspeed_ref.yaml
@@ -33,5 +33,3 @@ mindspeed:
   strategy: ${oc.select:actor_rollout_ref.actor.mindspeed.strategy,''}
   mcore_kwargs: ${oc.select:actor_rollout_ref.actor.mindspeed.mcore_kwargs,{}}
   fsdp_kwargs: ${oc.select:actor_rollout_ref.actor.mindspeed.fsdp_kwargs,{}}
-
-load_weight: True

--- a/verl/trainer/config/sft_trainer_engine.yaml
+++ b/verl/trainer/config/sft_trainer_engine.yaml
@@ -55,8 +55,6 @@ checkpoint:
 
   # For more flexibility, you can specify the contents to load from the checkpoint.
   load_contents: ${checkpoint.save_contents}
-  # Mbridge config extension.
-  mbridge_config: {}
 
 trainer:
   default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -118,6 +118,14 @@ class BaseCheckpointManager:
         """
         return "extra" in self.checkpoint_load_contents
 
+    @property
+    def should_load_hf_model(self) -> bool:
+        """
+        Returns True if 'hf_model' is in checkpoint_load_contents, indicating an HF-format model
+        checkpoint should be loaded (e.g. via a bridge).
+        """
+        return "hf_model" in self.checkpoint_load_contents
+
     def load_checkpoint(self, local_path: str, hdfs_path: str = None, del_local_after_load: bool = False):
         raise NotImplementedError
 

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -30,7 +30,6 @@ from megatron.core.transformer.enums import AttnBackend
 from packaging import version
 from transformers import GenerationConfig
 
-from verl.models.weight_loader_registry import get_weight_saver
 from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.fs import is_non_local, local_mkdir_safe
 from verl.utils.logger import log_with_rank
@@ -55,57 +54,31 @@ if not mcore_ge_014:
 
 
 class MegatronCheckpointManager(BaseCheckpointManager):
-    """
-    Checkpoint manager for Megatron-LM distributed training.
+    """Checkpoint manager for Megatron-LM distributed training.
 
-    This class manages the saving and loading of model checkpoints in a Megatron-LM
-    distributed training environment. It handles various aspects of checkpointing
-    including model states, optimizer states, learning rate schedulers, and random
-    number generator states, ensuring compatibility with HuggingFace formats.
+    Two model-checkpoint backends are supported, controlled by ``use_mbridge``:
 
-    Key features:
-    - Distributed checkpoint saving and loading using Megatron's dist_checkpointing
-    - Support for tensor parallel, pipeline parallel, and data parallel configurations
-    - Automatic handling of model state dictionaries across multiple pipeline stages
-    - Integration with HuggingFace model configurations and tokenizers
-    - Random number generator state management for reproducibility
-    - Support for both synchronous and asynchronous checkpoint operations
+    * **mbridge (default)** -- saves / loads model weights in HuggingFace format
+      via megatron-bridge.  Both ``"model"`` and ``"hf_model"`` in
+      ``save_contents`` produce the same HF checkpoint (saved only once).
 
-    The manager automatically handles:
-    - Directory structure creation based on global steps and process ranks
-    - Model configuration and tokenizer saving in HuggingFace format
-    - Optimizer and scheduler state persistence
-    - CUDA RNG state management for deterministic training
-    - Checkpoint cleanup and retention policies
+    * **dist_checkpoint** -- saves model weights using Megatron's native
+      ``dist_checkpointing`` (sharded across ranks).  ``"hf_model"`` in
+      ``save_contents`` is **not** supported with this backend (raises error).
+
+    Optimizer, LR-scheduler, and RNG states always go through
+    ``dist_checkpointing`` regardless of the model backend.
 
     Args:
-        model: The Megatron model instance to checkpoint
-        optimizer: The optimizer instance (optional)
-        lr_scheduler: The learning rate scheduler instance (optional)
-
-    Attributes:
-        model: Reference to the Megatron model being checkpointed
-        optimizer: Reference to the optimizer (if provided)
-        lr_scheduler: Reference to the learning rate scheduler (if provided)
-        rank: Current process rank in the distributed setup
-
-    Example:
-        ```python
-        checkpoint_manager = MegatronCheckpointManager(
-            model=megatron_model,
-            optimizer=optimizer,
-            lr_scheduler=scheduler
-        )
-
-        checkpoint_manager.save_checkpoint(
-            local_path="checkpoints/step_1000",
-            global_step=1000
-        )
-
-        checkpoint_manager.load_checkpoint(
-            local_path="checkpoints/step_1000"
-        )
-        ```
+        model: The Megatron model instance to checkpoint.
+        optimizer: The optimizer instance.
+        lr_scheduler: The learning rate scheduler instance.
+        use_mbridge: If ``True`` (default), model weights are saved/loaded via
+            megatron-bridge in HuggingFace format.  Requires ``bridge`` to be
+            provided.  If ``False``, ``dist_checkpointing`` is used for model
+            weights.
+        use_dist_checkpointing: Legacy alias -- when provided, it sets
+            ``use_mbridge = not use_dist_checkpointing``.
     """
 
     def __init__(
@@ -125,7 +98,8 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         optimizer_scheduler,
         use_distributed_optimizer: bool,
         use_checkpoint_opt_param_scheduler: bool = False,
-        use_dist_checkpointing: bool = True,
+        use_dist_checkpointing: bool | None = None,
+        use_mbridge: bool = True,
         bridge=None,
         provider=None,
         peft_cls=None,
@@ -142,9 +116,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.config = config
         self.transformer_config = transformer_config
         self.role = role
-        self.is_value_model = False
-        if self.role in ["reward", "critic"]:
-            self.is_value_model = True
+        self.is_value_model = self.role in ("reward", "critic")
         self.model_config = model_config
         self.hf_config = hf_config
         self.param_dtype = param_dtype
@@ -157,15 +129,57 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.vanilla_bridge = self.provider is None
         self.peft_cls = peft_cls
         self.rank = torch.distributed.get_rank()
-        # Megatron-Bridge is Okay to load/save HF checkpoint for value model as well
-        self.use_dist_checkpointing = (
-            use_dist_checkpointing or not self.bridge or (self.vanilla_bridge and self.is_value_model)
-        )
-        self.use_hf_checkpoint = not self.use_dist_checkpointing
 
-        self.weight_saver = None
-        if self.bridge is None:
-            self.weight_saver = get_weight_saver(self.arch)
+        # --- Resolve backend ---------------------------------------------------
+        # Legacy callers may still pass ``use_dist_checkpointing``; translate it.
+        if use_dist_checkpointing is not None:
+            use_mbridge = not use_dist_checkpointing
+
+        if use_mbridge and self.bridge is None:
+            raise ValueError(
+                "MegatronCheckpointManager: use_mbridge=True requires a bridge "
+                "instance. Either pass `bridge=...` or set `use_mbridge=False` "
+                "to use dist_checkpointing for model weights."
+            )
+
+        self.use_mbridge = use_mbridge
+        # Aliases kept so the rest of the codebase can read them without change.
+        self.use_dist_checkpointing = not self.use_mbridge
+        self.use_hf_checkpoint = self.use_mbridge
+
+        # --- Validate & resolve save_contents vs backend ----------------------
+        # Per the RFC:
+        #   mbridge   + model    → save HF model via bridge
+        #   mbridge   + hf_model → same as model (deduplicated, save once)
+        #   dist_ckpt + model    → save via mcore dist_checkpointing
+        #   dist_ckpt + hf_model → ERROR (not supported)
+        #   both backends False  → ERROR
+        if not self.use_mbridge and not self.use_dist_checkpointing:
+            raise ValueError(
+                "MegatronCheckpointManager: at least one model-weight backend "
+                "must be enabled (use_mbridge or dist_checkpointing)."
+            )
+
+        if self.should_save_hf_model and not self.use_mbridge:
+            raise ValueError(
+                "save_contents contains 'hf_model' but mbridge is disabled. "
+                "'hf_model' is only supported with mbridge. Either enable "
+                "mbridge or remove 'hf_model' from save_contents."
+            )
+
+        # Whether we actually need to write model weights via each backend.
+        # When mbridge is active, both 'model' and 'hf_model' resolve to a
+        # single HF save (deduplicated).
+        self._save_model_via_mbridge = self.use_mbridge and (self.should_save_model or self.should_save_hf_model)
+        self._save_model_via_dist_ckpt = self.use_dist_checkpointing and self.should_save_model
+
+        # PEFT adapter shards always live in dist_checkpoint even with mbridge,
+        # because bridge handles only the base model.
+        self._save_peft_adapters_in_dist_ckpt = self._save_model_via_mbridge and self.peft_cls is not None
+
+        self._load_model_via_mbridge = self.use_mbridge and self.should_load_model and self.peft_cls is None
+        # PEFT adapters always live in the dist_checkpoint directory.
+        self._load_model_via_dist_ckpt = self.should_load_model and (not self.use_mbridge or self.peft_cls is not None)
 
     def get_rng_state(self, use_dist_ckpt: bool = True, data_parallel_random_init: bool = False):
         """collect rng state across data parallel ranks"""
@@ -247,65 +261,63 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             return common_path
         return os.path.join(common_path, basename)
 
-    def generate_state_dict(
+    # -- Sharded state dict builders -------------------------------------------
+    # Each builder produces an independent piece of the dist_checkpoint state
+    # dict.  Callers compose exactly the pieces they need rather than building
+    # one monolithic dict every time.
+
+    def _build_model_sharded_state_dict(self, metadata: dict) -> dict:
+        """Build the model's sharded state dict for all VPP ranks.
+
+        This is used both for persisting model weights (dist_ckpt backend) and
+        as metadata input for the optimizer's ``sharded_state_dict()`` method
+        (every Megatron optimizer takes ``model_sharded_state_dict`` as its
+        first argument but only reads it — the model tensors are not included
+        in the optimizer's output).
+        """
+        model_sharded_state_dict = {}
+        model_metadata = dict(metadata)
+        model_metadata["dp_cp_group"] = mpu.get_data_parallel_group(with_context_parallel=True)
+        for vpp_rank, model in enumerate(self.model):
+            if len(self.model) > 1:
+                mpu.set_virtual_pipeline_model_parallel_rank(vpp_rank)
+                key = f"model{vpp_rank}"
+            else:
+                key = "model"
+            if hasattr(model, "module"):
+                model = model.module
+            model_sharded_state_dict[key] = model.sharded_state_dict(metadata=model_metadata)
+        return model_sharded_state_dict
+
+    def _build_optimizer_state_dict(
         self,
-        generate_model: bool = True,
-        generate_optimizer: bool = True,
-        generate_extra: bool = True,
+        model_sharded_state_dict: dict,
+        metadata: dict,
         is_loading: bool = False,
-        metadata: dict | None = None,
-    ):
-        # For save dist checkpointing
+    ) -> dict:
+        """Build the optimizer (+ LR scheduler) sharded state dict.
+
+        ``model_sharded_state_dict`` is required because Megatron's optimizer
+        ``sharded_state_dict()`` uses the model's sharding layout to map
+        optimizer states to parameter shards.  It is consumed read-only and
+        its entries do **not** appear in the returned dict.
+        """
+        torch.distributed.barrier()
+        sharded_state_dict_kwargs = {"is_loading": is_loading}
+        if metadata is not None and mcore_ge_014:
+            sharded_state_dict_kwargs["metadata"] = metadata
         state_dict = {}
-        base_metadata = metadata or self._build_sharded_state_dict_metadata()
-
-        should_generate_model_sections = generate_model or generate_optimizer
-
-        # All ranks save model state dict when it is needed for either model checkpointing
-        # or optimizer sharded_state_dict generation.
-        if should_generate_model_sections:
-            for vpp_rank, model in enumerate(self.model):
-                if len(self.model) > 1:
-                    mpu.set_virtual_pipeline_model_parallel_rank(vpp_rank)
-                    key = f"model{vpp_rank}" if len(self.model) > 1 else "model"
-                else:
-                    key = "model"
-                if hasattr(model, "module"):
-                    model = model.module
-
-                # GPTModel's sharded_state_dict function when having mtp requires metadata['dp_cp_group']
-                model_metadata = dict(base_metadata)
-                model_metadata["dp_cp_group"] = mpu.get_data_parallel_group(with_context_parallel=True)
-                kwargs = {"metadata": model_metadata}
-                state_dict[key] = model.sharded_state_dict(**kwargs)
-
-        # Optimizer State Dict
-        if generate_optimizer:
-            torch.distributed.barrier()
-            sharded_state_dict_kwargs = {"is_loading": is_loading}
-            if base_metadata is not None:
-                # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.14.0/megatron/core/optimizer/distrib_optimizer.py#L1109-L1123
-                if mcore_ge_014:
-                    sharded_state_dict_kwargs["metadata"] = base_metadata
-            optimizer_sharded_states = self.optimizer.sharded_state_dict(state_dict, **sharded_state_dict_kwargs)
-            state_dict["optimizer"] = optimizer_sharded_states
-
-            if self.lr_scheduler is not None:
-                lr_state_dict = self.lr_scheduler.state_dict()
-                state_dict["lr_scheduler"] = lr_state_dict
-
-        if not generate_model:
-            for key in list(state_dict.keys()):
-                if self._is_model_state_key(key):
-                    state_dict.pop(key)
-
-        # RNG States State Dict
-        if generate_extra:
-            torch.distributed.barrier()
-            rng_state = self.get_rng_state()
-            state_dict["rng_state"] = rng_state
-
+        state_dict["optimizer"] = self.optimizer.sharded_state_dict(
+            model_sharded_state_dict, **sharded_state_dict_kwargs
+        )
+        if self.lr_scheduler is not None:
+            state_dict["lr_scheduler"] = self.lr_scheduler.state_dict()
         return state_dict
+
+    def _build_extra_state_dict(self) -> dict:
+        """Build the extra state dict (RNG states)."""
+        torch.distributed.barrier()
+        return {"rng_state": self.get_rng_state()}
 
     def _build_sharded_state_dict_metadata(self) -> dict:
         """Builds metadata used for sharded_state_dict versioning.
@@ -344,10 +356,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         metadata["singleton_local_shards"] = False
         metadata["chained_optim_avoid_prefix"] = True
         return metadata
-
-    @staticmethod
-    def _is_model_state_key(key: str) -> bool:
-        return key == "model" or (key.startswith("model") and key[5:].isdigit())
 
     @staticmethod
     def _has_checkpoint_files(path: str) -> bool:
@@ -404,7 +412,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         if local_path is not None:
             assert os.path.exists(local_path), f"Checkpoint path {local_path} does not exist."
 
-        # For load optimizer dist_ckpt
         try:
             import transformer_engine
 
@@ -418,40 +425,46 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         load_content_metadata = getattr(dist_checkpointing, "load_content_metadata", None)
         if load_content_metadata is None:
-            # For backward compatibility
-            sharded_sd_metadata = None
+            metadata = None
         else:
-            sharded_sd_metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
-        if sharded_sd_metadata is None:
+            metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
+        if metadata is None:
             if self.use_distributed_optimizer:
-                # Backward-compatibility with old checkpoints which don't have content versioning
-                # Can be removed after ending support for MLM optimizer checkpoints with MCore < v0.13
-                # (for MCore v0.13+ checkpoints `sharded_sd_metadata is not None`)
-                sharded_sd_metadata = {
-                    "distrib_optim_sharding_type": "fully_sharded_model_space",
-                }
+                metadata = {"distrib_optim_sharding_type": "fully_sharded_model_space"}
             else:
-                sharded_sd_metadata = self._build_sharded_state_dict_metadata()
+                metadata = self._build_sharded_state_dict_metadata()
 
-        # Get State Dict for loading
-        should_load_dist_model = self.should_load_model and (self.use_dist_checkpointing or self.peft_cls is not None)
-        sharded_state_dict = self.generate_state_dict(
-            should_load_dist_model,
-            self.should_load_optimizer,
-            self.should_load_extra,
-            is_loading=True,
-            metadata=sharded_sd_metadata,
-        )
+        # ── Compose the sharded state dict from individual pieces ─────────────
+        # Same principle as save: optimizer and extra always go through
+        # dist_checkpointing.  Model sharded state dict is only built when
+        # needed (optimizer metadata input or loading model weights via dist_ckpt).
+        sharded_state_dict = {}
+
+        model_sharded_state_dict = None
+        if self.should_load_optimizer or self._load_model_via_dist_ckpt:
+            model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
+
+        if self.should_load_optimizer:
+            sharded_state_dict.update(
+                self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
+            )
+
+        if self.should_load_extra:
+            sharded_state_dict.update(self._build_extra_state_dict())
+
+        if self._load_model_via_dist_ckpt:
+            sharded_state_dict.update(model_sharded_state_dict)
+
         sharded_state_dict = self._maybe_filter_peft_state_dict(sharded_state_dict)
         log_with_rank(f"Generated state dict for loading: {sharded_state_dict.keys()}", rank=self.rank, logger=logger)
 
-        # Load Dist Checkpointing
         state_dict = load_dist_checkpointing(
             sharded_state_dict=sharded_state_dict,
             ckpt_dir=dist_checkpoint_path,
         )
 
-        if should_load_dist_model:
+        # ── Load model weights ────────────────────────────────────────────────
+        if self._load_model_via_dist_ckpt:
             assert "model" in state_dict or any(
                 f"model{vpp_rank}" in state_dict for vpp_rank in range(len(self.model))
             ), f"Model state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
@@ -470,38 +483,33 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             else:
                 log_with_rank(f"Loaded sharded model checkpoint from {local_path}", rank=self.rank, logger=logger)
 
-        # Skip HF checkpoint loading if PEFT is used
-        elif self.should_load_model and self.use_hf_checkpoint and self.peft_cls is None:
+        elif self._load_model_via_mbridge:
             hf_model_path = get_hf_model_checkpoint_path(local_path)
-            if self.vanilla_bridge:
-                self.bridge.load_weights(self.model, hf_model_path)
-            else:
-                self.bridge.load_hf_weights(self.model, hf_model_path)
+            self._load_model_via_bridge(hf_model_path)
             log_with_rank(f"Loaded HF model checkpoint from {hf_model_path} with bridge", rank=self.rank, logger=logger)
 
+        # ── Load optimizer / LR scheduler ─────────────────────────────────────
         if self.should_load_optimizer:
             assert "optimizer" in state_dict, (
                 f"Optimizer state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
             )
-            optimizer_state_dict = state_dict["optimizer"]
-            self.optimizer.load_state_dict(optimizer_state_dict)
+            self.optimizer.load_state_dict(state_dict["optimizer"])
             log_with_rank(f"Loaded optimizer checkpoint from {local_path}", rank=self.rank, logger=logger)
             if self.use_checkpoint_opt_param_scheduler:
                 assert "lr_scheduler" in state_dict, (
                     f"LR scheduler state dict not found in {state_dict.keys()}. Please check the checkpoint file "
                     f"{local_path}."
                 )
-                lr_scheduler_state_dict = state_dict["lr_scheduler"]
                 if self.lr_scheduler is not None:
-                    self.lr_scheduler.load_state_dict(lr_scheduler_state_dict)
+                    self.lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
                     log_with_rank(f"Loaded LR scheduler checkpoint from {local_path}", rank=self.rank, logger=logger)
 
+        # ── Load RNG states ───────────────────────────────────────────────────
         if self.should_load_extra:
             assert "rng_state" in state_dict, (
                 f"RNG state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
             )
-            rng_state = state_dict["rng_state"]
-            self.load_rng_states(rng_state)
+            self.load_rng_states(state_dict["rng_state"])
             log_with_rank(f"Loaded RNG states from {local_path}", rank=self.rank, logger=logger)
 
         if del_local_after_load:
@@ -514,8 +522,130 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                     logger=logger,
                 )
 
+    # -- Bridge helpers --------------------------------------------------------
+
+    def _get_bridge_extended_args(self):
+        """Build extra kwargs for ``bridge.save_weights`` from checkpoint config."""
+        extended_args = {}
+        mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
+        for sig in inspect.signature(self.bridge.save_weights).parameters:
+            if sig in ("weights_path", "models"):
+                continue
+            if sig in mbridge_config:
+                extended_args[sig] = mbridge_config[sig]
+        return extended_args
+
+    def _save_model_via_bridge(self, hf_ckpt_path: str):
+        """Save model weights through megatron-bridge."""
+        if self.vanilla_bridge:
+            self.bridge.save_weights(self.model, hf_ckpt_path, **self._get_bridge_extended_args())
+        else:
+            if self.peft_cls is not None:
+                hf_adapter_ckpt_path = os.path.join(hf_ckpt_path, "adapter")
+                self.bridge.save_hf_adapter(self.model, hf_adapter_ckpt_path, self.peft_cls)
+                log_with_rank(
+                    f"Saved HF PEFT adapter checkpoint to {hf_adapter_ckpt_path}",
+                    rank=self.rank,
+                    logger=logger,
+                    log_only_rank_0=True,
+                )
+            else:
+                self.bridge.save_hf_weights(self.model, hf_ckpt_path)
+
+    def _load_model_via_bridge(self, hf_model_path: str):
+        """Load model weights through megatron-bridge."""
+        if self.vanilla_bridge:
+            self.bridge.load_weights(self.model, hf_model_path)
+        else:
+            self.bridge.load_hf_weights(self.model, hf_model_path)
+
+    def _save_hf_config_and_tokenizer(self, local_path: str):
+        """Rank-0 saves HF config, tokenizer, and generation config."""
+        if self.rank != 0:
+            return
+        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
+        if self.processing_class is not None:
+            self.processing_class.save_pretrained(hf_config_tokenizer_path)
+        self.hf_config.save_pretrained(hf_config_tokenizer_path)
+        if hasattr(self.hf_config, "name_or_path") and self.hf_config.name_or_path:
+            try:
+                generation_config = GenerationConfig.from_pretrained(self.hf_config.name_or_path)
+                generation_config.save_pretrained(hf_config_tokenizer_path)
+            except Exception:
+                pass
+        log_with_rank(
+            f"Saved Huggingface config and tokenizer to {hf_config_tokenizer_path}",
+            rank=self.rank,
+            logger=logger,
+            log_only_rank_0=True,
+        )
+
+    def _save_transformer_config(self, local_path: str):
+        """Rank-0 serialises the Megatron TransformerConfig to JSON."""
+        if self.rank != 0:
+            return
+        print(self.transformer_config)
+        bypass_keys = [
+            "finalize_model_grads_func",
+            "grad_scale_func",
+            "no_sync_func",
+            "grad_sync_func",
+            "param_sync_func",
+            "generation_config",
+            "_pg_collection",
+        ]
+        backup = {}
+        for k in bypass_keys:
+            if hasattr(self.transformer_config, k):
+                backup[k] = getattr(self.transformer_config, k, None)
+                delattr(self.transformer_config, k)
+        transformer_config_dict = asdict(self.transformer_config)
+        for k in backup:
+            setattr(self.transformer_config, k, backup[k])
+        to_convert_types = {torch.dtype: str, AttnBackend: str}
+        ignore_types = [Callable]
+        pop_keys = []
+        for key, value in transformer_config_dict.items():
+            if type(value) in to_convert_types:
+                transformer_config_dict[key] = to_convert_types[type(value)](value)
+            if type(value) in ignore_types:
+                pop_keys.append(key)
+            if callable(value):
+                pop_keys.append(key)
+        for key in pop_keys:
+            transformer_config_dict.pop(key)
+        transformer_config_path = get_transformer_config_checkpoint_path(local_path)
+        with open(transformer_config_path, "w") as f:
+            json.dump(transformer_config_dict, f, indent=2)
+
+    # -- Save / Load ----------------------------------------------------------
+
+    def _save_dist_checkpoint(self, dist_checkpoint_path: str, state_dict: dict):
+        """Persist ``state_dict`` via Megatron dist_checkpointing.
+
+        The caller is responsible for composing exactly the pieces that belong
+        in the dist_checkpoint directory (optimizer, extra, and optionally
+        model / PEFT adapter shards).
+
+        Returns the async save request when ``async_save`` is enabled, or
+        ``None`` for synchronous saves.
+        """
+        sharded_sd_metadata = self._build_sharded_state_dict_metadata()
+
+        async_save_request = save_dist_checkpointing(
+            sharded_state_dict=state_dict,
+            ckpt_path=dist_checkpoint_path,
+            async_save=self.checkpoint_config.async_save,
+            content_metadata=sharded_sd_metadata,
+        )
+
+        if not self.checkpoint_config.async_save:
+            assert async_save_request is None, "Async save request should be None when not using async save."
+            torch.distributed.barrier()
+
+        return async_save_request
+
     def save_checkpoint(self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep=None):
-        # record the previous global step
         self.previous_global_step = global_step
 
         if not self.checkpoint_config.async_save:
@@ -523,236 +653,80 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         local_path = local_mkdir_safe(local_path)
         dist_checkpoint_path = get_dist_checkpoint_path(local_path)
+        metadata = self._build_sharded_state_dict_metadata()
 
-        # Note that model weights, optimizer states, and extra states are generated
-        # together in a state dict, we save them in one time
-        if self.use_dist_checkpointing:
-            # Generate state dict for saving
-            sharded_sd_metadata = self._build_sharded_state_dict_metadata()
-            state_dict = self.generate_state_dict(
-                self.should_save_model,
-                self.should_save_optimizer,
-                self.should_save_extra,
-                metadata=sharded_sd_metadata,
-            )
-            state_dict = self._maybe_filter_peft_state_dict(state_dict)
-            log_with_rank(f"Generated state dict for saving: {state_dict.keys()}", rank=self.rank, logger=logger)
-            for vpp_rank, model in enumerate(self.model):
-                if len(self.model) > 1:
-                    model_i_keys = state_dict[f"model{vpp_rank}"].keys()
-                    log_with_rank(f"Generated state dict for saving: {model_i_keys}", rank=self.rank, logger=logger)
-                else:
-                    log_with_rank(
-                        f"Generated state dict for saving: {state_dict['model'].keys()}", rank=self.rank, logger=logger
-                    )
-            # Start Async save if enabled
-            async_save_request = save_dist_checkpointing(
-                sharded_state_dict=state_dict,
-                ckpt_path=dist_checkpoint_path,
-                async_save=self.checkpoint_config.async_save,
-                content_metadata=sharded_sd_metadata,
-            )
+        # ── Compose the dist_checkpoint state dict ──────────────────────────────
+        # dist_checkpointing is the universal backend for optimizer and extra
+        # states, regardless of which model backend (mbridge / dist_ckpt) is
+        # used.  Model weights only go into dist_ckpt when mbridge is disabled
+        # (or for PEFT adapters which bridge doesn't handle).
+        #
+        # The model sharded state dict is built as a transient dependency when
+        # the optimizer needs it — Megatron's optimizer.sharded_state_dict()
+        # requires the model's sharding layout as read-only input.
+        dist_ckpt_state_dict = {}
 
-            # Synchronize all async save requests
-            if not self.checkpoint_config.async_save:
-                assert async_save_request is None, "Async save request should be None when not using async save."
-                torch.distributed.barrier()
-        else:
-            assert self.use_hf_checkpoint, "When not using distributed checkpointing, use_hf_checkpoint should be True."
-            # Generate optimizer and exra state dicts
-            sharded_sd_metadata = self._build_sharded_state_dict_metadata()
-            state_dict = self.generate_state_dict(
-                generate_model=self.should_save_model and self.peft_cls is not None,
-                generate_optimizer=self.should_save_optimizer,
-                generate_extra=self.should_save_extra,
-                metadata=sharded_sd_metadata,
-            )
-            state_dict = self._maybe_filter_peft_state_dict(state_dict)
-            # Save optimizer and extra states to local path
-            # Start Async save if enabled
-            async_save_request = save_dist_checkpointing(
-                sharded_state_dict=state_dict,
-                ckpt_path=dist_checkpoint_path,
-                async_save=self.checkpoint_config.async_save,
-                content_metadata=sharded_sd_metadata,
-            )
+        # Optimizer needs model sharded state dict as metadata input.
+        model_sharded_state_dict = None
+        if self.should_save_optimizer or self._save_model_via_dist_ckpt or self._save_peft_adapters_in_dist_ckpt:
+            model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
-            # Synchronize all async save requests
-            if not self.checkpoint_config.async_save:
-                assert async_save_request is None, "Async save request should be None when not using async save."
-                torch.distributed.barrier()
-
-        if self.should_save_model:
-            if self.use_hf_checkpoint:
-                # Use mbridge to save HF model checkpoint
-                log_with_rank(f"Saving HF model checkpoint to {local_path} with bridge", rank=self.rank, logger=logger)
-                hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                if self.vanilla_bridge:
-                    extended_args = {}
-                    mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
-                    for sig in inspect.signature(self.bridge.save_weights).parameters:
-                        if sig == "weights_path" or sig == "models":
-                            continue
-                        if sig in mbridge_config:
-                            extended_args[sig] = mbridge_config[sig]
-                    self.bridge.save_weights(self.model, hf_ckpt_path, **extended_args)
-                else:
-                    if self.peft_cls is not None:
-                        hf_adapter_ckpt_path = os.path.join(hf_ckpt_path, "adapter")
-                        self.bridge.save_hf_adapter(self.model, hf_adapter_ckpt_path, self.peft_cls)
-                        log_with_rank(
-                            f"Saved HF PEFT adapter checkpoint to {hf_adapter_ckpt_path}",
-                            rank=self.rank,
-                            logger=logger,
-                            log_only_rank_0=True,
-                        )
-                    else:
-                        self.bridge.save_hf_weights(self.model, hf_ckpt_path)
-
-                log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
-
-            # Only rank 0 saves the hf config and tokenizer to huggingface path
-            # No matter whether we save hf model or not
-            if self.rank == 0:
-                # Save tokenizer
-                hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
-                if self.processing_class is not None:
-                    self.processing_class.save_pretrained(hf_config_tokenizer_path)
-                # Save huggingface config
-                self.hf_config.save_pretrained(hf_config_tokenizer_path)
-                if hasattr(self.hf_config, "name_or_path") and self.hf_config.name_or_path:
-                    try:
-                        generation_config = GenerationConfig.from_pretrained(self.hf_config.name_or_path)
-                        generation_config.save_pretrained(hf_config_tokenizer_path)
-                    except Exception:
-                        # if the generation config isn't available, we don't save it
-                        pass
-                log_with_rank(
-                    f"Saved Huggingface config and tokenizer to {hf_config_tokenizer_path}",
-                    rank=self.rank,
-                    logger=logger,
-                    log_only_rank_0=True,
-                )
+        if self.should_save_optimizer:
+            dist_ckpt_state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata))
 
         if self.should_save_extra:
-            if self.rank == 0:
-                # Save transformer config
-                print(self.transformer_config)
-                bypass_keys = [
-                    "finalize_model_grads_func",
-                    "grad_scale_func",
-                    "no_sync_func",
-                    "grad_sync_func",
-                    "param_sync_func",
-                    "generation_config",
-                    "_pg_collection",
-                ]
-                backup = {}
-                for k in bypass_keys:
-                    if hasattr(self.transformer_config, k):
-                        backup[k] = getattr(self.transformer_config, k, None)
-                        delattr(self.transformer_config, k)
-                transformer_config_dict = asdict(self.transformer_config)
-                for k in backup:
-                    setattr(self.transformer_config, k, backup[k])
-                to_convert_types = {torch.dtype: str, AttnBackend: str}
-                ignore_types = [Callable]
-                pop_keys = []
-                for key, value in transformer_config_dict.items():
-                    if type(value) in to_convert_types:
-                        transformer_config_dict[key] = to_convert_types[type(value)](value)
-                    if type(value) in ignore_types:
-                        pop_keys.append(key)
-                    if callable(value):
-                        pop_keys.append(key)
-                for key in pop_keys:
-                    transformer_config_dict.pop(key)
-                transformer_config_path = get_transformer_config_checkpoint_path(local_path)
-                with open(transformer_config_path, "w") as f:
-                    json.dump(transformer_config_dict, f, indent=2)
+            dist_ckpt_state_dict.update(self._build_extra_state_dict())
 
-        if self.should_save_hf_model and not self.use_hf_checkpoint:
-            # wait for everyone to dump to local
-            if self.bridge is not None:
-                hf_model_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                if self.vanilla_bridge:
-                    extended_args = {}
-                    mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
-                    for sig in inspect.signature(self.bridge.save_weights).parameters:
-                        if sig == "weights_path" or sig == "models":
-                            continue
-                        if sig in mbridge_config:
-                            extended_args[sig] = mbridge_config[sig]
-                    self.bridge.save_weights(self.model, hf_model_ckpt_path, **extended_args)
-                else:
-                    self.bridge.save_hf_weights(self.model, hf_model_ckpt_path)
-            else:
-                state_dict = self.weight_saver(
-                    self.model,
-                    self.hf_config,
-                    dtype=self.param_dtype,
-                    is_value_model=self.is_value_model,
-                    tie_word_embeddings=self.share_embeddings_and_output_weights,
-                )
+        # Model shards go into dist_ckpt only when mbridge is disabled.
+        if self._save_model_via_dist_ckpt:
+            dist_ckpt_state_dict.update(model_sharded_state_dict)
+            log_with_rank(
+                f"dist_ckpt will save model shards: {model_sharded_state_dict.keys()}",
+                rank=self.rank,
+                logger=logger,
+            )
 
-                torch.distributed.barrier()
-                if self.rank == 0:
-                    hf_model_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                    import warnings
+        # PEFT adapter shards always live in dist_ckpt (bridge handles base model only).
+        if self._save_peft_adapters_in_dist_ckpt:
+            peft_state = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
+            dist_ckpt_state_dict.update(peft_state)
 
-                    from accelerate import init_empty_weights
+        # ── 1. Save composed state dict via dist_checkpointing ─────────────────
+        async_save_request = None
+        if dist_ckpt_state_dict:
+            async_save_request = self._save_dist_checkpoint(dist_checkpoint_path, dist_ckpt_state_dict)
 
-                    with init_empty_weights(), warnings.catch_warnings():
-                        warnings.simplefilter("ignore")
-                        if "mistral7b-rm" in self.config.model.path:
-                            from transformers import MistralForSequenceClassification
+        # ── 2. Save model weights via mbridge (HF format) ─────────────────────
+        if self._save_model_via_mbridge:
+            hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
+            log_with_rank(f"Saving HF model checkpoint to {hf_ckpt_path} with bridge", rank=self.rank, logger=logger)
+            self._save_model_via_bridge(hf_ckpt_path)
+            log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
 
-                            model = MistralForSequenceClassification.from_pretrained(
-                                self.config.model.path
-                            )  # use score head instead of lm_head
-                            state_dict["score.weight"] = state_dict["score.weight"]
-                        else:
-                            from transformers import AutoModelForCausalLM
+        # ── 3. HF config / tokenizer (rank 0) ────────────────────────────────
+        if self._save_model_via_mbridge:
+            self._save_hf_config_and_tokenizer(local_path)
 
-                            model = AutoModelForCausalLM.from_pretrained(self.config.model.path, torch_dtype="auto")
-                    model.save_pretrained(hf_model_ckpt_path, state_dict=state_dict)
-                    log_with_rank(
-                        f"Saved Huggingface config and tokenizer to {hf_model_ckpt_path}",
-                        rank=self.rank,
-                        logger=logger,
-                        log_only_rank_0=True,
-                    )
+        # ── 4. Transformer config (rank 0) ────────────────────────────────────
+        if self.should_save_extra:
+            self._save_transformer_config(local_path)
 
-                    if hdfs_path is not None:
-                        log_with_rank(
-                            f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger, log_only_rank_0=True
-                        )
-                        from verl.utils import hdfs_io
-
-                        hdfs_io.makedirs(hdfs_path, exist_ok=True)
-                        hdfs_io.copy(src=hf_model_ckpt_path, dst=hdfs_path, dirs_exist_ok=True)
-                        log_with_rank(
-                            f"HDFS checkpoint uploaded to {hdfs_path}",
-                            rank=self.rank,
-                            logger=logger,
-                            log_only_rank_0=True,
-                        )
+        # ── 5. Finalization (HDFS upload, tracker, retention) ─────────────────
+        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
+        saved_dist_ckpt = bool(dist_ckpt_state_dict)
 
         def finalize_save_fn():
-            # Rank 0 uploads checkpoint to HDFS if hdfs_path is provided
-            log_with_rank(
-                f"Dist checkpointing save completed for {dist_checkpoint_path}", rank=self.rank, logger=logger
-            )
-            if self.rank == 0:
-                if hdfs_path is not None:
-                    log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
-                    from verl.utils import hdfs_io
+            log_with_rank(f"Checkpoint save completed for {local_path}", rank=self.rank, logger=logger)
+            if self.rank == 0 and hdfs_path is not None:
+                log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
+                from verl.utils import hdfs_io
 
-                    hdfs_io.makedirs(hdfs_path, exist_ok=True)
+                hdfs_io.makedirs(hdfs_path, exist_ok=True)
+                if saved_dist_ckpt:
                     hdfs_io.copy(src=dist_checkpoint_path, dst=hdfs_path, dirs_exist_ok=True)
+                if self._save_model_via_mbridge:
                     hdfs_io.copy(src=hf_config_tokenizer_path, dst=hdfs_path, dirs_exist_ok=True)
 
-            # update latest_checkpointed_iteration.txt when async_save is True
             if self.checkpoint_config.async_save and self.rank == 0:
                 log_with_rank(
                     f"Update latest_checkpointed_iteration.txt to step {global_step}",
@@ -767,8 +741,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
             self.register_checkpoint(local_path, max_ckpt_to_keep)
 
-        if self.checkpoint_config.async_save:
-            assert async_save_request is not None, "Async save request should not be None when using async save."
+        if self.checkpoint_config.async_save and async_save_request is not None:
             async_save_request.add_finalize_fn(finalize_save_fn)
             from megatron.core.dist_checkpointing.strategies.base import async_calls
 

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -595,13 +595,15 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             "_pg_collection",
         ]
         backup = {}
-        for k in bypass_keys:
-            if hasattr(self.transformer_config, k):
-                backup[k] = getattr(self.transformer_config, k, None)
-                delattr(self.transformer_config, k)
-        transformer_config_dict = asdict(self.transformer_config)
-        for k in backup:
-            setattr(self.transformer_config, k, backup[k])
+        try:
+            for k in bypass_keys:
+                if hasattr(self.transformer_config, k):
+                    backup[k] = getattr(self.transformer_config, k, None)
+                    delattr(self.transformer_config, k)
+            transformer_config_dict = asdict(self.transformer_config)
+        finally:
+            for k in backup:
+                setattr(self.transformer_config, k, backup[k])
         to_convert_types = {torch.dtype: str, AttnBackend: str}
         ignore_types = [Callable]
         pop_keys = []

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -115,32 +115,42 @@ def _config_to_shallow_dict(config):
 class MegatronCheckpointManager(BaseCheckpointManager):
     """Checkpoint manager for Megatron-LM distributed training.
 
-    Model weights are saved/loaded in exactly one format, selected by a
-    single flag that matches the user-facing YAML config (
-    ``*.megatron.use_dist_checkpointing``):
+    * ``use_dist_checkpointing`` -- when ``True``, Megatron sharded weights for
+      the ``model`` slot are saved/loaded via ``dist_checkpointing`` under
+      ``model/dist_ckpt/`` (mirrors ``*.megatron.use_dist_checkpointing``).
 
-    * ``use_dist_checkpointing=False`` (default) -- HuggingFace format via
-      megatron-bridge, under ``model/huggingface/``. Requires a ``bridge``.
-    * ``use_dist_checkpointing=True`` -- Megatron native sharded format via
-      ``dist_checkpointing``, under ``model/dist_ckpt/``.
+    * **HuggingFace / mbridge** -- any HF-format model weights (``hf_model`` in
+      contents, or ``model`` when not using dist shards for that slot) require a
+      non-``None`` ``bridge`` instance. The engine constructs the bridge when
+      mbridge is enabled.
+
+    These combine: e.g. ``save_contents=['model', 'hf_model', ...]`` with
+    ``use_dist_checkpointing=True`` and a ``bridge`` writes both
+    ``model/dist_ckpt/`` and ``model/huggingface/``.
+
+    When ``use_dist_checkpointing=False``, the ``model`` entry maps to the HF
+    tree only (no Megatron model shards unless PEFT adapter shards are needed).
 
     Optimizer, LR-scheduler, and RNG states always go through
     ``dist_checkpointing`` regardless of the model format.
 
-    Interaction with ``save_contents``:
+    Interaction with ``save_contents`` / ``load_contents``:
 
-    * ``model`` -- saved via the selected format.
-    * ``hf_model`` -- requires ``use_dist_checkpointing=False`` (i.e. the HF
-      path); deduplicated against ``model`` when both are present.
+    * ``model`` -- HF via ``bridge`` if not ``use_dist_checkpointing``; Megatron
+      shards if ``use_dist_checkpointing``; both trees when ``hf_model`` is also
+      listed and ``bridge`` is provided.
+    * ``hf_model`` -- HF weights via ``bridge``; requires ``bridge`` is not
+      ``None``. With only the HF ``model`` path, ``model`` and ``hf_model`` are
+      deduplicated (saved once).
 
     Args:
         model: The Megatron model instance to checkpoint.
         optimizer: The optimizer instance.
         lr_scheduler: The learning rate scheduler instance.
-        use_dist_checkpointing: If ``True``, save/load model weights via
-            Megatron's native ``dist_checkpointing``. If ``False`` (default),
-            save/load HuggingFace weights via ``bridge``. Mirrors the
-            ``*.megatron.use_dist_checkpointing`` YAML field.
+        use_dist_checkpointing: If ``True``, include Megatron ``dist_checkpointing``
+            shards for the ``model`` slot. Mirrors ``*.megatron.use_dist_checkpointing``.
+        bridge: mbridge / Megatron-Bridge instance for HF save/load; required whenever
+            checkpoint contents request HF-format model weights.
     """
 
     def __init__(
@@ -193,30 +203,36 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.use_megatron_fsdp = use_megatron_fsdp
         self.rank = torch.distributed.get_rank()
 
-        # One flag, one source of truth.  Mirrors the user-facing YAML key
-        # ``*.megatron.use_dist_checkpointing``. Every save/load branch below
-        # is expressed via the ``should_{save,load}_{hf,dist_ckpt}_model``
-        # properties, which fold this flag with
-        # ``checkpoint_{save,load}_contents`` into a single boolean each.
+        # ``use_dist_checkpointing`` selects Megatron shards for the ``model``
+        # slot; HF weights always go through ``bridge`` when requested by
+        # ``save_contents`` / ``load_contents``.
         self.use_dist_checkpointing = use_dist_checkpointing
+
+        if "hf_model" in self.checkpoint_save_contents and self.bridge is None:
+            raise ValueError(
+                "`save_contents` contains 'hf_model' but `bridge` is None. "
+                "HuggingFace-format model weights require mbridge (pass `bridge=...`) "
+                "or remove 'hf_model' from `save_contents`."
+            )
+        if "hf_model" in self.checkpoint_load_contents and self.bridge is None:
+            raise ValueError(
+                "`load_contents` contains 'hf_model' but `bridge` is None. "
+                "Pass `bridge=...` or remove 'hf_model' from `load_contents`."
+            )
 
         if self.should_save_hf_model and self.bridge is None:
             raise ValueError(
                 "MegatronCheckpointManager: HF-format model weights require "
                 "a bridge instance. Either pass `bridge=...` or set "
-                "`use_dist_checkpointing=True` to use dist_checkpointing."
+                "`use_dist_checkpointing=True` to use dist_checkpointing for the "
+                "`model` slot only."
             )
 
-        # 'hf_model' is produced only via bridge; rejecting it explicitly here
-        # (vs. the derived ``should_save_hf_model`` override below) keeps the
-        # error message tied to the user's raw input.
-        if "hf_model" in self.checkpoint_save_contents and use_dist_checkpointing:
+        if self.should_load_hf_model and self.bridge is None:
             raise ValueError(
-                "`save_contents` contains 'hf_model' but "
-                "`use_dist_checkpointing=True` selects the dist_checkpointing "
-                "path; 'hf_model' is only produced via bridge. Either drop "
-                "'hf_model' from `save_contents` or set "
-                "`use_dist_checkpointing=False`."
+                "MegatronCheckpointManager: loading HF-format model weights requires "
+                "a bridge instance. Pass `bridge=...` or set "
+                "`use_dist_checkpointing=True` for the `model` slot."
             )
 
     # ------------------------------------------------------------------
@@ -227,11 +243,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
     @property
     def should_save_hf_model(self) -> bool:
-        """True when this save must emit HF-format model weights via bridge.
-
-        Fires when ``save_contents`` asks for ``hf_model`` OR when it asks
-        for ``model`` and the backend is HF (``use_dist_checkpointing=False``).
-        """
+        """True when this save must emit HF-format model weights via bridge."""
         return "hf_model" in self.checkpoint_save_contents or (
             "model" in self.checkpoint_save_contents and not self.use_dist_checkpointing
         )
@@ -492,12 +504,18 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             }
             if self.peft_cls is not None:
                 model_entry["peft_adapter_path"] = os.path.join(hf_rel, "adapter")
-            contents["model"] = model_entry
+            hybrid_weights = self.should_save_dist_ckpt_model
+            if not hybrid_weights:
+                contents["model"] = model_entry
             if "hf_model" in self.checkpoint_save_contents:
                 contents["hf_model"] = {
                     "path": hf_rel,
                     "format": "huggingface",
-                    "note": "deduplicated with 'model' on the HF path",
+                    "note": (
+                        "deduplicated with 'model' on the HF path"
+                        if not hybrid_weights
+                        else "HF export alongside Megatron model shards under model/dist_ckpt/",
+                    ),
                 }
 
         if self.should_save_dist_ckpt_model:
@@ -574,6 +592,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             "global_step": int(global_step),
             "world_size": self.world_size,
             "backend": {
+                "has_bridge": self.bridge is not None,
                 "use_dist_checkpointing": self.use_dist_checkpointing,
                 "peft": self.peft_cls is not None,
             },
@@ -1159,10 +1178,14 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             ├── ckpt_contents.json       # manifest (read first to locate any piece)
             ├── transformer_config.json  # when 'extra' is in save_contents
             ├── model/
-            │   ├── huggingface/         # HF weights via bridge (default) + config + tokenizer
-            │   └── dist_ckpt/           # Megatron shards (use_dist_checkpointing=True / PEFT)
+            │   ├── huggingface/         # HF weights when ``bridge`` is set (+ ``hf_model`` / HF ``model`` path)
+            │   └── dist_ckpt/           # Megatron model shards when ``use_dist_checkpointing``;
+            │                            # also PEFT adapters with mbridge
             ├── optimizer/dist_ckpt/     # optimizer + lr_scheduler shards
             └── extra/dist_ckpt/         # rng_state shards
+
+        With a non-``None`` ``bridge`` and ``use_dist_checkpointing=True``, both
+        ``model/huggingface/`` and ``model/dist_ckpt/`` may be populated in one save.
 
         Rank 0 writes ``ckpt_contents.json`` last, so its presence signals a
         fully-complete save (including async dist_checkpointing writes).

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -34,8 +34,13 @@ from verl.utils.fs import is_non_local, local_mkdir_safe
 from verl.utils.logger import log_with_rank
 from verl.utils.megatron.dist_checkpointing import load_dist_checkpointing, save_dist_checkpointing
 from verl.utils.megatron_utils import (
-    get_dist_checkpoint_path,
+    get_checkpoint_contents_manifest_path,
+    get_extra_dist_checkpoint_path,
     get_hf_model_checkpoint_path,
+    get_legacy_dist_checkpoint_path,
+    get_legacy_hf_model_checkpoint_path,
+    get_model_dist_checkpoint_path,
+    get_optimizer_dist_checkpoint_path,
     get_transformer_config_checkpoint_path,
 )
 
@@ -426,28 +431,242 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         metadata["chained_optim_avoid_prefix"] = True
         return metadata
 
+    # -- Contents manifest -----------------------------------------------------
+    # A small human-readable JSON file (``ckpt_contents.json``) written at the
+    # root of the checkpoint directory, describing which logical contents were
+    # saved and where to find them.  Intended for users who need to locate a
+    # particular artifact (HF weights, optimizer shards, transformer config,
+    # …) without re-deriving the layout from code.
+
+    # Bump when the schema changes in a backwards-incompatible way.
+    #
+    #  v1: single ``dist_ckpt/`` and ``huggingface/`` directly under the
+    #      checkpoint root (legacy, no longer produced).
+    #  v2: split into ``model/``, ``optimizer/``, ``extra/`` subdirectories;
+    #      HF tree is nested at ``model/huggingface/``.
+    MANIFEST_SCHEMA_VERSION = 2
+
+    def _build_checkpoint_manifest(
+        self,
+        local_path: str,
+        global_step: int,
+        saved_any_dist_ckpt: bool,
+    ) -> dict:
+        """Compose the ``ckpt_contents.json`` payload for this save.
+
+        All paths in the returned mapping are relative to ``local_path`` so
+        the manifest stays valid if the checkpoint directory is moved or
+        uploaded to remote storage.  The ``contents`` section maps each
+        logical piece that was saved to its on-disk location; the
+        ``directories`` section lists each top-level subdirectory with a
+        short description of what it contains.
+        """
+
+        def _rel(abs_path: str) -> str:
+            return os.path.relpath(abs_path, local_path)
+
+        model_dist_rel = _rel(get_model_dist_checkpoint_path(local_path))
+        optim_dist_rel = _rel(get_optimizer_dist_checkpoint_path(local_path))
+        extra_dist_rel = _rel(get_extra_dist_checkpoint_path(local_path))
+        hf_rel = _rel(get_hf_model_checkpoint_path(local_path))
+        transformer_config_rel = _rel(get_transformer_config_checkpoint_path(local_path))
+
+        contents: dict[str, dict] = {}
+
+        if self._save_model_via_mbridge:
+            model_entry: dict = {
+                "path": hf_rel,
+                "format": "huggingface",
+                "backend": "mbridge",
+            }
+            if self.peft_cls is not None:
+                model_entry["peft_adapter_path"] = os.path.join(hf_rel, "adapter")
+            contents["model"] = model_entry
+            if self.should_save_hf_model:
+                contents["hf_model"] = {
+                    "path": hf_rel,
+                    "format": "huggingface",
+                    "note": "deduplicated with 'model' when mbridge is enabled",
+                }
+
+        if self._save_model_via_dist_ckpt:
+            contents["model"] = {
+                "path": model_dist_rel,
+                "format": "megatron_dist_checkpoint",
+                "backend": "dist_checkpointing",
+            }
+
+        if self._save_peft_adapters_in_dist_ckpt:
+            contents["peft_adapters"] = {
+                "path": model_dist_rel,
+                "format": "megatron_dist_checkpoint",
+                "note": "PEFT adapter shards sit next to base-model HF weights, under model/dist_ckpt/.",
+            }
+
+        if self.should_save_optimizer:
+            contents["optimizer"] = {
+                "path": optim_dist_rel,
+                "format": "megatron_dist_checkpoint",
+            }
+            if self.lr_scheduler is not None:
+                contents["lr_scheduler"] = {
+                    "path": optim_dist_rel,
+                    "format": "megatron_dist_checkpoint",
+                    "key": "lr_scheduler",
+                }
+
+        if self.should_save_extra:
+            contents["rng_state"] = {
+                "path": extra_dist_rel,
+                "format": "megatron_dist_checkpoint",
+                "key": "rng_state",
+            }
+            contents["transformer_config"] = {
+                "path": transformer_config_rel,
+                "format": "json",
+            }
+
+        if self._save_model_via_mbridge:
+            contents["hf_config"] = {
+                "path": hf_rel,
+                "format": "huggingface",
+                "note": "config.json, tokenizer, and optional generation_config.json",
+            }
+            if self.processing_class is not None:
+                contents["tokenizer"] = {
+                    "path": hf_rel,
+                    "format": "huggingface",
+                }
+
+        directories: dict[str, str] = {}
+        if self._save_model_via_mbridge:
+            directories[hf_rel] = (
+                "HuggingFace-format artifacts written via mbridge: model weights, "
+                "config.json, tokenizer files, and optional generation_config.json."
+            )
+        if self._save_model_via_dist_ckpt or self._save_peft_adapters_in_dist_ckpt:
+            directories[model_dist_rel] = (
+                "Megatron dist_checkpointing shards for model weights (or PEFT adapter shards when mbridge is enabled)."
+            )
+        if self.should_save_optimizer:
+            directories[optim_dist_rel] = (
+                "Megatron dist_checkpointing shards for the optimizer state (includes lr_scheduler when present)."
+            )
+        if self.should_save_extra:
+            directories[extra_dist_rel] = "Megatron dist_checkpointing shards for extra state (rng_state)."
+
+        manifest = {
+            "schema_version": self.MANIFEST_SCHEMA_VERSION,
+            "framework": "megatron",
+            "role": self.role,
+            "arch": self.arch,
+            "global_step": int(global_step),
+            "world_size": self.world_size,
+            "backend": {
+                "use_mbridge": self.use_mbridge,
+                "use_dist_checkpointing": self.use_dist_checkpointing,
+                "peft": self.peft_cls is not None,
+            },
+            "save_contents": list(self.checkpoint_save_contents),
+            "contents": contents,
+            "directories": directories,
+            "saved_any_dist_ckpt": bool(saved_any_dist_ckpt),
+        }
+        return manifest
+
+    def _write_checkpoint_manifest(
+        self,
+        local_path: str,
+        global_step: int,
+        saved_any_dist_ckpt: bool,
+    ):
+        """Rank-0 writes the ``ckpt_contents.json`` manifest.
+
+        Written last so its presence signals a fully-completed save (useful
+        when scanning checkpoint directories to find valid snapshots).
+        """
+        if self.rank != 0:
+            return
+        manifest = self._build_checkpoint_manifest(local_path, global_step, saved_any_dist_ckpt)
+        manifest_path = get_checkpoint_contents_manifest_path(local_path)
+        tmp_path = manifest_path + ".tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, manifest_path)
+        log_with_rank(
+            f"Wrote checkpoint contents manifest to {manifest_path}",
+            rank=self.rank,
+            logger=logger,
+            log_only_rank_0=True,
+        )
+
+    # -- Load ------------------------------------------------------------------
+
+    def _load_model_via_bridge(self, hf_model_path: str):
+        """Load model weights through megatron-bridge."""
+        if self.vanilla_bridge:
+            self.bridge.load_weights(self.model, hf_model_path)
+        else:
+            self.bridge.load_hf_weights(self.model, hf_model_path)
+
     @staticmethod
     def _has_checkpoint_files(path: str) -> bool:
         return os.path.isdir(path) and any(os.scandir(path))
 
-    def _raise_for_unsupported_peft_checkpoint_layout(self, local_path: str, dist_checkpoint_path: str):
-        if self.peft_cls is None or not self.should_load_model or self._has_checkpoint_files(dist_checkpoint_path):
+    @staticmethod
+    def _raise_for_old_layout(local_path: str) -> None:
+        """Fail fast with a pointer to the migration script for pre-v2 layouts.
+
+        The v2 layout nests dist_ckpt under ``model/``, ``optimizer/``,
+        ``extra/``; the legacy (v1) layout put ``dist_ckpt/`` and
+        ``huggingface/`` directly at the checkpoint root.  We only flag a
+        directory as legacy when it has no v2 subdirectories **and** still
+        has a non-empty root-level ``dist_ckpt/`` or ``huggingface/``.
+        """
+        if not os.path.isdir(local_path):
+            return
+        has_v2 = any(os.path.isdir(os.path.join(local_path, sub)) for sub in ("model", "optimizer", "extra"))
+        if has_v2:
+            return
+
+        legacy_dist = get_legacy_dist_checkpoint_path(local_path)
+        legacy_hf = get_legacy_hf_model_checkpoint_path(local_path)
+        if os.path.isdir(legacy_dist) and any(os.scandir(legacy_dist)):
+            detected = f"legacy dist_ckpt/ directly under {local_path}"
+        elif os.path.isdir(legacy_hf) and any(os.scandir(legacy_hf)):
+            detected = f"legacy huggingface/ directly under {local_path}"
+        else:
+            return
+
+        raise RuntimeError(
+            f"Detected deprecated Megatron checkpoint layout ({detected}). The current "
+            "loader expects the split layout (model/, optimizer/, extra/ subdirectories). "
+            "Migrate the checkpoint in place with:\n"
+            "    python scripts/migrate_megatron_checkpoint_layout.py --checkpoint "
+            f"{local_path}\n"
+            "or use a freshly-saved checkpoint."
+        )
+
+    def _raise_for_unsupported_peft_checkpoint_layout(self, local_path: str, model_dist_path: str):
+        if self.peft_cls is None or not self.should_load_model or self._has_checkpoint_files(model_dist_path):
             return
 
         legacy_adapter_ckpt_path = os.path.join(local_path, "adapter_checkpoint")
-        hf_adapter_ckpt_path = os.path.join(local_path, "huggingface", "adapter")
+        hf_adapter_ckpt_path = os.path.join(local_path, "model", "huggingface", "adapter")
 
         if os.path.isdir(legacy_adapter_ckpt_path):
             raise RuntimeError(
                 f"Found legacy PEFT checkpoint at {legacy_adapter_ckpt_path}, but checkpoint resume now expects "
-                f"adapter weights in {dist_checkpoint_path}. Resave/convert the checkpoint or load the adapter via "
+                f"adapter weights in {model_dist_path}. Resave/convert the checkpoint or load the adapter via "
                 "`lora.adapter_path`."
             )
 
         if os.path.isfile(os.path.join(hf_adapter_ckpt_path, "adapter_config.json")):
             raise RuntimeError(
                 f"Found exported HF PEFT adapter at {hf_adapter_ckpt_path}, but `load_checkpoint()` resumes from "
-                f"{dist_checkpoint_path}. HF adapter exports are not used for trainer resume; keep the distributed "
+                f"{model_dist_path}. HF adapter exports are not used for trainer resume; keep the distributed "
                 "checkpoint or load the adapter separately via `lora.adapter_path`."
             )
 
@@ -460,7 +679,10 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         return apply_peft_adapter_filter_to_state_dict(state_dict, self.peft_cls)
 
     def _load_megatron_fsdp_checkpoint(self, local_path: str, del_local_after_load=False):
-        dist_checkpoint_path = get_dist_checkpoint_path(local_path)
+        # Megatron-FSDP writes a single combined DTensor checkpoint at the
+        # model dist path (see ``_save_megatron_fsdp_checkpoint``); load it
+        # back from the same location under the v2 layout.
+        dist_checkpoint_path = get_model_dist_checkpoint_path(local_path)
         if not os.path.isfile(os.path.join(dist_checkpoint_path, ".metadata")):
             raise FileNotFoundError(f"Megatron-FSDP checkpoint metadata not found at {dist_checkpoint_path}/.metadata.")
 
@@ -591,9 +813,31 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             raise KeyError
         tensor_parallel.get_cuda_rng_tracker().set_states(rng_states["rng_tracker_states"])
 
+    def _load_content_metadata(self, ckpt_dir: str) -> dict:
+        """Fetch MCore's content_metadata for a dist_ckpt dir with a fallback."""
+        load_content_metadata = getattr(dist_checkpointing, "load_content_metadata", None)
+        metadata = None
+        if load_content_metadata is not None and self._has_checkpoint_files(ckpt_dir):
+            metadata = load_content_metadata(checkpoint_dir=ckpt_dir)
+        if metadata is None:
+            if self.use_distributed_optimizer:
+                metadata = {"distrib_optim_sharding_type": "fully_sharded_model_space"}
+            else:
+                metadata = self._build_sharded_state_dict_metadata()
+        return metadata
+
     def load_checkpoint(self, local_path: str, hdfs_path: str = None, del_local_after_load=False):
+        """Load a Megatron checkpoint in the v2 split layout.
+
+        Each dist_checkpointing subtree (``model/dist_ckpt/``,
+        ``optimizer/dist_ckpt/``, ``extra/dist_ckpt/``) is loaded
+        independently, and any pre-v2 layout is rejected upfront with a
+        pointer at the migration script.
+        """
         if local_path is not None:
             assert os.path.exists(local_path), f"Checkpoint path {local_path} does not exist."
+
+        self._raise_for_old_layout(local_path)
 
         try:
             import transformer_engine
@@ -603,102 +847,100 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         except Exception:
             pass
 
+        # Megatron-FSDP keeps a single combined DTensor checkpoint (model +
+        # optimizer + extra in one directory) rather than the v2 three-tree
+        # split, so it has its own dedicated loader and short-circuits here.
         if self.use_megatron_fsdp:
             self._load_megatron_fsdp_checkpoint(local_path, del_local_after_load=del_local_after_load)
             return
 
-        dist_checkpoint_path = get_dist_checkpoint_path(local_path)
+        model_dist_path = get_model_dist_checkpoint_path(local_path)
+        optim_dist_path = get_optimizer_dist_checkpoint_path(local_path)
+        extra_dist_path = get_extra_dist_checkpoint_path(local_path)
 
-        self._raise_for_unsupported_peft_checkpoint_layout(local_path, dist_checkpoint_path)
+        self._raise_for_unsupported_peft_checkpoint_layout(local_path, model_dist_path)
 
-        load_content_metadata = getattr(dist_checkpointing, "load_content_metadata", None)
-        if load_content_metadata is None:
-            metadata = None
-        else:
-            metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
-        if metadata is None:
-            if self.use_distributed_optimizer:
-                metadata = {"distrib_optim_sharding_type": "fully_sharded_model_space"}
-            else:
-                metadata = self._build_sharded_state_dict_metadata()
+        # Pick metadata from the first subtree that actually exists; all
+        # three trees are written with the same content_metadata and we
+        # need a single consistent value for composing sharded state dicts.
+        metadata_source = next(
+            (p for p in (model_dist_path, optim_dist_path, extra_dist_path) if self._has_checkpoint_files(p)),
+            model_dist_path,
+        )
+        metadata = self._load_content_metadata(metadata_source)
 
-        # ── Compose the sharded state dict from individual pieces ─────────────
-        # Same principle as save: optimizer and extra always go through
-        # dist_checkpointing.  Model sharded state dict is only built when
-        # needed (optimizer metadata input or loading model weights via dist_ckpt).
-        sharded_state_dict = {}
-
+        # Model sharded state dict is shared across the model-load and
+        # optimizer-load metadata inputs, so build it once when either path
+        # needs it.
         model_sharded_state_dict = None
         if self.should_load_optimizer or self._load_model_via_dist_ckpt:
             model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
-        if self.should_load_optimizer:
-            sharded_state_dict.update(
-                self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
+        # ── Load model weights ──────────────────────────────────────────────
+        if self._load_model_via_dist_ckpt:
+            model_sd = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
+            loaded_model = load_dist_checkpointing(
+                sharded_state_dict=model_sd,
+                ckpt_dir=model_dist_path,
             )
-
-        if self.should_load_extra:
-            sharded_state_dict.update(self._build_extra_state_dict())
-
-        if self._load_model_via_dist_ckpt:
-            sharded_state_dict.update(model_sharded_state_dict)
-
-        sharded_state_dict = self._maybe_filter_peft_state_dict(sharded_state_dict)
-        log_with_rank(f"Generated state dict for loading: {sharded_state_dict.keys()}", rank=self.rank, logger=logger)
-
-        state_dict = load_dist_checkpointing(
-            sharded_state_dict=sharded_state_dict,
-            ckpt_dir=dist_checkpoint_path,
-        )
-
-        # ── Load model weights ────────────────────────────────────────────────
-        if self._load_model_via_dist_ckpt:
-            assert "model" in state_dict or any(
-                f"model{vpp_rank}" in state_dict for vpp_rank in range(len(self.model))
-            ), f"Model state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
-            for vpp_rank, model in enumerate(self.model):
+            assert "model" in loaded_model or any(
+                f"model{vpp_rank}" in loaded_model for vpp_rank in range(len(self.model))
+            ), f"Model state dict not found in {loaded_model.keys()}. Please check the checkpoint file {local_path}."
+            for vpp_rank in range(len(self.model)):
                 if len(self.model) == 1:
-                    model_state_dict = state_dict["model"]
+                    model_state_dict = loaded_model["model"]
                 else:
-                    assert f"model{vpp_rank}" in state_dict, f"model{vpp_rank} not found in state_dict"
-                    model_state_dict = state_dict[f"model{vpp_rank}"]
+                    assert f"model{vpp_rank}" in loaded_model, f"model{vpp_rank} not found in state_dict"
+                    model_state_dict = loaded_model[f"model{vpp_rank}"]
                 mpu.set_virtual_pipeline_model_parallel_rank(vpp_rank)
                 self.model[vpp_rank].load_state_dict(model_state_dict, strict=self.peft_cls is None)
             if self.peft_cls is not None:
-                log_with_rank(
-                    f"Loaded PEFT adapter checkpoint from {dist_checkpoint_path}", rank=self.rank, logger=logger
-                )
+                log_with_rank(f"Loaded PEFT adapter checkpoint from {model_dist_path}", rank=self.rank, logger=logger)
             else:
-                log_with_rank(f"Loaded sharded model checkpoint from {local_path}", rank=self.rank, logger=logger)
+                log_with_rank(f"Loaded sharded model checkpoint from {model_dist_path}", rank=self.rank, logger=logger)
 
         elif self._load_model_via_mbridge:
             hf_model_path = get_hf_model_checkpoint_path(local_path)
             self._load_model_via_bridge(hf_model_path)
             log_with_rank(f"Loaded HF model checkpoint from {hf_model_path} with bridge", rank=self.rank, logger=logger)
 
-        # ── Load optimizer / LR scheduler ─────────────────────────────────────
+        # ── Load optimizer / LR scheduler ───────────────────────────────────
         if self.should_load_optimizer:
-            assert "optimizer" in state_dict, (
-                f"Optimizer state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
+            optim_sd = self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
+            loaded_optim = load_dist_checkpointing(
+                sharded_state_dict=optim_sd,
+                ckpt_dir=optim_dist_path,
             )
-            self.optimizer.load_state_dict(state_dict["optimizer"])
-            log_with_rank(f"Loaded optimizer checkpoint from {local_path}", rank=self.rank, logger=logger)
+            assert "optimizer" in loaded_optim, (
+                f"Optimizer state dict not found in {loaded_optim.keys()}. "
+                f"Please check the checkpoint file {optim_dist_path}."
+            )
+            self.optimizer.load_state_dict(loaded_optim["optimizer"])
+            log_with_rank(f"Loaded optimizer checkpoint from {optim_dist_path}", rank=self.rank, logger=logger)
             if self.use_checkpoint_opt_param_scheduler:
-                assert "lr_scheduler" in state_dict, (
-                    f"LR scheduler state dict not found in {state_dict.keys()}. Please check the checkpoint file "
-                    f"{local_path}."
+                assert "lr_scheduler" in loaded_optim, (
+                    f"LR scheduler state dict not found in {loaded_optim.keys()}. "
+                    f"Please check the checkpoint file {optim_dist_path}."
                 )
                 if self.lr_scheduler is not None:
-                    self.lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
-                    log_with_rank(f"Loaded LR scheduler checkpoint from {local_path}", rank=self.rank, logger=logger)
+                    self.lr_scheduler.load_state_dict(loaded_optim["lr_scheduler"])
+                    log_with_rank(
+                        f"Loaded LR scheduler checkpoint from {optim_dist_path}", rank=self.rank, logger=logger
+                    )
 
-        # ── Load RNG states ───────────────────────────────────────────────────
+        # ── Load RNG states ─────────────────────────────────────────────────
         if self.should_load_extra:
-            assert "rng_state" in state_dict, (
-                f"RNG state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
+            extra_sd = self._build_extra_state_dict()
+            loaded_extra = load_dist_checkpointing(
+                sharded_state_dict=extra_sd,
+                ckpt_dir=extra_dist_path,
             )
-            self.load_rng_states(state_dict["rng_state"])
-            log_with_rank(f"Loaded RNG states from {local_path}", rank=self.rank, logger=logger)
+            assert "rng_state" in loaded_extra, (
+                f"RNG state dict not found in {loaded_extra.keys()}. "
+                f"Please check the checkpoint file {extra_dist_path}."
+            )
+            self.load_rng_states(loaded_extra["rng_state"])
+            log_with_rank(f"Loaded RNG states from {extra_dist_path}", rank=self.rank, logger=logger)
 
         if del_local_after_load:
             try:
@@ -710,7 +952,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                     logger=logger,
                 )
 
-    # -- Bridge helpers --------------------------------------------------------
+    # -- Save ------------------------------------------------------------------
 
     def _get_bridge_extended_args(self):
         """Build extra kwargs for ``bridge.save_weights`` from checkpoint config."""
@@ -739,13 +981,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 )
             else:
                 self.bridge.save_hf_weights(self.model, hf_ckpt_path)
-
-    def _load_model_via_bridge(self, hf_model_path: str):
-        """Load model weights through megatron-bridge."""
-        if self.vanilla_bridge:
-            self.bridge.load_weights(self.model, hf_model_path)
-        else:
-            self.bridge.load_hf_weights(self.model, hf_model_path)
 
     def _save_hf_config_and_tokenizer(self, local_path: str):
         """Rank-0 saves HF config, tokenizer, and generation config."""
@@ -784,14 +1019,14 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 default=lambda o: o.to_dict() if hasattr(o, "to_dict") else o,
             )
 
-    # -- Save / Load ----------------------------------------------------------
-
     def _save_dist_checkpoint(self, dist_checkpoint_path: str, state_dict: dict):
         """Persist ``state_dict`` via Megatron dist_checkpointing.
 
-        The caller is responsible for composing exactly the pieces that belong
-        in the dist_checkpoint directory (optimizer, extra, and optionally
-        model / PEFT adapter shards).
+        Writes one self-contained ``torch_dist`` directory under
+        ``dist_checkpoint_path``.  Callers compose the exact state dict to go
+        into this directory; in the v2 layout there are up to three such
+        directories per checkpoint (``model/dist_ckpt/``,
+        ``optimizer/dist_ckpt/``, ``extra/dist_ckpt/``).
 
         Returns the async save request when ``async_save`` is enabled, or
         ``None`` for synchronous saves.
@@ -811,41 +1046,149 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         return async_save_request
 
+    def _schedule_dist_checkpoint_saves(self, items: list[tuple[str, dict]]) -> list:
+        """Schedule one dist_checkpointing save per non-empty state dict.
+
+        ``items`` is an ordered list of ``(path, state_dict)`` pairs.  Empty
+        state dicts are skipped so a disabled content (e.g. no optimizer)
+        does not create an empty on-disk directory.  Returns the async save
+        requests in the same order they were scheduled; for synchronous
+        saves the list is empty.
+        """
+        async_requests: list = []
+        for path, state_dict in items:
+            if not state_dict:
+                continue
+            req = self._save_dist_checkpoint(path, state_dict)
+            if req is not None:
+                async_requests.append(req)
+        return async_requests
+
+    def _finalize_save(
+        self,
+        *,
+        local_path: str,
+        hdfs_path: str | None,
+        global_step: int,
+        max_ckpt_to_keep,
+        saved_any_dist_ckpt: bool,
+    ) -> None:
+        """Run post-write bookkeeping: manifest, HDFS upload, tracker, retention.
+
+        This is invoked either immediately after synchronous saves, or via
+        Megatron's ``AsyncCallsQueue`` finalize hook attached to the last
+        scheduled async request — see ``_dispatch_finalize``.  Either way it
+        runs exactly once per save, after every per-content write has
+        completed on every rank.
+        """
+        log_with_rank(f"Checkpoint save completed for {local_path}", rank=self.rank, logger=logger)
+
+        # Write the contents manifest last so its presence indicates a
+        # fully-complete save (including async dist_checkpointing writes).
+        self._write_checkpoint_manifest(local_path, global_step, saved_any_dist_ckpt)
+
+        if self.rank == 0 and hdfs_path is not None:
+            log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
+            from verl.utils import hdfs_io
+
+            hdfs_io.makedirs(hdfs_path, exist_ok=True)
+            # Upload the entire checkpoint directory as a single recursive
+            # copy.  This keeps HDFS and local layouts identical (model/,
+            # optimizer/, extra/, manifest, transformer_config.json).
+            hdfs_io.copy(src=local_path, dst=hdfs_path, dirs_exist_ok=True)
+
+        if self.checkpoint_config.async_save and self.rank == 0:
+            log_with_rank(
+                f"Update latest_checkpointed_iteration.txt to step {global_step}",
+                rank=self.rank,
+                logger=logger,
+            )
+            local_latest_checkpointed_iteration = os.path.join(
+                os.path.dirname(os.path.dirname(local_path)), "latest_checkpointed_iteration.txt"
+            )
+            with open(local_latest_checkpointed_iteration, "w") as f:
+                f.write(str(global_step))
+
+        self.register_checkpoint(local_path, max_ckpt_to_keep)
+
+    def _dispatch_finalize(self, async_requests: list, finalize_save_fn) -> None:
+        """Run ``finalize_save_fn`` now, or after all async writes complete.
+
+        When ``async_save`` is enabled and at least one dist_checkpointing
+        request was scheduled, attach the finalize callback to the **last**
+        request and enqueue every request on Megatron's ``AsyncCallsQueue``.
+        The queue processes requests in FIFO order within a rank and
+        all-reduces between each to keep ranks in sync, so attaching to the
+        last request guarantees ``finalize_save_fn`` runs only after every
+        per-content write has completed on every rank.
+
+        In all other cases (sync save, or async save with nothing to write)
+        the callback fires immediately on the calling thread.
+        """
+        if self.checkpoint_config.async_save and async_requests:
+            async_requests[-1].add_finalize_fn(finalize_save_fn)
+            from megatron.core.dist_checkpointing.strategies.base import async_calls
+
+            for req in async_requests:
+                async_calls.schedule_async_request(req)
+        else:
+            finalize_save_fn()
+
     def save_checkpoint(self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep=None):
+        """Save a Megatron checkpoint under ``local_path`` (layout schema v2).
+
+        Contents are split across three sibling directories so each piece can
+        be inspected or managed independently::
+
+            local_path/
+            ├── ckpt_contents.json       # manifest (read first to locate any piece)
+            ├── transformer_config.json  # when 'extra' is in save_contents
+            ├── model/
+            │   ├── huggingface/         # mbridge HF weights + config + tokenizer
+            │   └── dist_ckpt/           # Megatron model shards (mbridge off / PEFT)
+            ├── optimizer/dist_ckpt/     # optimizer + lr_scheduler shards
+            └── extra/dist_ckpt/         # rng_state shards
+
+        Rank 0 writes ``ckpt_contents.json`` last, so its presence signals a
+        fully-complete save (including async dist_checkpointing writes).
+        See ``docs/advance/checkpoint.rst`` ("Locating saved contents") for
+        the manifest schema.
+        """
         self.previous_global_step = global_step
 
         if not self.checkpoint_config.async_save:
             self.ensure_checkpoint_capacity(max_ckpt_to_keep)
 
         local_path = local_mkdir_safe(local_path)
-        dist_checkpoint_path = get_dist_checkpoint_path(local_path)
-
         # ── 1. Save dist_checkpoint payload ───────────────────────────────────
-        # Megatron-FSDP uses its own DTensor-based writer and replaces the
-        # dist_checkpointing composition pipeline entirely.  All other model /
-        # config / tokenizer paths below still apply (and are no-ops when not
-        # configured).  FSDP saves synchronously, so no async request is
-        # produced.
-        async_save_request = None
-        saved_dist_ckpt = False
+        # Two save paths exist:
+        #
+        # * Megatron-FSDP uses its own DTensor-based writer that bundles
+        #   model + optimizer + extra into a single combined directory.  It
+        #   replaces the per-content dist_checkpointing composition entirely
+        #   and saves synchronously (no async request is produced).  We
+        #   route the combined checkpoint to the model dist path so the rest
+        #   of the v2 layout (HF model, transformer config, manifest) still
+        #   lines up at the sibling locations.
+        #
+        # * Otherwise we use Megatron dist_checkpointing per-content (model /
+        #   optimizer / extra) so each piece can be independently located,
+        #   GC'd, or uploaded.  Model weights only go into dist_ckpt when
+        #   mbridge is disabled (or for PEFT adapters which bridge doesn't
+        #   handle).  The model sharded state dict is built once as a shared
+        #   dependency: Megatron's optimizer.sharded_state_dict() reads it as
+        #   metadata, and we may additionally persist it (or a PEFT-filtered
+        #   subset) as the model content itself.
+        model_state_dict: dict = {}
+        optimizer_state_dict: dict = {}
+        extra_state_dict: dict = {}
+        fsdp_saved = False
+
         if self.use_megatron_fsdp:
-            self._save_megatron_fsdp_checkpoint(dist_checkpoint_path)
-            saved_dist_ckpt = True
+            self._save_megatron_fsdp_checkpoint(get_model_dist_checkpoint_path(local_path))
+            fsdp_saved = True
         else:
             metadata = self._build_sharded_state_dict_metadata()
-
-            # ── Compose the dist_checkpoint state dict ────────────────────────
-            # dist_checkpointing is the universal backend for optimizer and
-            # extra states, regardless of which model backend (mbridge /
-            # dist_ckpt) is used.  Model weights only go into dist_ckpt when
-            # mbridge is disabled (or for PEFT adapters which bridge doesn't
-            # handle).
-            #
-            # The model sharded state dict is built as a transient dependency
-            # when the optimizer needs it — Megatron's
-            # optimizer.sharded_state_dict() requires the model's sharding
-            # layout as read-only input.
-            dist_ckpt_state_dict = {}
 
             model_sharded_state_dict = None
             if (
@@ -855,83 +1198,67 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             ):
                 model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
-            if self.should_save_optimizer:
-                dist_ckpt_state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata))
-
-            if self.should_save_extra:
-                dist_ckpt_state_dict.update(self._build_extra_state_dict())
-
             if self._save_model_via_dist_ckpt:
-                dist_ckpt_state_dict.update(model_sharded_state_dict)
+                model_state_dict.update(model_sharded_state_dict)
                 log_with_rank(
-                    f"dist_ckpt will save model shards: {model_sharded_state_dict.keys()}",
+                    f"model/dist_ckpt will save model shards: {model_sharded_state_dict.keys()}",
                     rank=self.rank,
                     logger=logger,
                 )
-
-            # PEFT adapter shards always live in dist_ckpt (bridge handles
-            # base model only).
             if self._save_peft_adapters_in_dist_ckpt:
                 peft_state = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
-                dist_ckpt_state_dict.update(peft_state)
+                model_state_dict.update(peft_state)
 
-            if dist_ckpt_state_dict:
-                async_save_request = self._save_dist_checkpoint(dist_checkpoint_path, dist_ckpt_state_dict)
-                saved_dist_ckpt = True
+            if self.should_save_optimizer:
+                optimizer_state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata))
 
-        # ── 2. Save model weights via mbridge (HF format) ─────────────────────
+        # FSDP already wrote model + optimizer + extra into one combined
+        # checkpoint above, so the per-content state dicts stay empty and
+        # ``_schedule_dist_checkpoint_saves`` becomes a no-op for that path.
+        if self.should_save_extra and not fsdp_saved:
+            extra_state_dict.update(self._build_extra_state_dict())
+
+        # ── 1b. Save each dist_checkpointing tree ───────────────────────────
+        # Preserve a stable schedule order (model → optimizer → extra) so the
+        # async finalize callback (attached to the last request by
+        # ``_dispatch_finalize``) only fires after all three writes complete.
+        async_requests = self._schedule_dist_checkpoint_saves(
+            [
+                (get_model_dist_checkpoint_path(local_path), model_state_dict),
+                (get_optimizer_dist_checkpoint_path(local_path), optimizer_state_dict),
+                (get_extra_dist_checkpoint_path(local_path), extra_state_dict),
+            ]
+        )
+
+        # ── 2. Save model weights via mbridge (HF format) ───────────────────
         if self._save_model_via_mbridge:
             hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
             log_with_rank(f"Saving HF model checkpoint to {hf_ckpt_path} with bridge", rank=self.rank, logger=logger)
             self._save_model_via_bridge(hf_ckpt_path)
             log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
 
-        # ── 3. HF config / tokenizer (rank 0) ────────────────────────────────
+        # ── 3. HF config / tokenizer (rank 0) ───────────────────────────────
         if self._save_model_via_mbridge:
             self._save_hf_config_and_tokenizer(local_path)
 
-        # ── 4. Transformer config (rank 0) ────────────────────────────────────
+        # ── 4. Transformer config (rank 0, at checkpoint root) ──────────────
         if self.should_save_extra:
             self._save_transformer_config(local_path)
 
-        # ── 5. Finalization (HDFS upload, tracker, retention) ─────────────────
-        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
-
-        def finalize_save_fn():
-            log_with_rank(f"Checkpoint save completed for {local_path}", rank=self.rank, logger=logger)
-            if self.rank == 0 and hdfs_path is not None:
-                log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
-                from verl.utils import hdfs_io
-
-                hdfs_io.makedirs(hdfs_path, exist_ok=True)
-                if saved_dist_ckpt:
-                    hdfs_io.copy(src=dist_checkpoint_path, dst=hdfs_path, dirs_exist_ok=True)
-                if self._save_model_via_mbridge:
-                    hdfs_io.copy(src=hf_config_tokenizer_path, dst=hdfs_path, dirs_exist_ok=True)
-
-            if self.checkpoint_config.async_save and self.rank == 0:
-                log_with_rank(
-                    f"Update latest_checkpointed_iteration.txt to step {global_step}",
-                    rank=self.rank,
-                    logger=logger,
-                )
-                local_latest_checkpointed_iteration = os.path.join(
-                    os.path.dirname(os.path.dirname(local_path)), "latest_checkpointed_iteration.txt"
-                )
-                with open(local_latest_checkpointed_iteration, "w") as f:
-                    f.write(str(global_step))
-
-            self.register_checkpoint(local_path, max_ckpt_to_keep)
-
-        if self.checkpoint_config.async_save and async_save_request is not None:
-            async_save_request.add_finalize_fn(finalize_save_fn)
-            try:
-                from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue
-
-                AsyncCallsQueue(persistent=False).schedule_async_request(async_save_request)
-            except ImportError:
-                from megatron.core.dist_checkpointing.strategies.base import async_calls
-
-                async_calls.schedule_async_request(async_save_request)
-        else:
-            finalize_save_fn()
+        # ── 5. Finalization (manifest, HDFS upload, tracker, retention) ─────
+        # FSDP saves synchronously and produces no async request, so the
+        # finalize callback fires immediately for that path even though we
+        # still need to record that a dist_ckpt was written.
+        saved_any_dist_ckpt = fsdp_saved or bool(
+            model_state_dict or optimizer_state_dict or extra_state_dict
+        )
+        self._dispatch_finalize(
+            async_requests,
+            lambda: self._finalize_save(
+                local_path=local_path,
+                hdfs_path=hdfs_path,
+                global_step=global_step,
+                max_ckpt_to_keep=max_ckpt_to_keep,
+                saved_any_dist_ckpt=saved_any_dist_ckpt,
+            ),
+        )

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -723,9 +723,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         sharded_state_dict = {}
         model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
         sharded_state_dict.update(model_sharded_state_dict)
-        sharded_state_dict.update(
-            self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
-        )
+        sharded_state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True))
         sharded_state_dict.update(self._build_extra_state_dict())
 
         from megatron.bridge.training.checkpointing import load_fsdp_dtensor_checkpoint
@@ -1287,9 +1285,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         # FSDP saves synchronously and produces no async request, so the
         # finalize callback fires immediately for that path even though we
         # still need to record that a dist_ckpt was written.
-        saved_any_dist_ckpt = fsdp_saved or bool(
-            model_state_dict or optimizer_state_dict or extra_state_dict
-        )
+        saved_any_dist_ckpt = fsdp_saved or bool(model_state_dict or optimizer_state_dict or extra_state_dict)
         self._dispatch_finalize(
             async_requests,
             lambda: self._finalize_save(

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -29,7 +29,6 @@ from megatron.core.dist_checkpointing.mapping import ShardedObject
 from packaging import version
 from transformers import GenerationConfig
 
-from verl.models.weight_loader_registry import get_weight_saver
 from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.fs import is_non_local, local_mkdir_safe
 from verl.utils.logger import log_with_rank
@@ -109,57 +108,31 @@ def _config_to_shallow_dict(config):
 
 
 class MegatronCheckpointManager(BaseCheckpointManager):
-    """
-    Checkpoint manager for Megatron-LM distributed training.
+    """Checkpoint manager for Megatron-LM distributed training.
 
-    This class manages the saving and loading of model checkpoints in a Megatron-LM
-    distributed training environment. It handles various aspects of checkpointing
-    including model states, optimizer states, learning rate schedulers, and random
-    number generator states, ensuring compatibility with HuggingFace formats.
+    Two model-checkpoint backends are supported, controlled by ``use_mbridge``:
 
-    Key features:
-    - Distributed checkpoint saving and loading using Megatron's dist_checkpointing
-    - Support for tensor parallel, pipeline parallel, and data parallel configurations
-    - Automatic handling of model state dictionaries across multiple pipeline stages
-    - Integration with HuggingFace model configurations and tokenizers
-    - Random number generator state management for reproducibility
-    - Support for both synchronous and asynchronous checkpoint operations
+    * **mbridge (default)** -- saves / loads model weights in HuggingFace format
+      via megatron-bridge.  Both ``"model"`` and ``"hf_model"`` in
+      ``save_contents`` produce the same HF checkpoint (saved only once).
 
-    The manager automatically handles:
-    - Directory structure creation based on global steps and process ranks
-    - Model configuration and tokenizer saving in HuggingFace format
-    - Optimizer and scheduler state persistence
-    - CUDA RNG state management for deterministic training
-    - Checkpoint cleanup and retention policies
+    * **dist_checkpoint** -- saves model weights using Megatron's native
+      ``dist_checkpointing`` (sharded across ranks).  ``"hf_model"`` in
+      ``save_contents`` is **not** supported with this backend (raises error).
+
+    Optimizer, LR-scheduler, and RNG states always go through
+    ``dist_checkpointing`` regardless of the model backend.
 
     Args:
-        model: The Megatron model instance to checkpoint
-        optimizer: The optimizer instance (optional)
-        lr_scheduler: The learning rate scheduler instance (optional)
-
-    Attributes:
-        model: Reference to the Megatron model being checkpointed
-        optimizer: Reference to the optimizer (if provided)
-        lr_scheduler: Reference to the learning rate scheduler (if provided)
-        rank: Current process rank in the distributed setup
-
-    Example:
-        ```python
-        checkpoint_manager = MegatronCheckpointManager(
-            model=megatron_model,
-            optimizer=optimizer,
-            lr_scheduler=scheduler
-        )
-
-        checkpoint_manager.save_checkpoint(
-            local_path="checkpoints/step_1000",
-            global_step=1000
-        )
-
-        checkpoint_manager.load_checkpoint(
-            local_path="checkpoints/step_1000"
-        )
-        ```
+        model: The Megatron model instance to checkpoint.
+        optimizer: The optimizer instance.
+        lr_scheduler: The learning rate scheduler instance.
+        use_mbridge: If ``True`` (default), model weights are saved/loaded via
+            megatron-bridge in HuggingFace format.  Requires ``bridge`` to be
+            provided.  If ``False``, ``dist_checkpointing`` is used for model
+            weights.
+        use_dist_checkpointing: Legacy alias -- when provided, it sets
+            ``use_mbridge = not use_dist_checkpointing``.
     """
 
     def __init__(
@@ -179,7 +152,8 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         optimizer_scheduler,
         use_distributed_optimizer: bool,
         use_checkpoint_opt_param_scheduler: bool = False,
-        use_dist_checkpointing: bool = True,
+        use_dist_checkpointing: bool | None = None,
+        use_mbridge: bool = True,
         use_megatron_fsdp: bool = False,
         bridge=None,
         provider=None,
@@ -197,9 +171,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.config = config
         self.transformer_config = transformer_config
         self.role = role
-        self.is_value_model = False
-        if self.role in ["reward", "critic"]:
-            self.is_value_model = True
+        self.is_value_model = self.role in ("reward", "critic")
         self.model_config = model_config
         self.hf_config = hf_config
         self.param_dtype = param_dtype
@@ -213,15 +185,57 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.peft_cls = peft_cls
         self.use_megatron_fsdp = use_megatron_fsdp
         self.rank = torch.distributed.get_rank()
-        # Megatron-Bridge is Okay to load/save HF checkpoint for value model as well
-        self.use_dist_checkpointing = (
-            use_dist_checkpointing or not self.bridge or (self.vanilla_bridge and self.is_value_model)
-        )
-        self.use_hf_checkpoint = not self.use_dist_checkpointing
 
-        self.weight_saver = None
-        if self.bridge is None:
-            self.weight_saver = get_weight_saver(self.arch)
+        # --- Resolve backend ---------------------------------------------------
+        # Legacy callers may still pass ``use_dist_checkpointing``; translate it.
+        if use_dist_checkpointing is not None:
+            use_mbridge = not use_dist_checkpointing
+
+        if use_mbridge and self.bridge is None:
+            raise ValueError(
+                "MegatronCheckpointManager: use_mbridge=True requires a bridge "
+                "instance. Either pass `bridge=...` or set `use_mbridge=False` "
+                "to use dist_checkpointing for model weights."
+            )
+
+        self.use_mbridge = use_mbridge
+        # Aliases kept so the rest of the codebase can read them without change.
+        self.use_dist_checkpointing = not self.use_mbridge
+        self.use_hf_checkpoint = self.use_mbridge
+
+        # --- Validate & resolve save_contents vs backend ----------------------
+        # Per the RFC:
+        #   mbridge   + model    → save HF model via bridge
+        #   mbridge   + hf_model → same as model (deduplicated, save once)
+        #   dist_ckpt + model    → save via mcore dist_checkpointing
+        #   dist_ckpt + hf_model → ERROR (not supported)
+        #   both backends False  → ERROR
+        if not self.use_mbridge and not self.use_dist_checkpointing:
+            raise ValueError(
+                "MegatronCheckpointManager: at least one model-weight backend "
+                "must be enabled (use_mbridge or dist_checkpointing)."
+            )
+
+        if self.should_save_hf_model and not self.use_mbridge:
+            raise ValueError(
+                "save_contents contains 'hf_model' but mbridge is disabled. "
+                "'hf_model' is only supported with mbridge. Either enable "
+                "mbridge or remove 'hf_model' from save_contents."
+            )
+
+        # Whether we actually need to write model weights via each backend.
+        # When mbridge is active, both 'model' and 'hf_model' resolve to a
+        # single HF save (deduplicated).
+        self._save_model_via_mbridge = self.use_mbridge and (self.should_save_model or self.should_save_hf_model)
+        self._save_model_via_dist_ckpt = self.use_dist_checkpointing and self.should_save_model
+
+        # PEFT adapter shards always live in dist_checkpoint even with mbridge,
+        # because bridge handles only the base model.
+        self._save_peft_adapters_in_dist_ckpt = self._save_model_via_mbridge and self.peft_cls is not None
+
+        self._load_model_via_mbridge = self.use_mbridge and self.should_load_model and self.peft_cls is None
+        # PEFT adapters always live in the dist_checkpoint directory.
+        self._load_model_via_dist_ckpt = self.should_load_model and (not self.use_mbridge or self.peft_cls is not None)
 
     def get_rng_state(self, use_dist_ckpt: bool = True, data_parallel_random_init: bool = False):
         """collect rng state across data parallel ranks"""
@@ -308,69 +322,69 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             return common_path
         return os.path.join(common_path, basename)
 
-    def generate_state_dict(
+    # -- Sharded state dict builders -------------------------------------------
+    # Each builder produces an independent piece of the dist_checkpoint state
+    # dict.  Callers compose exactly the pieces they need rather than building
+    # one monolithic dict every time.
+
+    def _build_model_sharded_state_dict(self, metadata: dict) -> dict:
+        """Build the model's sharded state dict for all VPP ranks.
+
+        This is used both for persisting model weights (dist_ckpt backend) and
+        as metadata input for the optimizer's ``sharded_state_dict()`` method
+        (every Megatron optimizer takes ``model_sharded_state_dict`` as its
+        first argument but only reads it — the model tensors are not included
+        in the optimizer's output).
+        """
+        model_sharded_state_dict = {}
+        model_metadata = dict(metadata)
+        model_metadata["dp_cp_group"] = mpu.get_data_parallel_group(with_context_parallel=True)
+        for vpp_rank, model in enumerate(self.model):
+            if len(self.model) > 1:
+                mpu.set_virtual_pipeline_model_parallel_rank(vpp_rank)
+                key = f"model{vpp_rank}"
+            else:
+                key = "model"
+            if self.use_megatron_fsdp:
+                # Megatron-FSDP wraps the model and exposes a DTensor-aware
+                # state-dict; the standard ``sharded_state_dict`` path doesn't
+                # apply.
+                model_sharded_state_dict[key] = model.state_dict_for_save_checkpoint()
+                continue
+            if hasattr(model, "module"):
+                model = model.module
+            model_sharded_state_dict[key] = model.sharded_state_dict(metadata=model_metadata)
+        return model_sharded_state_dict
+
+    def _build_optimizer_state_dict(
         self,
-        generate_model: bool = True,
-        generate_optimizer: bool = True,
-        generate_extra: bool = True,
+        model_sharded_state_dict: dict,
+        metadata: dict,
         is_loading: bool = False,
-        metadata: dict | None = None,
-    ):
-        # For save dist checkpointing
+    ) -> dict:
+        """Build the optimizer (+ LR scheduler) sharded state dict.
+
+        ``model_sharded_state_dict`` is required because Megatron's optimizer
+        ``sharded_state_dict()`` uses the model's sharding layout to map
+        optimizer states to parameter shards.  It is consumed read-only and
+        its entries do **not** appear in the returned dict.
+        """
+        torch.distributed.barrier()
+        sharded_state_dict_kwargs = {"is_loading": is_loading}
+        if metadata is not None and mcore_ge_014:
+            sharded_state_dict_kwargs["metadata"] = metadata
         state_dict = {}
-        base_metadata = metadata or self._build_sharded_state_dict_metadata()
-
-        should_generate_model_sections = generate_model or generate_optimizer
-
-        # All ranks save model state dict when it is needed for either model checkpointing
-        # or optimizer sharded_state_dict generation.
-        if should_generate_model_sections:
-            for vpp_rank, model in enumerate(self.model):
-                if len(self.model) > 1:
-                    mpu.set_virtual_pipeline_model_parallel_rank(vpp_rank)
-                    key = f"model{vpp_rank}"
-                else:
-                    key = "model"
-
-                if self.use_megatron_fsdp:
-                    state_dict[key] = model.state_dict_for_save_checkpoint()
-                else:
-                    if hasattr(model, "module"):
-                        model = model.module
-
-                    # GPTModel's sharded_state_dict function when having mtp requires metadata['dp_cp_group']
-                    model_metadata = dict(base_metadata)
-                    model_metadata["dp_cp_group"] = mpu.get_data_parallel_group(with_context_parallel=True)
-                    kwargs = {"metadata": model_metadata}
-                    state_dict[key] = model.sharded_state_dict(**kwargs)
-
-        # Optimizer State Dict
-        if generate_optimizer:
-            torch.distributed.barrier()
-            sharded_state_dict_kwargs = {"is_loading": is_loading}
-            if base_metadata is not None:
-                # https://github.com/NVIDIA/Megatron-LM/blob/core_v0.14.0/megatron/core/optimizer/distrib_optimizer.py#L1109-L1123
-                if mcore_ge_014:
-                    sharded_state_dict_kwargs["metadata"] = base_metadata
-            optimizer_sharded_states = self.optimizer.sharded_state_dict(state_dict, **sharded_state_dict_kwargs)
-            state_dict["optimizer"] = optimizer_sharded_states
-
-            if self.lr_scheduler is not None:
-                lr_state_dict = self.lr_scheduler.state_dict()
-                state_dict["lr_scheduler"] = lr_state_dict
-
-        if not generate_model:
-            for key in list(state_dict.keys()):
-                if self._is_model_state_key(key):
-                    state_dict.pop(key)
-
-        # RNG States State Dict
-        if generate_extra:
-            torch.distributed.barrier()
-            rng_state = self.get_rng_state()
-            state_dict["rng_state"] = rng_state
-
+        state_dict["optimizer"] = self.optimizer.sharded_state_dict(
+            model_sharded_state_dict, **sharded_state_dict_kwargs
+        )
+        if self.lr_scheduler is not None:
+            state_dict["lr_scheduler"] = self.lr_scheduler.state_dict()
         return state_dict
+
+    def _build_extra_state_dict(self) -> dict:
+        """Build the extra state dict (RNG states)."""
+        torch.distributed.barrier()
+        return {"rng_state": self.get_rng_state()}
 
     def _build_sharded_state_dict_metadata(self) -> dict:
         """Builds metadata used for sharded_state_dict versioning.
@@ -413,10 +427,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         return metadata
 
     @staticmethod
-    def _is_model_state_key(key: str) -> bool:
-        return key == "model" or (key.startswith("model") and key[5:].isdigit())
-
-    @staticmethod
     def _has_checkpoint_files(path: str) -> bool:
         return os.path.isdir(path) and any(os.scandir(path))
 
@@ -454,13 +464,18 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         if not os.path.isfile(os.path.join(dist_checkpoint_path, ".metadata")):
             raise FileNotFoundError(f"Megatron-FSDP checkpoint metadata not found at {dist_checkpoint_path}/.metadata.")
 
-        sharded_state_dict = self.generate_state_dict(
-            generate_model=True,
-            generate_optimizer=True,
-            generate_extra=True,
-            is_loading=True,
-            metadata=self._build_sharded_state_dict_metadata(),
+        # Build a full template (model + optimizer + extra) regardless of the
+        # ``should_load_*`` flags so the DTensor loader can match every entry
+        # written at save time.  Per-section gating happens below when the
+        # loaded tensors are applied back to the live objects.
+        metadata = self._build_sharded_state_dict_metadata()
+        sharded_state_dict = {}
+        model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
+        sharded_state_dict.update(model_sharded_state_dict)
+        sharded_state_dict.update(
+            self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
         )
+        sharded_state_dict.update(self._build_extra_state_dict())
 
         from megatron.bridge.training.checkpointing import load_fsdp_dtensor_checkpoint
 
@@ -507,12 +522,30 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 )
 
     def _save_megatron_fsdp_checkpoint(self, dist_checkpoint_path: str):
-        state_dict = self.generate_state_dict(
-            generate_model=self.should_save_model,
-            generate_optimizer=self.should_save_optimizer,
-            generate_extra=self.should_save_extra,
-            metadata=self._build_sharded_state_dict_metadata(),
-        )
+        """Save a Megatron-FSDP (DTensor) checkpoint.
+
+        Composes the state dict from the same builders used by the
+        dist_checkpointing path, then preprocesses it for the DTensor
+        ``torch.distributed.checkpoint`` writer.  Megatron-FSDP saves
+        synchronously and returns no async request.
+        """
+        metadata = self._build_sharded_state_dict_metadata()
+        state_dict = {}
+
+        # The optimizer's ``sharded_state_dict()`` needs the model layout as
+        # input; build the model state dict whenever we save model weights or
+        # optimizer states.
+        model_sharded_state_dict = None
+        if self.should_save_model or self.should_save_optimizer:
+            model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
+            if self.should_save_model:
+                state_dict.update(model_sharded_state_dict)
+
+        if self.should_save_optimizer:
+            state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata))
+
+        if self.should_save_extra:
+            state_dict.update(self._build_extra_state_dict())
 
         from megatron.bridge.training.checkpointing import save_fsdp_dtensor_checkpoint
 
@@ -562,7 +595,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         if local_path is not None:
             assert os.path.exists(local_path), f"Checkpoint path {local_path} does not exist."
 
-        # For load optimizer dist_ckpt
         try:
             import transformer_engine
 
@@ -581,40 +613,46 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         load_content_metadata = getattr(dist_checkpointing, "load_content_metadata", None)
         if load_content_metadata is None:
-            # For backward compatibility
-            sharded_sd_metadata = None
+            metadata = None
         else:
-            sharded_sd_metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
-        if sharded_sd_metadata is None:
+            metadata = load_content_metadata(checkpoint_dir=dist_checkpoint_path)
+        if metadata is None:
             if self.use_distributed_optimizer:
-                # Backward-compatibility with old checkpoints which don't have content versioning
-                # Can be removed after ending support for MLM optimizer checkpoints with MCore < v0.13
-                # (for MCore v0.13+ checkpoints `sharded_sd_metadata is not None`)
-                sharded_sd_metadata = {
-                    "distrib_optim_sharding_type": "fully_sharded_model_space",
-                }
+                metadata = {"distrib_optim_sharding_type": "fully_sharded_model_space"}
             else:
-                sharded_sd_metadata = self._build_sharded_state_dict_metadata()
+                metadata = self._build_sharded_state_dict_metadata()
 
-        # Get State Dict for loading
-        should_load_dist_model = self.should_load_model and (self.use_dist_checkpointing or self.peft_cls is not None)
-        sharded_state_dict = self.generate_state_dict(
-            should_load_dist_model,
-            self.should_load_optimizer,
-            self.should_load_extra,
-            is_loading=True,
-            metadata=sharded_sd_metadata,
-        )
+        # ── Compose the sharded state dict from individual pieces ─────────────
+        # Same principle as save: optimizer and extra always go through
+        # dist_checkpointing.  Model sharded state dict is only built when
+        # needed (optimizer metadata input or loading model weights via dist_ckpt).
+        sharded_state_dict = {}
+
+        model_sharded_state_dict = None
+        if self.should_load_optimizer or self._load_model_via_dist_ckpt:
+            model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
+
+        if self.should_load_optimizer:
+            sharded_state_dict.update(
+                self._build_optimizer_state_dict(model_sharded_state_dict, metadata, is_loading=True)
+            )
+
+        if self.should_load_extra:
+            sharded_state_dict.update(self._build_extra_state_dict())
+
+        if self._load_model_via_dist_ckpt:
+            sharded_state_dict.update(model_sharded_state_dict)
+
         sharded_state_dict = self._maybe_filter_peft_state_dict(sharded_state_dict)
         log_with_rank(f"Generated state dict for loading: {sharded_state_dict.keys()}", rank=self.rank, logger=logger)
 
-        # Load Dist Checkpointing
         state_dict = load_dist_checkpointing(
             sharded_state_dict=sharded_state_dict,
             ckpt_dir=dist_checkpoint_path,
         )
 
-        if should_load_dist_model:
+        # ── Load model weights ────────────────────────────────────────────────
+        if self._load_model_via_dist_ckpt:
             assert "model" in state_dict or any(
                 f"model{vpp_rank}" in state_dict for vpp_rank in range(len(self.model))
             ), f"Model state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
@@ -633,38 +671,33 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             else:
                 log_with_rank(f"Loaded sharded model checkpoint from {local_path}", rank=self.rank, logger=logger)
 
-        # Skip HF checkpoint loading if PEFT is used
-        elif self.should_load_model and self.use_hf_checkpoint and self.peft_cls is None:
+        elif self._load_model_via_mbridge:
             hf_model_path = get_hf_model_checkpoint_path(local_path)
-            if self.vanilla_bridge:
-                self.bridge.load_weights(self.model, hf_model_path)
-            else:
-                self.bridge.load_hf_weights(self.model, hf_model_path)
+            self._load_model_via_bridge(hf_model_path)
             log_with_rank(f"Loaded HF model checkpoint from {hf_model_path} with bridge", rank=self.rank, logger=logger)
 
+        # ── Load optimizer / LR scheduler ─────────────────────────────────────
         if self.should_load_optimizer:
             assert "optimizer" in state_dict, (
                 f"Optimizer state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
             )
-            optimizer_state_dict = state_dict["optimizer"]
-            self.optimizer.load_state_dict(optimizer_state_dict)
+            self.optimizer.load_state_dict(state_dict["optimizer"])
             log_with_rank(f"Loaded optimizer checkpoint from {local_path}", rank=self.rank, logger=logger)
             if self.use_checkpoint_opt_param_scheduler:
                 assert "lr_scheduler" in state_dict, (
                     f"LR scheduler state dict not found in {state_dict.keys()}. Please check the checkpoint file "
                     f"{local_path}."
                 )
-                lr_scheduler_state_dict = state_dict["lr_scheduler"]
                 if self.lr_scheduler is not None:
-                    self.lr_scheduler.load_state_dict(lr_scheduler_state_dict)
+                    self.lr_scheduler.load_state_dict(state_dict["lr_scheduler"])
                     log_with_rank(f"Loaded LR scheduler checkpoint from {local_path}", rank=self.rank, logger=logger)
 
+        # ── Load RNG states ───────────────────────────────────────────────────
         if self.should_load_extra:
             assert "rng_state" in state_dict, (
                 f"RNG state dict not found in {state_dict.keys()}. Please check the checkpoint file {local_path}."
             )
-            rng_state = state_dict["rng_state"]
-            self.load_rng_states(rng_state)
+            self.load_rng_states(state_dict["rng_state"])
             log_with_rank(f"Loaded RNG states from {local_path}", rank=self.rank, logger=logger)
 
         if del_local_after_load:
@@ -677,8 +710,108 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                     logger=logger,
                 )
 
+    # -- Bridge helpers --------------------------------------------------------
+
+    def _get_bridge_extended_args(self):
+        """Build extra kwargs for ``bridge.save_weights`` from checkpoint config."""
+        extended_args = {}
+        mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
+        for sig in inspect.signature(self.bridge.save_weights).parameters:
+            if sig in ("weights_path", "models"):
+                continue
+            if sig in mbridge_config:
+                extended_args[sig] = mbridge_config[sig]
+        return extended_args
+
+    def _save_model_via_bridge(self, hf_ckpt_path: str):
+        """Save model weights through megatron-bridge."""
+        if self.vanilla_bridge:
+            self.bridge.save_weights(self.model, hf_ckpt_path, **self._get_bridge_extended_args())
+        else:
+            if self.peft_cls is not None:
+                hf_adapter_ckpt_path = os.path.join(hf_ckpt_path, "adapter")
+                self.bridge.save_hf_adapter(self.model, hf_adapter_ckpt_path, self.peft_cls)
+                log_with_rank(
+                    f"Saved HF PEFT adapter checkpoint to {hf_adapter_ckpt_path}",
+                    rank=self.rank,
+                    logger=logger,
+                    log_only_rank_0=True,
+                )
+            else:
+                self.bridge.save_hf_weights(self.model, hf_ckpt_path)
+
+    def _load_model_via_bridge(self, hf_model_path: str):
+        """Load model weights through megatron-bridge."""
+        if self.vanilla_bridge:
+            self.bridge.load_weights(self.model, hf_model_path)
+        else:
+            self.bridge.load_hf_weights(self.model, hf_model_path)
+
+    def _save_hf_config_and_tokenizer(self, local_path: str):
+        """Rank-0 saves HF config, tokenizer, and generation config."""
+        if self.rank != 0:
+            return
+        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
+        if self.processing_class is not None:
+            self.processing_class.save_pretrained(hf_config_tokenizer_path)
+        self.hf_config.save_pretrained(hf_config_tokenizer_path)
+        if hasattr(self.hf_config, "name_or_path") and self.hf_config.name_or_path:
+            try:
+                generation_config = GenerationConfig.from_pretrained(self.hf_config.name_or_path)
+                generation_config.save_pretrained(hf_config_tokenizer_path)
+            except Exception:
+                pass
+        log_with_rank(
+            f"Saved Huggingface config and tokenizer to {hf_config_tokenizer_path}",
+            rank=self.rank,
+            logger=logger,
+            log_only_rank_0=True,
+        )
+
+    def _save_transformer_config(self, local_path: str):
+        """Rank-0 serialises the Megatron TransformerConfig to JSON."""
+        if self.rank != 0:
+            return
+        print(self.transformer_config)
+        transformer_config_dict = _to_json_safe_config_dict(_config_to_shallow_dict(self.transformer_config))
+        transformer_config_path = get_transformer_config_checkpoint_path(local_path)
+        # NOTE: With Megatron-Bridge backend, a circular import issue occurs when transformers version >= 5.4.0.
+        with open(transformer_config_path, "w") as f:
+            json.dump(
+                transformer_config_dict,
+                f,
+                indent=2,
+                default=lambda o: o.to_dict() if hasattr(o, "to_dict") else o,
+            )
+
+    # -- Save / Load ----------------------------------------------------------
+
+    def _save_dist_checkpoint(self, dist_checkpoint_path: str, state_dict: dict):
+        """Persist ``state_dict`` via Megatron dist_checkpointing.
+
+        The caller is responsible for composing exactly the pieces that belong
+        in the dist_checkpoint directory (optimizer, extra, and optionally
+        model / PEFT adapter shards).
+
+        Returns the async save request when ``async_save`` is enabled, or
+        ``None`` for synchronous saves.
+        """
+        sharded_sd_metadata = self._build_sharded_state_dict_metadata()
+
+        async_save_request = save_dist_checkpointing(
+            sharded_state_dict=state_dict,
+            ckpt_path=dist_checkpoint_path,
+            async_save=self.checkpoint_config.async_save,
+            content_metadata=sharded_sd_metadata,
+        )
+
+        if not self.checkpoint_config.async_save:
+            assert async_save_request is None, "Async save request should be None when not using async save."
+            torch.distributed.barrier()
+
+        return async_save_request
+
     def save_checkpoint(self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep=None):
-        # record the previous global step
         self.previous_global_step = global_step
 
         if not self.checkpoint_config.async_save:
@@ -686,219 +819,96 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         local_path = local_mkdir_safe(local_path)
         dist_checkpoint_path = get_dist_checkpoint_path(local_path)
-        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
 
-        # Note that model weights, optimizer states, and extra states are generated
-        # together in a state dict, we save them in one time
+        # ── 1. Save dist_checkpoint payload ───────────────────────────────────
+        # Megatron-FSDP uses its own DTensor-based writer and replaces the
+        # dist_checkpointing composition pipeline entirely.  All other model /
+        # config / tokenizer paths below still apply (and are no-ops when not
+        # configured).  FSDP saves synchronously, so no async request is
+        # produced.
+        async_save_request = None
+        saved_dist_ckpt = False
         if self.use_megatron_fsdp:
-            async_save_request = self._save_megatron_fsdp_checkpoint(dist_checkpoint_path)
-        elif self.use_dist_checkpointing:
-            # Generate state dict for saving
-            sharded_sd_metadata = self._build_sharded_state_dict_metadata()
-            state_dict = self.generate_state_dict(
-                self.should_save_model,
-                self.should_save_optimizer,
-                self.should_save_extra,
-                metadata=sharded_sd_metadata,
-            )
-            state_dict = self._maybe_filter_peft_state_dict(state_dict)
-            log_with_rank(f"Generated state dict for saving: {state_dict.keys()}", rank=self.rank, logger=logger)
-
-            for vpp_rank, model in enumerate(self.model):
-                if len(self.model) > 1:
-                    model_i_keys = state_dict[f"model{vpp_rank}"].keys()
-                    log_with_rank(f"Generated state dict for saving: {model_i_keys}", rank=self.rank, logger=logger)
-                else:
-                    log_with_rank(
-                        f"Generated state dict for saving: {state_dict['model'].keys()}",
-                        rank=self.rank,
-                        logger=logger,
-                    )
-            # Start Async save if enabled
-            async_save_request = save_dist_checkpointing(
-                sharded_state_dict=state_dict,
-                ckpt_path=dist_checkpoint_path,
-                async_save=self.checkpoint_config.async_save,
-                content_metadata=sharded_sd_metadata,
-            )
-
-            # Synchronize all async save requests
-            if not self.checkpoint_config.async_save:
-                assert async_save_request is None, "Async save request should be None when not using async save."
-                torch.distributed.barrier()
+            self._save_megatron_fsdp_checkpoint(dist_checkpoint_path)
+            saved_dist_ckpt = True
         else:
-            assert self.use_hf_checkpoint, "When not using distributed checkpointing, use_hf_checkpoint should be True."
-            # Generate optimizer and exra state dicts
-            sharded_sd_metadata = self._build_sharded_state_dict_metadata()
-            state_dict = self.generate_state_dict(
-                generate_model=self.should_save_model and self.peft_cls is not None,
-                generate_optimizer=self.should_save_optimizer,
-                generate_extra=self.should_save_extra,
-                metadata=sharded_sd_metadata,
-            )
-            state_dict = self._maybe_filter_peft_state_dict(state_dict)
-            # Save optimizer and extra states to local path
-            # Start Async save if enabled
-            async_save_request = save_dist_checkpointing(
-                sharded_state_dict=state_dict,
-                ckpt_path=dist_checkpoint_path,
-                async_save=self.checkpoint_config.async_save,
-                content_metadata=sharded_sd_metadata,
-            )
+            metadata = self._build_sharded_state_dict_metadata()
 
-            # Synchronize all async save requests
-            if not self.checkpoint_config.async_save:
-                assert async_save_request is None, "Async save request should be None when not using async save."
-                torch.distributed.barrier()
+            # ── Compose the dist_checkpoint state dict ────────────────────────
+            # dist_checkpointing is the universal backend for optimizer and
+            # extra states, regardless of which model backend (mbridge /
+            # dist_ckpt) is used.  Model weights only go into dist_ckpt when
+            # mbridge is disabled (or for PEFT adapters which bridge doesn't
+            # handle).
+            #
+            # The model sharded state dict is built as a transient dependency
+            # when the optimizer needs it — Megatron's
+            # optimizer.sharded_state_dict() requires the model's sharding
+            # layout as read-only input.
+            dist_ckpt_state_dict = {}
 
-        if self.should_save_model:
-            if self.use_hf_checkpoint:
-                # Use mbridge to save HF model checkpoint
-                log_with_rank(f"Saving HF model checkpoint to {local_path} with bridge", rank=self.rank, logger=logger)
-                hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                if self.vanilla_bridge:
-                    extended_args = {}
-                    mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
-                    for sig in inspect.signature(self.bridge.save_weights).parameters:
-                        if sig == "weights_path" or sig == "models":
-                            continue
-                        if sig in mbridge_config:
-                            extended_args[sig] = mbridge_config[sig]
-                    self.bridge.save_weights(self.model, hf_ckpt_path, **extended_args)
-                else:
-                    if self.peft_cls is not None:
-                        hf_adapter_ckpt_path = os.path.join(hf_ckpt_path, "adapter")
-                        self.bridge.save_hf_adapter(self.model, hf_adapter_ckpt_path, self.peft_cls)
-                        log_with_rank(
-                            f"Saved HF PEFT adapter checkpoint to {hf_adapter_ckpt_path}",
-                            rank=self.rank,
-                            logger=logger,
-                            log_only_rank_0=True,
-                        )
-                    else:
-                        self.bridge.save_hf_weights(self.model, hf_ckpt_path, strict=self.checkpoint_config.strict)
+            model_sharded_state_dict = None
+            if (
+                self.should_save_optimizer
+                or self._save_model_via_dist_ckpt
+                or self._save_peft_adapters_in_dist_ckpt
+            ):
+                model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
-                log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
+            if self.should_save_optimizer:
+                dist_ckpt_state_dict.update(self._build_optimizer_state_dict(model_sharded_state_dict, metadata))
 
-            # Only rank 0 saves the hf config and tokenizer to huggingface path
-            # No matter whether we save hf model or not
-            if self.rank == 0:
-                # Save tokenizer
-                if self.processing_class is not None:
-                    self.processing_class.save_pretrained(hf_config_tokenizer_path)
-                # Save huggingface config
-                self.hf_config.save_pretrained(hf_config_tokenizer_path)
-                if hasattr(self.hf_config, "name_or_path") and self.hf_config.name_or_path:
-                    try:
-                        generation_config = GenerationConfig.from_pretrained(self.hf_config.name_or_path)
-                        generation_config.save_pretrained(hf_config_tokenizer_path)
-                    except Exception:
-                        # if the generation config isn't available, we don't save it
-                        pass
+            if self.should_save_extra:
+                dist_ckpt_state_dict.update(self._build_extra_state_dict())
+
+            if self._save_model_via_dist_ckpt:
+                dist_ckpt_state_dict.update(model_sharded_state_dict)
                 log_with_rank(
-                    f"Saved Huggingface config and tokenizer to {hf_config_tokenizer_path}",
+                    f"dist_ckpt will save model shards: {model_sharded_state_dict.keys()}",
                     rank=self.rank,
                     logger=logger,
-                    log_only_rank_0=True,
                 )
 
+            # PEFT adapter shards always live in dist_ckpt (bridge handles
+            # base model only).
+            if self._save_peft_adapters_in_dist_ckpt:
+                peft_state = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
+                dist_ckpt_state_dict.update(peft_state)
+
+            if dist_ckpt_state_dict:
+                async_save_request = self._save_dist_checkpoint(dist_checkpoint_path, dist_ckpt_state_dict)
+                saved_dist_ckpt = True
+
+        # ── 2. Save model weights via mbridge (HF format) ─────────────────────
+        if self._save_model_via_mbridge:
+            hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
+            log_with_rank(f"Saving HF model checkpoint to {hf_ckpt_path} with bridge", rank=self.rank, logger=logger)
+            self._save_model_via_bridge(hf_ckpt_path)
+            log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
+
+        # ── 3. HF config / tokenizer (rank 0) ────────────────────────────────
+        if self._save_model_via_mbridge:
+            self._save_hf_config_and_tokenizer(local_path)
+
+        # ── 4. Transformer config (rank 0) ────────────────────────────────────
         if self.should_save_extra:
-            if self.rank == 0:
-                # Save transformer config
-                print(self.transformer_config)
-                transformer_config_dict = _to_json_safe_config_dict(_config_to_shallow_dict(self.transformer_config))
-                transformer_config_path = get_transformer_config_checkpoint_path(local_path)
-                # NOTE: With Megatron-Bridge backend, a circular import issue occurs when transformers version >= 5.4.0.
-                with open(transformer_config_path, "w") as f:
-                    json.dump(
-                        transformer_config_dict,
-                        f,
-                        indent=2,
-                        default=lambda o: o.to_dict() if hasattr(o, "to_dict") else o,
-                    )
+            self._save_transformer_config(local_path)
 
-        if self.should_save_hf_model and not self.use_hf_checkpoint:
-            # wait for everyone to dump to local
-            if self.bridge is not None:
-                hf_model_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                if self.vanilla_bridge:
-                    extended_args = {}
-                    mbridge_config = getattr(self.checkpoint_config, "mbridge_config", None) or {}
-                    for sig in inspect.signature(self.bridge.save_weights).parameters:
-                        if sig == "weights_path" or sig == "models":
-                            continue
-                        if sig in mbridge_config:
-                            extended_args[sig] = mbridge_config[sig]
-                    self.bridge.save_weights(self.model, hf_model_ckpt_path, **extended_args)
-                else:
-                    self.bridge.save_hf_weights(self.model, hf_model_ckpt_path)
-            else:
-                state_dict = self.weight_saver(
-                    self.model,
-                    self.hf_config,
-                    dtype=self.param_dtype,
-                    is_value_model=self.is_value_model,
-                    tie_word_embeddings=self.share_embeddings_and_output_weights,
-                )
-
-                torch.distributed.barrier()
-                if self.rank == 0:
-                    hf_model_ckpt_path = get_hf_model_checkpoint_path(local_path)
-                    import warnings
-
-                    from accelerate import init_empty_weights
-
-                    with init_empty_weights(), warnings.catch_warnings():
-                        warnings.simplefilter("ignore")
-                        if "mistral7b-rm" in self.config.model.path:
-                            from transformers import MistralForSequenceClassification
-
-                            model = MistralForSequenceClassification.from_pretrained(
-                                self.config.model.path
-                            )  # use score head instead of lm_head
-                            state_dict["score.weight"] = state_dict["score.weight"]
-                        else:
-                            from transformers import AutoModelForCausalLM
-
-                            model = AutoModelForCausalLM.from_pretrained(self.config.model.path, torch_dtype="auto")
-                    model.save_pretrained(hf_model_ckpt_path, state_dict=state_dict)
-                    log_with_rank(
-                        f"Saved Huggingface config and tokenizer to {hf_model_ckpt_path}",
-                        rank=self.rank,
-                        logger=logger,
-                        log_only_rank_0=True,
-                    )
-
-                    if hdfs_path is not None:
-                        log_with_rank(
-                            f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger, log_only_rank_0=True
-                        )
-                        from verl.utils import hdfs_io
-
-                        hdfs_io.makedirs(hdfs_path, exist_ok=True)
-                        hdfs_io.copy(src=hf_model_ckpt_path, dst=hdfs_path, dirs_exist_ok=True)
-                        log_with_rank(
-                            f"HDFS checkpoint uploaded to {hdfs_path}",
-                            rank=self.rank,
-                            logger=logger,
-                            log_only_rank_0=True,
-                        )
+        # ── 5. Finalization (HDFS upload, tracker, retention) ─────────────────
+        hf_config_tokenizer_path = get_hf_model_checkpoint_path(local_path)
 
         def finalize_save_fn():
-            # Rank 0 uploads checkpoint to HDFS if hdfs_path is provided
-            log_with_rank(
-                f"Dist checkpointing save completed for {dist_checkpoint_path}", rank=self.rank, logger=logger
-            )
-            if self.rank == 0:
-                if hdfs_path is not None:
-                    log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
-                    from verl.utils import hdfs_io
+            log_with_rank(f"Checkpoint save completed for {local_path}", rank=self.rank, logger=logger)
+            if self.rank == 0 and hdfs_path is not None:
+                log_with_rank(f"Uploading checkpoint to {hdfs_path}", rank=self.rank, logger=logger)
+                from verl.utils import hdfs_io
 
-                    hdfs_io.makedirs(hdfs_path, exist_ok=True)
+                hdfs_io.makedirs(hdfs_path, exist_ok=True)
+                if saved_dist_ckpt:
                     hdfs_io.copy(src=dist_checkpoint_path, dst=hdfs_path, dirs_exist_ok=True)
+                if self._save_model_via_mbridge:
                     hdfs_io.copy(src=hf_config_tokenizer_path, dst=hdfs_path, dirs_exist_ok=True)
 
-            # update latest_checkpointed_iteration.txt when async_save is True
             if self.checkpoint_config.async_save and self.rank == 0:
                 log_with_rank(
                     f"Update latest_checkpointed_iteration.txt to step {global_step}",
@@ -913,8 +923,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
             self.register_checkpoint(local_path, max_ckpt_to_keep)
 
-        if self.checkpoint_config.async_save:
-            assert async_save_request is not None, "Async save request should not be None when using async save."
+        if self.checkpoint_config.async_save and async_save_request is not None:
             async_save_request.add_finalize_fn(finalize_save_fn)
             try:
                 from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -115,29 +115,32 @@ def _config_to_shallow_dict(config):
 class MegatronCheckpointManager(BaseCheckpointManager):
     """Checkpoint manager for Megatron-LM distributed training.
 
-    Two model-checkpoint backends are supported, controlled by ``use_mbridge``:
+    Model weights are saved/loaded in exactly one format, selected by a
+    single flag that matches the user-facing YAML config (
+    ``*.megatron.use_dist_checkpointing``):
 
-    * **mbridge (default)** -- saves / loads model weights in HuggingFace format
-      via megatron-bridge.  Both ``"model"`` and ``"hf_model"`` in
-      ``save_contents`` produce the same HF checkpoint (saved only once).
-
-    * **dist_checkpoint** -- saves model weights using Megatron's native
-      ``dist_checkpointing`` (sharded across ranks).  ``"hf_model"`` in
-      ``save_contents`` is **not** supported with this backend (raises error).
+    * ``use_dist_checkpointing=False`` (default) -- HuggingFace format via
+      megatron-bridge, under ``model/huggingface/``. Requires a ``bridge``.
+    * ``use_dist_checkpointing=True`` -- Megatron native sharded format via
+      ``dist_checkpointing``, under ``model/dist_ckpt/``.
 
     Optimizer, LR-scheduler, and RNG states always go through
-    ``dist_checkpointing`` regardless of the model backend.
+    ``dist_checkpointing`` regardless of the model format.
+
+    Interaction with ``save_contents``:
+
+    * ``model`` -- saved via the selected format.
+    * ``hf_model`` -- requires ``use_dist_checkpointing=False`` (i.e. the HF
+      path); deduplicated against ``model`` when both are present.
 
     Args:
         model: The Megatron model instance to checkpoint.
         optimizer: The optimizer instance.
         lr_scheduler: The learning rate scheduler instance.
-        use_mbridge: If ``True`` (default), model weights are saved/loaded via
-            megatron-bridge in HuggingFace format.  Requires ``bridge`` to be
-            provided.  If ``False``, ``dist_checkpointing`` is used for model
-            weights.
-        use_dist_checkpointing: Legacy alias -- when provided, it sets
-            ``use_mbridge = not use_dist_checkpointing``.
+        use_dist_checkpointing: If ``True``, save/load model weights via
+            Megatron's native ``dist_checkpointing``. If ``False`` (default),
+            save/load HuggingFace weights via ``bridge``. Mirrors the
+            ``*.megatron.use_dist_checkpointing`` YAML field.
     """
 
     def __init__(
@@ -157,8 +160,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         optimizer_scheduler,
         use_distributed_optimizer: bool,
         use_checkpoint_opt_param_scheduler: bool = False,
-        use_dist_checkpointing: bool | None = None,
-        use_mbridge: bool = True,
+        use_dist_checkpointing: bool = False,
         use_megatron_fsdp: bool = False,
         bridge=None,
         provider=None,
@@ -191,56 +193,65 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         self.use_megatron_fsdp = use_megatron_fsdp
         self.rank = torch.distributed.get_rank()
 
-        # --- Resolve backend ---------------------------------------------------
-        # Legacy callers may still pass ``use_dist_checkpointing``; translate it.
-        if use_dist_checkpointing is not None:
-            use_mbridge = not use_dist_checkpointing
+        # One flag, one source of truth.  Mirrors the user-facing YAML key
+        # ``*.megatron.use_dist_checkpointing``. Every save/load branch below
+        # is expressed via the ``should_{save,load}_{hf,dist_ckpt}_model``
+        # properties, which fold this flag with
+        # ``checkpoint_{save,load}_contents`` into a single boolean each.
+        self.use_dist_checkpointing = use_dist_checkpointing
 
-        if use_mbridge and self.bridge is None:
+        if self.should_save_hf_model and self.bridge is None:
             raise ValueError(
-                "MegatronCheckpointManager: use_mbridge=True requires a bridge "
-                "instance. Either pass `bridge=...` or set `use_mbridge=False` "
-                "to use dist_checkpointing for model weights."
+                "MegatronCheckpointManager: HF-format model weights require "
+                "a bridge instance. Either pass `bridge=...` or set "
+                "`use_dist_checkpointing=True` to use dist_checkpointing."
             )
 
-        self.use_mbridge = use_mbridge
-        # Aliases kept so the rest of the codebase can read them without change.
-        self.use_dist_checkpointing = not self.use_mbridge
-        self.use_hf_checkpoint = self.use_mbridge
-
-        # --- Validate & resolve save_contents vs backend ----------------------
-        # Per the RFC:
-        #   mbridge   + model    → save HF model via bridge
-        #   mbridge   + hf_model → same as model (deduplicated, save once)
-        #   dist_ckpt + model    → save via mcore dist_checkpointing
-        #   dist_ckpt + hf_model → ERROR (not supported)
-        #   both backends False  → ERROR
-        if not self.use_mbridge and not self.use_dist_checkpointing:
+        # 'hf_model' is produced only via bridge; rejecting it explicitly here
+        # (vs. the derived ``should_save_hf_model`` override below) keeps the
+        # error message tied to the user's raw input.
+        if "hf_model" in self.checkpoint_save_contents and use_dist_checkpointing:
             raise ValueError(
-                "MegatronCheckpointManager: at least one model-weight backend "
-                "must be enabled (use_mbridge or dist_checkpointing)."
+                "`save_contents` contains 'hf_model' but "
+                "`use_dist_checkpointing=True` selects the dist_checkpointing "
+                "path; 'hf_model' is only produced via bridge. Either drop "
+                "'hf_model' from `save_contents` or set "
+                "`use_dist_checkpointing=False`."
             )
 
-        if self.should_save_hf_model and not self.use_mbridge:
-            raise ValueError(
-                "save_contents contains 'hf_model' but mbridge is disabled. "
-                "'hf_model' is only supported with mbridge. Either enable "
-                "mbridge or remove 'hf_model' from save_contents."
-            )
+    # ------------------------------------------------------------------
+    # Backend-aware specialisations of ``should_{save,load}_{hf,dist_ckpt}_model``.
+    # Each property is the *single expression* guarding one dispatch
+    # branch, so save/load code never re-derives the same boolean.
+    # ------------------------------------------------------------------
 
-        # Whether we actually need to write model weights via each backend.
-        # When mbridge is active, both 'model' and 'hf_model' resolve to a
-        # single HF save (deduplicated).
-        self._save_model_via_mbridge = self.use_mbridge and (self.should_save_model or self.should_save_hf_model)
-        self._save_model_via_dist_ckpt = self.use_dist_checkpointing and self.should_save_model
+    @property
+    def should_save_hf_model(self) -> bool:
+        """True when this save must emit HF-format model weights via bridge.
 
-        # PEFT adapter shards always live in dist_checkpoint even with mbridge,
-        # because bridge handles only the base model.
-        self._save_peft_adapters_in_dist_ckpt = self._save_model_via_mbridge and self.peft_cls is not None
+        Fires when ``save_contents`` asks for ``hf_model`` OR when it asks
+        for ``model`` and the backend is HF (``use_dist_checkpointing=False``).
+        """
+        return "hf_model" in self.checkpoint_save_contents or (
+            "model" in self.checkpoint_save_contents and not self.use_dist_checkpointing
+        )
 
-        self._load_model_via_mbridge = self.use_mbridge and self.should_load_model and self.peft_cls is None
-        # PEFT adapters always live in the dist_checkpoint directory.
-        self._load_model_via_dist_ckpt = self.should_load_model and (not self.use_mbridge or self.peft_cls is not None)
+    @property
+    def should_save_dist_ckpt_model(self) -> bool:
+        """True when this save must emit Megatron sharded model weights."""
+        return "model" in self.checkpoint_save_contents and self.use_dist_checkpointing
+
+    @property
+    def should_load_hf_model(self) -> bool:
+        """True when model weights must be loaded from an HF-format checkpoint via bridge."""
+        return "hf_model" in self.checkpoint_load_contents or (
+            "model" in self.checkpoint_load_contents and not self.use_dist_checkpointing
+        )
+
+    @property
+    def should_load_dist_ckpt_model(self) -> bool:
+        """True when model weights must be loaded from a Megatron sharded checkpoint."""
+        return "model" in self.checkpoint_load_contents and self.use_dist_checkpointing
 
     def get_rng_state(self, use_dist_ckpt: bool = True, data_parallel_random_init: bool = False):
         """collect rng state across data parallel ranks"""
@@ -473,7 +484,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         contents: dict[str, dict] = {}
 
-        if self._save_model_via_mbridge:
+        if self.should_save_hf_model:
             model_entry: dict = {
                 "path": hf_rel,
                 "format": "huggingface",
@@ -482,21 +493,21 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             if self.peft_cls is not None:
                 model_entry["peft_adapter_path"] = os.path.join(hf_rel, "adapter")
             contents["model"] = model_entry
-            if self.should_save_hf_model:
+            if "hf_model" in self.checkpoint_save_contents:
                 contents["hf_model"] = {
                     "path": hf_rel,
                     "format": "huggingface",
-                    "note": "deduplicated with 'model' when mbridge is enabled",
+                    "note": "deduplicated with 'model' on the HF path",
                 }
 
-        if self._save_model_via_dist_ckpt:
+        if self.should_save_dist_ckpt_model:
             contents["model"] = {
                 "path": model_dist_rel,
                 "format": "megatron_dist_checkpoint",
                 "backend": "dist_checkpointing",
             }
 
-        if self._save_peft_adapters_in_dist_ckpt:
+        if self.should_save_hf_model and self.peft_cls is not None:
             contents["peft_adapters"] = {
                 "path": model_dist_rel,
                 "format": "megatron_dist_checkpoint",
@@ -526,7 +537,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 "format": "json",
             }
 
-        if self._save_model_via_mbridge:
+        if self.should_save_hf_model:
             contents["hf_config"] = {
                 "path": hf_rel,
                 "format": "huggingface",
@@ -539,12 +550,12 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 }
 
         directories: dict[str, str] = {}
-        if self._save_model_via_mbridge:
+        if self.should_save_hf_model:
             directories[hf_rel] = (
                 "HuggingFace-format artifacts written via mbridge: model weights, "
                 "config.json, tokenizer files, and optional generation_config.json."
             )
-        if self._save_model_via_dist_ckpt or self._save_peft_adapters_in_dist_ckpt:
+        if self.should_save_dist_ckpt_model or (self.should_save_hf_model and self.peft_cls is not None):
             directories[model_dist_rel] = (
                 "Megatron dist_checkpointing shards for model weights (or PEFT adapter shards when mbridge is enabled)."
             )
@@ -563,7 +574,6 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             "global_step": int(global_step),
             "world_size": self.world_size,
             "backend": {
-                "use_mbridge": self.use_mbridge,
                 "use_dist_checkpointing": self.use_dist_checkpointing,
                 "peft": self.peft_cls is not None,
             },
@@ -604,7 +614,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
     # -- Load ------------------------------------------------------------------
 
-    def _load_model_via_bridge(self, hf_model_path: str):
+    def _load_model_as_hf_via_bridge(self, hf_model_path: str):
         """Load model weights through megatron-bridge."""
         if self.vanilla_bridge:
             self.bridge.load_weights(self.model, hf_model_path)
@@ -871,13 +881,18 @@ class MegatronCheckpointManager(BaseCheckpointManager):
 
         # Model sharded state dict is shared across the model-load and
         # optimizer-load metadata inputs, so build it once when either path
-        # needs it.
+        # needs it. The dist_ckpt model load and the HF+PEFT load both read
+        # Megatron shards, so either branch requires the sharded SD.
         model_sharded_state_dict = None
-        if self.should_load_optimizer or self._load_model_via_dist_ckpt:
+        if (
+            self.should_load_optimizer
+            or self.should_load_dist_ckpt_model
+            or (self.should_load_hf_model and self.peft_cls is not None)
+        ):
             model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
         # ── Load model weights ──────────────────────────────────────────────
-        if self._load_model_via_dist_ckpt:
+        if self.should_load_dist_ckpt_model or (self.should_load_hf_model and self.peft_cls is not None):
             model_sd = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
             loaded_model = load_dist_checkpointing(
                 sharded_state_dict=model_sd,
@@ -899,9 +914,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             else:
                 log_with_rank(f"Loaded sharded model checkpoint from {model_dist_path}", rank=self.rank, logger=logger)
 
-        elif self._load_model_via_mbridge:
+        elif self.should_load_hf_model and self.peft_cls is None:
             hf_model_path = get_hf_model_checkpoint_path(local_path)
-            self._load_model_via_bridge(hf_model_path)
+            self._load_model_as_hf_via_bridge(hf_model_path)
             log_with_rank(f"Loaded HF model checkpoint from {hf_model_path} with bridge", rank=self.rank, logger=logger)
 
         # ── Load optimizer / LR scheduler ───────────────────────────────────
@@ -965,7 +980,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                 extended_args[sig] = mbridge_config[sig]
         return extended_args
 
-    def _save_model_via_bridge(self, hf_ckpt_path: str):
+    def _save_model_as_hf_via_bridge(self, hf_ckpt_path: str):
         """Save model weights through megatron-bridge."""
         if self.vanilla_bridge:
             self.bridge.save_weights(self.model, hf_ckpt_path, **self._get_bridge_extended_args())
@@ -1144,8 +1159,8 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             ├── ckpt_contents.json       # manifest (read first to locate any piece)
             ├── transformer_config.json  # when 'extra' is in save_contents
             ├── model/
-            │   ├── huggingface/         # mbridge HF weights + config + tokenizer
-            │   └── dist_ckpt/           # Megatron model shards (mbridge off / PEFT)
+            │   ├── huggingface/         # HF weights via bridge (default) + config + tokenizer
+            │   └── dist_ckpt/           # Megatron shards (use_dist_checkpointing=True / PEFT)
             ├── optimizer/dist_ckpt/     # optimizer + lr_scheduler shards
             └── extra/dist_ckpt/         # rng_state shards
 
@@ -1174,11 +1189,11 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         # * Otherwise we use Megatron dist_checkpointing per-content (model /
         #   optimizer / extra) so each piece can be independently located,
         #   GC'd, or uploaded.  Model weights only go into dist_ckpt when
-        #   mbridge is disabled (or for PEFT adapters which bridge doesn't
-        #   handle).  The model sharded state dict is built once as a shared
-        #   dependency: Megatron's optimizer.sharded_state_dict() reads it as
-        #   metadata, and we may additionally persist it (or a PEFT-filtered
-        #   subset) as the model content itself.
+        #   ``use_dist_checkpointing=True`` (or for PEFT adapters which
+        #   bridge doesn't handle).  The model sharded state dict is built
+        #   once as a shared dependency: Megatron's optimizer.sharded_state_dict()
+        #   reads it as metadata, and we may additionally persist it (or a
+        #   PEFT-filtered subset) as the model content itself.
         model_state_dict: dict = {}
         optimizer_state_dict: dict = {}
         extra_state_dict: dict = {}
@@ -1193,19 +1208,19 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             model_sharded_state_dict = None
             if (
                 self.should_save_optimizer
-                or self._save_model_via_dist_ckpt
-                or self._save_peft_adapters_in_dist_ckpt
+                or self.should_save_dist_ckpt_model
+                or (self.should_save_hf_model and self.peft_cls is not None)
             ):
                 model_sharded_state_dict = self._build_model_sharded_state_dict(metadata)
 
-            if self._save_model_via_dist_ckpt:
+            if self.should_save_dist_ckpt_model:
                 model_state_dict.update(model_sharded_state_dict)
                 log_with_rank(
                     f"model/dist_ckpt will save model shards: {model_sharded_state_dict.keys()}",
                     rank=self.rank,
                     logger=logger,
                 )
-            if self._save_peft_adapters_in_dist_ckpt:
+            if self.should_save_hf_model and self.peft_cls is not None:
                 peft_state = self._maybe_filter_peft_state_dict(dict(model_sharded_state_dict))
                 model_state_dict.update(peft_state)
 
@@ -1230,15 +1245,15 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             ]
         )
 
-        # ── 2. Save model weights via mbridge (HF format) ───────────────────
-        if self._save_model_via_mbridge:
+        # ── 2. Save model weights in HF format via bridge ───────────────────
+        if self.should_save_hf_model:
             hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
             log_with_rank(f"Saving HF model checkpoint to {hf_ckpt_path} with bridge", rank=self.rank, logger=logger)
-            self._save_model_via_bridge(hf_ckpt_path)
+            self._save_model_as_hf_via_bridge(hf_ckpt_path)
             log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
 
         # ── 3. HF config / tokenizer (rank 0) ───────────────────────────────
-        if self._save_model_via_mbridge:
+        if self.should_save_hf_model:
             self._save_hf_config_and_tokenizer(local_path)
 
         # ── 4. Transformer config (rank 0, at checkpoint root) ──────────────

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -746,21 +746,147 @@ def load_megatron_optimizer(optimizers):
         get_torch_device().empty_cache()
 
 
-def get_dist_checkpoint_path(checkpoint_path):
+# ---------------------------------------------------------------------------
+# Megatron checkpoint layout
+# ---------------------------------------------------------------------------
+#
+# Each Megatron checkpoint directory (``local_path``) has the following shape::
+#
+#     local_path/
+#     ├── ckpt_contents.json           # manifest (authoritative mapping)
+#     ├── transformer_config.json      # rank-0, when 'extra' is saved
+#     ├── model/
+#     │   ├── huggingface/             # mbridge-saved HF weights + config + tokenizer
+#     │   └── dist_ckpt/               # Megatron sharded model shards (mbridge off or PEFT)
+#     ├── optimizer/
+#     │   └── dist_ckpt/               # optimizer state + lr_scheduler
+#     └── extra/
+#         └── dist_ckpt/               # rng_state
+#
+# All helpers below return the canonical path for a given component.  They
+# do not check whether the directory contains data — callers decide whether
+# to read it based on the manifest / save_contents.
+
+
+_MODEL_SUBDIR = "model"
+_OPTIMIZER_SUBDIR = "optimizer"
+_EXTRA_SUBDIR = "extra"
+_DIST_CKPT_SUBDIR = "dist_ckpt"
+_HUGGINGFACE_SUBDIR = "huggingface"
+
+
+def get_model_checkpoint_path(checkpoint_path):
+    """Directory holding model-weight artifacts (HF and/or Megatron shards)."""
     local_mkdir_safe(checkpoint_path)
-    local_mkdir_safe(os.path.join(checkpoint_path, "dist_ckpt"))
-    return os.path.join(checkpoint_path, "dist_ckpt")
+    p = os.path.join(checkpoint_path, _MODEL_SUBDIR)
+    local_mkdir_safe(p)
+    return p
+
+
+def get_optimizer_checkpoint_path(checkpoint_path):
+    """Directory holding optimizer + lr_scheduler dist_checkpointing shards."""
+    local_mkdir_safe(checkpoint_path)
+    p = os.path.join(checkpoint_path, _OPTIMIZER_SUBDIR)
+    local_mkdir_safe(p)
+    return p
+
+
+def get_extra_checkpoint_path(checkpoint_path):
+    """Directory holding 'extra' artifacts (rng_state)."""
+    local_mkdir_safe(checkpoint_path)
+    p = os.path.join(checkpoint_path, _EXTRA_SUBDIR)
+    local_mkdir_safe(p)
+    return p
+
+
+def get_model_dist_checkpoint_path(checkpoint_path):
+    """``model/dist_ckpt/`` — used when mbridge is disabled or for PEFT adapter shards."""
+    p = os.path.join(get_model_checkpoint_path(checkpoint_path), _DIST_CKPT_SUBDIR)
+    local_mkdir_safe(p)
+    return p
+
+
+def get_optimizer_dist_checkpoint_path(checkpoint_path):
+    """``optimizer/dist_ckpt/`` — optimizer + lr_scheduler dist_checkpointing directory."""
+    p = os.path.join(get_optimizer_checkpoint_path(checkpoint_path), _DIST_CKPT_SUBDIR)
+    local_mkdir_safe(p)
+    return p
+
+
+def get_extra_dist_checkpoint_path(checkpoint_path):
+    """``extra/dist_ckpt/`` — rng_state dist_checkpointing directory."""
+    p = os.path.join(get_extra_checkpoint_path(checkpoint_path), _DIST_CKPT_SUBDIR)
+    local_mkdir_safe(p)
+    return p
 
 
 def get_hf_model_checkpoint_path(checkpoint_path):
-    local_mkdir_safe(checkpoint_path)
-    local_mkdir_safe(os.path.join(checkpoint_path, "huggingface"))
-    return os.path.join(checkpoint_path, "huggingface")
+    """``model/huggingface/`` — HuggingFace-format weights, config, and tokenizer.
+
+    Historically this lived at ``<checkpoint>/huggingface``; as of layout
+    schema v2 it is nested under ``model/``.  See
+    :py:func:`verl.utils.checkpoint.megatron_checkpoint_manager.MegatronCheckpointManager._raise_for_old_layout`
+    for old-layout detection.
+    """
+    p = os.path.join(get_model_checkpoint_path(checkpoint_path), _HUGGINGFACE_SUBDIR)
+    local_mkdir_safe(p)
+    return p
 
 
 def get_transformer_config_checkpoint_path(checkpoint_path):
+    """``transformer_config.json`` at the checkpoint root (written by rank 0)."""
     os.makedirs(checkpoint_path, exist_ok=True)
     return os.path.join(checkpoint_path, "transformer_config.json")
+
+
+def get_checkpoint_contents_manifest_path(checkpoint_path):
+    """Path to the ``ckpt_contents.json`` manifest describing saved contents.
+
+    The manifest is a human- and tool-readable mapping from logical content
+    (e.g. ``model``, ``optimizer``, ``hf_model``) to its on-disk location
+    inside ``checkpoint_path``.  Users looking for a specific artifact in a
+    Megatron checkpoint should consult this file first — see
+    ``docs/advance/checkpoint.rst`` ("Locating saved contents") for the
+    schema, and
+    :py:meth:`verl.utils.checkpoint.megatron_checkpoint_manager.MegatronCheckpointManager._build_checkpoint_manifest`
+    for the implementation.
+    """
+    os.makedirs(checkpoint_path, exist_ok=True)
+    return os.path.join(checkpoint_path, "ckpt_contents.json")
+
+
+# --- Legacy (pre-v2) helpers ------------------------------------------------
+#
+# Old layouts put ``dist_ckpt/`` and ``huggingface/`` directly at the
+# checkpoint root.  These helpers are retained **only** so that the
+# migration script (``scripts/migrate_megatron_checkpoint_layout.py``) and
+# the old-layout detector can address those paths without hardcoding
+# literals.  New code must not call them.
+
+
+def get_legacy_dist_checkpoint_path(checkpoint_path):
+    return os.path.join(checkpoint_path, _DIST_CKPT_SUBDIR)
+
+
+def get_legacy_hf_model_checkpoint_path(checkpoint_path):
+    return os.path.join(checkpoint_path, _HUGGINGFACE_SUBDIR)
+
+
+def get_dist_checkpoint_path(checkpoint_path):  # pragma: no cover - back-compat shim
+    """Deprecated — kept only so stale imports fail loudly via the layout detector.
+
+    In the v2 layout there is no longer a single ``dist_ckpt/`` directory;
+    optimizer, extra, and (optionally) model live in separate subtrees.
+    Use the explicit ``get_{model,optimizer,extra}_dist_checkpoint_path``
+    helpers instead.
+    """
+    raise RuntimeError(
+        "get_dist_checkpoint_path is deprecated. The Megatron checkpoint layout "
+        "now splits optimizer/extra/(model) into separate directories. Use the "
+        "explicit helpers: get_model_dist_checkpoint_path, "
+        "get_optimizer_dist_checkpoint_path, get_extra_dist_checkpoint_path. "
+        "To migrate an old checkpoint, run scripts/migrate_megatron_checkpoint_layout.py."
+    )
 
 
 def convert_megatron_model_to_transformers_model(

--- a/verl/workers/config/__init__.py
+++ b/verl/workers/config/__init__.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import actor, critic, disaggregation, engine, model, optimizer, reward, rollout
+from . import actor, checkpoint, critic, disaggregation, engine, model, optimizer, reward, rollout
 from .actor import *  # noqa: F401
+from .checkpoint import *  # noqa: F401
 from .critic import *  # noqa: F401
 from .disaggregation import *  # noqa: F401
 from .distillation import *  # noqa: F401
@@ -33,4 +34,5 @@ __all__ = (
     + model.__all__
     + distillation.__all__
     + disaggregation.__all__
+    + checkpoint.__all__
 )

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -22,6 +22,7 @@ from verl.trainer.config import CheckpointConfig, RolloutCorrectionConfig
 from verl.utils.profiler.config import ProfilerConfig
 from verl.utils.qat import QATConfig
 
+from .checkpoint import McoreCheckpointConfig, MindSpeedCheckpointConfig
 from .engine import (
     FSDPEngineConfig,
     McoreEngineConfig,
@@ -264,16 +265,17 @@ class McoreActorConfig(ActorConfig):
 
     Args:
         strategy (str): Training strategy set to 'megatron' for Megatron parallelism.
-        load_weight (bool): Whether to load model weights from checkpoint.
         megatron (dict[str, Any]): Configuration for Megatron parallelism settings.
         profile (dict[str, Any]): Configuration for profiling settings.
+        checkpoint (McoreCheckpointConfig): Megatron-specific checkpoint config
+            that adds ``mbridge_config`` on top of the base checkpoint fields.
     """
 
     strategy: str = "megatron"
-    load_weight: bool = True
     megatron: McoreEngineConfig = field(default_factory=McoreEngineConfig)
     profile: dict[str, Any] = field(default_factory=dict)
     use_rollout_log_probs: bool = False
+    checkpoint: McoreCheckpointConfig = field(default_factory=McoreCheckpointConfig)
 
     def __post_init__(self):
         """Validate FSDP actor configuration parameters."""
@@ -396,17 +398,18 @@ class MindSpeedActorConfig(ActorConfig):
 
     Args:
         strategy (str): Training strategy set to 'mindspeed' for mindspeed parallelism.
-        load_weight (bool): Whether to load model weights from checkpoint.
         mindspeed (dict[str, Any]): Configuration for mindspeed parallelism settings.
         profile (dict[str, Any]): Configuration for profiling settings.
         use_rollout_log_probs (bool): Whether to use log probabilities from rollout engine.
+        checkpoint (MindSpeedCheckpointConfig): MindSpeed-specific checkpoint config
+            (inherits ``mbridge_config`` from :class:`McoreCheckpointConfig`).
     """
 
     strategy: str = "mindspeed"
-    load_weight: bool = True
     mindspeed: MindSpeedEngineConfig = field(default_factory=MindSpeedEngineConfig)
     profile: dict[str, Any] = field(default_factory=dict)
     use_rollout_log_probs: bool = False
+    checkpoint: MindSpeedCheckpointConfig = field(default_factory=MindSpeedCheckpointConfig)
 
     def __post_init__(self):
         """Validate MindSpeed actor configuration parameters."""

--- a/verl/workers/config/checkpoint.py
+++ b/verl/workers/config/checkpoint.py
@@ -1,0 +1,60 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-specific extensions of :class:`verl.trainer.config.CheckpointConfig`.
+
+The base :class:`CheckpointConfig` lives in ``verl/trainer/config/config.py`` and
+carries only fields that every backend understands (``save_contents``,
+``load_contents``, ``async_save``). Anything that is meaningful only to one
+training backend (e.g. mbridge options for Megatron) goes into a subclass here,
+mirroring how ``ActorConfig`` / ``McoreActorConfig`` are split between
+``verl/trainer/config`` and ``verl/workers/config``.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from verl.trainer.config import CheckpointConfig
+
+__all__ = ["McoreCheckpointConfig", "MindSpeedCheckpointConfig"]
+
+
+@dataclass
+class McoreCheckpointConfig(CheckpointConfig):
+    """Checkpoint config for the Megatron-Core backend.
+
+    Adds the mbridge-specific knobs consumed by
+    :class:`verl.utils.checkpoint.megatron_checkpoint_manager.MegatronCheckpointManager`
+    when it forwards kwargs to ``bridge.save_weights()``.
+
+    Args:
+        mbridge_config (dict[str, Any]): Extra kwargs forwarded to
+            ``bridge.save_weights``. Typical keys include
+            ``distributed_filesystem`` and ``memory_efficient`` for the
+            ``vanilla_mbridge`` path. Keys that are not accepted by the active
+            bridge's ``save_weights`` signature are silently ignored.
+    """
+
+    mbridge_config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MindSpeedCheckpointConfig(McoreCheckpointConfig):
+    """Checkpoint config for the MindSpeed backend.
+
+    MindSpeed reuses the Megatron checkpoint manager and therefore inherits the
+    mbridge knob from :class:`McoreCheckpointConfig`. A dedicated class is kept
+    so MindSpeed-only fields (should any appear in the future) have a natural
+    home and so the ``_target_`` in MindSpeed yamls mirrors the backend name.
+    """

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -21,6 +21,7 @@ from verl.base_config import BaseConfig
 from verl.trainer.config import BaseModelConfig, CheckpointConfig
 from verl.utils.profiler import ProfilerConfig
 
+from .checkpoint import McoreCheckpointConfig, MindSpeedCheckpointConfig
 from .engine import (
     FSDPEngineConfig,
     McoreEngineConfig,
@@ -164,13 +165,14 @@ class McoreCriticConfig(CriticConfig):
     Args:
         nccl_timeout (int): NCCL timeout in seconds for distributed operations.
         megatron (Dict[str, Any]): Megatron-specific parallelism settings.
-        load_weight (bool): Whether to load initial weights.
+        checkpoint (McoreCheckpointConfig): Megatron-specific checkpoint config
+            that adds ``mbridge_config`` on top of the base checkpoint fields.
     """
 
     strategy: str = "megatron"
     nccl_timeout: int = 600
     megatron: McoreEngineConfig = field(default_factory=McoreEngineConfig)
-    load_weight: bool = True
+    checkpoint: McoreCheckpointConfig = field(default_factory=McoreCheckpointConfig)
 
     def validate(self, n_gpus: int, train_batch_size: int):
         """Validate Megatron critic configuration with runtime parameters."""
@@ -287,13 +289,14 @@ class MindSpeedCriticConfig(CriticConfig):
     Args:
         nccl_timeout (int): NCCL timeout in seconds for distributed operations.
         mindspeed (Dict[str, Any]): mindspeed-specific parallelism settings.
-        load_weight (bool): Whether to load initial weights.
+        checkpoint (MindSpeedCheckpointConfig): MindSpeed-specific checkpoint config
+            (inherits ``mbridge_config`` from :class:`McoreCheckpointConfig`).
     """
 
     strategy: str = "mindspeed"
     nccl_timeout: int = 600
     mindspeed: MindSpeedEngineConfig = field(default_factory=MindSpeedEngineConfig)
-    load_weight: bool = True
+    checkpoint: MindSpeedCheckpointConfig = field(default_factory=MindSpeedCheckpointConfig)
 
     def validate(self, n_gpus: int, train_batch_size: int):
         """Validate mindspeed critic configuration with runtime parameters."""

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -419,10 +419,10 @@ class MegatronEngine(BaseEngine):
             optimizer_scheduler=self.lr_scheduler,
             use_distributed_optimizer=self.engine_config.use_distributed_optimizer,
             use_checkpoint_opt_param_scheduler=self.optimizer_config.use_checkpoint_opt_param_scheduler,
+            use_mbridge=not self.engine_config.use_dist_checkpointing,
             bridge=self.bridge,
             provider=self.provider,
             peft_cls=self.peft_cls,
-            use_dist_checkpointing=self.engine_config.use_dist_checkpointing,
         )
 
         self.to(

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -429,10 +429,10 @@ class MegatronEngine(BaseEngine):
             optimizer_scheduler=self.lr_scheduler,
             use_distributed_optimizer=self.engine_config.use_distributed_optimizer,
             use_checkpoint_opt_param_scheduler=self.optimizer_config.use_checkpoint_opt_param_scheduler,
+            use_mbridge=not self.engine_config.use_dist_checkpointing,
             bridge=self.bridge,
             provider=self.provider,
             peft_cls=self.peft_cls,
-            use_dist_checkpointing=self.engine_config.use_dist_checkpointing,
             use_megatron_fsdp=self.engine_config.use_megatron_fsdp,
         )
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -429,7 +429,7 @@ class MegatronEngine(BaseEngine):
             optimizer_scheduler=self.lr_scheduler,
             use_distributed_optimizer=self.engine_config.use_distributed_optimizer,
             use_checkpoint_opt_param_scheduler=self.optimizer_config.use_checkpoint_opt_param_scheduler,
-            use_mbridge=not self.engine_config.use_dist_checkpointing,
+            use_dist_checkpointing=self.engine_config.use_dist_checkpointing,
             bridge=self.bridge,
             provider=self.provider,
             peft_cls=self.peft_cls,

--- a/verl/workers/megatron_workers.py
+++ b/verl/workers/megatron_workers.py
@@ -683,9 +683,9 @@ class ActorRolloutRefWorker(MegatronWorker, DistProfilerExtension):
                 optimizer_scheduler=self.actor_optimizer_scheduler,
                 use_distributed_optimizer=self.config.actor.megatron.use_distributed_optimizer,
                 use_checkpoint_opt_param_scheduler=self.config.actor.optim.use_checkpoint_opt_param_scheduler,
+                use_mbridge=not self.config.actor.megatron.use_dist_checkpointing,
                 bridge=self.bridge,
                 provider=self.provider,
-                use_dist_checkpointing=self.config.actor.megatron.use_dist_checkpointing,
                 peft_cls=self.peft_cls,
             )
 
@@ -1239,9 +1239,9 @@ class CriticWorker(MegatronWorker, DistProfilerExtension):
             optimizer_scheduler=self.critic_optimizer_scheduler,
             use_distributed_optimizer=self.config.megatron.use_distributed_optimizer,
             use_checkpoint_opt_param_scheduler=self.config.optim.use_checkpoint_opt_param_scheduler,
+            use_mbridge=not self.config.megatron.use_dist_checkpointing,
             bridge=self.bridge,
             provider=self.provider,
-            use_dist_checkpointing=self.config.megatron.use_dist_checkpointing,
             peft_cls=self.peft_cls,
         )
 


### PR DESCRIPTION
### What does this PR do?

Refactoring Megatron checkpoint menager to avoid complex logics, following the way mentioned in https://github.com/verl-project/verl/issues/5630

# Problem

Now the mcore checkpoint manager has multiple backends: `mbridge, dist_checkpointing, verl original implemenation`, and there are 2 model related `save_contents` APIs: `model, hf_model`, which is complex in implemenation.

Also, the API implementation in codes is complex, `save_contents` are transformed with `should_save_xxx` judgement and the backends converted to `use_xxx` judgement. These naming is confusing and makes users difficult to understand saving logics.

# Refactor: Megatron checkpoint layout + checkpoint manager

## 1. New checkpoint structure (layout schema v2)

Follow the style of FSDP checkpoint manager, save by contents:

```
checkpoints/${project}/${experiment}/global_step_${i}/${role}/
├── ckpt_contents.json          # manifest (written last = save is complete)
├── transformer_config.json     # rank-0, when 'extra' is saved
├── model/
│   ├── huggingface/            # mbridge: HF weights + config + tokenizer
│   └── dist_ckpt/              # mbridge off: model shards / mbridge on + PEFT: adapter shards
├── optimizer/
│   └── dist_ckpt/              # optimizer + lr_scheduler shards
└── extra/
    └── dist_ckpt/              # rng_state shards
```

Old (v1) layout, for reference:

```
${role}/
├── dist_ckpt/        # optimizer + rng + (maybe) model shards, all mixed
├── huggingface/      # optional
└── transformer_config.json
```

## 2. New input behavior

- Backend flag renamed: `use_dist_checkpointing` → `use_mbridge`.
  - `use_dist_checkpointing` is still accepted as a legacy alias (`use_mbridge = not use_dist_checkpointing`).
- `save_contents` × backend matrix (validated up front in `__init__`):

  | Backend              | `save_contents`   | Behaviour                                         |
  |----------------------|-------------------|---------------------------------------------------|
  | `mbridge` (default)  | `model`           | HF save into `model/huggingface/`                 |
  | `mbridge`            | `hf_model`        | HF save into `model/huggingface/`                 |
  | `mbridge`            | both              | Same save, deduplicated (written once)            |
  | `dist_checkpoint`    | `model`           | Sharded save into `model/dist_ckpt/`              |
  | `dist_checkpoint`    | `hf_model`        | **Error** — only mbridge supports `hf_model`      |
  | both disabled        | any               | **Error** — at least one model backend required   |

- `optimizer` and `extra` always go through `dist_checkpointing`, regardless of backend.
- Loading a v1 checkpoint raises a clear error with a pointer to the migration script.

## 3. Old → new checkpoint converter

`scripts/migrate_megatron_checkpoint_layout.py`:

```bash
# Single role directory:
python scripts/migrate_megatron_checkpoint_layout.py \
    --checkpoint /path/to/global_step_N/actor

# Every step under a run:
python scripts/migrate_megatron_checkpoint_layout.py \
    --checkpoint-root /path/to/run --all-steps
```

- `--mode hardlink` (default) / `symlink` / `copy`.
- Idempotent (no-op on a v2 checkpoint).
- Works because `dist_checkpointing.load` is key-driven — it ignores unexpected entries, so the migrator can point `model/dist_ckpt/`, `optimizer/dist_ckpt/`, `extra/dist_ckpt/` at the same original `dist_ckpt/` data.

## 4. `MegatronCheckpointManager` structure

The manager is now organised into four layers:

- **util** — path helpers for every component of the v2 layout (`model/`, `model/dist_ckpt/`, `model/huggingface/`, `optimizer/dist_ckpt/`, `extra/dist_ckpt/`, `transformer_config.json`, `ckpt_contents.json`), plus detectors for the legacy v1 layout.
- **build** — composable builders for the sharded state dict (model / optimizer / extra), plus the `ckpt_contents.json` manifest payload. Save and load paths now only build the pieces they actually need, instead of one monolithic dict.
- **load** — validates layout (v1 → migration hint), reads the manifest, dispatches to the right backend (mbridge / dist_ckpt / PEFT).
- **save** — dispatches to the right backend per component, writes HF/tokenizer/transformer_config side files, then writes the manifest last via atomic rename so its presence signals a complete checkpoint.


cc @ISEEKYAN @vermouth1992 @PeterSH6 @wuxibin89 @khazic @tongyx361 

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Can continuous training:

<img width="1380" height="627" alt="image" src="https://github.com/user-attachments/assets/9a7247ce-357d-474b-b2bd-267a6bc88fac" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
