### PR TITLE
[fsdp] fix: FSDP2 CPUOffloadPolicy crashes in get_per_tensor_param during weight sync

### DIFF
--- a/tests/models/test_fsdp2_cpuoffload_state_dict.py
+++ b/tests/models/test_fsdp2_cpuoffload_state_dict.py
@@ -1,0 +1,149 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression test for GitHub issue #5995:
+FSDP2 CPUOffloadPolicy + state_dict() crashes with device mismatch during update_weights.
+
+When offload_policy=True, FSDP2 uses CPUOffloadPolicy to manage parameter placement.
+However, get_per_tensor_param() calls self.module.state_dict() which crashes because
+parameters are on CPU while PyTorch's state_dict hooks expect CUDA tensors.
+
+Usage:
+    # Requires at least 2 GPUs
+    pytest tests/models/test_fsdp2_cpuoffload_state_dict.py -s -x
+"""
+
+import os
+
+os.environ["NCCL_DEBUG"] = "WARN"
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from transformers import AutoConfig, AutoModelForCausalLM, Qwen3Config
+
+from verl.trainer.config import CheckpointConfig
+from verl.utils.fsdp_utils import offload_fsdp_model_to_cpu
+from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
+from verl.workers.engine import BaseEngine, EngineRegistry
+
+
+def _create_model(tmp_path, config):
+    """Create a small model for testing."""
+    model = AutoModelForCausalLM.from_config(config)
+    path = os.path.join(tmp_path, "test_model")
+    model.save_pretrained(path)
+    config.save_pretrained(path)
+    return path
+
+
+def _worker(rank: int, world_size: int, rendezvous_file: str, model_path: str,
+            offload_policy: bool):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    ref_model_config = AutoConfig.from_pretrained(model_path)
+    with torch.device("meta"):
+        ref_model = AutoModelForCausalLM.from_config(ref_model_config)
+
+    model_config = HFModelConfig(path=model_path, load_tokenizer=False)
+    engine_config = FSDPEngineConfig(
+        forward_only=False,
+        fsdp_size=world_size,
+        strategy="fsdp2",
+        offload_policy=offload_policy,
+        param_offload=True,
+        optimizer_offload=True,
+    )
+    optimizer_config = FSDPOptimizerConfig()
+    checkpoint_config = CheckpointConfig()
+
+    engine: BaseEngine = EngineRegistry.new(
+        model_type="language_model",
+        backend="fsdp2",
+        model_config=model_config,
+        engine_config=engine_config,
+        optimizer_config=optimizer_config,
+        checkpoint_config=checkpoint_config,
+    )
+
+    engine.initialize()
+
+    # Simulate post-training state where params have been offloaded to CPU.
+    if offload_policy:
+        # CPUOffloadPolicy: FSDP2 manages offload automatically after forward/backward.
+        # Force params to CPU to simulate this state.
+        engine.module.cpu()
+        torch.cuda.empty_cache()
+    else:
+        # Manual offload (param_offload=True): verl calls offload_fsdp_model_to_cpu()
+        # after training step. Simulate this.
+        offload_fsdp_model_to_cpu(engine.module)
+
+    # This is the call that crashes with issue #5995 (offload_policy=True):
+    # get_per_tensor_param() -> self.module.state_dict()
+    # RuntimeError: Attempted to set the storage of a tensor on device "cpu"
+    # to a storage on different device "cuda:0"
+    per_tensor_params, _ = engine.get_per_tensor_param()
+
+    ref_state_dict = ref_model.state_dict()
+
+    for key, value in per_tensor_params:
+        assert key in ref_state_dict, f"{key} not in ref_state_dict"
+        assert value.shape == ref_state_dict[key].shape, (
+            f"{key} shape mismatch: {value.shape} != {ref_state_dict[key].shape}"
+        )
+        if rank == 0:
+            print(f"  {key}: {value.shape}")
+
+    mode = "offload_policy (CPUOffloadPolicy)" if offload_policy else "param_offload (manual)"
+    if rank == 0:
+        print(f"SUCCESS: get_per_tensor_param() [{mode}] completed without error")
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    "offload_policy",
+    [False, True],
+    ids=["param_offload_manual", "offload_policy_cpuoffloadpolicy"],
+)
+def test_fsdp2_get_per_tensor_param_with_cpuoffload(tmp_path, offload_policy):
+    """Test get_per_tensor_param with both FSDP2 offload modes after params are on CPU.
+
+    param_offload (manual): verl manages offload, load_fsdp_model_to_gpu + state_dict().
+    offload_policy (CPUOffloadPolicy): FSDP2 manages offload, needs get_fsdp_full_state_dict (#5995).
+    """
+    world_size = min(torch.cuda.device_count(), 4)
+    if world_size < 2:
+        pytest.skip("Need at least 2 GPUs")
+
+    config = Qwen3Config(num_hidden_layers=2)
+    model_path = _create_model(str(tmp_path), config)
+    rendezvous_file = str(tmp_path / f"rdzv_{offload_policy}")
+
+    mp.spawn(
+        fn=_worker,
+        args=(world_size, rendezvous_file, model_path, offload_policy),
+        nprocs=world_size,
+        join=True,
+    )

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -48,6 +48,7 @@ from verl.utils.fsdp_utils import (
     fsdp2_clip_grad_norm_,
     fsdp2_load_full_state_dict,
     fsdp_version,
+    get_fsdp_full_state_dict,
     get_fsdp_wrap_policy,
     get_init_weight_context_manager,
     init_fn,
@@ -748,7 +749,8 @@ class FSDPEngine(BaseEngine):
     def get_per_tensor_param(self, layered_summon=False, base_sync_done=False, **kwargs):
         log_gpu_memory_usage("Before load_fsdp_model_to_gpu", logger=logger)
 
-        load_fsdp_model_to_gpu(self.module)
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.module)
 
         log_gpu_memory_usage("After load_fsdp_model_to_gpu", logger=logger)
 
@@ -771,7 +773,13 @@ class FSDPEngine(BaseEngine):
                     params = self.module.state_dict()
                     params = normalize_peft_param_name(params)
         else:
-            params = self.module.state_dict()
+            if fsdp_version(self.module) == 2 and not self._is_offload_param:
+                # FSDP2 + CPUOffloadPolicy: use get_fsdp_full_state_dict which internally calls
+                # get_model_state_dict with full_state_dict=True. Direct self.module.state_dict()
+                # crashes when CPUOffloadPolicy has offloaded params to CPU (#5995).
+                params = get_fsdp_full_state_dict(self.module, offload_to_cpu=False, rank0_only=False)
+            else:
+                params = self.module.state_dict()
 
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
 


### PR DESCRIPTION
### What does this PR do?

Fixes #5995. When using FSDP2 with offload_policy=True (CPUOffloadPolicy), get_per_tensor_param() crashes during weight sync to the vLLM rollout engine:

  RuntimeError: Attempted to set the storage of a tensor on device "cpu"
  to a storage on different device "cuda:0"

  Root cause: After training, FSDP2's CPUOffloadPolicy offloads params to CPU. get_per_tensor_param() then calls self.module.state_dict(), which crashes because FSDP2's native state_dict() cannot handle
  CPU-offloaded params.

Fix: For FSDP2, use get_fsdp_full_state_dict() instead


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `vllm_omni`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Reproduced the crash in a regression test (test_fsdp2_cpuoffload_state_dict.py). Without the fix the test fails with the device mismatch error; with the fix both cases pass. Verified on 2×H100.

pytest tests/models/test_fsdp2_cpuoffload_state_dict.py -s -x -v



### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
