### PR TITLE
fix(utils): normalize chat template output for transformers>=5 compatibility

### DIFF
--- a/verl/utils/chat_template.py
+++ b/verl/utils/chat_template.py
@@ -76,7 +76,7 @@ def apply_chat_template(
         list[int] | str: tokenized ids or text string.
     """
     try:
-        return processor.apply_chat_template(
+        output = processor.apply_chat_template(
             messages,
             tokenize=tokenize,
             add_generation_prompt=add_generation_prompt,
@@ -84,6 +84,9 @@ def apply_chat_template(
             return_dict=return_dict,
             **kwargs,
         )
+        if tokenize and not return_dict:
+            output = normalize_token_ids(output)
+        return output
     except Exception:
         # Qwen3.5 apply_chat_template needs messages with at least one user message
         dummy_user_message = [{"role": "user", "content": [{"type": "text", "text": ""}]}]
@@ -107,10 +110,15 @@ def apply_chat_template(
         if not tokenize:  # tokenize=False
             return output[len(dummy_user_prefix) :]
         elif not return_dict:  # tokenize=True and return_dict=False
-            if isinstance(output[0], list):  # transformers>=5
+            if isinstance(output, (list, tuple)) and len(output) > 0 and isinstance(output[0], list):
+                # transformers>=5 returns list[list[int]] for single-input tokenize=True
                 assert len(output) == 1, "output must be a list[int] or list[list[int]]"
                 dummy_user_prefix = dummy_user_prefix[0]
                 output = output[0]
+            else:
+                # transformers>=5 may return BatchEncoding/mapping; normalize both prefix and output
+                dummy_user_prefix = normalize_token_ids(dummy_user_prefix)
+                output = normalize_token_ids(output)
             return output[len(dummy_user_prefix) :]
         else:  # tokenize=True and return_dict=True and return_tensors="pt"
             dummy_user_prefix = dict(dummy_user_prefix)


### PR DESCRIPTION
## Summary

Fixes #6080

**Problem:** `transformers>=5` changed the return type of `tokenizer.apply_chat_template(tokenize=True)` from `list[int]` to a `BatchEncoding`/mapping object. The `apply_chat_template()` wrapper in `verl/utils/chat_template.py` returns this value directly without normalization, so downstream code (reward computation, token ID handling) receives a malformed object instead of a flat `list[int]`. This causes `critic/rewards/mean` to stay at `0.0` during GRPO training — silently broken with no error or warning.

**Root cause:** The normal (try) path and the exception-handler (Qwen3.5 fallback) path in `apply_chat_template()` both return raw output from `processor.apply_chat_template(tokenize=True)` without passing it through the existing `normalize_token_ids()` helper that was specifically designed to handle this transformers version difference.

**Fix:**
- In the normal path: call `normalize_token_ids(output)` when `tokenize=True` and `return_dict=False`
- In the exception handler: add an `else` branch that handles `BatchEncoding`/mapping types via `normalize_token_ids()`, and also harden the existing `list[list[int]]` type check with a guard against non-list `output`

## Changes

- **`verl/utils/chat_template.py`**: Normalize `apply_chat_template()` output in both code paths when returning token IDs