### PR TITLE
[fix] restore ByteLevel tokenizer for LLaMA-family models under transformers>=5 

### DIFF
--- a/tests/utils/test_tokenizer_fix_bytelevel.py
+++ b/tests/utils/test_tokenizer_fix_bytelevel.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+from tokenizers.pre_tokenizers import Metaspace
+from tokenizers.decoders import ByteLevel
+
+from verl.utils.tokenizer import hf_tokenizer
+
+
+class _FakeTokenizer:
+    def __init__(self, pre_tokenizer, decoder):
+        self.backend_tokenizer = type("B", (), {"pre_tokenizer": pre_tokenizer, "decoder": decoder})()
+
+    def encode(self, text, add_special_tokens=False):
+        return [p for p, _ in self.backend_tokenizer.pre_tokenizer.pre_tokenize_str(text)]
+
+    def decode(self, tokens):
+        return self.backend_tokenizer.decoder.decode(tokens)
+
+
+def test_hf_tokenizer_fixes_bytelevel_mismatch():
+    # Simulate transformers>=5 broken state: Metaspace pre_tokenizer, ByteLevel vocabulary.
+    # hf_tokenizer must patch pre_tokenizer to ByteLevel so encode→decode preserves spaces.
+    tok = _FakeTokenizer(Metaspace(), ByteLevel())
+    with patch("transformers.AutoTokenizer.from_pretrained", return_value=tok):
+        result = hf_tokenizer("dummy-model", correct_pad_token=False)
+    assert " " in result.decode(result.encode("a b"))

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -56,6 +56,29 @@ def normalize_token_ids(tokenized_output) -> list[int]:
     return normalized_ids
 
 
+def _fix_bytelevel_mismatch(tokenizer):
+    # transformers>=5 sets Metaspace pre_tokenizer for LLaMA-family models whose
+    # vocabulary uses the ByteLevel (Ġ) convention, silently dropping all spaces.
+    # Detect by actually encoding a space-containing string and checking the round-trip.
+    # Patch both pre_tokenizer and decoder back to ByteLevel to restore correctness.
+    try:
+        bt = tokenizer.backend_tokenizer
+        # Use type name instead of str() to avoid a Rust panic in older tokenizers
+        # when serialising pre_tokenizers with non-ASCII Unicode characters.
+        if type(bt.pre_tokenizer).__name__ != "Metaspace":
+            return
+        # Behavioural check: if a space survives encode→decode, no patch needed.
+        probe_ids = tokenizer.encode("a b", add_special_tokens=False)
+        if " " in tokenizer.decode(probe_ids):
+            return
+        from tokenizers.pre_tokenizers import ByteLevel as BLPre
+        from tokenizers.decoders import ByteLevel as BLDec
+        bt.pre_tokenizer = BLPre(add_prefix_space=False)
+        bt.decoder = BLDec()
+    except BaseException:
+        pass
+
+
 def set_pad_token_id(tokenizer):
     """Set pad_token_id to eos_token_id if it is None.
 
@@ -96,6 +119,7 @@ def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kw
         kwargs["eos_token"] = "<end_of_turn>"
         kwargs["eos_token_id"] = 107
     tokenizer = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
+    _fix_bytelevel_mismatch(tokenizer)
     if correct_pad_token:
         set_pad_token_id(tokenizer)
     return tokenizer


### PR DESCRIPTION
Fix https://github.com/verl-project/verl/issues/6080