### PR TITLE
[magatron_utils, critic] fix: resolve critic optimizer hang when using mbridge with shared embeddings

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -230,8 +230,6 @@ def make_megatron_module(
         override_model_config = {}
     
     if bridge is not None:
-        if hasattr(bridge, 'hf_config') and hasattr(wrap_config, 'share_embeddings_and_output_weights'):
-            bridge.hf_config.tie_word_embeddings = wrap_config.share_embeddings_and_output_weights
         if provider is None:
             from verl.models.mcore.mbridge import freeze_moe_router, make_value_model
 

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -228,8 +228,9 @@ def make_megatron_module(
 
     if override_model_config is None:
         override_model_config = {}
-
+    
     if bridge is not None:
+        bridge.hf_config['tie_word_embeddings']=wrap_config.share_embeddings_and_output_weights
         if provider is None:
             from verl.models.mcore.mbridge import freeze_moe_router, make_value_model
 

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -230,7 +230,8 @@ def make_megatron_module(
         override_model_config = {}
     
     if bridge is not None:
-        bridge.hf_config.tie_word_embeddings = wrap_config.share_embeddings_and_output_weights
+        if hasattr(bridge, 'hf_config') and hasattr(wrap_config, 'share_embeddings_and_output_weights'):
+            bridge.hf_config.tie_word_embeddings = wrap_config.share_embeddings_and_output_weights
         if provider is None:
             from verl.models.mcore.mbridge import freeze_moe_router, make_value_model
 

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -230,7 +230,7 @@ def make_megatron_module(
         override_model_config = {}
     
     if bridge is not None:
-        bridge.hf_config['tie_word_embeddings']=wrap_config.share_embeddings_and_output_weights
+        bridge.hf_config.tie_word_embeddings = wrap_config.share_embeddings_and_output_weights
         if provider is None:
             from verl.models.mcore.mbridge import freeze_moe_router, make_value_model
 


### PR DESCRIPTION
### What does this PR do?
When performing PPO training using Megatron and mbridge with Pipeline Parallelism (PP) enabled, all critic update processes would hang.

After investigation, the root cause was identified: when the critic's embedding and output weights are shared, the output layer is replaced. This prevents the embedding layer from receiving gradients from the output layer, leading to a synchronization deadlock and the subsequent process hang.

In mbridge/mbridge/core/llm_bridge.py (line 173), the code currently uses:

```Python
share_embeddings_and_output_weights = getattr(
    self.hf_config, "tie_word_embeddings", False
)
```

As a result, the share_embeddings_and_output_weights parameter in wrap_config does not actually influence the model loading behavior as intended. This PR ensures the configuration is correctly respected to prevent the deadlock.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: No similar PRs found
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Fix bug with a single-line change.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
