### PR TITLE
[trainer] fix: convert numpy arrays to native types before dumping rollout JSONL

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -444,7 +444,9 @@ class RayPPOTrainer:
             scores = batch.batch["token_level_scores"].sum(-1).cpu().tolist()
             sample_gts = [item.non_tensor_batch.get("reward_model", {}).get("ground_truth", None) for item in batch]
 
-            reward_extra_infos_to_dump = reward_extra_infos_dict.copy()
+            reward_extra_infos_to_dump = {
+                k: (v.tolist() if isinstance(v, np.ndarray) else v) for k, v in reward_extra_infos_dict.items()
+            }
             if "request_id" in batch.non_tensor_batch:
                 reward_extra_infos_dict.setdefault(
                     "request_id",


### PR DESCRIPTION
## Fix

`TypeError: Object of type int64 is not JSON serializable` in
`RayPPOTrainer._log_rollout_data` when a custom reward function puts
numpy-typed values into `reward_extra_info`.

Values in `reward_extra_infos_dict` come from `extract_reward()` →
`batch.non_tensor_batch[...]`, i.e. numpy arrays. `_validate()` already
does `.tolist()` on the same data; `_log_rollout_data` skipped it.
This PR applies the same boundary conversion.

## Relation to #6062

#6062 added `json.dumps(..., default=str)` to keep the dump from
crashing. This PR is complementary, not a replacement:

- `default=str` is a last-resort fallback — it stringifies anything
  `json` can't serialize, including numpy scalars. That means numpy
  `int64(3)` silently becomes `"3"` in the JSONL.
- Boundary `.tolist()` converts numpy containers to native Python before
  they reach `json.dumps`, so integers stay integers.

With both in place, numpy data gets the correct native-type output, and
any genuinely non-serializable object (e.g. custom classes that might
slip in via `ground_truth`) is still caught by `default=str`.

## Duplicate-work check

```
gh pr list --repo verl-project/verl --state open --search "dump_generations"
gh pr list --repo verl-project/verl --state open --search "log_rollout_data"
gh pr list --repo verl-project/verl --state all  --search "int64 JSON serializable"
```

Only related hit is merged PR #6062; see section above.

## Test plan

- Reproduced the traceback on a downstream training run with a custom
  reward returning `{"num_turns": int}` in `reward_extra_info`; without
  patch, `_dump_generations` crashes on the first call.
- Minimal standalone repro confirmed: baseline `json.dumps` fails on
  `np.int64`; with `.tolist()` boundary conversion, output is native
  integer `3` rather than string `"3"` produced by `default=str` alone.
- `pre-commit run --files verl/trainer/ppo/ray_trainer.py`: all hooks
  pass.

## AI-assisted disclosure

AI assistance (Claude) used. Submitter reviewed every changed line.