### PR TITLE
feat: add data.max_pixels and data.min_pixels config for image resizing

### DIFF
--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -106,6 +106,8 @@ class MultiTurnSFTDataset(Dataset):
         self.image_patch_size = config.get(
             "image_patch_size", processor.image_processor.patch_size if processor else None
         )
+        self.max_pixels = config.get("max_pixels", None)
+        self.min_pixels = config.get("min_pixels", None)
         self.tools_key = config.get("tools_key", "tools")
         self.enable_thinking_key = config.get("enable_thinking_key", "enable_thinking")
         self.enable_thinking_default = config.get("enable_thinking_default", None)
@@ -271,7 +273,7 @@ class MultiTurnSFTDataset(Dataset):
             segments = [item for item in segments if item != ""]
             for segment in segments:
                 if segment == "<image>":
-                    image = process_image(images[image_offset], image_patch_size=self.image_patch_size)
+                    image = process_image(images[image_offset], image_patch_size=self.image_patch_size, max_pixels=self.max_pixels, min_pixels=self.min_pixels)
                     content_list.append({"type": "image", "image": image})
                     image_offset += 1
                 elif segment == "<video>":

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -108,6 +108,8 @@ class RLHFDataset(Dataset):
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
         self.image_patch_size = config.get("image_patch_size", 14)
+        self.max_pixels = config.get("max_pixels", None)
+        self.min_pixels = config.get("min_pixels", None)
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.return_full_prompt = config.get("return_full_prompt", False)
@@ -204,7 +206,7 @@ class RLHFDataset(Dataset):
                         )
                         if image_key in doc and doc[image_key]:
                             images = [
-                                process_image(image, image_patch_size=self.image_patch_size) for image in doc[image_key]
+                                process_image(image, image_patch_size=self.image_patch_size, max_pixels=self.max_pixels, min_pixels=self.min_pixels) for image in doc[image_key]
                             ]
                         else:
                             images = None
@@ -409,6 +411,21 @@ class RLHFDataset(Dataset):
             videos: List of videos, each video is a tuple of (video_tensor, video_metadata).
         """
         from qwen_vl_utils import process_vision_info
+
+        # Inject max_pixels/min_pixels from config into image dicts within messages
+        max_pixels = config.get("max_pixels", None)
+        min_pixels = config.get("min_pixels", None)
+        if max_pixels is not None or min_pixels is not None:
+            import copy
+            messages = copy.deepcopy(messages)
+            for msg in messages:
+                if isinstance(msg.get("content"), list):
+                    for item in msg["content"]:
+                        if isinstance(item, dict) and ("image" in item or "image_url" in item):
+                            if max_pixels is not None and "max_pixels" not in item:
+                                item["max_pixels"] = max_pixels
+                            if min_pixels is not None and "min_pixels" not in item:
+                                item["min_pixels"] = min_pixels
 
         images, videos = process_vision_info(messages, image_patch_size=image_patch_size, return_video_metadata=True)
         return images, videos

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -19,15 +19,24 @@ import torch
 from PIL import Image
 
 
-def process_image(image: dict | Image.Image, image_patch_size: int = 14) -> Image.Image:
+def process_image(image: dict | Image.Image, image_patch_size: int = 14, max_pixels: int | None = None, min_pixels: int | None = None) -> Image.Image:
     from qwen_vl_utils import fetch_image
 
     if isinstance(image, Image.Image):
         return image.convert("RGB")
 
+    if not isinstance(image, dict):
+        image = {"image": image}
+
     if "bytes" in image:
         assert "image" not in image, "Cannot have both `bytes` and `image`"
         image["image"] = Image.open(BytesIO(image["bytes"]))
+
+    # Inject max_pixels/min_pixels from config if not already set in the image dict
+    if max_pixels is not None and "max_pixels" not in image:
+        image["max_pixels"] = max_pixels
+    if min_pixels is not None and "min_pixels" not in image:
+        image["min_pixels"] = min_pixels
 
     try:
         ans = fetch_image(image, image_patch_size=image_patch_size)


### PR DESCRIPTION
Allow users to control image visual token count via command-line config `data.max_pixels` and `data.min_pixels`, which are passed through to qwen_vl_utils.fetch_image's smart_resize function.

This fixes the issue where large images (e.g. InfographicsVQA) produce excessive visual tokens that exceed max_prompt_length, causing vLLM to fail with "max_tokens must be at least 1, got 0".

Usage:
  python -m verl.trainer.main_ppo \
      data.max_pixels=3211264 \
      data.min_pixels=3136 \
      ...

Changes:
- vision_utils.py: process_image accepts and injects max_pixels/min_pixels
- rl_dataset.py: reads config, passes to process_image and process_vision_info
- multiturn_sft_dataset.py: reads config, passes to process_image

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
