### PR TITLE
[rollout] fix: truncate routed_experts to response_length to match truncated response_ids

### DIFF
--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -173,7 +173,11 @@ class ToolAgentLoop(AgentLoopBase):
             else None,
             num_turns=agent_data.user_turns + agent_data.assistant_turns + 1,
             metrics=agent_data.metrics,
-            routed_experts=agent_data.routed_experts,
+            routed_experts=(
+                agent_data.routed_experts[: self.response_length]
+                if agent_data.routed_experts is not None
+                else None
+            ),
             extra_fields=agent_data.extra_fields,
         )
         output.extra_fields.update({"turn_scores": agent_data.turn_scores, "tool_rewards": agent_data.tool_rewards})

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -174,7 +174,7 @@ class ToolAgentLoop(AgentLoopBase):
             num_turns=agent_data.user_turns + agent_data.assistant_turns + 1,
             metrics=agent_data.metrics,
             routed_experts=(
-                agent_data.routed_experts[: self.response_length]
+                agent_data.routed_experts[: len(prompt_ids) + self.response_length]
                 if agent_data.routed_experts is not None
                 else None
             ),


### PR DESCRIPTION
## Summary

Fixes #6080... wait no, fixes #6027.

**Problem:** In `ToolAgentLoop`, when `response_ids` exceed `response_length` they are sliced to `response_length` (line 168), but `routed_experts` is passed through untruncated. This causes a shape mismatch in downstream tensor assignment:

```
RuntimeError: The expanded size of the tensor (17804) must match the existing size (18057)
at non-singleton dimension 1.
Target sizes: [1, 17804, 40, 8]. Tensor sizes: [18057, 40, 8]
```

**Root cause:** `agent_loop.py` builds `input_ids` from the **truncated** `response_ids` (so `total_length` is smaller), but reads `length` from the **untruncated** `routed_experts.shape[0]`. When it tries to assign `experts_tensor` (size 18057) into the sliced `routed_experts[:, start_pos:end_pos]` (size 17804), the dimensions don't match.

**Fix:** Truncate `routed_experts` along the sequence dimension to `response_length` when constructing `AgentLoopOutput`, matching the existing truncation applied to `response_ids`, `response_mask`, and `response_logprobs`.

## Changes

- `verl/experimental/agent_loop/tool_agent_loop.py`: Slice `routed_experts[:self.response_length]` before passing to output, with None guard for cases where routed_experts is not collected.

## Test plan

- [x] Code review: fix follows same truncation pattern already used for response_ids/response_mask/response_logprobs on the same line
- [ ] Reproduce: MoE model + router_replay=R3 + small response_length + ToolAgentLoop should no longer crash with dimension mismatch