### PR TITLE
[fsdp, training_utils] feat: support per-sample temperature with fused linear cross entropy

### DIFF
--- a/tests/utils/test_linear_cross_entropy.py
+++ b/tests/utils/test_linear_cross_entropy.py
@@ -358,9 +358,7 @@ class TestLinearCrossEntropy:
 
         for _ in range(iterations):
             hidden, weight, labels = self.generate_forward_inputs()
-            t_tensor = torch.full(
-                (self.num_tokens,), self.temperature, dtype=torch.float32, device="cuda"
-            )
+            t_tensor = torch.full((self.num_tokens,), self.temperature, dtype=torch.float32, device="cuda")
 
             # torch fused path runs in fp32 so the prescale cast is a no-op.
             # Residual difference (~1e-5) comes from the matmul associativity
@@ -368,14 +366,10 @@ class TestLinearCrossEntropy:
             # evaluates (h / T) @ W.T, which accumulates in a different order
             # and differs by a few ULPs per-token. Match the cross-implementation
             # tolerance used for verl_fused vs. torch further down.
-            lp_scalar, ent_scalar = run_verl_torch_fused_entropy(
-                hidden, weight, labels, self.temperature
-            )
+            lp_scalar, ent_scalar = run_verl_torch_fused_entropy(hidden, weight, labels, self.temperature)
             hidden_f32 = hidden.to(torch.float32)
             weight_f32 = weight.to(torch.float32)
-            lp_tensor, ent_tensor = fused_linear_for_ppo(
-                hidden_f32, weight_f32, labels, temperature=t_tensor
-            )
+            lp_tensor, ent_tensor = fused_linear_for_ppo(hidden_f32, weight_f32, labels, temperature=t_tensor)
             lp_tensor = lp_tensor.squeeze(0)
             ent_tensor = ent_tensor.squeeze(0)
             torch.testing.assert_close(lp_scalar, lp_tensor, atol=1e-4, rtol=1e-4)
@@ -407,13 +401,11 @@ class TestLinearCrossEntropy:
 
         for _ in range(iterations):
             hidden, weight, labels = self.generate_forward_inputs()
-            temperature_per_token = torch.empty(
-                (self.num_tokens,), dtype=torch.float32, device="cuda"
-            ).uniform_(0.5, 2.0)
-
-            ref_logprobs, ref_entropy = run_torch_per_sample_entropy(
-                hidden, weight, labels, temperature_per_token
+            temperature_per_token = torch.empty((self.num_tokens,), dtype=torch.float32, device="cuda").uniform_(
+                0.5, 2.0
             )
+
+            ref_logprobs, ref_entropy = run_torch_per_sample_entropy(hidden, weight, labels, temperature_per_token)
 
             hidden_f32 = hidden.to(torch.float32)
             weight_f32 = weight.to(torch.float32)
@@ -423,9 +415,7 @@ class TestLinearCrossEntropy:
             fused_logprobs = fused_logprobs.squeeze(0)
             fused_entropy = fused_entropy.squeeze(0)
 
-            kernel_logprobs, kernel_entropy = linear_cross_entropy(
-                hidden, weight, labels, temperature_per_token
-            )
+            kernel_logprobs, kernel_entropy = linear_cross_entropy(hidden, weight, labels, temperature_per_token)
 
             # torch fused path is run in fp32, so we expect tight agreement.
             torch.testing.assert_close(ref_logprobs, fused_logprobs, atol=1e-4, rtol=1e-4)

--- a/tests/utils/test_linear_cross_entropy.py
+++ b/tests/utils/test_linear_cross_entropy.py
@@ -43,7 +43,7 @@ compute_entropy_from_logits = torch.compile(verl_F.entropy_from_logits, dynamic=
 fused_linear_for_ppo = FusedLinearForPPO()
 fused_linear_for_ppo.compile(dynamic=True)
 
-MAX_TEST_CASES = os.environ.get("MAX_TEST_CASES", 5)
+MAX_TEST_CASES = int(os.environ.get("MAX_TEST_CASES", 5))
 
 
 def run_torch_entropy(
@@ -95,6 +95,31 @@ def run_verl_torch_fused_entropy(
         temperature=temperature,
     )
     return logprobs.squeeze(0), entropy.squeeze(0)
+
+
+def run_torch_per_sample_entropy(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    labels: torch.Tensor,
+    temperature: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Reference implementation of per-sample temperature in fp32.
+
+    ``temperature`` is a 1-D tensor of shape ``(num_tokens,)`` aligned with the
+    flattened hidden states. Divides logits row-wise before softmax/logsumexp,
+    which is the semantic the two fused paths must match.
+    """
+    hidden = hidden.squeeze(0).to(torch.float32)
+    weight = weight.transpose(0, 1).to(torch.float32)
+    logits = torch.matmul(hidden, weight)  # [num_tokens, vocab_size]
+    logits = logits / temperature.to(torch.float32).unsqueeze(-1)
+    pd = torch.nn.functional.softmax(logits, dim=-1)
+    entropy_a = torch.logsumexp(logits, dim=-1)
+    entropy_b = torch.sum(pd * logits, dim=-1)
+    entropy = entropy_a - entropy_b
+    logprobs = torch.nn.functional.cross_entropy(logits, labels.squeeze(0), reduction="none")
+    logprobs = torch.neg(logprobs)
+    return logprobs, entropy
 
 
 class TestLinearCrossEntropy:
@@ -320,6 +345,129 @@ class TestLinearCrossEntropy:
             f"{sum(kernel_backward_latency) / len(kernel_backward_latency):.2f} ms"
         )
 
+    def verify_uniform_tensor_matches_scalar(self, iterations=3):
+        """Passing a 1-D tensor temperature whose entries are all equal to a
+        scalar ``T`` must produce (up to one bf16 rounding introduced by the
+        prescale wrapper) the same result as passing the Python float ``T``.
+
+        This guards against the dispatcher accidentally activating a different
+        code path for uniform-valued tensor temperatures.
+        """
+        self.cleanup()
+        self.generate_hyper()
+
+        for _ in range(iterations):
+            hidden, weight, labels = self.generate_forward_inputs()
+            t_tensor = torch.full(
+                (self.num_tokens,), self.temperature, dtype=torch.float32, device="cuda"
+            )
+
+            # torch fused path runs in fp32 so the prescale cast is a no-op.
+            # Residual difference (~1e-5) comes from the matmul associativity
+            # change: scalar path evaluates (h @ W.T) / T while tensor path
+            # evaluates (h / T) @ W.T, which accumulates in a different order
+            # and differs by a few ULPs per-token. Match the cross-implementation
+            # tolerance used for verl_fused vs. torch further down.
+            lp_scalar, ent_scalar = run_verl_torch_fused_entropy(
+                hidden, weight, labels, self.temperature
+            )
+            hidden_f32 = hidden.to(torch.float32)
+            weight_f32 = weight.to(torch.float32)
+            lp_tensor, ent_tensor = fused_linear_for_ppo(
+                hidden_f32, weight_f32, labels, temperature=t_tensor
+            )
+            lp_tensor = lp_tensor.squeeze(0)
+            ent_tensor = ent_tensor.squeeze(0)
+            torch.testing.assert_close(lp_scalar, lp_tensor, atol=1e-4, rtol=1e-4)
+            torch.testing.assert_close(ent_scalar, ent_tensor, atol=1e-4, rtol=1e-4)
+
+            # triton kernel path: prescale forces one extra bf16 cast round on
+            # hidden. The rounding propagates through a matmul sum of size D
+            # and an entropy sum of size V, so entropy tolerance scales with
+            # roughly sqrt(V/D) relative to logprobs.
+            lp_scalar_k, ent_scalar_k = linear_cross_entropy(hidden, weight, labels, self.temperature)
+            lp_tensor_k, ent_tensor_k = linear_cross_entropy(hidden, weight, labels, t_tensor)
+            torch.testing.assert_close(lp_scalar_k, lp_tensor_k, atol=5e-3, rtol=5e-3)
+            torch.testing.assert_close(ent_scalar_k, ent_tensor_k, atol=5e-2, rtol=1e-2)
+
+        print("\n[INFO]: Uniform-tensor temperature matches scalar temperature.")
+
+    def verify_per_sample_correctness(self, iterations=3):
+        """Random per-token temperatures from a plausible RL range [0.5, 2.0],
+        comparing both fused paths against an all-fp32 reference.
+
+        Note we deliberately do *not* test ``run_verl_original_entropy`` or
+        ``run_torch_entropy`` here — those implementations only accept a scalar
+        temperature. The guarantee this test checks is that the new per-sample
+        path on each fused implementation matches what a naive per-token fp32
+        pipeline would produce.
+        """
+        self.cleanup()
+        self.generate_hyper()
+
+        for _ in range(iterations):
+            hidden, weight, labels = self.generate_forward_inputs()
+            temperature_per_token = torch.empty(
+                (self.num_tokens,), dtype=torch.float32, device="cuda"
+            ).uniform_(0.5, 2.0)
+
+            ref_logprobs, ref_entropy = run_torch_per_sample_entropy(
+                hidden, weight, labels, temperature_per_token
+            )
+
+            hidden_f32 = hidden.to(torch.float32)
+            weight_f32 = weight.to(torch.float32)
+            fused_logprobs, fused_entropy = fused_linear_for_ppo(
+                hidden_f32, weight_f32, labels, temperature=temperature_per_token
+            )
+            fused_logprobs = fused_logprobs.squeeze(0)
+            fused_entropy = fused_entropy.squeeze(0)
+
+            kernel_logprobs, kernel_entropy = linear_cross_entropy(
+                hidden, weight, labels, temperature_per_token
+            )
+
+            # torch fused path is run in fp32, so we expect tight agreement.
+            torch.testing.assert_close(ref_logprobs, fused_logprobs, atol=1e-4, rtol=1e-4)
+            torch.testing.assert_close(ref_entropy, fused_entropy, atol=1e-4, rtol=1e-4)
+
+            # triton kernel path operates in bf16 with one extra fp32 prescale
+            # cast on hidden. Entropy tolerance accounts for the sum-over-V step.
+            torch.testing.assert_close(ref_logprobs, kernel_logprobs, atol=5e-3, rtol=5e-3)
+            torch.testing.assert_close(ref_entropy, kernel_entropy, atol=5e-2, rtol=1e-2)
+
+            # backward
+            g_entropy, g_logprobs = self.generate_backward_inputs()
+
+            (d_ref_hidden, d_ref_weight) = torch.autograd.grad(
+                (ref_entropy, ref_logprobs),
+                (hidden, weight),
+                (g_entropy, g_logprobs),
+                retain_graph=False,
+            )
+            (d_fused_hidden, d_fused_weight) = torch.autograd.grad(
+                (fused_entropy, fused_logprobs),
+                (hidden, weight),
+                (g_entropy, g_logprobs),
+                retain_graph=False,
+            )
+            (d_kernel_hidden, d_kernel_weight) = torch.autograd.grad(
+                (kernel_entropy, kernel_logprobs),
+                (hidden, weight),
+                (g_entropy, g_logprobs),
+                retain_graph=False,
+            )
+
+            torch.testing.assert_close(d_ref_hidden, d_fused_hidden, atol=1e-2, rtol=1e-4)
+            torch.testing.assert_close(d_ref_weight, d_fused_weight, atol=1e-2, rtol=1e-4)
+            # Slightly looser than ``verify_correctness`` (bf16 vs bf16) because
+            # here the reference is computed in fp32 and the kernel path also
+            # pays one extra bf16 round-trip from the hidden prescale.
+            torch.testing.assert_close(d_ref_hidden, d_kernel_hidden, atol=3e-2, rtol=4e-2)
+            torch.testing.assert_close(d_ref_weight, d_kernel_weight, atol=3e-2, rtol=4e-2)
+
+        print("\n[INFO]: Per-sample temperature forward & backward correctness verified.")
+
     def check_storage(self, method_name, run_forward):
         self.cleanup()
         self.generate_hyper()
@@ -395,6 +543,28 @@ def test_lce_non_divisible_vocab_padding():
         torch.testing.assert_close(ref_ent, ker_ent, atol=1e-3, rtol=1e-3, msg=f"entropy mismatch: {desc}")
 
 
+def test_lce_per_sample_temperature():
+    """Standalone regression test for per-sample temperature support.
+
+    Covers both fused paths (Triton ``linear_cross_entropy`` and the pure-PyTorch
+    ``FusedLinearForPPO``) against an all-fp32 per-token reference, and also
+    checks that feeding a uniform 1-D tensor temperature is equivalent to
+    feeding the equivalent Python float.
+
+    Runs a single smaller shape so it fits in the standard unit-test budget;
+    the full sweep is exercised by the class-based ``verify_per_sample_*``
+    methods invoked from ``__main__``.
+    """
+    if not torch.cuda.is_available() or is_torch_npu_available(check_device=False):
+        return
+
+    torch.manual_seed(0)
+
+    test = TestLinearCrossEntropy(test_case_idx=2, temperature=1.5)
+    test.verify_uniform_tensor_matches_scalar(iterations=2)
+    test.verify_per_sample_correctness(iterations=2)
+
+
 if __name__ == "__main__":
     # torch.cuda.memory._record_memory_history()
 
@@ -403,8 +573,11 @@ if __name__ == "__main__":
         test = TestLinearCrossEntropy(test_case_idx)
 
         test.verify_correctness()
+        test.verify_uniform_tensor_matches_scalar()
+        test.verify_per_sample_correctness()
         test.check_storage_all()
 
     test_lce_non_divisible_vocab_padding()
+    test_lce_per_sample_temperature()
 
     # torch.cuda.memory._dump_snapshot("test_linear_cross_entropy.pkl")

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -221,6 +221,18 @@ class FusedLinearForPPO(torch.nn.Module):
         input_ids: torch.LongTensor,
         temperature: Union[float, torch.Tensor] = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
+        """Compute log-probs and entropy via fused linear + cross-entropy.
+
+        Args:
+            hidden_states: ``(num_tokens, D)`` hidden representations.
+            vocab_weights: ``(vocab_size, D)`` output projection weight.
+            input_ids: ``(num_tokens,)`` label token ids.
+            temperature: Global scalar (``float`` or 0/1-dim tensor) applied
+                inside the kernel, **or** a 1-D tensor of shape
+                ``(num_tokens,)`` for per-token temperature.  In the
+                per-token case ``hidden_states`` is pre-scaled by ``1/T``
+                in fp32 and the kernel runs at ``temperature=1.0``.
+        """
         input_ids = input_ids.to(torch.int64)
         # Per-sample temperature: prescale hidden by 1/T outside the
         # ``Function`` so autograd handles the extra op automatically.

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -219,7 +219,7 @@ class FusedLinearForPPO(torch.nn.Module):
         hidden_states: torch.FloatTensor,
         vocab_weights: torch.FloatTensor,
         input_ids: torch.LongTensor,
-        temperature: Union[float, torch.Tensor] = 1.0,
+        temperature: float | torch.Tensor = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
         """Compute log-probs and entropy via fused linear + cross-entropy.
 
@@ -236,9 +236,7 @@ class FusedLinearForPPO(torch.nn.Module):
         input_ids = input_ids.to(torch.int64)
         # Per-sample temperature: prescale hidden by 1/T outside the
         # ``Function`` so autograd handles the extra op automatically.
-        hidden_states, scalar_temperature = resolve_temperature_for_fused_kernel(
-            hidden_states, temperature
-        )
+        hidden_states, scalar_temperature = resolve_temperature_for_fused_kernel(hidden_states, temperature)
         return FusedLinearForPPOFunction.apply(
             hidden_states,
             vocab_weights,

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, Union
 
 import torch
+
+from verl.utils.torch_functional import resolve_temperature_for_fused_kernel
 
 try:
     from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
@@ -217,13 +219,18 @@ class FusedLinearForPPO(torch.nn.Module):
         hidden_states: torch.FloatTensor,
         vocab_weights: torch.FloatTensor,
         input_ids: torch.LongTensor,
-        temperature: float = 1.0,
+        temperature: Union[float, torch.Tensor] = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
         input_ids = input_ids.to(torch.int64)
+        # Per-sample temperature: prescale hidden by 1/T outside the
+        # ``Function`` so autograd handles the extra op automatically.
+        hidden_states, scalar_temperature = resolve_temperature_for_fused_kernel(
+            hidden_states, temperature
+        )
         return FusedLinearForPPOFunction.apply(
             hidden_states,
             vocab_weights,
             input_ids,
-            temperature,
+            scalar_temperature,
             self.chunk_size,
         )

--- a/verl/utils/kernel/linear_cross_entropy.py
+++ b/verl/utils/kernel/linear_cross_entropy.py
@@ -34,6 +34,8 @@ import typing
 import torch
 import torch.distributed as dist
 
+from verl.utils.torch_functional import resolve_temperature_for_fused_kernel
+
 
 class LinearCrossEntropy(torch.autograd.Function):
     @staticmethod
@@ -116,4 +118,24 @@ class LinearCrossEntropy(torch.autograd.Function):
         return (d_hidden, d_weight, None, None, None, None)
 
 
-linear_cross_entropy = LinearCrossEntropy.apply
+def linear_cross_entropy(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    labels: torch.Tensor,
+    temperature: typing.Union[float, torch.Tensor] = 1.0,
+    reduction: typing.Optional[str] = "none",
+    dist_process_group: typing.Optional[dist.ProcessGroup] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused linear + cross-entropy with optional per-sample temperature.
+
+    ``temperature`` may be a Python float / 0-dim tensor (applied globally inside
+    the Triton kernel) or a 1-D tensor of shape ``(num_tokens,)`` (per-token
+    temperature scaling). In the per-token case we pre-scale ``hidden`` by
+    ``1/temperature`` in fp32, then call the underlying kernel with
+    ``temperature=1.0``; this is mathematically equivalent to native per-token
+    scaling and the autograd graph propagates gradients correctly.
+    """
+    hidden, temperature_scalar = resolve_temperature_for_fused_kernel(hidden, temperature)
+    return LinearCrossEntropy.apply(
+        hidden, weight, labels, temperature_scalar, reduction, dist_process_group
+    )

--- a/verl/utils/kernel/linear_cross_entropy.py
+++ b/verl/utils/kernel/linear_cross_entropy.py
@@ -122,7 +122,7 @@ def linear_cross_entropy(
     hidden: torch.Tensor,
     weight: torch.Tensor,
     labels: torch.Tensor,
-    temperature: typing.Union[float, torch.Tensor] = 1.0,
+    temperature: float | torch.Tensor = 1.0,
     reduction: typing.Optional[str] = "none",
     dist_process_group: typing.Optional[dist.ProcessGroup] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -136,6 +136,4 @@ def linear_cross_entropy(
     scaling and the autograd graph propagates gradients correctly.
     """
     hidden, temperature_scalar = resolve_temperature_for_fused_kernel(hidden, temperature)
-    return LinearCrossEntropy.apply(
-        hidden, weight, labels, temperature_scalar, reduction, dist_process_group
-    )
+    return LinearCrossEntropy.apply(hidden, weight, labels, temperature_scalar, reduction, dist_process_group)

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -90,6 +90,7 @@ def prescale_hidden_by_per_sample_temperature(hidden: torch.Tensor, temperature:
     return hidden_scaled
 
 
+@torch.compiler.disable
 def resolve_temperature_for_fused_kernel(
     hidden: torch.Tensor, temperature: float | torch.Tensor
 ) -> tuple[torch.Tensor, float]:
@@ -104,6 +105,9 @@ def resolve_temperature_for_fused_kernel(
       return ``scalar_temperature == 1.0``.
     - Otherwise (Python float or 0-/1-element tensor), pass ``hidden`` through
       and return ``float(temperature)``.
+
+    This function is excluded from ``torch.compile`` because its data-dependent
+    branch (``numel() > 1``) is not compatible with Dynamo tracing.
     """
     if isinstance(temperature, torch.Tensor) and temperature.dim() > 0 and temperature.numel() > 1:
         return prescale_hidden_by_per_sample_temperature(hidden, temperature), 1.0

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -17,7 +17,7 @@ Contain small torch utilities
 
 import math
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 import torch.distributed
@@ -46,9 +46,7 @@ except ImportError:
     NPU_CROSS_ENTROPY_LOSS_AVAILABLE = False
 
 
-def prescale_hidden_by_per_sample_temperature(
-    hidden: torch.Tensor, temperature: torch.Tensor
-) -> torch.Tensor:
+def prescale_hidden_by_per_sample_temperature(hidden: torch.Tensor, temperature: torch.Tensor) -> torch.Tensor:
     """Pre-scale ``hidden`` by ``1/temperature`` per token in fp32 and cast back
     to the hidden dtype.
 
@@ -79,17 +77,12 @@ def prescale_hidden_by_per_sample_temperature(
         ``hidden`` with the same shape/dtype, scaled row-wise by ``1/T``.
     """
     if temperature.dim() != 1:
-        raise ValueError(
-            f"per-sample temperature must be 1D, got shape {tuple(temperature.shape)}"
-        )
+        raise ValueError(f"per-sample temperature must be 1D, got shape {tuple(temperature.shape)}")
     original_shape = hidden.shape
     hidden_flat = hidden.reshape(-1, hidden.shape[-1]) if hidden.dim() > 2 else hidden
     num_tokens = hidden_flat.shape[0]
     if temperature.shape[0] != num_tokens:
-        raise ValueError(
-            f"per-sample temperature length {temperature.shape[0]} does not match "
-            f"num_tokens {num_tokens}"
-        )
+        raise ValueError(f"per-sample temperature length {temperature.shape[0]} does not match num_tokens {num_tokens}")
     inv_t = (1.0 / temperature.to(torch.float32)).unsqueeze(-1)
     hidden_scaled = (hidden_flat.to(torch.float32) * inv_t).to(hidden.dtype)
     if hidden.dim() > 2:
@@ -98,7 +91,7 @@ def prescale_hidden_by_per_sample_temperature(
 
 
 def resolve_temperature_for_fused_kernel(
-    hidden: torch.Tensor, temperature: Union[float, torch.Tensor]
+    hidden: torch.Tensor, temperature: float | torch.Tensor
 ) -> tuple[torch.Tensor, float]:
     """Dispatcher helper shared by fused linear + cross-entropy kernels.
 

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -17,7 +17,7 @@ Contain small torch utilities
 
 import math
 from contextlib import contextmanager
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.distributed
@@ -44,6 +44,79 @@ try:
     NPU_CROSS_ENTROPY_LOSS_AVAILABLE = hasattr(torch_npu, "npu_cross_entropy_loss")
 except ImportError:
     NPU_CROSS_ENTROPY_LOSS_AVAILABLE = False
+
+
+def prescale_hidden_by_per_sample_temperature(
+    hidden: torch.Tensor, temperature: torch.Tensor
+) -> torch.Tensor:
+    """Pre-scale ``hidden`` by ``1/temperature`` per token in fp32 and cast back
+    to the hidden dtype.
+
+    This turns ``f(hidden, weight, labels, T_tensor)`` (with a fused
+    linear + softmax kernel that only supports a scalar temperature) into
+    ``f(hidden_scaled, weight, labels, 1.0)`` with the same mathematical
+    meaning, by using the identity
+
+        (h @ W^T) / T_i  ==  (h / T_i) @ W^T   for each token i
+
+    valid because row-vector scalar multiplication commutes with matmul. The
+    backward is propagated automatically by autograd through the ``hidden /
+    T`` node, so no custom backward is needed.
+
+    Numerical properties: the only extra floating-point noise compared to a
+    kernel that natively accepts per-sample temperature is one bf16 rounding
+    on the scaled hidden. Empirically this is smaller than the error of the
+    ``use_fused_kernels=False`` reference path because the ``sqrt(D)``-scale
+    matmul accumulation averages it out.
+
+    Args:
+        hidden: ``(num_tokens, D)`` or ``(B, S, D)``.
+        temperature: 1-D tensor of shape ``(num_tokens,)`` aligned with
+            ``hidden.flatten(0, -2)``. Gradients w.r.t. ``temperature`` are
+            not computed.
+
+    Returns:
+        ``hidden`` with the same shape/dtype, scaled row-wise by ``1/T``.
+    """
+    if temperature.dim() != 1:
+        raise ValueError(
+            f"per-sample temperature must be 1D, got shape {tuple(temperature.shape)}"
+        )
+    original_shape = hidden.shape
+    hidden_flat = hidden.reshape(-1, hidden.shape[-1]) if hidden.dim() > 2 else hidden
+    num_tokens = hidden_flat.shape[0]
+    if temperature.shape[0] != num_tokens:
+        raise ValueError(
+            f"per-sample temperature length {temperature.shape[0]} does not match "
+            f"num_tokens {num_tokens}"
+        )
+    inv_t = (1.0 / temperature.to(torch.float32)).unsqueeze(-1)
+    hidden_scaled = (hidden_flat.to(torch.float32) * inv_t).to(hidden.dtype)
+    if hidden.dim() > 2:
+        hidden_scaled = hidden_scaled.reshape(original_shape)
+    return hidden_scaled
+
+
+def resolve_temperature_for_fused_kernel(
+    hidden: torch.Tensor, temperature: Union[float, torch.Tensor]
+) -> tuple[torch.Tensor, float]:
+    """Dispatcher helper shared by fused linear + cross-entropy kernels.
+
+    Returns ``(hidden_out, scalar_temperature)`` such that any downstream fused
+    kernel that only accepts a ``float`` temperature can still implement
+    per-sample temperature semantics:
+
+    - If ``temperature`` is a 1-D tensor with more than one element, pre-scale
+      ``hidden`` via :func:`prescale_hidden_by_per_sample_temperature` and
+      return ``scalar_temperature == 1.0``.
+    - Otherwise (Python float or 0-/1-element tensor), pass ``hidden`` through
+      and return ``float(temperature)``.
+    """
+    if isinstance(temperature, torch.Tensor) and temperature.dim() > 0 and temperature.numel() > 1:
+        return prescale_hidden_by_per_sample_temperature(hidden, temperature), 1.0
+    if isinstance(temperature, torch.Tensor):
+        return hidden, float(temperature.item())
+    return hidden, float(temperature)
 
 
 def gather_from_labels(data: torch.Tensor, label: torch.Tensor) -> torch.Tensor:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -871,6 +871,15 @@ class EngineTrainModeCtx(BaseEngineCtx):
 @EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
 class FSDPEngineWithLMHead(FSDPEngine):
     def prepare_model_inputs(self, micro_batch: TensorDict):
+        """Prepare model inputs from a micro batch for forward pass.
+
+        ``micro_batch["temperature"]`` may be a Python float (applied to
+        all tokens) or a 1-D ``torch.Tensor`` of shape ``(batch_size,)``
+        for per-sample temperature.  Per-sample temperature is supported
+        when ``use_fused_kernels=True`` **and** ``use_remove_padding=True``
+        (via hidden-state pre-scaling); the padded + fused path still
+        requires a scalar.
+        """
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -875,10 +875,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         temperature = micro_batch["temperature"]
-        temperature_item = temperature
-        if use_fused_kernels:
-            assert not isinstance(temperature, torch.Tensor), (
-                "use_fused_kernels does not support per sample temperature yet"
+        # Fused kernels + remove_padding accept per-token temperature via
+        # prescaling; the padded path still requires a scalar.
+        if use_fused_kernels and not use_remove_padding:
+            assert not isinstance(temperature, torch.Tensor) or temperature.numel() == 1, (
+                "use_fused_kernels without remove_padding only supports scalar temperature"
             )
         assert pad_mode == DatasetPadMode.NO_PADDING, f"pad_mode {pad_mode} not supported"
 
@@ -1002,7 +1003,16 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
         extra_args = {}
         if use_fused_kernels:
-            extra_args["temperature"] = temperature_item
+            if use_remove_padding:
+                # 1-D per-token tensor, aligned with the flattened hidden states.
+                extra_args["temperature"] = temperature_rmpad
+            else:
+                # Uniformity is enforced by the assertion above, so take any entry.
+                extra_args["temperature"] = (
+                    float(temperature.view(-1)[0].item())
+                    if isinstance(temperature, torch.Tensor)
+                    else float(temperature)
+                )
             extra_args["return_dict"] = True
 
         model_inputs.update(multi_modal_inputs)


### PR DESCRIPTION
## Summary
Currently `use_fused_kernels=True` requires a scalar `temperature`, which blocks RL training setups that need per-sample temperatures (e.g. teacher/distillation mixing, mixed data). This PR makes both fused implementations accept either a Python scalar (unchanged) or a 1-D per-token tensor, without regressing the scalar fast path.

The approach is to pre-scale the hidden states by `1/T` in fp32 before the fused matmul and then run the kernel with `temperature=1.0`. Since softmax and logsumexp are invariant to a constant multiplicative factor on logits, this is mathematically equivalent to the `logits / T -> cross_entropy` baseline and keeps the kernel's memory and compute profile essentially unchanged.

## Changes
- `verl/utils/torch_functional.py`: new `prescale_hidden_by_per_sample_temperature` and `resolve_temperature_for_fused_kernel` helpers.
- `verl/utils/kernel/linear_cross_entropy.py` (Triton): accept `Union[float, Tensor]`, dispatch via helper.
- `verl/utils/experimental/torch_functional.py` (`FusedLinearForPPO`): same dispatch.
- `verl/workers/engine/fsdp/transformer_impl.py`: forward `temperature_rmpad` to the fused kernel when `use_remove_padding=True`; keep scalar-only assertion on the non-remove-padding path.
- `tests/utils/test_linear_cross_entropy.py`: add uniform-tensor-equals-scalar and per-sample-vs-fp32-reference tests (fwd + bwd) for both Triton and PyTorch fused paths. Also fixes a pre-existing `TypeError` when `MAX_TEST_CASES` is set from the shell (stringified int).

## Tests
`pytest tests/utils/test_linear_cross_entropy.py -v`