### PR TITLE
[megatron] fix: the NPU error that occurs after migrating from megatron worker to engine worker.

### DIFF
--- a/verl/workers/engine/__init__.py
+++ b/verl/workers/engine/__init__.py
@@ -50,17 +50,18 @@ except ImportError:
 
 # Mindspeed must be imported before Megatron to ensure the related monkey patches take effect as expected
 try:
-    from .mindspeed import MindspeedEngineWithLMHead, MindSpeedLLMEngineWithLMHead
+    from .mindspeed import MindspeedEngineWithLMHead, MindspeedEngineWithValueHead, MindSpeedLLMEngineWithLMHead
 
-    __all__ += ["MindspeedEngineWithLMHead", "MindSpeedLLMEngineWithLMHead"]
+    __all__ += ["MindspeedEngineWithLMHead", "MindspeedEngineWithValueHead", "MindSpeedLLMEngineWithLMHead"]
 except ImportError:
     MindspeedEngineWithLMHead = None
+    MindspeedEngineWithValueHead = None
     MindSpeedLLMEngineWithLMHead = None
 
 try:
-    from .megatron import MegatronEngine, MegatronEngineWithLMHead
+    from .megatron import MegatronEngine, MegatronEngineWithLMHead, MegatronEngineWithValueHead
 
-    __all__ += ["MegatronEngine", "MegatronEngineWithLMHead"]
+    __all__ += ["MegatronEngine", "MegatronEngineWithLMHead", "MegatronEngineWithValueHead"]
 except ImportError:
     MegatronEngine = None
     MegatronEngineWithLMHead = None

--- a/verl/workers/engine/megatron/__init__.py
+++ b/verl/workers/engine/megatron/__init__.py
@@ -21,9 +21,9 @@ from verl.utils.device import is_cuda_available
 if not is_cuda_available and "TORCH_CUDA_ARCH_LIST" not in os.environ:
     os.environ["TORCH_CUDA_ARCH_LIST"] = "8.0"
 
-from .transformer_impl import MegatronEngine, MegatronEngineWithLMHead  # noqa: E402
+from .transformer_impl import MegatronEngine, MegatronEngineWithLMHead, MegatronEngineWithValueHead  # noqa: E402
 
 if not is_cuda_available:
     del os.environ["TORCH_CUDA_ARCH_LIST"]
 
-__all__ = ["MegatronEngine", "MegatronEngineWithLMHead"]
+__all__ = ["MegatronEngine", "MegatronEngineWithLMHead", "MegatronEngineWithValueHead"]

--- a/verl/workers/engine/mindspeed/__init__.py
+++ b/verl/workers/engine/mindspeed/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .transformer_impl import MindspeedEngineWithLMHead, MindSpeedLLMEngineWithLMHead
+from .transformer_impl import MindspeedEngineWithLMHead, MindspeedEngineWithValueHead, MindSpeedLLMEngineWithLMHead
 
-__all__ = ["MindspeedEngineWithLMHead", "MindSpeedLLMEngineWithLMHead"]
+__all__ = ["MindspeedEngineWithLMHead", "MindspeedEngineWithValueHead", "MindSpeedLLMEngineWithLMHead"]

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -31,7 +31,7 @@ from verl.workers.config import (
 )
 
 from ..base import EngineRegistry
-from ..megatron import MegatronEngineWithLMHead
+from ..megatron import MegatronEngineWithLMHead, MegatronEngineWithValueHead
 from .utils import (
     apply_patch,
     gpt_model_provider,
@@ -66,6 +66,30 @@ class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
             repatch(repatch_config)
         super()._init_device_mesh()
 
+@EngineRegistry.register(model_type="value_model", backend="megatron", device="npu")
+class MindspeedEngineWithValueHead(MegatronEngineWithValueHead):
+    def __init__(
+        self,
+        model_config: HFModelConfig,
+        engine_config: McoreEngineConfig,
+        optimizer_config: McoreOptimizerConfig,
+        checkpoint_config: CheckpointConfig,
+    ):
+        super().__init__(model_config, engine_config, optimizer_config, checkpoint_config)
+
+    def _init_device_mesh(self):
+        # repatch must happen before initialize_model_parallel so that
+        # initialize_model_parallel_cp_wrapper is in effect when the call is made.
+        # The initial MindSpeed patch pass sees context_parallel_size=1 (default) because
+        # verl passes CP size via hydra config rather than --context-parallel-size CLI arg,
+        # so the CP ring-rank initialization wrapper is not registered on the first pass.
+        if repatch is not None:
+            repatch_config = dict(self.engine_config.get("override_transformer_config", {}))
+            repatch_config.setdefault("use_flash_attn", True)
+            if self.engine_config.context_parallel_size > 1:
+                repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
+            repatch(repatch_config)
+        super()._init_device_mesh()
 
 @EngineRegistry.register(model_type="language_model", backend="mindspeed_llm", device="npu")
 class MindSpeedLLMEngineWithLMHead(MegatronEngineWithLMHead):

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -40,6 +40,13 @@ from .utils import (
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+def _mindspeed_repatch(engine_config):
+    if repatch is not None:
+        repatch_config = dict(engine_config.get("override_transformer_config", {}))
+        repatch_config.setdefault("use_flash_attn", True)
+        if engine_config.context_parallel_size > 1:
+            repatch_config["context_parallel_size"] = engine_config.context_parallel_size
+        repatch(repatch_config)
 
 @EngineRegistry.register(model_type="language_model", backend="megatron", device="npu")
 class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
@@ -58,12 +65,7 @@ class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
         # The initial MindSpeed patch pass sees context_parallel_size=1 (default) because
         # verl passes CP size via hydra config rather than --context-parallel-size CLI arg,
         # so the CP ring-rank initialization wrapper is not registered on the first pass.
-        if repatch is not None:
-            repatch_config = dict(self.engine_config.get("override_transformer_config", {}))
-            repatch_config.setdefault("use_flash_attn", True)
-            if self.engine_config.context_parallel_size > 1:
-                repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
-            repatch(repatch_config)
+        _mindspeed_repatch(self.engine_config)
         super()._init_device_mesh()
 
 @EngineRegistry.register(model_type="value_model", backend="megatron", device="npu")
@@ -83,12 +85,7 @@ class MindspeedEngineWithValueHead(MegatronEngineWithValueHead):
         # The initial MindSpeed patch pass sees context_parallel_size=1 (default) because
         # verl passes CP size via hydra config rather than --context-parallel-size CLI arg,
         # so the CP ring-rank initialization wrapper is not registered on the first pass.
-        if repatch is not None:
-            repatch_config = dict(self.engine_config.get("override_transformer_config", {}))
-            repatch_config.setdefault("use_flash_attn", True)
-            if self.engine_config.context_parallel_size > 1:
-                repatch_config["context_parallel_size"] = self.engine_config.context_parallel_size
-            repatch(repatch_config)
+        _mindspeed_repatch(self.engine_config)
         super()._init_device_mesh()
 
 @EngineRegistry.register(model_type="language_model", backend="mindspeed_llm", device="npu")

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -49,6 +49,7 @@ def _mindspeed_repatch(engine_config):
             repatch_config["context_parallel_size"] = engine_config.context_parallel_size
         repatch(repatch_config)
 
+
 @EngineRegistry.register(model_type="language_model", backend="megatron", device="npu")
 class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
     def __init__(

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -40,6 +40,7 @@ from .utils import (
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+
 def _mindspeed_repatch(engine_config):
     if repatch is not None:
         repatch_config = dict(engine_config.get("override_transformer_config", {}))
@@ -68,6 +69,7 @@ class MindspeedEngineWithLMHead(MegatronEngineWithLMHead):
         _mindspeed_repatch(self.engine_config)
         super()._init_device_mesh()
 
+
 @EngineRegistry.register(model_type="value_model", backend="megatron", device="npu")
 class MindspeedEngineWithValueHead(MegatronEngineWithValueHead):
     def __init__(
@@ -87,6 +89,7 @@ class MindspeedEngineWithValueHead(MegatronEngineWithValueHead):
         # so the CP ring-rank initialization wrapper is not registered on the first pass.
         _mindspeed_repatch(self.engine_config)
         super()._init_device_mesh()
+
 
 @EngineRegistry.register(model_type="language_model", backend="mindspeed_llm", device="npu")
 class MindSpeedLLMEngineWithLMHead(MegatronEngineWithLMHead):

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -20,11 +20,6 @@ from functools import partial
 from itertools import chain
 from typing import Optional
 
-try:
-    from verl.workers.engine.mindspeed.transformer_impl import repatch
-except ImportError:
-    repatch = None
-
 import torch
 from codetiming import Timer
 from omegaconf import DictConfig, open_dict

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -20,6 +20,11 @@ from functools import partial
 from itertools import chain
 from typing import Optional
 
+try:
+    from verl.workers.engine.mindspeed.transformer_impl import repatch
+except ImportError:
+    repatch = None
+
 import torch
 from codetiming import Timer
 from omegaconf import DictConfig, open_dict


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

After migrating from megatron worker to engine worker, there is no longer Critic worker to use. 
Fix the error occurs on NPU: AssertionError: Unknown device: npu for model_type: value_model and backend: megatron.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
