### PR TITLE
[trainer, doc, test] fix: validate old log-prob bypass mode

### DIFF
--- a/docs/algo/rollout_corr.md
+++ b/docs/algo/rollout_corr.md
@@ -517,11 +517,13 @@ rollout_correction:
 
 - Set `actor_rollout_ref.rollout.calculate_log_probs: true`
 
-**Additional requirements for bypass mode:**
+**Synchronous PPO behavior:**
 
-- Set `actor_rollout_ref.actor.use_rollout_log_probs: true`
-- Set `actor_rollout_ref.actor.policy_loss.loss_mode: bypass_mode`
-- Set rollout correction config via `actor_rollout_ref.actor.policy_loss.rollout_correction`
+- No actor-side `policy_loss` override is required in the user config.
+- The trainer copies rollout-produced `rollout_log_probs` into `old_log_probs`.
+- The trainer wires `actor_rollout_ref.actor.policy_loss.loss_mode=bypass_mode` internally for the actor update.
+- The actor update still computes current actor log-probs for gradients.
+- This is not identical to decoupled PPO, where `old_log_probs` are recomputed by the actor before the update.
 
 **Theory:** See [rollout_corr_math.md §3.1.2](rollout_corr_math.md#312-bypass-mode-two-policies)
 
@@ -790,11 +792,22 @@ actor_rollout_ref:
     calculate_log_probs: true # Required!
 ```
 
-### Additional Configurations for Bypass Mode
+### Skipping Actor Old-Log-Prob Recomputation
 
-- Set `actor_rollout_ref.actor.use_rollout_log_probs: true`
-- Set `actor_rollout_ref.actor.policy_loss.loss_mode: bypass_mode`
-- Set rollout correction config via `actor_rollout_ref.actor.policy_loss.rollout_correction`
+To skip the trainer-side actor `compute_log_prob` pass, use bypass mode:
+
+```yaml
+algorithm:
+  rollout_correction:
+    bypass_mode: true
+    loss_type: ppo_clip
+
+actor_rollout_ref:
+  rollout:
+    calculate_log_probs: true
+```
+
+This copies rollout-produced `rollout_log_probs` into `old_log_probs`. It does not skip the actor update forward/backward pass, which still computes current actor log-probs for gradients.
 
 ### Metrics
 

--- a/tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
+++ b/tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from verl import DataProto
+from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
+from verl.utils import config as config_utils
+from verl.utils.config import _validate_rollout_log_probs_for_bypass, validate_config
+
+
+class _FakeActorConfig:
+    def validate(self, *_args, **_kwargs):
+        return None
+
+
+def _bypass_config(calculate_log_probs: bool):
+    return OmegaConf.create(
+        {
+            "algorithm": {"rollout_correction": {"bypass_mode": True}},
+            "actor_rollout_ref": {"rollout": {"calculate_log_probs": calculate_log_probs}},
+        }
+    )
+
+
+def test_apply_bypass_mode_sets_old_log_probs_from_rollout_log_probs():
+    rollout_log_probs = torch.tensor([[-1.0, -2.0], [-3.0, -4.0]])
+    batch = DataProto.from_dict(tensors={"rollout_log_probs": rollout_log_probs})
+    policy_loss_config = OmegaConf.create({"loss_mode": "vanilla"})
+    rollout_corr_config = OmegaConf.create({"bypass_mode": True, "loss_type": "ppo_clip"})
+
+    apply_bypass_mode(
+        batch=batch,
+        rollout_corr_config=rollout_corr_config,
+        policy_loss_config=policy_loss_config,
+    )
+
+    assert torch.equal(batch.batch["old_log_probs"], rollout_log_probs)
+    assert policy_loss_config.loss_mode == "bypass_mode"
+    assert policy_loss_config.rollout_correction.bypass_mode is True
+    assert policy_loss_config.rollout_correction.loss_type == "ppo_clip"
+
+
+def test_apply_bypass_mode_requires_rollout_log_probs():
+    batch = DataProto.from_dict(tensors={"response_mask": torch.ones(2, 2)})
+    policy_loss_config = OmegaConf.create({"loss_mode": "vanilla"})
+
+    with pytest.raises(ValueError, match="calculate_log_probs=true"):
+        apply_bypass_mode(
+            batch=batch,
+            rollout_corr_config=OmegaConf.create({"bypass_mode": True}),
+            policy_loss_config=policy_loss_config,
+        )
+
+
+def test_validate_bypass_mode_requires_rollout_log_probs():
+    with pytest.raises(ValueError, match="actor_rollout_ref.rollout.calculate_log_probs=true"):
+        _validate_rollout_log_probs_for_bypass(_bypass_config(calculate_log_probs=False))
+
+
+def test_validate_bypass_mode_accepts_rollout_log_probs():
+    _validate_rollout_log_probs_for_bypass(_bypass_config(calculate_log_probs=True))
+
+
+def test_validate_bypass_mode_ignores_decoupled_mode_without_rollout_log_probs():
+    config = OmegaConf.create(
+        {
+            "algorithm": {"rollout_correction": {"bypass_mode": False}},
+            "actor_rollout_ref": {"rollout": {"calculate_log_probs": False}},
+        }
+    )
+
+    _validate_rollout_log_probs_for_bypass(config)
+
+
+def test_validate_config_rejects_bypass_without_rollout_log_probs(monkeypatch):
+    config = OmegaConf.create(
+        {
+            "trainer": {"n_gpus_per_node": 1, "nnodes": 1},
+            "data": {"train_batch_size": 1},
+            "algorithm": {
+                "rollout_correction": {"bypass_mode": True},
+                "use_kl_in_reward": False,
+            },
+            "actor_rollout_ref": {
+                "actor": {"use_dynamic_bsz": True, "use_kl_loss": False},
+                "rollout": {
+                    "calculate_log_probs": False,
+                    "val_kwargs": {"do_sample": False},
+                    "name": "vllm",
+                },
+                "model": {},
+            },
+        }
+    )
+    monkeypatch.setattr(config_utils, "omega_conf_to_dataclass", lambda _config: _FakeActorConfig())
+
+    with pytest.raises(ValueError, match="actor_rollout_ref.rollout.calculate_log_probs=true"):
+        validate_config(config=config, use_reference_policy=False, use_critic=False)
+
+
+def test_validate_config_accepts_bypass_with_rollout_log_probs(monkeypatch):
+    config = OmegaConf.create(
+        {
+            "trainer": {"n_gpus_per_node": 1, "nnodes": 1},
+            "data": {"train_batch_size": 1},
+            "algorithm": {
+                "rollout_correction": {"bypass_mode": True},
+                "use_kl_in_reward": False,
+            },
+            "actor_rollout_ref": {
+                "actor": {"use_dynamic_bsz": True, "use_kl_loss": False},
+                "rollout": {
+                    "calculate_log_probs": True,
+                    "val_kwargs": {"do_sample": False},
+                    "name": "vllm",
+                },
+                "model": {},
+            },
+        }
+    )
+    monkeypatch.setattr(config_utils, "omega_conf_to_dataclass", lambda _config: _FakeActorConfig())
+
+    validate_config(config=config, use_reference_policy=False, use_critic=False)

--- a/tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
+++ b/tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 from omegaconf import OmegaConf
+from tensordict import TensorDict
 
 from verl import DataProto
-from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
+from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode, apply_bypass_mode_to_tq_batch
 from verl.utils import config as config_utils
 from verl.utils.config import _validate_rollout_log_probs_for_bypass, validate_config
 
@@ -64,6 +67,39 @@ def test_apply_bypass_mode_requires_rollout_log_probs():
             rollout_corr_config=OmegaConf.create({"bypass_mode": True}),
             policy_loss_config=policy_loss_config,
         )
+
+
+def test_tq_bypass_returns_updated_kv_batch_meta():
+    rollout_log_probs = torch.tensor([[-1.0, -2.0]])
+    input_batch = SimpleNamespace(keys=["sample-0"], partition_id="train")
+    updated_batch = SimpleNamespace(
+        keys=input_batch.keys,
+        partition_id=input_batch.partition_id,
+        fields=["rollout_log_probs", "old_log_probs"],
+    )
+    put_calls = []
+
+    class FakeTQ:
+        @staticmethod
+        def kv_batch_get(keys, partition_id, select_fields):
+            assert keys == input_batch.keys
+            assert partition_id == input_batch.partition_id
+            assert select_fields == ["rollout_log_probs"]
+            return TensorDict({"rollout_log_probs": rollout_log_probs.clone()}, batch_size=[1])
+
+        @staticmethod
+        def kv_batch_put(keys, partition_id, fields):
+            assert keys == input_batch.keys
+            assert partition_id == input_batch.partition_id
+            assert "rollout_log_probs" not in fields
+            assert torch.equal(fields["old_log_probs"], rollout_log_probs)
+            put_calls.append(fields.clone())
+            return updated_batch
+
+    result = apply_bypass_mode_to_tq_batch(input_batch, FakeTQ)
+
+    assert result is updated_batch
+    assert len(put_calls) == 1
 
 
 def test_validate_bypass_mode_requires_rollout_log_probs():

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -484,7 +484,9 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
         # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
         #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-        bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+        bypass_recomputing_logprobs = bool(rollout_corr_config and rollout_corr_config.get("bypass_mode", False))
+        metrics["trainer/old_log_prob_bypassed"] = int(bypass_recomputing_logprobs)
+        metrics["trainer/old_log_prob_recomputed"] = int(not bypass_recomputing_logprobs)
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
             from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
 
@@ -570,7 +572,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
             # Only runs in decoupled mode (computes once per batch using stable π_old)
             # In bypass mode, this is skipped - actor computes metrics from evolving π_θ vs π_rollout
             rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-            bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+            bypass_recomputing_logprobs = bool(rollout_corr_config and rollout_corr_config.get("bypass_mode", False))
             if (
                 rollout_corr_config is not None
                 and "rollout_log_probs" in batch.batch

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -76,7 +76,10 @@ from verl.trainer.ppo.metric_utils import (
 )
 from verl.trainer.ppo.padding_utils import upsample_batch_to_divisible_size
 from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage
-from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
+from verl.trainer.ppo.rollout_corr_helper import (
+    apply_bypass_mode_to_tq_batch,
+    compute_rollout_correction_and_add_to_batch,
+)
 from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_teacher_policy
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils import tensordict_utils as tu
@@ -1202,12 +1205,7 @@ class PPOTrainer:
         metrics["trainer/old_log_prob_bypassed"] = int(bypass_recomputing_logprobs)
         metrics["trainer/old_log_prob_recomputed"] = int(not bypass_recomputing_logprobs)
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
-            data = tq.kv_batch_get(
-                keys=batch.keys, partition_id=batch.partition_id, select_fields=["rollout_log_probs"]
-            )
-            data["old_log_probs"] = data.pop("rollout_log_probs")
-            tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
-            return batch
+            return apply_bypass_mode_to_tq_batch(batch, tq)
 
         # 1. compute log probs
         batch.extra_info.update(

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1198,14 +1198,16 @@ class PPOTrainer:
         # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
         #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-        bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+        bypass_recomputing_logprobs = bool(rollout_corr_config and rollout_corr_config.get("bypass_mode", False))
+        metrics["trainer/old_log_prob_bypassed"] = int(bypass_recomputing_logprobs)
+        metrics["trainer/old_log_prob_recomputed"] = int(not bypass_recomputing_logprobs)
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
             data = tq.kv_batch_get(
                 keys=batch.keys, partition_id=batch.partition_id, select_fields=["rollout_log_probs"]
             )
             data["old_log_probs"] = data.pop("rollout_log_probs")
             tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
-            return
+            return batch
 
         # 1. compute log probs
         batch.extra_info.update(

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1420,7 +1420,11 @@ class RayPPOTrainer:
                     # - Decoupled mode: Recomputes old_log_probs as proximal anchor (3 policies: π_rollout, π_old, π_θ)
                     #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
                     rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
-                    bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+                    bypass_recomputing_logprobs = bool(
+                        rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+                    )
+                    metrics["trainer/old_log_prob_bypassed"] = int(bypass_recomputing_logprobs)
+                    metrics["trainer/old_log_prob_recomputed"] = int(not bypass_recomputing_logprobs)
                     if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
                         from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
 

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -1135,3 +1135,10 @@ def apply_bypass_mode(
         policy_loss_config["rollout_correction"] = rollout_corr_config
         # Always use bypass_mode loss function which handles both loss_types
         policy_loss_config["loss_mode"] = "bypass_mode"
+
+
+def apply_bypass_mode_to_tq_batch(batch: Any, tq_module: Any) -> Any:
+    """Set old_log_probs from rollout_log_probs in TransferQueue and return updated metadata."""
+    data = tq_module.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=["rollout_log_probs"])
+    data["old_log_probs"] = data.pop("rollout_log_probs")
+    return tq_module.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -71,6 +71,19 @@ def update_dict_with_config(dictionary: dict, config: DictConfig):
             dictionary[key] = getattr(config, key)
 
 
+def _validate_rollout_log_probs_for_bypass(config: DictConfig) -> None:
+    rollout_corr_config = config.algorithm.get("rollout_correction", None)
+    if not rollout_corr_config or not rollout_corr_config.get("bypass_mode", False):
+        return
+
+    if not config.actor_rollout_ref.rollout.calculate_log_probs:
+        raise ValueError(
+            "algorithm.rollout_correction.bypass_mode=true requires "
+            "actor_rollout_ref.rollout.calculate_log_probs=true because old_log_probs "
+            "are sourced from rollout_log_probs and actor old-log-prob recomputation is skipped."
+        )
+
+
 def validate_config(
     config: DictConfig,
     use_reference_policy: bool,
@@ -168,6 +181,8 @@ def validate_config(
 
     if config.algorithm.get("use_kl_in_reward", False) and config.actor_rollout_ref.actor.use_kl_loss:
         print("NOTICE: You have both enabled in-reward kl and kl loss.")
+
+    _validate_rollout_log_probs_for_bypass(config)
 
     # critic
     if use_critic:


### PR DESCRIPTION
### What does this PR do?

Addresses #3996.

This PR tightens the rollout-correction bypass path that avoids recomputing actor old log-probs when the rollout already produced `rollout_log_probs`. It makes the mode fail fast when the required rollout log-prob source is disabled, documents the intended configuration, and adds CPU coverage for the batch rewrite and config validation behavior.

The issue reports that on-policy training can compute actor log-probs twice: once during the trainer's `compute_log_prob` old-log-prob phase, and again inside the actor update where the current policy log-probs are already available. The existing bypass mode is the narrow path for skipping the trainer-side old-log-prob recomputation, but it was easy to enable without also enabling rollout log-prob generation. That could push the failure later into training, where the missing `rollout_log_probs` key is harder to diagnose.

### Duplicate-work check

I ran the required duplicate checks before opening this draft:

```bash
gh issue view 3996 --repo verl-project/verl --comments
gh pr list --repo verl-project/verl --state open --search "3996 in:body" --limit 20 --json number,title,url,author,updatedAt,body
gh pr list --repo verl-project/verl --state open --search "bypass_mode rollout_log_probs" --limit 20 --json number,title,url,author,updatedAt,body
gh pr list --repo verl-project/verl --state open --search "old_log_probs rollout_log_probs" --limit 20 --json number,title,url,author,updatedAt,body
gh pr list --repo verl-project/verl --state open --search "rollout_correction bypass_mode" --limit 20 --json number,title,url,author,updatedAt,body
gh pr list --repo verl-project/verl --state open --search "old log prob bypass" --limit 20 --json number,title,url,author,updatedAt,body
gh pr list --repo verl-project/verl --state open --search "compute_log_prob old_log_probs" --limit 20 --json number,title,url,author,updatedAt,body
```

Results:

- No open PR mentioned `#3996` in the body.
- No open PR matched the direct `bypass_mode rollout_log_probs`, `old log prob bypass`, or `compute_log_prob old_log_probs` searches.
- #4930 is related to bypass mode, but it fixes config timing for #4912 and does not cover the #3996 old-log-prob recomputation path, rollout-log-prop prerequisite validation, trainer metrics, or docs added here.
- #6009 mentions `old_log_probs` in a mask-nesting performance change, but it is a separate transport/padding PR and does not address this issue.

### Design & code changes

- Adds validation in `verl/utils/config.py` so `algorithm.rollout_correction.bypass_mode=true` requires `actor_rollout_ref.rollout.calculate_log_probs=true`.
- Preserves the existing bypass behavior in PPO trainers while adding explicit metrics:
  - `trainer/old_log_prob_bypassed`
  - `trainer/old_log_prob_recomputed`
- Applies the same observability to the experimental separation trainer and synchronous PPO path.
- Fixes the synchronous PPO bypass branch to return the updated `KVBatchMeta` from `kv_batch_put` after writing `old_log_probs`, so downstream TransferQueue metadata includes the new field.
- Factors the TransferQueue bypass rewrite into a small helper and covers it with a regression test.
- Updates `docs/algo/rollout_corr.md` with the public knobs needed for bypass mode.
- Adds focused CPU tests for `apply_bypass_mode`, TransferQueue metadata return behavior, missing rollout log-probs, and config validation.

### Tests

```bash
PATH=/tmp/verl-issue-3996-worktree/.venv/bin:$PATH .venv/bin/python -m pytest tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py tests/trainer/ppo/test_rollout_corr.py tests/trainer/ppo/test_rollout_corr_integration.py tests/trainer/ppo/test_core_algos_on_cpu.py tests/utils/debug/test_metrics.py tests/special_sanity/test_config_docs.py tests/utils/test_config_on_cpu.py
```

Result: `64 passed, 3 warnings in 6.91s`.

The warnings are existing local warnings from `tests/utils/test_config_on_cpu.py` dataclass collection and `tests/trainer/ppo/test_rollout_corr.py::test_metrics_completeness` returning a bool.

```bash
.venv/bin/python -m ruff check verl/trainer/ppo/rollout_corr_helper.py verl/trainer/main_ppo_sync.py tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
.venv/bin/python -m ruff format --check verl/trainer/ppo/rollout_corr_helper.py verl/trainer/main_ppo_sync.py tests/trainer/ppo/test_old_log_prob_bypass_on_cpu.py
git diff --check
```

Results:

- Ruff check: passed.
- Ruff format check: passed.
- Whitespace check: passed.

Note: I first tried the repo's normal `uv run pytest ...` path, but the local resolver selected optional `prime`/`pyext` dependencies that fail on this macOS/Python environment because `pyext==0.7` imports the removed `inspect.getargspec`. I then used a minimal Python 3.12 `.venv` with the required test/runtime dependencies and reran the focused validation above.

### API and usage

No new user-facing config keys are introduced. Users who want the bypass path should configure:

```yaml
actor_rollout_ref:
  rollout:
    calculate_log_probs: true

algorithm:
  rollout_correction:
    bypass_mode: true
    loss_type: ppo_clip
```

### AI assistance

AI assistance was used to analyze, implement, review, test, and draft this PR. The submitting human should review every changed line and be prepared to defend the change end-to-end before marking this ready for review.
