### PR TITLE
[rollout,vllm] feat: split large weight into chunks in NCCL/NIXL checkpoint engine

### DIFF
--- a/tests/checkpoint_engine/test_correctness_on_gpu.py
+++ b/tests/checkpoint_engine/test_correctness_on_gpu.py
@@ -40,6 +40,7 @@ async def test_nccl_checkpoint_engine(
     num_rollout,
     num_nodes=1,
     num_gpus_per_node=_ngpus,
+    bucket_size_mb=128,
     check_allclose=True,
     model_path="~/models/Qwen/Qwen3-8B-Base",
 ):
@@ -57,7 +58,9 @@ async def test_nccl_checkpoint_engine(
 
     # initialize config
     checkpoint_engine_config = CheckpointEngineConfig(
-        backend="nccl", engine_kwargs={"nccl": {"rebuild_group": rebuild_group}}
+        backend="nccl",
+        update_weights_bucket_megabytes=bucket_size_mb,
+        engine_kwargs={"nccl": {"rebuild_group": rebuild_group}},
     )
     model_config = HFModelConfig(path=model_path, use_remove_padding=True)
     rollout_config = RolloutConfig(name="vllm", checkpoint_engine=checkpoint_engine_config)
@@ -89,6 +92,7 @@ async def test_nixl_checkpoint_engine(
     device,
     num_nodes=1,
     num_gpus_per_node=8,
+    bucket_size_mb=128,
     check_allclose=True,
     model_path="~/models/Qwen/Qwen3-8B-Base",
 ):
@@ -114,7 +118,9 @@ async def test_nixl_checkpoint_engine(
     )
 
     # initialize config
-    checkpoint_engine_config = CheckpointEngineConfig(backend="nixl", engine_kwargs={"nixl": {"device": device}})
+    checkpoint_engine_config = CheckpointEngineConfig(
+        backend="nixl", update_weights_bucket_megabytes=bucket_size_mb, engine_kwargs={"nixl": {"device": device}}
+    )
     model_config = HFModelConfig(path=model_path, use_remove_padding=True)
     rollout_config = RolloutConfig(name="vllm", checkpoint_engine=checkpoint_engine_config)
 

--- a/tests/checkpoint_engine/test_utils.py
+++ b/tests/checkpoint_engine/test_utils.py
@@ -85,6 +85,7 @@ class MockServerAdapter(BaseRollout):
             received = self.received_weights[name]
             assert torch.allclose(weight.to(received.device), received), f"weight {name} not equal"
         self.received_weights.clear()
+        print("Check passed, all weights are equal!")
 
 
 class MockReplica(RolloutReplica):

--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -217,3 +217,12 @@ class TestBucketedWeightTransferIPC:
         numel = (1 << 20) // 4
         specs = [("exact_fit", (numel,), torch.float32)]
         _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False)
+
+    def test_large_weight(self):
+        specs = [("embedding", (1024, 1024), torch.float32)]  # 4MB
+        specs.extend([(f"layer{i}.weight", (128,), torch.bfloat16) for i in range(5)])
+        specs.append(("gate_up_proj", (1024, 1024), torch.float32))  # 4MB
+        specs.extend([(f"layer{i}.weight", (128,), torch.bfloat16) for i in range(20)])
+        specs.append(("lm_head", (1024, 1024), torch.float32))  # 4MB
+
+        _transfer_and_validate(specs, bucket_size_mb=1, use_shm=False)

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, Generator, TypedDict
+from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Generator
 
 import ray
 import torch
@@ -26,13 +27,23 @@ from verl.utils.import_utils import import_external_libs
 from verl.utils.ray_utils import auto_await
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig, RolloutConfig
 from verl.workers.rollout import BaseRollout, RolloutReplica, get_rollout_class
+from verl.workers.rollout.utils import ensure_async_iterator
 
 
-class TensorMeta(TypedDict):
+@dataclass
+class TensorMeta:
     name: str
+    """The name of the weight tensor."""
     shape: torch.Size
+    """The shape of the weight tensor."""
     dtype: torch.dtype
+    """The dtype of the weight tensor."""
+    chunk_offset: int
+    """The chunk offset of the weight tensor."""
+    chunk_size: int
+    """The chunk size of the weight tensor."""
     offset: int
+    """The offset of the weight tensor in the bucket."""
 
 
 class CheckpointEngineRegistry:
@@ -448,3 +459,74 @@ class CheckpointEngineManager:
 
         # 8. resume all unfinished requests for partial rollout
         await asyncio.gather(*[r.resume_generation() for r in self.replicas])
+
+
+async def split_weight_chunks(
+    weights: Generator[tuple[str, torch.Tensor], None, None], bucket_size: int
+) -> AsyncGenerator[tuple[TensorMeta, torch.Tensor], None]:
+    """Split the weight into chunks.
+
+    Args:
+        weights: The weights generator.
+        bucket_size: Max bucket size in bytes.
+
+    Yields:
+        A tuple of the weight chunk metadata and the buffer.
+    """
+    async for name, weight in ensure_async_iterator(weights):
+        buffer = weight.view(-1).view(torch.uint8)
+        chunk_offset = 0
+        while chunk_offset < weight.nbytes:
+            chunk_size = min(bucket_size, weight.nbytes - chunk_offset)
+            tensor_meta = TensorMeta(
+                name=name,
+                shape=weight.shape,
+                dtype=weight.dtype,
+                chunk_offset=chunk_offset,
+                chunk_size=chunk_size,
+                offset=None,
+            )
+            yield (tensor_meta, buffer[chunk_offset : chunk_offset + chunk_size])
+            chunk_offset += chunk_size
+
+
+async def merge_weight_chunks(
+    chunks: Generator[tuple[TensorMeta, torch.Tensor], None, None], bucket_size: int
+) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    """Merge the weight chunks into the original weight.
+
+    Args:
+        chunks: The chunks generator.
+        bucket_size: Max bucket size in bytes.
+
+    Yields:
+        A tuple of the name of the weight tensor and the tensor itself.
+    """
+    merge_name, merge_weight, merge_buffer, merge_offset = None, None, None, 0
+    async for tensor_meta, chunk in chunks:
+        assert chunk.dtype == torch.uint8, f"Chunk dtype must be uint8, but got {chunk.dtype}"
+        nbytes = tensor_meta.shape.numel() * tensor_meta.dtype.itemsize
+
+        # weight is small enough to fit in one bucket
+        if nbytes <= bucket_size:
+            assert merge_weight is None, f"Weight must be None, but got {merge_name}"
+            name, weight = tensor_meta.name, chunk.view(tensor_meta.dtype).view(tensor_meta.shape)
+            yield (name, weight)
+            continue
+
+        if merge_weight is None:
+            assert tensor_meta.chunk_offset == 0, f"Chunk offset must be 0, but got {tensor_meta}"
+            merge_name, merge_weight = (
+                tensor_meta.name,
+                torch.empty(tensor_meta.shape, dtype=tensor_meta.dtype, device=chunk.device),
+            )
+            merge_buffer = merge_weight.view(-1).view(torch.uint8)
+            merge_offset = 0
+
+        assert tensor_meta.name == merge_name
+        assert merge_offset == tensor_meta.chunk_offset
+        merge_buffer[tensor_meta.chunk_offset : tensor_meta.chunk_offset + tensor_meta.chunk_size] = chunk
+        merge_offset += tensor_meta.chunk_size
+        if tensor_meta.chunk_offset + tensor_meta.chunk_size == nbytes:
+            yield (merge_name, merge_weight)
+            merge_name, merge_weight, merge_buffer, merge_offset = None, None, None, 0

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -27,7 +27,13 @@ import ray.util.collective as collective
 import torch
 import zmq
 
-from verl.checkpoint_engine.base import CheckpointEngine, CheckpointEngineRegistry, TensorMeta
+from verl.checkpoint_engine.base import (
+    CheckpointEngine,
+    CheckpointEngineRegistry,
+    TensorMeta,
+    merge_weight_chunks,
+    split_weight_chunks,
+)
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 
 logger = logging.getLogger(__name__)
@@ -241,9 +247,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
         start_time = time.time()
         bucket_meta: dict[str, TensorMeta] = {}
         offset = 0
-        for name, weight in weights:
+        async for tensor_meta, chunk in split_weight_chunks(weights, self.bucket_size):
             # fill the tensor bucket
-            if offset + weight.nbytes > self.bucket_size:
+            if offset + tensor_meta.chunk_size > self.bucket_size:
                 torch.cuda.synchronize()
 
                 # wait previous broadcast op finish
@@ -264,18 +270,13 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 bucket_meta = {}
                 offset = 0
 
-            assert offset + weight.nbytes <= self.bucket_size, (
-                f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
-            )
+            assert offset + tensor_meta.chunk_size <= self.bucket_size
+            assert tensor_meta.name not in bucket_meta
 
-            bucket_meta[name] = {
-                "name": name,
-                "shape": weight.shape,
-                "dtype": weight.dtype,
-                "offset": offset,
-            }
-            send_buf[offset : offset + weight.nbytes] = cp.asarray(weight.view(-1).view(torch.uint8))
-            offset += weight.nbytes
+            tensor_meta.offset = offset
+            bucket_meta[tensor_meta.name] = tensor_meta
+            send_buf[offset : offset + tensor_meta.chunk_size] = cp.asarray(chunk)
+            offset += tensor_meta.chunk_size
 
         # broadcast last bucket
         torch.cuda.synchronize()
@@ -299,6 +300,15 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+        """
+        async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
+            yield name, weight
+
+    async def _receive_weight_chunks(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+        """Receive the weight chunks of the model.
+
+        Yields:
+            A tuple of the name of the weight tensor and the chunk itself.
         """
         assert self.rank > 0, "Rank 0 should not receive weights."
         send_buf, recv_buf = self.send_buf, self.recv_buf
@@ -332,11 +342,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
             )
 
             # 2. yield tensor from send_buf
-            for name, meta in metadata["bucket_meta"].items():
-                dtype, shape = meta["dtype"], meta["shape"]
-                size = dtype.itemsize * shape.numel()
-                tensor = send_buf[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
-                yield name, tensor
+            for name, tensor_meta in metadata["bucket_meta"].items():
+                tensor = send_buf[tensor_meta.offset : tensor_meta.offset + tensor_meta.chunk_size]
+                yield tensor_meta, tensor
 
             # 3. wait for next bucket broadcast finish
             metadata = await broadcast_op.wait_for_complete()
@@ -348,11 +356,9 @@ class NCCLCheckpointEngine(CheckpointEngine):
             send_buf, recv_buf = recv_buf, send_buf
 
         # yield tensor from send_buf
-        for name, meta in metadata["bucket_meta"].items():
-            dtype, shape = meta["dtype"], meta["shape"]
-            size = dtype.itemsize * shape.numel()
-            tensor = send_buf[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
-            yield name, tensor
+        for name, tensor_meta in metadata["bucket_meta"].items():
+            tensor = send_buf[tensor_meta.offset : tensor_meta.offset + tensor_meta.chunk_size]
+            yield tensor_meta, tensor
 
         time_cost = time.time() - start_time
         bandwidth = total_bytes / time_cost / (1024 * 1024 * 1024)

--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -31,7 +31,13 @@ import torch
 import zmq
 import zmq.asyncio
 
-from verl.checkpoint_engine.base import CheckpointEngine, CheckpointEngineRegistry, TensorMeta
+from verl.checkpoint_engine.base import (
+    CheckpointEngine,
+    CheckpointEngineRegistry,
+    TensorMeta,
+    merge_weight_chunks,
+    split_weight_chunks,
+)
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 
 logger = logging.getLogger(__name__)
@@ -384,9 +390,9 @@ class NIXLCheckpointEngine(CheckpointEngine):
         start_time = time.time()
         bucket_meta: dict[str, TensorMeta] = {}
         offset = 0
-        for name, weight in weights:
+        async for tensor_meta, chunk in split_weight_chunks(weights, self.bucket_size):
             # fill the tensor bucket
-            if offset + weight.nbytes > self.bucket_size:
+            if offset + tensor_meta.chunk_size > self.bucket_size:
                 torch.cuda.synchronize()
 
                 # wait previous bucket to be received
@@ -407,18 +413,13 @@ class NIXLCheckpointEngine(CheckpointEngine):
                 bucket_meta = {}
                 offset = 0
 
-            assert offset + weight.nbytes <= self.bucket_size, (
-                f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
-            )
+            assert offset + tensor_meta.chunk_size <= self.bucket_size
+            assert tensor_meta.name not in bucket_meta
 
-            bucket_meta[name] = {
-                "name": name,
-                "shape": weight.shape,
-                "dtype": weight.dtype,
-                "offset": offset,
-            }
-            send_buf[offset : offset + weight.nbytes].copy_(weight.view(-1).view(torch.uint8), non_blocking=True)
-            offset += weight.nbytes
+            tensor_meta.offset = offset
+            bucket_meta[tensor_meta.name] = tensor_meta
+            send_buf[offset : offset + tensor_meta.chunk_size].copy_(chunk, non_blocking=True)
+            offset += tensor_meta.chunk_size
 
         # send last bucket meta to next agent
         torch.cuda.synchronize()
@@ -437,6 +438,15 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+        """
+        async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
+            yield name, weight
+
+    async def _receive_weight_chunks(self) -> AsyncGenerator[tuple[TensorMeta, torch.Tensor], None]:
+        """Receive the weight chunks of the model.
+
+        Yields:
+            A tuple of the chunk metadata and the chunk buffer view in send_buf.
         """
         assert self.prev_agent is not None, "Previous agent is not set."
         send_buf, recv_buf = self.send_buf, self.recv_buf
@@ -472,11 +482,9 @@ class NIXLCheckpointEngine(CheckpointEngine):
             read_op.begin_read()
 
             # 3. yield tensor from send_buf
-            for name, meta in metadata["bucket_meta"].items():
-                dtype, shape = meta["dtype"], meta["shape"]
-                size = dtype.itemsize * shape.numel()
-                tensor = send_buf[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
-                yield name, tensor
+            for name, tensor_meta in metadata["bucket_meta"].items():
+                tensor = send_buf[tensor_meta.offset : tensor_meta.offset + tensor_meta.chunk_size]
+                yield tensor_meta, tensor
 
             # 4. wait for next agent read complete and read from previous agent complete
             if readable_op is not None:
@@ -502,11 +510,9 @@ class NIXLCheckpointEngine(CheckpointEngine):
             )
 
         # yield tensor from send_buf
-        for name, meta in metadata["bucket_meta"].items():
-            dtype, shape = meta["dtype"], meta["shape"]
-            size = dtype.itemsize * shape.numel()
-            tensor = send_buf[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
-            yield name, tensor
+        for name, tensor_meta in metadata["bucket_meta"].items():
+            tensor = send_buf[tensor_meta.offset : tensor_meta.offset + tensor_meta.chunk_size]
+            yield tensor_meta, tensor
 
         # wait for next agent read complete
         if readable_op is not None:

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -38,6 +38,7 @@ class TensorMetadata(TypedDict):
     shape: torch.Size
     dtype: torch.dtype
     offset: int
+    handle: tuple
 
 
 # copy from https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/rlhf_utils.py
@@ -125,23 +126,27 @@ class BucketedWeightSender:
                 # weight = weight.to(dtype, non_blocking=True)
 
                 # fill the tensor bucket
-                if offset + weight.nbytes > self.bucket_size:
+                if offset + weight.nbytes > self.bucket_size and len(bucket_meta) > 0:
                     get_torch_device().synchronize()
                     self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
                     self.socket.recv()
                     bucket_meta = {}
                     offset = 0
 
-                # TODO: slice embedding layer weight into chunks
-                assert offset + weight.nbytes <= self.bucket_size, (
-                    f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
-                    f"Please increase rollout.update_weights_bucket_megabytes({self.bucket_size_mb} MB)."
-                )
+                if offset + weight.nbytes > self.bucket_size:
+                    assert not self.use_shm, (
+                        f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
+                        f"Please increase rollout.update_weights_bucket_megabytes({self.bucket_size_mb} MB)."
+                    )
+                    self._direct_send_large_weight(name, weight)
+                    continue
+
                 bucket_meta[name] = {
                     "name": name,
                     "shape": weight.shape,
                     "dtype": weight.dtype,
                     "offset": offset,
+                    "handle": None,
                 }
                 self.buffer[offset : offset + weight.nbytes].copy_(weight.view(-1).view(torch.uint8), non_blocking=True)
                 offset += weight.nbytes
@@ -208,6 +213,22 @@ class BucketedWeightSender:
         get_torch_device().ipc_collect()
         get_torch_device().empty_cache()
 
+    def _direct_send_large_weight(self, name: str, weight: torch.Tensor):
+        """Send a weight larger than the bucket size via cuda ipc or share memory."""
+        logger.debug(f"Direct sending large weight {name}({weight.shape}, {weight.dtype})")
+        # TODO: support fallback to shared memory
+        handle = reduce_tensor(weight)
+        bucket_meta: dict[str, TensorMetadata] = {}
+        bucket_meta[name] = {
+            "name": name,
+            "shape": weight.shape,
+            "dtype": weight.dtype,
+            "offset": 0,
+            "handle": handle,
+        }
+        self.socket.send_pyobj({"bucket_meta": bucket_meta, "is_last": False})
+        self.socket.recv()
+
 
 class BucketedWeightReceiver:
     """
@@ -253,7 +274,11 @@ class BucketedWeightReceiver:
                 metadata = self.socket.recv_pyobj()
                 weights, tensor = [], None
                 for name, meta in metadata["bucket_meta"].items():
-                    shape, dtype, offset = meta["shape"], meta["dtype"], meta["offset"]
+                    shape, dtype, offset, handle = meta["shape"], meta["dtype"], meta["offset"], meta["handle"]
+                    if handle is not None:
+                        tensor = rebuild_ipc(handle, self.device.index)
+                        weights.append((name, tensor))
+                        continue
                     size = dtype.itemsize * shape.numel()
                     tensor = self.buffer[offset : offset + size].view(dtype=dtype).view(shape)
                     if self.use_shm:


### PR DESCRIPTION
### What does this PR do?

Before this PR, NCCL/NIXL checkpoint engine and vLLM CUDA IPC buffer size (controlled by `rollout.checkpoint_engine.update_weights_bucket_megabytes`) must be larger than the largest weight. So during weight synchronization, each GPU must has additional memory:
- Colocated: all-gather full weight + cuda ipc buffer, `max_weight_size * 2`
- Fully async:  double buffer(NCCL/NIXL checkpoint engine) + cuda ipc buffer, `max_weight_size * 3`

While transformers>5, the `gate_up_proj` has been fused into single weight with shape `[num_experts, 2 * intermediate_dim, hidden_dim]`. For example, Qwen/Qwen3.5-397B-A17B gate_up_proj size is 8GB in bfloat16. This cause huge peak memory during weight synchronization.

This PR introduce two changes
1. CUDA IPC buffer size can be smaller than largest weight. If weight size is larger than cuda ipc buffer size, bypass buffer and directly send it, reducing peak memory from `max_weight_size * 2` to `max_weight_size + cuda_ipc_buffer_size`.
2.  NCCL/NIXL checkpoint engine send/recv bucket size can be smaller than largest weight. If weight size is larger than bucket size, split it into chunks in sender and merge it from chunks in receiver, reducing peak memory from `max_weight_size * 3` to `max_weight_size + 3 * cuda_ipc_buffer_size`

While the peak memory is still bounded by `max_weight_size`, we will address it in future PR.