### PR TITLE
[trainer] fix: support non-last ragged dim in nested tensor rebuild

### DIFF
--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -885,6 +885,41 @@ def test_chunk_tensordict_preserves_3d_nested_tensor_layout_with_equal_seq_len_p
     assert torch.equal(chunks[1]["position_ids"].offsets(), expected_chunk_1.offsets())
 
 
+def test_chunk_tensordict_preserves_3d_nested_tensor_layout_with_non_last_ragged_idx():
+    """Regression test: chunk_tensordict must handle nested tensors where the ragged dimension is not the last one."""
+    topk = 64
+    elements = [torch.randn(5, topk), torch.randn(8, topk), torch.randn(3, topk), torch.randn(7, topk)]
+    teacher_logprobs = tu.nested_tensor_from_tensor_list(elements, ragged_idx=1)
+
+    input_ids = torch.nested.as_nested_tensor(
+        [torch.arange(5), torch.arange(8), torch.arange(3), torch.arange(7)], layout=torch.jagged
+    )
+    td = tu.get_tensordict({"input_ids": input_ids, "teacher_logprobs": teacher_logprobs})
+
+    chunks = tu.chunk_tensordict(td, chunks=2)
+
+    assert chunks[0]["teacher_logprobs"]._ragged_idx == 1
+    assert torch.equal(chunks[0]["teacher_logprobs"].unbind(0)[0], elements[0])
+    assert torch.equal(chunks[0]["teacher_logprobs"].unbind(0)[1], elements[1])
+    assert chunks[1]["teacher_logprobs"]._ragged_idx == 1
+    assert torch.equal(chunks[1]["teacher_logprobs"].unbind(0)[0], elements[2])
+    assert torch.equal(chunks[1]["teacher_logprobs"].unbind(0)[1], elements[3])
+
+
+def test_index_select_tensor_dict_preserves_3d_nested_tensor_layout_with_non_last_ragged_idx():
+    """Regression test: index_select_tensor_dict must handle nested tensors where the ragged dim is not the last."""
+    topk = 64
+    elements = [torch.randn(5, topk), torch.randn(8, topk), torch.randn(3, topk), torch.randn(7, topk)]
+    teacher_logprobs = tu.nested_tensor_from_tensor_list(elements, ragged_idx=1)
+    td = tu.get_tensordict({"teacher_logprobs": teacher_logprobs})
+
+    selected = tu.index_select_tensor_dict(td, torch.tensor([1, 3]))
+
+    assert selected["teacher_logprobs"]._ragged_idx == 1
+    assert torch.equal(selected["teacher_logprobs"].unbind(0)[0], elements[1])
+    assert torch.equal(selected["teacher_logprobs"].unbind(0)[1], elements[3])
+
+
 def test_assign_non_tensor_stack_with_nested_lists():
     """Test assign_non_tensor_stack with lists of lists."""
     td = tu.get_tensordict({"obs": torch.randn(3, 4)}, non_tensor_dict={})

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -164,15 +164,16 @@ def nested_tensor_from_tensor_list(tensors: list[torch.Tensor], ragged_idx: int 
     sample_dim = tensors[0].dim()
     if ragged_idx is None:
         ragged_idx = sample_dim
-    assert ragged_idx == sample_dim, (
-        f"Only last-dimension ragged tensors are supported. Got {ragged_idx=} and {sample_dim=}"
+    assert 1 <= ragged_idx <= sample_dim, (
+        f"ragged_idx must be in [1, {sample_dim}]. Got {ragged_idx=} and {sample_dim=}"
     )
 
     if sample_dim == 1:
         return torch.nested.as_nested_tensor(tensors, layout=torch.jagged)
 
-    values = torch.cat(tensors, dim=-1)
-    lengths = torch.tensor([tensor.shape[-1] for tensor in tensors], dtype=torch.long, device=values.device)
+    cat_dim = ragged_idx - 1
+    values = torch.cat(tensors, dim=cat_dim)
+    lengths = torch.tensor([tensor.shape[cat_dim] for tensor in tensors], dtype=torch.long, device=values.device)
     offsets = torch.zeros(len(tensors) + 1, dtype=torch.long, device=values.device)
     torch.cumsum(lengths, dim=0, out=offsets[1:])
 
@@ -213,7 +214,8 @@ def concat_nested_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
         unbind_tensor = tensor.unbind(0)
         unbind_tensors.extend(list(unbind_tensor))
 
-    return nested_tensor_from_tensor_list(unbind_tensors, ragged_idx=tensors[0].dim() - 1)
+    ragged_idx = getattr(tensors[0], "_ragged_idx", tensors[0].dim() - 1)
+    return nested_tensor_from_tensor_list(unbind_tensors, ragged_idx=ragged_idx)
 
 
 def concat_tensordict_with_none_bsz(data: list[TensorDict]):
@@ -358,12 +360,15 @@ def chunk_tensordict(td: TensorDict, chunks: int) -> list[TensorDict]:
             for i, chunk_td in enumerate(tds):
                 chunk_lengths = lengths[i * chunk_size : (i + 1) * chunk_size]
                 chunk_tensors = [padded_chunks[i][j, :seq_len] for j, seq_len in enumerate(chunk_lengths)]
-                chunk_td[key] = nested_tensor_from_tensor_list(chunk_tensors, ragged_idx=nt.dim() - 1)
+                chunk_td[key] = nested_tensor_from_tensor_list(
+                    chunk_tensors, ragged_idx=getattr(nt, "_ragged_idx", nt.dim() - 1)
+                )
             continue
 
         for i, chunk_td in enumerate(tds):
             chunk_td[key] = nested_tensor_from_tensor_list(
-                list(tensors[i * chunk_size : (i + 1) * chunk_size]), ragged_idx=nt.dim() - 1
+                list(tensors[i * chunk_size : (i + 1) * chunk_size]),
+                ragged_idx=getattr(nt, "_ragged_idx", nt.dim() - 1),
             )
 
     return tds
@@ -489,7 +494,9 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
             elif isinstance(tensor, torch.Tensor) and tensor.is_nested:
                 tensor_lst = tensor.unbind()  # for performance
                 selected_tensors = [tensor_lst[idx] for idx in indices]
-                data_dict[key] = nested_tensor_from_tensor_list(selected_tensors, ragged_idx=tensor.dim() - 1)
+                data_dict[key] = nested_tensor_from_tensor_list(
+                    selected_tensors, ragged_idx=getattr(tensor, "_ragged_idx", tensor.dim() - 1)
+                )
             else:
                 # This handles NonTensorStack (indexable by batch dim) and NonTensorData (scalar metadata).
                 if tensor.shape:


### PR DESCRIPTION


### What does this PR do?

Fixes #6152. Nested_tensor_from_tensor_list (introduced in #6127) hardcodes dim=-1 for torch.cat, assuming the ragged dimension is always the last one. This breaks for tensors like teacher_logprobs (batch, [seq_len], topk) where _ragged_idx=1.

Fix: use ragged_idx to determine the cat dimension, and read actual _ragged_idx from the nested tensor at all call sites instead of assuming dim()-1.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

ut

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
