### PR TITLE
[fully_async] fix: preserve per-iteration routed_experts on partial rollout resume

### DIFF
--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -103,7 +103,7 @@ class FullyAsyncLLMServerManager(AsyncLLMServerManager):
                     final_output.routed_experts = output.routed_experts
                 else:
                     final_output.routed_experts = torch.cat(
-                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids):]],
+                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids) :]],
                         dim=0,
                     )
             if output.num_preempted is not None:

--- a/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
+++ b/verl/experimental/fully_async_policy/agent_loop/agent_loop.py
@@ -17,6 +17,7 @@ import os
 from typing import Any, Optional
 
 import ray
+import torch
 from omegaconf import DictConfig
 
 from verl.experimental.agent_loop.agent_loop import (
@@ -95,10 +96,16 @@ class FullyAsyncLLMServerManager(AsyncLLMServerManager):
             final_output.token_ids.extend(output.token_ids)
             if output.log_probs is not None:
                 final_output.log_probs.extend(output.log_probs)
-            # sglang returns routed_experts for the full sequence (prompt + all tokens),
-            # so on partial rollout resume the new output already covers all positions.
-            if output.routed_experts is not None:
-                final_output.routed_experts = output.routed_experts
+            # On partial rollout resume the model version may differ, so keep
+            # existing routing and only append routing for newly generated tokens.
+            if output.routed_experts is not None and len(output.token_ids) > 0:
+                if final_output.routed_experts is None:
+                    final_output.routed_experts = output.routed_experts
+                else:
+                    final_output.routed_experts = torch.cat(
+                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids):]],
+                        dim=0,
+                    )
             if output.num_preempted is not None:
                 final_output.num_preempted += output.num_preempted
             final_output.stop_reason = output.stop_reason


### PR DESCRIPTION
### What does this PR do?

Fixes `routed_experts` merging during partial rollout resume in fully async training.

sglang returns `routed_experts` for the full sequence (prompt + all tokens). The previous fix (#6030) replaced `routed_experts` entirely on each resume iteration. However, in fully async training the model weights can update between partial rollout iterations, so the latest call's routing reflects the new model — not the one that actually generated earlier tokens.

This PR instead keeps each iteration's routing for the tokens it actually generated by slicing `output.routed_experts[-len(output.token_ids):]` and concatenating.

Follows up on #6030.

### Checklist Before Starting

- [x] Search for similar PRs: [routed_experts partial rollout](https://github.com/verl-project/verl/pulls?q=is%3Apr+routed_experts+partial+rollout) — #6030 was merged with simple replace; this PR improves on it.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Tested on 64-expert 10B MoE model (sglang rollout + megatron actor, R3 mode, async with partial rollout):

- **Simple replace** (red): `actor/ppo_kl` spikes up to 2.8e-4 in early training, volatile
- **Per-iteration routing** (blue): smoother `ppo_kl`, stays below 2.0e-4

<img width="1349" height="822" alt="recap_vs_simple" src="https://github.com/user-attachments/assets/f92b4250-07ff-4cac-9dab-832fc59a6267" />

- red - before fix 
- blue - after fix

### API and Usage Example

No API changes. Existing partial rollout + R3 router replay config works as before:

```bash
async_training.partial_rollout=True
actor_rollout_ref.actor.megatron.router_replay.mode=R3
actor_rollout_ref.rollout.enable_rollout_routing_replay=True
```

### Design & Code Changes

Single file change in `verl/experimental/fully_async_policy/agent_loop/agent_loop.py`:

1. On first partial rollout iteration (`final_output.routed_experts is None`): take full `output.routed_experts` (covers prompt + first batch of tokens)
2. On subsequent iterations: slice only newly generated tokens' routing (`output.routed_experts[-len(output.token_ids):]`) and concatenate with existing
3. Guard with `len(output.token_ids) > 0` to avoid `[-0:]` slicing bug (would select entire tensor)
4. Re-add `import torch` for `torch.cat`

**Why not simple replace?** The actor update runs with the latest weights (v2). Theoretically v2 routing + v2 weights gives a cleaner π_v2. But empirically, preserving per-iteration routing gives smoother KL — the routing signal from the generating model matters more than weight-routing consistency.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` — all passed.
- [ ] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). — N/A, no doc changes needed.
- [ ] Add unit or end-to-end test(s) — not feasible: requires MoE model + async partial rollout + multi-GPU. Validated via experiment on 64-expert 10B model.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
