### PR TITLE
[algo] test DrGRPO loss aggregation semantics

### DIFF
--- a/docs/algo/grpo.md
+++ b/docs/algo/grpo.md
@@ -38,7 +38,7 @@ Despite that many configurations start with the `ppo_` prefix, they work across 
 
 - `algorithm.adv_estimator`: Default is gae. Please set it to grpo instead
 
-- `actor_rollout_ref.actor.loss_agg_mode`: Default is "token-mean". Options include "token-mean", "seq-mean-token-sum", "seq-mean-token-mean". The original GRPO paper takes the sample-level loss (seq-mean-token-mean), which may be unstable in long-CoT scenarios. All GRPO example scripts provided in verl uses the default configuration "token-mean" for loss aggregation instead.
+- `actor_rollout_ref.actor.loss_agg_mode`: Default is "token-mean". Options include "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", and "seq-mean-token-sum-norm". The original GRPO paper takes the sample-level loss (seq-mean-token-mean), which may be unstable in long-CoT scenarios. All GRPO example scripts provided in verl uses the default configuration "token-mean" for loss aggregation instead.
 
 Instead of adding KL penalty in the reward, GRPO regularizes by directly adding the KL divergence between the trained policy and the reference policy to the loss:
 
@@ -56,7 +56,7 @@ Instead of adding KL penalty in the reward, GRPO regularizes by directly adding 
 
 Configure the following to enable DrGRPO, with all other parameters the same as GRPO's:
 
-- `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which turns off seq-dim averaging
+- `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which sums token losses per response, averages those response-level sums over the global PPO mini-batch, and divides by a response-length normalizer. In formula form, this is `L = (1 / B) * sum_i [sum_t L_it * mask_it] / C`, where `B` is the global PPO mini-batch sequence count and `C` is the normalizer.
 - `actor_rollout_ref.actor.loss_scale_factor`: (Optional) Set to a constant integer (e.g., max response length) to ensure consistent normalization throughout training. If not set, uses the current batch's response length.
 - `actor_rollout_ref.actor.use_kl_loss`: Please set it to False for DrGRPO
 - `algorithm.norm_adv_by_std_in_grpo`: False, which turns off standard deviation norm

--- a/examples/grpo_trainer/README.md
+++ b/examples/grpo_trainer/README.md
@@ -36,7 +36,7 @@ Despite that many configurations start with the `ppo_` prefix, they work across 
 
 - `algorithm.adv_estimator`: Default is gae. Please set it to grpo instead
 
-- `actor_rollout_ref.actor.loss_agg_mode`: Default is "token-mean". Options include "token-mean", "seq-mean-token-sum", "seq-mean-token-mean". The original GRPO paper takes the sample-level loss (seq-mean-token-mean), which may be unstable in long-CoT scenarios. All GRPO example scripts provided in verl uses the default configuration "token-mean" for loss aggregation instead.
+- `actor_rollout_ref.actor.loss_agg_mode`: Default is "token-mean". Options include "token-mean", "seq-mean-token-sum", "seq-mean-token-mean", and "seq-mean-token-sum-norm". The original GRPO paper takes the sample-level loss (seq-mean-token-mean), which may be unstable in long-CoT scenarios. All GRPO example scripts provided in verl uses the default configuration "token-mean" for loss aggregation instead.
 
 Instead of adding KL penalty in the reward, GRPO regularizes by directly adding the KL divergence between the trained policy and the reference policy to the loss:
 
@@ -54,7 +54,7 @@ The work [Understanding R1-Zero-Like Training: A Critical Perspective](https://a
 
 Configure the following to enable DrGRPO, with all other parameters the same as GRPO's:
 
-- `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which turns off seq-dim averaging
+- `actor_rollout_ref.actor.loss_agg_mode`: "seq-mean-token-sum-norm", which sums token losses per response, averages those response-level sums over the global PPO mini-batch, and divides by a response-length normalizer. In formula form, this is `L = (1 / B) * sum_i [sum_t L_it * mask_it] / C`, where `B` is the global PPO mini-batch sequence count and `C` is the normalizer.
 - `actor_rollout_ref.actor.loss_scale_factor`: (Optional) Set to a constant integer (e.g., max response length) to ensure consistent normalization throughout training. If not set, uses the current batch's response length.
 - `actor_rollout_ref.actor.use_kl_loss`: Please set it to False for DrGRPO
 - `algorithm.norm_adv_by_std_in_grpo`: False, which turns off standard deviation norm

--- a/tests/trainer/ppo/test_loss_aggregation_on_cpu.py
+++ b/tests/trainer/ppo/test_loss_aggregation_on_cpu.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import agg_loss
+
+
+def _drgrpo_oracle(loss_mat: torch.Tensor, loss_mask: torch.Tensor, normalizer: int, batch_size: int):
+    seq_losses = torch.sum(loss_mat * loss_mask, dim=-1)
+    seq_mask = torch.sum(loss_mask, dim=-1) > 0
+    return torch.sum(seq_losses[seq_mask]) / (batch_size * normalizer)
+
+
+def test_seq_mean_token_sum_norm_matches_single_dp_oracle():
+    loss_mat = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+        ]
+    )
+    loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+
+    loss = agg_loss(loss_mat, loss_mask, loss_agg_mode="seq-mean-token-sum-norm")
+    expected = _drgrpo_oracle(loss_mat, loss_mask, normalizer=loss_mask.shape[-1], batch_size=3)
+
+    torch.testing.assert_close(loss, expected)
+
+
+def test_seq_mean_token_sum_norm_respects_loss_scale_factor():
+    loss_mat = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+        ]
+    )
+    loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    loss_scale_factor = 10
+
+    loss = agg_loss(
+        loss_mat,
+        loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        loss_scale_factor=loss_scale_factor,
+    )
+    expected = _drgrpo_oracle(loss_mat, loss_mask, normalizer=loss_scale_factor, batch_size=3)
+
+    torch.testing.assert_close(loss, expected)
+
+
+def test_seq_mean_token_sum_norm_gradient_scale():
+    loss_mat = torch.tensor(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, 11.0, 12.0],
+        ],
+        requires_grad=True,
+    )
+    loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    loss_scale_factor = 8
+
+    loss = agg_loss(
+        loss_mat,
+        loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        loss_scale_factor=loss_scale_factor,
+    )
+    loss.backward()
+
+    expected_grad = loss_mask / (loss_mask.shape[0] * loss_scale_factor)
+    torch.testing.assert_close(loss_mat.grad, expected_grad)
+
+
+def test_seq_mean_token_sum_norm_dp_average_matches_full_batch():
+    full_loss_mat = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ],
+        requires_grad=True,
+    )
+    full_loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 0.0, 1.0],
+        ]
+    )
+    loss_scale_factor = 6
+
+    full_loss = agg_loss(
+        full_loss_mat,
+        full_loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        loss_scale_factor=loss_scale_factor,
+    )
+    full_loss.backward()
+
+    rank0_loss_mat = full_loss_mat[:2].detach().clone().requires_grad_(True)
+    rank1_loss_mat = full_loss_mat[2:].detach().clone().requires_grad_(True)
+    rank0_loss_mask = full_loss_mask[:2]
+    rank1_loss_mask = full_loss_mask[2:]
+
+    rank0_loss = agg_loss(
+        rank0_loss_mat,
+        rank0_loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        dp_size=2,
+        global_batch_size=full_loss_mask.shape[0],
+        loss_scale_factor=loss_scale_factor,
+    )
+    rank1_loss = agg_loss(
+        rank1_loss_mat,
+        rank1_loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        dp_size=2,
+        global_batch_size=full_loss_mask.shape[0],
+        loss_scale_factor=loss_scale_factor,
+    )
+    averaged_rank_loss = (rank0_loss + rank1_loss) / 2
+    averaged_rank_loss.backward()
+
+    torch.testing.assert_close(averaged_rank_loss, full_loss.detach())
+    rank_grad = torch.cat([rank0_loss_mat.grad, rank1_loss_mat.grad], dim=0)
+    torch.testing.assert_close(rank_grad, full_loss_mat.grad)
+
+
+def test_seq_mean_token_sum_norm_rejects_missing_global_batch_for_dp():
+    loss_mat = torch.ones(2, 4)
+    loss_mask = torch.ones(2, 4)
+
+    with pytest.raises(ValueError, match="global_batch_size is required"):
+        agg_loss(loss_mat, loss_mask, loss_agg_mode="seq-mean-token-sum-norm", dp_size=2)
+
+
+def test_seq_mean_token_sum_norm_empty_rows_are_explicit():
+    loss_mat = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+        ]
+    )
+    loss_mask = torch.tensor(
+        [
+            [1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+        ]
+    )
+    loss_scale_factor = 3
+
+    fallback_loss = agg_loss(
+        loss_mat,
+        loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        loss_scale_factor=loss_scale_factor,
+    )
+    explicit_global_loss = agg_loss(
+        loss_mat,
+        loss_mask,
+        loss_agg_mode="seq-mean-token-sum-norm",
+        global_batch_size=loss_mask.shape[0],
+        loss_scale_factor=loss_scale_factor,
+    )
+
+    non_empty_row_count = 2
+    fallback_expected = _drgrpo_oracle(
+        loss_mat,
+        loss_mask,
+        normalizer=loss_scale_factor,
+        batch_size=non_empty_row_count,
+    )
+    explicit_expected = _drgrpo_oracle(
+        loss_mat,
+        loss_mask,
+        normalizer=loss_scale_factor,
+        batch_size=loss_mask.shape[0],
+    )
+
+    torch.testing.assert_close(fallback_loss, fallback_expected)
+    torch.testing.assert_close(explicit_global_loss, explicit_expected)
+    assert not torch.isclose(fallback_loss, explicit_global_loss)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1154,7 +1154,9 @@ def agg_loss(
     Args:
         loss_mat: micro batch loss matrix, (bs, response_length)
         loss_mask: micro batch loss mask, (bs, response_length)
-        loss_agg_mode: method to aggregate the loss matrix into a scalar
+        loss_agg_mode: method to aggregate the loss matrix into a scalar. "seq-mean-token-sum-norm"
+            sums token losses per sequence, averages those sums over the global batch, then divides by
+            loss_scale_factor or the response horizon.
         dp_size: data parallel size
         batch_num_tokens: number of valid tokens in global batch
         global_batch_size: global batch size

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -118,7 +118,8 @@ class ActorConfig(BaseConfig):
         clip_ratio_high (float): Upper bound for PPO clipping ratio.
         policy_loss (PolicyLossConfig): Configuration for policy loss computation.
         clip_ratio_c (float): Clipping ratio for critic loss.
-        loss_agg_mode (str): Loss aggregation mode. Options: 'token-mean', 'sample-mean'.
+        loss_agg_mode (str): Loss aggregation mode. Options: 'token-mean', 'seq-mean-token-sum',
+            'seq-mean-token-mean', 'seq-mean-token-sum-norm'.
         loss_scale_factor (Optional[int]): Scale factor for 'seq-mean-token-sum-norm' loss aggregation mode.
             If None, uses response_length. Set to a constant to ensure consistent normalization.
         entropy_coeff (float): Entropy coefficient for regularization.


### PR DESCRIPTION
## Summary

Addresses #3741.

This PR locks down and documents the current DrGRPO `seq-mean-token-sum-norm` loss aggregation behavior without changing the production loss formula.

Changes:
- add focused CPU tests for `seq-mean-token-sum-norm` scalar value, explicit `loss_scale_factor`, gradient scale, DP-averaged gradient equivalence, missing global-batch metadata, and fully masked row denominator behavior
- clarify the `agg_loss()` docstring for DrGRPO-style sequence-sum normalization
- update GRPO docs and the GRPO example README so they no longer say this mode "turns off seq-dim averaging"
- fix the stale `ActorConfig.loss_agg_mode` option list

## Root Cause / Issue Context

Issue #3741 points at an older implementation where `seq-mean-token-sum-norm` summed per-sequence losses and divided only by the response horizon. That would scale the loss and gradient by the local batch size.

Current `main` already routes this mode through `agg_loss()`, where the actor loss computes a sequence-level token sum, averages those sums over the global PPO mini-batch, and then divides by `loss_scale_factor` or the response horizon. This is equivalent to `torch.mean(seq_losses) / C` in the single-DP case and preserves the intended global objective under DDP/FSDP gradient averaging.

The remaining gap was that this behavior was not covered by focused tests and the docs still described the mode inaccurately.

## Duplicate-Work Check

Before opening this PR, I checked:

```bash
gh issue view 3741 --repo verl-project/verl --comments
gh pr list --repo verl-project/verl --state open --search "3741 in:body"
gh pr list --repo verl-project/verl --state open --search "seq-mean-token-sum-norm DrGRPO loss_agg_mode"
gh pr list --repo verl-project/verl --state open --search "loss_agg_mode"
```

Results:
- no open PR directly referenced `#3741`
- no open PR matched the DrGRPO-specific search
- broader `loss_agg_mode` results include related work such as #4721, but that PR is a broad gradient-accumulation test suite and does not directly answer #3741's DrGRPO scalar/gradient-scale concern

## Validation

Commands run:

```bash
PYTHONPATH=. .venv/bin/python -m pytest tests/trainer/ppo/test_core_algos_on_cpu.py -q
PYTHONPATH=. .venv/bin/python -m pytest tests/trainer/ppo/test_loss_aggregation_on_cpu.py -q
PYTHONPATH=. .venv/bin/python -m pytest tests/workers/config/test_actor_config_on_cpu.py -q
.venv/bin/ruff check tests/trainer/ppo/test_loss_aggregation_on_cpu.py verl/trainer/ppo/core_algos.py verl/workers/config/actor.py
.venv/bin/ruff format tests/trainer/ppo/test_loss_aggregation_on_cpu.py verl/trainer/ppo/core_algos.py verl/workers/config/actor.py --check
git diff --check
```

Results:
- `tests/trainer/ppo/test_core_algos_on_cpu.py`: 22 passed
- `tests/trainer/ppo/test_loss_aggregation_on_cpu.py`: 6 passed
- `tests/workers/config/test_actor_config_on_cpu.py`: 10 passed, 5 existing warnings
- ruff check/format: passed
- `git diff --check`: passed

Validation note: `uv run pytest ...` was attempted, but this checkout's project sync currently tries to resolve incompatible optional extras. I used a focused Python 3.10 validation environment with `PYTHONPATH=.` to avoid that resolver issue and run the relevant CPU tests directly.