### PR TITLE
[fully_async] fix: avoid blocking ray.get inside async actor methods

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -666,7 +666,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
     async def _should_pause_generation(self) -> bool:
         """Determine whether the build should be paused"""
-        queue_stats = self.message_queue_client.get_statistics_sync()
+        queue_stats = await self.message_queue_client.get_statistics()
         queue_size = queue_stats["queue_size"]
 
         if queue_size >= self.max_queue_size:
@@ -689,7 +689,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         return False
 
     async def get_statistics(self) -> dict:
-        queue_stats = self.message_queue_client.get_statistics_sync()
+        queue_stats = await self.message_queue_client.get_statistics()
 
         stats = {
             # monitor stats

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 import os
 import time
@@ -247,7 +248,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         queue_len = 0
         while len(queue_samples) < self.required_samples:
             # Get a single sample and wait until there is a sample or None is received
-            sample, queue_len = self.message_queue_client.get_sample_sync()
+            sample, queue_len = await self.message_queue_client.get_sample()
 
             if sample is None:
                 print(
@@ -523,7 +524,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         )
 
         # Reset staleness in rollouter
-        timing_raw = ray.get(self.rollouter.reset_staleness.remote())
+        timing_raw = await asyncio.wrap_future(self.rollouter.reset_staleness.remote().future())
         self.logger.log(
             data=timing_raw,
             step=self.current_param_version,
@@ -603,7 +604,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         train_val_metrics = await self._validate_process()
 
         # Wait for rollouter validation result and log
-        val_metrics: ValidateMetrics = ray.get(val_future)
+        val_metrics: ValidateMetrics = await asyncio.wrap_future(val_future.future())
         if train_val_metrics:
             # Merge trainer and rollouter validation results
             with marked_timer("timing_s/merge_val", self.timing_raw):


### PR DESCRIPTION
### What does this PR do?

Fix blocking `ray.get` call sites inside `async def` methods on the `FullyAsyncTrainer` / `FullyAsyncRollouter` async Ray actors in `verl/experimental/fully_async_policy/`.

Sync `ray.get` inside an `async def` on a Ray async actor blocks the actor's event loop.

1. Ray runtime prints `Using blocking ray.get inside async actor. This blocks the event loop...` at every affected site.
2. `message_queue.py` already marks the sync helpers as `"deprecated, use <async variant> instead"` and the async variants are already implemented.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

1×8 H200, Qwen3-4B-Instruct-2507, 50-step fully_async PPO smoke run (1 rollouter TP=4 + 1 trainer TP=2).

- Pre-patch and post-patch both: 50/50 steps succeed
- step_wall, update_actor, gen, MFU, param_sync, all within run-to-run noise
- `Using blocking ray.get inside async actor` warnings gone

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`