### PR TITLE
[misc] fix: correct PrecisionType iteration and supported_types

### DIFF
--- a/verl/utils/torch_dtypes.py
+++ b/verl/utils/torch_dtypes.py
@@ -16,18 +16,20 @@ Adapted from Cruise.
 """
 
 import torch
+from enum import Enum
 
 HALF_LIST = [16, "16", "fp16", "float16", torch.float16]
 FLOAT_LIST = [32, "32", "fp32", "float32", torch.float32]
 BFLOAT_LIST = ["bf16", "bfloat16", torch.bfloat16]
 
-
-class PrecisionType:
+class PrecisionType(str, Enum):
     """Type of precision used.
 
-    >>> PrecisionType.HALF == 16
+    >>> PrecisionType.HALF == "16"
     True
-    >>> PrecisionType.HALF in (16, "16")
+    >>> PrecisionType.HALF in ("16", "32")
+    True
+    >>> PrecisionType.HALF.value == "16"
     True
     """
 
@@ -37,13 +39,18 @@ class PrecisionType:
     BFLOAT = "bf16"
     MIXED = "mixed"
 
-    @staticmethod
-    def supported_type(precision: str | int) -> bool:
-        return any(x == precision for x in PrecisionType)
+    @classmethod
+    def supported_type(cls, precision: str | int) -> bool:
+        return (
+            precision in HALF_LIST
+            or precision in FLOAT_LIST
+            or precision in BFLOAT_LIST
+            or precision in (item.value for item in cls)
+        )
 
-    @staticmethod
-    def supported_types() -> list[str]:
-        return [x.value for x in PrecisionType]
+    @classmethod
+    def supported_types(cls) -> list[str]:
+        return [item.value for item in cls]
 
     @staticmethod
     def is_fp16(precision):


### PR DESCRIPTION
### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/volcengine/verl/issues?q=is%3Aissue%20PrecisionType
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### What does this PR do?

Fixes a runtime bug in `PrecisionType.supported_type()` and `PrecisionType.supported_types()`:

1. `supported_type()` previously attempted `for x in PrecisionType`, which raises `TypeError: 'type' object is not iterable` because `PrecisionType` was a plain class.
2. `supported_types()` used `x.value` on plain class attributes, which also fails for the same reason.

This PR converts `PrecisionType` to `str, Enum`, enabling correct iteration and `.value` access while preserving backward compatibility (e.g., `PrecisionType.HALF == "16"` remains `True`).

Additionally, the docstring doctests were corrected: `PrecisionType.HALF == 16` was never `True` (string vs int), so the example was misleading.

### Specific Changes

- Changed `class PrecisionType:` to `class PrecisionType(str, Enum):`
- Replaced `@staticmethod` with `@classmethod` for `supported_type` and `supported_types` so they can iterate over `cls`
- Fixed docstring examples to use valid comparisons (`== "16"` instead of `== 16`)
- Kept all other static methods (`is_fp16`, `is_fp32`, `is_bf16`, `to_dtype`, `to_str`) unchanged to maintain backward compatibility

### Test

```python
# Before this PR, both calls crash
&gt;&gt;&gt; PrecisionType.supported_type("16")
TypeError: 'type' object is not iterable

&gt;&gt;&gt; PrecisionType.supported_types()
TypeError: 'type' object is not iterable

# After this PR
&gt;&gt;&gt; PrecisionType.supported_type("16")
True
&gt;&gt;&gt; PrecisionType.supported_type(16)
True
&gt;&gt;&gt; PrecisionType.supported_type("bf16")
True
&gt;&gt;&gt; PrecisionType.supported_types()
['16', '32', '64', 'bf16', 'mixed']
&gt;&gt;&gt; PrecisionType.HALF == "16"
True