### PR TITLE
[vllm_omni, rollout] fix: forward-compat with vllm-omni multi-LoRA API rename

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -171,7 +171,14 @@ class vLLMOmniHttpServer(vLLMHttpServer):
                 extra_args[k] = v
         sampling_kwargs["extra_args"] = extra_args
         if lora_request is not None:
-            sampling_kwargs["lora_request"] = lora_request
+            # vllm-omni >=0.19 renames lora_request/lora_scale to the plural
+            # lora_requests/lora_scales (list form) for multi-LoRA composition.
+            # Detect which field the installed version exposes so this adapter
+            # works on both pre- and post-rename releases.
+            if "lora_requests" in OmniDiffusionSamplingParams.__dataclass_fields__:
+                sampling_kwargs["lora_requests"] = [lora_request]
+            else:
+                sampling_kwargs["lora_request"] = lora_request
         diffusion_sampling_params = OmniDiffusionSamplingParams(**sampling_kwargs)
 
         # Call AsyncOmni.generate() with the correct API

--- a/verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py
@@ -177,6 +177,12 @@ class vLLMOmniHttpServer(vLLMHttpServer):
             # works on both pre- and post-rename releases.
             if "lora_requests" in OmniDiffusionSamplingParams.__dataclass_fields__:
                 sampling_kwargs["lora_requests"] = [lora_request]
+                # On the post-rename API the singular "lora_scale" key from
+                # sampling_params would have fallen into extra_args above (no
+                # such field on the dataclass); lift it back out into the
+                # plural lora_scales so the scale actually takes effect.
+                if "lora_scale" in extra_args:
+                    sampling_kwargs["lora_scales"] = [extra_args.pop("lora_scale")]
             else:
                 sampling_kwargs["lora_request"] = lora_request
         diffusion_sampling_params = OmniDiffusionSamplingParams(**sampling_kwargs)


### PR DESCRIPTION
### What does this PR do?

Makes `vllm_omni_async_server.generate()` forward-compatible with the upcoming vllm-omni multi-LoRA API rename ([vllm-project/vllm-omni#2309](https://github.com/vllm-project/vllm-omni/pull/2309)), which renames

- `OmniDiffusionSamplingParams.lora_request: LoRARequest | None` → `lora_requests: list[LoRARequest]`
- `OmniDiffusionSamplingParams.lora_scale: float` → `lora_scales: list[float]`

to support multi-LoRA composition on a single diffusion request.

Today VERL constructs sampling params with the singular key:

```python
if lora_request is not None:
    sampling_kwargs["lora_request"] = lora_request
```

That `TypeError`s the moment rollout installs a vllm-omni release containing the rename, because the dataclass no longer has a `lora_request` field. This PR detects which field name the installed vllm-omni exposes at runtime via `OmniDiffusionSamplingParams.__dataclass_fields__` and populates the correct one — keeping the adapter working on both the currently-pinned `vllm-omni==0.18.0` (singular) and any post-rename release (plural, one element list wrapping the single LoRA that this adapter currently supports).

### Checklist Before Starting

- [x] Search for similar PRs:
  - `gh pr list --repo volcengine/verl --state all --search \"vllm_omni_async_server\"` — no results
  - `gh pr list --repo volcengine/verl --state open --search \"vllm_omni lora\"` — no results
  - `gh issue list --repo volcengine/verl --state all --search \"vllm_omni multi-lora\"` — no results
- [x] PR title format: `[vllm_omni, rollout] fix: …`
- [x] Not a breaking change: both API shapes remain supported on the VERL side.

### Test

CI pins `vllm-omni==0.18.0` (singular API). Under that pin, the branch selected at runtime is the `else` branch, which is byte-identical to the pre-patch behavior, so all existing tests in `tests/workers/rollout/rollout_vllm/test_vllm_omni_generate.py` continue to hold without modification.

The plural branch activates once rollout bumps its pin past the rename; at that point the same test file exercises the new path. No additional unit tests are added in this PR because the rename hasn't landed in a released vllm-omni yet — pinning a test against a future API shape would require vendoring it.

Manually verified the dataclass-field probe on both branches of vllm-omni:

```python
# vllm-omni 0.18.0
>>> "lora_requests" in OmniDiffusionSamplingParams.__dataclass_fields__
False
# vllm-omni multi-lora-v2 (PR #2309 head)
>>> "lora_requests" in OmniDiffusionSamplingParams.__dataclass_fields__
True
```

### API and Usage Example

No public VERL API change. The rollout continues to accept exactly one LoRA adapter per request (same `self.lora_as_adapter` / `VLLM_LORA_INT_ID` plumbing as today); the patch only affects how that single adapter is handed to `OmniDiffusionSamplingParams`.

### Design & Code Changes

Single file touched: `verl/workers/rollout/vllm_rollout/vllm_omni_async_server.py` — 8 inserted, 1 deleted.

```python
if lora_request is not None:
    # vllm-omni >=0.19 renames lora_request/lora_scale to the plural
    # lora_requests/lora_scales (list form) for multi-LoRA composition.
    # Detect which field the installed version exposes so this adapter
    # works on both pre- and post-rename releases.
    if "lora_requests" in OmniDiffusionSamplingParams.__dataclass_fields__:
        sampling_kwargs["lora_requests"] = [lora_request]
    else:
        sampling_kwargs["lora_request"] = lora_request
```

### AI assistance disclosure

This PR was drafted with Claude Code. The human submitter reviewed every changed line and defends the change end-to-end.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [x] Pre-commit clean (one-file, dataclass-fields probe, no format/lint changes).
- [x] Not related to the `recipe` submodule.

Signed-off-by: ultranationalism <www913363043@gmail.com>