### PR TITLE
Improve GSM8K reward data_source diagnostics

### DIFF
--- a/docs/examples/gsm8k_example.rst
+++ b/docs/examples/gsm8k_example.rst
@@ -48,6 +48,14 @@ Step 1: Prepare dataset
    cd examples/data_preprocess
    python3 gsm8k.py --local_save_dir ~/data/gsm8k
 
+.. note::
+
+   The generated parquet uses ``data_source = "openai/gsm8k"`` to select the
+   built-in GSM8K reward function. Keep this value even if the raw dataset was
+   downloaded from a local path or mirror. If you use another source name,
+   configure ``reward.custom_reward_function.path`` and
+   ``reward.custom_reward_function.name``.
+
 Step 2: Download Model
 ----------------------
 

--- a/docs/preparation/prepare_data.rst
+++ b/docs/preparation/prepare_data.rst
@@ -86,6 +86,15 @@ In the ``make_map_fn``, each data field should consist of the following
 5. ``extra_info``: Record some information of the current prompt. Not
    use for now.
 
+.. note::
+
+   ``data_source`` is a logical reward-function key, not necessarily the
+   physical dataset path. For the built-in GSM8K reward function, keep
+   ``data_source`` as ``openai/gsm8k`` even if the raw dataset was loaded from a
+   local directory or mirror. If you use a custom source name, configure
+   ``reward.custom_reward_function.path`` and
+   ``reward.custom_reward_function.name``.
+
 .. code:: python
 
    def extract_solution(solution_str):

--- a/docs/start/quickstart.rst
+++ b/docs/start/quickstart.rst
@@ -48,6 +48,27 @@ We preprocess the dataset in parquet format so that (1) it contains necessary fi
 
    python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k
 
+.. note::
+
+   The ``data_source`` column in the generated parquet is used to select the
+   rule-based reward function. For the built-in GSM8K reward, keep this value
+   as ``openai/gsm8k`` even if the raw dataset was loaded from a local path or
+   mirror. If you use a custom dataset identifier, configure
+   ``reward.custom_reward_function.path`` and
+   ``reward.custom_reward_function.name``.
+
+   To inspect the generated parquet:
+
+   .. code-block:: python
+
+      import os
+      import pandas as pd
+
+      path = os.path.expanduser("~/data/gsm8k/train.parquet")
+      df = pd.read_parquet(path)
+      print(df["data_source"].drop_duplicates().head())
+      print(df[["data_source", "reward_model"]].head(1).to_dict("records"))
+
 Step 2: Download a model for post-training
 -------------------------------------------
 
@@ -70,7 +91,7 @@ answer from both the solution and model's output using regular
 expression matching. We assign a reward of 1 to correct
 answer, 0.0 to incorrect answer and 0 to no answer. 
 
-For more details, please refer to `verl/utils/reward_score/gsm8k.py <https://github.com/verl-project/verl/blob/v0.4.1/verl/utils/reward_score/gsm8k.py>`_.
+For more details, please refer to `verl/utils/reward_score/gsm8k.py <https://github.com/verl-project/verl/blob/main/verl/utils/reward_score/gsm8k.py>`_.
 
 **Training Script**
 

--- a/examples/sglang_multiturn/README.md
+++ b/examples/sglang_multiturn/README.md
@@ -13,6 +13,12 @@ python3 gsm8k_multiturn_w_tool.py
 
 This will download and preprocess the GSM8K dataset into ~/data/gsm8k/.
 
+The generated parquet keeps `data_source` as `openai/gsm8k`, which is the
+logical key used by the built-in GSM8K reward function. Keep that value even if
+the raw dataset comes from a local path or mirror. If you use another
+`data_source`, configure `reward.custom_reward_function.path` and
+`reward.custom_reward_function.name`.
+
 ### Step 2: Run Multi-Turn Rollout
 
 If you have 8 GPUs

--- a/tests/experimental/reward_loop/test_reward_manager_data_source_on_cpu.py
+++ b/tests/experimental/reward_loop/test_reward_manager_data_source_on_cpu.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+from verl import DataProto
+from verl.experimental.reward_loop.reward_manager.limited import RateLimitedRewardManager
+from verl.experimental.reward_loop.reward_manager.naive import NaiveRewardManager
+
+
+class FakeTokenizer:
+    def decode(self, token_ids, skip_special_tokens=True):
+        return "reasoning #### 42"
+
+
+def _make_reward_batch(data_source_marker):
+    non_tensors = {
+        "reward_model": np.array([{"style": "rule", "ground_truth": "42"}], dtype=object),
+        "extra_info": np.array([{"split": "train", "index": 7}], dtype=object),
+    }
+    if data_source_marker != "missing":
+        non_tensors["data_source"] = np.array([data_source_marker], dtype=object)
+
+    return DataProto.from_dict(
+        tensors={
+            "prompts": torch.tensor([[1, 2]], dtype=torch.long),
+            "responses": torch.tensor([[3, 4, 0]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 0]], dtype=torch.long),
+        },
+        non_tensors=non_tensors,
+    )
+
+
+@pytest.mark.parametrize(
+    ("data_source_marker", "reason"),
+    [
+        ("missing", "missing"),
+        ("", "empty"),
+        ("   ", "empty"),
+    ],
+)
+@pytest.mark.parametrize("manager_cls", [NaiveRewardManager, RateLimitedRewardManager])
+def test_reward_manager_rejects_missing_or_empty_data_source(manager_cls, data_source_marker, reason):
+    called = False
+
+    def compute_score(**kwargs):
+        nonlocal called
+        called = True
+        return 1.0
+
+    manager = manager_cls(config=None, tokenizer=FakeTokenizer(), compute_score=compute_score)
+    batch = _make_reward_batch(data_source_marker)
+
+    with pytest.raises(ValueError) as exc_info:
+        manager.loop.run_until_complete(manager.run_single(batch))
+
+    message = str(exc_info.value)
+    assert f"Reward data source is {reason}" in message
+    assert "openai/gsm8k" in message
+    assert "examples/data_preprocess/gsm8k.py" in message
+    assert "reward.custom_reward_function.path" in message
+    assert "split='train'" in message
+    assert "index=7" in message
+    assert not called

--- a/tests/utils/reward_score/test_default_compute_score_on_cpu.py
+++ b/tests/utils/reward_score/test_default_compute_score_on_cpu.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.utils.reward_score import default_compute_score
+
+
+def test_gsm8k_default_reward_scores_correct_answer():
+    assert default_compute_score("openai/gsm8k", "reasoning #### 42", "42") == 1.0
+
+
+def test_gsm8k_default_reward_scores_incorrect_answer():
+    assert default_compute_score("openai/gsm8k", "reasoning #### 41", "42") == 0.0
+
+
+@pytest.mark.parametrize("data_source", ["", "   ", None, "/some/path/gsm8k"])
+def test_unsupported_reward_source_error_is_actionable(data_source):
+    with pytest.raises(NotImplementedError) as exc_info:
+        default_compute_score(data_source, "reasoning #### 42", "42")
+
+    message = str(exc_info.value)
+    assert f"data_source={data_source!r}" in message
+    assert "openai/gsm8k" in message
+    assert "examples/data_preprocess/gsm8k.py" in message
+    assert "reward.custom_reward_function.path" in message

--- a/verl/experimental/reward_loop/reward_manager/base.py
+++ b/verl/experimental/reward_loop/reward_manager/base.py
@@ -53,6 +53,36 @@ class RewardManagerBase(ABC):
             return
         cls._class_initialized = True
 
+    def _require_data_source(self, data_item: Any) -> Any:
+        non_tensor_batch = data_item.non_tensor_batch or {}
+        if "data_source" not in non_tensor_batch:
+            self._raise_data_source_error("missing", data_item)
+
+        data_source = non_tensor_batch["data_source"]
+        if data_source is None or (isinstance(data_source, str) and data_source.strip() == ""):
+            self._raise_data_source_error("empty", data_item)
+        return data_source
+
+    def _raise_data_source_error(self, reason: str, data_item: Any):
+        non_tensor_batch = data_item.non_tensor_batch or {}
+        extra_info = non_tensor_batch.get("extra_info", {})
+        context = []
+        if isinstance(extra_info, dict):
+            for key in ("split", "index"):
+                if key in extra_info:
+                    context.append(f"{key}={extra_info[key]!r}")
+
+        message = (
+            f"Reward data source is {reason}. The non-tensor batch field `data_source` selects the rule-based "
+            "reward function. For the GSM8K quickstart, regenerate the parquet files with "
+            "`python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k` and keep "
+            "`data_source` as `openai/gsm8k`. For custom datasets, configure "
+            "`reward.custom_reward_function.path` and `reward.custom_reward_function.name`."
+        )
+        if context:
+            message += f" Sample context: {', '.join(context)}."
+        raise ValueError(message)
+
     @abstractmethod
     async def run_single(self, data: DataProto):
         raise NotImplementedError

--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -57,7 +57,7 @@ class DAPORewardManager(RewardManagerBase):
         valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
         valid_response_ids = response_ids[:valid_response_length]
 
-        data_source = data_item.non_tensor_batch["data_source"]
+        data_source = self._require_data_source(data_item)
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
         extra_info = data_item.non_tensor_batch.get("extra_info", {})
 

--- a/verl/experimental/reward_loop/reward_manager/gdpo.py
+++ b/verl/experimental/reward_loop/reward_manager/gdpo.py
@@ -40,7 +40,7 @@ class GDPORewardManager(RewardManagerBase):
         valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
         valid_response_ids = response_ids[:valid_response_length]
 
-        data_source = data_item.non_tensor_batch["data_source"]
+        data_source = self._require_data_source(data_item)
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
         extra_info = data_item.non_tensor_batch.get("extra_info", {})
         extra_info["experiment_name"] = self.config.trainer.experiment_name

--- a/verl/experimental/reward_loop/reward_manager/limited.py
+++ b/verl/experimental/reward_loop/reward_manager/limited.py
@@ -404,7 +404,7 @@ class RateLimitedRewardManager(RewardManagerBase):
         valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
         valid_response_ids = response_ids[:valid_response_length]
 
-        data_source = data_item.non_tensor_batch["data_source"]
+        data_source = self._require_data_source(data_item)
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
         extra_info = data_item.non_tensor_batch.get("extra_info", {})
         tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)

--- a/verl/experimental/reward_loop/reward_manager/naive.py
+++ b/verl/experimental/reward_loop/reward_manager/naive.py
@@ -39,7 +39,7 @@ class NaiveRewardManager(RewardManagerBase):
         valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
         valid_response_ids = response_ids[:valid_response_length]
 
-        data_source = data_item.non_tensor_batch["data_source"]
+        data_source = self._require_data_source(data_item)
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
         extra_info = data_item.non_tensor_batch.get("extra_info", {})
         tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)

--- a/verl/experimental/reward_loop/reward_manager/remote.py
+++ b/verl/experimental/reward_loop/reward_manager/remote.py
@@ -80,7 +80,7 @@ class RemoteRewardManager(RewardManagerBase):
         valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
         valid_response_ids = response_ids[:valid_response_length]
 
-        data_source = data_item.non_tensor_batch["data_source"]
+        data_source = self._require_data_source(data_item)
         ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
         extra_info = data_item.non_tensor_batch.get("extra_info", {})
         tool_extra_fields = data_item.non_tensor_batch.get("tool_extra_fields", None)

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -15,6 +15,75 @@
 
 from verl.utils.import_utils import deprecated
 
+_GSM8K_DATA_SOURCE = "openai/gsm8k"
+_GSM8K_PREPROCESS_CMD = "python3 examples/data_preprocess/gsm8k.py --local_save_dir ~/data/gsm8k"
+
+_SUPPORTED_REWARD_DATA_SOURCES = {
+    _GSM8K_DATA_SOURCE: "GSM8K rule reward",
+    "lighteval/MATH": "MATH rule reward",
+    "DigitalLearningGmbH/MATH-lighteval": "MATH rule reward",
+    "HuggingFaceH4/MATH-500": "MATH rule reward",
+    "math_dapo": "DAPO math rule reward",
+    "math": "DAPO math rule reward",
+    "math_dapo_reasoning": "DAPO math rule reward",
+    "aime*": "AIME-style math rule reward",
+    "numina_aops_forum": "Prime math reward",
+    "numina_synthetic_math": "Prime math reward",
+    "numina_amc_aime": "Prime math reward",
+    "numina_synthetic_amc": "Prime math reward",
+    "numina_cn_k12": "Prime math reward",
+    "numina_olympiads": "Prime math reward",
+    "codecontests": "Code reward",
+    "apps": "Code reward",
+    "codeforces": "Code reward",
+    "taco": "Code reward",
+    "hiyouga/geometry3k": "Geo3K rule reward",
+    "searchR1_nq": "SearchR1 QA reward",
+    "searchR1_triviaqa": "SearchR1 QA reward",
+    "searchR1_popqa": "SearchR1 QA reward",
+    "searchR1_hotpotqa": "SearchR1 QA reward",
+    "searchR1_2wikimultihopqa": "SearchR1 QA reward",
+    "searchR1_musique": "SearchR1 QA reward",
+    "searchR1_bamboogle": "SearchR1 QA reward",
+}
+
+
+def _format_supported_data_sources() -> str:
+    return ", ".join(sorted(_SUPPORTED_REWARD_DATA_SOURCES))
+
+
+def _looks_like_gsm8k_or_path(data_source) -> bool:
+    if data_source is None:
+        return True
+    data_source_str = str(data_source).strip()
+    if not data_source_str:
+        return True
+    normalized = data_source_str.lower()
+    return "gsm8k" in normalized or data_source_str.startswith(("/", "./", "../", "~")) or "\\" in data_source_str
+
+
+def _raise_unsupported_data_source(data_source):
+    message_parts = [
+        f"Reward function is not implemented for data_source={data_source!r}.",
+        f"Supported built-in reward data sources include: {_format_supported_data_sources()}.",
+    ]
+    if _looks_like_gsm8k_or_path(data_source):
+        message_parts.append(
+            "If you are running the GSM8K quickstart, regenerate the parquet files with "
+            f"`{_GSM8K_PREPROCESS_CMD}` and keep the emitted "
+            f"`data_source` value as `{_GSM8K_DATA_SOURCE}`. Do not replace it with a local dataset path "
+            "or mirror name."
+        )
+    message_parts.append(
+        "For custom datasets or custom data_source values, configure "
+        "`reward.custom_reward_function.path` and `reward.custom_reward_function.name`."
+    )
+    raise NotImplementedError(" ".join(message_parts))
+
+
+def _is_aime_data_source(data_source) -> bool:
+    return isinstance(data_source, str) and data_source.startswith("aime")
+
 
 def default_compute_score(
     data_source,
@@ -41,7 +110,7 @@ def default_compute_score(
     Raises:
         NotImplementedError: If the reward function is not implemented for the given data source.
     """
-    if data_source == "openai/gsm8k":
+    if data_source == _GSM8K_DATA_SOURCE:
         from . import gsm8k
 
         res = gsm8k.compute_score(solution_str, ground_truth)
@@ -56,7 +125,7 @@ def default_compute_score(
 
         # from . import math_verify
         # res = math_verify.compute_score(solution_str, ground_truth)
-    elif data_source in ["math_dapo", "math", "math_dapo_reasoning"] or data_source.startswith("aime"):
+    elif data_source in ["math_dapo", "math", "math_dapo_reasoning"] or _is_aime_data_source(data_source):
         from . import math_dapo
 
         res = math_dapo.compute_score(solution_str, ground_truth)
@@ -104,7 +173,7 @@ def default_compute_score(
         res = search_r1_like_qa_em.compute_score(solution_str, ground_truth)
 
     else:
-        raise NotImplementedError(f"Reward function is not implemented for {data_source=}")
+        _raise_unsupported_data_source(data_source)
 
     if isinstance(res, dict):
         return res


### PR DESCRIPTION
## Summary

Fixes #3450.

This PR improves the diagnostics around rule-based reward dispatch when `data_source` is missing, empty, or set to a value that does not map to a built-in reward function.

- Add actionable `default_compute_score` errors that show supported built-in reward `data_source` keys, GSM8K quickstart recovery steps, and the custom reward function config path.
- Add early missing/empty `data_source` validation for text reward-loop managers (`naive`, `dapo`, `gdpo`, `remote`, and `rate_limited`) so users see a clear configuration/data-preparation error before reward computation starts.
- Clarify in the GSM8K and data-preparation docs that `data_source` is a logical reward-function key and should remain `openai/gsm8k` for the built-in GSM8K reward, even if the raw dataset came from a local path or mirror.
- Add focused CPU tests for GSM8K default reward scoring, actionable unsupported-source errors, and reward-manager validation.

## Root Cause

The GSM8K quickstart preprocessing emits `data_source = "openai/gsm8k"`, which is how the built-in reward dispatcher selects `verl.utils.reward_score.gsm8k`. If that column is blank, missing, or overwritten with a local dataset path or mirror name, the dispatcher falls through to a terse `NotImplementedError` and does not explain how to recover.

## Duplicate Work Check

This is not duplicating an existing open PR:

- `gh issue view 3450 --repo verl-project/verl --comments`
- `gh pr list --repo verl-project/verl --state open --search "3450 in:body"` returned no open PRs.
- `gh pr list --repo verl-project/verl --state open --search "reward data_source GSM8K diagnostics"` returned no open PRs.
- `gh pr list --repo verl-project/verl --state open --search "default_compute_score data_source GSM8K"` returned no open PRs.
- `gh pr list --repo verl-project/verl --state open --search "Reward function is not implemented data_source"` surfaced #2854, which is an async reward-agent recipe and does not address the GSM8K quickstart diagnostic path fixed here.

## Validation

- `/tmp/verl-issue-3450-review-venv/bin/python -m pytest tests/utils/reward_score/test_default_compute_score_on_cpu.py tests/experimental/reward_loop/test_reward_manager_data_source_on_cpu.py -q`  
  Result: `12 passed, 2 warnings`
- `/tmp/verl-issue-3450-review-venv/bin/ruff check verl/utils/reward_score/__init__.py verl/experimental/reward_loop/reward_manager/base.py verl/experimental/reward_loop/reward_manager/naive.py verl/experimental/reward_loop/reward_manager/dapo.py verl/experimental/reward_loop/reward_manager/gdpo.py verl/experimental/reward_loop/reward_manager/remote.py verl/experimental/reward_loop/reward_manager/limited.py tests/utils/reward_score/test_default_compute_score_on_cpu.py tests/experimental/reward_loop/test_reward_manager_data_source_on_cpu.py`  
  Result: passed
- `git diff --check`  
  Result: passed
- `PATH=/tmp/verl-issue-3450-review-venv/bin:$PATH /tmp/verl-issue-3450-review-venv/bin/pre-commit run --files ...` on the changed files  
  Result: passed, including ruff, ruff-format, mypy, generated config check, docs checks, license, naming, and compileall
