### PR TITLE
[veomni] feat: fix VeOmni SP for VL models and add Qwen3.5 support

### DIFF
--- a/tests/workers/test_veomni_sp_utils.py
+++ b/tests/workers/test_veomni_sp_utils.py
@@ -1,0 +1,194 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for VeOmni SP (Sequence Parallelism) utilities.
+
+These tests validate:
+1. _prepare_veomni_flash_attention_kwargs: various position_ids shapes (requires veomni)
+2. VL_TYPE2INDEX: Qwen3.5 model support
+3. compute_topk_loss: veomni strategy match
+"""
+
+import os
+
+import pytest
+import torch
+
+veomni_available = True
+try:
+    from verl.workers.engine.veomni.transformer_impl import (
+        _prepare_veomni_flash_attention_kwargs,
+    )
+except ImportError:
+    veomni_available = False
+
+
+@pytest.mark.skipif(not veomni_available, reason="veomni or ray not installed")
+class TestPrepareVeomniFlashAttentionKwargs:
+    """Test _prepare_veomni_flash_attention_kwargs with various position_ids layouts."""
+
+    def test_1d_flat_packed(self):
+        """1D: (total_nnz,) - flat packed format."""
+        position_ids = torch.tensor([0, 1, 2, 0, 1])
+        result = _prepare_veomni_flash_attention_kwargs(position_ids)
+        assert "cu_seq_lens_q" in result
+        assert "cu_seq_lens_k" in result
+        assert "max_length_q" in result
+        assert "max_length_k" in result
+
+    def test_2d_standard_packed(self):
+        """2D: (1, total_nnz) - standard packed format."""
+        position_ids = torch.tensor([[0, 1, 2, 0, 1]])
+        result = _prepare_veomni_flash_attention_kwargs(position_ids)
+        assert "cu_seq_lens_q" in result
+
+    def test_3d_rope_dim_1_nnz(self):
+        """3D: (rope_dim, 1, total_nnz) - VeRL mRoPE packed format."""
+        position_ids = torch.tensor([
+            [[0, 1, 2, 0, 1]],
+            [[0, 1, 2, 0, 1]],
+            [[0, 1, 2, 0, 1]],
+        ])
+        assert position_ids.shape == (3, 1, 5)
+        result = _prepare_veomni_flash_attention_kwargs(position_ids)
+        assert "cu_seq_lens_q" in result
+
+    def test_3d_1_rope_dim_nnz(self):
+        """3D: (1, rope_dim, total_nnz) - alternative layout."""
+        position_ids = torch.tensor([
+            [
+                [0, 1, 2, 0, 1],
+                [0, 1, 2, 0, 1],
+                [0, 1, 2, 0, 1],
+            ]
+        ])
+        assert position_ids.shape == (1, 3, 5)
+        result = _prepare_veomni_flash_attention_kwargs(position_ids)
+        assert "cu_seq_lens_q" in result
+
+    def test_3d_rope_dim_batch_nnz(self):
+        """3D: (rope_dim, batch, total_nnz) - take first rope dim."""
+        position_ids = torch.tensor([
+            [[0, 1, 2, 0, 1], [0, 1, 0, 1, 2]],
+            [[0, 1, 2, 0, 1], [0, 1, 0, 1, 2]],
+            [[0, 1, 2, 0, 1], [0, 1, 0, 1, 2]],
+        ])
+        assert position_ids.shape == (3, 2, 5)
+        result = _prepare_veomni_flash_attention_kwargs(position_ids)
+        assert "cu_seq_lens_q" in result
+
+    def test_3d_unsupported_shape_raises(self):
+        """3D with ambiguous shape should raise ValueError."""
+        position_ids = torch.zeros(2, 2, 5, dtype=torch.long)
+        with pytest.raises(ValueError, match="Unsupported 3D position_ids shape"):
+            _prepare_veomni_flash_attention_kwargs(position_ids)
+
+    def test_4d_raises(self):
+        """4D tensor should raise ValueError."""
+        position_ids = torch.zeros(1, 1, 1, 5, dtype=torch.long)
+        with pytest.raises(ValueError, match="Unsupported position_ids rank"):
+            _prepare_veomni_flash_attention_kwargs(position_ids)
+
+
+# ---- Source-level tests that don't require runtime imports ----
+# These parse the source AST directly to verify structural correctness.
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestVLTypeIndex:
+    """Test VL_TYPE2INDEX includes Qwen3.5 models (source-level parsing)."""
+
+    @pytest.fixture(autouse=True)
+    def _load_source(self):
+        utils_path = os.path.join(REPO_ROOT, "verl", "workers", "engine", "veomni", "utils.py")
+        with open(utils_path) as f:
+            self.source = f.read()
+
+    def test_qwen3_5_present(self):
+        assert '"qwen3_5"' in self.source, "qwen3_5 should be in VL_TYPE2INDEX"
+        assert "248056" in self.source, "Qwen3.5 IMAGE_INPUT_INDEX should be 248056"
+        assert "248057" in self.source, "Qwen3.5 VIDEO_INPUT_INDEX should be 248057"
+
+    def test_qwen3_5_moe_present(self):
+        assert '"qwen3_5_moe"' in self.source, "qwen3_5_moe should be in VL_TYPE2INDEX"
+
+    def test_existing_models_untouched(self):
+        """Ensure existing model entries are not accidentally removed."""
+        assert '"qwen2_5_vl"' in self.source
+        assert '"qwen3_vl"' in self.source
+        assert '"deepseek_v3"' in self.source, "deepseek_v3 in MOE_PARAM_HANDERS should not be removed"
+
+
+class TestDistillationLossVeomniStrategy:
+    """Test that compute_topk_loss supports veomni strategy (source-level parsing)."""
+
+    def test_veomni_strategy_in_source(self):
+        """Verify 'veomni' is matched alongside 'fsdp' in compute_topk_loss."""
+        losses_path = os.path.join(REPO_ROOT, "verl", "trainer", "distillation", "losses.py")
+        with open(losses_path) as f:
+            source = f.read()
+        assert '"fsdp" | "veomni"' in source, (
+            "compute_topk_loss should match 'veomni' alongside 'fsdp'"
+        )
+
+
+class TestTransformerImplSPLogic:
+    """Source-level verification of SP-related changes in transformer_impl.py."""
+
+    @pytest.fixture(autouse=True)
+    def _load_source(self):
+        impl_path = os.path.join(REPO_ROOT, "verl", "workers", "engine", "veomni", "transformer_impl.py")
+        with open(impl_path) as f:
+            self.source = f.read()
+
+    def test_pixel_values_videos_in_padding_features(self):
+        """pixel_values_videos should be in padding_features for video SP support."""
+        assert '"pixel_values_videos"' in self.source
+
+    def test_dict_keys_iteration_safe(self):
+        """__call__ should iterate over list(batch.keys()) to avoid dict mutation."""
+        assert "list(batch.keys())" in self.source
+
+    def test_sp_structure_follows_upstream(self):
+        """prepare_model_inputs should follow upstream structure: collator before cu_seq_lens."""
+        prep_pos = self.source.find("def prepare_model_inputs")
+        assert prep_pos > 0
+        section = self.source[prep_pos:]
+        # sp_shard_collator(model_inputs) should appear before _prepare_veomni_flash_attention_kwargs
+        collator_call_pos = section.find("sp_shard_collator(model_inputs)")
+        fa_pos = section.find("_prepare_veomni_flash_attention_kwargs(model_inputs")
+        assert collator_call_pos > 0, "sp_shard_collator(model_inputs) call should exist"
+        assert fa_pos > 0, "_prepare_veomni_flash_attention_kwargs call should exist"
+        assert collator_call_pos < fa_pos, (
+            "SP collator should run before cu_seq_lens computation (upstream structure)"
+        )
+        # position_ids SP slice should happen after cu_seq_lens
+        sp_slice_pos = section.find("sp_shard_collator.sp_slice(model_inputs")
+        assert sp_slice_pos > fa_pos, (
+            "position_ids SP slice should happen after cu_seq_lens computation"
+        )
+
+    def test_1d_position_ids_support(self):
+        """_prepare_veomni_flash_attention_kwargs should handle 1D position_ids."""
+        assert "position_ids.dim() == 1" in self.source
+
+    def test_no_chinese_comments(self):
+        """No Chinese comments should be present in the modified file."""
+        # Check for common Chinese characters
+        import re
+        chinese_pattern = re.compile(r"[\u4e00-\u9fff]")
+        for i, line in enumerate(self.source.split("\n"), 1):
+            if line.lstrip().startswith("#") and chinese_pattern.search(line):
+                pytest.fail(f"Chinese comment found at line {i}: {line.strip()}")

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -135,7 +135,7 @@ def compute_topk_loss(
     - teacher_mass: (bsz, seqlen/cp_size)
     """
     match config.strategy:
-        case "fsdp":
+        case "fsdp" | "veomni":
             import verl.trainer.distillation.fsdp.losses as fsdp_losses
 
             distillation_loss_fn = fsdp_losses.compute_forward_kl_topk

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -563,8 +563,8 @@ class OmniSequenceShardCollator:
         return torch.cat((tensor, pad), dim=dim)
 
     def __call__(self, batch: Sequence[dict[str, "torch.Tensor"]]) -> dict[str, "torch.Tensor"]:
-        for key in batch.keys():
-            if key in self.padding_features.keys():
+        for key in list(batch.keys()):
+            if key in self.padding_features:
                 batch[key] = self.sp_padding(
                     batch[key],
                     dim=self.sp_slice_features.get(key, -1),
@@ -573,7 +573,7 @@ class OmniSequenceShardCollator:
                 )
 
         # sp slice
-        for key in batch.keys():
+        for key in list(batch.keys()):
             if key in self.sp_slice_features.keys():
                 batch[key] = self.sp_slice(batch[key], dim=self.sp_slice_features[key])
 
@@ -584,27 +584,44 @@ def _prepare_veomni_flash_attention_kwargs(position_ids: torch.Tensor) -> dict[s
     """Normalize packed position_ids layout and derive varlen FlashAttention kwargs.
 
     Supported formats for use_remove_padding=true:
+        - 1D: (total_nnz,) - flat packed format
         - 2D: (1, total_nnz) - standard packed format
-        - 3D: (rope_dim, 1, total_nnz) - VeRL mRoPE packed format
+        - 3D: (rope_dim, 1, total_nnz) or (1, rope_dim, total_nnz) - VeRL mRoPE packed format
     """
-    if position_ids.dim() == 2:
-        # (1, total_nnz) - standard packed format
+    if position_ids.dim() == 1:
+        fa_position_ids = position_ids.unsqueeze(0)
+    elif position_ids.dim() == 2:
         fa_position_ids = position_ids
     elif position_ids.dim() == 3:
-        # (rope_dim, 1, total_nnz) - VeRL mRoPE packed format
+        # For mRoPE models, position_ids can have various 3D layouts.
+        # We use heuristics to identify the rope_dim axis (typically 3 or 4)
+        # and extract a single-dim view for cu_seq_lens computation.
         if position_ids.shape[1] == 1:
+            # (rope_dim, 1, total_nnz) - VeRL mRoPE packed format
             fa_position_ids = position_ids[0]
+        elif position_ids.shape[0] == 1:
+            # (1, rope_dim, total_nnz) - alternative layout
+            fa_position_ids = position_ids[:, 0, :]
+        elif position_ids.shape[0] in (3, 4):
+            # (rope_dim, batch, total_nnz) - rope_dim is 3 (Qwen2.5-VL) or 4 (Qwen3.5-VL)
+            fa_position_ids = position_ids[0]
+        elif position_ids.shape[1] in (3, 4):
+            # (batch, rope_dim, total_nnz) - transposed layout
+            fa_position_ids = position_ids[:, 0, :]
         else:
             raise ValueError(
-                f"Unsupported 3D position_ids shape: {tuple(position_ids.shape)}, expected (rope_dim, 1, total_nnz)"
+                f"Unsupported 3D position_ids shape: {tuple(position_ids.shape)}, "
+                f"expected (rope_dim, 1, total_nnz) or (1, rope_dim, total_nnz)"
             )
     else:
         raise ValueError(
             f"Unsupported position_ids rank: {position_ids.dim()}, "
-            f"expected 2 (1, total_nnz) or 3 (rope_dim, 1, total_nnz)"
+            f"expected 1, 2, or 3"
         )
 
-    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(fa_position_ids)
+    (cu_seq_lens_q, cu_seq_lens_k), (max_length_q, max_length_k) = prepare_fa_kwargs_from_position_ids(
+        fa_position_ids
+    )
     return {
         "cu_seq_lens_q": cu_seq_lens_q,
         "cu_seq_lens_k": cu_seq_lens_k,

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -21,6 +21,14 @@ VL_TYPE2INDEX = {
         "IMAGE_INPUT_INDEX": 151655,
         "VIDEO_INPUT_INDEX": 151656,
     },
+    "qwen3_5": {
+        "IMAGE_INPUT_INDEX": 248056,
+        "VIDEO_INPUT_INDEX": 248057,
+    },
+    "qwen3_5_moe": {
+        "IMAGE_INPUT_INDEX": 248056,
+        "VIDEO_INPUT_INDEX": 248057,
+    },
     "qwen3_vl": {
         "IMAGE_INPUT_INDEX": 151655,
         "VIDEO_INPUT_INDEX": 151656,


### PR DESCRIPTION
This PR fixes several issues in VeOmni's Sequence Parallelism (SP) implementation for Vision-Language models and adds Qwen3.5 model support.

## Changes

### Fix SP data preparation ordering in VeOmniEngineWithLMHead
- Compute FlashAttention kwargs (cu_seq_lens) on the FULL position_ids BEFORE SP slicing. Previously cu_seq_lens was computed after SP slicing, which caused incorrect attention boundaries in packed sequence mode.
- SP slice position_ids separately after cu_seq_lens computation to maintain correct per-shard positions.
- Remove now-unused `sp_shard_collator` variable; create collator inline within the SP branch.

### Extend _prepare_veomni_flash_attention_kwargs
- Support 1D position_ids (total_nnz,) in addition to 2D and 3D.
- Handle additional 3D layouts: (1, rope_dim, total_nnz) and (rope_dim, batch, total_nnz) for mRoPE models (rope_dim is typically 3 for Qwen2.5-VL or 4 for Qwen3.5-VL).

### Fix OmniSequenceShardCollator
- Add `pixel_values_videos` to padding_features and padding_scale for video modality SP support.
- Fix dict mutation during iteration: iterate over `list(batch.keys())` instead of `batch.keys()` directly (defensive programming).

### Add Qwen3.5 model support
- Add qwen3_5 and qwen3_5_moe to VL_TYPE2INDEX with correct IMAGE/VIDEO_INPUT_INDEX values (248056/248057), matching the official HuggingFace Qwen3.5-VL config.json.
- Add qwen3_5_moe to MOE_PARAM_HANDERS (same handler as qwen3_moe, sharing the stacked expert parameter layout).

### Add veomni strategy to distillation loss
- Match 'veomni' alongside 'fsdp' in compute_topk_loss() so that VeOmniEngine can reuse FSDP's topk forward KL loss implementation.

### Tests
- Add tests/workers/test_veomni_sp_utils.py with:
  - Runtime tests for _prepare_veomni_flash_attention_kwargs (requires veomni)
  - Source-level tests for VL_TYPE2INDEX, MOE_PARAM_HANDERS, distillation loss, SP ordering, and code quality.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
