### PR TITLE
[veomni] feat: use VeOmni's native return_log_probs path to compute log_probs

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a1 --ignore-requires-python --no-deps
+          pip3 install veomni==0.1.9a4 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==4.57.3
       - name: Prepare GSM8K dataset
         run: |

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           pip install -r requirements-npu.txt
           pip install --no-deps -e .
-          pip install veomni==0.1.9a1 --ignore-requires-python --no-deps
+          pip install veomni==0.1.9a4 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip install transformers==4.57.3
       - name: Check final pip list
         run: |

--- a/.github/workflows/e2e_sft_llm.yml
+++ b/.github/workflows/e2e_sft_llm.yml
@@ -105,7 +105,7 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a1 --ignore-requires-python --no-deps
+          pip3 install veomni==0.1.9a4 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==4.57.3
       - name: Prepare gsm8k dataset
         run: |

--- a/.github/workflows/e2e_sft_llm_ascend.yml
+++ b/.github/workflows/e2e_sft_llm_ascend.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install the current repository
         run: |
           pip install --no-deps -e .
-          pip install veomni==0.1.9a1 --ignore-requires-python --no-deps
+          pip install veomni==0.1.9a4 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip install transformers==4.57.3
           pip install pandas==2.3.3
           pip uninstall -y mbridge

--- a/.github/workflows/e2e_sft_vlm.yml
+++ b/.github/workflows/e2e_sft_vlm.yml
@@ -105,7 +105,7 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a1 --ignore-requires-python --no-deps
+          pip3 install veomni==0.1.9a4 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==4.57.3
       - name: Prepare pokemon-gpt4o-captions dataset
         run: |

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -43,6 +43,11 @@ actor_rollout_ref:
       enable_reentrant: false
       attn_implementation: flash_attention_2
       moe_implementation: fused
+      cross_entropy_loss_implementation: eager
+      rms_norm_implementation: eager
+      swiglu_mlp_implementation: eager
+      rotary_pos_emb_implementation: eager
+      load_balancing_loss_implementation: eager
       force_use_huggingface: false
       activation_gpu_limit: 0.0
     _target_: verl.workers.config.VeOmniActorConfig
@@ -202,6 +207,11 @@ actor_rollout_ref:
       enable_reentrant: false
       attn_implementation: ${oc.select:actor_rollout_ref.actor.veomni.attn_implementation,flash_attention_2}
       moe_implementation: ${oc.select:actor_rollout_ref.actor.veomni.moe_implementation,fused}
+      cross_entropy_loss_implementation: ${oc.select:actor_rollout_ref.actor.veomni.cross_entropy_loss_implementation,eager}
+      rms_norm_implementation: ${oc.select:actor_rollout_ref.actor.veomni.rms_norm_implementation,eager}
+      swiglu_mlp_implementation: ${oc.select:actor_rollout_ref.actor.veomni.swiglu_mlp_implementation,eager}
+      rotary_pos_emb_implementation: ${oc.select:actor_rollout_ref.actor.veomni.rotary_pos_emb_implementation,eager}
+      load_balancing_loss_implementation: ${oc.select:actor_rollout_ref.actor.veomni.load_balancing_loss_implementation,eager}
       force_use_huggingface: false
       activation_gpu_limit: 0.0
     _target_: verl.workers.config.VeOmniActorConfig
@@ -473,6 +483,11 @@ critic:
     enable_reentrant: false
     attn_implementation: flash_attention_2
     moe_implementation: fused
+    cross_entropy_loss_implementation: eager
+    rms_norm_implementation: eager
+    swiglu_mlp_implementation: eager
+    rotary_pos_emb_implementation: eager
+    load_balancing_loss_implementation: eager
     force_use_huggingface: false
     activation_gpu_limit: 0.0
   _target_: verl.workers.config.VeOmniCriticConfig

--- a/verl/trainer/config/engine/veomni.yaml
+++ b/verl/trainer/config/engine/veomni.yaml
@@ -51,6 +51,17 @@ attn_implementation: flash_attention_2
 # eager or fused
 moe_implementation: fused
 
+# Kernel backends consumed by VeOmni's per-model device_patch
+# (apply_per_model_patches → OpsImplementationConfig). Defaults match VeOmni's
+# defaults; set rms_norm_implementation=triton + rotary_pos_emb_implementation=triton
+# on DeepSeek-V3 / Moonlight to keep the FSDP actor bitwise-aligned with vexact's
+# rollout. See VeOmni docs/design/kernel_selection.md for the full backend matrix.
+cross_entropy_loss_implementation: eager
+rms_norm_implementation: eager
+swiglu_mlp_implementation: eager
+rotary_pos_emb_implementation: eager
+load_balancing_loss_implementation: eager
+
 force_use_huggingface: false
 
 activation_gpu_limit: 0.0

--- a/verl/trainer/config/ref/veomni_ref.yaml
+++ b/verl/trainer/config/ref/veomni_ref.yaml
@@ -20,5 +20,10 @@ veomni:
   param_offload: ${oc.select:actor_rollout_ref.actor.veomni.param_offload,False}
   attn_implementation: ${oc.select:actor_rollout_ref.actor.veomni.attn_implementation,flash_attention_2}
   moe_implementation: ${oc.select:actor_rollout_ref.actor.veomni.moe_implementation,fused}
+  cross_entropy_loss_implementation: ${oc.select:actor_rollout_ref.actor.veomni.cross_entropy_loss_implementation,eager}
+  rms_norm_implementation: ${oc.select:actor_rollout_ref.actor.veomni.rms_norm_implementation,eager}
+  swiglu_mlp_implementation: ${oc.select:actor_rollout_ref.actor.veomni.swiglu_mlp_implementation,eager}
+  rotary_pos_emb_implementation: ${oc.select:actor_rollout_ref.actor.veomni.rotary_pos_emb_implementation,eager}
+  load_balancing_loss_implementation: ${oc.select:actor_rollout_ref.actor.veomni.load_balancing_loss_implementation,eager}
   forward_only: True
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -302,6 +302,20 @@ class VeOmniEngineConfig(EngineConfig):
             2. `fused`
             default "fused"
             Note: In case VeOmni add more moe_implementation, please check https://github.com/ByteDance-Seed/VeOmni/
+        cross_entropy_loss_implementation (str): Cross-entropy kernel selected via VeOmni's
+            ``OpsImplementationConfig``. Common values: ``"eager"`` (default), ``"liger_kernel"``,
+            ``"npu"``. See VeOmni docs for the full registry.
+        rms_norm_implementation (str): RMSNorm kernel. ``"eager"`` (HF default),
+            ``"triton"`` (batch-invariant Triton kernel — required to keep vexact's rollout
+            and the FSDP actor bitwise-aligned on DeepSeek-V3 / Moonlight), ``"liger_kernel"``,
+            ``"npu"``.
+        swiglu_mlp_implementation (str): SwiGLU MLP kernel. ``"eager"`` (default) or
+            ``"liger_kernel"``.
+        rotary_pos_emb_implementation (str): RoPE kernel. ``"eager"`` (default), ``"triton"``
+            (deterministic Triton bmm — required for bitwise-aligned RoPE on DeepSeek-V3 /
+            Moonlight), ``"liger_kernel"``, ``"npu"``.
+        load_balancing_loss_implementation (str): MoE load-balancing loss kernel.
+            ``"eager"`` (default) or ``"triton"``.
         force_use_huggingface (bool): Force loading model from huggingface, default False
         activation_gpu_limit (float): When enabling activation offload, `activation_gpu_limit` GB
             activations are allowed to reserve on GPU, default 0.0
@@ -342,6 +356,15 @@ class VeOmniEngineConfig(EngineConfig):
     enable_reentrant: bool = False
     attn_implementation: str = "flash_attention_2"
     moe_implementation: str = "fused"
+    # Kernel-backend selectors for VeOmni's per-model patches; passed into
+    # OpsImplementationConfig and consumed by apply_per_model_patches in each
+    # model's device_patch.py. Defaults match VeOmni's OpsImplementationConfig
+    # defaults so existing configs see no change.
+    cross_entropy_loss_implementation: str = "eager"
+    rms_norm_implementation: str = "eager"
+    swiglu_mlp_implementation: str = "eager"
+    rotary_pos_emb_implementation: str = "eager"
+    load_balancing_loss_implementation: str = "eager"
     force_use_huggingface: bool = False
     activation_gpu_limit: float = 0.0
     basic_modules: Optional[list[str]] = field(default_factory=list)

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -21,6 +21,7 @@ import torch
 import torch.distributed as dist
 from tensordict import TensorDict
 from torch.distributed.tensor import DTensor
+from veomni.arguments import OpsImplementationConfig
 from veomni.distributed import parallel_state
 from veomni.distributed.offloading import build_activation_offloading_context
 from veomni.distributed.torch_parallelize import build_parallelize_model
@@ -194,13 +195,26 @@ class VeOmniEngine(FSDPEngine):
         return lr_scheduler
 
     def _build_model_optimizer(self):
+        # build_foundation_model runs apply_ops_config(ops_implementation)
+        # before constructing the model, so per-model device_patch files see
+        # the resolved kernel backends.
+        ops_implementation = OpsImplementationConfig(
+            attn_implementation=self.engine_config.attn_implementation,
+            moe_implementation=self.engine_config.moe_implementation,
+            cross_entropy_loss_implementation=self.engine_config.cross_entropy_loss_implementation,
+            rms_norm_implementation=self.engine_config.rms_norm_implementation,
+            swiglu_mlp_implementation=self.engine_config.swiglu_mlp_implementation,
+            rotary_pos_emb_implementation=self.engine_config.rotary_pos_emb_implementation,
+            load_balancing_loss_implementation=self.engine_config.load_balancing_loss_implementation,
+        )
+
         # Load base model with specified configuration and dtype
         module = build_foundation_model(
             config_path=self.model_config.local_hf_config_path,
             weights_path=self.model_config.local_path,
             torch_dtype="float32" if self.engine_config.mixed_precision else "bfloat16",
             attn_implementation=self.engine_config.attn_implementation,
-            moe_implementation=self.engine_config.moe_implementation,
+            ops_implementation=ops_implementation,
             init_device=self.engine_config.init_device,
         )
         log_gpu_memory_usage("After load base model", logger=logger)

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -649,4 +649,16 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             if sp_enabled:
                 model_inputs["position_ids"] = sp_shard_collator.sp_slice(model_inputs["position_ids"], dim=-1)
 
+        # Activate VeOmni's chunk_logprobs path: ForCausalLMLoss short-circuits
+        # to per-token log_probs/entropy on return_log_probs=True. Pass the
+        # already-rolled labels as shift_labels so chunk_logprobs skips its
+        # internal causal shift and the output seq length matches the input —
+        # prepare_model_outputs().squeeze(0) then lands at (total_nnz,).
+        use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
+        if use_fused_kernels and use_remove_padding:
+            shift_labels = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
+            model_inputs["labels"] = input_ids_rmpad
+            model_inputs["shift_labels"] = shift_labels
+            model_inputs["return_log_probs"] = True
+
         return model_inputs, output_args


### PR DESCRIPTION
## Summary

`VeOmniEngine` previously had no path to populate `output.log_probs` /
`output.entropy` when `actor_rollout_ref.model.use_fused_kernels=True`,
so `FSDPEngine.prepare_model_outputs` crashed at `_compute_old_log_prob` with:

```
AttributeError: 'CausalLMOutputWithPast' object has no attribute 'log_probs'
```

Reproduces on any model whose `*ForCausalLM.forward` would normally route
through verl's `dense_common.forward_with_torch_backend`
(e.g. Moonlight-16B-A3B-Instruct / `model_type=deepseek_v3` loaded with
`trust_remote_code=True`, `model_engine=veomni`).

## Approach

Instead of re-installing verl's `patch_forward_with_backends` swap inside
`VeOmniEngine`, this PR uses **VeOmni's own** native per-token log-probs
path (added in ByteDance-Seed/VeOmni#711, extended in #720) to populate the
same fields the verl monkey patch would have. Concretely:

- **VeOmni side**: every patched `*ForCausalLM.forward` (deepseek_v3, llama,
  qwen2/3/3moe/3.5/3.5moe/3vl/3vlmoe/3omnimoe, qwen2.5omni, seed_oss,
  glm_moe_dsa) now does `loss, _, log_probs, entropy = self.loss_function(...)`
  and returns `CausalLMOutputWithLogProbs(log_probs=..., entropy=...)`.
  `ForCausalLMLoss` short-circuits to `chunk_logprobs_function` whenever the
  caller forwards `return_log_probs=True` through `forward(**kwargs)`.

- **verl side** (this PR):
  `VeOmniEngineWithLMHead.prepare_model_inputs` injects three kwargs into
  `model_inputs` whenever `use_fused_kernels=True` and
  `use_remove_padding=True`:
    - `labels` = the packed `input_ids_rmpad` (shape `[1, total_nnz/sp + pad]`);
    - `shift_labels` = the pre-rolled labels already living in
      `output_args[\"input_ids_rmpad_rolled\"]`, unsqueezed back to `[1, …]`.
      Passing `shift_labels` makes `chunk_logprobs_function` skip its internal
      causal shift, so the output seq length matches the input — and
      `prepare_model_outputs.squeeze(0)` lands at the `(total_nnz,)` shape
      verl already expects;
    - `return_log_probs=True` to flip `ForCausalLMLoss` onto the chunked
      log-probs / entropy path.

Net result: zero per-model verl forward overrides to maintain. VLM / MoE
forwards keep their VeOmni-installed pre-sharding visual-fusion / SP-aware
variants untouched. The previous draft of this PR had to skip VLM
model_types explicitly because verl's VLM `forward_with_torch_backend` would
otherwise overwrite VeOmni's patched forward; that whole concern goes away.

The PR also threads `OpsImplementationConfig` through `VeOmniEngine` (split
into its own commit + Hydra schema regen) — both because it's required for
the new `build_foundation_model(ops_implementation=…)` API after VeOmni's
kernel registry refactor, and because it's the natural plumbing for users
to opt into `triton` / `liger_kernel` / `npu` backends through Hydra.

## Commit map

- `feat: thread OpsImplementationConfig through VeOmniEngine` — adds the
  seven `*_implementation` fields to `VeOmniEngineConfig` and uses them
  to build an `OpsImplementationConfig` passed to `build_foundation_model`.
- `config: add ops_implementation fields to Hydra schema yamls` — regen of
  `engine/veomni.yaml`, `ref/veomni_ref.yaml`, and the composed
  `_generated_ppo_veomni_trainer.yaml`.
- `feat: use VeOmni's native return_log_probs path for fused-kernel log_probs/entropy`
  — the `prepare_model_inputs` injection.

## Dependency

Requires `veomni` >= release containing both `ByteDance-Seed/VeOmni#711`
(chunked per-token log-probs) and `#720` (forward `temperature`, return
per-token entropy from the log-probs path). Without #720,
`output.entropy` is missing and `prepare_model_outputs` would fail when
`calculate_entropy=True`.

## Duplicate check

```
gh pr list --repo verl-project/verl --state open --search 'veomni return_log_probs in:title,body'
gh pr list --repo verl-project/verl --state open --search 'veomni native log_probs in:title,body'
gh issue list --repo verl-project/verl --state open --search 'veomni CausalLMOutputForPPO log_probs'
```

All empty — no overlap with existing work.

## Test plan

- [x] **Bitwise rollout-actor alignment** on Moonlight-16B-A3B-Instruct
  (deepseek_v3 architecture) with the GRPO + gsm8k recipe at
  \`examples/moe/run_moonlight_gsm8k.sh\`. Four consecutive training steps
  with \`training/rollout_probs_diff_max == 0.0\`,
  \`training/rollout_probs_diff_mean == 0.0\`,
  \`training/rollout_actor_probs_pearson_corr == 1.0\` — i.e. exactly
  matches what the verl monkey-patched path produced before, on the same
  recipe + same hardware (8×B200).
- [x] Lint clean: \`ruff format --check\` + \`ruff check\` on all touched
  files.
- [ ] Reviewer reproduction: same recipe, with a VeOmni release that
  includes both #711 and #720 once available.

## AI assistance

This patch was authored with AI assistance (Claude Code). The submitting
human reviewed every changed line and re-ran the end-to-end Moonlight gsm8k
bitwise alignment check on 8×B200 before requesting review.