### PR TITLE
[fully_async, ckpt, rollout, trainer, tool, cfg] fix: ROCm async training compatibility for AMD MI300X

### DIFF
--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -230,9 +230,11 @@ class NCCLCheckpointEngine(CheckpointEngine):
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
         # For trainer rank other than 0, consume weights without sending.
+        # synchronize() after each weight to keep all_gather calls aligned with rank 0,
+        # preventing FSDP2 collective deadlock when weights is a lazy generator.
         if self.rank < 0:
             for name, weight in weights:
-                pass
+                torch.cuda.synchronize()
             return
 
         send_buf, recv_buf = self.send_buf, self.recv_buf

--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
@@ -1,6 +1,6 @@
 hydra:
   searchpath:
-    - file://verl/trainer/config
+    - pkg://verl.trainer.config
 
 defaults:
   - ppo_trainer

--- a/verl/tools/sandbox_fusion_tools.py
+++ b/verl/tools/sandbox_fusion_tools.py
@@ -90,7 +90,7 @@ def init_execution_pool(
     if mode == PoolMode.ThreadMode:
         return (
             ray.remote(ExecutionWorker)
-            .options(max_concurrency=num_workers)
+            .options(name="sandbox-execution-pool", get_if_exists=True, max_concurrency=num_workers)
             .remote(enable_global_rate_limit=enable_global_rate_limit, rate_limit=rate_limit)
         )
     else:

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -31,6 +31,7 @@ PPO_RAY_RUNTIME_ENV = {
         # https://www.hiascend.com/document/detail/zh/canncommercial/83RC1/maintenref/envvar/envref_07_0143.html
         "HCCL_HOST_SOCKET_PORT_RANGE": "auto",
         "HCCL_NPU_SOCKET_PORT_RANGE": "auto",
+        "HSA_NO_SCRATCH_RECLAIM": "1",
     },
 }
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -422,7 +422,7 @@ class RayPPOTrainer:
         lines = []
         for i in range(n):
             entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False))
+            lines.append(json.dumps(entry, ensure_ascii=False, default=str))
 
         with open(filename, "w") as f:
             f.write("\n".join(lines) + "\n")

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -155,11 +155,23 @@ class BucketedWeightSender:
 
     def _init_socket(self):
         """Initialize ZMQ REQ socket and bind."""
+        if self.zmq_handle.startswith("ipc://"):
+            ipc_path = self.zmq_handle[len("ipc://") :]
+            try:
+                os.remove(ipc_path)
+            except FileNotFoundError:
+                pass
         self.socket = self.zmq_context.socket(zmq.REQ)
         self.socket.bind(self.zmq_handle)
 
     def _init_buffer(self):
-        """build communication buffer"""
+        """build communication buffer, reuse if already allocated"""
+        if self.buffer is not None and not self.use_shm:
+            handle = reduce_tensor(self.buffer)
+            self.socket.send_pyobj(handle)
+            self.socket.recv()
+            return
+
         buffer, shm = None, None
         if not self.use_shm:
             buffer = torch.empty(self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}")
@@ -181,17 +193,22 @@ class BucketedWeightSender:
         self.shm = shm
 
     def _cleanup(self):
-        """clean up"""
+        """clean up socket but keep buffer for reuse"""
         if self.socket is not None:
             self.socket.close()
             self.socket = None
-        del self.buffer
-        self.buffer = None
+        if self.zmq_handle.startswith("ipc://"):
+            ipc_path = self.zmq_handle[len("ipc://") :]
+            try:
+                os.remove(ipc_path)
+            except FileNotFoundError:
+                pass
         if self.shm is not None:
             self.shm.close()
             self.shm.unlink()
             del self.shm
             self.shm = None
+            self.buffer = None
         gc.collect()
         get_torch_device().ipc_collect()
         get_torch_device().empty_cache()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -176,11 +176,15 @@ class vLLMColocateWorkerExtension:
         # patch weight loader to support MoE model
         patch_vllm_moe_model_weight_loader(self.model_runner.model)
 
-    def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
+    def update_weights_from_ipc(
+        self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False, replica_rank: int = 0
+    ):
         """Update the weights of the rollout model."""
         from vllm.platforms import current_platform
 
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+        self._replica_rank = replica_rank
 
         if current_platform.device_type == "npu" and self.device is None:
             self.device = torch.device(f"npu:{self.local_rank}")
@@ -265,9 +269,8 @@ class vLLMColocateWorkerExtension:
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication."""
-        if not hasattr(self, "device_uuid") or not self.device_uuid:
-            self.device_uuid = get_device_uuid(self.device.index)
-        return f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        replica_rank = getattr(self, "_replica_rank", 0)
+        return f"ipc:///tmp/rl-colocate-zmq-replica-{replica_rank}-rank-{self.local_rank}.sock"
 
 
 class vLLMOmniColocateWorkerExtension(_OmniWorkerBase):
@@ -292,10 +295,14 @@ class vLLMOmniColocateWorkerExtension(_OmniWorkerBase):
 
         return super().__new__(cls)
 
-    def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
+    def update_weights_from_ipc(
+        self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False, replica_rank: int = 0
+    ):
         """Update the weights of the rollout model."""
 
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
+
+        self._replica_rank = replica_rank
 
         # In async mode, make sure the old lora is removed before adding the new one
         if peft_config and base_sync_done:
@@ -331,9 +338,8 @@ class vLLMOmniColocateWorkerExtension(_OmniWorkerBase):
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication."""
-        if not hasattr(self, "device_uuid") or not self.device_uuid:
-            self.device_uuid = get_device_uuid(self.device.index)
-        return f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        replica_rank = getattr(self, "_replica_rank", 0)
+        return f"ipc:///tmp/rl-colocate-zmq-replica-{replica_rank}-rank-{self.local_rank}.sock"
 
 
 class SuppressSignalInThread:

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -95,7 +95,7 @@ class ServerAdapter(BaseRollout):
             self.sleep_level = VLLM_SLEEP_LEVEL
 
         self.device_uuid = get_device_uuid(get_device_id())
-        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-{self.device_uuid}.sock"
+        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-replica-{self.replica_rank}-rank-{rank % local_world_size}.sock"
 
         self.use_shm = not is_support_ipc()
         if self.use_shm:
@@ -160,16 +160,17 @@ class ServerAdapter(BaseRollout):
         future = await self._execute_method(
             "update_weights_from_ipc",
             non_block=True,
-            kwargs={**kwargs, "use_shm": self.use_shm},
+            kwargs={**kwargs, "use_shm": self.use_shm, "replica_rank": self.replica_rank},
         )
 
-        bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
-        sender = BucketedWeightSender(
-            zmq_handle=self.zmq_handle,
-            bucket_size_mb=bucket_size_mb,
-            use_shm=self.use_shm,
-        )
-        await sender.async_send_weights(weights)
+        if not hasattr(self, "_weight_sender") or self._weight_sender is None:
+            bucket_size_mb = self.config.checkpoint_engine.update_weights_bucket_megabytes
+            self._weight_sender = BucketedWeightSender(
+                zmq_handle=self.zmq_handle,
+                bucket_size_mb=bucket_size_mb,
+                use_shm=self.use_shm,
+            )
+        await self._weight_sender.async_send_weights(weights)
 
         if future is not None:
             await future


### PR DESCRIPTION
### What does this PR do?

Fix multiple issues that prevent fully async FSDP2 training from working on AMD ROCm platforms (MI300X series).

**Environment:**
- AMD Instinct MI3xx (8× GPU, 192 GB HBM each), ROCm 7.2.0, PyTorch 2.10.0+rocm7.2.0, vLLM v0.19.1rc0
- Cross-validated on NVIDIA H20 with CUDA, vLLM 0.18.2 (latest verl main + this patch): no regression observed up to step 86, where a pre-existing bug (`AttributeError: 'list' object has no attribute 'dim'` in `agent_loop.py:696`) is hit — this bug exists with or without this patch and is unrelated to these changes.

**Training curves (MI3xx vs H20) and training script will be attached in PR comments.**
[dapo_7b_fully_async.sh](https://github.com/user-attachments/files/26700697/dapo_7b_fully_async.sh)
<img width="2234" height="1181" alt="qwen2 5_7b_fully_async" src="https://github.com/user-attachments/assets/03d72c65-a9a4-4596-be92-4245074c5bdb" />

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=is%3Apr+rocm+async
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Validated by full async FSDP2 DAPO/GRPO RL + ReTool training on AMD MI3xx:
- 250+ global steps completed, 60+ weight synchronization cycles without OOM or deadlock
- Cross-validated on NVIDIA H20: training runs normally with this patch applied (no regression)

Applied this patch on latest verl main (commit 9b54564f) + vLLM 0.18.2 on NVIDIA H20. Training ran normally up to step 86 / global_step 344, where a pre-existing bug in agent_loop.py:698 is hit:

File "verl/experimental/agent_loop/agent_loop.py", line 698, in _agent_loop_postprocess
    if response_mask_output["input_ids"].dim() == 1:
AttributeError: 'list' object has no attribute 'dim'
This is caused by tokenizer.pad() returning a Python list instead of a torch.Tensor for response_mask in certain edge cases, even with return_tensors="pt". This bug exists on the current main branch with or without this patch — it is not introduced by any changes in this PR. The file agent_loop.py is not modified in this PR.

MI3xx (ROCm 7.2): 250+ global steps, 60+ weight syncs completed without OOM or deadlock. The same agent_loop.py bug was also encountered on MI3xx at a later step, confirming it is platform-independent.

### API and Usage Example

No API changes. All fixes are internal implementation details.

### Design & Code Changes

1. **Fix FSDP2 collective deadlock in weight sync** (`nccl_checkpoint_engine.py`)
   
   - `get_per_tensor_param()` returns a lazy generator where each element calls `full_tensor()`, triggering FSDP `all_gather`
   - In `send_weights`, rank 0 has broadcast I/O waits between weights, while rank < 0 consumed via bare `pass` loop — timing divergence causes misaligned `all_gather` calls → deadlock
   - Fix: add `torch.cuda.synchronize()` after each weight in the rank < 0 path to keep `all_gather` calls aligned with rank 0 (negligible overhead: µs-level sync vs ms-level `all_gather`)

2. **Add `HSA_NO_SCRATCH_RECLAIM` env var** (`constants_ppo.py`)
   
   - Required by AMD RCCL on MI300X; without it, FSDP initialization fails with `ncclSystemError`

3. **Fix `numpy.bool_` JSON serialization** (`ray_trainer.py`)
   
   - Add `default=str` fallback for `json.dumps` since numpy 2.x `bool_` is no longer a Python `bool` subclass

4. **ZMQ IPC handle: use (replica_rank, local_rank) instead of GPU UUID** (`vllm_rollout.py`, `utils.py`)
   
   - On ROCm, `CheckpointEngineWorker` and vLLM worker see different GPU UUIDs due to different `CUDA_VISIBLE_DEVICES`/`HIP_VISIBLE_DEVICES` settings
   - Use `(replica_rank, local_rank)` tuple to construct socket path, supporting multi-replica-per-node setups
   - `replica_rank` is passed from sender to receiver via `update_weights_from_ipc` kwargs

5. **Clean up stale ZMQ IPC socket files** (`bucketed_weight_transfer.py`)
   
   - Remove leftover `.sock` files before `bind()` and after `close()` to prevent `Address already in use` on restart

6. **Persist IPC weight sync buffer to prevent OOM** (`bucketed_weight_transfer.py`, `vllm_rollout.py`)
   
   - On ROCm/HIP, `torch.cuda.empty_cache()` does not effectively return physical memory to the system
   - Repeated alloc/free of 2 GB IPC buffer causes HIP memory fragmentation → OOM after ~16 weight sync cycles (verified: step 64 crash with `HIP out of memory` at `_init_buffer`)
   - Fix: allocate buffer once and reuse across sync iterations; cache `BucketedWeightSender` instance in `ServerAdapter`
   - Memory cost: 2 GB per rollout GPU (~1% of 192 GB), acceptable trade-off

7. **Fix Hydra searchpath** (`fully_async_ppo_trainer.yaml`)
   
   - Use `pkg://verl.trainer.config` instead of `file://verl/trainer/config` for editable installs

8. **Sandbox Ray actor reuse** (`sandbox_fusion_tools.py`)
   
   - Add `name` and `get_if_exists=True` to prevent duplicate `ExecutionWorker` actor creation

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). The official documents will be compiled after the merger.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: These fixes target ROCm-specific runtime behavior (HIP memory management, RCCL env vars, GPU UUID mismatch) that cannot be reproduced in CI without AMD GPU hardware.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
