### PR TITLE
[one-step-off] Add DAPO dynamic sampling

### DIFF
--- a/docs/advance/one_step_off.md
+++ b/docs/advance/one_step_off.md
@@ -231,6 +231,37 @@ The default mode is `bypass_ppo_clip`, but other modification strategies can als
 In the current implementation, we no longer provide SPMD model rollout mode.
 Instead, we have switched to AgentLoop mode, which also supports multi-turn tool calling.
 
+### DAPO Dynamic Sampling
+
+One-step-off DAPO supports opt-in dynamic sampling with `algorithm.filter_groups`.
+When enabled, each candidate rollout batch is grouped by prompt `uid`, prompt
+groups whose configured metric is constant across responses are filtered out,
+and more `data.gen_batch_size` prompts are generated until
+`data.train_batch_size` prompt groups are available. The final training batch is
+then aligned to `data.train_batch_size * actor_rollout_ref.rollout.n`
+trajectories.
+
+All backfill attempts for one final training batch run inside the same
+asynchronous generation future, before the next actor-to-rollout weight sync.
+This preserves the one-step-off policy relationship while restoring DAPO group
+filtering behavior.
+
+Example overrides:
+
+```shell
++data.gen_batch_size=1536 \
+data.train_batch_size=512 \
++algorithm.filter_groups.enable=True \
++algorithm.filter_groups.metric=acc \
++algorithm.filter_groups.max_num_gen_batches=10
+```
+
+`algorithm.filter_groups.metric=seq_final_reward` requires `token_level_rewards`
+to already exist, so one-step-off DAPO should use `acc`, `score`, `seq_reward`,
+or another reward extra key unless the reward/log-prob ordering is changed.
+`actor_rollout_ref.rollout.skip_rollout=True` is not supported together with
+dynamic sampling.
+
 ## Usage
 
 ### FSDP2 Configuration Example

--- a/docs/algo/dapo.md
+++ b/docs/algo/dapo.md
@@ -85,6 +85,8 @@ Setting `filter_groups.enable` to `True` will filter out groups whose outputs' `
 
 The trainer will repeat sampling with `gen_batch_size` until there are enough qualified groups for `train_batch_size` or reaching the upper limit specified by `max_num_gen_batches`.
 
+The one-step-off policy trainer supports the same opt-in group filtering path. In that mode the trainer filters each candidate generation batch before launching the next training update, and all backfill attempts for the final training batch use the same rollout weight snapshot.
+
 Core relevant code:
 
 ```python

--- a/tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
+++ b/tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from verl import DataProto
+from verl.experimental.one_step_off_policy.ray_trainer import OneStepOffRayTrainer, PrecomputedReward
+
+
+class _AsyncRolloutManager:
+    async def clear_kv_cache(self):
+        return None
+
+
+def _trainer_for_fit_generate():
+    trainer = OneStepOffRayTrainer.__new__(OneStepOffRayTrainer)
+    trainer.metrics = {}
+    trainer.timing_raw = {}
+    trainer.config = SimpleNamespace(
+        actor_rollout_ref=SimpleNamespace(
+            rollout=SimpleNamespace(
+                temperature=1.0,
+            ),
+        ),
+    )
+    trainer.is_last_step = True
+    trainer.async_rollout_manager = _AsyncRolloutManager()
+    trainer._fit_update_weights = lambda: None
+    trainer.reward_tensor = None
+    trainer.reward_extra_infos_dict = {}
+    return trainer
+
+
+def _batch():
+    return DataProto.from_dict(
+        tensors={
+            "responses": torch.zeros((2, 2), dtype=torch.long),
+            "attention_mask": torch.ones((2, 3), dtype=torch.long),
+        },
+        non_tensors={},
+        meta_info={"timing": {"agent_loop/generate_sequences/mean": 1.0}},
+    )
+
+
+class _DynamicRolloutManager:
+    def __init__(self):
+        self.calls = 0
+
+    async def generate_sequences(self, gen_batch):
+        self.calls += 1
+        if self.calls == 1:
+            reward_values = [[0, 1], [0, 2], [0, 5], [0, 5]]
+            acc = [0, 1, 1, 1]
+        else:
+            reward_values = [[0, 0], [0, 0], [0, 3], [0, 4]]
+            acc = [0, 0, 0, 1]
+
+        return DataProto.from_dict(
+            tensors={
+                "responses": torch.zeros((len(gen_batch), 2), dtype=torch.long),
+                "attention_mask": torch.ones((len(gen_batch), 3), dtype=torch.long),
+                "rm_scores": torch.tensor(reward_values, dtype=torch.float32),
+            },
+            non_tensors={"acc": np.array(acc)},
+            meta_info={"timing": {"agent_loop/generate_sequences/mean": 1.0}, "reward_extra_keys": ["acc"]},
+        )
+
+
+def test_fit_generate_sets_precomputed_reward_payload():
+    trainer = _trainer_for_fit_generate()
+    reward_tensor = torch.tensor([[0.0, 1.0], [0.0, 2.0]])
+    reward_payload = PrecomputedReward(reward_tensor, {"acc": [0, 1]})
+
+    async def run():
+        future = asyncio.Future()
+        future.set_result(
+            ({"dynamic_sampling/kept_prompts": 1.0}, {"generate_async": 2.0}, 0, _batch(), reward_payload)
+        )
+        batch, next_future = await trainer._fit_generate(future, iter(()))
+        return batch, next_future
+
+    batch, next_future = asyncio.run(run())
+
+    assert next_future is None
+    assert trainer.reward_tensor is reward_tensor
+    assert trainer.reward_extra_infos_dict == {"acc": [0, 1]}
+    assert trainer.metrics["dynamic_sampling/kept_prompts"] == 1.0
+    assert trainer.timing_raw["generate_async"] == 2.0
+    assert "timing" not in batch.meta_info
+
+
+def test_fit_compute_reward_reuses_precomputed_reward():
+    trainer = OneStepOffRayTrainer.__new__(OneStepOffRayTrainer)
+    trainer.reward_tensor = torch.ones((1, 1))
+    batch = _batch()
+
+    assert trainer._fit_compute_reward(batch) is batch
+
+
+def test_dynamic_sampling_enable_check_handles_missing_config():
+    trainer = OneStepOffRayTrainer.__new__(OneStepOffRayTrainer)
+    trainer.config = SimpleNamespace(algorithm={})
+
+    assert not trainer._is_dynamic_sampling_enabled()
+
+    trainer.config = SimpleNamespace(algorithm={"filter_groups": {"enable": True}})
+    assert trainer._is_dynamic_sampling_enabled()
+
+
+def test_async_dynamic_sampling_backfills_until_train_prompt_batch_is_ready():
+    trainer = OneStepOffRayTrainer.__new__(OneStepOffRayTrainer)
+    trainer.config = SimpleNamespace(
+        actor_rollout_ref=SimpleNamespace(rollout=SimpleNamespace(n=2)),
+        algorithm=SimpleNamespace(filter_groups={"metric": "acc", "max_num_gen_batches": 3}),
+        data=SimpleNamespace(train_batch_size=2),
+        trainer=SimpleNamespace(balance_batch=False),
+    )
+    trainer.global_steps = 3
+    trainer.use_rm = False
+    trainer.async_rollout_manager = _DynamicRolloutManager()
+    trainer._get_gen_batch = lambda batch: DataProto.from_dict(
+        tensors={"prompts": torch.zeros((len(batch), 1), dtype=torch.long)}
+    )
+
+    continuous_iterator = iter(
+        [
+            (0, {"prompts": torch.ones((2, 1), dtype=torch.long)}),
+            (0, {"prompts": torch.full((2, 1), 2, dtype=torch.long)}),
+        ]
+    )
+
+    metrics, timing_raw, epoch, batch, reward_payload = asyncio.run(
+        trainer._async_gen_next_dynamic_batch(continuous_iterator)
+    )
+
+    assert epoch == 0
+    assert trainer.async_rollout_manager.calls == 2
+    assert len(batch) == 4
+    assert isinstance(reward_payload, PrecomputedReward)
+    assert reward_payload.tensor.sum(dim=-1).tolist() == [1, 2, 3, 4]
+    assert reward_payload.extra_infos["acc"].tolist() == [0, 1, 0, 1]
+    assert metrics["dynamic_sampling/num_gen_batches"] == 2.0
+    assert metrics["dynamic_sampling/num_prompt_in_batch"] == 2.0
+    assert timing_raw["generate_async"] >= 0.0

--- a/tests/utils/test_dynamic_sampling.py
+++ b/tests/utils/test_dynamic_sampling.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+from verl import DataProto
+from verl.utils.filtering import DynamicSamplingAccumulator
+
+
+def _batch(uids, reward_values, extra_infos=None, meta_info=None, token_level_rewards=None):
+    reward_values = torch.tensor(reward_values, dtype=torch.float32)
+    tensors = {
+        "responses": torch.zeros((len(uids), reward_values.shape[-1]), dtype=torch.long),
+        "attention_mask": torch.ones((len(uids), reward_values.shape[-1] + 1), dtype=torch.long),
+        "rm_scores": reward_values,
+    }
+    if token_level_rewards is not None:
+        tensors["token_level_rewards"] = torch.tensor(token_level_rewards, dtype=torch.float32)
+    non_tensors = {"uid": np.array(uids, dtype=object)}
+    if extra_infos:
+        non_tensors.update({key: np.array(value, dtype=object) for key, value in extra_infos.items()})
+    return DataProto.from_dict(tensors=tensors, non_tensors=non_tensors, meta_info=meta_info or {})
+
+
+def test_filters_uniform_prompt_groups_and_keeps_aligned_rewards():
+    batch = _batch(
+        ["a", "a", "b", "b", "c", "c"],
+        [[0, 1], [0, 2], [0, 5], [0, 5], [0, 0], [0, 0]],
+        extra_infos={"acc": [0, 1, 1, 1, 0, 0]},
+        meta_info={"timing": {"rollout": 1.0}, "reward_extra_keys": ["acc"]},
+    )
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 1}, 1, 2)
+
+    result = sampler.add_candidate(batch, batch.batch["rm_scores"], {"acc": batch.non_tensor_batch["acc"]})
+    final_batch, reward_tensor, reward_extra_infos, metrics = sampler.finalize()
+
+    assert result.ready
+    assert final_batch.non_tensor_batch["uid"].tolist() == ["a", "a"]
+    assert reward_tensor.tolist() == [[0, 1], [0, 2]]
+    assert reward_extra_infos["acc"].tolist() == [0, 1]
+    assert final_batch.meta_info == {"reward_extra_keys": ["acc"]}
+    assert metrics["dynamic_sampling/kept_prompts"] == 1.0
+    assert metrics["dynamic_sampling/dropped_prompts"] == 2.0
+
+
+def test_accumulates_multiple_candidate_batches_and_truncates_to_train_size():
+    first = _batch(
+        ["a", "a", "b", "b"],
+        [[0, 1], [0, 2], [0, 5], [0, 5]],
+        extra_infos={"acc": [0, 1, 1, 1]},
+        meta_info={"timing": {"rollout": 1.0}, "reward_extra_keys": ["acc"]},
+    )
+    second = _batch(
+        ["c", "c", "d", "d"],
+        [[0, 0], [0, 0], [0, 3], [0, 4]],
+        extra_infos={"acc": [0, 0, 0, 1]},
+        meta_info={"timing": {"rollout": 2.0}, "reward_extra_keys": ["acc"]},
+    )
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 3}, 2, 2)
+
+    assert not sampler.add_candidate(first, first.batch["rm_scores"], {"acc": first.non_tensor_batch["acc"]}).ready
+    assert sampler.should_continue()
+    assert sampler.add_candidate(second, second.batch["rm_scores"], {"acc": second.non_tensor_batch["acc"]}).ready
+    final_batch, reward_tensor, reward_extra_infos, metrics = sampler.finalize()
+
+    assert final_batch.non_tensor_batch["uid"].tolist() == ["a", "a", "d", "d"]
+    assert reward_tensor.sum(dim=-1).tolist() == [1, 2, 3, 4]
+    assert reward_extra_infos["acc"].tolist() == [0, 1, 0, 1]
+    assert metrics["dynamic_sampling/num_gen_batches"] == 2.0
+    assert metrics["dynamic_sampling/num_prompt_in_batch"] == 2.0
+
+
+def test_seq_reward_uses_reward_tensor_when_token_level_scores_are_absent():
+    batch = _batch(
+        ["a", "a", "b", "b"],
+        [[0, 1], [0, 1], [0, 2], [0, 3]],
+        meta_info={"timing": {"rollout": 1.0}},
+    )
+    sampler = DynamicSamplingAccumulator({"metric": "seq_reward", "max_num_gen_batches": 1}, 1, 2)
+
+    sampler.add_candidate(batch, batch.batch["rm_scores"], {})
+    final_batch, reward_tensor, reward_extra_infos, _ = sampler.finalize()
+
+    assert final_batch.non_tensor_batch["uid"].tolist() == ["b", "b"]
+    assert reward_tensor.sum(dim=-1).tolist() == [2, 3]
+    assert reward_extra_infos == {}
+
+
+def test_seq_final_reward_requires_token_level_rewards():
+    batch = _batch(["a", "a"], [[0, 1], [0, 2]])
+    sampler = DynamicSamplingAccumulator({"metric": "seq_final_reward", "max_num_gen_batches": 1}, 1, 2)
+
+    with pytest.raises(ValueError, match="seq_final_reward"):
+        sampler.add_candidate(batch, batch.batch["rm_scores"], {})
+
+
+def test_max_num_gen_batches_stops_underfilled_sampling():
+    batch = _batch(["a", "a", "b", "b"], [[0, 1], [0, 1], [0, 2], [0, 2]], extra_infos={"acc": [1, 1, 0, 0]})
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 1}, 1, 2)
+
+    result = sampler.add_candidate(batch, batch.batch["rm_scores"], {"acc": batch.non_tensor_batch["acc"]})
+
+    assert not result.ready
+    assert not sampler.should_continue()
+    with pytest.raises(ValueError, match="num_prompt_in_batch=0"):
+        sampler.finalize()
+
+
+def test_prompt_groups_must_match_rollout_n():
+    batch = _batch(["a", "a", "b"], [[0, 1], [0, 2], [0, 3]], extra_infos={"acc": [0, 1, 1]})
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 1}, 1, 2)
+
+    with pytest.raises(ValueError, match="rollout_n=2"):
+        sampler.add_candidate(batch, batch.batch["rm_scores"], {"acc": batch.non_tensor_batch["acc"]})
+
+
+def test_missing_metric_raises_clear_error():
+    batch = _batch(["a", "a"], [[0, 1], [0, 2]])
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 1}, 1, 2)
+
+    with pytest.raises(ValueError, match="Could not find filter metric 'acc'"):
+        sampler.add_candidate(batch, batch.batch["rm_scores"], {})
+
+
+def test_reward_extra_keys_must_be_stable_across_candidates():
+    first = _batch(["a", "a"], [[0, 1], [0, 2]], extra_infos={"acc": [0, 1]})
+    second = _batch(["b", "b"], [[0, 3], [0, 4]], extra_infos={"acc": [0, 1], "score": [0, 1]})
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 2}, 2, 2)
+
+    sampler.add_candidate(first, first.batch["rm_scores"], {"acc": first.non_tensor_batch["acc"]})
+    with pytest.raises(ValueError, match="Reward extra info keys must be stable"):
+        sampler.add_candidate(
+            second,
+            second.batch["rm_scores"],
+            {"acc": second.non_tensor_batch["acc"], "score": second.non_tensor_batch["score"]},
+        )
+
+
+def test_reward_extra_infos_must_match_batch_length():
+    batch = _batch(["a", "a"], [[0, 1], [0, 2]], extra_infos={"acc": [0, 1]})
+    sampler = DynamicSamplingAccumulator({"metric": "acc", "max_num_gen_batches": 1}, 1, 2)
+
+    with pytest.raises(ValueError, match="length 1 must match batch length 2"):
+        sampler.add_candidate(batch, batch.batch["rm_scores"], {"score": np.array([0])})

--- a/verl/experimental/one_step_off_policy/README.md
+++ b/verl/experimental/one_step_off_policy/README.md
@@ -221,6 +221,37 @@ The default mode is `bypass_ppo_clip`, but other modification strategies can als
 In the current implementation, we no longer provide SPMD model rollout mode.
 Instead, we have switched to AgentLoop mode, which also supports multi-turn tool calling.
 
+### DAPO Dynamic Sampling
+
+One-step-off DAPO supports opt-in dynamic sampling with `algorithm.filter_groups`.
+When enabled, each candidate rollout batch is grouped by prompt `uid`, prompt
+groups whose configured metric is constant across responses are filtered out,
+and more `data.gen_batch_size` prompts are generated until
+`data.train_batch_size` prompt groups are available. The final training batch is
+then aligned to `data.train_batch_size * actor_rollout_ref.rollout.n`
+trajectories.
+
+All backfill attempts for one final training batch run inside the same
+asynchronous generation future, before the next actor-to-rollout weight sync.
+This preserves the one-step-off policy relationship while restoring DAPO group
+filtering behavior.
+
+Example overrides:
+
+```shell
++data.gen_batch_size=1536 \
+data.train_batch_size=512 \
++algorithm.filter_groups.enable=True \
++algorithm.filter_groups.metric=acc \
++algorithm.filter_groups.max_num_gen_batches=10
+```
+
+`algorithm.filter_groups.metric=seq_final_reward` requires `token_level_rewards`
+to already exist, so one-step-off DAPO should use `acc`, `score`, `seq_reward`,
+or another reward extra key unless the reward/log-prob ordering is changed.
+`actor_rollout_ref.rollout.skip_rollout=True` is not supported together with
+dynamic sampling.
+
 ## Usage
 
 ### FSDP2 Configuration Example

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -20,8 +20,9 @@ This trainer supports model-agonistic model initialization with huggingface
 
 import asyncio
 import uuid
+from dataclasses import dataclass
 from pprint import pprint
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
 import ray
@@ -41,8 +42,15 @@ from verl.trainer.ppo.ray_trainer import (
 from verl.trainer.ppo.reward import extract_reward
 from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_reward_model
 from verl.utils.debug import marked_timer
+from verl.utils.filtering import DynamicSamplingAccumulator
 from verl.utils.rollout_skip import RolloutSkip
 from verl.utils.tracking import ValidationGenerationsLogger
+
+
+@dataclass
+class PrecomputedReward:
+    tensor: torch.Tensor
+    extra_infos: dict[str, Any]
 
 
 class OneStepOffRayTrainer(SeparateRayPPOTrainer):
@@ -136,6 +144,7 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
         self.future_reward = None
         self.reward_tensor = None
         self.reward_extra_infos_dict = {}
+        self.enable_dynamic_sampling = self._is_dynamic_sampling_enabled()
 
     def _create_actor_rollout_classes(self):
         for role in [Role.Actor]:
@@ -193,7 +202,16 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
             for batch_dict in iterator:
                 yield epoch, batch_dict
 
+    def _is_dynamic_sampling_enabled(self) -> bool:
+        filter_groups_config = self.config.algorithm.get("filter_groups", None)
+        return bool(filter_groups_config and filter_groups_config.get("enable", False))
+
     async def _async_gen_next_batch(self, continuous_iterator):
+        if self.enable_dynamic_sampling:
+            return await self._async_gen_next_dynamic_batch(continuous_iterator)
+        return await self._async_gen_next_single_batch(continuous_iterator)
+
+    async def _async_gen_next_single_batch(self, continuous_iterator):
         """
         Call parameter synchronization and asynchronous sequence generation.
         """
@@ -246,6 +264,106 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
         # Return the original, now-modified `batch` and the `future_reward`
         return metrics, timing_raw, epoch, batch, future_reward
 
+    async def _async_gen_next_dynamic_batch(self, continuous_iterator):
+        """Generate, filter, and backfill candidate batches for one training step."""
+        metrics = {}
+        timing_raw = {}
+        epoch = None
+        rollout_n = self.config.actor_rollout_ref.rollout.n
+        dynamic_sampler = DynamicSamplingAccumulator(
+            self.config.algorithm.filter_groups,
+            train_prompt_bsz=self.config.data.train_batch_size,
+            rollout_n=rollout_n,
+        )
+
+        while True:
+            try:
+                epoch, batch_dict = next(continuous_iterator)
+            except StopIteration:
+                if dynamic_sampler.num_gen_batches == 0:
+                    return None
+                raise ValueError(
+                    "Train dataloader exhausted before dynamic sampling collected enough prompt groups. "
+                    f"num_prompt_in_batch={dynamic_sampler.num_prompt_in_batch}, "
+                    f"train_batch_size={self.config.data.train_batch_size}"
+                ) from None
+            except Exception as e:
+                print(f"Error in async_gen_next_dynamic_batch: {e}")
+                return None
+
+            batch = DataProto.from_single_dict(batch_dict)
+            batch.non_tensor_batch["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object)
+
+            gen_batch = self._get_gen_batch(batch)
+            gen_batch.meta_info["global_steps"] = self.global_steps
+            gen_batch.meta_info["dynamic_sampling_gen_batch"] = dynamic_sampler.num_gen_batches
+            gen_batch_output = gen_batch.repeat(repeat_times=rollout_n, interleave=True)
+
+            with marked_timer("generate_async", timing_raw, color="purple"):
+                gen_batch_output = await self.async_rollout_manager.generate_sequences(gen_batch_output)
+
+            batch = batch.repeat(repeat_times=rollout_n, interleave=True)
+            batch = batch.union(gen_batch_output)
+            self._merge_dynamic_sampling_timing(timing_raw, batch.meta_info.pop("timing", {}))
+
+            if "response_mask" not in batch.batch.keys():
+                batch.batch["response_mask"] = compute_response_mask(batch)
+
+            batch, reward_tensor, reward_extra_infos_dict = self._compute_or_extract_reward_for_filtering(batch)
+            result = dynamic_sampler.add_candidate(batch, reward_tensor, reward_extra_infos_dict)
+            metrics.update(result.metrics)
+
+            if result.ready:
+                break
+            if not dynamic_sampler.should_continue():
+                raise ValueError(
+                    f"num_prompt_in_batch={dynamic_sampler.num_prompt_in_batch} "
+                    f"< train_batch_size={self.config.data.train_batch_size}. "
+                    f"num_gen_batches={dynamic_sampler.num_gen_batches} "
+                    f">= max_num_gen_batches={dynamic_sampler.max_num_gen_batches}. "
+                    "Generated too many batches. Please check whether the data are too difficult, "
+                    "or set max_num_gen_batches=0 to allow unlimited trials."
+                )
+
+        batch, reward_tensor, reward_extra_infos_dict, filter_metrics = dynamic_sampler.finalize()
+        metrics.update(filter_metrics)
+
+        if self.config.trainer.balance_batch:
+            self._balance_batch(batch, metrics=metrics)
+
+        batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
+        batch.meta_info["timing"] = {}
+        self._attach_images_seqlens_if_present(batch)
+        return metrics, timing_raw, epoch, batch, PrecomputedReward(reward_tensor, reward_extra_infos_dict)
+
+    @staticmethod
+    def _merge_dynamic_sampling_timing(timing_raw: dict, candidate_timing: dict):
+        for key, value in candidate_timing.items():
+            timing_raw[key] = timing_raw.get(key, 0.0) + value
+
+    @staticmethod
+    def _attach_images_seqlens_if_present(batch: DataProto):
+        if "multi_modal_inputs" not in batch.non_tensor_batch:
+            return
+        images_seqlens_all = []
+        for multi_modal_input in batch.non_tensor_batch["multi_modal_inputs"]:
+            if multi_modal_input is None or "image_grid_thw" not in multi_modal_input:
+                continue
+            images_seqlens_all.extend(multi_modal_input["images_seqlens"].tolist())
+        batch.meta_info["images_seqlens"] = images_seqlens_all
+
+    def _compute_or_extract_reward_for_filtering(self, batch: DataProto):
+        if "rm_scores" not in batch.batch.keys():
+            if not self.use_rm:
+                raise ValueError(
+                    "Dynamic sampling requires rm_scores from AgentLoop reward computation or a reward model. "
+                    "No rm_scores were found in the generated batch."
+                )
+            batch_reward = self._compute_reward_colocate(batch)
+            batch = batch.union(batch_reward)
+        reward_tensor, reward_extra_infos_dict = extract_reward(batch)
+        return batch, reward_tensor, reward_extra_infos_dict
+
     @staticmethod
     @ray.remote
     def _launch_individual_rewards(batch, config, tokenizer):
@@ -286,6 +404,8 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
                 return
 
         if self.config.actor_rollout_ref.rollout.get("skip_rollout", False):
+            if self.enable_dynamic_sampling:
+                raise ValueError("rollout.skip_rollout is not supported with algorithm.filter_groups.enable=True")
             rollout_skip = RolloutSkip(self.config, self.actor_rollout_wg)
             rollout_skip.wrap_generate_sequences()
 
@@ -383,10 +503,13 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
         with marked_timer("gen", timing_raw, color="red"):
             _metrics, _timing_raw, epoch, batch, future_reward = await batch_data_future
             batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-            timing_raw.update(batch.meta_info["timing"])
+            timing_raw.update(batch.meta_info.get("timing", {}))
             timing_raw.update(_timing_raw)
             metrics.update(_metrics)
             batch.meta_info.pop("timing", None)
+            if isinstance(future_reward, PrecomputedReward):
+                self.reward_tensor = future_reward.tensor
+                self.reward_extra_infos_dict = future_reward.extra_infos
 
         # sync weights from actor to rollout
         with marked_timer("sync_rollout_weights", timing_raw, color="purple"):
@@ -401,3 +524,8 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
             batch_data_future = None
 
         return batch, batch_data_future
+
+    def _fit_compute_reward(self, batch: DataProto) -> DataProto:
+        if self.reward_tensor is not None:
+            return batch
+        return super()._fit_compute_reward(batch)

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_4_12.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_4_12.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=12
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 # Ray
 # RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
@@ -69,8 +73,12 @@ python3 -m verl.experimental.one_step_off_policy.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64.sh
@@ -59,8 +59,12 @@ NNODES_TRAIN=${NNODES_TRAIN:-8}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=16
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 test_freq=20
 
 python -m verl.experimental.one_step_off_policy.main_ppo \
@@ -71,8 +75,12 @@ python -m verl.experimental.one_step_off_policy.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64_ris.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64_ris.sh
@@ -59,8 +59,12 @@ NNODES_TRAIN=${NNODES_TRAIN:-8}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=16
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 test_freq=20
 
 # https://github.com/verl-project/verl/blob/main/docs/algo/rollout_corr.md
@@ -81,8 +85,12 @@ python -m verl.experimental.one_step_off_policy.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_colocate.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_colocate.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=12
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 # Ray
 # RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
@@ -64,8 +68,12 @@ python3 -m verl.trainer.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_4_12.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_4_12.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=12
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 # Ray
 # RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
@@ -69,8 +73,12 @@ python3 -m verl.experimental.one_step_off_policy.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_colocate.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_colocate.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=12
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 # Ray
 # RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
@@ -64,8 +68,12 @@ python3 -m verl.trainer.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_4_12.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_4_12.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=12
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 
 # Ray
@@ -78,8 +82,12 @@ python3 -m verl.experimental.one_step_off_policy.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.strategy=megatron \

--- a/verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_colocate.sh
+++ b/verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_colocate.sh
@@ -23,8 +23,12 @@ overlong_penalty_factor=1.0
 loss_agg_mode="token-mean"
 
 train_prompt_bsz=512
+gen_prompt_bsz=${gen_prompt_bsz:-1536}
 n_resp_per_prompt=16
 train_prompt_mini_bsz=32
+enable_filter_groups=${enable_filter_groups:-True}
+filter_groups_metric=${filter_groups_metric:-acc}
+max_num_gen_batches=${max_num_gen_batches:-10}
 
 # Ray
 # RAY_ADDRESS=${RAY_ADDRESS:-"http://localhost:8265"}
@@ -73,8 +77,12 @@ python3 -m verl.trainer.main_ppo \
     data.max_prompt_length=${max_prompt_length} \
     data.max_response_length=${max_response_length} \
     data.train_batch_size=${train_prompt_bsz} \
+    +data.gen_batch_size=${gen_prompt_bsz} \
     actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
     algorithm.adv_estimator=${adv_estimator} \
+    +algorithm.filter_groups.enable=${enable_filter_groups} \
+    +algorithm.filter_groups.metric=${filter_groups_metric} \
+    +algorithm.filter_groups.max_num_gen_batches=${max_num_gen_batches} \
     algorithm.use_kl_in_reward=${use_kl_in_reward} \
     algorithm.kl_ctrl.kl_coef=${kl_coef} \
     actor_rollout_ref.actor.strategy=megatron \

--- a/verl/utils/filtering/__init__.py
+++ b/verl/utils/filtering/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .dynamic_sampling import DynamicSamplingAccumulator, DynamicSamplingResult
+
+__all__ = ["DynamicSamplingAccumulator", "DynamicSamplingResult"]

--- a/verl/utils/filtering/dynamic_sampling.py
+++ b/verl/utils/filtering/dynamic_sampling.py
@@ -1,0 +1,302 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import torch
+
+from verl import DataProto
+
+
+@dataclass(frozen=True)
+class DynamicSamplingResult:
+    """Cumulative status after adding one candidate generation batch."""
+
+    ready: bool
+    metrics: dict[str, float]
+
+
+class DynamicSamplingAccumulator:
+    """Accumulate informative prompt groups for DAPO-style dynamic sampling.
+
+    The accumulator is intentionally trainer-agnostic. It only knows how to
+    filter `DataProto` rows by prompt `uid`, keep reward payloads aligned with
+    the filtered rows, and stop when enough prompt groups have been retained.
+    """
+
+    def __init__(self, filter_config: Any, train_prompt_bsz: int, rollout_n: int):
+        self.filter_config = filter_config
+        self.train_prompt_bsz = int(train_prompt_bsz)
+        self.rollout_n = int(rollout_n)
+        self.metric_name = _get_config_value(filter_config, "metric")
+        self.max_num_gen_batches = int(_get_config_value(filter_config, "max_num_gen_batches", 0) or 0)
+
+        if self.train_prompt_bsz <= 0:
+            raise ValueError(f"train_prompt_bsz must be positive, got {self.train_prompt_bsz}")
+        if self.rollout_n <= 0:
+            raise ValueError(f"rollout_n must be positive, got {self.rollout_n}")
+        if not self.metric_name:
+            raise ValueError("algorithm.filter_groups.metric must be set when filter_groups is enabled")
+
+        self.num_gen_batches = 0
+        self.num_prompt_in_batch = 0
+        self._kept_batches: list[DataProto] = []
+        self._kept_reward_tensors: list[torch.Tensor] = []
+        self._kept_reward_extra_infos: list[dict[str, np.ndarray]] = []
+        self._reward_extra_keys: tuple[str, ...] | None = None
+
+        self._kept_prompts = 0
+        self._dropped_prompts = 0
+        self._kept_trajectories = 0
+        self._dropped_trajectories = 0
+
+    def add_candidate(
+        self,
+        batch: DataProto,
+        reward_tensor: torch.Tensor,
+        reward_extra_infos_dict: dict[str, Any],
+    ) -> DynamicSamplingResult:
+        """Filter one candidate generation batch and append its kept groups."""
+
+        self.num_gen_batches += 1
+        metric_values = self._extract_metric(batch, reward_tensor, reward_extra_infos_dict)
+        uids = _require_1d_array(batch.non_tensor_batch.get("uid"), "uid")
+        if len(uids) != len(batch):
+            raise ValueError(f"uid length {len(uids)} must match batch length {len(batch)}")
+        if len(metric_values) != len(batch):
+            raise ValueError(
+                f"filter metric {self.metric_name!r} length {len(metric_values)} must match batch length {len(batch)}"
+            )
+        if reward_tensor.shape[0] != len(batch):
+            raise ValueError(f"reward tensor batch size {reward_tensor.shape[0]} must match batch length {len(batch)}")
+
+        prompt_uid2metric_vals: dict[Any, list[float]] = defaultdict(list)
+        prompt_uids_in_order = []
+        seen_uids = set()
+        for uid, metric_value in zip(uids, metric_values, strict=True):
+            if uid not in seen_uids:
+                prompt_uids_in_order.append(uid)
+                seen_uids.add(uid)
+            prompt_uid2metric_vals[uid].append(float(metric_value))
+
+        invalid_group_sizes = {
+            uid: len(prompt_uid2metric_vals[uid])
+            for uid in prompt_uids_in_order
+            if len(prompt_uid2metric_vals[uid]) != self.rollout_n
+        }
+        if invalid_group_sizes:
+            raise ValueError(
+                f"Each prompt group must contain rollout_n={self.rollout_n} trajectories for dynamic sampling. "
+                f"Invalid group sizes: {invalid_group_sizes}"
+            )
+
+        kept_prompt_uids = [
+            uid
+            for uid in prompt_uids_in_order
+            if np.std(prompt_uid2metric_vals[uid]) > 0 or len(prompt_uid2metric_vals[uid]) == 1
+        ]
+        kept_prompt_uid_set = set(kept_prompt_uids)
+        kept_traj_idxs = np.asarray(
+            [idx for idx, uid in enumerate(uids) if uid in kept_prompt_uid_set],
+            dtype=np.int64,
+        )
+
+        num_prompts = len(prompt_uids_in_order)
+        num_kept_prompts = len(kept_prompt_uids)
+        num_kept_trajectories = int(kept_traj_idxs.shape[0])
+        self.num_prompt_in_batch += num_kept_prompts
+        self._kept_prompts += num_kept_prompts
+        self._dropped_prompts += num_prompts - num_kept_prompts
+        self._kept_trajectories += num_kept_trajectories
+        self._dropped_trajectories += len(batch) - num_kept_trajectories
+
+        if num_kept_trajectories > 0:
+            kept_batch = batch[kept_traj_idxs]
+            kept_batch.meta_info = _stable_meta_info_for_concat(kept_batch.meta_info)
+            self._kept_batches.append(kept_batch)
+            tensor_indices = torch.as_tensor(kept_traj_idxs, dtype=torch.long, device=reward_tensor.device)
+            self._kept_reward_tensors.append(reward_tensor[tensor_indices])
+            self._kept_reward_extra_infos.append(
+                self._slice_reward_extra_infos(reward_extra_infos_dict, kept_traj_idxs, batch_len=len(batch))
+            )
+
+        return DynamicSamplingResult(ready=self.is_ready(), metrics=self.metrics)
+
+    def is_ready(self) -> bool:
+        return self.num_prompt_in_batch >= self.train_prompt_bsz
+
+    def should_continue(self) -> bool:
+        return not self.is_ready() and (
+            self.max_num_gen_batches <= 0 or self.num_gen_batches < self.max_num_gen_batches
+        )
+
+    def finalize(self) -> tuple[DataProto, torch.Tensor, dict[str, np.ndarray], dict[str, float]]:
+        if not self.is_ready():
+            raise ValueError(
+                f"num_prompt_in_batch={self.num_prompt_in_batch} < train_prompt_bsz={self.train_prompt_bsz}. "
+                f"Generated {self.num_gen_batches} batch(es), max_num_gen_batches={self.max_num_gen_batches}."
+            )
+        if not self._kept_batches:
+            raise ValueError("No trajectories were kept by dynamic sampling")
+
+        batch = self._kept_batches[0] if len(self._kept_batches) == 1 else DataProto.concat(self._kept_batches)
+        reward_tensor = (
+            self._kept_reward_tensors[0]
+            if len(self._kept_reward_tensors) == 1
+            else torch.cat(self._kept_reward_tensors, dim=0)
+        )
+        reward_extra_infos = _concat_reward_extra_infos(self._kept_reward_extra_infos, self._reward_extra_keys or ())
+
+        traj_bsz = self.train_prompt_bsz * self.rollout_n
+        batch = batch[:traj_bsz]
+        reward_tensor = reward_tensor[:traj_bsz]
+        reward_extra_infos = {key: value[:traj_bsz] for key, value in reward_extra_infos.items()}
+        return batch, reward_tensor, reward_extra_infos, self.metrics
+
+    @property
+    def metrics(self) -> dict[str, float]:
+        total_prompts = self._kept_prompts + self._dropped_prompts
+        kept_ratio = self._kept_prompts / total_prompts if total_prompts > 0 else 0.0
+        reached_max = (
+            self.max_num_gen_batches > 0 and self.num_gen_batches >= self.max_num_gen_batches and not self.is_ready()
+        )
+        return {
+            "dynamic_sampling/num_gen_batches": float(self.num_gen_batches),
+            "dynamic_sampling/num_prompt_in_batch": float(self.num_prompt_in_batch),
+            "dynamic_sampling/kept_prompts": float(self._kept_prompts),
+            "dynamic_sampling/dropped_prompts": float(self._dropped_prompts),
+            "dynamic_sampling/kept_trajectories": float(self._kept_trajectories),
+            "dynamic_sampling/dropped_trajectories": float(self._dropped_trajectories),
+            "dynamic_sampling/kept_prompt_ratio": float(kept_ratio),
+            "dynamic_sampling/reached_max_num_gen_batches": float(reached_max),
+        }
+
+    def _extract_metric(
+        self,
+        batch: DataProto,
+        reward_tensor: torch.Tensor,
+        reward_extra_infos_dict: dict[str, Any],
+    ) -> np.ndarray:
+        metric_name = self.metric_name
+        if metric_name == "seq_reward":
+            scores = batch.batch["token_level_scores"] if "token_level_scores" in batch.batch.keys() else reward_tensor
+            return _tensor_to_numpy_1d(scores.sum(dim=-1), metric_name)
+
+        if metric_name == "seq_final_reward":
+            if "token_level_rewards" not in batch.batch.keys():
+                raise ValueError(
+                    "algorithm.filter_groups.metric='seq_final_reward' requires token_level_rewards, "
+                    "which are not available before one-step-off advantage/KL computation. "
+                    "Use metric='seq_reward', 'acc', or another reward extra key instead."
+                )
+            return _tensor_to_numpy_1d(batch.batch["token_level_rewards"].sum(dim=-1), metric_name)
+
+        if metric_name in reward_extra_infos_dict:
+            return _values_to_numpy_1d(reward_extra_infos_dict[metric_name], metric_name)
+        if metric_name in batch.non_tensor_batch:
+            return _values_to_numpy_1d(batch.non_tensor_batch[metric_name], metric_name)
+        if metric_name in batch.batch.keys():
+            value = batch.batch[metric_name]
+            if value.ndim > 1:
+                value = value.sum(dim=-1)
+            return _tensor_to_numpy_1d(value, metric_name)
+
+        available = sorted(
+            set(batch.non_tensor_batch.keys()) | set(batch.batch.keys()) | set(reward_extra_infos_dict.keys())
+        )
+        raise ValueError(f"Could not find filter metric {metric_name!r}. Available keys: {available}")
+
+    def _slice_reward_extra_infos(
+        self,
+        reward_extra_infos_dict: dict[str, Any],
+        indices: np.ndarray,
+        batch_len: int,
+    ) -> dict[str, np.ndarray]:
+        normalized = {
+            key: _require_1d_array(value, f"reward_extra_infos_dict[{key!r}]")
+            for key, value in reward_extra_infos_dict.items()
+        }
+        for key, value in normalized.items():
+            if len(value) != batch_len:
+                raise ValueError(
+                    f"reward_extra_infos_dict[{key!r}] length {len(value)} must match batch length {batch_len}"
+                )
+        reward_extra_keys = tuple(sorted(normalized.keys()))
+        if self._reward_extra_keys is None:
+            self._reward_extra_keys = reward_extra_keys
+        elif reward_extra_keys != self._reward_extra_keys:
+            raise ValueError(
+                f"Reward extra info keys must be stable across dynamic sampling batches. "
+                f"Expected {self._reward_extra_keys}, got {reward_extra_keys}."
+            )
+        return {key: value[indices] for key, value in normalized.items()}
+
+
+def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    if hasattr(config, "get"):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _stable_meta_info_for_concat(meta_info: dict[str, Any]) -> dict[str, Any]:
+    stable_meta_info = {}
+    if "reward_extra_keys" in meta_info:
+        stable_meta_info["reward_extra_keys"] = sorted(meta_info["reward_extra_keys"])
+    return stable_meta_info
+
+
+def _tensor_to_numpy_1d(value: torch.Tensor, name: str) -> np.ndarray:
+    if value.ndim != 1:
+        raise ValueError(f"{name} must be 1-D after reduction, got shape {tuple(value.shape)}")
+    return value.detach().cpu().numpy()
+
+
+def _values_to_numpy_1d(value: Any, name: str) -> np.ndarray:
+    array = _require_1d_array(value, name)
+    try:
+        return array.astype(np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain numeric values for dynamic sampling") from exc
+
+
+def _require_1d_array(value: Any, name: str) -> np.ndarray:
+    if value is None:
+        raise ValueError(f"{name} is required for dynamic sampling")
+    if isinstance(value, torch.Tensor):
+        array = value.detach().cpu().numpy()
+    elif isinstance(value, np.ndarray):
+        array = value
+    else:
+        array = np.asarray(value, dtype=object)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D sequence, got shape {array.shape}")
+    return array
+
+
+def _concat_reward_extra_infos(
+    reward_extra_infos: list[dict[str, np.ndarray]],
+    reward_extra_keys: tuple[str, ...],
+) -> dict[str, np.ndarray]:
+    if not reward_extra_keys:
+        return {}
+    return {
+        key: np.concatenate([extra_info[key] for extra_info in reward_extra_infos], axis=0) for key in reward_extra_keys
+    }


### PR DESCRIPTION
## Summary

Addresses #3539 by restoring opt-in DAPO-style dynamic sampling for the one-step-off policy trainer.

This PR adds a shared dynamic sampling accumulator, wires it into `verl.experimental.one_step_off_policy.ray_trainer.OneStepOffRayTrainer`, updates the one-step-off DAPO launch scripts to enable group filtering, and documents the supported configuration.

## Root Cause

The one-step-off DAPO path can generate `rollout.n` responses per prompt, but it did not include the DAPO group-filter/backfill loop. As a result, prompt groups whose reward metric was constant across all responses were still used for training, which diverges from the intended DAPO dynamic sampling flow.

## Changes

- Added `verl.utils.filtering.DynamicSamplingAccumulator` to filter prompt groups by `uid`, keep reward tensors and reward-extra info aligned, and backfill until `data.train_batch_size` prompt groups are available.
- Added one-step-off trainer support for `algorithm.filter_groups`, including reward extraction before filtering and reuse of the precomputed reward payload during the normal training step.
- Kept all backfill attempts for a final training batch inside the same async generation future, before the next actor-to-rollout weight sync, so the one-step-off policy relationship is preserved.
- Added guardrails for unsupported `seq_final_reward` ordering, `rollout.skip_rollout`, prompt-group size mismatches, reward-extra alignment, and stable reward-extra metadata.
- Updated one-step-off DAPO FSDP2, SGLang, Megatron, colocate, and RIS scripts to set `+data.gen_batch_size` and `+algorithm.filter_groups.*`.
- Added focused unit tests for the standalone accumulator and the async one-step-off dynamic backfill path.
- Updated DAPO and one-step-off documentation.

## Duplicate Work Check

I checked for duplicate open work before opening this PR:

- `gh issue view 3539 --repo verl-project/verl --comments`
- `gh pr list --repo verl-project/verl --state open --search "3539 in:body"`
- `gh pr list --repo verl-project/verl --state open --search "one-step off dynamic sampling"`
- `gh pr list --repo verl-project/verl --state open --search "dynamic sampling filter groups"`

No open PR directly addresses #3539. PR #2988 is related dynamic sampling work, but it is broader/main-trainer scoped and does not provide this one-step-off integration.

## Validation

Ran in the isolated worktree:

```bash
.venv310/bin/python -m pytest tests/utils/test_dynamic_sampling.py tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
.venv310/bin/ruff check verl/utils/filtering/dynamic_sampling.py verl/utils/filtering/__init__.py verl/experimental/one_step_off_policy/ray_trainer.py tests/utils/test_dynamic_sampling.py tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
.venv310/bin/ruff format --check verl/utils/filtering/dynamic_sampling.py verl/utils/filtering/__init__.py verl/experimental/one_step_off_policy/ray_trainer.py tests/utils/test_dynamic_sampling.py tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
.venv310/bin/python -m py_compile verl/utils/filtering/dynamic_sampling.py verl/experimental/one_step_off_policy/ray_trainer.py tests/utils/test_dynamic_sampling.py tests/experimental/one_step_off_policy/test_one_step_off_dynamic_sampling.py
bash -n verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_4_12.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_64_64_ris.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_colocate.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_4_12.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_fsdp2_sglang_colocate.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_4_12.sh verl/experimental/one_step_off_policy/shell/dapo_7b_math_megatron_colocate.sh
git diff --check
```

Also verified Hydra composition for both `one_step_off_ppo_trainer` and `one_step_off_ppo_megatron_trainer` with:

```bash
+data.gen_batch_size=1536 data.train_batch_size=512 +algorithm.filter_groups.enable=True +algorithm.filter_groups.metric=acc +algorithm.filter_groups.max_num_gen_batches=10
```

The focused pytest run passed with `13 passed`; only pre-existing local warnings were emitted from Ray state API deprecation and the NPU router replay warning.
