### PR TITLE
[trainer, worker] feat: grouped mini-batching for multi-output rollouts in main_ppo_sync

### DIFF
--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1380,10 +1380,10 @@ class PPOTrainer:
     def _update_critic(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Update the critic network."""
         ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
-        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        num_prompts = len(set(k.rsplit("_", 2)[0] for k in batch.keys))
+        num_mini_batch = max(1, num_prompts // ppo_mini_batch_size)
         extra_info = {
-            "global_batch_size": ppo_mini_batch_size,
-            "mini_batch_size": ppo_mini_batch_size,
+            "num_mini_batch": num_mini_batch,
             "epochs": self.config.critic.ppo_epochs,
             "seed": self.config.critic.data_loader_seed,
             "dataloader_kwargs": {"shuffle": self.config.critic.shuffle},
@@ -1402,7 +1402,8 @@ class PPOTrainer:
     def _update_actor(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Update the actor network."""
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
-        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        num_prompts = len(set(k.rsplit("_", 2)[0] for k in batch.keys))
+        num_mini_batch = max(1, num_prompts // ppo_mini_batch_size)
         calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
             self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
         )
@@ -1414,8 +1415,7 @@ class PPOTrainer:
         extra_info = {
             "calculate_entropy": calculate_entropy,
             "distillation_use_topk": distillation_use_topk,
-            "global_batch_size": ppo_mini_batch_size,
-            "mini_batch_size": ppo_mini_batch_size,
+            "num_mini_batch": num_mini_batch,
             "epochs": self.config.actor_rollout_ref.actor.ppo_epochs,
             "seed": self.config.actor_rollout_ref.actor.data_loader_seed,
             "dataloader_kwargs": {"shuffle": self.config.actor_rollout_ref.actor.shuffle},

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1009,18 +1009,9 @@ class PPOTrainer:
             dp_rank_mapping = worker_group._dispatch_info[role]
         dp_size = max(dp_rank_mapping) + 1
 
-        # TODO: It would be better to pad or upsample, but this is not supported by TransferQueue at the moment.
+        # TODO: up sampling if batch is not divisible by dp_size
         if len(batch) % dp_size != 0:
-            trim_size = len(batch) % dp_size
-            batch = KVBatchMeta(
-                keys=batch.keys[: len(batch) - trim_size],
-                tags=batch.tags[: len(batch) - trim_size],
-                partition_id=batch.partition_id,
-                fields=batch.fields,
-                extra_info=batch.extra_info,
-            )
-            global_seqlen_lst = torch.tensor([tag["seq_len"] for tag in batch.tags], dtype=torch.int64)
-            workload_lst = calculate_workload(global_seqlen_lst)
+            raise ValueError(f"Batch size {len(batch)} is not divisible by dp_size {dp_size}")
 
         # reorder based on index. The data will be automatically equally partitioned by dispatch function
         global_partition_lst = get_seqlen_balanced_partitions(workload_lst, k_partitions=dp_size, equal_size=True)
@@ -1029,7 +1020,6 @@ class PPOTrainer:
             seqlen_list=global_seqlen_lst.tolist(), partitions=global_partition_lst, prefix=logging_prefix
         )
         metrics.update(global_balance_stats)
-        return batch
 
     def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the old log prob of the batch."""
@@ -1403,7 +1393,7 @@ class PPOTrainer:
                 batch = self._compute_reward_colocate(batch)
 
         # 4. balance batch across data parallel groups
-        batch = self._balance_batch(batch, metrics=metrics)
+        self._balance_batch(batch, metrics=metrics)
 
         # 5. compute old_log_prob
         with marked_timer("old_log_prob", timing_raw, color="blue"):

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1189,7 +1189,6 @@ class PPOTrainer:
             seqlen_list=global_seqlen_lst.tolist(), partitions=global_partition_lst, prefix=logging_prefix
         )
         metrics.update(global_balance_stats)
-        return batch
 
     def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the old log prob of the batch."""
@@ -1589,7 +1588,7 @@ class PPOTrainer:
                 batch = self._compute_reward_colocate(batch)
 
         # 4. balance batch across data parallel groups
-        batch = self._balance_batch(batch, metrics=metrics)
+        self._balance_batch(batch, metrics=metrics)
 
         # 5. compute old_log_prob
         with marked_timer("old_log_prob", timing_raw, color="blue"):

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1009,9 +1009,18 @@ class PPOTrainer:
             dp_rank_mapping = worker_group._dispatch_info[role]
         dp_size = max(dp_rank_mapping) + 1
 
-        # TODO: up sampling if batch is not divisible by dp_size
+        # TODO: It would be better to pad or upsample, but this is not supported by TransferQueue at the moment.
         if len(batch) % dp_size != 0:
-            raise ValueError(f"Batch size {len(batch)} is not divisible by dp_size {dp_size}")
+            trim_size = len(batch) % dp_size
+            batch = KVBatchMeta(
+                keys=batch.keys[: len(batch) - trim_size],
+                tags=batch.tags[: len(batch) - trim_size],
+                partition_id=batch.partition_id,
+                fields=batch.fields,
+                extra_info=batch.extra_info,
+            )
+            global_seqlen_lst = torch.tensor([tag["seq_len"] for tag in batch.tags], dtype=torch.int64)
+            workload_lst = calculate_workload(global_seqlen_lst)
 
         # reorder based on index. The data will be automatically equally partitioned by dispatch function
         global_partition_lst = get_seqlen_balanced_partitions(workload_lst, k_partitions=dp_size, equal_size=True)
@@ -1020,6 +1029,7 @@ class PPOTrainer:
             seqlen_list=global_seqlen_lst.tolist(), partitions=global_partition_lst, prefix=logging_prefix
         )
         metrics.update(global_balance_stats)
+        return batch
 
     def _compute_old_log_prob(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Compute the old log prob of the batch."""
@@ -1200,10 +1210,10 @@ class PPOTrainer:
     def _update_critic(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Update the critic network."""
         ppo_mini_batch_size = self.config.critic.ppo_mini_batch_size
-        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        num_prompts = len(set(k.rsplit("_", 2)[0] for k in batch.keys))
+        num_mini_batch = max(1, num_prompts // ppo_mini_batch_size)
         extra_info = {
-            "global_batch_size": ppo_mini_batch_size,
-            "mini_batch_size": ppo_mini_batch_size,
+            "num_mini_batch": num_mini_batch,
             "epochs": self.config.critic.ppo_epochs,
             "seed": self.config.critic.data_loader_seed,
             "dataloader_kwargs": {"shuffle": self.config.critic.shuffle},
@@ -1222,14 +1232,14 @@ class PPOTrainer:
     def _update_actor(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
         """Update the actor network."""
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
-        ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
+        num_prompts = len(set(k.rsplit("_", 2)[0] for k in batch.keys))
+        num_mini_batch = max(1, num_prompts // ppo_mini_batch_size)
         calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
             self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
         )
         extra_info = {
             "calculate_entropy": calculate_entropy,
-            "global_batch_size": ppo_mini_batch_size,
-            "mini_batch_size": ppo_mini_batch_size,
+            "num_mini_batch": num_mini_batch,
             "epochs": self.config.actor_rollout_ref.actor.ppo_epochs,
             "seed": self.config.actor_rollout_ref.actor.data_loader_seed,
             "dataloader_kwargs": {"shuffle": self.config.actor_rollout_ref.actor.shuffle},
@@ -1393,7 +1403,7 @@ class PPOTrainer:
                 batch = self._compute_reward_colocate(batch)
 
         # 4. balance batch across data parallel groups
-        self._balance_batch(batch, metrics=metrics)
+        batch = self._balance_batch(batch, metrics=metrics)
 
         # 5. compute old_log_prob
         with marked_timer("old_log_prob", timing_raw, color="blue"):

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -612,6 +612,58 @@ def make_iterator(tensordict: TensorDict, mini_batch_size, epochs, seed=None, da
     return iter(get_data())
 
 
+def make_grouped_iterator(
+    tensordict: TensorDict, num_mini_batch: int, epochs: int, seed=None, shuffle=True, group_key: str = "uid"
+):
+    """Create an iterator that yields mini-batches grouped by group_key.
+
+    All sequences sharing the same group_key are kept in the same mini-batch.
+    Unique group_keys are split into num_mini_batch groups, so mini-batch tensor
+    sizes may vary.
+    """
+    from collections import defaultdict
+
+    uids = get(tensordict, group_key)
+    uid_to_indices = defaultdict(list)
+    for idx, uid in enumerate(uids):
+        uid_to_indices[uid].append(idx)
+    unique_uids = list(uid_to_indices.keys())
+
+    assert num_mini_batch <= len(unique_uids), (
+        f"num_mini_batch ({num_mini_batch}) > number of unique group keys ({len(unique_uids)})"
+    )
+
+    def get_data():
+        for epoch in range(epochs):
+            if shuffle:
+                epoch_seed = seed + epoch if seed is not None else None
+                if epoch_seed is not None:
+                    g = torch.Generator()
+                    g.manual_seed(epoch_seed)
+                    perm = torch.randperm(len(unique_uids), generator=g).tolist()
+                else:
+                    perm = torch.randperm(len(unique_uids)).tolist()
+                shuffled_uids = [unique_uids[i] for i in perm]
+            else:
+                shuffled_uids = unique_uids
+
+            chunk_size = len(shuffled_uids) // num_mini_batch
+            remainder = len(shuffled_uids) % num_mini_batch
+
+            start = 0
+            for i in range(num_mini_batch):
+                end = start + chunk_size + (1 if i < remainder else 0)
+                batch_uids = shuffled_uids[start:end]
+                start = end
+
+                indices = []
+                for uid in batch_uids:
+                    indices.extend(uid_to_indices[uid])
+                yield index_select_tensor_dict(tensordict, torch.tensor(indices))
+
+    return iter(get_data())
+
+
 def assert_tensordict_eq(tensordict1: TensorDict, tensordict2: TensorDict):
     """Assert that two TensorDicts are equal.
 

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -585,6 +585,58 @@ def make_iterator(tensordict: TensorDict, mini_batch_size, epochs, seed=None, da
     return iter(get_data())
 
 
+def make_grouped_iterator(
+    tensordict: TensorDict, num_mini_batch: int, epochs: int, seed=None, shuffle=True, group_key: str = "uid"
+):
+    """Create an iterator that yields mini-batches grouped by group_key.
+
+    All sequences sharing the same group_key are kept in the same mini-batch.
+    Unique group_keys are split into num_mini_batch groups, so mini-batch tensor
+    sizes may vary.
+    """
+    from collections import defaultdict
+
+    uids = get(tensordict, group_key)
+    uid_to_indices = defaultdict(list)
+    for idx, uid in enumerate(uids):
+        uid_to_indices[uid].append(idx)
+    unique_uids = list(uid_to_indices.keys())
+
+    assert num_mini_batch <= len(unique_uids), (
+        f"num_mini_batch ({num_mini_batch}) > number of unique group keys ({len(unique_uids)})"
+    )
+
+    def get_data():
+        for epoch in range(epochs):
+            if shuffle:
+                epoch_seed = seed + epoch if seed is not None else None
+                if epoch_seed is not None:
+                    g = torch.Generator()
+                    g.manual_seed(epoch_seed)
+                    perm = torch.randperm(len(unique_uids), generator=g).tolist()
+                else:
+                    perm = torch.randperm(len(unique_uids)).tolist()
+                shuffled_uids = [unique_uids[i] for i in perm]
+            else:
+                shuffled_uids = unique_uids
+
+            chunk_size = len(shuffled_uids) // num_mini_batch
+            remainder = len(shuffled_uids) % num_mini_batch
+
+            start = 0
+            for i in range(num_mini_batch):
+                end = start + chunk_size + (1 if i < remainder else 0)
+                batch_uids = shuffled_uids[start:end]
+                start = end
+
+                indices = []
+                for uid in batch_uids:
+                    indices.extend(uid_to_indices[uid])
+                yield index_select_tensor_dict(tensordict, torch.tensor(indices))
+
+    return iter(get_data())
+
+
 def assert_tensordict_eq(tensordict1: TensorDict, tensordict2: TensorDict):
     """Assert that two TensorDicts are equal.
 

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -307,9 +307,13 @@ class TrainingWorker(Worker, DistProfilerExtension):
                 dp_group = self.engine.get_data_parallel_group()
                 dp_world = torch.distributed.get_world_size(dp_group)
                 if dp_world > 1:
-                    sizes = [None] * dp_world
-                    torch.distributed.all_gather_object(sizes, local_batch_size, dp_group)
-                    global_batch_size = sum(sizes)
+                    global_batch_size_tensor = torch.tensor(
+                        local_batch_size, device=mini_batch_td.device, dtype=torch.long
+                    )
+                    torch.distributed.all_reduce(
+                        global_batch_size_tensor, op=torch.distributed.ReduceOp.SUM, group=dp_group
+                    )
+                    global_batch_size = global_batch_size_tensor.item()
                 else:
                     global_batch_size = local_batch_size
 

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -254,31 +254,40 @@ class TrainingWorker(Worker, DistProfilerExtension):
 
         assert mini_batch_size is not None or num_mini_batch is not None
 
-        if mini_batch_size is None:
-            assert batch_size_per_dp % num_mini_batch == 0, f"Got {batch_size_per_dp=} and {num_mini_batch=}"
-            mini_batch_size_per_gpu = batch_size_per_dp // num_mini_batch
-        else:
-            assert mini_batch_size % self.engine.get_data_parallel_size() == 0, (
-                f"Got {mini_batch_size=} and {self.engine.get_data_parallel_size()=}"
+        if num_mini_batch is not None and "uid" in data.keys():
+            shuffle = dataloader_kwargs.get("shuffle", True)
+            dataloader = tu.make_grouped_iterator(
+                data,
+                num_mini_batch=num_mini_batch,
+                epochs=epochs,
+                seed=seed + self.engine.get_data_parallel_rank(),
+                shuffle=shuffle,
             )
-            mini_batch_size_per_gpu = mini_batch_size // self.engine.get_data_parallel_size()
+            total_num_iterations = num_mini_batch * epochs
+        else:
+            if mini_batch_size is None:
+                assert batch_size_per_dp % num_mini_batch == 0, f"Got {batch_size_per_dp=} and {num_mini_batch=}"
+                mini_batch_size_per_gpu = batch_size_per_dp // num_mini_batch
+            else:
+                assert mini_batch_size % self.engine.get_data_parallel_size() == 0, (
+                    f"Got {mini_batch_size=} and {self.engine.get_data_parallel_size()=}"
+                )
+                mini_batch_size_per_gpu = mini_batch_size // self.engine.get_data_parallel_size()
 
-        # make iterator
-        dataloader = tu.make_iterator(
-            data,
-            mini_batch_size=mini_batch_size_per_gpu,
-            epochs=epochs,
-            seed=seed + self.engine.get_data_parallel_rank(),
-            dataloader_kwargs=dataloader_kwargs,
-        )
+            dataloader = tu.make_iterator(
+                data,
+                mini_batch_size=mini_batch_size_per_gpu,
+                epochs=epochs,
+                seed=seed + self.engine.get_data_parallel_rank(),
+                dataloader_kwargs=dataloader_kwargs,
+            )
+            total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
         with (
             self.engine.train_mode(disable_auto_offload=disable_auto_offload),
             Timer(name="train_batch", logger=None),
         ):
-            # update
             output_lst = []
-            total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
             for batch_idx, mini_batch_td in enumerate(dataloader):
                 # add global token num
@@ -295,9 +304,20 @@ class TrainingWorker(Worker, DistProfilerExtension):
                 else:
                     global_token_num = None
 
+                local_batch_size = mini_batch_td.batch_size[0]
+                dp_group = self.engine.get_data_parallel_group()
+                dp_world = torch.distributed.get_world_size(dp_group)
+                if dp_world > 1:
+                    sizes = [None] * dp_world
+                    torch.distributed.all_gather_object(sizes, local_batch_size, dp_group)
+                    global_batch_size = sum(sizes)
+                else:
+                    global_batch_size = local_batch_size
+
                 tu.assign_non_tensor(
                     mini_batch_td,
                     global_token_num=NonTensorData(global_token_num),
+                    global_batch_size=global_batch_size,
                     update_lr_scheduler=batch_idx == total_num_iterations - 1,
                     disable_auto_offload=True,
                 )

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -253,31 +253,40 @@ class TrainingWorker(Worker, DistProfilerExtension):
 
         assert mini_batch_size is not None or num_mini_batch is not None
 
-        if mini_batch_size is None:
-            assert batch_size_per_dp % num_mini_batch == 0, f"Got {batch_size_per_dp=} and {num_mini_batch=}"
-            mini_batch_size_per_gpu = batch_size_per_dp // num_mini_batch
-        else:
-            assert mini_batch_size % self.engine.get_data_parallel_size() == 0, (
-                f"Got {mini_batch_size=} and {self.engine.get_data_parallel_size()=}"
+        if num_mini_batch is not None and "uid" in data.keys():
+            shuffle = dataloader_kwargs.get("shuffle", True)
+            dataloader = tu.make_grouped_iterator(
+                data,
+                num_mini_batch=num_mini_batch,
+                epochs=epochs,
+                seed=seed + self.engine.get_data_parallel_rank(),
+                shuffle=shuffle,
             )
-            mini_batch_size_per_gpu = mini_batch_size // self.engine.get_data_parallel_size()
+            total_num_iterations = num_mini_batch * epochs
+        else:
+            if mini_batch_size is None:
+                assert batch_size_per_dp % num_mini_batch == 0, f"Got {batch_size_per_dp=} and {num_mini_batch=}"
+                mini_batch_size_per_gpu = batch_size_per_dp // num_mini_batch
+            else:
+                assert mini_batch_size % self.engine.get_data_parallel_size() == 0, (
+                    f"Got {mini_batch_size=} and {self.engine.get_data_parallel_size()=}"
+                )
+                mini_batch_size_per_gpu = mini_batch_size // self.engine.get_data_parallel_size()
 
-        # make iterator
-        dataloader = tu.make_iterator(
-            data,
-            mini_batch_size=mini_batch_size_per_gpu,
-            epochs=epochs,
-            seed=seed + self.engine.get_data_parallel_rank(),
-            dataloader_kwargs=dataloader_kwargs,
-        )
+            dataloader = tu.make_iterator(
+                data,
+                mini_batch_size=mini_batch_size_per_gpu,
+                epochs=epochs,
+                seed=seed + self.engine.get_data_parallel_rank(),
+                dataloader_kwargs=dataloader_kwargs,
+            )
+            total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
         with (
             self.engine.train_mode(disable_auto_offload=disable_auto_offload),
             Timer(name="train_batch", logger=None),
         ):
-            # update
             output_lst = []
-            total_num_iterations = data.shape[0] // mini_batch_size_per_gpu * epochs
 
             for batch_idx, mini_batch_td in enumerate(dataloader):
                 # add global token num
@@ -294,9 +303,20 @@ class TrainingWorker(Worker, DistProfilerExtension):
                 else:
                     global_token_num = None
 
+                local_batch_size = mini_batch_td.batch_size[0]
+                dp_group = self.engine.get_data_parallel_group()
+                dp_world = torch.distributed.get_world_size(dp_group)
+                if dp_world > 1:
+                    sizes = [None] * dp_world
+                    torch.distributed.all_gather_object(sizes, local_batch_size, dp_group)
+                    global_batch_size = sum(sizes)
+                else:
+                    global_batch_size = local_batch_size
+
                 tu.assign_non_tensor(
                     mini_batch_td,
                     global_token_num=NonTensorData(global_token_num),
+                    global_batch_size=global_batch_size,
                     update_lr_scheduler=batch_idx == total_num_iterations - 1,
                     disable_auto_offload=True,
                 )

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -308,9 +308,13 @@ class TrainingWorker(Worker, DistProfilerExtension):
                 dp_group = self.engine.get_data_parallel_group()
                 dp_world = torch.distributed.get_world_size(dp_group)
                 if dp_world > 1:
-                    sizes = [None] * dp_world
-                    torch.distributed.all_gather_object(sizes, local_batch_size, dp_group)
-                    global_batch_size = sum(sizes)
+                    global_batch_size_tensor = torch.tensor(
+                        local_batch_size, device=mini_batch_td.device, dtype=torch.long
+                    )
+                    torch.distributed.all_reduce(
+                        global_batch_size_tensor, op=torch.distributed.ReduceOp.SUM, group=dp_group
+                    )
+                    global_batch_size = global_batch_size_tensor.item()
                 else:
                     global_batch_size = local_batch_size
 


### PR DESCRIPTION
### What does this PR do?

When using multi-output rollouts, mini-batch splitting can break sequences from the same prompt across different PPO mini-batches. Namely, each global batch is split into mini-batches of `actor.ppo_mini_batch_size * rollout.n` sequences, which does not necessarily correspond to the sequences corresponding to `actor.ppo_mini_batch_size` different prompts when using multi-output rollouts.
This also results in an inconsistent number of model updates per training iteration.

This PR fixes this by:
- Adding `make_grouped_iterator` in `tensordict_utils.py` that keeps same-UID sequences together in mini-batches
- Computing `num_mini_batch` from unique prompts instead of `mini_batch_size * rollout.n`.
- Computing `global_batch_size` dynamically via `all_reduce` across DP ranks.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: [main_ppo_sync](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+main_ppo_sync)
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Validated experimentally with multi-output training where each session has a variable number of outputs.

### API and Usage Example

No API changes. The behavior is automatic — `ppo_mini_batch_size` is interpreted as the number of unique prompts per mini-batch, and the grouped iterator keeps all outputs from the same prompt together.

### Design & Code Changes

- **`verl/utils/tensordict_utils.py`**: New `make_grouped_iterator` function that groups sequences by a key (default: `uid`) and splits unique groups into `num_mini_batch` chunks.
- **`verl/workers/engine_workers.py`**: `TrainingWorker.train_batch` uses `make_grouped_iterator` when `num_mini_batch` and `uid` are available. Computes `global_batch_size` dynamically via `all_gather_object` since grouped mini-batches may have variable sizes across DP ranks.
- **`verl/trainer/main_ppo_sync.py`**: `_update_actor` / `_update_critic`: Compute `num_mini_batch` from unique UIDs rather than scaling `mini_batch_size` by `rollout.n`.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). Not necessary
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: changes are covered by existing tests
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable
