### PR TITLE
[sglang] feat: restrict abort and resume requests to primary server only

### DIFF
--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -479,9 +479,13 @@ class SGLangHttpServer:
         self.global_steps = global_steps
 
     async def abort_all_requests(self):
+        if self.node_rank != 0:
+            return
         await self.tokenizer_manager.pause_generation(PauseGenerationReqInput(mode="abort"))
 
     async def resume_generation(self):
+        if self.node_rank != 0:
+            return
         await self.tokenizer_manager.continue_generation(ContinueGenerationReqInput())
 
     async def start_profile(self, **kwargs):
@@ -612,3 +616,15 @@ class SGLangReplica(RolloutReplica):
             if is_valid_ipv6_address(server_address)
             else f"{server_address}:{server_port}"
         )
+
+    async def abort_all_requests(self):
+        """Abort all ongoing generation requests on the primary server.
+
+        SGLang control RPCs are only served by the node-rank 0 server for a
+        multi-node replica, so avoid broadcasting this call to every server.
+        """
+        await self.servers[0].abort_all_requests.remote()
+
+    async def resume_generation(self):
+        """Resume generation on the primary server after abort_all_requests."""
+        await self.servers[0].resume_generation.remote()


### PR DESCRIPTION
## Summary

This MR fixes the SGLang partial-rollout control path for multi-node rollout replicas.

In the current implementation, `abort_all_requests()` and `resume_generation()` are broadcast to all SGLang server actors in a replica. For multi-node SGLang replicas, only the node-rank 0 server owns the control/http path, while non-zero node ranks do not fully serve these control RPCs. This can lead to failures such as:

`AttributeError: 'NoneType' object has no attribute 'pause_generation'`

## Root Cause

`RolloutReplica.abort_all_requests()` / `resume_generation()` broadcast control calls to all `self.servers`.

For SGLang multi-node replicas, non-zero `node_rank` servers return early during HTTP/control setup, so sending `pause_generation()` / `continue_generation()` to them is unsafe.

## Fix

- Add `node_rank != 0` guards in `SGLangHttpServer.abort_all_requests()` and `resume_generation()`
- Override `SGLangReplica.abort_all_requests()` and `resume_generation()` to send control RPCs only to `self.servers[0]`

This keeps the fix aligned with the actual SGLang multi-node control topology and avoids unnecessary fan-out for control-only operations.

