### PR TITLE
[ci] chore: add ascend 8.5.1 torch2.9.0 qwen3.5 dockerfile for A2 and A3

### DIFF
--- a/docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a2_qwen3_5
+++ b/docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a2_qwen3_5
@@ -1,0 +1,54 @@
+FROM quay.io/ascend/vllm-ascend:v0.18.0rc1
+
+ARG SOC_VERSION="ascend910_9392"
+ARG TRANSFORMERS_COMMIT="cc7ab9be"
+ARG TORCH_VERSION="2.9.0"
+ARG TORCH_NPU_VERSION="2.9.0"
+
+ENV HF_ENDPOINT=https://hf-mirror.com
+
+# 配置 pip 镜像源
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip config set global.trusted-host pypi.tuna.tsinghua.edu.cn
+
+# 换 apt 国内源 + 安装系统依赖
+RUN sed -i 's|http://archive.ubuntu.com|https://mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com|https://mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list && \
+    apt-get -o Acquire::Check-Valid-Until=false update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev wget git curl jq vim build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --upgrade pip packaging setuptools==80.10.2
+
+# 直接从宿主机复制，不需要网络克隆
+COPY transformers/ /workspace/transformers/
+COPY verl/ /workspace/verl/
+COPY MindSpeed/ /workspace/MindSpeed/
+COPY Megatron-LM/ /workspace/Megatron-LM/
+
+# 安装 MindSpeed 和 Megatron-LM
+RUN pip install -e /workspace/MindSpeed && \
+    pip install -e /workspace/Megatron-LM
+
+# 安装 transformers
+RUN pip install -e /workspace/transformers && \
+    pip uninstall -y triton || true
+
+# 安装 verl
+RUN cd /workspace/verl && \
+    pip install -r requirements-npu.txt && \
+    pip install -v -e .
+
+# 安装 mbridge、torch
+RUN pip install \
+        mbridge \
+        torch==${TORCH_VERSION} \
+        torch_npu==${TORCH_NPU_VERSION}
+
+# 统一清理
+RUN rm -rf /tmp/* /var/tmp/* && pip cache purge
+
+RUN pip list
+
+CMD ["/bin/bash"]

--- a/docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a3_qwen3_5
+++ b/docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a3_qwen3_5
@@ -1,0 +1,54 @@
+FROM quay.io/ascend/vllm-ascend:v0.18.0rc1-a3
+
+ARG SOC_VERSION="ascend910_9392"
+ARG TRANSFORMERS_COMMIT="cc7ab9be"
+ARG TORCH_VERSION="2.9.0"
+ARG TORCH_NPU_VERSION="2.9.0"
+
+ENV HF_ENDPOINT=https://hf-mirror.com
+
+# 配置 pip 镜像源
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip config set global.trusted-host pypi.tuna.tsinghua.edu.cn
+
+# 换 apt 国内源 + 安装系统依赖
+RUN sed -i 's|http://archive.ubuntu.com|https://mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.ubuntu.com|https://mirrors.tuna.tsinghua.edu.cn|g' /etc/apt/sources.list && \
+    apt-get -o Acquire::Check-Valid-Until=false update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev wget git curl jq vim build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip install --upgrade pip packaging setuptools==80.10.2
+
+# 直接从宿主机复制，不需要网络克隆
+COPY transformers/ /workspace/transformers/
+COPY verl/ /workspace/verl/
+COPY MindSpeed/ /workspace/MindSpeed/
+COPY Megatron-LM/ /workspace/Megatron-LM/
+
+# 安装 MindSpeed 和 Megatron-LM
+RUN pip install -e /workspace/MindSpeed && \
+    pip install -e /workspace/Megatron-LM
+
+# 安装 transformers
+RUN pip install -e /workspace/transformers && \
+    pip uninstall -y triton || true
+
+# 安装 verl
+RUN cd /workspace/verl && \
+    pip install -r requirements-npu.txt && \
+    pip install -v -e .
+
+# 安装 mbridge、torch
+RUN pip install \
+        mbridge \
+        torch==${TORCH_VERSION} \
+        torch_npu==${TORCH_NPU_VERSION}
+
+# 统一清理
+RUN rm -rf /tmp/* /var/tmp/* && pip cache purge
+
+RUN pip list
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
### What does this PR do?

Add Dockerfiles for Ascend 8.5.1 + Torch 2.9.0 + Qwen3.5 environments for both A2 and A3 to support image build and CI integration.


### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- Verified the files can be submitted correctly.
- Local build passed.
- Validated on both A2 and A3.

### API and Usage Example

No API changes.


# No API usage changes in this PR


### Design & Code Changes

* add `docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a2_qwen3_5`
* add `docker/ascend/Dockerfile.ascend_8.5.1_torch2.9.0_a3_qwen3_5`
* support Ascend 8.5.1 + Torch 2.9.0 + Qwen3.5 image build for A2 and A3

### Checklist Before Submitting

* [ ] Read the [[Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md)](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
* [ ] Apply [[pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
* [ ] Add / Update [[the documentation](https://github.com/volcengine/verl/tree/main/docs)](https://github.com/volcengine/verl/tree/main/docs).
* [ ] Add unit or end-to-end test(s) to [[the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows)](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: this PR only adds Dockerfiles and does not change runtime logic or public APIs.
* [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [[the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
* [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.




