### PR TITLE
[trainer] fix: include uid and sort by uid in validation generation dumps in main_ppo_sync

### DIFF
--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -955,12 +955,19 @@ class PPOTrainer:
         # dump to local dir
         val_data_dir = self.config.trainer.get("validation_data_dir", None)
         if val_data_dir:
+            sorted_indices = sorted(range(len(sample_uids)), key=lambda i: sample_uids[i])
+            dump_inputs = [sample_inputs[i] for i in sorted_indices]
+            dump_outputs = [sample_outputs[i] for i in sorted_indices]
+            dump_gts = [sample_gts[i] for i in sorted_indices]
+            dump_scores = [sample_scores[i] for i in sorted_indices]
+            dump_extra = {k: [v[i] for i in sorted_indices] for k, v in reward_extra_infos_dict.items()}
+            dump_extra["uid"] = [sample_uids[i] for i in sorted_indices]
             self._dump_generations(
-                inputs=sample_inputs,
-                outputs=sample_outputs,
-                gts=sample_gts,
-                scores=sample_scores,
-                reward_extra_infos_dict=reward_extra_infos_dict,
+                inputs=dump_inputs,
+                outputs=dump_outputs,
+                gts=dump_gts,
+                scores=dump_scores,
+                reward_extra_infos_dict=dump_extra,
                 dump_path=val_data_dir,
             )
 


### PR DESCRIPTION
### What does this PR do?

In `main_ppo_sync`, `_validate` builds `sample_uids` from each batch but never passes them to `_dump_generations`, so validation JSONL files contained no `uid` field. This makes it impossible to trace a dumped sample back to its source.

The training/rollout dump path (`_maybe_dump_generations`) already adds and sorts by uid. This PR brings the validation path to parity.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [`uid validation dump`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+uid+validation+dump), [`validation dump uid`](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+validation+dump+uid)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

No API change. When `trainer.validation_data_dir` is set, the output JSONL files will now include a `uid` field and rows will be sorted by uid, so rollouts with multiple outputs are together in the dumped file.

### Design & Code Changes

- Sort validation samples by uid before dumping, using sorted copies so `_val_metrics_update` is unaffected
- Add `"uid"` into `reward_extra_infos_dict` for the dump, consistent with rollout path

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not necessary
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: not necessary
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.