### PR TITLE
[hardware, fsdp, vllm, trainer, ray] feat: add Intel XPU support for e2e GRPO/PPO/SFT training

### DIFF
--- a/docker/xpu/Dockerfile.xpu
+++ b/docker/xpu/Dockerfile.xpu
@@ -104,8 +104,8 @@ ENV NO_PROXY=127.0.0.1,localhost,::1
 # SYCL device selector: setvars.sh may leave this as "level_zero:" (empty
 # after ':') which causes SIGABRT in any subprocess that initialises SYCL.
 # Ray also rejects '*' — must be explicit device indices.
-# Override at docker run time: -e ONEAPI_DEVICE_SELECTOR=level_zero:0,1,2,3
-ENV ONEAPI_DEVICE_SELECTOR=level_zero:0,1
+# Do NOT hardcode — sitecustomize.py auto-detects GPU count at startup.
+# Override at docker run time if needed: -e ONEAPI_DEVICE_SELECTOR=level_zero:0,1,2,3
 
 # sitecustomize.py: fix ONEAPI_DEVICE_SELECTOR at Python startup for EVERY
 # Python process (including vLLM's _run_in_subprocess model registry check).
@@ -122,7 +122,12 @@ snippet = (\
 'import os as _os\\n'\
 '_sel = _os.environ.get(\"ONEAPI_DEVICE_SELECTOR\", \"\")\\n'\
 'if not _sel or _sel.endswith(\":\"):\\n'\
-'    _os.environ[\"ONEAPI_DEVICE_SELECTOR\"] = \"level_zero:0,1\"\\n'\
+'    try:\\n'\
+'        import torch; _n = torch.xpu.device_count()\\n'\
+'    except Exception:\\n'\
+'        _n = len(list(_os.path.exists(f\"/dev/dri/renderD{128+i}\") for i in range(16) if _os.path.exists(f\"/dev/dri/renderD{128+i}\")))\\n'\
+'        _n = max(_n, 1)\\n'\
+'    _os.environ[\"ONEAPI_DEVICE_SELECTOR\"] = \"level_zero:\" + \",\".join(str(i) for i in range(_n))\\n'\
 ); \
 existing = p.read_text() if p.exists() else ''; \
 p.write_text(existing + ('\\n' if existing and not existing.endswith('\\n') else '') + snippet)\

--- a/docker/xpu/Dockerfile.xpu
+++ b/docker/xpu/Dockerfile.xpu
@@ -1,0 +1,131 @@
+# verl on Intel XPU (Data Center GPU Max / Arc Pro / Arc)
+#
+# Based on vLLM's Dockerfile.xpu pattern (intel/deep-learning-essentials base).
+#
+# Build:
+#   docker build -t verl-xpu:latest -f docker/xpu/Dockerfile.xpu .
+#
+# Behind a corporate proxy:
+#   docker build --build-arg http_proxy=... --build-arg https_proxy=... ...
+#
+# Run (mount GPU devices + render group):
+#   docker run -it --rm \
+#     --device /dev/dri --group-add render \
+#     --shm-size 16g \
+#     -v $HOME/data:/root/data \
+#     verl-xpu:latest
+#
+# Tested on: 4x Intel Arc Pro B60 (Battlemage, 24 GB VRAM each)
+
+FROM intel/deep-learning-essentials:2025.3.2-0-devel-ubuntu24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.12
+ARG TORCH_VERSION=2.11.0
+ARG TRITON_XPU_VERSION=3.7.0
+ARG VLLM_VERSION=0.17.1
+ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/xpu"
+
+WORKDIR /workspace
+
+# --- System dependencies ---
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ cmake libnuma-dev wget git curl build-essential \
+        python3.12 python3.12-dev python3-pip ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# --- Intel GPU user-mode drivers (UMD) from GitHub releases ---
+# Avoids apt repo dependency issues; pins exact versions for reproducibility.
+# Pinned to compute-runtime 26.09 — fixes P2P IPC, torch.compile, and XCCL
+# MAX/MIN/AVG bugs present in 25.44/25.48.
+RUN mkdir /tmp/neo && cd /tmp/neo && \
+    wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.30.1/intel-igc-core-2_2.30.1+20950_amd64.deb && \
+    wget -q https://github.com/intel/intel-graphics-compiler/releases/download/v2.30.1/intel-igc-opencl-2_2.30.1+20950_amd64.deb && \
+    wget -q https://github.com/intel/compute-runtime/releases/download/26.09.37435.1/intel-ocloc_26.09.37435.1-0_amd64.deb && \
+    wget -q https://github.com/intel/compute-runtime/releases/download/26.09.37435.1/intel-opencl-icd_26.09.37435.1-0_amd64.deb && \
+    wget -q https://github.com/intel/compute-runtime/releases/download/26.09.37435.1/libigdgmm12_22.9.0_amd64.deb && \
+    wget -q https://github.com/intel/compute-runtime/releases/download/26.09.37435.1/libze-intel-gpu1_26.09.37435.1-0_amd64.deb && \
+    wget -q https://github.com/oneapi-src/level-zero/releases/download/v1.28.0/level-zero_1.28.0+u24.04_amd64.deb && \
+    dpkg -i *.deb && \
+    cd / && rm -rf /tmp/neo
+
+# --- oneCCL with Battlemage (BMG) support ---
+# Default oneAPI 2025.2 oneCCL lacks BMG support; install specific version.
+ARG ONECCL_INSTALLER="intel-oneccl-2021.15.7.8_offline.sh"
+RUN wget -q "https://github.com/uxlfoundation/oneCCL/releases/download/2021.15.7/${ONECCL_INSTALLER}" && \
+    bash "${ONECCL_INSTALLER}" -a --silent --eula accept && \
+    rm "${ONECCL_INSTALLER}" && \
+    echo "source /opt/intel/oneapi/setvars.sh --force" >> /root/.bashrc && \
+    echo "source /opt/intel/oneapi/ccl/2021.15/env/vars.sh --force" >> /root/.bashrc
+RUN rm -f /opt/intel/oneapi/ccl/latest && \
+    ln -s /opt/intel/oneapi/ccl/2021.15 /opt/intel/oneapi/ccl/latest
+
+SHELL ["bash", "-c"]
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+
+# --- PyTorch with XPU support ---
+RUN python3 -m pip install --no-cache-dir \
+        torch==${TORCH_VERSION} torchvision torchaudio \
+        --index-url https://download.pytorch.org/whl/xpu && \
+    python3 -m pip install --no-cache-dir \
+        triton-xpu==${TRITON_XPU_VERSION} \
+        --index-url https://download.pytorch.org/whl/xpu && \
+    python3 -m pip install --no-cache-dir dpctl
+
+# --- vLLM with XPU support (build from source) ---
+RUN git clone --depth 1 --branch v${VLLM_VERSION} \
+        https://github.com/vllm-project/vllm.git /opt/vllm && \
+    cd /opt/vllm && \
+    source /opt/intel/oneapi/setvars.sh --force && \
+    python3 -m pip install --no-cache-dir -r requirements/xpu.txt && \
+    VLLM_TARGET_DEVICE=xpu python3 -m pip install --no-build-isolation --no-cache-dir -v . && \
+    python3 -m pip cache purge
+
+# --- verl dependencies ---
+COPY requirements-xpu.txt /tmp/requirements-xpu.txt
+RUN python3 -m pip install --no-cache-dir -r /tmp/requirements-xpu.txt && \
+    python3 -m pip install --no-cache-dir transformers
+
+# --- Install verl ---
+COPY . /workspace/verl
+WORKDIR /workspace/verl
+RUN python3 -m pip install --no-deps --no-cache-dir -v -e .
+
+# --- oneCCL workarounds (pre-DLE 2026.0 driver) ---
+ENV CCL_ATL_SHM=1
+ENV CCL_BUFFER_CACHE=0
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
+# Ensure Ray's internal gRPC (localhost) is never routed through the corporate proxy.
+# Without this, ray.init() times out when http_proxy is set in the container.
+ENV no_proxy=127.0.0.1,localhost,::1
+ENV NO_PROXY=127.0.0.1,localhost,::1
+# SYCL device selector: setvars.sh may leave this as "level_zero:" (empty
+# after ':') which causes SIGABRT in any subprocess that initialises SYCL.
+# Ray also rejects '*' — must be explicit device indices.
+# Override at docker run time: -e ONEAPI_DEVICE_SELECTOR=level_zero:0,1,2,3
+ENV ONEAPI_DEVICE_SELECTOR=level_zero:0,1
+
+# sitecustomize.py: fix ONEAPI_DEVICE_SELECTOR at Python startup for EVERY
+# Python process (including vLLM's _run_in_subprocess model registry check).
+# Ray workers are fresh processes that may not inherit the corrected env from
+# the parent shell — this ensures even deeply nested subprocesses get a valid
+# device selector rather than the broken "level_zero:" value from setvars.sh.
+# The path is resolved dynamically to support any Python prefix / base image.
+RUN python3 -c "\
+import site, pathlib; \
+lib = pathlib.Path(site.getsitepackages()[0]).parent; \
+p = lib / 'sitecustomize.py'; \
+snippet = (\
+'# verl-xpu: fix ONEAPI_DEVICE_SELECTOR at startup\\n'\
+'import os as _os\\n'\
+'_sel = _os.environ.get(\"ONEAPI_DEVICE_SELECTOR\", \"\")\\n'\
+'if not _sel or _sel.endswith(\":\"):\\n'\
+'    _os.environ[\"ONEAPI_DEVICE_SELECTOR\"] = \"level_zero:0,1\"\\n'\
+); \
+existing = p.read_text() if p.exists() else ''; \
+p.write_text(existing + ('\\n' if existing and not existing.endswith('\\n') else '') + snippet)\
+"
+
+CMD ["bash", "-c", "source /root/.bashrc && exec bash"]

--- a/docker/xpu/README.md
+++ b/docker/xpu/README.md
@@ -1,0 +1,68 @@
+# verl on Intel XPU
+
+## Supported Hardware
+
+- Intel Data Center GPU Max Series (Ponte Vecchio)
+- Intel Arc Pro B-Series (Battlemage)
+- Intel Arc A-Series (Alchemist)
+
+## Quick Start
+
+### Build the Docker image
+
+```bash
+# Standard build
+docker build -t verl-xpu:latest -f docker/xpu/Dockerfile.xpu .
+
+# Behind a corporate proxy
+docker build \
+  --build-arg http_proxy=$http_proxy \
+  --build-arg https_proxy=$https_proxy \
+  -t verl-xpu:latest -f docker/xpu/Dockerfile.xpu .
+```
+
+### Run with GPU access
+
+```bash
+# Find render group GID on host
+RENDER_GID=$(getent group render | cut -d: -f3)
+
+docker run -it --rm \
+  --device /dev/dri --group-add ${RENDER_GID} \
+  --shm-size 16g \
+  -v $HOME/data:/root/data \
+  verl-xpu:latest
+```
+
+### Run e2e tests inside the container
+
+```bash
+# SFT smoke test (4 GPU)
+NUM_GPUS=4 bash tests/special_xpu/run_sft_xpu.sh
+
+# GRPO e2e with vLLM rollout (2 GPU)
+NUM_GPUS=2 bash tests/special_xpu/run_grpo_xpu.sh
+
+# PPO e2e with critic model (4 GPU)
+NUM_GPUS=4 bash tests/special_xpu/run_ppo_xpu.sh
+```
+
+## Dependencies
+
+| Package | Version | Source |
+|---------|---------|--------|
+| PyTorch | 2.11.0+xpu | `https://download.pytorch.org/whl/xpu` |
+| oneccl-bind-pt | (matches torch) | `https://download.pytorch.org/whl/xpu` |
+| triton-xpu | 3.7.0 | `https://download.pytorch.org/whl/xpu` |
+| vLLM | >= 0.17 | Built from source with `VLLM_TARGET_DEVICE=xpu` |
+| vllm-xpu-kernels | 0.1.5 | GitHub release (pulled by vLLM XPU build) |
+| transformers | latest | PyPI |
+
+## Known Workarounds (pre-DLE 2026.0 driver)
+
+Multi-GPU requires these environment variables due to Level Zero IPC limitations:
+
+```bash
+export CCL_ATL_SHM=1        # Route collectives via /dev/shm
+export CCL_BUFFER_CACHE=0    # Prevent stale IPC handle cache
+```

--- a/requirements-xpu.txt
+++ b/requirements-xpu.txt
@@ -1,0 +1,31 @@
+# Requirements for Intel XPU (Data Center GPU Max / Arc Pro / Arc)
+#
+# PyTorch with XPU support must be installed separately:
+#   pip install torch==2.11.0+xpu torchvision torchaudio --index-url https://download.pytorch.org/whl/xpu
+#   pip install triton-xpu==3.7.0 --index-url https://download.pytorch.org/whl/xpu
+#
+# vLLM >= 0.17 with XPU support must be built from source:
+#   VLLM_TARGET_DEVICE=xpu pip install --no-build-isolation -v .
+#
+# flash-attn CUDA package is NOT needed — XPU uses SDPA which dispatches
+# to Intel's SYCL-TLA Flash kernel automatically (10-22x faster than eager).
+accelerate
+codetiming
+datasets
+dill
+dpctl
+einops
+hydra-core
+numpy
+packaging>=20.0
+pandas
+peft>=0.15.2
+pyarrow>=15.0.0
+pybind11
+pylatexenc
+ray[default]
+tensorboard
+tensordict>=0.8.0,<=0.10.0,!=0.9.0
+torchdata
+transformers
+wandb

--- a/requirements-xpu.txt
+++ b/requirements-xpu.txt
@@ -28,4 +28,5 @@ tensorboard
 tensordict>=0.8.0,<=0.10.0,!=0.9.0
 torchdata
 transformers
+trl<0.18
 wandb

--- a/requirements-xpu.txt
+++ b/requirements-xpu.txt
@@ -28,5 +28,5 @@ tensorboard
 tensordict>=0.8.0,<=0.10.0,!=0.9.0
 torchdata
 transformers
-trl<0.18
+trl<=0.9.6
 wandb

--- a/tests/special_xpu/run_grpo_xpu.sh
+++ b/tests/special_xpu/run_grpo_xpu.sh
@@ -26,6 +26,9 @@ export CCL_ATL_SHM=${CCL_ATL_SHM:-1}
 export CCL_BUFFER_CACHE=${CCL_BUFFER_CACHE:-0}
 # Disable topology recognition — assume XeLink across devices
 export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+# Disable topo algo — ZE_AFFINITY_MASK renumbers all worker devices to 0,
+# causing oneCCL to think all ranks are on the same device (oversubscription).
+export CCL_TOPO_ALGO=0
 
 # XPU device selection: use ZE_AFFINITY_MASK (Level Zero) for device restriction.
 # vLLM 0.17+ XPU platform uses ZE_AFFINITY_MASK as device_control_env_var; setting

--- a/tests/special_xpu/run_grpo_xpu.sh
+++ b/tests/special_xpu/run_grpo_xpu.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# E2E GRPO test on Intel XPU — mirrors tests/special_npu/run_qwen2_5_05b_grpo.sh
+#
+# Validates the full RL training loop on XPU:
+#   FSDP training (actor + ref) → vLLM rollout → reward → train
+#
+# Prerequisites:
+#   - PyTorch with XPU support (torch.xpu.is_available() == True)
+#   - vLLM >= 0.17 with XPU platform support
+#   - oneCCL for xccl distributed backend
+#
+# Known workarounds (pre-DLE 2026.0):
+#   CCL_ATL_SHM=1 CCL_BUFFER_CACHE=0  (Level Zero IPC bug on PCIe cards)
+#
+# Usage:
+#   NUM_GPUS=2 bash tests/special_xpu/run_grpo_xpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-2}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+
+# oneCCL workarounds for multi-GPU (pre-DLE 2026.0 driver)
+export CCL_ATL_SHM=${CCL_ATL_SHM:-1}
+export CCL_BUFFER_CACHE=${CCL_BUFFER_CACHE:-0}
+# Disable topology recognition — assume XeLink across devices
+export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+
+# XPU device selection: use ZE_AFFINITY_MASK (Level Zero) for device restriction.
+# vLLM 0.17+ XPU platform uses ZE_AFFINITY_MASK as device_control_env_var; setting
+# ONEAPI_DEVICE_SELECTOR=level_zero:N,M breaks the FLA/triton SYCL JIT init path.
+_DEVICES=$(seq 0 $((NUM_GPUS-1)) | paste -sd',')
+export ZE_AFFINITY_MASK="${_DEVICES}"
+
+# XPU fix: Ray pre-starts ~100 idle workers, each opens an L0 context on the GPU.
+# torch.xpu.mem_get_info() counts their combined context overhead (~20 GB) as "used"
+# even though actual allocations succeed fine. This causes vLLM's pre-flight memory
+# check to abort with a false OOM. Two fixes:
+#   1. Reduce Ray prestarted workers to avoid L0 context memory pressure
+#   2. Patch vLLM's request_memory to skip the check on XPU
+export RAY_NUM_PRESTART_PYTHON_WORKERS=0
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=128 \
+    data.filter_overlong_prompts=True \
+    data.truncation='error' \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=5e-7 \
+    actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=sdpa \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.use_torch_compile=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.n=2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    trainer.critic_warmup=0 \
+    trainer.logger=console \
+    trainer.project_name='verl_xpu_grpo_e2e' \
+    trainer.experiment_name='qwen2_5_05b_xpu_grpo' \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 \
+    +ray_kwargs.ray_init.num_gpus=${NUM_GPUS} $@

--- a/tests/special_xpu/run_ppo_xpu.sh
+++ b/tests/special_xpu/run_ppo_xpu.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# E2E PPO (GAE) test on Intel XPU — mirrors tests/special_npu/run_qwen3_06b_ppo.sh
+#
+# Validates PPO training with critic model on XPU:
+#   FSDP training (actor + critic + ref) → vLLM rollout → GAE reward → train
+#
+# Usage:
+#   NUM_GPUS=4 bash tests/special_xpu/run_ppo_xpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-4}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+
+# oneCCL workarounds for multi-GPU (pre-DLE 2026.0 driver)
+export CCL_ATL_SHM=${CCL_ATL_SHM:-1}
+export CCL_BUFFER_CACHE=${CCL_BUFFER_CACHE:-0}
+# Disable topology recognition — assume XeLink across devices
+export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+
+# XPU device selection: use ZE_AFFINITY_MASK (Level Zero) for device restriction.
+# vLLM 0.17+ XPU platform uses ZE_AFFINITY_MASK as device_control_env_var; setting
+# ONEAPI_DEVICE_SELECTOR=level_zero:N,M breaks the FLA/triton SYCL JIT init path.
+_DEVICES=$(seq 0 $((NUM_GPUS-1)) | paste -sd',')
+export ZE_AFFINITY_MASK="${_DEVICES}"
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=gae \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=16 \
+    data.max_prompt_length=512 \
+    data.max_response_length=128 \
+    data.shuffle=False \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=False \
+    critic.model.path="${MODEL_PATH}" \
+    critic.model.enable_gradient_checkpointing=True \
+    critic.ppo_micro_batch_size_per_gpu=1 \
+    critic.fsdp.param_offload=True \
+    critic.fsdp.optimizer_offload=True \
+    trainer.critic_warmup=0 \
+    trainer.logger='["console"]' \
+    trainer.project_name='verl_xpu_ppo_e2e' \
+    trainer.experiment_name='qwen2_5_05b_xpu_ppo' \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.nnodes=1 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=-1 \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 $@

--- a/tests/special_xpu/run_ppo_xpu.sh
+++ b/tests/special_xpu/run_ppo_xpu.sh
@@ -18,12 +18,18 @@ export CCL_ATL_SHM=${CCL_ATL_SHM:-1}
 export CCL_BUFFER_CACHE=${CCL_BUFFER_CACHE:-0}
 # Disable topology recognition — assume XeLink across devices
 export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+# Disable topo algo — ZE_AFFINITY_MASK renumbers all worker devices to 0,
+# causing oneCCL to think all ranks are on the same device (oversubscription).
+export CCL_TOPO_ALGO=0
 
 # XPU device selection: use ZE_AFFINITY_MASK (Level Zero) for device restriction.
 # vLLM 0.17+ XPU platform uses ZE_AFFINITY_MASK as device_control_env_var; setting
 # ONEAPI_DEVICE_SELECTOR=level_zero:N,M breaks the FLA/triton SYCL JIT init path.
 _DEVICES=$(seq 0 $((NUM_GPUS-1)) | paste -sd',')
 export ZE_AFFINITY_MASK="${_DEVICES}"
+
+# XPU fix: Ray pre-starts ~100 idle workers, each opens an L0 context on the GPU.
+export RAY_NUM_PRESTART_PYTHON_WORKERS=0
 
 python3 -m verl.trainer.main_ppo \
     algorithm.adv_estimator=gae \
@@ -35,6 +41,7 @@ python3 -m verl.trainer.main_ppo \
     data.shuffle=False \
     actor_rollout_ref.model.path="${MODEL_PATH}" \
     actor_rollout_ref.model.use_remove_padding=False \
+    +actor_rollout_ref.model.override_config.attn_implementation=sdpa \
     actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.optim.lr=1e-6 \
     actor_rollout_ref.actor.ppo_mini_batch_size=8 \
@@ -48,9 +55,14 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.rollout.name=vllm \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.4 \
     actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
     critic.optim.lr=1e-5 \
     critic.model.use_remove_padding=False \
     critic.model.path="${MODEL_PATH}" \
+    +critic.model.override_config.attn_implementation=sdpa \
     critic.model.enable_gradient_checkpointing=True \
     critic.ppo_micro_batch_size_per_gpu=1 \
     critic.fsdp.param_offload=True \
@@ -64,4 +76,5 @@ python3 -m verl.trainer.main_ppo \
     trainer.save_freq=-1 \
     trainer.test_freq=-1 \
     trainer.total_epochs=1 \
-    trainer.total_training_steps=1 $@
+    trainer.total_training_steps=1 \
+    +ray_kwargs.ray_init.num_gpus=${NUM_GPUS} $@

--- a/tests/special_xpu/run_sft_xpu.sh
+++ b/tests/special_xpu/run_sft_xpu.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# SFT smoke test on Intel XPU — validates FSDP multi-GPU training without vLLM.
+#
+# Usage:
+#   NUM_GPUS=4 bash tests/special_xpu/run_sft_xpu.sh
+
+set -x
+
+NUM_GPUS=${NUM_GPUS:-4}
+MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
+MODEL_PATH=${MODEL_PATH:-${MODEL_ID}}
+
+# oneCCL workarounds for multi-GPU (pre-DLE 2026.0 driver)
+export CCL_ATL_SHM=${CCL_ATL_SHM:-1}
+export CCL_BUFFER_CACHE=${CCL_BUFFER_CACHE:-0}
+# Disable topology recognition — assume XeLink across devices
+export CCL_TOPO_FABRIC_VERTEX_CONNECTION_CHECK=0
+
+# XPU device selection: use ZE_AFFINITY_MASK (Level Zero) for device restriction.
+# SFT uses torchrun (no vLLM) but keeping the same env var as GRPO/PPO avoids
+# confusion and works correctly with Level Zero device renumbering.
+_DEVICES=$(seq 0 $((NUM_GPUS-1)) | paste -sd',')
+export ZE_AFFINITY_MASK="${_DEVICES}"
+
+# Use python -m torch.distributed.run instead of torchrun so the correct
+# Python interpreter is used regardless of PATH (e.g. inside conda envs).
+PYTHON3=$(python3 -c "import torch; import sys; print(sys.executable)" 2>/dev/null || command -v python3)
+$PYTHON3 -m torch.distributed.run --nproc-per-node=${NUM_GPUS} --standalone \
+    -m verl.trainer.sft_trainer \
+    data.train_files=$HOME/data/gsm8k/train_sft.parquet \
+    data.val_files=$HOME/data/gsm8k/test_sft.parquet \
+    data.train_batch_size=8 \
+    data.max_length=1024 \
+    model.path="${MODEL_PATH}" \
+    model.trust_remote_code=True \
+    model.use_remove_padding=False \
+    +model.override_config.attn_implementation=sdpa \
+    trainer.default_local_dir=./checkpoints/xpu_sft_test \
+    trainer.project_name='verl_xpu_sft_e2e' \
+    trainer.experiment_name='qwen2_5_05b_xpu_sft' \
+    trainer.logger=console \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=5 \
+    data.micro_batch_size_per_gpu=1 \
+    trainer.save_freq=-1 \
+    trainer.n_gpus_per_node=${NUM_GPUS} $@

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -26,6 +26,7 @@ from verl.utils.device import (
     get_torch_device,
     get_visible_devices_keyword,
     is_npu_available,
+    is_xpu_available,
 )
 
 from .decorator import Dispatch, Execute, register
@@ -275,10 +276,23 @@ class Worker(WorkerHelper):
             # environment variable for each actor, unless
             # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set,
             # so we need to set local rank when the flag is set.
+            # Ray's IntelGPUAccelerator registers XPU as "GPU", same as CUDA.
             device_name = "NPU" if is_npu_available else "GPU"
             local_rank = ray.get_runtime_context().get_accelerator_ids()[device_name][0]
             os.environ["LOCAL_RANK"] = local_rank
             get_torch_device().set_device(int(local_rank))
+
+        # XPU: Keep ONEAPI_DEVICE_SELECTOR consistent with ZE_AFFINITY_MASK.
+        # Ray's IntelGPUAccelerator sets ZE_AFFINITY_MASK for device isolation
+        # (e.g. "1" for the second GPU).  Level Zero re-numbers the masked
+        # devices 0..n-1, so the selector must be "level_zero:0" not
+        # "level_zero:1".  Setting this at the same point we write the
+        # visibility env var avoids needing sanitize calls elsewhere.
+        if is_xpu_available:
+            ze_mask = os.environ.get("ZE_AFFINITY_MASK", "")
+            if ze_mask:
+                n = len(ze_mask.split(","))
+                os.environ["ONEAPI_DEVICE_SELECTOR"] = f"level_zero:{','.join(str(i) for i in range(n))}"
 
     def _configure_with_store(self, store: dict):
         """

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -137,7 +137,8 @@ class RayResourcePool(ResourcePool):
         # print(f"pg_name_prefix = {pg_name_prefix}")
         if device_name == "npu":
             device_name = "NPU"
-        elif device_name == "cuda":
+        elif device_name in ("cuda", "xpu"):
+            # Ray's IntelGPUAccelerator registers XPU as "GPU", same as CUDA
             device_name = "GPU"
 
         bundle = {"CPU": self.max_colocate_count}
@@ -394,9 +395,10 @@ class RayClassWithInitArgs(ClassWithInitArgs):
         }
         options.update(self._options)
 
-        if use_gpu and device_name == "cuda":
+        if use_gpu and device_name in ("cuda", "xpu"):
+            # Ray's IntelGPUAccelerator registers XPU as "GPU", same as CUDA
             options["num_gpus"] = num_gpus
-        if use_gpu and device_name == "npu":
+        elif use_gpu and device_name == "npu":
             options["resources"] = {"NPU": num_gpus}
 
         if len(self._additional_resource) > 1:

--- a/verl/third_party/vllm/__init__.py
+++ b/verl/third_party/vllm/__init__.py
@@ -16,7 +16,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from packaging import version as vs
 
-from verl.utils.device import is_npu_available
+from verl.utils.device import is_npu_available, is_xpu_available
 from verl.utils.import_utils import is_sglang_available
 
 
@@ -40,6 +40,11 @@ if package_version is None:
         )
 elif is_npu_available:
     # sleep_mode=2 is not supported on vllm-ascend for now, will remove this restriction when this ability is ready.
+    VLLM_SLEEP_LEVEL = 1
+    from vllm import LLM
+    from vllm.distributed import parallel_state
+elif is_xpu_available:
+    # XPU MemPool (sleep_mode=2) is not available yet; use level 1.
     VLLM_SLEEP_LEVEL = 1
     from vllm import LLM
     from vllm.distributed import parallel_state

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -17,6 +17,8 @@ import os
 
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
+from verl.utils.device import is_xpu_available
+
 PPO_RAY_RUNTIME_ENV = {
     "env_vars": {
         "TOKENIZERS_PARALLELISM": "true",
@@ -52,4 +54,16 @@ def get_ppo_ray_runtime_env():
     for key in list(runtime_env["env_vars"].keys()):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)
+
+    # Intel XPU: propagate ONEAPI_DEVICE_SELECTOR to Ray workers only when running
+    # on XPU.  Ray workers are fresh processes that do not inherit the parent shell
+    # environment; without this, vLLM subprocesses may receive a broken
+    # 'level_zero:' value from Intel setvars.sh and SIGABRT immediately.
+    # We re-insert even if the key was already in os.environ (and thus removed by
+    # the filter above) because workers need to receive the *current* value.
+    if is_xpu_available:
+        oneapi_selector = os.environ.get("ONEAPI_DEVICE_SELECTOR")
+        if oneapi_selector:
+            runtime_env["env_vars"]["ONEAPI_DEVICE_SELECTOR"] = oneapi_selector
+
     return runtime_env

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -426,7 +426,9 @@ class SFTTrainer:
                         # average over data parallel group
                         dp_group = self.engine.get_data_parallel_group()
                         if dp_group is not None:
-                            torch.distributed.all_reduce(val_loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+                            from verl.utils.distributed import all_reduce_avg
+
+                            all_reduce_avg(val_loss, group=dp_group)
 
                     if is_logging:
                         metric = {"val/loss": val_loss.detach().item()}

--- a/verl/utils/attention_utils.py
+++ b/verl/utils/attention_utils.py
@@ -20,11 +20,13 @@ _index_first_axis, _pad_input, _rearrange, _unpad_input = None, None, None, None
 def _get_attention_functions() -> tuple[Callable, Callable, Callable, Callable]:
     """Dynamically import attention functions based on available hardware."""
 
-    from verl.utils.device import is_torch_npu_available
+    from verl.utils.device import is_torch_npu_available, is_xpu_available
 
     global _index_first_axis, _pad_input, _rearrange, _unpad_input
 
-    if is_torch_npu_available(check_device=False):
+    if is_torch_npu_available(check_device=False) or is_xpu_available:
+        # Use pure-PyTorch implementations for NPU and XPU (no flash_attn.bert_padding dependency).
+        # These are device-agnostic and also used by the trainer process on CPU tensors.
         from verl.utils.npu_flash_attn_utils import index_first_axis, pad_input, rearrange, unpad_input
     else:
         from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -43,16 +43,44 @@ def is_torch_npu_available(check_device=True) -> bool:
         return False
 
 
+def is_torch_xpu_available(check_device=True) -> bool:
+    """Check if Intel XPU is available for PyTorch operations.
+
+    Args:
+        check_device: If True, check actual device availability.
+            If False, only check for torch.xpu namespace.
+
+    Returns:
+        bool: True if XPU is available, False otherwise.
+    """
+    try:
+        if not hasattr(torch, "xpu"):
+            return False
+        if check_device:
+            return torch.xpu.is_available()
+        return True
+    except (ImportError, AttributeError):
+        return False
+
+
 is_cuda_available = torch.cuda.is_available()
 is_npu_available = is_torch_npu_available()
+is_xpu_available = is_torch_xpu_available()
 
 
 def get_resource_name() -> str:
     """Function that return ray resource name based on the device type.
     Returns:
-        ray resource name string, either "GPU" or "NPU".
+        ray resource name string: "GPU" (CUDA and XPU — Ray's IntelGPUAccelerator
+        registers XPU as "GPU"), or "NPU" for Ascend.
     """
-    return "GPU" if is_cuda_available else "NPU"
+    if is_cuda_available:
+        return "GPU"
+    elif is_npu_available:
+        return "NPU"
+    elif is_xpu_available:
+        return "GPU"  # Ray's IntelGPUAccelerator registers XPU as "GPU"
+    return "GPU"
 
 
 def get_visible_devices_keyword() -> str:
@@ -65,7 +93,13 @@ def get_visible_devices_keyword() -> str:
         str: 'CUDA_VISIBLE_DEVICES' if CUDA is available,
             'ASCEND_RT_VISIBLE_DEVICES' otherwise.
     """
-    return "CUDA_VISIBLE_DEVICES" if not is_torch_npu_available(check_device=False) else "ASCEND_RT_VISIBLE_DEVICES"
+    if is_cuda_available:
+        return "CUDA_VISIBLE_DEVICES"
+    elif is_npu_available:
+        return "ASCEND_RT_VISIBLE_DEVICES"
+    elif is_xpu_available:
+        return "ZE_AFFINITY_MASK"  # bare IDs work; ONEAPI_DEVICE_SELECTOR needs level_zero: prefix
+    return "CUDA_VISIBLE_DEVICES"
 
 
 def get_device_name() -> str:
@@ -81,6 +115,8 @@ def get_device_name() -> str:
         device = "cuda"
     elif is_npu_available:
         device = "npu"
+    elif is_xpu_available:
+        device = "xpu"
     else:
         device = "cpu"
     return device
@@ -124,6 +160,8 @@ def get_nccl_backend() -> str:
     """
     if is_npu_available:
         return "hccl"
+    elif is_xpu_available:
+        return "xccl"
     else:
         # default to nccl
         return "nccl"
@@ -164,6 +202,14 @@ def auto_set_device(config) -> None:
                 )
 
             config.trainer.device = "npu"
+        elif is_torch_xpu_available():
+            if config.trainer.device not in ["cpu", "xpu"]:
+                logger.warning(
+                    f"Detect setting config.trainer.device to {config.trainer.device} for Intel XPU, "
+                    f"automatically set to `xpu` instead."
+                )
+
+            config.trainer.device = "xpu"
         # Other cases: set device to "cuda" via config file, no need to change.
 
 
@@ -349,6 +395,12 @@ def is_support_ipc() -> bool:
             raise RuntimeError(f"Failed to execute npu-smi command: {e}") from e
         except Exception as e:
             raise RuntimeError(f"Error checking IPC support: {e}") from e
+
+    if is_xpu_available:
+        # rebuild_ipc() assumes a CUDA 8-element IPC handle tuple (index 6 = device_id).
+        # XPU uses a different SYCL IPC handle format, so the CUDA path would corrupt data.
+        # Fall back to shared memory until XPU IPC handle support is added.
+        return False
 
     # For other devices (CPU), return False
     return False

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -21,7 +21,7 @@ from datetime import timedelta
 import ray
 import torch.distributed
 
-from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device, is_npu_available
+from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device, is_npu_available, is_xpu_available
 from verl.utils.net_utils import is_ipv6
 
 
@@ -58,8 +58,13 @@ def set_numa_affinity():
 
 
 def initialize_global_process_group(timeout_second=36000):
+    backend = get_nccl_backend()
+    device_name = get_device_name()
+    # XPU requires composite backend so both CPU and XPU tensors are supported
+    if device_name == "xpu":
+        backend = f"cpu:gloo,xpu:{backend}"
     torch.distributed.init_process_group(
-        get_nccl_backend(),
+        backend,
         timeout=timedelta(seconds=timeout_second),
         init_method=os.environ.get("DIST_INIT_METHOD", None),
     )
@@ -75,6 +80,16 @@ def initialize_global_process_group(timeout_second=36000):
 def destroy_global_process_group():
     if torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
+
+
+def all_reduce_avg(tensor, group=None):
+    """All-reduce with AVG, using SUM + division on backends that lack ReduceOp.AVG (e.g. xccl/oneCCL)."""
+    if is_xpu_available:
+        torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.SUM, group=group)
+        tensor /= torch.distributed.get_world_size(group)
+    else:
+        torch.distributed.all_reduce(tensor, op=torch.distributed.ReduceOp.AVG, group=group)
+    return tensor
 
 
 def initialize_global_process_group_ray(timeout_second=None, backend=None):
@@ -111,8 +126,6 @@ def stateless_init_process_group(master_address, master_port, rank, world_size, 
 
     from torch.distributed import TCPStore
     from vllm.distributed.utils import StatelessProcessGroup
-
-    from verl.utils.device import is_npu_available
 
     if is_npu_available:
         from vllm_ascend.distributed.device_communicators.pyhccl import PyHcclCommunicator as PyNcclCommunicator

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -32,7 +32,7 @@ from torch.distributed.fsdp._runtime_utils import _lazy_init
 from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 from transformers.trainer_pt_utils import get_module_class_from_name
 
-from verl.utils.device import get_device_id, get_device_name, get_torch_device
+from verl.utils.device import get_device_id, get_device_name, get_torch_device, is_xpu_available
 from verl.utils.model import check_exclude_modules, check_target_modules
 
 if version.parse(torch.__version__) >= version.parse("2.6"):
@@ -559,6 +559,19 @@ def apply_fsdp2(model, fsdp_kwargs, config):
     #     print(f"wrap module {model.__class__.__name__}")
     with maybe_patch_fsdp_module(model):
         fully_shard(model, **fsdp_kwargs)  # fsdp2 will not reshard_after_forward for root module
+
+    # oneCCL (xccl) doesn't support ReduceOp.AVG in reduce_scatter;
+    # force SUM reduction with manual division instead.
+    # set_force_sum_reduction_for_comms was added in PyTorch 2.5 (FSDP2);
+    # guard with hasattr so this doesn't crash on older builds.
+    if is_xpu_available:
+        if not hasattr(model, "set_force_sum_reduction_for_comms"):
+            raise RuntimeError(
+                "[XPU] model.set_force_sum_reduction_for_comms is not available. "
+                "FSDP2 reduce_scatter would silently use ReduceOp.AVG which is broken "
+                "on xccl (torch-xpu-ops#3020). Upgrade to PyTorch >= 2.5."
+            )
+        model.set_force_sum_reduction_for_comms(True)
 
 
 def get_shard_placement_fn(fsdp_size):

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -635,12 +635,14 @@ def patch_valuehead_model(model) -> None:
 def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code):
     from transformers import AutoModelForCausalLM, AutoModelForTokenClassification
 
+    attn_impl = getattr(model_config, "_attn_implementation", "flash_attention_2")
+
     try:
         model = AutoModelForTokenClassification.from_pretrained(
             pretrained_model_name_or_path=local_path,
             torch_dtype=torch_dtype,
             config=model_config,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_impl,
             trust_remote_code=trust_remote_code,
         )
         return model
@@ -662,7 +664,7 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
         pretrained_model_name_or_path=local_path,
         torch_dtype=torch_dtype,
         config=model_config,
-        attn_implementation="flash_attention_2",
+        attn_implementation=attn_impl,
         trust_remote_code=trust_remote_code,
     )
     # vlm models

--- a/verl/utils/profiler/performance.py
+++ b/verl/utils/profiler/performance.py
@@ -23,6 +23,7 @@ import torch.distributed as dist
 from codetiming import Timer
 
 from verl.utils.device import get_device_id, get_torch_device
+from verl.utils.distributed import all_reduce_avg
 from verl.utils.logger import DecoratorLoggerBase
 
 
@@ -217,7 +218,12 @@ def reduce_timing(
         key_list.append(key)
         timing_list.append(timing_raw[key])
     timing_list = torch.tensor(timing_list, dtype=torch.float32, device=get_device_id())
-    torch.distributed.all_reduce(timing_list, op=reduce_op)
+    if reduce_op == torch.distributed.ReduceOp.AVG:
+        # all_reduce_avg uses SUM+division to work around xccl ReduceOp.AVG bug
+        # (torch-xpu-ops#3020) and for any backend that lacks AVG support.
+        all_reduce_avg(timing_list)
+    else:
+        torch.distributed.all_reduce(timing_list, op=reduce_op)
     timing_list = [tensor.item() for tensor in timing_list.to("cpu")]
     timing_generate = {key_list[i]: timing_list[i] for i in range(len(key_list))}
     return timing_generate

--- a/verl/utils/vllm/xpu_patches.py
+++ b/verl/utils/vllm/xpu_patches.py
@@ -1,0 +1,185 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runtime patches for colocated FSDP + vLLM on Intel XPU.
+
+Root cause: XPU has no CuMemAllocator equivalent.  CUDA uses a shared memory
+pool so that FSDP and vLLM see a unified allocation picture; on XPU they
+each see raw Level-Zero driver free-memory.
+
+  Upstream fix in progress:
+    https://github.com/vllm-project/vllm/pull/37149   (XpuMemAllocator /
+    transparent sleep mode — draft, requires torch-xpu 2.11)
+
+Remove the patches in apply() once PR #37149 merges and torch-xpu ≥ 2.11 is
+the minimum supported version.
+
+Usage:
+    python3 -c "from verl.utils.vllm import xpu_patches; xpu_patches.apply()"
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# If this is set, patches have already been applied in this process.
+_APPLIED = False
+
+
+def _patch_request_memory() -> bool:
+    """Wrap vllm.v1.worker.utils.request_memory to skip the OOM check on XPU.
+
+    vLLM checks ``free_memory >= requested_memory`` at startup.  When FSDP is
+    already resident on the GPU this raises ValueError even though FSDP will
+    CPU-offload before inference begins.
+
+    The check is skipped entirely on XPU because Level-Zero context overhead
+    from Ray pre-started workers inflates ``used`` memory by ~20 GB, making
+    the free-memory figure unreliable.
+
+    Upstream reference: https://github.com/vllm-project/vllm/pull/37149
+    """
+    try:
+        import torch
+        import vllm.v1.worker.utils as _utils
+
+        if not hasattr(_utils, "request_memory"):
+            logger.warning(
+                "[XPU patch] vllm.v1.worker.utils.request_memory not found — skipping Patch 1 (API may have changed)"
+            )
+            return False
+
+        if getattr(_utils.request_memory, "_xpu_patched", False):
+            return True  # already applied
+
+        _orig = _utils.request_memory
+
+        def _patched_request_memory(init_snapshot, requested_memory):
+            if hasattr(torch, "xpu") and torch.xpu.is_available():
+                # XPU: Level-Zero context overhead inflates "used" memory.
+                # FSDP will CPU-offload before inference so the ValueError is
+                # spurious.  See verl/utils/vllm/xpu_patches.py for details.
+                return
+            return _orig(init_snapshot, requested_memory)
+
+        _patched_request_memory._xpu_patched = True
+        _utils.request_memory = _patched_request_memory
+        logger.info("[XPU patch] Applied Patch 1: request_memory OOM check skipped on XPU")
+        return True
+
+    except ImportError as e:
+        logger.warning(f"[XPU patch] Could not import vllm.v1.worker.utils: {e} — skipping Patch 1")
+        return False
+
+
+def _patch_profiling_assert() -> bool:
+    """Wrap the vLLM GPUWorker profiling method to tolerate the XPU assert.
+
+    vLLM asserts that free GPU memory did not grow during the profiling run.
+    When FSDP offloads parameters to CPU during vLLM init, free memory
+    *increases*, tripping the assert even though this is expected behaviour.
+
+    Instead of string-patching the source, we wrap the method and convert the
+    AssertionError to a warning on XPU only.
+
+    Affected code (vllm/v1/worker/gpu_worker.py):
+        assert self.init_snapshot.free_memory >= free_gpu_memory, (...)
+
+    Upstream reference: https://github.com/vllm-project/vllm/pull/36720
+      (same assert hit ROCm; xinyu-intel noted "Similar on XPU" but no XPU
+      fix was submitted upstream)
+    """
+    try:
+        import torch
+        from vllm.v1.worker.gpu_worker import GPUWorker
+
+        # The assert lives in the method that calls profile_run and then
+        # compares snapshots — typically `determine_num_available_blocks`.
+        # Try both known method names for robustness across vLLM versions.
+        _TARGET_METHODS = ("determine_num_available_blocks", "profile_run")
+
+        patched_any = False
+        for method_name in _TARGET_METHODS:
+            orig = getattr(GPUWorker, method_name, None)
+            if orig is None:
+                continue
+            if getattr(orig, "_xpu_patched", False):
+                patched_any = True
+                continue
+
+            def _make_patched(original, mname):
+                def _patched(self, *args, **kwargs):
+                    try:
+                        return original(self, *args, **kwargs)
+                    except AssertionError as exc:
+                        if hasattr(torch, "xpu") and torch.xpu.is_available():
+                            logger.warning(
+                                f"[XPU patch] Suppressed profiling AssertionError in "
+                                f"GPUWorker.{mname} (FSDP offloaded params, free "
+                                f"memory increased — expected on XPU). "
+                                f"Original: {exc}"
+                            )
+                            # Return expected type to avoid TypeError in caller
+                            return (0, 0) if mname == "determine_num_available_blocks" else None
+                        raise
+
+                _patched._xpu_patched = True
+                _patched.__name__ = original.__name__
+                _patched.__qualname__ = original.__qualname__
+                return _patched
+
+            setattr(GPUWorker, method_name, _make_patched(orig, method_name))
+            logger.info(f"[XPU patch] Applied Patch 2: GPUWorker.{method_name} profiling assert wrapped")
+            patched_any = True
+
+        if not patched_any:
+            logger.warning(
+                f"[XPU patch] None of {_TARGET_METHODS} found on GPUWorker — "
+                "skipping Patch 2 (vLLM API may have changed)"
+            )
+        return patched_any
+
+    except ImportError as e:
+        logger.warning(f"[XPU patch] Could not import vllm.v1.worker.gpu_worker: {e} — skipping Patch 2")
+        return False
+
+
+def apply() -> None:
+    """Apply all XPU-specific vLLM patches.  Safe to call multiple times.
+
+    Returns quietly if vLLM is not installed or patches are already applied.
+    """
+    global _APPLIED
+    if _APPLIED:
+        return
+
+    try:
+        import torch
+
+        if not (hasattr(torch, "xpu") and torch.xpu.is_available()):
+            return  # Only apply patches on XPU hosts
+    except ImportError:
+        logger.warning("[XPU patch] torch not found — skipping XPU vLLM patches")
+        return
+    except Exception:
+        return
+
+    p1 = _patch_request_memory()
+    p2 = _patch_profiling_assert()
+
+    if p1 and p2:
+        logger.info("[XPU patch] All vLLM XPU patches applied successfully")
+    elif not p1 and not p2:
+        logger.warning("[XPU patch] No patches applied — check vLLM installation")
+
+    _APPLIED = True

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -904,7 +904,7 @@ class EngineTrainModeCtx(BaseEngineCtx):
         super().__exit__(exc_type, exc_value, traceback)
 
 
-@EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="language_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu", "xpu"])
 class FSDPEngineWithLMHead(FSDPEngine):
     def prepare_model_inputs(self, micro_batch: TensorDict):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
@@ -1246,7 +1246,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
             return loss, output
 
 
-@EngineRegistry.register(model_type="value_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu"])
+@EngineRegistry.register(model_type="value_model", backend=["fsdp", "fsdp2"], device=["cuda", "npu", "xpu"])
 class FSDPEngineWithValueHead(FSDPEngineWithLMHead):
     """
     The only difference between critic and actor is how the raw model output is processed

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -21,7 +21,7 @@ from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
-from verl.utils.device import is_npu_available
+from verl.utils.device import is_npu_available, is_xpu_available
 from verl.utils.py_functional import append_to_dict
 from verl.utils.seqlen_balancing import rearrange_micro_batches, restore_dynamic_batch
 
@@ -53,6 +53,9 @@ def enable_full_determinism(seed: int):
     if is_npu_available:
         torch.npu.manual_seed(seed)
         torch.npu.manual_seed_all(seed)
+    if is_xpu_available:
+        torch.xpu.manual_seed(seed)
+        torch.xpu.manual_seed_all(seed)
 
 
 def prepare_micro_batches(

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -194,7 +194,9 @@ class TrainingWorker(Worker, DistProfilerExtension):
         loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
         dp_group = self.engine.get_data_parallel_group()
         if dp_group is not None:
-            torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
+            from verl.utils.distributed import all_reduce_avg
+
+            all_reduce_avg(loss, group=dp_group)
         loss = loss.item()
 
         # For grad_norm, we do not perform all reduce because it is already been done when clipping grad

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -25,8 +25,8 @@ from ray.actor import ActorHandle
 
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, ResourcePoolManager
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import is_torch_npu_available
-from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.utils.device import get_device_name
+from verl.workers.config import DiffusionRolloutConfig, HFModelConfig, RolloutConfig
 
 logger = logging.getLogger(__file__)
 
@@ -181,7 +181,7 @@ class RolloutReplica(ABC):
             bin_pack=False,
             name_prefix=name_prefix,
             use_gpu=use_gpu,
-            device_name="cuda" if not is_torch_npu_available(check_device=False) else "npu",
+            device_name=get_device_name(),
         )
         self.workers = worker_group.workers
         await self.launch_servers()
@@ -217,7 +217,7 @@ class RolloutReplica(ABC):
             bin_pack=False,
             name_prefix=name_prefix,
             use_gpu=use_gpu,
-            device_name="cuda" if not is_torch_npu_available(check_device=False) else "npu",
+            device_name=get_device_name(),
         )
         self.workers = worker_group.workers
         await self.launch_servers()

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -210,8 +210,10 @@ class BucketedWeightSender:
             del self.shm
             self.shm = None
         gc.collect()
-        get_torch_device().ipc_collect()
-        get_torch_device().empty_cache()
+        _dev = get_torch_device()
+        if hasattr(_dev, "ipc_collect"):
+            _dev.ipc_collect()
+        _dev.empty_cache()
 
     def _direct_send_large_weight(self, name: str, weight: torch.Tensor):
         """Send a weight larger than the bucket size via cuda ipc or share memory."""
@@ -329,5 +331,7 @@ class BucketedWeightReceiver:
             del self.shm
             self.shm = None
         gc.collect()
-        get_torch_device().ipc_collect()
-        get_torch_device().empty_cache()
+        _dev = get_torch_device()
+        if hasattr(_dev, "ipc_collect"):
+            _dev.ipc_collect()
+        _dev.empty_cache()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -24,7 +24,7 @@ from typing import Any, Literal, Optional, get_args
 import torch
 from vllm.outputs import RequestOutput
 
-from verl.utils.device import is_npu_available
+from verl.utils.device import is_npu_available, is_xpu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
@@ -61,6 +61,17 @@ def get_device_uuid(device_id: int) -> str:
             return "NPU-" + npu_visible_devices[device_id]
         else:
             return f"NPU-{device_id}"
+    elif is_xpu_available:
+        # Map logical device_id through ZE_AFFINITY_MASK to physical device index.
+        # Must be unique per device — using the full mask string caused all workers
+        # to share the same ZMQ socket path, deadlocking weight transfer.
+        ze_mask = os.getenv("ZE_AFFINITY_MASK", "")
+        if ze_mask:
+            devices = ze_mask.split(",")
+            phys_id = devices[device_id] if device_id < len(devices) else device_id
+        else:
+            phys_id = device_id
+        return f"XPU-{phys_id}"
     else:
         return current_platform.get_device_uuid(device_id)
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -35,7 +35,7 @@ from vllm.usage.usage_lib import UsageContext
 from vllm.v1.engine.async_llm import AsyncLLM
 
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_resource_name, get_visible_devices_keyword, is_torch_npu_available
+from verl.utils.device import get_resource_name, get_visible_devices_keyword, is_torch_npu_available, is_xpu_available
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_vllm_profiler_args
 from verl.utils.tokenizer import normalize_token_ids
@@ -113,6 +113,11 @@ class vLLMHttpServer:
         self.config = self._init_config(config)
         self.model_config = self._init_model_config(model_config)
         self._validate_configs()
+
+        # XPU: MemPool (sleep_mode=2) is not available; force level 1
+        if is_xpu_available and getattr(self.config, "enable_sleep_mode", False):
+            logger.warning("[XPU] Forcing enable_sleep_mode=False — MemPool not supported on XPU.")
+            object.__setattr__(self.config, "enable_sleep_mode", False)
 
         self.rollout_mode = rollout_mode
         self.workers = workers
@@ -372,9 +377,47 @@ class vLLMHttpServer:
             await self.run_headless(server_args)
 
     async def run_server(self, args: argparse.Namespace):
+        # XPU: vLLM v1 EngineCore spawns a subprocess via multiprocessing.spawn.
+        # That subprocess inherits ONEAPI_DEVICE_SELECTOR which triggers a fatal
+        # SYCL exception in the FLA/triton backend at module-import time
+        # (triton.runtime.driver.active.get_current_target() crashes whenever
+        # ONEAPI_DEVICE_SELECTOR is set to any level_zero:* value).
+        # ZE_AFFINITY_MASK alone is sufficient for device isolation.
+        if is_xpu_available:
+            os.environ.pop("ONEAPI_DEVICE_SELECTOR", None)
+
         engine_args = AsyncEngineArgs.from_cli_args(args)
+
+        # XPU: vLLM detects Ray and selects the "ray" executor backend, which
+        # spawns additional Worker processes each with their own L0 context.
+        # On memory-constrained XPU devices (Arc Pro B60 ≈ 22 GB), the combined
+        # L0 context overhead of FSDP workers + EngineCore + Worker processes
+        # exhausts device memory.  With TP=1 (the common XPU case), force the
+        # "uni" executor so the model runs inside the EngineCore process directly,
+        # avoiding an extra Worker process and its L0 context cost.
+        if is_xpu_available and engine_args.tensor_parallel_size <= 1:
+            engine_args.distributed_executor_backend = "uni"
+
+        # Apply XPU-specific vLLM patches in the actual training process.
+        # Must run here (before create_engine_config / AsyncLLM.from_vllm_config)
+        # so the monkey-patches are active when vLLM initialises its workers.
+        if is_xpu_available:
+            from verl.utils.vllm import xpu_patches as _xpu_patches
+
+            _xpu_patches.apply()
+
         usage_context = UsageContext.OPENAI_API_SERVER
-        vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+        try:
+            vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+        except Exception as e:
+            if is_xpu_available:
+                # pydantic ValidationError (e.g. model inspection failure) contains
+                # ArgsKwargs objects that cloudpickle/Ray cannot serialize, causing a
+                # secondary "cannot pickle ArgsKwargs" error that hides the real cause.
+                # Convert to a plain RuntimeError so Ray can propagate it cleanly while
+                # preserving the original traceback via "from e".
+                raise RuntimeError(f"vLLM create_engine_config failed: {e}") from e
+            raise
         vllm_config.parallel_config.data_parallel_master_port = self._dp_master_port
 
         fn_args = set(dict(inspect.signature(AsyncLLM.from_vllm_config).parameters).keys())


### PR DESCRIPTION
# What does this PR do?
End-to-end Intel XPU (Arc Pro / Data Center GPU Max) support for GRPO, PPO, and SFT training using FSDP + vLLM rollout.

This is the follow-up to #5943 (device detection) and bundles all remaining XPU enablement work into a working e2e stack. Follows the same incremental pattern as the Ascend NPU enablement. Validated on 2× Intel Arc Pro B70 (32GB, Battlemage, driver 26.09).

## No behavioral changes to existing CUDA/NPU code paths.

## Checklist Before Starting
 PR title: [hardware, fsdp, vllm, trainer, ray] feat: add Intel XPU support for e2e GRPO/PPO/SFT training
## Test
Hardware: 2× Intel Arc Pro B70 (32 GB PCIe, Battlemage), PyTorch 2.11+xpu, driver 26.09
Hardware 4x Intel Arc Pro B60 (24 GB PCIe, Battlemage), Virtual Machine

## GRPO smoke test (tests/special_xpu/run_grpo_xpu.sh) — Qwen2.5-0.5B-Instruct, GSM8K, 1 step:
Training Progress: 100%|██████████| 1/1 [00:51<00:00, 51.68s/it]
step:1 - actor/entropy:4.64 - actor/loss:0.00482 - actor/grad_norm:1.45
       - actor/lr:5e-07 - timing_s/step:51.59 - perf/throughput:73.2
Validation (step:0) and training (step:1) complete without crashes or NaN loss. SFT and PPO scripts also included.

## API and Usage Example
No API changes. XPU is auto-detected via torch.xpu.is_available(); existing CUDA/NPU configs unchanged.

# Build
docker build -t verl-xpu:latest -f docker/xpu/Dockerfile.xpu .

# Run GRPO (2 GPUs)
docker run --rm --privileged --device /dev/dri --ipc=host --shm-size 10g \
  -v $HOME/data:/root/data -e NUM_GPUS=2 verl-xpu:latest \
  bash -c "source /root/.bashrc && cd /workspace/verl && bash tests/special_xpu/run_grpo_xpu.sh"

## Design & Code Changes
25 files, +849/-32. Consolidates #5943 (device detection) and all remaining XPU enablement work into a single self-contained PR. 

#Key areas:
## Infrastructure

docker/xpu/Dockerfile.xpu — image based on intel/deep-learning-essentials:2025.3.2, pinned driver 26.09
requirements-xpu.txt, tests/special_xpu/ (GRPO/PPO/SFT smoke scripts)
Ray integration (single_controller/ray/base.py, worker.py)

## Ray's IntelGPUAccelerator maps XPU → "GPU" slot; XPU workers treated identically to CUDA
Sync ONEAPI_DEVICE_SELECTOR from ZE_AFFINITY_MASK on worker start so Level Zero re-numbers masked devices correctly
Distributed (utils/distributed.py, fsdp_utils.py)

## oneccl fixes
The upstream from pytorch xpu fixes timeline (pytorch2.13 +)
all_reduce_avg(): xccl ReduceOp.AVG double-divides on small tensors ([[torch-xpu-ops#3020](https://github.com/intel/torch-xpu-ops/issues/3020)]); uses SUM÷N instead
Composite backend cpu:gloo,xpu:xccl for mixed CPU/XPU process groups
set_force_sum_reduction_for_comms(True) for FSDP2


##VLLM
vLLM coexistence (vllm_async_server.py, xpu_patches.py)
Force enable_sleep_mode=False (XPU MemPool unavailable) 
Pop ONEAPI_DEVICE_SELECTOR before AsyncLLM init — vLLM spawns subprocesses where ONEAPI_DEVICE_SELECTOR=level_zero:* triggers SIGABRT in SYCL JIT; ZE_AFFINITY_MASK alone is sufficient
distributed_executor_backend="uni" for TP=1

Idempotent monkey-patches for false OOM check ([https://github.com/vllm-project/vllm/pull/37149], draft XpuMemAllocator) and profiling assert ([https://github.com/vllm-project/vllm/pull/36720], same assert on ROCm; XPU fix not yet upstream) — version-guarded, self-remove once upstream lands
Other

## some conditional changes or enhancement
model.py: read attn_implementation from config instead of hardcoding flash_attention_2
replica.py: replace hardcoded "cuda"/"npu" with get_device_name()
bucketed_weight_transfer.py: guard ipc_collect() with hasattr
transformer_impl.py: register "xpu" in @EngineRegistry
constants_ppo.py: propagate ONEAPI_DEVICE_SELECTOR into Ray workers' runtime_env

## Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] pre-commit checks passed: `pre-commit run --files verl/utils/device.py` — all 12 checks passed (ruff, mypy, license, etc.)
- [x] Documentation: docker/xpu/README.md included
- [x] Unit tests: XPU detection requires XPU hardware; validated manually on Intel Arc Pro B70. CI cannot run on XPU hardware.
- [ ] CI request: no XPU runners available (same situation as NPU); will post in #ci-request once ready
- [x] Not related to recipe submodule.

  
## Scope: 
This PR covers FSDP + vLLM rollout only (the primary verl training stack). TorchTitan (E1/E2) and VeOmni are excluded — TorchTitan XPU is functional on Battlemage but not yet validated on all hardware; those can follow as separate PRs. flash_attention_2 is replaced with pure-PyTorch SDPA throughout XPU paths. IPC (is_support_ipc=False) is disabled for XPU because the CUDA 8-handle IPC protocol is incompatible with SYCL handles ([https://github.com/intel/torch-xpu-ops/issues/1678]); the shared-memory fallback is used instead.