### PR TITLE
[trainer] fix: preserve jagged tensor layout when rebuilding nested tensors with same sequence length

### DIFF
--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -128,6 +128,27 @@ def test_index_select_tensor_dict():
     tu.assert_tensordict_eq(selected_data, target_select_data)
 
 
+def test_index_select_tensor_dict_preserves_3d_nested_tensor_layout_with_equal_seq_len():
+    position_ids = tu.nested_tensor_from_tensor_list(
+        [
+            torch.arange(2).expand(4, 2),
+            torch.arange(5).expand(4, 5),
+            (torch.arange(5) + 10).expand(4, 5),
+            torch.arange(3).expand(4, 3),
+        ]
+    )
+    data = tu.get_tensordict({"position_ids": position_ids})
+
+    selected = tu.index_select_tensor_dict(data, torch.tensor([1, 2]))
+    expected = tu.nested_tensor_from_tensor_list([position_ids[1], position_ids[2]], ragged_idx=2)
+
+    assert selected["position_ids"]._ragged_idx == 2
+    assert selected["position_ids"].values().shape == torch.Size([4, 10])
+    assert torch.equal(selected["position_ids"].values(), expected.values())
+    assert torch.equal(selected["position_ids"].offsets(), expected.offsets())
+    tu.assert_tensordict_eq(selected, tu.get_tensordict({"position_ids": expected}))
+
+
 def test_tensordict_with_images():
     # each sample contains a sequence with multiple images of different sizes
     vocab_size = 128
@@ -835,6 +856,33 @@ def test_chunk_tensordict():
                         assert expect is None
                     else:
                         assert torch.all(torch.eq(tensor.data["pixel_values"], expect["pixel_values"])).item()
+
+
+def test_chunk_tensordict_preserves_3d_nested_tensor_layout_with_equal_seq_len_per_chunk():
+    position_ids = tu.nested_tensor_from_tensor_list(
+        [
+            torch.arange(2).expand(4, 2),
+            (torch.arange(2) + 10).expand(4, 2),
+            torch.arange(5).expand(4, 5),
+            (torch.arange(5) + 20).expand(4, 5),
+        ]
+    )
+    input_ids = torch.nested.as_nested_tensor(
+        [torch.arange(2), torch.arange(2) + 10, torch.arange(5), torch.arange(5) + 20], layout=torch.jagged
+    )
+    td = tu.get_tensordict({"input_ids": input_ids, "position_ids": position_ids})
+
+    chunks = tu.chunk_tensordict(td, chunks=2)
+
+    expected_chunk_0 = tu.nested_tensor_from_tensor_list([position_ids[0], position_ids[1]], ragged_idx=2)
+    expected_chunk_1 = tu.nested_tensor_from_tensor_list([position_ids[2], position_ids[3]], ragged_idx=2)
+
+    assert chunks[0]["position_ids"]._ragged_idx == 2
+    assert chunks[1]["position_ids"]._ragged_idx == 2
+    assert torch.equal(chunks[0]["position_ids"].values(), expected_chunk_0.values())
+    assert torch.equal(chunks[1]["position_ids"].values(), expected_chunk_1.values())
+    assert torch.equal(chunks[0]["position_ids"].offsets(), expected_chunk_0.offsets())
+    assert torch.equal(chunks[1]["position_ids"].offsets(), expected_chunk_1.offsets())
 
 
 def test_assign_non_tensor_stack_with_nested_lists():

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -18,6 +18,8 @@ from enum import Enum
 import torch
 from tensordict.tensorclass import NonTensorData
 
+from verl.utils.tensordict_utils import nested_tensor_from_tensor_list
+
 
 class DatasetPadMode(str, Enum):
     """Padding mode for dataset"""
@@ -68,15 +70,7 @@ class SFTTensorCollator:
             if isinstance(batch[0][key], torch.Tensor):
                 tensors = [item[key] for item in batch]
                 if tensors[0].dim() >= 2:
-                    # For multi-dim tensors (e.g., 3D position_ids with shape (num_heads, seq_len)),
-                    # use nested_tensor_from_jagged with explicit jagged_dim to avoid ambiguity
-                    # when all samples share the same seq_len.
-                    values = torch.cat(tensors, dim=-1)
-                    lengths = torch.tensor([t.shape[-1] for t in tensors])
-                    offsets = torch.zeros(len(tensors) + 1, dtype=torch.long)
-                    torch.cumsum(lengths, dim=0, out=offsets[1:])
-                    final_batch[key] = torch.nested.nested_tensor_from_jagged(values, offsets=offsets)
-                    final_batch[key]._ragged_idx = 2
+                    final_batch[key] = nested_tensor_from_tensor_list(tensors)
                 else:
                     final_batch[key] = torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
             else:

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -159,6 +159,26 @@ def get_non_tensor_data(data: TensorDict, key: str, default):
     return unwrap_non_tensor_data(output)
 
 
+def nested_tensor_from_tensor_list(tensors: list[torch.Tensor], ragged_idx: int | None = None) -> torch.Tensor:
+    assert len(tensors) > 0, "Must provide at least one tensor"
+    sample_dim = tensors[0].dim()
+    if ragged_idx is None:
+        ragged_idx = sample_dim
+    assert ragged_idx == sample_dim, f"Only last-dimension ragged tensors are supported. Got {ragged_idx=} and {sample_dim=}"
+
+    if sample_dim == 1:
+        return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
+
+    values = torch.cat(tensors, dim=-1)
+    lengths = torch.tensor([tensor.shape[-1] for tensor in tensors], dtype=torch.long, device=values.device)
+    offsets = torch.zeros(len(tensors) + 1, dtype=torch.long, device=values.device)
+    torch.cumsum(lengths, dim=0, out=offsets[1:])
+
+    nested_tensor = torch.nested.nested_tensor_from_jagged(values=values, offsets=offsets)
+    nested_tensor._ragged_idx = ragged_idx
+    return nested_tensor
+
+
 def concat_nested_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
     """Concatenate multiple nested tensors along the batch dimension.
 
@@ -191,8 +211,7 @@ def concat_nested_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
         unbind_tensor = tensor.unbind(0)
         unbind_tensors.extend(list(unbind_tensor))
 
-    tensor = torch.nested.as_nested_tensor(unbind_tensors, layout=torch.jagged)
-    return tensor
+    return nested_tensor_from_tensor_list(unbind_tensors, ragged_idx=tensors[0].dim() - 1)
 
 
 def concat_tensordict_with_none_bsz(data: list[TensorDict]):
@@ -337,12 +356,12 @@ def chunk_tensordict(td: TensorDict, chunks: int) -> list[TensorDict]:
             for i, chunk_td in enumerate(tds):
                 chunk_lengths = lengths[i * chunk_size : (i + 1) * chunk_size]
                 chunk_tensors = [padded_chunks[i][j, :seq_len] for j, seq_len in enumerate(chunk_lengths)]
-                chunk_td[key] = torch.nested.as_nested_tensor(chunk_tensors, layout=torch.jagged)
+                chunk_td[key] = nested_tensor_from_tensor_list(chunk_tensors, ragged_idx=nt.dim() - 1)
             continue
 
         for i, chunk_td in enumerate(tds):
-            chunk_td[key] = torch.nested.as_nested_tensor(
-                tensors[i * chunk_size : (i + 1) * chunk_size], layout=torch.jagged
+            chunk_td[key] = nested_tensor_from_tensor_list(
+                list(tensors[i * chunk_size : (i + 1) * chunk_size]), ragged_idx=nt.dim() - 1
             )
 
     return tds
@@ -467,9 +486,8 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
                 data_dict[key] = tensor[indices]
             elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
                 tensor_lst = tensor.unbind()  # for performance
-                data_dict[key] = torch.nested.as_nested_tensor(
-                    [tensor_lst[idx] for idx in indices], layout=torch.jagged
-                )
+                selected_tensors = [tensor_lst[idx] for idx in indices]
+                data_dict[key] = nested_tensor_from_tensor_list(selected_tensors, ragged_idx=tensor.dim() - 1)
             else:
                 # This handles NonTensorStack (indexable by batch dim) and NonTensorData (scalar metadata).
                 if tensor.shape:

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -164,7 +164,9 @@ def nested_tensor_from_tensor_list(tensors: list[torch.Tensor], ragged_idx: int 
     sample_dim = tensors[0].dim()
     if ragged_idx is None:
         ragged_idx = sample_dim
-    assert ragged_idx == sample_dim, f"Only last-dimension ragged tensors are supported. Got {ragged_idx=} and {sample_dim=}"
+    assert ragged_idx == sample_dim, (
+        f"Only last-dimension ragged tensors are supported. Got {ragged_idx=} and {sample_dim=}"
+    )
 
     if sample_dim == 1:
         return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

This PR fixes incorrect rebuilding of 3D jagged NestedTensors after selection/chunking, when the selected samples happen to share the same sequence length. It replaces ambiguous torch.nested.as_nested_tensor(...) rewrapping with an explicit helper that preserves the intended last-dimension jagged layout, and adds regression tests for the affected position_ids paths. 

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
