### PR TITLE
docs: fix typo Hellasage -> HellaSwag

### DIFF
--- a/docs/examples/ppo_code_architecture.rst
+++ b/docs/examples/ppo_code_architecture.rst
@@ -22,7 +22,7 @@ For ``RLHFDataset`` (Default), at least 1 fields are required:
 
 We already provide some examples of processing the datasets to parquet
 files in `data_preprocess directory <https://github.com/verl-project/verl/blob/main/examples/data_preprocess>`_. Currently, we support
-preprocess of GSM8k, MATH, Hellasage, Full_hh_rlhf datasets. See :doc:`../preparation/prepare_data` for
+preprocess of GSM8k, MATH, HellaSwag, Full_hh_rlhf datasets. See :doc:`../preparation/prepare_data` for
 more information.
 
 Define the reward functions for different datasets


### PR DESCRIPTION
### What does this PR do?

 Corrects a typo in the PPO code architecture documentation: Hellasage → HellaSwag. HellaSwag is a well-known NLP reasoning dataset used for evaluating language model performance.

### Checklist Before Starting

 - Search for similar PRs: No open PRs found for "HellaSwag" or "Hellasage"
 - Format the PR title as [{modules}] {type}: {description} ✓

### Test

 This is a documentation-only change (typo fix in .rst file). No code changes required.


### Design & Code Changes


  Single file changed:
  - docs/examples/ppo_code_architecture.rst: Line 25 - corrected "Hellasage" to "HellaSwag"
