### PR TITLE
[fully_async] fix: allow drain loop to resume early on parameter sync when partial_rollout is enabled

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -188,6 +188,11 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         # is the most robust workaround.
         self.condition = asyncio.Condition()
         self.lock = self.condition._lock
+        # When partial_rollout is enabled, in-flight long-tail tasks will be aborted+resumed across
+        # parameter syncs anyway, so the drain loop in _processor_worker doesn't need to wait for them
+        # to finish. This event lets reset_staleness wake the drain loop early so new samples can be
+        # submitted to idle replicas while the long-tail tasks keep running in the background.
+        self._sync_interrupt_event = asyncio.Event()
 
     async def set_message_queue_client(self, message_queue_client: MessageQueueClient):
         """Set message queue client"""
@@ -261,6 +266,15 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 f"idle_ratio: {timing_raw['fully_async/rollouter/idle_ratio']:.4f}"
             )
             self.step_start_time = time.time()
+
+        # If partial_rollout is enabled, wake the drain loop in _processor_worker so it can
+        # exit early and resume submitting new samples to idle replicas. The remaining active
+        # long-tail tasks will keep running in the background and be aborted+resumed by the next
+        # sync. We set the event outside the lock because asyncio.Event.set() is non-blocking
+        # and does not require the lock.
+        if self.config.async_training.get("partial_rollout", False):
+            self._sync_interrupt_event.set()
+
         return timing_raw
 
     def _maybe_log_val_generations(self, inputs, outputs, scores):
@@ -461,6 +475,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """
         Streaming worker coroutines, a sample is submitted for processing without waiting for batches
         """
+        partial_rollout_enabled = self.config.async_training.get("partial_rollout", False)
         while True:
             if self.paused or await self._should_pause_generation():
                 print(
@@ -468,15 +483,59 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 )
                 async with self.lock:
                     self.paused = True
-                while self.active_tasks:
-                    async with self.lock:
-                        # After acquiring the lock, the number of active_tasks may change, need to be verified again
-                        if self.active_tasks:
-                            done_tasks, self.active_tasks = await asyncio.wait(
-                                self.active_tasks, return_when=asyncio.FIRST_COMPLETED
-                            )
-                            for task in done_tasks:
-                                await task
+                    # Reset the sync-interrupt signal at the start of each drain so we only react
+                    # to syncs that happen during this drain window.
+                    if partial_rollout_enabled:
+                        self._sync_interrupt_event.clear()
+
+                interrupt_future = None
+                try:
+                    if partial_rollout_enabled:
+                        interrupt_future = asyncio.ensure_future(self._sync_interrupt_event.wait())
+
+                    while self.active_tasks:
+                        if partial_rollout_enabled and interrupt_future is not None:
+                            # Wait for either: (a) at least one active task finishes, or
+                            # (b) a parameter sync signals us to break drain early so new
+                            # samples can be submitted to free replicas. We do NOT hold the
+                            # lock during the wait, so reset_staleness can acquire it to
+                            # clear `paused` and update staleness_samples concurrently.
+                            wait_set = set(self.active_tasks) | {interrupt_future}
+                            done, _pending = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
+                            actual_done = done - {interrupt_future}
+                            if actual_done:
+                                async with self.lock:
+                                    for task in actual_done:
+                                        self.active_tasks.discard(task)
+                                        await task
+                            if interrupt_future in done:
+                                # reset_staleness already set self.paused=False; bail out so the
+                                # outer loop can immediately pop new samples while remaining
+                                # long-tail tasks keep running in the background.
+                                print(
+                                    "[FullyAsyncRollouter][Processor] "
+                                    "Drain interrupted by parameter sync, resuming generation early "
+                                    f"(active long-tail tasks remaining: {len(self.active_tasks)})"
+                                )
+                                break
+                        else:
+                            async with self.lock:
+                                # After acquiring the lock, the number of active_tasks may change,
+                                # need to be verified again.
+                                if self.active_tasks:
+                                    done_tasks, self.active_tasks = await asyncio.wait(
+                                        self.active_tasks, return_when=asyncio.FIRST_COMPLETED
+                                    )
+                                    for task in done_tasks:
+                                        await task
+                finally:
+                    if interrupt_future is not None and not interrupt_future.done():
+                        interrupt_future.cancel()
+                        # Use gather(return_exceptions=True) to swallow CancelledError raised
+                        # from interrupt_future itself, while still letting an outer cancel of
+                        # _processor_worker propagate (gather will be cancelled by the outer
+                        # cancel and re-raise CancelledError out of this finally block).
+                        await asyncio.gather(interrupt_future, return_exceptions=True)
 
                 async with self.lock:
                     while self.paused:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -181,18 +181,11 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
     def _init_async_objects(self):
         # Initialize asyncio synchronization primitives.
-        # We let asyncio.Condition create the Lock internally to ensure they share the same Event Loop.
-        # This avoids 'ValueError: loop argument must agree with lock' which can occur in Ray environments
-        # where the lock's captured loop (get_running_loop) differs from Condition's default loop check.
-        # Explicitly passing the loop is deprecated/removed in Python 3.10+, so this reverse-initialization
-        # is the most robust workaround.
-        self.condition = asyncio.Condition()
-        self.lock = self.condition._lock
-        # When partial_rollout is enabled, in-flight long-tail tasks will be aborted+resumed across
-        # parameter syncs anyway, so the drain loop in _processor_worker doesn't need to wait for them
-        # to finish. This event lets reset_staleness wake the drain loop early so new samples can be
-        # submitted to idle replicas while the long-tail tasks keep running in the background.
-        self._sync_interrupt_event = asyncio.Event()
+        # `lock` protects shared state: paused / active_tasks / staleness_samples / timing fields.
+        self.lock = asyncio.Lock()
+        # `_resume_event` signals that the rollouter is currently running (paused == False).
+        self._resume_event = asyncio.Event()
+        self._resume_event.set()
 
     async def set_message_queue_client(self, message_queue_client: MessageQueueClient):
         """Set message queue client"""
@@ -245,7 +238,9 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """
         async with self.lock:
             self.paused = False
-            self.condition.notify_all()
+            # Wake the drain loop in _processor_worker so it can exit early and resume submitting
+            # new samples to idle replicas instead of waiting for long-tail in-flight tasks.
+            self._resume_event.set()
             # every time param change, reset staleness_samples
             self.staleness_samples = len(self.active_tasks) + await self.message_queue_client.get_queue_size()
             timing_raw = {}
@@ -266,14 +261,6 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 f"idle_ratio: {timing_raw['fully_async/rollouter/idle_ratio']:.4f}"
             )
             self.step_start_time = time.time()
-
-        # If partial_rollout is enabled, wake the drain loop in _processor_worker so it can
-        # exit early and resume submitting new samples to idle replicas. The remaining active
-        # long-tail tasks will keep running in the background and be aborted+resumed by the next
-        # sync. We set the event outside the lock because asyncio.Event.set() is non-blocking
-        # and does not require the lock.
-        if self.config.async_training.get("partial_rollout", False):
-            self._sync_interrupt_event.set()
 
         return timing_raw
 
@@ -475,7 +462,6 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """
         Streaming worker coroutines, a sample is submitted for processing without waiting for batches
         """
-        partial_rollout_enabled = self.config.async_training.get("partial_rollout", False)
         while True:
             if self.paused or await self._should_pause_generation():
                 print(
@@ -483,64 +469,40 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 )
                 async with self.lock:
                     self.paused = True
-                    # Reset the sync-interrupt signal at the start of each drain so we only react
-                    # to syncs that happen during this drain window.
-                    if partial_rollout_enabled:
-                        self._sync_interrupt_event.clear()
+                    self._resume_event.clear()
 
-                interrupt_future = None
+                resume_future = asyncio.ensure_future(self._resume_event.wait())
                 try:
-                    if partial_rollout_enabled:
-                        interrupt_future = asyncio.ensure_future(self._sync_interrupt_event.wait())
-
-                    while self.active_tasks:
-                        if partial_rollout_enabled and interrupt_future is not None:
-                            # Wait for either: (a) at least one active task finishes, or
-                            # (b) a parameter sync signals us to break drain early so new
-                            # samples can be submitted to free replicas. We do NOT hold the
-                            # lock during the wait, so reset_staleness can acquire it to
-                            # clear `paused` and update staleness_samples concurrently.
-                            wait_set = set(self.active_tasks) | {interrupt_future}
-                            done, _pending = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
-                            actual_done = done - {interrupt_future}
-                            if actual_done:
-                                async with self.lock:
-                                    for task in actual_done:
-                                        self.active_tasks.discard(task)
-                                        await task
-                            if interrupt_future in done:
-                                # reset_staleness already set self.paused=False; bail out so the
-                                # outer loop can immediately pop new samples while remaining
-                                # long-tail tasks keep running in the background.
-                                print(
-                                    "[FullyAsyncRollouter][Processor] "
-                                    "Drain interrupted by parameter sync, resuming generation early "
-                                    f"(active long-tail tasks remaining: {len(self.active_tasks)})"
-                                )
-                                break
-                        else:
+                    # Drain: wait for either (a) at least one active task to finish, or
+                    # (b) a resume signal (reset_staleness / monitor flipping paused=False) to
+                    # break the drain early so new samples can be submitted to free replicas.
+                    # We do NOT hold the lock during the wait, so publishers can acquire it to
+                    # update paused / staleness_samples concurrently.
+                    while self.active_tasks and not resume_future.done():
+                        wait_set = set(self.active_tasks) | {resume_future}
+                        done, _pending = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
+                        actual_done = done - {resume_future}
+                        if actual_done:
                             async with self.lock:
-                                # After acquiring the lock, the number of active_tasks may change,
-                                # need to be verified again.
-                                if self.active_tasks:
-                                    done_tasks, self.active_tasks = await asyncio.wait(
-                                        self.active_tasks, return_when=asyncio.FIRST_COMPLETED
-                                    )
-                                    for task in done_tasks:
-                                        await task
-                finally:
-                    if interrupt_future is not None and not interrupt_future.done():
-                        interrupt_future.cancel()
-                        # Use gather(return_exceptions=True) to swallow CancelledError raised
-                        # from interrupt_future itself, while still letting an outer cancel of
-                        # _processor_worker propagate (gather will be cancelled by the outer
-                        # cancel and re-raise CancelledError out of this finally block).
-                        await asyncio.gather(interrupt_future, return_exceptions=True)
+                                for task in actual_done:
+                                    self.active_tasks.discard(task)
+                                    await task
+                        if resume_future in done:
+                            print(
+                                "[FullyAsyncRollouter][Processor] "
+                                "Drain interrupted by resume signal, resuming generation early "
+                                f"(active tasks remaining: {len(self.active_tasks)})"
+                            )
+                            break
 
-                async with self.lock:
-                    while self.paused:
+                    # block until resuming
+                    if not resume_future.done():
                         self.idle_start_time = time.time()
-                        await self.condition.wait()
+                        await resume_future
+                finally:
+                    if not resume_future.done():
+                        resume_future.cancel()
+                        await asyncio.gather(resume_future, return_exceptions=True)
                 continue
             # Get sample from appropriate queue and immediately mark task as done
             rollout_sample = await self.pending_queue.get()
@@ -572,11 +534,9 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                             await task
 
             # Submit single sample processing
+            if self.paused:
+                await self._resume_event.wait()
             async with self.lock:
-                # After the pause is over, the lock is acquired and it is necessary
-                # to determine whether it is the pause phase, otherwise continue to wait
-                while self.paused:
-                    await self.condition.wait()
                 task = safe_create_task(
                     self._process_single_sample_streaming(rollout_sample),
                     name=rollout_sample.sample_id,
@@ -676,6 +636,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         async with self.lock:
             self.paused = False
             self.running = True
+            self._resume_event.set()
 
         # Create the main asynchronous task
         generation_task = safe_create_task(self._streaming_generation_main(), name="generation_task")
@@ -723,8 +684,8 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             if self.paused and not await self._should_pause_generation():
                 async with self.lock:
                     self.paused = False
-                    print("[FullyAsyncRollouter][ShouldPause] notify all wait tasks.")
-                    self.condition.notify_all()
+                    print("[FullyAsyncRollouter][ShouldPause] resume rollouter.")
+                    self._resume_event.set()
 
     async def _should_pause_generation(self) -> bool:
         """Determine whether the build should be paused"""


### PR DESCRIPTION
### What does this PR do?

> Makes the `FullyAsyncRollouter` drain loop interruptible, so new samples can be dispatched to idle replicas without waiting for long-tail in-flight tasks to finish.

Previously, once `_processor_worker` entered the drain loop (`while self.active_tasks: ...`), it blocked until all in-flight tasks completed. 

Fix: replace the existing `asyncio.Condition` with a single `asyncio.Event` (_resume_event) that publishers (reset_staleness, _async_monitor_loop) set when flipping `paused=False`. The drain loop now waits on both active_tasks and resume_future and breaks early when the event fires, while remaining long-tail tasks keep running in the background.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
