### PR TITLE
fix(mcore): pad valid tokens to padded length in CP preprocess to avoid OOB indexing

### DIFF
--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -103,6 +103,13 @@ def preprocess_packed_seqs(
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
             # split to 2 chunks
             d = input_ids[i, attention_mask[i]]
+            # Pad valid tokens to seqlen_padded_i so that CP chunk indices
+            # (computed in padded coordinate space) stay within bounds.
+            if d.shape[0] < seqlen_padded_i:
+                d = torch.cat(
+                    [d, torch.zeros(seqlen_padded_i - d.shape[0], dtype=d.dtype, device=d.device)],
+                    dim=0,
+                )
             first_start = half_seqlen * cp_rank
             first_end = min(half_seqlen * (cp_rank + 1), d.shape[0])
             first_len = max(first_end - first_start, 0)


### PR DESCRIPTION
## Summary

Fixes #5981 — **CP preprocess crashes on short/heavily padded sequences** with `RuntimeError: The expanded size of the tensor (N) must match the existing size (0)`.

## Problem

In `preprocess_packed_seqs()` (`verl/models/mcore/util.py`), when `context_parallel_size > 1`:

1. `d = input_ids[i, attention_mask[i]]` extracts only **valid** tokens (e.g. length 38)
2. CP chunk indices (`first_start`, `remain_start`, `remain_end`) are computed in **padded** coordinate space based on `seqlen_padded_i` (e.g. 128, aligned to `tp_size * cp_size * 2`)
3. Slicing `d[padded_index:]` on a tensor of length 38 with index 112+ produces empty/wrong slices → crash or silent corruption

This affects any workload where valid sequence length is significantly smaller than the alignment-padded length (common with short prompts + large TP×CP grids).

## Fix

Pad `d` from `seqlen_valid` to `seqlen_padded_i` with zeros **before** applying CP chunk slicing. This matches the defensive padding already present in `preprocess_thd_engine()` for the same class of issue.

## Changes

- **`verl/models/mcore/util.py`** — `preprocess_packed_seqs()`: add 7-line padding guard when `cp_size > 1` and `d.shape[0] < seqlen_padded_i`

## Test plan

- [x] Code review: fix follows same pattern as existing padding in `preprocess_thd_engine()`
- [ ] Manual smoke test: Qwen3-VL SFT with CP>1, TP>1, short sequences (requires multi-GPU setup)