### PR TITLE
[rollout] feat: improve error messages for malformed tool calls

### DIFF
--- a/tests/experimental/agent_loop/test_call_tool_on_cpu.py
+++ b/tests/experimental/agent_loop/test_call_tool_on_cpu.py
@@ -1,0 +1,142 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ToolAgentLoop._call_tool error handling (no GPU required).
+
+Tests that malformed tool calls return specific, actionable error messages
+instead of generic exception strings.
+"""
+
+import unittest
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+from verl.tools.schemas import ToolResponse
+
+
+@dataclass
+class FakeFunctionCall:
+    """Minimal FunctionCall for testing."""
+
+    name: str
+    arguments: str
+
+
+@dataclass
+class FakeAgentData:
+    """Minimal AgentData for testing."""
+
+    tools_kwargs: dict = field(default_factory=dict)
+
+
+class FakeTool:
+    """A fake tool that succeeds."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    async def create(self, create_kwargs=None):
+        return "instance_1", ToolResponse()
+
+    async def execute(self, instance_id, parameters, **kwargs):
+        return ToolResponse(text=f"OK: {parameters}"), 1.0, {}
+
+    async def release(self, instance_id):
+        pass
+
+
+class FakeFailingTool(FakeTool):
+    """A fake tool that raises during execute."""
+
+    async def execute(self, instance_id, parameters, **kwargs):
+        raise RuntimeError("database connection failed")
+
+
+def _make_tool_agent_loop(tools: dict[str, Any]):
+    """Create a minimal ToolAgentLoop instance with only the fields _call_tool needs."""
+    from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
+
+    mock = MagicMock(spec=ToolAgentLoop)
+    mock.tools = tools
+    mock.max_tool_response_length = 10000
+    mock.tool_response_truncate_side = "left"
+    # Bind the real _call_tool method to our mock
+    mock._call_tool = ToolAgentLoop._call_tool.__get__(mock, ToolAgentLoop)
+    return mock
+
+
+class TestCallToolErrorHandling(unittest.IsolatedAsyncioTestCase):
+    """Test ToolAgentLoop._call_tool error handling for malformed tool calls."""
+
+    def setUp(self):
+        self.tools = {
+            "calculator": FakeTool("calculator"),
+            "search": FakeTool("search"),
+        }
+        self.loop = _make_tool_agent_loop(self.tools)
+        self.agent_data = FakeAgentData()
+
+    async def test_valid_tool_call(self):
+        """Valid tool call should succeed."""
+        tool_call = FakeFunctionCall(name="calculator", arguments='{"a": 3, "b": 5}')
+        response, reward, _ = await self.loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 1.0
+        assert "OK" in response.text
+
+    async def test_unknown_function_name(self):
+        """Unknown function name should list available tools."""
+        tool_call = FakeFunctionCall(name="calculater", arguments='{"a": 3}')
+        response, reward, _ = await self.loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 0.0
+        assert "Unknown function" in response.text
+        assert "calculater" in response.text
+        assert "calculator" in response.text
+        assert "search" in response.text
+
+    async def test_invalid_json_arguments(self):
+        """Invalid JSON arguments should report parse error."""
+        tool_call = FakeFunctionCall(name="calculator", arguments="{a: 3}")
+        response, reward, _ = await self.loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 0.0
+        assert "Invalid JSON" in response.text
+        assert "calculator" in response.text
+
+    async def test_empty_arguments(self):
+        """Empty string arguments should report parse error."""
+        tool_call = FakeFunctionCall(name="calculator", arguments="")
+        response, reward, _ = await self.loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 0.0
+        assert "Invalid JSON" in response.text
+
+    async def test_none_arguments(self):
+        """None arguments should report error."""
+        tool_call = FakeFunctionCall(name="calculator", arguments=None)
+        response, reward, _ = await self.loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 0.0
+        assert "Invalid JSON" in response.text
+
+    async def test_tool_execution_error(self):
+        """Tool execution failure should include tool name in error."""
+        tools = {"failing_tool": FakeFailingTool("failing_tool")}
+        loop = _make_tool_agent_loop(tools)
+        tool_call = FakeFunctionCall(name="failing_tool", arguments='{"query": "test"}')
+        response, reward, _ = await loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 0.0
+        assert "failing_tool" in response.text
+        assert "database connection failed" in response.text
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -437,12 +437,27 @@ class ToolAgentLoop(AgentLoopBase):
         self, tool_call: FunctionCall, tools_kwargs: dict[str, Any], agent_data: AgentData
     ) -> tuple[ToolResponse, float, dict]:
         """Call tool and return tool response."""
-        tool, instance_id = None, None
         active_tools = getattr(agent_data, "_active_tools", self.tools)
+
+        # Validate tool name
+        tool_name = tool_call.name
+        if tool_name not in active_tools:
+            available = list(active_tools.keys())
+            msg = f"Unknown function '{tool_name}'. Available tools: {available}"
+            logger.warning(msg)
+            return ToolResponse(text=msg), 0.0, {}
+
+        # Validate tool arguments
         try:
-            # TODO: append malformed tool_call to the prompt: invalid function name or arguments
-            tool_name = tool_call.name
             tool_args = json.loads(tool_call.arguments)
+        except (json.JSONDecodeError, TypeError) as e:
+            msg = f"Invalid JSON in arguments for '{tool_name}': {e}"
+            logger.warning(msg)
+            return ToolResponse(text=msg), 0.0, {}
+
+        # Execute tool
+        tool, instance_id = None, None
+        try:
             tool = active_tools[tool_name]
             kwargs = tools_kwargs.get(tool_name, {})
             instance_id, _ = await tool.create(create_kwargs=kwargs.get("create_kwargs", {}))
@@ -450,14 +465,8 @@ class ToolAgentLoop(AgentLoopBase):
                 instance_id, tool_args, agent_data=agent_data
             )
         except Exception as e:
-            logger.warning(f"Error when executing tool: {e}")
-            return (
-                ToolResponse(
-                    text=f"Error when executing tool: {e}",
-                ),
-                0.0,
-                {},
-            )
+            logger.warning(f"Error executing tool '{tool_name}': {e}")
+            return ToolResponse(text=f"Error executing tool '{tool_name}': {e}"), 0.0, {}
         finally:
             if tool and instance_id:
                 await tool.release(instance_id)


### PR DESCRIPTION
Split the catch-all exception handler in _call_tool() into specific error cases so the LLM receives actionable feedback for self-correction:

- Unknown function name: lists available tools
- Invalid JSON arguments: reports parse error with tool name
- Tool execution failure: includes tool name in error message


### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test


Added CPU unit tests that call the real _call_tool method via mock.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
