### PR TITLE
[veomni] fix: use local paths for VeOmni model loading

### DIFF
--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -196,8 +196,8 @@ class VeOmniEngine(FSDPEngine):
     def _build_model_optimizer(self):
         # Load base model with specified configuration and dtype
         module = build_foundation_model(
-            config_path=self.model_config.hf_config_path,
-            weights_path=self.model_config.path,
+            config_path=self.model_config.local_hf_config_path,
+            weights_path=self.model_config.local_path,
             torch_dtype="float32" if self.engine_config.mixed_precision else "bfloat16",
             attn_implementation=self.engine_config.attn_implementation,
             moe_implementation=self.engine_config.moe_implementation,
@@ -210,7 +210,7 @@ class VeOmniEngine(FSDPEngine):
         module = build_parallelize_model(
             module,
             init_device=self.engine_config.init_device,
-            weights_path=self.model_config.path,
+            weights_path=self.model_config.local_path,
             enable_full_shard=self.engine_config.enable_full_shard,
             enable_mixed_precision=self.engine_config.mixed_precision,
             enable_gradient_checkpointing=self.model_config.enable_gradient_checkpointing,


### PR DESCRIPTION
### What does this PR do?

Switch the VeOmni FSDP engine to load the model config and weights from the *local* paths resolved by `model_config` (`local_hf_config_path` and `local_path`) instead of the remote/original paths (`hf_config_path` and `path`). When the model is downloaded to a local cache (e.g., HDFS → local), the remote-style paths are not directly readable by `build_foundation_model` / `build_parallelize_model`, causing load failures.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+veomni+local_path
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Verified locally by launching a VeOmni FSDP training run against a model whose weights were downloaded to a local path; loading now succeeds where it previously failed because the engine attempted to read from the non-local `hf_config_path` / `path`.

### API and Usage Example

No API change. Existing configs continue to work; `model_config.local_hf_config_path` and `model_config.local_path` are populated by the existing model resolution path.

### Design & Code Changes

`verl/workers/engine/veomni/transformer_impl.py`:
- `_build_model_optimizer`: pass `model_config.local_hf_config_path` to `build_foundation_model` for `config_path` and `model_config.local_path` for `weights_path`.
- Pass `model_config.local_path` to `build_parallelize_model` for `weights_path`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --files verl/workers/engine/veomni/transformer_impl.py` — all hooks pass (ruff, ruff format, mypy, license, device API, DataProto usage, naming conventions, compile, etc.).
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: change is a path-source swap inside the VeOmni engine wiring; covered by existing VeOmni FSDP integration paths and validated by a local training run.