### PR TITLE
[trainer] fix: add missing rollout dump and corrected validation logging in main_ppo_sync

### DIFF
--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -22,6 +22,7 @@ Differs from original PPO trainer in main_ppo.py:
 """
 
 import asyncio
+import json
 import logging
 import os
 import threading
@@ -942,6 +943,90 @@ class PPOTrainer:
         # Log to each configured logger
         self.validation_generations_logger.log(self.config.trainer.logger, samples, self.global_steps)
 
+    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
+        """Dump rollout/validation samples as JSONL."""
+        os.makedirs(dump_path, exist_ok=True)
+        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
+
+        n = len(inputs)
+        base_data = {
+            "input": inputs,
+            "output": outputs,
+            "gts": gts,
+            "score": scores,
+            "step": [self.global_steps] * n,
+        }
+
+        for k, v in reward_extra_infos_dict.items():
+            if len(v) == n:
+                base_data[k] = v
+
+        def json_encode_default(obj):
+            if isinstance(obj, np.integer):
+                return int(obj)
+            elif isinstance(obj, np.floating):
+                return float(obj)
+            elif isinstance(obj, np.bool_):
+                return bool(obj)
+            elif isinstance(obj, np.ndarray):
+                return obj.tolist()
+            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+        lines = []
+        for i in range(n):
+            entry = {k: v[i] for k, v in base_data.items()}
+            lines.append(json.dumps(entry, ensure_ascii=False, default=json_encode_default))
+
+        with open(filename, "w") as f:
+            f.write("\n".join(lines) + "\n")
+
+        print(f"Dumped generations to {filename}")
+
+    def _log_rollout_data(self, batch: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
+        """Fetch rollout data from TransferQueue and dump sorted by uid."""
+        with marked_timer("dump_rollout_generations", timing_raw, color="green"):
+            fields = ["uid", "prompts", "responses", "rm_scores", "reward_model"]
+            data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
+            data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+
+            uids = data.pop("uid").tolist()
+            inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["prompts"]]
+            outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["responses"]]
+            scores = data["rm_scores"].sum(dim=1).tolist()
+
+            reward_model = data.pop("reward_model", None)
+            if reward_model is not None:
+                gts = [item.get("ground_truth", None) for item in reward_model.tolist()]
+            else:
+                gts = [None] * len(uids)
+
+            # Sort by uid key ({sample}_{rollout}_{output})
+            sort_keys = []
+            for key in batch.keys:
+                parts = key.rsplit("_", 2)
+                if len(parts) == 3:
+                    sort_keys.append((parts[0], int(parts[1]), int(parts[2])))
+                else:
+                    sort_keys.append((key, 0, 0))
+            sorted_indices = sorted(range(len(sort_keys)), key=lambda i: sort_keys[i])
+
+            inputs = [inputs[i] for i in sorted_indices]
+            outputs = [outputs[i] for i in sorted_indices]
+            gts = [gts[i] for i in sorted_indices]
+            scores = [scores[i] for i in sorted_indices]
+
+            reward_extra_infos_dict = {"uid": [batch.keys[i] for i in sorted_indices]}
+
+            self._dump_generations(
+                inputs=inputs,
+                outputs=outputs,
+                gts=gts,
+                scores=scores,
+                reward_extra_infos_dict=reward_extra_infos_dict,
+                dump_path=rollout_data_dir,
+            )
+
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict[str, float]:
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
         metric_dict = {}
@@ -1378,7 +1463,12 @@ class PPOTrainer:
                 # 5. record metrics
                 self._compute_metrics(batch, metrics, timing_raw, global_steps=self.global_steps, epoch=epoch)
 
-                # 6. cleanup transfer queue and replay buffer
+                # 6. dump rollout generations if enabled
+                rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
+                if rollout_data_dir:
+                    self._log_rollout_data(batch, timing_raw, rollout_data_dir)
+
+                # 7. cleanup transfer queue and replay buffer
                 tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
                 self.replay_buffer.remove(batch.partition_id, batch.keys)
 

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -858,8 +858,24 @@ class PPOTrainer:
                 self.checkpoint_manager.update_weights()
 
             # 4. collect necessary data for logging
+            # For multi-output agent loops, only use the final output per session for metrics.
+            # Keys have format {uid}_{session_id}_{index}; keep only the highest index per session.
+            final_indices = []
+            session_max: dict[str, tuple[int, int]] = {}  # session_key -> (max_index, position)
+            for pos, key in enumerate(batch.keys):
+                parts = key.rsplit("_", 2)
+                if len(parts) == 3:
+                    session_key = f"{parts[0]}_{parts[1]}"
+                    index = int(parts[2])
+                    if session_key not in session_max or index > session_max[session_key][0]:
+                        session_max[session_key] = (index, pos)
+                else:
+                    session_max[key] = (0, pos)
+            final_indices = sorted(pos for _, pos in session_max.values())
+            final_keys = [batch.keys[i] for i in final_indices]
+
             fields = ["uid", "prompts", "responses", "rm_scores", "num_turns", "reward_model", "data_source"]
-            data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
+            data = tq.kv_batch_get(keys=final_keys, partition_id=batch.partition_id, select_fields=fields)
             data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
             data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
 

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -903,7 +903,9 @@ class PPOTrainer:
             if extra_fields_list is not None:
                 n_prior = len(reward_extra_infos_dict["reward"]) - len(extra_fields_list.tolist())
                 for extra_field in extra_fields_list.tolist():
-                    reward_extra_info = extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                    reward_extra_info = (
+                        extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                    )
                     for key in reward_extra_infos_dict:
                         if key != "reward" and key not in reward_extra_info:
                             reward_extra_infos_dict[key].append(None)

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -875,7 +875,16 @@ class PPOTrainer:
             final_indices = sorted(pos for _, pos in session_max.values())
             final_keys = [batch.keys[i] for i in final_indices]
 
-            fields = ["uid", "prompts", "responses", "rm_scores", "num_turns", "reward_model", "data_source"]
+            fields = [
+                "uid",
+                "prompts",
+                "responses",
+                "rm_scores",
+                "num_turns",
+                "reward_model",
+                "data_source",
+                "extra_fields",
+            ]
             data = tq.kv_batch_get(keys=final_keys, partition_id=batch.partition_id, select_fields=fields)
             data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
             data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
@@ -889,6 +898,20 @@ class PPOTrainer:
             sample_scores.extend(scores)
             sample_turns.extend(data.pop("num_turns").tolist())
             reward_extra_infos_dict["reward"].extend(scores)
+
+            extra_fields_list = data.pop("extra_fields", None)
+            if extra_fields_list is not None:
+                n_prior = len(reward_extra_infos_dict["reward"]) - len(extra_fields_list.tolist())
+                for extra_field in extra_fields_list.tolist():
+                    reward_extra_info = extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                    for key in reward_extra_infos_dict:
+                        if key != "reward" and key not in reward_extra_info:
+                            reward_extra_infos_dict[key].append(None)
+                    for key, value in reward_extra_info.items():
+                        if key not in reward_extra_infos_dict:
+                            reward_extra_infos_dict[key] = [None] * n_prior
+                        reward_extra_infos_dict[key].append(value)
+                    n_prior += 1
 
             reward_model = data.pop("reward_model", None)
             if reward_model is not None:


### PR DESCRIPTION
### What does this PR do?

Fixes three issues in `main_ppo_sync.py`'s validation and logging:

1. **`_dump_generations` is called but never defined.** `_validate()` calls `self._dump_generations()` (via `validation_data_dir` config) but the method doesn't exist on `PPOTrainer` — it would crash at runtime. Added the method (with numpy type serialization, which prevents crashes for int and bool types), plus `_log_rollout_data()` and the `rollout_data_dir` config hook for training rollout dumps.

1. **Validation fetches all multi-output keys instead of final-only.** With multi-output agent loops, each session produces keys `{uid}_{session_id}_{0..N}`. `_validate()` was fetching all of them for metrics, which resulted in many different `@k` metrics being logged when the number of outputs was different from session to session.
Rewards and advantages are being computed in terms of the last output in a session, so we have changed the `_validate` metrics to also be computed in terms of the last output also.

3. **`extra_fields` not fetched during validation.** Custom reward metrics in `extra_fields.reward_extra_info` were not collected, so they never appeared in val-aux logs.



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [main_ppo_sync](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+main_ppo_sync)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

These changes are in the sync trainer's logging/validation path which requires a full distributed training setup to test end-to-end. Validated by running PPO training with multi-output agent loops and confirming:
- validate@k metrics correctly count unique sessions (not individual outputs)
- `validation_data_dir` produces JSONL dumps without crashing
- `rollout_data_dir` produces JSONL dumps sorted by uid
- `reward_extra_info` metrics appear in val-aux logs

### API and Usage Example

No changes, matches functionality in `main_ppo`

### Design & Code Changes

- `_validate()`: Filter `batch.keys` to final output per `{uid}_{session_id}` group before fetching data. Fetch `extra_fields` and extract `reward_extra_info` into `reward_extra_infos_dict`.
- `_dump_generations()`: New method (matches `ray_trainer.py`), with `json_encode_default` for numpy types.
- `_log_rollout_data()`: New method to fetch and dump training rollout data sorted by uid key.
- `fit()` training loop: Added `rollout_data_dir` config check between metrics and cleanup steps.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (not necessary)
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: not necessary, as there are no similar tests for `main_ppo`
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. (not applicable)
