### PR TITLE
Honor inference chat template history in ToolAgentLoop

### DIFF
--- a/docs/advance/agent_loop.rst
+++ b/docs/advance/agent_loop.rst
@@ -181,6 +181,26 @@ This inconsistency is not a big problem for serving/agent system, but is critica
 It causes the trajectory deviate from the policy model distribution. We have observed that apply_chat_template
 to the final chat history messages make PPO training not even converged in single-turn.
 
+Reasoning model history in tool agent loops
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For reasoning models, users may want later tool-agent turns to see previous
+assistant answers without previous hidden reasoning content. ``ToolAgentLoop``
+uses the flat token history by default, so rollout generation and training
+log-prob recomputation share the same causal context. This keeps the strict
+token-in/token-out behavior described above, but it can make long reasoning
+traces accumulate in later prompts.
+
+To match production-style chat-template behavior for later rollout turns, set
+``actor_rollout_ref.rollout.multi_turn.use_inference_chat_template=True``.
+With this option, ``ToolAgentLoop`` renders a structured generation message
+history through the model chat template for the prompt sent to the rollout
+server. The returned training trajectory remains the flat token sequence with
+``response_mask`` marking assistant-generated tokens as ``1`` and tool
+observations as ``0``. Exact training where later turns cannot attend to
+previous hidden reasoning while those reasoning tokens are still trained would
+require turn-segmented training or an equivalent attention-mask design.
+
 vLLM
 ^^^^
 

--- a/docs/sglang_multiturn/multiturn.rst
+++ b/docs/sglang_multiturn/multiturn.rst
@@ -302,6 +302,17 @@ We are still evaluating the impact of these issues. If you experience context le
 
 ``actor_rollout_ref.rollout.multi_turn.use_inference_chat_template = True``
 
+When using the experimental ``ToolAgentLoop``, this option controls the prompt
+ids sent to the rollout server for later turns. The loop keeps a structured
+generation message history and renders that history with the model chat
+template when this option is enabled. The recorded training trajectory remains
+the flat token sequence of generated assistant tokens and tool observation
+tokens, with ``response_mask`` set to ``1`` for assistant-generated tokens and
+``0`` for tool observations. Exact training where later turns cannot attend to
+previous hidden reasoning while those reasoning tokens are still trained would
+require a turn-segmented training representation or an equivalent attention-mask
+design.
+
 GSM8K Multi-turn Training Performance  
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
@@ -95,8 +95,9 @@ class FakeTokenizer:
 
 
 class FakeServerManager:
-    def __init__(self, response_texts: list[str]):
+    def __init__(self, response_texts: list[str], extra_fields: list[dict[str, Any]] | None = None):
         self.response_texts = list(response_texts)
+        self.extra_fields = list(extra_fields) if extra_fields is not None else None
         self.prompt_ids_history: list[list[int]] = []
 
     async def generate(
@@ -112,10 +113,15 @@ class FakeServerManager:
         self.prompt_ids_history.append(list(prompt_ids))
         response_text = self.response_texts.pop(0)
         token_ids = [ord(char) for char in response_text]
+        extra_fields = (
+            self.extra_fields.pop(0)
+            if self.extra_fields is not None
+            else {"global_steps": len(self.prompt_ids_history)}
+        )
         return TokenOutput(
             token_ids=token_ids,
             log_probs=[0.0] * len(token_ids),
-            extra_fields={"global_steps": len(self.prompt_ids_history)},
+            extra_fields=extra_fields,
         )
 
 
@@ -176,10 +182,14 @@ def _make_config(use_inference_chat_template: bool):
     )
 
 
-def _make_tool_agent_loop(use_inference_chat_template: bool, response_texts: list[str]):
+def _make_tool_agent_loop(
+    use_inference_chat_template: bool,
+    response_texts: list[str],
+    extra_fields: list[dict[str, Any]] | None = None,
+):
     config = _make_config(use_inference_chat_template)
     tokenizer = FakeTokenizer()
-    server_manager = FakeServerManager(response_texts)
+    server_manager = FakeServerManager(response_texts, extra_fields=extra_fields)
     loop = ToolAgentLoop(
         trainer_config=DictConfigWrap(config),
         server_manager=server_manager,
@@ -243,6 +253,24 @@ async def test_inference_chat_template_uses_generation_messages_without_previous
     assert output.extra_fields["use_inference_chat_template"] is True
     assert output.extra_fields["max_generation_prompt_length"] == len(server_manager.prompt_ids_history[1])
     assert raw_prompt == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_multi_round_generation_keeps_max_global_steps():
+    first_response = 'visible answer<tool_call>{"name":"calculator","arguments":{"a":3}}</tool_call>'
+    second_response = "final response"
+    loop, _, _ = _make_tool_agent_loop(
+        use_inference_chat_template=True,
+        response_texts=[first_response, second_response],
+        extra_fields=[
+            {"max_global_steps": 7, "min_global_steps": 7},
+            {"max_global_steps": 3, "min_global_steps": 3},
+        ],
+    )
+
+    output = await loop.run({}, raw_prompt=[{"role": "user", "content": "hello"}])
+
+    assert output.extra_fields["max_global_steps"] == 7
 
 
 @pytest.mark.asyncio

--- a/tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
@@ -1,0 +1,266 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.experimental.agent_loop.agent_loop import DictConfigWrap
+from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
+from verl.tools.schemas import (
+    OpenAIFunctionParametersSchema,
+    OpenAIFunctionPropertySchema,
+    OpenAIFunctionSchema,
+    OpenAIFunctionToolSchema,
+    ToolResponse,
+)
+from verl.utils.dataset.rl_dataset import RLHFDataset
+from verl.workers.rollout.replica import TokenOutput
+
+
+class FakeTokenizer:
+    pad_token = "<pad>"
+
+    def __init__(self):
+        self.chat_template_calls: list[dict[str, Any]] = []
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return [ord(char) for char in text]
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = True) -> str:
+        del skip_special_tokens
+        return "".join(chr(token_id) for token_id in ids)
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tokenize: bool = True,
+        add_generation_prompt: bool = True,
+        tools: list[dict[str, Any]] | None = None,
+        return_dict: bool = False,
+        **kwargs,
+    ) -> list[int] | str:
+        del return_dict, kwargs
+        rendered = self.render_messages(messages, tools=tools, add_generation_prompt=add_generation_prompt)
+        self.chat_template_calls.append(
+            {
+                "messages": json.loads(json.dumps(messages)),
+                "tools": json.loads(json.dumps(tools)) if tools is not None else None,
+                "rendered": rendered,
+            }
+        )
+        if not tokenize:
+            return rendered
+        return self.encode(rendered)
+
+    def render_messages(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        add_generation_prompt: bool = True,
+    ) -> str:
+        del tools
+        rendered_messages = []
+        for message in messages:
+            content = message.get("content", "")
+            if isinstance(content, list):
+                content = json.dumps(content, sort_keys=True)
+            if message.get("role") == "assistant":
+                content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL)
+            rendered = f"{message['role']}:{content}"
+            if message.get("tool_calls"):
+                rendered += f":tool_calls={json.dumps(message['tool_calls'], sort_keys=True)}"
+            rendered_messages.append(rendered)
+        if add_generation_prompt:
+            rendered_messages.append("assistant:")
+        return "|".join(rendered_messages)
+
+
+class FakeServerManager:
+    def __init__(self, response_texts: list[str]):
+        self.response_texts = list(response_texts)
+        self.prompt_ids_history: list[list[int]] = []
+
+    async def generate(
+        self,
+        request_id: str,
+        *,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        image_data: list[Any] | None = None,
+        video_data: list[Any] | None = None,
+    ) -> TokenOutput:
+        del request_id, sampling_params, image_data, video_data
+        self.prompt_ids_history.append(list(prompt_ids))
+        response_text = self.response_texts.pop(0)
+        token_ids = [ord(char) for char in response_text]
+        return TokenOutput(
+            token_ids=token_ids,
+            log_probs=[0.0] * len(token_ids),
+            extra_fields={"global_steps": len(self.prompt_ids_history)},
+        )
+
+
+@dataclass
+class FakeTool:
+    name: str = "calculator"
+
+    def __post_init__(self):
+        self.tool_schema = OpenAIFunctionToolSchema(
+            type="function",
+            function=OpenAIFunctionSchema(
+                name=self.name,
+                description="Calculator tool",
+                parameters=OpenAIFunctionParametersSchema(
+                    type="object",
+                    properties={"a": OpenAIFunctionPropertySchema(type="integer")},
+                    required=["a"],
+                ),
+            ),
+        )
+
+    async def create(self, create_kwargs=None):
+        del create_kwargs
+        return "instance", ToolResponse()
+
+    async def execute(self, instance_id, parameters, **kwargs):
+        del instance_id, parameters, kwargs
+        return ToolResponse(text="tool result"), 0.0, {}
+
+    async def release(self, instance_id):
+        del instance_id
+
+
+def _make_config(use_inference_chat_template: bool):
+    return OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "rollout": {
+                    "prompt_length": 256,
+                    "response_length": 512,
+                    "multi_turn": {
+                        "enable": True,
+                        "max_assistant_turns": None,
+                        "tool_config_path": None,
+                        "max_user_turns": None,
+                        "max_parallel_calls": 1,
+                        "max_tool_response_length": 256,
+                        "tool_response_truncate_side": "middle",
+                        "use_inference_chat_template": use_inference_chat_template,
+                        "tokenization_sanity_check_mode": "strict",
+                        "format": "hermes",
+                    },
+                },
+                "model": {},
+            },
+            "data": {"apply_chat_template_kwargs": {}},
+        }
+    )
+
+
+def _make_tool_agent_loop(use_inference_chat_template: bool, response_texts: list[str]):
+    config = _make_config(use_inference_chat_template)
+    tokenizer = FakeTokenizer()
+    server_manager = FakeServerManager(response_texts)
+    loop = ToolAgentLoop(
+        trainer_config=DictConfigWrap(config),
+        server_manager=server_manager,
+        tokenizer=tokenizer,
+        processor=None,
+        dataset_cls=RLHFDataset,
+        data_config=DictConfigWrap(config.data),
+    )
+    tool = FakeTool()
+    loop.tools = {tool.name: tool}
+    loop.tool_schemas = [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True)]
+    return loop, tokenizer, server_manager
+
+
+@pytest.mark.asyncio
+async def test_default_history_uses_flat_prompt_ids_for_generation():
+    response_text = "plain answer"
+    loop, tokenizer, server_manager = _make_tool_agent_loop(
+        use_inference_chat_template=False,
+        response_texts=[response_text],
+    )
+    raw_prompt = [{"role": "user", "content": "hello"}]
+
+    output = await loop.run({}, raw_prompt=raw_prompt)
+
+    expected_prompt = tokenizer.encode(tokenizer.render_messages(raw_prompt))
+    assert server_manager.prompt_ids_history == [expected_prompt]
+    assert output.response_ids == tokenizer.encode(response_text)
+    assert output.response_mask == [1] * len(output.response_ids)
+    assert output.extra_fields["use_inference_chat_template"] is False
+    assert output.extra_fields["generation_vs_flat_prompt_delta"] == 0
+    assert raw_prompt == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_inference_chat_template_uses_generation_messages_without_previous_reasoning():
+    first_response = (
+        '<think>secret scratchpad</think>visible answer<tool_call>{"name":"calculator","arguments":{"a":3}}</tool_call>'
+    )
+    second_response = "final response"
+    loop, tokenizer, server_manager = _make_tool_agent_loop(
+        use_inference_chat_template=True,
+        response_texts=[first_response, second_response],
+    )
+    raw_prompt = [{"role": "user", "content": "hello"}]
+
+    output = await loop.run({}, raw_prompt=raw_prompt)
+
+    assert len(server_manager.prompt_ids_history) == 2
+    second_prompt = tokenizer.decode(server_manager.prompt_ids_history[1])
+    assert "secret scratchpad" not in second_prompt
+    assert "visible answer" in second_prompt
+    assert "tool:tool result" in second_prompt
+    assert "tool_calls" in second_prompt
+    assert "calculator" in second_prompt
+
+    first_response_ids = tokenizer.encode(first_response)
+    assert output.response_ids[: len(first_response_ids)] == first_response_ids
+    assert output.response_mask[: len(first_response_ids)] == [1] * len(first_response_ids)
+    assert 0 in output.response_mask
+    assert output.extra_fields["use_inference_chat_template"] is True
+    assert output.extra_fields["max_generation_prompt_length"] == len(server_manager.prompt_ids_history[1])
+    assert raw_prompt == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_inference_chat_template_uses_active_tool_schemas():
+    response_text = "plain answer"
+    loop, tokenizer, _ = _make_tool_agent_loop(
+        use_inference_chat_template=True,
+        response_texts=[response_text],
+    )
+    unused_tool = FakeTool(name="unused")
+    loop.tools[unused_tool.name] = unused_tool
+    loop.tool_schemas.append(unused_tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True))
+
+    await loop.run(
+        {},
+        raw_prompt=[{"role": "user", "content": "hello"}],
+        extra_info={"tool_selection": ["calculator"]},
+    )
+
+    generation_call = tokenizer.chat_template_calls[-1]
+    assert [tool["function"]["name"] for tool in generation_call["tools"]] == ["calculator"]

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -60,6 +61,7 @@ class AgentData:
         tools_kwargs: dict[str, Any],
     ):
         self.messages = messages
+        self.generation_messages = list(messages)
         self.image_data = image_data
         self.video_data = video_data
         self.metrics = metrics
@@ -73,6 +75,7 @@ class AgentData:
         self.response_logprobs: list[float] = []
         self.turn_scores: list[float] = []
         self.tool_rewards: list[float] = []
+        self.seen_output_extra_fields = False
         self.user_turns = 0
         self.assistant_turns = 0
 
@@ -195,14 +198,74 @@ class ToolAgentLoop(AgentLoopBase):
         agent_data.prompt_ids = prompt_ids
         return AgentState.GENERATING
 
+    async def _get_generation_prompt_ids(self, agent_data: AgentData) -> list[int]:
+        """Return the prompt ids that should be sent to the rollout server for this turn."""
+        if not self.rollout_config.multi_turn.use_inference_chat_template:
+            return agent_data.prompt_ids
+
+        schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
+        return await self.apply_chat_template(
+            agent_data.generation_messages,
+            tools=schemas,
+            images=agent_data.image_data,
+            videos=agent_data.video_data,
+        )
+
+    def _record_generation_prompt_diagnostics(self, agent_data: AgentData, generation_prompt_ids: list[int]) -> None:
+        generation_prompt_length = len(generation_prompt_ids)
+        flat_token_history_length = len(agent_data.prompt_ids)
+        agent_data.extra_fields["use_inference_chat_template"] = (
+            self.rollout_config.multi_turn.use_inference_chat_template
+        )
+        agent_data.extra_fields["last_generation_prompt_length"] = generation_prompt_length
+        agent_data.extra_fields["max_generation_prompt_length"] = max(
+            agent_data.extra_fields.get("max_generation_prompt_length", 0),
+            generation_prompt_length,
+        )
+        agent_data.extra_fields["flat_token_history_length"] = flat_token_history_length
+        agent_data.extra_fields["generation_vs_flat_prompt_delta"] = (
+            generation_prompt_length - flat_token_history_length
+        )
+
+    def _build_assistant_tool_calls(
+        self, agent_data: AgentData, tool_calls: list[FunctionCall]
+    ) -> list[dict[str, Any]]:
+        """Convert parsed tool calls to the OpenAI-style shape expected by chat templates."""
+        formatted_tool_calls = []
+        for idx, tool_call in enumerate(tool_calls):
+            try:
+                arguments = json.loads(tool_call.arguments)
+            except (json.JSONDecodeError, TypeError):
+                arguments = tool_call.arguments
+            formatted_tool_calls.append(
+                {
+                    "id": f"call_{agent_data.request_id}_{agent_data.assistant_turns}_{idx}",
+                    "type": "function",
+                    "function": {
+                        "name": tool_call.name,
+                        "arguments": arguments,
+                    },
+                }
+            )
+        return formatted_tool_calls
+
+    def _append_generation_assistant_message(
+        self, agent_data: AgentData, content: str, tool_calls: list[FunctionCall]
+    ) -> None:
+        message: dict[str, Any] = {"role": "assistant", "content": content}
+        if tool_calls:
+            message["tool_calls"] = self._build_assistant_tool_calls(agent_data, tool_calls)
+        agent_data.generation_messages.append(message)
+
     async def _handle_generating_state(
         self, agent_data: AgentData, sampling_params: dict[str, Any], ignore_termination: bool = False
     ) -> AgentState:
         """Handle the generating state: generate model response and check for tool calls."""
+        generation_prompt_ids = await self._get_generation_prompt_ids(agent_data)
         with simple_timer("generate_sequences", agent_data.metrics):
             output: TokenOutput = await self.server_manager.generate(
                 request_id=agent_data.request_id,
-                prompt_ids=agent_data.prompt_ids,
+                prompt_ids=generation_prompt_ids,
                 sampling_params=sampling_params,
                 image_data=agent_data.image_data,
                 video_data=agent_data.video_data,
@@ -214,13 +277,15 @@ class ToolAgentLoop(AgentLoopBase):
         else:
             agent_data.metrics["num_preempted"] += output.num_preempted if output.num_preempted is not None else 0
 
-        if not agent_data.extra_fields:
+        if output.extra_fields and not agent_data.seen_output_extra_fields:
             agent_data.extra_fields.update(output.extra_fields)
-        else:
+            agent_data.seen_output_extra_fields = True
+        elif output.extra_fields:
             # Multi-round calls, only update the maximum max_global_steps.
             max_global_steps = output.extra_fields.get("max_global_steps", None)
             if max_global_steps:
                 agent_data.extra_fields["max_global_steps"] = max_global_steps
+        self._record_generation_prompt_diagnostics(agent_data, generation_prompt_ids)
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
@@ -243,7 +308,8 @@ class ToolAgentLoop(AgentLoopBase):
         # Extract tool calls (use per-sample tools if routed)
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
-        _, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        self._append_generation_assistant_message(agent_data, content, agent_data.tool_calls)
 
         if agent_data.tool_calls:
             return AgentState.PROCESSING_TOOLS
@@ -315,6 +381,7 @@ class ToolAgentLoop(AgentLoopBase):
                 agent_data.tool_rewards.append(tool_reward)
 
         agent_data.messages.extend(add_messages)
+        agent_data.generation_messages.extend(copy.deepcopy(add_messages))
 
         if self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -283,8 +283,13 @@ class ToolAgentLoop(AgentLoopBase):
         elif output.extra_fields:
             # Multi-round calls, only update the maximum max_global_steps.
             max_global_steps = output.extra_fields.get("max_global_steps", None)
-            if max_global_steps:
-                agent_data.extra_fields["max_global_steps"] = max_global_steps
+            if max_global_steps is not None:
+                current_max_global_steps = agent_data.extra_fields.get("max_global_steps", None)
+                agent_data.extra_fields["max_global_steps"] = (
+                    max_global_steps
+                    if current_max_global_steps is None
+                    else max(current_max_global_steps, max_global_steps)
+                )
         self._record_generation_prompt_diagnostics(agent_data, generation_prompt_ids)
 
         agent_data.assistant_turns += 1

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -188,7 +188,9 @@ multi_turn:
   # truncate side of tool response: left, middle, right
   tool_response_truncate_side: middle
 
-  # - When set to True, the model's default chat template is used for multi-turn rollout, which typically matches production behavior.
+  # - When set to True, the model's default chat template is used for multi-turn rollout,
+  #   including ToolAgentLoop generation prompts. This typically matches production behavior
+  #   and may omit previous hidden reasoning content for reasoning-model templates.
   # - When set to False, the token ids recorded for training are used instead; unlike the default chat template, these always include the model's full output,
   #   which may contain additional content such as reasoning content. This maintains the consistency between training and rollout, but it will lead to longer prompts.
   use_inference_chat_template: False

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -81,6 +81,8 @@ class MultiTurnConfig(BaseConfig):
     max_parallel_calls: int = 1
     max_tool_response_length: int = 256
     tool_response_truncate_side: str = "middle"
+    # Use rendered inference chat history for multi-turn generation prompts.
+    # Default keeps flat training-token history as generation context.
     use_inference_chat_template: bool = False
     tokenization_sanity_check_mode: str = "strict"
     format: str = "hermes"


### PR DESCRIPTION
## Summary

Fixes #4109.

This PR makes `ToolAgentLoop` honor `multi_turn.use_inference_chat_template` for generation prompts while preserving the existing flat token trajectory used for training. In opt-in mode, each generation step is rendered from a structured generation-only message history, so model-specific chat templates can omit prior hidden reasoning while still keeping tool calls, tool responses, multimodal inputs, and active tool schemas available to inference.

Key changes:

- Add a separate `generation_messages` history for generation prompt rendering.
- Re-render generation prompts through the existing inference chat template path when `multi_turn.use_inference_chat_template=true`.
- Preserve `prompt_ids`, `response_ids`, `response_mask`, and `response_logprobs` as the flat training trajectory.
- Keep parsed assistant tool calls and tool responses available in generation history.
- Add rollout diagnostics for flat-vs-generation prompt lengths.
- Document the behavior and the remaining exact segmented-training limitation.
- Add CPU coverage for flat history, inference-template history, tool-call preservation, tool response masking, and active tool schema selection.

## Root Cause

`use_inference_chat_template` existed in config, but `ToolAgentLoop` continued to send the accumulated flat token trajectory directly to the inference server. For reasoning models that expose hidden reasoning tokens in generated text, that meant old reasoning could be re-fed into later generation turns even when the tokenizer/chat template would otherwise remove it from assistant history.

## Duplicate-Work Check

Before opening this PR, I ran the required duplicate-work checks:

```bash
gh issue view 4109 --repo verl-project/verl --comments
gh pr list --repo verl-project/verl --state open --search "4109 in:body"
gh pr list --repo verl-project/verl --state open --search "reasoning history tool agent loop inference chat template"
```

The two PR searches returned no open PRs, so this is not duplicating an existing open PR.

## Validation

```bash
PYTHONPATH=. uv run --no-sync pytest tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
PYTHONPATH=. uv run --no-sync pytest tests/experimental/agent_loop/test_call_tool_on_cpu.py tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
uv run --no-sync ruff check verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
uv run --no-sync ruff format --check verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
/usr/local/bin/python3 -m py_compile verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_history_on_cpu.py
git diff --check
```

Results:

- `3 passed` for the new history tests.
- `8 passed` for adjacent agent-loop CPU tests.
- Ruff check and format check passed.
- Python compile passed.
- Diff whitespace check passed.

I did not run the heavier model/backend integration test because it requires full runtime backend/model availability beyond this local CPU validation pass.
