### PR TITLE
Add configurable filtering for validation metrics

### DIFF
--- a/verl/experimental/vla/rob_ray_trainer.py
+++ b/verl/experimental/vla/rob_ray_trainer.py
@@ -39,6 +39,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_throughout_metrics,
     compute_timing_metrics,
     process_validation_metrics,
+    should_keep_validation_metric,
 )
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer, apply_kl_penalty, compute_advantage
 from verl.trainer.ppo.reward import compute_reward
@@ -640,12 +641,20 @@ class RobRayPPOTrainer(RayPPOTrainer):
         data_sources = np.concatenate(data_source_lst, axis=0)
 
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+
+        metrics_cfg = getattr(self.config.trainer, "metrics", None)
+        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
+        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():
             core_var = "acc" if "acc" in var2metric2val else "reward"
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
+                    if not should_keep_validation_metric(metric_name, enabled_metrics):
+                        continue
+
                     if (
                         (var_name == core_var)
                         and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])

--- a/verl/experimental/vla/rob_ray_trainer.py
+++ b/verl/experimental/vla/rob_ray_trainer.py
@@ -39,6 +39,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_throughout_metrics,
     compute_timing_metrics,
     process_validation_metrics,
+    get_enabled_metrics,
     should_keep_validation_metric,
 )
 from verl.trainer.ppo.ray_trainer import RayPPOTrainer, apply_kl_penalty, compute_advantage
@@ -642,9 +643,7 @@ class RobRayPPOTrainer(RayPPOTrainer):
 
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
 
-        metrics_cfg = getattr(self.config.trainer, "metrics", None)
-        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
-        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+        enabled_metrics = get_enabled_metrics(self.config)
 
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():

--- a/verl/trainer/config/_generated_diffusion_trainer.yaml
+++ b/verl/trainer/config/_generated_diffusion_trainer.yaml
@@ -656,6 +656,8 @@ trainer:
   - console
   - wandb
   log_val_generations: 0
+  metrics:
+    enabled_metrics: null
   rollout_data_dir: null
   validation_data_dir: null
   nnodes: 1

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -849,6 +849,8 @@ trainer:
   - console
   - wandb
   log_val_generations: 0
+  metrics:
+    enabled_metrics: null
   rollout_data_dir: null
   validation_data_dir: null
   nnodes: 1

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -785,6 +785,8 @@ trainer:
   - console
   - wandb
   log_val_generations: 0
+  metrics:
+    enabled_metrics: null
   rollout_data_dir: null
   validation_data_dir: null
   nnodes: 1

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -807,6 +807,8 @@ trainer:
   - console
   - wandb
   log_val_generations: 0
+  metrics:
+    enabled_metrics: null
   rollout_data_dir: null
   validation_data_dir: null
   nnodes: 1

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -762,6 +762,8 @@ trainer:
   - console
   - wandb
   log_val_generations: 0
+  metrics:
+    enabled_metrics: null
   rollout_data_dir: null
   validation_data_dir: null
   nnodes: 1

--- a/verl/trainer/config/diffusion_trainer.yaml
+++ b/verl/trainer/config/diffusion_trainer.yaml
@@ -109,6 +109,10 @@ trainer:
   # Number of generations to log during validation
   log_val_generations: 0
 
+  # Optional validation metric filter. Keep null to preserve current behavior.
+  metrics:
+    enabled_metrics: null
+
   # Directory for logging rollout data; no dump if null
   rollout_data_dir: null
 

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -133,6 +133,10 @@ trainer:
   # Number of generations to log during validation
   log_val_generations: 0
 
+  # Optional validation metric filter. Keep null to preserve current behavior.
+  metrics:
+    enabled_metrics: null
+
   # Directory for logging rollout data; no dump if null
   rollout_data_dir: null
 

--- a/verl/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl/trainer/diffusion/ray_diffusion_trainer.py
@@ -48,6 +48,7 @@ from verl.trainer.ppo.core_algos import get_adv_estimator_fn
 from verl.trainer.ppo.metric_utils import (
     compute_variance_proxy_metrics,
     process_validation_metrics,
+    get_enabled_metrics,
     should_keep_validation_metric,
 )
 from verl.trainer.ppo.reward import extract_reward
@@ -525,9 +526,7 @@ class RayFlowGRPOTrainer:
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns):
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
 
-        metrics_cfg = getattr(self.config.trainer, "metrics", None)
-        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
-        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+        enabled_metrics = get_enabled_metrics(self.config)
 
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():

--- a/verl/trainer/diffusion/ray_diffusion_trainer.py
+++ b/verl/trainer/diffusion/ray_diffusion_trainer.py
@@ -45,7 +45,11 @@ from verl.trainer.diffusion.diffusion_metric_utils import (
     compute_timing_metrics_diffusion,
 )
 from verl.trainer.ppo.core_algos import get_adv_estimator_fn
-from verl.trainer.ppo.metric_utils import compute_variance_proxy_metrics, process_validation_metrics
+from verl.trainer.ppo.metric_utils import (
+    compute_variance_proxy_metrics,
+    process_validation_metrics,
+    should_keep_validation_metric,
+)
 from verl.trainer.ppo.reward import extract_reward
 from verl.trainer.ppo.utils import Role, WorkerType, need_reference_policy, need_reward_model
 from verl.utils import tensordict_utils as tu
@@ -520,12 +524,20 @@ class RayFlowGRPOTrainer:
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns):
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+
+        metrics_cfg = getattr(self.config.trainer, "metrics", None)
+        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
+        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():
             core_var = "acc" if "acc" in var2metric2val else "reward"
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
+                    if not should_keep_validation_metric(metric_name, enabled_metrics):
+                        continue
+
                     if (
                         (var_name == core_var)
                         and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -73,6 +73,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
     process_validation_metrics,
+    get_enabled_metrics,
     should_keep_validation_metric,
 )
 from verl.trainer.ppo.padding_utils import upsample_batch_to_divisible_size
@@ -1081,9 +1082,7 @@ class PPOTrainer:
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict[str, float]:
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
 
-        metrics_cfg = getattr(self.config.trainer, "metrics", None)
-        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
-        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+        enabled_metrics = get_enabled_metrics(self.config)
 
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -73,6 +73,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
     process_validation_metrics,
+    should_keep_validation_metric,
 )
 from verl.trainer.ppo.padding_utils import upsample_batch_to_divisible_size
 from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage
@@ -1079,12 +1080,20 @@ class PPOTrainer:
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns) -> dict[str, float]:
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+
+        metrics_cfg = getattr(self.config.trainer, "metrics", None)
+        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
+        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():
             core_var = "acc" if "acc" in var2metric2val else "reward"
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
+                    if not should_keep_validation_metric(metric_name, enabled_metrics):
+                        continue
+
                     if (
                         (var_name == core_var)
                         and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -19,7 +19,7 @@ import logging
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable
-
+from omegaconf import OmegaConf
 import numpy as np
 import torch
 
@@ -549,6 +549,12 @@ def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> flo
     maj_val = vote2vals[maj_vote][0]
 
     return maj_val
+
+
+def get_enabled_metrics(config) -> set[str] | None:
+    """Extract and convert enabled_metrics from trainer config to a set."""
+    enabled_metrics = OmegaConf.select(config, "trainer.metrics.enabled_metrics", default=None)
+    return set(enabled_metrics) if enabled_metrics is not None else None
 
 
 def should_keep_validation_metric(metric_name: str, enabled_metrics: set[str] | None) -> bool:

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -551,6 +551,14 @@ def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> flo
     return maj_val
 
 
+def should_keep_validation_metric(metric_name: str, enabled_metrics: set[str] | None) -> bool:
+    """Return whether a validation metric should be logged."""
+    if enabled_metrics is None:
+        return True
+    metric_prefix = metric_name.split("@", 1)[0]
+    return metric_prefix in enabled_metrics
+
+
 def process_validation_metrics(
     data_sources: list[str], sample_uids: list[str], infos_dict: dict[str, list[Any]], seed: int = 42
 ) -> dict[str, dict[str, dict[str, float]]]:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -48,6 +48,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
     process_validation_metrics,
+    should_keep_validation_metric,
 )
 from verl.trainer.ppo.reward import extract_reward
 from verl.trainer.ppo.utils import (
@@ -635,12 +636,20 @@ class RayPPOTrainer:
 
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns):
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
+
+        metrics_cfg = getattr(self.config.trainer, "metrics", None)
+        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
+        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():
             core_var = "acc" if "acc" in var2metric2val else "reward"
             for var_name, metric2val in var2metric2val.items():
                 n_max = max([int(name.split("@")[-1].split("/")[0]) for name in metric2val.keys()])
                 for metric_name, metric_val in metric2val.items():
+                    if not should_keep_validation_metric(metric_name, enabled_metrics):
+                        continue
+
                     if (
                         (var_name == core_var)
                         and any(metric_name.startswith(pfx) for pfx in ["mean", "maj", "best"])

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -48,6 +48,7 @@ from verl.trainer.ppo.metric_utils import (
     compute_timing_metrics,
     compute_variance_proxy_metrics,
     process_validation_metrics,
+    get_enabled_metrics,
     should_keep_validation_metric,
 )
 from verl.trainer.ppo.reward import extract_reward
@@ -637,9 +638,7 @@ class RayPPOTrainer:
     def _val_metrics_update(self, data_sources, sample_uids, reward_extra_infos_dict, sample_turns):
         data_src2var2metric2val = process_validation_metrics(data_sources, sample_uids, reward_extra_infos_dict)
 
-        metrics_cfg = getattr(self.config.trainer, "metrics", None)
-        enabled_metrics = None if metrics_cfg is None else getattr(metrics_cfg, "enabled_metrics", None)
-        enabled_metrics = set(enabled_metrics) if enabled_metrics is not None else None
+        enabled_metrics = get_enabled_metrics(self.config)
 
         metric_dict = {}
         for data_source, var2metric2val in data_src2var2metric2val.items():


### PR DESCRIPTION
## Summary
This PR adds configurable filtering for validation metrics so users can control which validation metrics are logged.

## What changed
- add `trainer.metrics.enabled_metrics` to PPO and diffusion trainer configs
- add `should_keep_validation_metric()` helper in `metric_utils.py`
- apply metric filtering in PPO, sync PPO, diffusion, and VLA validation metric logging paths
- regenerate `_generated_*.yaml` config references

## Notes
- default behavior is unchanged when `enabled_metrics` is `null`
- filtering is based on metric prefixes such as `mean`, `std`, `best`, `worst`, and `maj`
- This PR is a follow-up implementation for #968.