### PR TITLE
[fully_async] fix: replace routed_experts on partial rollout resume i…

### DIFF
--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -17,7 +17,6 @@ import os
 from typing import Any, Optional
 
 import ray
-import torch
 from omegaconf import DictConfig
 
 from verl.experimental.agent_loop.agent_loop import (
@@ -96,11 +95,10 @@ class FullyAsyncLLMServerManager(AsyncLLMServerManager):
             final_output.token_ids.extend(output.token_ids)
             if output.log_probs is not None:
                 final_output.log_probs.extend(output.log_probs)
+            # sglang returns routed_experts for the full sequence (prompt + all tokens),
+            # so on partial rollout resume the new output already covers all positions.
             if output.routed_experts is not None:
-                if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
-                else:
-                    final_output.routed_experts = torch.cat([final_output.routed_experts, output.routed_experts], dim=0)
+                final_output.routed_experts = output.routed_experts
             if output.num_preempted is not None:
                 final_output.num_preempted += output.num_preempted
             final_output.stop_reason = output.stop_reason


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in `FullyAsyncLLMServerManager.generate()` where `routed_experts` was incorrectly concatenated via `torch.cat` during partial rollout resume, causing duplicated routing data and broken MoE expert replay in the actor.

sglang returns `routed_experts` for the **full sequence** (prompt + all generated tokens). Evidence from sglang source:

1. **[`io_struct.py#L1020`](https://github.com/sgl-project/sglang/blob/v0.5.9/python/sglang/srt/managers/io_struct.py#L1020)** — field definition:
   ```python
   # The routed experts for each token, including both input and output tokens
   # routed_experts[i] is a tensor of shape (token, layer, top_k) for request i
   routed_experts: List[Optional[torch.Tensor]]
   ```

2. **`schedule_batch.py`** — `seqlen` used to collect routing covers the full sequence:
   ```python
   @property
   def seqlen(self) -> int:
       return len(self.origin_input_ids) + len(self.output_ids)
   ```

3. **`topk.py#L1049-1051`** — capture is unconditional (no prefill/decode check):
   ```python
   get_global_experts_capturer().capture(layer_id=layer_id, topk_ids=topk_ids)
   ```

4. **`scheduler_output_processor_mixin.py#L105-111`** — collection uses full `seqlen`:
   ```python
   req.routed_experts = get_global_experts_capturer().get_routed_experts(
       req_pool_idx=req.req_pool_idx,
       seqlen=req.seqlen,  # origin_input_ids + output_ids
       req_to_token_pool=self.req_to_token_pool,
   )
   ```

When partial rollout resumes after abort, the input becomes `prompt + already_generated_tokens`. sglang re-processes the entire input during prefill and returns `routed_experts` covering all positions. The old code concatenated this with the previous `routed_experts`:

```
old routing:    prompt + A B C
new routing:    prompt + A B C + D E
concat result:  prompt + A B C + prompt + A B C + D E   <-- duplicated!
expected:       prompt + A B C + D E
```

This shifted the routing and caused incorrect MoE expert replay, leading to `actor/ppo_kl` spikes.

**Fix:** replace `routed_experts` instead of concatenating, since the resumed call already covers all positions.

Related: #4348 (partial rollout RFC), #4101 (R3 router replay), #5344 (R3 in fully async)

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=routed_experts+partial_rollout
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- Ran async training with `partial_rollout=True` and `enable_rollout_routing_replay=True` (R3 mode)
- Verified `actor/ppo_kl` no longer spikes after partial rollout resume
- Verified `routed_experts` tensor shape matches `(prompt_len + response_len, num_layers, top_k)` after resume

### Design & Code Changes

Single-line change in `verl/experimental/fully_async_policy/agent_loop/agent_loop.py`:

```diff
- if output.routed_experts is not None:
-     if final_output.routed_experts is None:
-         final_output.routed_experts = output.routed_experts
-     else:
-         final_output.routed_experts = torch.cat([final_output.routed_experts, output.routed_experts], dim=0)
+ # sglang returns routed_experts for the full sequence (prompt + all tokens),
+ # so on partial rollout resume the new output already covers all positions.
+ if output.routed_experts is not None:
+     final_output.routed_experts = output.routed_experts
```

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: This is an async distributed training bug that requires multi-node sglang + megatron setup with MoE model and partial rollout enabled. Not feasible to reproduce in CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
