### PR TITLE
[megatron] fix: avoid 2x peak host memory on Megatron model offload

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -491,8 +491,44 @@ def offload_megatron_model_to_cpu(models):
                 for buffer in buffers:
                     # offload parameters
                     if buffer.param_data.storage().size() > 0:
-                        buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()
-                        buffer.param_data_size = buffer.param_data.storage().size()
+                        # Reuse a single pinned cpu_data buffer per DDP buffer.
+                        # The previous implementation reallocated cpu_data via
+                        # `.cpu().pin_memory()` on every offload. Python evaluates
+                        # the RHS before the assignment, so the new pinned block is
+                        # allocated while the old cpu_data is still referenced --
+                        # peak host memory at the moment of allocation is 2x
+                        # param_data size. On large Megatron models this transient
+                        # peak exceeds the cgroup limit and OOMKills the pod even
+                        # though steady-state usage would be 1x. Reallocating here
+                        # would re-trigger the same 2x peak, so we allocate at most
+                        # once per buffer and assert shape/dtype invariance on
+                        # subsequent calls -- a mismatch means a caller rebuilt
+                        # param_data under us, which is a bug we want surfaced
+                        # rather than silently worked around.
+                        existing = getattr(buffer.param_data, "cpu_data", None)
+                        if existing is None:
+                            buffer.param_data.cpu_data = torch.empty(
+                                buffer.param_data.size(),
+                                dtype=buffer.param_data.dtype,
+                                device="cpu",
+                                pin_memory=True,
+                            )
+                            buffer.param_data_size = buffer.param_data.storage().size()
+                        else:
+                            assert existing.shape == buffer.param_data.shape, (
+                                f"cpu_data shape {tuple(existing.shape)} != "
+                                f"param_data shape {tuple(buffer.param_data.shape)}; "
+                                "reallocating would reintroduce the 2x peak."
+                            )
+                            assert existing.dtype == buffer.param_data.dtype, (
+                                f"cpu_data dtype {existing.dtype} != "
+                                f"param_data dtype {buffer.param_data.dtype}; "
+                                "reallocating would reintroduce the 2x peak."
+                            )
+                        # Synchronous D2H copy into the preexisting pinned
+                        # buffer; must complete before resize_(0) frees the
+                        # GPU storage.
+                        buffer.param_data.cpu_data.copy_(buffer.param_data.data, non_blocking=False)
                         buffer.param_data.storage().resize_(0)
 
                     assert buffer.param_data_size == buffer.param_data.cpu_data.storage().size()


### PR DESCRIPTION
### What does this PR do?

Fix a 2x peak host-memory regression in `offload_megatron_model_to_cpu`
that OOMKills training pods on large Megatron models.

The current code reallocates the pinned host buffer on every offload
via `buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()`.
Python evaluates the RHS before the assignment, so the new pinned
block is allocated **while the old `cpu_data` is still referenced** —
peak host memory at the moment of allocation is 2x param_data size.
On large Megatron models this transient peak exceeds the cgroup limit
and OOMKills the pod even though steady-state usage would be 1x.

This PR allocates the pinned host buffer **once per DDP buffer** at the
first offload and copies into it on subsequent offloads, capping peak
at 1x. The load path
(`buffer.param_data.copy_(buffer.param_data.cpu_data, non_blocking=True)`)
and the checkpoint paths at lines 1619/1665 already assume `cpu_data`
persists, so reusing it makes that contract explicit rather than
accidental. A shape/dtype assert guards the invariant — silently
reallocating would reintroduce the same 2x peak.

> Edit (post-review): Earlier wording framed this as a "continuous host
> memory leak" attributing it to PyTorch's `CachingHostAllocator` not
> returning freed blocks. That was incorrect — freed pinned blocks
> are reusable and steady-state is bounded. The actual mechanism is
> the 2x transient peak from allocate-before-free, which fits the
> observed OOM-at-step-2/3 timing better than unbounded growth.
> Title, body, commit message, and code comments all updated.

### Checklist Before Starting

- [x] Search for similar PRs. Searches run:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+offload_megatron_model_to_cpu
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+pin_memory
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+CachingHostAllocator
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+cpu_data+megatron

  Closest existing PRs touch the same file but address different concerns:
  - #6095 (merged) — `[fully_async] Fix: fix megatron save and offload in case param_offload is on` — modifies `copy_megatron_model_to_cpu` / `restore_megatron_model_from_cpu`, not `offload_megatron_model_to_cpu`. Compatible: still relies on `cpu_data` being present and pinned, which this PR preserves.
  - #5751 (open) — `[megatron, ckpt] fix: reclaim host memory leaked by dist_checkpointing` — different host-memory issue (glibc anonymous `mmap` regions from `FileSystemWriterAsync.write_buckets`), not the pinned-buffer 2x peak fixed here. Adjacent symptom (host RAM pressure), different mechanism, complementary fix.
  - #5651 (open) — `[Megatron] feat: offload optimizer fp32 params to CPU` — adds optimizer fp32 offload. Different function, no overlap.

- [x] Title format `[megatron] fix: ...` matches the project convention.

### Test

Validated on Qwen3-235B-A22B in a real training environment (cgroup
limit 1700 GiB, Megatron DDP with parameter offload enabled).

| Configuration | Result |
|---|---|
| Pre-fix (current `main`) | OOMKilled at step 2/3, cgroup hit 1700 GiB |
| Post-fix (this PR) | 10/10 steps completed in 77.6 min, no OOM. Resident memory flat at ~1300 GiB across steps 2–10 with ~0.5 GiB/step residual drift (small, likely unrelated allocations). |

The data fits the 2x-peak diagnosis: post-fix steady state ≈ 1300 GiB,
pre-fix transient peak ≈ 2 × 1300 ≈ 2600 GiB, exceeding the 1700 GiB
cgroup limit on the first or second offload — which is exactly when
the OOMKill occurred.

CI tests not added: the bug is a transient peak in a memory-management
path that depends on real allocation pressure (cgroup limit + model
scale). Reproducing it deterministically in unit tests would require
either a long-running offload loop with allocator introspection or
mocking the host allocator — neither fits cleanly into the existing CI
workflows. The fix is validated on the model size where the bug
actually manifests (235B).

### API and Usage Example

No API change. Behavior is identical to the previous code on the first
offload of each DDP buffer; subsequent offloads write into the same
pinned host buffer instead of allocating a new one.

### Design & Code Changes

- `verl/utils/megatron_utils.py` — `offload_megatron_model_to_cpu`:
  - Replace `buffer.param_data.cpu_data = buffer.param_data.data.cpu().pin_memory()` on every call with a one-time `torch.empty(..., pin_memory=True)` per DDP buffer.
  - Subsequent offloads `copy_(non_blocking=False)` into the existing pinned buffer; storage of `param_data` is freed immediately as before.
  - Assert shape/dtype invariance on subsequent calls; reallocation would reintroduce the 2x peak, so the assert surfaces the bug rather than silently working around it.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks (`ruff check` and `ruff format --check` clean; full pre-commit run by submitter).
- [ ] Add / Update documentation — N/A (internal memory-management fix, no API/behavior change for users).
- [ ] Add unit or end-to-end test(s) — explained above why CI tests aren't feasible for this transient-peak bug.
- [ ] Once ready for CI, message `ci-request` channel.

### AI Assistance Disclosure

This fix was developed with AI assistance (Cursor + Claude). Per
`AGENTS.md`, the human submitter has reviewed every changed line,
validated the fix end-to-end on Qwen3-235B-A22B (results above), and
takes responsibility for the change. Commit trailer:
`Co-authored-by: Claude <noreply@anthropic.com>`.