### PR TITLE
[dataset] feat: estimate vision tokens for faster prompt filtering

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -16,6 +16,7 @@
 
 import copy
 import logging
+import math
 import os
 import re
 import traceback
@@ -107,7 +108,11 @@ class RLHFDataset(Dataset):
         self.prompt_key = config.get("prompt_key", "prompt")
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
-        self.image_patch_size = config.get("image_patch_size", 14)
+
+        image_processor = getattr(self.processor, "image_processor", None)
+        self.spatial_merge_size = getattr(image_processor, "merge_size", 1)
+        self.temporal_patch_size = getattr(image_processor, "temporal_patch_size", 1)
+        self.image_patch_size = config.get("image_patch_size", getattr(image_processor, "patch_size", 14))
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.return_full_prompt = config.get("return_full_prompt", False)
@@ -182,6 +187,62 @@ class RLHFDataset(Dataset):
 
         self.dataframe = self.maybe_filter_out_long_prompts(self.dataframe)
 
+    def _estimate_multimodal_prompt_tokens(
+        self, raw_prompt: str, images: list[Image.Image] | None = None, videos: list[torch.Tensor] | None = None
+    ) -> int:
+        def _estimate_qwen_image_tokens_from_size(
+            images: list[Image.Image] | None, patch_size: int = 14, merge_size: int = 2
+        ) -> int:
+            if images is None:
+                return 0
+            total = 0
+            for img in images:
+                w, h = img.size
+                total += math.ceil(w / (patch_size * merge_size)) * math.ceil(h / (patch_size * merge_size))
+            return total
+
+        def _estimate_qwen_video_tokens_from_shape(
+            videos: list[torch.Tensor] | None,
+            patch_size: int = 14,
+            merge_size: int = 2,
+            temporal_patch_size: int = 2,
+        ) -> int:
+            if videos is None:
+                return 0
+            total = 0
+            for video in videos:
+                if not hasattr(video, "shape") or len(video.shape) != 4:
+                    raise ValueError(f"video must have shape [frames, channels, height, width], got {type(video)}")
+                frames, _, height, width = video.shape
+                total += (
+                    math.ceil(frames / temporal_patch_size)
+                    * math.ceil(height / (patch_size * merge_size))
+                    * math.ceil(width / (patch_size * merge_size))
+                )
+            return total
+
+        num_text_tokens = len(
+            self.processor.tokenizer(
+                text=raw_prompt,
+                add_special_tokens=False,  # avoid adding special tokens
+                return_attention_mask=False,
+            )["input_ids"]
+        )
+        return (
+            num_text_tokens
+            + _estimate_qwen_image_tokens_from_size(
+                images=images,
+                patch_size=self.image_patch_size,
+                merge_size=self.spatial_merge_size,
+            )
+            + _estimate_qwen_video_tokens_from_shape(
+                videos=videos,
+                patch_size=self.image_patch_size,
+                merge_size=self.spatial_merge_size,
+                temporal_patch_size=self.temporal_patch_size,
+            )
+        )
+
     def maybe_filter_out_long_prompts(self, dataframe: datasets.Dataset = None):
         # filter out too long prompts
         if self.filter_overlong_prompts:
@@ -229,22 +290,25 @@ class RLHFDataset(Dataset):
                             videos = None
                             videos_kwargs = {}
 
+                        estimated_num_tokens = self._estimate_multimodal_prompt_tokens(
+                            raw_prompt=raw_prompt,
+                            images=images,
+                            videos=videos,
+                        )
+
                         if images is None and videos is None:
                             # only text prompt
-                            return len(
-                                processor.tokenizer(
-                                    text=raw_prompt,
-                                    add_special_tokens=False,  # avoid adding special tokens
-                                    return_attention_mask=False,
-                                )["input_ids"]
-                            )
+                            return estimated_num_tokens
                         else:
                             # multi-modal prompt
-                            return len(
-                                processor(text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs)[
-                                    "input_ids"
-                                ][0]
-                            )
+                            if estimated_num_tokens < 0.9 * self.max_prompt_length:
+                                return estimated_num_tokens
+                            else:
+                                return len(
+                                    processor(
+                                        text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs
+                                    )["input_ids"][0]
+                                )
                     except Exception:
                         print("Error processing one of the samples, skipping...")
                         traceback.print_exc()

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -222,11 +222,13 @@ class RLHFDataset(Dataset):
             return total
 
         num_text_tokens = len(
-            self.processor.tokenizer(
-                text=raw_prompt,
-                add_special_tokens=False,  # avoid adding special tokens
-                return_attention_mask=False,
-            )["input_ids"]
+            normalize_token_ids(
+                self.processor.tokenizer(
+                    text=raw_prompt,
+                    add_special_tokens=False,  # avoid adding special tokens
+                    return_attention_mask=False,
+                )["input_ids"]
+            )
         )
         return (
             num_text_tokens


### PR DESCRIPTION
### What does this PR do?

Extends RLHF dataset prompt-length filtering to roughly estimate multimodal token counts for video prompts before falling back to exact processor tokenization near the max prompt length threshold.

This accelerate `maybe_filter_out_long_prompts` for multi-modal data by accounting for visual tokens from processed image/video tensor shape, using Qwen-style patch, spatial merge, and temporal patch parameters.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pull/5004
  - https://github.com/verl-project/verl/pull/5799
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test
Before Optimization:
<img width="1645" height="45" alt="filter_prompt_before_optim" src="https://github.com/user-attachments/assets/4cc16316-fc2b-4d48-a576-44ed1a7a1358" />
After Optimization:
<img width="1645" height="90" alt="filter_prompt_after_optim" src="https://github.com/user-attachments/assets/00b4bf7b-71a8-48df-86e2-0fb452c7ff85" />

### API and Usage Example
No public API or config changes.

### Design & Code Changes
- Obtain `self.image_patch_size` from `processor.image_processor`.
- Encapsulates rough multimodal prompt token estimation for RLHFDataset.
- Estimates text tokens with the processor tokenizer.
- Estimates image visual tokens from resized image dimensions and Qwen-style patch/merge geometry.
- Estimates video visual tokens from processed video tensor shape [frames, channels, height, width] using temporal patch size, patch size, and spatial merge size.
- Keeps exact processor tokenization as the source of truth when the rough estimate is close (90%) to `max_prompt_length`.

### Checklist Before Submitting
- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed: internal dataset filtering behavior, no user-facing API/config change.
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [X] Once your PR is ready for CI, send a message in [the ci-request channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the verl Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the recipe submodule, please also update the reference to the submodule commit via git submodule update --remote or cd recipe && git pull origin main. N/A.