### PR TITLE
[sglang] feat: Patch sglang to support on-policy distillation teacher

### DIFF
--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -194,6 +194,12 @@ class DistillationTeacherModelConfig(BaseConfig):
                         f"({topk}) to enable distillation loss computation."
                     )
                 engine_kwargs["vllm"] = vllm_engine_kwargs
+            case "sglang":
+                # SGLang's top_logprobs_num is a per-request parameter, so there is no
+                # engine-boot cap to align (unlike vLLM's max_logprobs). The async
+                # server translates sampling_params["prompt_logprobs"] into
+                # return_logprob + logprob_start_len=0 + top_logprobs_num at call time.
+                pass
             case _:
                 raise NotImplementedError(
                     f"DistillationTeacherModelConfig does not support inference engine {engine_name}"

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -90,8 +90,7 @@ def _extract_prompt_logprobs_sglang(
             ids = [int(tok_id) for _, tok_id, _ in top_entries]
             logprobs = [float(logprob) for logprob, _, _ in top_entries]
             assert len(ids) == num_prompt_logprobs, (
-                f"SGLang returned {len(ids)} top logprobs at position {position}, "
-                f"expected {num_prompt_logprobs}."
+                f"SGLang returned {len(ids)} top logprobs at position {position}, expected {num_prompt_logprobs}."
             )
             prompt_ids_ls.append(ids)
             prompt_logprobs_ls.append(logprobs)

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -56,6 +56,57 @@ logger.setLevel(logging.INFO)
 visible_devices_keyword = get_visible_devices_keyword()
 
 
+def _extract_prompt_logprobs_sglang(
+    meta_info: dict,
+    num_prompt_logprobs: int,
+    sequence_length: int,
+    result_dict: dict[str, list],
+) -> None:
+    """Shape SGLang input-logprobs into the vLLM ``extract_prompt_logprobs`` contract.
+    Populates ``result_dict`` with two ``[sequence_length, max(num_prompt_logprobs, 1)]``
+    lists — ``prompt_ids`` and ``prompt_logprobs`` — so the distillation teacher
+    consumer in ``teacher_manager.AsyncTeacherLLMServerManager`` can treat vLLM and
+    SGLang teachers interchangeably.
+    SGLang returns input logprobs with length ``S == len(input_ids)`` whose first
+    entry has ``logprob=None`` (no predicting context). That matches the vLLM
+    convention, so we skip entry 0 and append a trailing dummy row to keep the
+    total length equal to the consumer's ``len(sequence_ids)`` assertion.
+    """
+    input_token_logprobs = meta_info.get("input_token_logprobs") or []
+    if num_prompt_logprobs > 0:
+        input_top_logprobs = meta_info.get("input_top_logprobs") or []
+    prompt_ids_ls: list[list[int]] = []
+    prompt_logprobs_ls: list[list[float]] = []
+    # Entry 0 has logprob=None (no predicting context); skip it, matching vLLM.
+    for position in range(1, len(input_token_logprobs)):
+        if num_prompt_logprobs == 0:
+            logprob, token_id, _ = input_token_logprobs[position]
+            prompt_ids_ls.append([int(token_id)])
+            prompt_logprobs_ls.append([float(logprob)])
+        else:
+            top_entries = input_top_logprobs[position]
+            # SGLang returns ranked best-first; we preserve that ordering so rank
+            # 0 is the top-1 token, matching the vLLM extractor's rank-1 slot.
+            ids = [int(tok_id) for _, tok_id, _ in top_entries]
+            logprobs = [float(logprob) for logprob, _, _ in top_entries]
+            assert len(ids) == num_prompt_logprobs, (
+                f"SGLang returned {len(ids)} top logprobs at position {position}, "
+                f"expected {num_prompt_logprobs}."
+            )
+            prompt_ids_ls.append(ids)
+            prompt_logprobs_ls.append(logprobs)
+    # Trailing dummy row so total length == len(sequence_ids), matching vLLM.
+    pad_width = max(num_prompt_logprobs, 1)
+    prompt_ids_ls.append([0] * pad_width)
+    prompt_logprobs_ls.append([0.0] * pad_width)
+    assert len(prompt_ids_ls) == sequence_length, (
+        f"SGLang prompt_logprobs length ({len(prompt_ids_ls)}) does not match "
+        f"sequence length ({sequence_length}); check logprob_start_len=0 invariant."
+    )
+    result_dict["prompt_ids"] = prompt_ids_ls
+    result_dict["prompt_logprobs"] = prompt_logprobs_ls
+
+
 class SGLangHttpServer:
     """SGLang http server in single node, this is equivalent to launch server with command line:
     ```
@@ -407,6 +458,13 @@ class SGLangHttpServer:
         sampling_params["max_new_tokens"] = max_new_tokens
         return_logprob = sampling_params.pop("logprobs", False)
 
+        # vLLM-style "prompt_logprobs=K" from the distillation teacher: request
+        # input-token logprobs for every position (top-K when K>0, sampled-token
+        # logprob only when K==0). Translate to SGLang's per-request logprob API.
+        prompt_logprobs = sampling_params.pop("prompt_logprobs", None)
+        if prompt_logprobs is not None:
+            return_logprob = True
+
         request = {
             "rid": request_id,
             "input_ids": prompt_ids,
@@ -416,6 +474,11 @@ class SGLangHttpServer:
             # TODO: support video input for sglang
             # video_data=video_data,
         }
+
+        if prompt_logprobs is not None:
+            request["logprob_start_len"] = 0
+            if prompt_logprobs > 0:
+                request["top_logprobs_num"] = prompt_logprobs
 
         if self.config.enable_rollout_routing_replay:
             request.update({"return_routed_experts": True})
@@ -466,12 +529,21 @@ class SGLangHttpServer:
                     -1, hf_config.num_hidden_layers, hf_config.num_experts_per_tok
                 )
 
+        extra_fields = {"global_steps": self.global_steps}
+        if prompt_logprobs is not None:
+            _extract_prompt_logprobs_sglang(
+                meta_info=meta_info,
+                num_prompt_logprobs=prompt_logprobs,
+                sequence_length=len(prompt_ids),
+                result_dict=extra_fields,
+            )
+
         return TokenOutput(
             token_ids=token_ids,
             log_probs=log_probs,
             routed_experts=routed_experts,
             stop_reason=finish_reason,
-            extra_fields={"global_steps": self.global_steps},
+            extra_fields=extra_fields,
         )
 
     async def set_global_steps(self, global_steps: int):


### PR DESCRIPTION
### What does this PR do?

On-policy distillation currently only supports vLLM as teacher inference engine.
This MR adds support for SGlang.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Reran examples/on_policy_distillation_trainer/run_qwen_gsm8k.sh and examples/on_policy_distillation_trainer/run_qwen_gsm8k_megatron.sh

Loss / reward / val scores roughly the same
- yellow - main branch
- red - dev branch (FSDP)
- blue - dev branch (megatron) (experiment configs modified to match FSDP)

<img width="2468" height="1298" alt="image" src="https://github.com/user-attachments/assets/e6a6534d-23e0-46d0-8067-663bce11ff18" />
<img width="926" height="688" alt="image" src="https://github.com/user-attachments/assets/0b8979b3-96e8-4c0a-abb0-ba6a0305be91" />
<img width="882" height="676" alt="image" src="https://github.com/user-attachments/assets/4232c722-dcd5-44a0-9ed2-116f4ed0401d" />

### API and Usage Example

```python
distillation.teacher_models.teacher_model.inference.name=sglang
```

### Design & Code Changes

Current convention is to patch verl/workers/rollout/sglang_rollout/async_sglang_server.py to match interface of vLLM for various functions. We do the same matching the current SamplingConfig call pattern located in teacher_manager.py.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
