### PR TITLE
[fsdp, megatron, vllm, trainer, algo, cfg] feat: Nitrobrew on-policy distillation (teacher hidden states communication + constant-memory fused KL)

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -59,6 +59,9 @@ on:
       - ".github/workflows/vllm.yml"
       - "tests/special_e2e/generation"
       - "tests/workers/rollout"
+      - "tests/experimental/teacher_loop"
+      - "verl/experimental/teacher_loop/**"
+      - "verl/trainer/distillation/**"
       - "verl/trainer/main_generation.py"
       - "verl/trainer/config/generation.yaml"
 
@@ -125,6 +128,9 @@ jobs:
       - name: Test vllm server abort functionality
         run: |
           pytest tests/workers/rollout/rollout_vllm/test_vllm_abort.py -v -s
+      - name: Test nitrobrew vLLM teacher (AsyncLLM pooling)
+        run: |
+          pytest tests/experimental/teacher_loop/test_nitrobrew_async_llm.py -v -s
 
   vllm_checkpoint_engine:
     needs: setup

--- a/tests/experimental/teacher_loop/__init__.py
+++ b/tests/experimental/teacher_loop/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Tilde Research
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .nitrobrew_teacher import NitrobrewTeacherModelManager
-from .teacher_model import MultiTeacherModelManager
-
-__all__ = ["MultiTeacherModelManager", "NitrobrewTeacherModelManager"]

--- a/tests/experimental/teacher_loop/test_nitrobrew_async_llm.py
+++ b/tests/experimental/teacher_loop/test_nitrobrew_async_llm.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU smoke test for the vLLM-backed nitrobrew teacher worker.
+
+Verifies that:
+  - The driver can load lm_head + compute SVD for a small model.
+  - A NitrobrewTeacherWorker actor boots an AsyncLLM in pooling+embed mode.
+  - compute_hidden_states returns a [S, d_comp] tensor in the expected dtype.
+"""
+
+import os
+
+import pytest
+import ray
+import torch
+
+from verl.experimental.teacher_loop.nitrobrew_teacher import (
+    NitrobrewTeacherWorker,
+    _compute_svd,
+    _load_lm_head_weight,
+)
+
+MODEL_PATH = os.environ.get("NITROBREW_TEST_MODEL", "Qwen/Qwen3-0.6B")
+D_COMP = 8
+DTYPE = "bfloat16"
+MAX_MODEL_LEN = 256
+
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA GPU")
+
+
+@pytest.fixture(scope="module")
+def ray_cluster():
+    if not ray.is_initialized():
+        ray.init(num_cpus=4, num_gpus=1, ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+def test_nitrobrew_teacher_worker_returns_compressed_hidden_states(ray_cluster):
+    w_t = _load_lm_head_weight(MODEL_PATH)
+    w_up, p_down = _compute_svd(w_t, d_comp=D_COMP, dtype=getattr(torch, DTYPE))
+    v, hidden = w_t.shape
+    assert w_up.shape == (v, D_COMP)
+    assert p_down.shape == (hidden, D_COMP)
+
+    worker = NitrobrewTeacherWorker.options(num_gpus=1, max_concurrency=4).remote()
+    ray.get(
+        worker.setup.remote(
+            MODEL_PATH,
+            D_COMP,
+            p_down.cpu().tolist(),
+            DTYPE,
+            1,  # tensor_parallel_size
+            0.5,  # gpu_memory_utilization
+            4,  # max_num_seqs
+            MAX_MODEL_LEN,
+            True,  # enforce_eager (avoid cuda-graph reservation in CI)
+        )
+    )
+
+    sequence_ids = list(range(32))
+    out = ray.get(worker.compute_hidden_states.remote(sequence_ids))
+    z = torch.tensor(out)
+    assert z.shape == (len(sequence_ids), D_COMP), z.shape
+    assert torch.isfinite(z).all()

--- a/tests/experimental/teacher_loop/test_nitrobrew_kernel_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_nitrobrew_kernel_on_cpu.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU correctness tests for the nitrobrew chunked-vocab KL kernels.
+
+Compares the chunked online-softmax forward (and the autograd backward) against
+a naive reference that materialises the full ``[N, V]`` teacher logits.
+"""
+
+import os
+
+# Ensure the @torch.compile decorators are no-ops on CPU runners.
+os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
+os.environ.setdefault("TORCHINDUCTOR_DISABLE", "1")
+
+import torch
+import torch.nn.functional as F
+
+from verl.trainer.distillation.fsdp.nitrobrew_loss import (
+    _chunked_kl_forward,
+    _chunked_reverse_kl_forward,
+    _NitrobrewKL,
+    _NitrobrewReverseKL,
+)
+
+
+def _naive_forward_kl(z: torch.Tensor, w: torch.Tensor, s: torch.Tensor, temperature: float = 1.0) -> torch.Tensor:
+    """KL(p_T || p_S) per token, computed by materialising teacher logits."""
+    zt = (z @ w.T).float() / temperature
+    s = s.float() / temperature
+    log_pt = F.log_softmax(zt, dim=-1)
+    log_ps = F.log_softmax(s, dim=-1)
+    pt = log_pt.exp()
+    return (pt * (log_pt - log_ps)).sum(dim=-1)
+
+
+def _naive_reverse_kl(z: torch.Tensor, w: torch.Tensor, s: torch.Tensor, temperature: float = 1.0) -> torch.Tensor:
+    """KL(p_S || p_T) per token, computed by materialising teacher logits."""
+    zt = (z @ w.T).float() / temperature
+    s = s.float() / temperature
+    log_pt = F.log_softmax(zt, dim=-1)
+    log_ps = F.log_softmax(s, dim=-1)
+    ps = log_ps.exp()
+    return (ps * (log_ps - log_pt)).sum(dim=-1)
+
+
+def _make_inputs(seed: int = 0, n: int = 4, v: int = 32, d: int = 8):
+    g = torch.Generator().manual_seed(seed)
+    z = torch.randn(n, d, generator=g)
+    w = torch.randn(v, d, generator=g) * 0.1
+    s = torch.randn(n, v, generator=g)
+    return z, w, s
+
+
+def test_chunked_forward_kl_matches_naive():
+    z, w, s = _make_inputs()
+    kl_chunked, _ = _chunked_kl_forward(z, w, s, chunk_V=4)
+    kl_naive = _naive_forward_kl(z, w, s)
+    assert torch.allclose(kl_chunked, kl_naive, atol=1e-5, rtol=1e-4), (
+        f"max abs diff = {(kl_chunked - kl_naive).abs().max().item()}"
+    )
+
+
+def test_chunked_reverse_kl_matches_naive():
+    z, w, s = _make_inputs(seed=1)
+    kl_chunked, _, _ = _chunked_reverse_kl_forward(z, w, s, chunk_V=4)
+    kl_naive = _naive_reverse_kl(z, w, s)
+    assert torch.allclose(kl_chunked, kl_naive, atol=1e-5, rtol=1e-4), (
+        f"max abs diff = {(kl_chunked - kl_naive).abs().max().item()}"
+    )
+
+
+def test_chunked_forward_kl_with_temperature():
+    z, w, s = _make_inputs(seed=2)
+    kl_chunked, _ = _chunked_kl_forward(z, w, s, chunk_V=8, temperature=0.7)
+    kl_naive = _naive_forward_kl(z, w, s, temperature=0.7)
+    assert torch.allclose(kl_chunked, kl_naive, atol=1e-5, rtol=1e-4)
+
+
+def test_forward_kl_backward_matches_autograd():
+    """_NitrobrewKL.backward must match a reference autograd through the naive forward."""
+    z, w, s = _make_inputs(seed=3)
+    s_chunked = s.clone().requires_grad_(True)
+    s_naive = s.clone().requires_grad_(True)
+
+    kl_chunked = _NitrobrewKL.apply(z, w, s_chunked, 4, 1.0, None)
+    kl_naive = _naive_forward_kl(z, w, s_naive)
+
+    grad_out = torch.randn_like(kl_chunked)
+    kl_chunked.backward(grad_out)
+    kl_naive.backward(grad_out)
+
+    assert torch.allclose(s_chunked.grad, s_naive.grad, atol=1e-5, rtol=1e-4), (
+        f"grad max abs diff = {(s_chunked.grad - s_naive.grad).abs().max().item()}"
+    )
+
+
+def test_reverse_kl_backward_matches_autograd():
+    z, w, s = _make_inputs(seed=4)
+    s_chunked = s.clone().requires_grad_(True)
+    s_naive = s.clone().requires_grad_(True)
+
+    kl_chunked = _NitrobrewReverseKL.apply(z, w, s_chunked, 4, 1.0)
+    kl_naive = _naive_reverse_kl(z, w, s_naive)
+
+    grad_out = torch.randn_like(kl_chunked)
+    kl_chunked.backward(grad_out)
+    kl_naive.backward(grad_out)
+
+    assert torch.allclose(s_chunked.grad, s_naive.grad, atol=1e-5, rtol=1e-4), (
+        f"grad max abs diff = {(s_chunked.grad - s_naive.grad).abs().max().item()}"
+    )

--- a/tests/experimental/teacher_loop/test_nitrobrew_svd_on_cpu.py
+++ b/tests/experimental/teacher_loop/test_nitrobrew_svd_on_cpu.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for nitrobrew driver-side SVD + safetensors lm_head loading."""
+
+import json
+import os
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from verl.experimental.teacher_loop.nitrobrew_teacher import (
+    _compute_svd,
+    _load_lm_head_weight,
+)
+
+# ---- _compute_svd ---------------------------------------------------------
+
+
+def test_compute_svd_full_rank_round_trips():
+    torch.manual_seed(0)
+    v, d = 16, 8
+    w_t = torch.randn(v, d)
+    w_up, p_down = _compute_svd(w_t, d_comp=d, dtype=torch.float32)
+
+    assert w_up.shape == (v, d)
+    assert p_down.shape == (d, d)
+    recon = w_up @ p_down.T
+    assert torch.allclose(recon, w_t, atol=1e-5, rtol=1e-4)
+
+
+def test_compute_svd_truncates_to_d_comp():
+    torch.manual_seed(1)
+    v, d, d_comp = 16, 8, 3
+    w_t = torch.randn(v, d)
+    w_up, p_down = _compute_svd(w_t, d_comp=d_comp, dtype=torch.float32)
+
+    assert w_up.shape == (v, d_comp)
+    assert p_down.shape == (d, d_comp)
+    # Truncated reconstruction error must equal sum of dropped singular values squared.
+    recon = w_up @ p_down.T
+    expected_err = (torch.linalg.svdvals(w_t)[d_comp:] ** 2).sum().sqrt()
+    actual_err = torch.linalg.norm(w_t - recon)
+    assert torch.allclose(actual_err, expected_err, atol=1e-5)
+
+
+def test_compute_svd_respects_dtype():
+    w_t = torch.randn(4, 4)
+    w_up, p_down = _compute_svd(w_t, d_comp=2, dtype=torch.bfloat16)
+    assert w_up.dtype == torch.bfloat16
+    assert p_down.dtype == torch.bfloat16
+
+
+# ---- _load_lm_head_weight -------------------------------------------------
+
+
+def _write_minimal_hf_repo(
+    tmp_path,
+    *,
+    tied: bool,
+    sharded: bool,
+) -> tuple[torch.Tensor, str]:
+    """Create a minimal HF-style repo on disk; return (lm_head, repo_dir)."""
+    repo = tmp_path / "model"
+    repo.mkdir()
+    config = {
+        "model_type": "qwen2",
+        "tie_word_embeddings": tied,
+        "hidden_size": 8,
+        "vocab_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "intermediate_size": 16,
+    }
+    (repo / "config.json").write_text(json.dumps(config))
+
+    torch.manual_seed(42)
+    lm_head = torch.randn(16, 8)
+    embed = torch.randn(16, 8)
+
+    if sharded:
+        # Put lm_head in shard A, embed in shard B; indexed via safetensors.index.json.
+        save_file({"lm_head.weight": lm_head}, str(repo / "model-00001.safetensors"))
+        save_file(
+            {"model.embed_tokens.weight": embed},
+            str(repo / "model-00002.safetensors"),
+        )
+        index = {
+            "metadata": {"total_size": 0},
+            "weight_map": {
+                "lm_head.weight": "model-00001.safetensors",
+                "model.embed_tokens.weight": "model-00002.safetensors",
+            },
+        }
+        (repo / "model.safetensors.index.json").write_text(json.dumps(index))
+    else:
+        # Single safetensors file with both tensors.
+        save_file(
+            {"lm_head.weight": lm_head, "model.embed_tokens.weight": embed},
+            str(repo / "model.safetensors"),
+        )
+
+    return (embed if tied else lm_head), str(repo)
+
+
+def test_load_lm_head_weight_single_file_untied(tmp_path):
+    expected, repo = _write_minimal_hf_repo(tmp_path, tied=False, sharded=False)
+    got = _load_lm_head_weight(repo)
+    assert got.shape == expected.shape
+    assert got.dtype == torch.float32
+    assert torch.allclose(got, expected.float())
+
+
+def test_load_lm_head_weight_single_file_tied(tmp_path):
+    expected, repo = _write_minimal_hf_repo(tmp_path, tied=True, sharded=False)
+    got = _load_lm_head_weight(repo)
+    assert torch.allclose(got, expected.float())
+
+
+def test_load_lm_head_weight_sharded_untied(tmp_path):
+    expected, repo = _write_minimal_hf_repo(tmp_path, tied=False, sharded=True)
+    got = _load_lm_head_weight(repo)
+    assert torch.allclose(got, expected.float())
+
+
+def test_load_lm_head_weight_missing_raises(tmp_path):
+    repo = tmp_path / "broken"
+    repo.mkdir()
+    (repo / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen2",
+                "tie_word_embeddings": False,
+                "hidden_size": 8,
+                "vocab_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "intermediate_size": 16,
+            }
+        )
+    )
+    save_file({"unrelated.weight": torch.zeros(4, 4)}, str(repo / "model.safetensors"))
+    with pytest.raises(ValueError, match="lm_head"):
+        _load_lm_head_weight(str(repo))
+
+
+# ---- end-to-end: load + SVD -----------------------------------------------
+
+
+def test_lm_head_to_svd_round_trip(tmp_path):
+    expected, repo = _write_minimal_hf_repo(tmp_path, tied=False, sharded=False)
+    w_t = _load_lm_head_weight(repo)
+    w_up, p_down = _compute_svd(w_t, d_comp=4, dtype=torch.float32)
+
+    assert w_up.shape == (expected.shape[0], 4)
+    assert p_down.shape == (expected.shape[1], 4)
+    # Truncated reconstruction must beat the trivial zero reconstruction.
+    err_trunc = torch.linalg.norm(w_t - w_up @ p_down.T)
+    err_zero = torch.linalg.norm(w_t)
+    assert err_trunc < err_zero
+
+
+# Skip noisy huggingface_hub network smoke if no token / offline.
+@pytest.mark.skipif(
+    not os.environ.get("HF_HUB_OFFLINE_TEST_OK"),
+    reason="requires opt-in env to hit huggingface_hub",
+)
+def test_load_from_hub_smoke():
+    # Tiny config-only repo; this is a smoke test for the snapshot_download path.
+    _ = _load_lm_head_weight("hf-internal-testing/tiny-random-Qwen2ForCausalLM")

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -31,6 +31,7 @@ license_head_meituan = "Copyright 2025 Meituan Ltd. and/or its affiliates"
 license_head_huawei = "Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_huawei_26 = "Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_nvidia = "Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved."
+license_head_tilde = "Copyright 2026 Tilde Research"
 license_headers = [
     license_head_bytedance,
     license_head_bytedance_25,
@@ -46,6 +47,7 @@ license_headers = [
     license_head_huawei,
     license_head_huawei_26,
     license_head_nvidia,
+    license_head_tilde,
 ]
 
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -240,6 +240,9 @@ class AgentLoopOutput(BaseModel):
             output["teacher_ids"] = teacher_ids
         if teacher_logprobs is not None:
             output["teacher_logprobs"] = teacher_logprobs
+        teacher_hidden_states = output["extra_fields"].pop("teacher_hidden_states", None)
+        if teacher_hidden_states is not None:
+            output["teacher_hidden_states"] = teacher_hidden_states
         return output
 
 
@@ -266,6 +269,8 @@ class _InternalAgentLoopOutput(AgentLoopOutput):
     """Padded log probabilities from teacher model for prompt/response tokens."""
     teacher_ids: Optional[torch.Tensor] = None
     """Padded token ids corresponding to the teacher log probabilities."""
+    teacher_hidden_states: torch.Tensor | None = None
+    """Padded teacher hidden states [1, S_padded, D_t] for Nitrobrew."""
     routed_experts: Optional[torch.Tensor] = None
     """Padded routed experts for the total tokens."""
     multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None
@@ -457,6 +462,7 @@ class AgentLoopWorker:
         teacher_servers: Optional[dict[str, list[tuple[str, ray.actor.ActorHandle]]]] = None,
         teacher_load_balancer_handle: Optional[dict[str, ray.actor.ActorHandle]] = None,
         reward_loop_worker_handles: list[ray.actor.ActorHandle] = None,
+        nitrobrew_worker_handles: dict[str, list] | None = None,
     ):
         """Initialize agent loop manager.
         Args:
@@ -466,6 +472,7 @@ class AgentLoopWorker:
             reward_loop_worker_handles (list[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
             teacher_servers: for each teacher key, the (address, handle) pairs of its LLM servers.
             teacher_load_balancer_handle: for each teacher key, the shared load balancer actor.
+            nitrobrew_worker_handles: for each teacher key, the Ray actor handles of NitrobrewTeacherWorkers.
         """
         self.config = config
         rollout_config, model_config = _get_rollout_and_model_config(config)
@@ -478,18 +485,29 @@ class AgentLoopWorker:
             self.distillation_loss_config: DistillationLossConfig = self.distillation_config.distillation_loss
             self.teacher_key: str = self.distillation_config.teacher_key
 
-            if not teacher_servers:
-                raise ValueError("Distillation is enabled but no teacher servers were provided.")
-            if not teacher_load_balancer_handle:
-                raise ValueError("Distillation is enabled but no teacher load balancer was provided.")
             if not hasattr(self, "teacher_server_manager"):
-                from verl.experimental.teacher_loop.teacher_manager import AsyncTeacherLLMServerManager
+                if self.distillation_loss_config.loss_settings.use_hidden_states:
+                    from verl.experimental.teacher_loop.nitrobrew_teacher import NitrobrewAsyncTeacherManager
 
-                self.teacher_server_manager = AsyncTeacherLLMServerManager(
-                    config=config,
-                    servers=teacher_servers,
-                    load_balancer_handle=teacher_load_balancer_handle,
-                )
+                    if not nitrobrew_worker_handles:
+                        raise ValueError(
+                            "Nitrobrew distillation requires nitrobrew_worker_handles but none were provided."
+                        )
+                    self.teacher_server_manager = NitrobrewAsyncTeacherManager(
+                        worker_handles=nitrobrew_worker_handles,
+                    )
+                else:
+                    if not teacher_servers:
+                        raise ValueError("Distillation is enabled but no teacher servers were provided.")
+                    if not teacher_load_balancer_handle:
+                        raise ValueError("Distillation is enabled but no teacher load balancer was provided.")
+                    from verl.experimental.teacher_loop.teacher_manager import AsyncTeacherLLMServerManager
+
+                    self.teacher_server_manager = AsyncTeacherLLMServerManager(
+                        config=config,
+                        servers=teacher_servers,
+                        load_balancer_handle=teacher_load_balancer_handle,
+                    )
 
         # for recipe to change
         if not hasattr(self, "server_manager"):
@@ -772,6 +790,17 @@ class AgentLoopWorker:
                 pad_token_id=self.tokenizer.pad_token_id,
             )
 
+        # Nitrobrew: pad teacher_hidden_states [S, D_t] to [1, S_padded, D_t].
+        teacher_hidden_states = output.extra_fields.pop("teacher_hidden_states", None)
+        if teacher_hidden_states is not None:
+            from torch.nn import functional as _F
+
+            prompt_width = prompt_output["input_ids"].shape[1]
+            response_width = response_output["input_ids"].shape[1]
+            left_pad = prompt_width - len(output.prompt_ids)
+            right_pad = response_width - len(output.response_ids)
+            teacher_hidden_states = _F.pad(teacher_hidden_states, (0, 0, left_pad, right_pad), value=0.0).unsqueeze(0)
+
         return _InternalAgentLoopOutput(
             prompt_ids=prompt_output["input_ids"],
             response_ids=response_output["input_ids"],
@@ -785,6 +814,7 @@ class AgentLoopWorker:
             multi_modal_data=output.multi_modal_data,
             teacher_logprobs=teacher_logprobs,
             teacher_ids=teacher_ids,
+            teacher_hidden_states=teacher_hidden_states,
             reward_score=output.reward_score,
             num_turns=output.num_turns,
             metrics=output.metrics,
@@ -898,7 +928,7 @@ class AgentLoopWorker:
         validate: bool,
         sample_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Compute teacher logprobs for single sample."""
+        """Compute teacher signal for single sample (top-k logprobs or hidden states)."""
         if self.distillation_enabled and not validate:
             routing_key = None
             if sample_kwargs is not None:
@@ -906,13 +936,21 @@ class AgentLoopWorker:
                 if routing_value is not None:
                     # Non-tensor batch values arrive as 0-d numpy objects / arrays; normalize to Python.
                     routing_key = routing_value.item() if hasattr(routing_value, "item") else routing_value
-            teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
-                sequence_ids=prompt_ids + response_ids,
-                multi_modal_data=output.multi_modal_data,
-                routing_key=routing_key,
-            )
-            output.extra_fields["teacher_ids"] = teacher_ids
-            output.extra_fields["teacher_logprobs"] = teacher_logprobs
+
+            if self.distillation_loss_config.loss_settings.use_hidden_states:
+                teacher_hidden_states = await self.teacher_server_manager.compute_teacher_hidden_states_single(
+                    sequence_ids=prompt_ids + response_ids,
+                    routing_key=routing_key,
+                )
+                output.extra_fields["teacher_hidden_states"] = teacher_hidden_states
+            else:
+                teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
+                    sequence_ids=prompt_ids + response_ids,
+                    multi_modal_data=output.multi_modal_data,
+                    routing_key=routing_key,
+                )
+                output.extra_fields["teacher_ids"] = teacher_ids
+                output.extra_fields["teacher_logprobs"] = teacher_logprobs
 
     def _postprocess(
         self,
@@ -936,6 +974,10 @@ class AgentLoopWorker:
         if inputs[0].teacher_logprobs is not None and inputs[0].teacher_ids is not None:
             optional_outputs["teacher_logprobs"] = torch.cat([input.teacher_logprobs for input in inputs], dim=0)
             optional_outputs["teacher_ids"] = torch.cat([input.teacher_ids for input in inputs], dim=0)
+        if inputs[0].teacher_hidden_states is not None:
+            optional_outputs["teacher_hidden_states"] = torch.cat(
+                [input.teacher_hidden_states for input in inputs], dim=0
+            )
         batch = TensorDict(
             {
                 "prompts": prompt_ids,  # [bsz, prompt_length]
@@ -1062,6 +1104,14 @@ class AgentLoopManager:
         self.teacher_model_manager = teacher_model_manager
         self.distillation_enabled = is_distillation_enabled(self.config.get("distillation", None))
 
+        self.use_hidden_states = False
+        if self.distillation_enabled:
+            from verl.utils.config import omega_conf_to_dataclass
+            from verl.workers.config import DistillationConfig as _DC
+
+            _dc: _DC = omega_conf_to_dataclass(self.config.get("distillation"))
+            self.use_hidden_states = _dc.distillation_loss.loss_settings.use_hidden_states
+
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
         # for recipe to change
@@ -1145,19 +1195,24 @@ class AgentLoopManager:
         load_balancer_handle = self.global_load_balancer
         servers = list(zip(self.server_addresses, self.server_handles, strict=True))
 
+        nitrobrew_worker_handles = None
         if self.distillation_enabled:
-            # teacher_model_manager exposes per-teacher dicts keyed by teacher key.
-            teacher_servers = {
-                key: list(
-                    zip(
-                        self.teacher_model_manager.server_addresses[key],
-                        self.teacher_model_manager.server_handles[key],
-                        strict=True,
+            if self.use_hidden_states:
+                nitrobrew_worker_handles = dict(self.teacher_model_manager.worker_handles)
+                teacher_servers = None
+                teacher_load_balancer_handle = None
+            else:
+                teacher_servers = {
+                    key: list(
+                        zip(
+                            self.teacher_model_manager.server_addresses[key],
+                            self.teacher_model_manager.server_handles[key],
+                            strict=True,
+                        )
                     )
-                )
-                for key in self.teacher_model_manager.server_addresses
-            }
-            teacher_load_balancer_handle = dict(self.teacher_model_manager.load_balancer_handle)
+                    for key in self.teacher_model_manager.server_addresses
+                }
+                teacher_load_balancer_handle = dict(self.teacher_model_manager.load_balancer_handle)
         else:
             teacher_servers = None
             teacher_load_balancer_handle = None
@@ -1179,6 +1234,7 @@ class AgentLoopManager:
                     teacher_servers,
                     teacher_load_balancer_handle,
                     self.reward_loop_worker_handles,
+                    nitrobrew_worker_handles,
                 )
             )
 

--- a/verl/experimental/teacher_loop/nitrobrew_teacher.py
+++ b/verl/experimental/teacher_loop/nitrobrew_teacher.py
@@ -12,21 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Nitrobrew teacher infrastructure.
+"""Nitrobrew teacher infrastructure (vLLM AsyncLLM pooling backend).
 
-Replaces the vLLM/SGLang-based teacher server when
-distillation.distillation_loss.loss_mode = "nitrobrew".
+Used when ``distillation.distillation_loss.loss_mode == "nitrobrew"``.
 
-Instead of top-k logprobs, the teacher returns:
-    - lm_head.weight  [V, D_t]  (once at init, distributed to actor ranks)
-    - hidden states    [S, D_t]  (per sequence, via Ray remote calls)
+Architecture::
 
-The student-side kernel reconstructs teacher logits on-the-fly as z @ W.T
-in vocabulary chunks, avoiding the O(N * V) materialisation.
+                      +----------------------------------+
+    AgentLoopWorker   |  NitrobrewAsyncTeacherManager    |
+                      |  (round-robin Ray remote calls)  |
+                      +-----------------+----------------+
+                                        | compute_hidden_states.remote(seq_ids)
+                      +-----------------v----------------+
+                      |  NitrobrewTeacherWorker (Ray)    |
+                      |  - vLLM AsyncLLM (pooling+embed) |
+                      |  - PoolingType.ALL -> [S, D]     |
+                      |  - on-actor [S, D] @ P_down      |
+                      |    -> [S, d_comp]                |
+                      +----------------------------------+
+
+Per-teacher SVD: ``W_T (lm_head) ~= W_up @ P_down.T`` with
+``W_up [V, d_comp]`` (sent to the actor for student-side logit
+reconstruction) and ``P_down [D, d_comp]`` (held by every teacher worker for
+on-device projection of hidden states before the Ray RPC boundary).
+
+Loading ``lm_head`` directly from safetensors avoids constructing a full HF
+model on the driver just to read a single matrix.
+
+Why this bypasses :class:`~verl.workers.rollout.replica.RolloutReplica` (the
+shared rollout/teacher abstraction used by the topk teacher in
+:mod:`~verl.experimental.teacher_loop.teacher_model`):
+
+1. vLLM's HTTP server (``/v1/embeddings``) returns one vector per *sequence*,
+   not per *token*. The ``runner="pooling"`` + ``convert="embed"`` +
+   ``PoolingParams(task="token_embed")`` (ALL pool) path is only reachable
+   via :meth:`AsyncLLM.encode` directly, so the standard ``vLLMHttpServer``
+   would need a custom RPC method to expose it.
+2. The ``P_down @ h`` projection from ``[S, D]`` to ``[S, d_comp]`` must run
+   on the actor *before* the network boundary -- otherwise the wire payload
+   is ``S * D``, defeating the whole nitrobrew communication-budget claim.
+3. Frozen teachers don't need the ``CheckpointEngineWorker`` weight-sync
+   stack that ``RolloutReplica.init_colocated`` spawns under the hood.
+
+TODO(nitrobrew): factor into a ``NitrobrewReplica(RolloutReplica)`` once
+vLLM exposes per-token embeddings via the HTTP server, so this module can
+collapse to a ``launch_servers`` override + a tiny ``NitrobrewServer`` actor.
 """
 
+import asyncio
+import json
 import logging
-from typing import Any
+import os
+import uuid
+from typing import Any, Optional
 
 import ray
 import torch
@@ -34,82 +72,212 @@ import torch
 logger = logging.getLogger(__name__)
 
 
+def _load_lm_head_weight(model_path: str) -> torch.Tensor:
+    """Read the teacher's lm_head (or tied embed_tokens) weight from safetensors.
+
+    Returns a CPU fp32 tensor of shape ``[V, D]``. Avoids constructing a full
+    ``AutoModelForCausalLM`` on the driver.
+    """
+    from huggingface_hub import snapshot_download
+    from safetensors.torch import load_file
+    from transformers import AutoConfig
+
+    from verl.utils.fs import copy_to_local
+
+    # copy_to_local resolves HDFS paths and returns local paths unchanged. It
+    # does not fetch HF Hub IDs (those still need snapshot_download below).
+    resolved = copy_to_local(model_path)
+    folder = (
+        resolved
+        if os.path.isdir(resolved)
+        else snapshot_download(resolved, allow_patterns=["*.safetensors*", "*.json"])
+    )
+
+    cfg = AutoConfig.from_pretrained(folder, trust_remote_code=True)
+    target_keys = (
+        ["model.embed_tokens.weight", "embed_tokens.weight"] if cfg.tie_word_embeddings else ["lm_head.weight"]
+    )
+
+    index_path = os.path.join(folder, "model.safetensors.index.json")
+    shard_for_key: dict[str, str] = {}
+    if os.path.exists(index_path):
+        with open(index_path) as f:
+            shard_for_key = json.load(f)["weight_map"]
+
+    for key in target_keys:
+        if shard_for_key:
+            shard = shard_for_key.get(key)
+            if shard is None:
+                continue
+            tensors = load_file(os.path.join(folder, shard))
+        else:
+            tensors = load_file(os.path.join(folder, "model.safetensors"))
+        if key in tensors:
+            return tensors[key].float()
+
+    raise ValueError(f"Could not find lm_head/embed_tokens weight in {model_path}")
+
+
+def _compute_svd(w_t: torch.Tensor, d_comp: int, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+    """Truncated SVD of the teacher's unembed: ``w_t ~= w_up @ p_down.T``.
+
+    Returns ``(w_up [V, d_comp], p_down [D, d_comp])`` cast to ``dtype``.
+    """
+    u, sigma, vh = torch.linalg.svd(w_t, full_matrices=False)
+    u_r = u[:, :d_comp]
+    sigma_r = sigma[:d_comp]
+    vh_r = vh[:d_comp, :]
+    w_up = (u_r * sigma_r.unsqueeze(0)).to(dtype)
+    p_down = vh_r.T.to(dtype)
+    return w_up, p_down
+
+
 @ray.remote
 class NitrobrewTeacherWorker:
-    """Loads teacher HF model and serves last-layer hidden states."""
+    """vLLM-backed teacher serving PCA-compressed hidden states.
 
-    def setup(self, model_path: str, torch_dtype: str = "bfloat16") -> list:
-        """Load teacher model, return lm_head.weight as nested list [V, D_t].
+    Wraps vLLM's :class:`AsyncLLM` in pooling+embed mode with per-token output
+    (``PoolingType.ALL``). Hidden states are projected on the actor's GPU to
+    ``d_comp`` *before* crossing the Ray RPC boundary, so the network payload
+    matches nitrobrew's communication budget regardless of teacher ``D``.
+    """
 
-        Returns:
-            lm_head.weight as Python list for Ray serialisation.
-        """
-        from transformers import AutoModelForCausalLM
+    async def setup(
+        self,
+        model_path: str,
+        d_comp: int,
+        p_down_list: list,
+        dtype: str,
+        tensor_parallel_size: int,
+        gpu_memory_utilization: float,
+        max_num_seqs: int,
+        max_model_len: int,
+        enforce_eager: bool,
+    ) -> None:
+        from vllm import AsyncEngineArgs
+        from vllm.v1.engine.async_llm import AsyncLLM
 
-        dtype = getattr(torch, torch_dtype)
-        logger.warning(f"NitrobrewTeacherWorker: loading {model_path} (dtype={torch_dtype})")
-        self._model = AutoModelForCausalLM.from_pretrained(
+        torch_dtype = getattr(torch, dtype)
+        self._d_comp = d_comp
+        self._dtype = torch_dtype
+        self._p_down_cpu = torch.tensor(p_down_list, dtype=torch_dtype)  # [D, d_comp]
+        self._p_down_dev: dict[torch.device, torch.Tensor] = {}
+
+        logger.warning(
+            "NitrobrewTeacherWorker: launching AsyncLLM (model=%s, tp=%d, max_num_seqs=%d, "
+            "max_model_len=%d, gmu=%.2f, enforce_eager=%s, dtype=%s)",
             model_path,
-            torch_dtype=dtype,
-            device_map="balanced",
+            tensor_parallel_size,
+            max_num_seqs,
+            max_model_len,
+            gpu_memory_utilization,
+            enforce_eager,
+            dtype,
         )
-        self._model.eval()
-        self._dtype = dtype
 
-        W = self._model.lm_head.weight.to(dtype).cpu()
-        logger.warning(f"NitrobrewTeacherWorker: lm_head.weight {W.shape}")
-        return W.tolist()
+        # ALL pooling cannot resume across steps, so prefill must complete in a
+        # single scheduler step. Cap per-step token budget at 4x max_model_len:
+        # enough to batch a few full-length sequences per wave without
+        # exhausting KV-cache headroom during vLLM's memory profile pass.
+        max_num_batched_tokens = min(max_num_seqs, 4) * max_model_len
+        engine_args = AsyncEngineArgs(
+            model=model_path,
+            runner="pooling",
+            convert="embed",
+            tensor_parallel_size=tensor_parallel_size,
+            dtype=dtype,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=max_num_batched_tokens,
+            enforce_eager=enforce_eager,
+            # ALL pooling rejects partial prefills; chunked prefill and prefix
+            # caching can both produce them, so disable both.
+            enable_chunked_prefill=False,
+            enable_prefix_caching=False,
+            disable_log_stats=True,
+        )
+        self._engine = AsyncLLM.from_engine_args(engine_args)
+        logger.warning("NitrobrewTeacherWorker: AsyncLLM ready")
 
-    def compute_hidden_states(self, sequence_ids: list[int]) -> list:
-        """Run teacher forward pass, return last hidden states [S, D_t] as nested list."""
-        first_device = next(self._model.parameters()).device
-        input_ids = torch.tensor([sequence_ids], dtype=torch.long, device=first_device)
+    def _p_down_on(self, device: torch.device) -> torch.Tensor:
+        cached = self._p_down_dev.get(device)
+        if cached is None:
+            cached = self._p_down_cpu.to(device, non_blocking=True)
+            self._p_down_dev[device] = cached
+        return cached
 
-        with torch.no_grad():
-            out = self._model(input_ids=input_ids, output_hidden_states=True, use_cache=False)
+    async def compute_hidden_states(self, sequence_ids: list[int]) -> list:
+        """Encode one sequence; return PCA-compressed hidden states ``[S, d_comp]``."""
+        from vllm import PoolingParams
+        from vllm.inputs import TokensPrompt
 
-        h_T = out.hidden_states[-1][0].to(self._dtype)
-        return h_T.cpu().tolist()
+        params = PoolingParams(task="token_embed", normalize=False)
+        prompt = TokensPrompt(prompt_token_ids=sequence_ids)
+
+        final = None
+        async for out in self._engine.encode(
+            prompt=prompt,
+            pooling_params=params,
+            request_id=uuid.uuid4().hex,
+        ):
+            final = out
+        assert final is not None, "AsyncLLM.encode produced no output"
+
+        h = final.outputs.data  # [S, D]
+        p = self._p_down_on(h.device)
+        z = torch.mm(h.to(self._dtype), p)  # [S, d_comp]
+        return z.cpu().tolist()
 
 
 class NitrobrewAsyncTeacherManager:
-    """Async client that round-robins hidden-state requests across NitrobrewTeacherWorker actors."""
+    """Async client that round-robins hidden-state requests across workers.
+
+    Mirrors the interface of ``AsyncTeacherLLMServerManager`` but returns
+    teacher hidden states instead of ``(teacher_ids, teacher_logprobs)``.
+    """
 
     def __init__(self, worker_handles: dict[str, list[Any]]):
         self._worker_handles = worker_handles
         self._counters = {key: 0 for key in worker_handles}
+        self._lock = asyncio.Lock()
 
-    def _resolve_key(self, routing_key: str | None) -> str:
+    def _resolve_key(self, routing_key: Optional[str]) -> str:
         if len(self._worker_handles) == 1:
             return next(iter(self._worker_handles))
         if routing_key is None or routing_key not in self._worker_handles:
             raise ValueError(
-                f"Routing key {routing_key!r} not found in nitrobrew workers: "
-                f"{sorted(self._worker_handles)}"
+                f"Routing key {routing_key!r} not found in nitrobrew workers: {sorted(self._worker_handles)}"
             )
         return routing_key
 
     async def compute_teacher_hidden_states_single(
         self,
         sequence_ids: list[int],
-        routing_key: str | None = None,
+        routing_key: Optional[str] = None,
     ) -> torch.Tensor:
-        """Request hidden states for a single sequence. Returns [S, D_t] on CPU."""
         key = self._resolve_key(routing_key)
         handles = self._worker_handles[key]
-        idx = self._counters[key] % len(handles)
-        self._counters[key] += 1
+        async with self._lock:
+            idx = self._counters[key] % len(handles)
+            self._counters[key] += 1
 
         result: list = await handles[idx].compute_hidden_states.remote(sequence_ids)
-        return torch.tensor(result, dtype=torch.bfloat16)
+        return torch.tensor(result, dtype=torch.bfloat16)  # [S, d_comp]
 
 
 class NitrobrewTeacherModelManager:
-    """Manages a pool of NitrobrewTeacherWorker Ray actors.
+    """Manage a pool of vLLM-backed :class:`NitrobrewTeacherWorker` Ray actors.
 
     Exposes:
-        worker_handles: dict[teacher_key, list[ActorHandle]]  -- for AgentLoopWorker
-        w_up:           torch.Tensor [V, D_t]                 -- for actor set_teacher_unembed
+      - ``worker_handles: dict[teacher_key, list[ActorHandle]]`` for
+        :class:`AgentLoopWorker`.
+      - ``w_up: torch.Tensor [V, d_comp]`` for actor-side
+        ``set_teacher_unembed``.
+
+    ``nitrobrew_d_comp`` and the inference settings (TP / GMU /
+    max_num_seqs / max_model_len / enforce_eager / dtype) are read from each
+    teacher's :class:`DistillationTeacherModelConfig`.
     """
 
     def __init__(
@@ -118,27 +286,73 @@ class NitrobrewTeacherModelManager:
         gpus_per_replica: int,
     ):
         self.worker_handles: dict[str, list] = {}
-        self.w_up: torch.Tensor | None = None
+        self.w_up: Optional[torch.Tensor] = None
 
         for key, teacher_cfg in teacher_model_configs.items():
+            d_comp = teacher_cfg.nitrobrew_d_comp
+            if d_comp is None:
+                raise ValueError(
+                    f"teacher_models['{key}'].nitrobrew_d_comp must be set when using the nitrobrew loss mode."
+                )
+
             num_replicas = teacher_cfg.num_replicas
             model_path = teacher_cfg.model_path
-            dtype = getattr(teacher_cfg, "torch_dtype", "bfloat16")
+            inference = teacher_cfg.inference
+            dtype = inference.dtype
+            tp = inference.tensor_model_parallel_size
+            gmu = inference.gpu_memory_utilization
+            max_num_seqs = inference.max_num_seqs
+            enforce_eager = inference.enforce_eager
+            # validate_and_prepare_for_distillation rewrites prompt_length to
+            # (prompt + response) and response_length to 1, so their sum is the
+            # required teacher context.
+            max_model_len = inference.max_model_len or (inference.prompt_length + inference.response_length)
+
+            torch_dtype = getattr(torch, dtype)
+
+            logger.warning(
+                "NitrobrewTeacherModelManager: loading lm_head for '%s' (%s) and computing SVD (d_comp=%d)",
+                key,
+                model_path,
+                d_comp,
+            )
+            w_t = _load_lm_head_weight(model_path)
+            w_up, p_down = _compute_svd(w_t, d_comp, torch_dtype)
+            del w_t
+            logger.warning(
+                "NitrobrewTeacherModelManager: SVD done w_up %s, p_down %s",
+                tuple(w_up.shape),
+                tuple(p_down.shape),
+            )
 
             handles = []
             for _ in range(num_replicas):
-                worker = NitrobrewTeacherWorker.options(num_gpus=gpus_per_replica).remote()
+                worker = NitrobrewTeacherWorker.options(
+                    num_gpus=gpus_per_replica,
+                    max_concurrency=max(max_num_seqs * 2, 256),
+                ).remote()
                 handles.append(worker)
             self.worker_handles[key] = handles
 
-            logger.warning(f"NitrobrewTeacherModelManager: running setup for teacher '{key}'")
-            w_list = ray.get(handles[0].setup.remote(model_path, dtype))
-            w = torch.tensor(w_list)
-
-            setup_futures = [h.setup.remote(model_path, dtype) for h in handles[1:]]
-            ray.get(setup_futures)
+            p_down_list = p_down.cpu().tolist()
+            ray.get(
+                [
+                    h.setup.remote(
+                        model_path,
+                        d_comp,
+                        p_down_list,
+                        dtype,
+                        tp,
+                        gmu,
+                        max_num_seqs,
+                        max_model_len,
+                        enforce_eager,
+                    )
+                    for h in handles
+                ]
+            )
 
             if self.w_up is None:
-                self.w_up = w
+                self.w_up = w_up
 
         assert self.w_up is not None, "No teacher models configured."

--- a/verl/experimental/teacher_loop/nitrobrew_teacher.py
+++ b/verl/experimental/teacher_loop/nitrobrew_teacher.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nitrobrew teacher infrastructure.
+
+Replaces the vLLM/SGLang-based teacher server when
+distillation.distillation_loss.loss_mode = "nitrobrew".
+
+Instead of top-k logprobs, the teacher returns:
+    - lm_head.weight  [V, D_t]  (once at init, distributed to actor ranks)
+    - hidden states    [S, D_t]  (per sequence, via Ray remote calls)
+
+The student-side kernel reconstructs teacher logits on-the-fly as z @ W.T
+in vocabulary chunks, avoiding the O(N * V) materialisation.
+"""
+
+import logging
+from typing import Any
+
+import ray
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@ray.remote
+class NitrobrewTeacherWorker:
+    """Loads teacher HF model and serves last-layer hidden states."""
+
+    def setup(self, model_path: str, torch_dtype: str = "bfloat16") -> list:
+        """Load teacher model, return lm_head.weight as nested list [V, D_t].
+
+        Returns:
+            lm_head.weight as Python list for Ray serialisation.
+        """
+        from transformers import AutoModelForCausalLM
+
+        dtype = getattr(torch, torch_dtype)
+        logger.warning(f"NitrobrewTeacherWorker: loading {model_path} (dtype={torch_dtype})")
+        self._model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            torch_dtype=dtype,
+            device_map="balanced",
+        )
+        self._model.eval()
+        self._dtype = dtype
+
+        W = self._model.lm_head.weight.to(dtype).cpu()
+        logger.warning(f"NitrobrewTeacherWorker: lm_head.weight {W.shape}")
+        return W.tolist()
+
+    def compute_hidden_states(self, sequence_ids: list[int]) -> list:
+        """Run teacher forward pass, return last hidden states [S, D_t] as nested list."""
+        first_device = next(self._model.parameters()).device
+        input_ids = torch.tensor([sequence_ids], dtype=torch.long, device=first_device)
+
+        with torch.no_grad():
+            out = self._model(input_ids=input_ids, output_hidden_states=True, use_cache=False)
+
+        h_T = out.hidden_states[-1][0].to(self._dtype)
+        return h_T.cpu().tolist()
+
+
+class NitrobrewAsyncTeacherManager:
+    """Async client that round-robins hidden-state requests across NitrobrewTeacherWorker actors."""
+
+    def __init__(self, worker_handles: dict[str, list[Any]]):
+        self._worker_handles = worker_handles
+        self._counters = {key: 0 for key in worker_handles}
+
+    def _resolve_key(self, routing_key: str | None) -> str:
+        if len(self._worker_handles) == 1:
+            return next(iter(self._worker_handles))
+        if routing_key is None or routing_key not in self._worker_handles:
+            raise ValueError(
+                f"Routing key {routing_key!r} not found in nitrobrew workers: "
+                f"{sorted(self._worker_handles)}"
+            )
+        return routing_key
+
+    async def compute_teacher_hidden_states_single(
+        self,
+        sequence_ids: list[int],
+        routing_key: str | None = None,
+    ) -> torch.Tensor:
+        """Request hidden states for a single sequence. Returns [S, D_t] on CPU."""
+        key = self._resolve_key(routing_key)
+        handles = self._worker_handles[key]
+        idx = self._counters[key] % len(handles)
+        self._counters[key] += 1
+
+        result: list = await handles[idx].compute_hidden_states.remote(sequence_ids)
+        return torch.tensor(result, dtype=torch.bfloat16)
+
+
+class NitrobrewTeacherModelManager:
+    """Manages a pool of NitrobrewTeacherWorker Ray actors.
+
+    Exposes:
+        worker_handles: dict[teacher_key, list[ActorHandle]]  -- for AgentLoopWorker
+        w_up:           torch.Tensor [V, D_t]                 -- for actor set_teacher_unembed
+    """
+
+    def __init__(
+        self,
+        teacher_model_configs: dict,
+        gpus_per_replica: int,
+    ):
+        self.worker_handles: dict[str, list] = {}
+        self.w_up: torch.Tensor | None = None
+
+        for key, teacher_cfg in teacher_model_configs.items():
+            num_replicas = teacher_cfg.num_replicas
+            model_path = teacher_cfg.model_path
+            dtype = getattr(teacher_cfg, "torch_dtype", "bfloat16")
+
+            handles = []
+            for _ in range(num_replicas):
+                worker = NitrobrewTeacherWorker.options(num_gpus=gpus_per_replica).remote()
+                handles.append(worker)
+            self.worker_handles[key] = handles
+
+            logger.warning(f"NitrobrewTeacherModelManager: running setup for teacher '{key}'")
+            w_list = ray.get(handles[0].setup.remote(model_path, dtype))
+            w = torch.tensor(w_list)
+
+            setup_futures = [h.setup.remote(model_path, dtype) for h in handles[1:]]
+            ray.get(setup_futures)
+
+            if self.w_up is None:
+                self.w_up = w
+
+        assert self.w_up is not None, "No teacher models configured."

--- a/verl/trainer/distillation/fsdp/nitrobrew_loss.py
+++ b/verl/trainer/distillation/fsdp/nitrobrew_loss.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nitrobrew: fused, constant-memory KL divergence from hidden states (FSDP path).
+
+Computes KL(teacher || student) or KL(student || teacher) without materialising
+the full [N, V] teacher logit tensor. Teacher logits are reconstructed on-the-fly
+as z @ W.T in vocabulary chunks of size C using single-pass online-softmax.
+
+Peak extra memory: O(N * C) per chunk, instead of O(N * V).
+"""
+
+import torch
+
+from verl.utils.ulysses import get_ulysses_sequence_parallel_world_size, slice_input_tensor
+from verl.workers.config import DistillationConfig
+
+_CHUNK_V: int = 1024
+
+
+# ---------------------------------------------------------------------------
+# Forward KL: KL(p_T || p_S)
+# ---------------------------------------------------------------------------
+
+
+@torch.compile
+def _fwd_chunk_update(
+    z_f: torch.Tensor,       # (N, D_t) float32
+    W_chunk: torch.Tensor,   # (C, D_t) float32
+    zs_chunk: torch.Tensor,  # (N, C)   float32
+    mt: torch.Tensor,        # (N,) running teacher max
+    st: torch.Tensor,        # (N,) sum exp(zt - mt)
+    tt: torch.Tensor,        # (N,) sum exp(zt - mt) * zt
+    ut: torch.Tensor,        # (N,) sum exp(zt - mt) * zs_clamped
+    s_min: torch.Tensor,     # (N, 1) floor for student logits
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Online-softmax update for one teacher vocab chunk."""
+    zt = z_f @ W_chunk.T
+    tile_mt = zt.max(dim=1).values
+    new_mt = torch.maximum(mt, tile_mt)
+    alpha = (mt - new_mt).exp()
+    pt = (zt - new_mt.unsqueeze(1)).exp()
+    st = st * alpha + pt.sum(dim=1)
+    tt = tt * alpha + (pt * zt).sum(dim=1)
+    zs_clamped = torch.maximum(zs_chunk, s_min)
+    ut = ut * alpha + (pt * zs_clamped).sum(dim=1)
+    return new_mt, st, tt, ut
+
+
+def _chunked_kl_forward(
+    z: torch.Tensor,              # (N, D_t)
+    W: torch.Tensor,              # (V, D_t)
+    student_logits: torch.Tensor, # (N, V)
+    chunk_V: int = _CHUNK_V,
+    temperature: float = 1.0,
+    log_prob_min_clamp: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Single-pass chunked forward. Returns (kl, t_lse) both (N,) float32."""
+    N = z.shape[0]
+    V = W.shape[0]
+    device = z.device
+
+    z_f = z.float()
+    W_f = W.to(device=device, dtype=torch.float32)
+    s_f = student_logits.float()
+
+    if temperature != 1.0:
+        inv_T = 1.0 / temperature
+        z_f = z_f * inv_T
+        s_f = s_f * inv_T
+
+    s_lse = s_f.logsumexp(dim=-1)
+
+    if log_prob_min_clamp is not None:
+        s_min = (s_lse + log_prob_min_clamp).unsqueeze(1)
+    else:
+        s_min = torch.full((1, 1), float("-inf"), dtype=torch.float32, device=device)
+
+    mt = torch.full((N,), float("-inf"), dtype=torch.float32, device=device)
+    st = torch.zeros(N, dtype=torch.float32, device=device)
+    tt = torch.zeros(N, dtype=torch.float32, device=device)
+    ut = torch.zeros(N, dtype=torch.float32, device=device)
+
+    for v in range(0, V, chunk_V):
+        mt, st, tt, ut = _fwd_chunk_update(
+            z_f, W_f[v : v + chunk_V], s_f[:, v : v + chunk_V],
+            mt, st, tt, ut, s_min,
+        )
+
+    t_lse = mt + st.log()
+    kl = tt / st - t_lse - ut / st + s_lse
+    return kl, t_lse
+
+
+# ---------------------------------------------------------------------------
+# Backward: standard d(KL)/d(zs_v) = p_S(v) - p_T(v)
+# ---------------------------------------------------------------------------
+
+
+@torch.compile
+def _bwd_chunk(
+    z_f: torch.Tensor,       # (N, D_t) float32
+    W_chunk: torch.Tensor,   # (C, D_t) float32
+    zs_chunk: torch.Tensor,  # (N, C)   float32
+    t_lse: torch.Tensor,     # (N,)
+    s_lse: torch.Tensor,     # (N,)
+    grad: torch.Tensor,      # (N,)
+) -> torch.Tensor:
+    """d(KL)/d(student_logits) for one vocab chunk. Returns (N, C)."""
+    zt = z_f @ W_chunk.T
+    p_T = (zt - t_lse.unsqueeze(1)).exp()
+    p_S = (zs_chunk - s_lse.unsqueeze(1)).exp()
+    return (p_S - p_T) * grad.unsqueeze(1)
+
+
+# ---------------------------------------------------------------------------
+# autograd.Function -- wires forward & backward
+# ---------------------------------------------------------------------------
+
+
+class _NitrobrewKL(torch.autograd.Function):
+    """KL(p_T || p_S) with chunked forward and backward over vocab axis."""
+
+    @staticmethod
+    def forward(ctx, z, W, student_logits, chunk_V, temperature=1.0,
+                log_prob_min_clamp=None):
+        kl, t_lse = _chunked_kl_forward(
+            z, W, student_logits, chunk_V, temperature, log_prob_min_clamp,
+        )
+        s_f = student_logits.float()
+        if temperature != 1.0:
+            s_f = s_f / temperature
+        s_lse = s_f.logsumexp(dim=-1)
+        ctx.save_for_backward(z, W, student_logits, t_lse, s_lse)
+        ctx.chunk_V = chunk_V
+        ctx.temperature = temperature
+        return kl
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        z, W, student_logits, t_lse, s_lse = ctx.saved_tensors
+        chunk_V = ctx.chunk_V
+        temperature = ctx.temperature
+        N, V = student_logits.shape
+        device = z.device
+
+        z_f = z.float()
+        W_f = W.to(device=device, dtype=torch.float32)
+        s_f = student_logits.float()
+        if temperature != 1.0:
+            inv_T = 1.0 / temperature
+            z_f = z_f * inv_T
+            s_f = s_f * inv_T
+        grad = grad_output.float()
+
+        grad_s = torch.empty(N, V, dtype=torch.float32, device=device)
+        for v in range(0, V, chunk_V):
+            grad_s[:, v : v + chunk_V] = _bwd_chunk(
+                z_f, W_f[v : v + chunk_V], s_f[:, v : v + chunk_V],
+                t_lse, s_lse, grad,
+            )
+
+        if temperature != 1.0:
+            grad_s = grad_s / temperature
+
+        return None, None, grad_s.to(student_logits.dtype), None, None, None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def compute_nitrobrew_kl(
+    student_logits: torch.Tensor,
+    teacher_hidden_states: torch.Tensor,
+    teacher_unembed: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    """Compute Nitrobrew forward KL loss KL(p_T || p_S) for the FSDP path."""
+    z, T_sp = _unpack_hidden_states(teacher_hidden_states, student_logits)
+    z_flat = z.view(T_sp, -1)
+    s_flat = student_logits.view(T_sp, -1)
+
+    loss_config = config.distillation_loss
+    per_token_kl = _NitrobrewKL.apply(
+        z_flat, teacher_unembed, s_flat, _CHUNK_V,
+        loss_config.kd_temperature, loss_config.log_prob_min_clamp,
+    )
+    return {"distillation_losses": per_token_kl.view(1, T_sp)}
+
+
+# ---------------------------------------------------------------------------
+# Reverse KL: KL(p_S || p_T)
+# ---------------------------------------------------------------------------
+
+
+@torch.compile
+def _rev_fwd_chunk(
+    z_f: torch.Tensor,       # (N, D_t)
+    W_chunk: torch.Tensor,   # (C, D_t)
+    zs_chunk: torch.Tensor,  # (N, C)
+    s_lse: torch.Tensor,     # (N,) pre-computed student log-partition
+    mt: torch.Tensor,        # (N,) running teacher max
+    st: torch.Tensor,        # (N,) running sum exp(z_t - mt)
+    ut: torch.Tensor,        # (N,) running sum p_S * z_t
+    et: torch.Tensor,        # (N,) running sum p_S * z_s
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Online-softmax update for one teacher vocab chunk of reverse KL."""
+    zt = z_f @ W_chunk.T
+
+    tile_mt = zt.max(dim=1).values
+    new_mt = torch.maximum(mt, tile_mt)
+    alpha = (mt - new_mt).exp()
+    st = st * alpha + (zt - new_mt.unsqueeze(1)).exp().sum(dim=1)
+
+    ps_chunk = (zs_chunk - s_lse.unsqueeze(1)).exp()
+    ut = ut + (ps_chunk * zt).sum(dim=1)
+    et = et + (ps_chunk * zs_chunk).sum(dim=1)
+
+    return new_mt, st, ut, et
+
+
+def _chunked_reverse_kl_forward(
+    z: torch.Tensor,              # (N, D_t)
+    W: torch.Tensor,              # (V, D_t)
+    student_logits: torch.Tensor, # (N, V)
+    chunk_V: int = _CHUNK_V,
+    temperature: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Chunked reverse KL forward. Returns (kl, t_lse, s_lse) all (N,) float32."""
+    N = z.shape[0]
+    V = W.shape[0]
+    device = z.device
+
+    z_f = z.float()
+    W_f = W.to(device=device, dtype=torch.float32)
+    s_f = student_logits.float()
+
+    if temperature != 1.0:
+        inv_T = 1.0 / temperature
+        z_f = z_f * inv_T
+        s_f = s_f * inv_T
+
+    s_lse = s_f.logsumexp(dim=-1)
+
+    mt = torch.full((N,), float("-inf"), dtype=torch.float32, device=device)
+    st = torch.zeros(N, dtype=torch.float32, device=device)
+    ut = torch.zeros(N, dtype=torch.float32, device=device)
+    et = torch.zeros(N, dtype=torch.float32, device=device)
+
+    for v in range(0, V, chunk_V):
+        mt, st, ut, et = _rev_fwd_chunk(
+            z_f, W_f[v : v + chunk_V], s_f[:, v : v + chunk_V],
+            s_lse, mt, st, ut, et,
+        )
+
+    t_lse = mt + st.log()
+    kl = et - ut - s_lse + t_lse
+    return kl, t_lse, s_lse
+
+
+@torch.compile
+def _rev_bwd_chunk(
+    z_f: torch.Tensor,       # (N, D_t)
+    W_chunk: torch.Tensor,   # (C, D_t)
+    zs_chunk: torch.Tensor,  # (N, C)
+    t_lse: torch.Tensor,     # (N,)
+    s_lse: torch.Tensor,     # (N,)
+    kl: torch.Tensor,        # (N,)
+    grad: torch.Tensor,      # (N,)
+) -> torch.Tensor:
+    """dKL(p_S||p_T)/dz_s(v) = p_S(v) * [log(p_S(v)/p_T(v)) - KL]. Returns (N, C)."""
+    zt = z_f @ W_chunk.T
+    log_ps = zs_chunk - s_lse.unsqueeze(1)
+    log_pt = zt - t_lse.unsqueeze(1)
+    ps = log_ps.exp()
+    return ps * (log_ps - log_pt - kl.unsqueeze(1)) * grad.unsqueeze(1)
+
+
+class _NitrobrewReverseKL(torch.autograd.Function):
+    """KL(p_S || p_T) with chunked forward and backward over vocab axis."""
+
+    @staticmethod
+    def forward(ctx, z, W, student_logits, chunk_V, temperature=1.0):
+        kl, t_lse, s_lse = _chunked_reverse_kl_forward(z, W, student_logits, chunk_V, temperature)
+        ctx.save_for_backward(z, W, student_logits, t_lse, s_lse, kl)
+        ctx.chunk_V = chunk_V
+        ctx.temperature = temperature
+        return kl
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        z, W, student_logits, t_lse, s_lse, kl = ctx.saved_tensors
+        chunk_V = ctx.chunk_V
+        temperature = ctx.temperature
+        N, V = student_logits.shape
+
+        z_f = z.float()
+        W_f = W.to(device=z.device, dtype=torch.float32)
+        s_f = student_logits.float()
+        if temperature != 1.0:
+            inv_T = 1.0 / temperature
+            z_f = z_f * inv_T
+            s_f = s_f * inv_T
+        grad = grad_output.float()
+
+        grad_s = torch.empty(N, V, dtype=torch.float32, device=z.device)
+        for v in range(0, V, chunk_V):
+            grad_s[:, v : v + chunk_V] = _rev_bwd_chunk(
+                z_f, W_f[v : v + chunk_V], s_f[:, v : v + chunk_V],
+                t_lse, s_lse, kl, grad,
+            )
+
+        if temperature != 1.0:
+            grad_s = grad_s / temperature
+
+        return None, None, grad_s.to(student_logits.dtype), None, None
+
+
+def compute_nitrobrew_reverse_kl(
+    student_logits: torch.Tensor,
+    teacher_hidden_states: torch.Tensor,
+    teacher_unembed: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    """Compute Nitrobrew reverse KL loss KL(p_S || p_T) for the FSDP path."""
+    z, T_sp = _unpack_hidden_states(teacher_hidden_states, student_logits)
+    z_flat = z.view(T_sp, -1)
+    s_flat = student_logits.view(T_sp, -1)
+
+    loss_config = config.distillation_loss
+    per_token_kl = _NitrobrewReverseKL.apply(
+        z_flat, teacher_unembed, s_flat, _CHUNK_V, loss_config.kd_temperature,
+    )
+    return {"distillation_losses": per_token_kl.view(1, T_sp)}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unpack_hidden_states(
+    teacher_hidden_states: torch.Tensor,
+    student_logits: torch.Tensor,
+) -> tuple[torch.Tensor, int]:
+    """Convert nested teacher hidden states to flat packed tensor. Returns (z, T_sp)."""
+    if teacher_hidden_states.is_nested:
+        z = teacher_hidden_states.values().unsqueeze(0)
+    else:
+        z = teacher_hidden_states.flatten(0, 1).unsqueeze(0)
+
+    if get_ulysses_sequence_parallel_world_size() > 1:
+        z = slice_input_tensor(z, dim=1)
+
+    assert z.shape[:2] == student_logits.shape[:2], (
+        f"Shape mismatch: z {z.shape[:2]} vs student_logits {student_logits.shape[:2]}"
+    )
+    return z, z.shape[1]

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -57,14 +57,16 @@ class DistillationLossSettings(BaseConfig):
     names: str | list[str] = field(default_factory=list)
     use_topk: bool = False
     use_estimator: bool = False
+    use_hidden_states: bool = False
 
     _mutable_fields = {"names"}
 
     def __post_init__(self):
         self.names = [self.names] if isinstance(self.names, str) else self.names
-        if sum([self.use_topk, self.use_estimator]) != 1:
+        if sum([self.use_topk, self.use_estimator, self.use_hidden_states]) != 1:
             raise ValueError(
-                f"Expected only one of use_estimator, use_topk, but got {self.use_estimator=}, {self.use_topk=}."
+                f"Expected exactly one of use_estimator, use_topk, use_hidden_states, "
+                f"but got {self.use_estimator=}, {self.use_topk=}, {self.use_hidden_states=}."
             )
 
 
@@ -127,33 +129,59 @@ def compute_topk_loss(
     student_logits: torch.Tensor,
     data_format: str,
 ) -> torch.Tensor:
-    """Compute the topk loss in logit processor.
+    """Compute per-token distillation loss in the logits processor.
 
-    Returns:
-    - distillation_losses: (bsz, seqlen/cp_size)
-    - student_mass: (bsz, seqlen/cp_size)
-    - teacher_mass: (bsz, seqlen/cp_size)
+    Dispatches to top-k or Nitrobrew (hidden-state) loss based on loss_mode.
     """
-    match config.strategy:
-        # VeOmni uses FSDP2 internally, so its loss computation is identical to FSDP.
-        case "fsdp" | "veomni":
-            import verl.trainer.distillation.fsdp.losses as fsdp_losses
+    loss_settings = distillation_config.distillation_loss.loss_settings
 
-            distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
-        case "megatron":
-            import verl.trainer.distillation.megatron.losses as megatron_losses
+    if loss_settings.use_hidden_states:
+        loss_mode = distillation_config.distillation_loss.loss_mode
+        use_reverse = loss_mode == "nitrobrew_reverse_kl"
+        match config.strategy:
+            case "fsdp" | "veomni":
+                import verl.trainer.distillation.fsdp.nitrobrew_loss as fsdp_nb
 
-            distillation_loss_fn = megatron_losses.compute_forward_kl_topk
-        case _:
-            raise NotImplementedError(f"Unsupported strategy: {config.strategy=}")
+                distillation_loss_fn = fsdp_nb.compute_nitrobrew_reverse_kl if use_reverse else fsdp_nb.compute_nitrobrew_kl
+            case "megatron":
+                import verl.trainer.distillation.megatron.nitrobrew_loss as megatron_nb
 
-    outputs = distillation_loss_fn(
-        student_logits=student_logits,
-        teacher_topk_log_probs=data["teacher_logprobs"],
-        teacher_topk_ids=data["teacher_ids"],
-        config=distillation_config,
-        data_format=data_format,
-    )
+                distillation_loss_fn = megatron_nb.compute_nitrobrew_kl
+                if use_reverse:
+                    raise NotImplementedError("Nitrobrew reverse KL not yet implemented for Megatron")
+            case _:
+                raise NotImplementedError(f"Nitrobrew not implemented for strategy: {config.strategy=}")
+
+        teacher_unembed = data["teacher_unembed"]
+        if hasattr(teacher_unembed, "data"):
+            teacher_unembed = teacher_unembed.data
+        outputs = distillation_loss_fn(
+            student_logits=student_logits,
+            teacher_hidden_states=data["teacher_hidden_states"],
+            teacher_unembed=teacher_unembed,
+            config=distillation_config,
+            data_format=data_format,
+        )
+    else:
+        match config.strategy:
+            case "fsdp" | "veomni":
+                import verl.trainer.distillation.fsdp.losses as fsdp_losses
+
+                distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
+            case "megatron":
+                import verl.trainer.distillation.megatron.losses as megatron_losses
+
+                distillation_loss_fn = megatron_losses.compute_forward_kl_topk
+            case _:
+                raise NotImplementedError(f"Unsupported strategy: {config.strategy=}")
+
+        outputs = distillation_loss_fn(
+            student_logits=student_logits,
+            teacher_topk_log_probs=data["teacher_logprobs"],
+            teacher_topk_ids=data["teacher_ids"],
+            config=distillation_config,
+            data_format=data_format,
+        )
 
     expected_shape = student_logits.shape[:2]
     for k, v in outputs.items():
@@ -329,6 +357,32 @@ def compute_forward_kl_topk(
     # Due to use of top-k, student and teacher distributions don't sum to 1 -> divergences can be negative.
     distillation_losses = distillation_losses.clamp_min(0.0)
 
+    return distillation_losses, distillation_metrics
+
+
+@register_distillation_loss(
+    DistillationLossSettings(names=["nitrobrew", "nitrobrew_reverse_kl"], use_hidden_states=True)
+)  # type: ignore[arg-type]
+def compute_nitrobrew_loss(
+    config: ActorConfig,
+    distillation_config: DistillationConfig,
+    model_output: dict,
+    data: TensorDict,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Aggregate Nitrobrew per-token KL (computed in logits processor)."""
+    distillation_losses = no_padding_2_padding(model_output["distillation_losses"], data)
+    if data["response_mask"].is_nested:
+        response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
+    else:
+        response_mask_bool = data["response_mask"].bool()
+    assert distillation_losses.shape == response_mask_bool.shape
+
+    # log_prob_min_clamp makes the computed KL no longer a true divergence -- it
+    # can go negative where the student locally outperforms the teacher on
+    # clamped tokens.  Floor at zero to prevent negative losses acting as reward.
+    distillation_losses = distillation_losses.clamp_min(0.0)
+
+    distillation_metrics: dict[str, Any] = {}
     return distillation_losses, distillation_metrics
 
 

--- a/verl/trainer/distillation/megatron/nitrobrew_loss.py
+++ b/verl/trainer/distillation/megatron/nitrobrew_loss.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Tilde Research
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Nitrobrew: fused, constant-memory KL divergence from hidden states (Megatron path).
+
+Same online-softmax chunking as the FSDP kernel, but adapted for vocab-parallel
+(TP-sharded) student logits. Each TP rank computes local accumulators over its
+V/tp vocab shard, then merges via all-gather for exact global log-partition values.
+
+Forward only -- reverse KL is not yet implemented for Megatron.
+"""
+
+import torch
+
+from verl.models.mcore.util import preprocess_bshd_engine, preprocess_thd_engine
+from verl.workers.config import DistillationConfig
+
+_CHUNK_V: int = 1024
+
+
+@torch.compile
+def _fwd_chunk_update(
+    z_f: torch.Tensor,       # (N, D_t)
+    W_chunk: torch.Tensor,   # (C, D_t)
+    zs_chunk: torch.Tensor,  # (N, C)
+    mt: torch.Tensor,        # (N,)
+    st: torch.Tensor,        # (N,) sum exp(zt - mt)
+    tt: torch.Tensor,        # (N,) sum exp(zt - mt) * zt
+    ut: torch.Tensor,        # (N,) sum exp(zt - mt) * zs_clamped
+    s_min: torch.Tensor,     # (N, 1) floor for student logits
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Online-softmax update for one local vocab chunk. Returns updated (mt, st, tt, ut)."""
+    zt = z_f @ W_chunk.T
+    tile_mt = zt.max(dim=1).values
+    new_mt = torch.maximum(mt, tile_mt)
+    alpha = (mt - new_mt).exp()
+    pt = (zt - new_mt.unsqueeze(1)).exp()
+    st = st * alpha + pt.sum(dim=1)
+    tt = tt * alpha + (pt * zt).sum(dim=1)
+    zs_clamped = torch.maximum(zs_chunk, s_min)
+    ut = ut * alpha + (pt * zs_clamped).sum(dim=1)
+    return new_mt, st, tt, ut
+
+
+def _chunked_local_lse_and_kl_accumulators(
+    z: torch.Tensor,                  # (N, D_t)
+    W_vp: torch.Tensor,              # (V/tp, D_t)
+    student_logits_vp: torch.Tensor,  # (N, V/tp)
+    chunk_V: int,
+    s_min: torch.Tensor,             # (N, 1)
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compute local (this TP rank) online-softmax accumulators. Returns (mt, st, tt, ut)."""
+    N = z.shape[0]
+    V_tp = W_vp.shape[0]
+    device = z.device
+
+    z_f = z.float()
+    W_f = W_vp.to(device=device, dtype=torch.float32)
+    s_f = student_logits_vp.float()
+
+    mt = torch.full((N,), float("-inf"), dtype=torch.float32, device=device)
+    st = torch.zeros(N, dtype=torch.float32, device=device)
+    tt = torch.zeros(N, dtype=torch.float32, device=device)
+    ut = torch.zeros(N, dtype=torch.float32, device=device)
+
+    for v in range(0, V_tp, chunk_V):
+        mt, st, tt, ut = _fwd_chunk_update(
+            z_f, W_f[v : v + chunk_V], s_f[:, v : v + chunk_V],
+            mt, st, tt, ut, s_min,
+        )
+    return mt, st, tt, ut
+
+
+def _merge_tp_accumulators(
+    mt: torch.Tensor,
+    st: torch.Tensor,
+    tt: torch.Tensor,
+    ut: torch.Tensor,
+    group: torch.distributed.ProcessGroup,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Merge online-softmax accumulators across TP ranks (exact)."""
+    ws = torch.distributed.get_world_size(group)
+    if ws == 1:
+        return mt, st, tt, ut
+
+    N = mt.shape[0]
+    device = mt.device
+    local = torch.stack([mt, st, tt, ut], dim=1)
+    gathered = [torch.empty_like(local) for _ in range(ws)]
+    torch.distributed.all_gather(gathered, local, group=group)
+
+    global_mt = torch.stack([g[:, 0] for g in gathered], dim=1).max(dim=1).values
+    global_st = torch.zeros(N, dtype=torch.float32, device=device)
+    global_tt = torch.zeros(N, dtype=torch.float32, device=device)
+    global_ut = torch.zeros(N, dtype=torch.float32, device=device)
+    for g in gathered:
+        alpha = (g[:, 0] - global_mt).exp()
+        global_st += g[:, 1] * alpha
+        global_tt += g[:, 2] * alpha
+        global_ut += g[:, 3] * alpha
+
+    return global_mt, global_st, global_tt, global_ut
+
+
+class _VocabParallelNitrobrewKL(torch.autograd.Function):
+    """KL(p_T || p_S) with TP-sharded vocab: chunked forward + all-gather merge."""
+
+    @staticmethod
+    def forward(ctx, vp_student_logits, teacher_z, W_vp, chunk_V, log_prob_min_clamp):
+        from megatron.core.parallel_state import get_tensor_model_parallel_group
+
+        N, V_tp = vp_student_logits.shape
+        device = teacher_z.device
+
+        s_f = vp_student_logits.float()
+
+        tp_group = get_tensor_model_parallel_group()
+        s_local_max = s_f.max(dim=-1).values
+        s_local_sumexp = (s_f - s_local_max.unsqueeze(-1)).exp().sum(-1)
+        s_max_all = s_local_max.clone()
+        torch.distributed.all_reduce(s_max_all, op=torch.distributed.ReduceOp.MAX, group=tp_group)
+        s_sumexp_all = s_local_sumexp * (s_local_max - s_max_all).exp()
+        torch.distributed.all_reduce(s_sumexp_all, op=torch.distributed.ReduceOp.SUM, group=tp_group)
+        s_lse_global = s_max_all + s_sumexp_all.log()
+
+        if log_prob_min_clamp is not None:
+            s_min = (s_lse_global + log_prob_min_clamp).unsqueeze(1)
+        else:
+            s_min = torch.full((1, 1), float("-inf"), dtype=torch.float32, device=device)
+
+        mt, st, tt, ut = _chunked_local_lse_and_kl_accumulators(
+            teacher_z, W_vp, vp_student_logits, chunk_V, s_min,
+        )
+        mt, st, tt, ut = _merge_tp_accumulators(mt, st, tt, ut, tp_group)
+
+        t_lse = mt + st.log()
+        per_token_kl = tt / st - t_lse - ut / st + s_lse_global
+
+        ctx.save_for_backward(teacher_z, W_vp, vp_student_logits, t_lse, s_lse_global)
+        ctx.chunk_V = chunk_V
+
+        return per_token_kl
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        teacher_z, W_vp, vp_student_logits, t_lse, s_lse = ctx.saved_tensors
+        N, V_tp = vp_student_logits.shape
+        chunk_V = ctx.chunk_V
+        device = teacher_z.device
+
+        z_f = teacher_z.float()
+        W_f = W_vp.to(device=device, dtype=torch.float32)
+        s_f = vp_student_logits.float()
+        grad = grad_output.float()
+
+        grad_s = torch.empty(N, V_tp, dtype=torch.float32, device=device)
+        for v in range(0, V_tp, chunk_V):
+            zt = z_f @ W_f[v : v + chunk_V].T
+            p_T = (zt - t_lse.unsqueeze(1)).exp()
+            p_S = (s_f[:, v : v + chunk_V] - s_lse.unsqueeze(1)).exp()
+            grad_s[:, v : v + chunk_V] = (p_S - p_T) * grad.unsqueeze(1)
+
+        return grad_s.to(vp_student_logits.dtype), None, None, None, None
+
+
+def compute_nitrobrew_kl(
+    student_logits: torch.Tensor,
+    teacher_hidden_states: torch.Tensor,
+    teacher_unembed: torch.Tensor,
+    config: DistillationConfig,
+    data_format: str,
+) -> dict[str, torch.Tensor]:
+    """Compute Nitrobrew forward KL using teacher hidden states (Megatron vocab-parallel path)."""
+    assert teacher_hidden_states.is_nested, "teacher_hidden_states must be nested after left_right_2_no_padding"
+
+    if data_format == "thd":
+        teacher_z_cp, *_ = preprocess_thd_engine(teacher_hidden_states, pre_process=True)
+    else:
+        teacher_z_cp, *_ = preprocess_bshd_engine(teacher_hidden_states, pre_process=True)
+
+    B, T_cp, V_tp = student_logits.shape
+    assert teacher_z_cp.shape[:2] == (B, T_cp), (
+        f"Shape mismatch: teacher_z {teacher_z_cp.shape[:2]} vs student {(B, T_cp)}"
+    )
+
+    N = B * T_cp
+    z_flat = teacher_z_cp.reshape(N, -1)
+    s_flat = student_logits.reshape(N, V_tp)
+
+    loss_config = config.distillation_loss
+    per_token_kl = _VocabParallelNitrobrewKL.apply(
+        s_flat, z_flat, teacher_unembed, _CHUNK_V, loss_config.log_prob_min_clamp,
+    )
+
+    return {"distillation_losses": per_token_kl.view(B, T_cp)}

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -827,14 +827,30 @@ class RayPPOTrainer:
 
         # initialize teacher loop manager
         if self.use_teacher_policy:
-            from verl.experimental.teacher_loop import MultiTeacherModelManager
-
-            teacher_resource_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
-            self.teacher_model_manager = MultiTeacherModelManager(
-                config=self.config,
-                resource_pool=teacher_resource_pool,
-            )
             self.distillation_config: DistillationConfig = omega_conf_to_dataclass(self.config.distillation)
+            use_hidden_states = self.distillation_config.distillation_loss.loss_settings.use_hidden_states
+
+            if use_hidden_states:
+                from verl.experimental.teacher_loop.nitrobrew_teacher import NitrobrewTeacherModelManager
+
+                teacher_resource_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
+                gpus_per_replica = self.distillation_config.teacher_models[
+                    next(iter(self.distillation_config.teacher_models))
+                ].per_replica_world_size
+
+                self.teacher_model_manager = NitrobrewTeacherModelManager(
+                    teacher_model_configs=self.distillation_config.teacher_models,
+                    gpus_per_replica=gpus_per_replica,
+                )
+                self.actor_rollout_wg.set_teacher_unembed(self.teacher_model_manager.w_up)
+            else:
+                from verl.experimental.teacher_loop import MultiTeacherModelManager
+
+                teacher_resource_pool = self.resource_pool_manager.get_resource_pool(Role.TeacherModel)
+                self.teacher_model_manager = MultiTeacherModelManager(
+                    config=self.config,
+                    resource_pool=teacher_resource_pool,
+                )
         else:
             self.teacher_model_manager = None
             self.distillation_config = None
@@ -1211,11 +1227,11 @@ class RayPPOTrainer:
         calculate_entropy = self.config.actor_rollout_ref.actor.calculate_entropy or (
             self.config.actor_rollout_ref.actor.entropy_coeff != 0.0
         )
-        distillation_use_topk = (
-            self.distillation_config.distillation_loss.loss_settings.use_topk
-            if is_distillation_enabled(self.config.get("distillation"))
-            else False
-        )
+        if is_distillation_enabled(self.config.get("distillation")):
+            _ls = self.distillation_config.distillation_loss.loss_settings
+            distillation_use_topk = _ls.use_topk or _ls.use_hidden_states
+        else:
+            distillation_use_topk = False
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
         ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -64,6 +64,7 @@ class DistillationLossConfig(BaseConfig):
 
     loss_mode: str = "k3"
     topk: Optional[int] = 128
+    kd_temperature: float = 1.0
     use_task_rewards: bool = True
     distillation_loss_coef: float = 1.0
     loss_max_clamp: Optional[float] = 10.0
@@ -157,7 +158,9 @@ class DistillationTeacherModelConfig(BaseConfig):
         if self.num_replicas is None:
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
 
-    def validate_and_prepare_for_distillation(self, use_topk: bool, topk: Optional[int]) -> None:
+    def validate_and_prepare_for_distillation(
+        self, use_topk: bool, topk: Optional[int], use_hidden_states: bool = False
+    ) -> None:
         # Prompt + Response from student are fed into teacher as context
         max_model_len = self.inference.max_model_len
         student_prompt_length = self.inference.prompt_length
@@ -171,7 +174,8 @@ class DistillationTeacherModelConfig(BaseConfig):
             )
         self.inference.prompt_length = self.inference.prompt_length + self.inference.response_length
         self.inference.response_length = 1
-        self._validate_topk_logprobs(use_topk=use_topk, topk=topk)
+        if not use_hidden_states:
+            self._validate_topk_logprobs(use_topk=use_topk, topk=topk)
 
     def _validate_topk_logprobs(self, use_topk: bool, topk: Optional[int]) -> None:
         if not use_topk:
@@ -264,6 +268,7 @@ class DistillationConfig(BaseConfig):
             teacher_model.validate_and_prepare_for_distillation(
                 use_topk=self.distillation_loss.loss_settings.use_topk,
                 topk=self.distillation_loss.topk,
+                use_hidden_states=self.distillation_loss.loss_settings.use_hidden_states,
             )
             teacher_world_size_sum += teacher_model.world_size
         total_pool_size = self.n_gpus_per_node * self.nnodes

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -15,7 +15,6 @@
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Optional
 
 from verl.base_config import BaseConfig
 from verl.utils.config import omega_conf_to_dataclass
@@ -63,12 +62,12 @@ class DistillationLossConfig(BaseConfig):
     """
 
     loss_mode: str = "k3"
-    topk: Optional[int] = 128
+    topk: int | None = 128
     kd_temperature: float = 1.0
     use_task_rewards: bool = True
     distillation_loss_coef: float = 1.0
-    loss_max_clamp: Optional[float] = 10.0
-    log_prob_min_clamp: Optional[float] = -10.0
+    loss_max_clamp: float | None = 10.0
+    log_prob_min_clamp: float | None = -10.0
 
     use_policy_gradient: bool = True
     policy_loss_mode: str = "vanilla"
@@ -84,7 +83,7 @@ class DistillationLossConfig(BaseConfig):
 
     # Store distillation loss settings for computing the specified loss_mode
     # Not set by user, populated at runtime
-    loss_settings: Optional[dict] = None
+    loss_settings: dict | None = None
 
     def __post_init__(self):
         self._mutable_fields.add("loss_settings")
@@ -133,10 +132,13 @@ class DistillationTeacherModelConfig(BaseConfig):
 
     _mutable_fields = BaseConfig._mutable_fields | {"num_replicas", "key"}
 
-    key: Optional[str] = None
-    model_path: Optional[str] = None
+    key: str | None = None
+    model_path: str | None = None
     inference: RolloutConfig = field(default_factory=RolloutConfig)
-    num_replicas: Optional[int] = 0
+    num_replicas: int | None = 0
+    # PCA rank used by the nitrobrew loss to compress this teacher's hidden
+    # states. Required when distillation_loss.loss_mode == "nitrobrew".
+    nitrobrew_d_comp: int | None = None
 
     @property
     def per_replica_world_size(self) -> int:
@@ -159,7 +161,7 @@ class DistillationTeacherModelConfig(BaseConfig):
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
 
     def validate_and_prepare_for_distillation(
-        self, use_topk: bool, topk: Optional[int], use_hidden_states: bool = False
+        self, use_topk: bool, topk: int | None, use_hidden_states: bool = False
     ) -> None:
         # Prompt + Response from student are fed into teacher as context
         max_model_len = self.inference.max_model_len
@@ -177,7 +179,7 @@ class DistillationTeacherModelConfig(BaseConfig):
         if not use_hidden_states:
             self._validate_topk_logprobs(use_topk=use_topk, topk=topk)
 
-    def _validate_topk_logprobs(self, use_topk: bool, topk: Optional[int]) -> None:
+    def _validate_topk_logprobs(self, use_topk: bool, topk: int | None) -> None:
         if not use_topk:
             return
         if topk is None:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -32,7 +32,7 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
 from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_device_name, is_npu_available, set_expandable_segments
+from verl.utils.device import get_device_id, get_device_name, is_npu_available, set_expandable_segments
 from verl.utils.distributed import initialize_global_process_group_ray, set_numa_affinity
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.import_utils import import_external_libs
@@ -661,7 +661,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             W_local = W[tp_rank * shard : (tp_rank + 1) * shard]
         else:
             W_local = W
-        self._teacher_unembed = W_local.cuda()
+        self._teacher_unembed = W_local.to(get_device_id())
 
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
     @DistProfiler.annotate(color="red", role="actor_update")

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -451,6 +451,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self.actor: TrainingWorker = None
         self.ref: TrainingWorker = None
         self.rollout: BaseRollout = None
+        self._teacher_unembed: torch.Tensor | None = None
         assert self.role in ["actor", "rollout", "ref", "actor_rollout", "actor_rollout_ref"]
         self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
         self._is_rollout = self.role in ["rollout", "actor_rollout", "actor_rollout_ref"]
@@ -642,10 +643,32 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         return output.cpu() if output is not None else None
 
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def set_teacher_unembed(self, W: torch.Tensor) -> None:
+        """Store teacher lm_head.weight for Nitrobrew loss. TP ranks take their vocab shard."""
+        assert "actor" in self.role, "set_teacher_unembed is only valid for actor workers"
+        strategy = self.config.actor.get("strategy", "fsdp")
+        if strategy == "megatron":
+            from megatron.core.parallel_state import (
+                get_tensor_model_parallel_rank,
+                get_tensor_model_parallel_world_size,
+            )
+
+            tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
+            V = W.shape[0]
+            shard = V // tp_size
+            W_local = W[tp_rank * shard : (tp_rank + 1) * shard]
+        else:
+            W_local = W
+        self._teacher_unembed = W_local.cuda()
+
     @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"))
     @DistProfiler.annotate(color="red", role="actor_update")
     @_with_routing_replay_flag(enabled=True)
     def update_actor(self, data: TensorDict) -> TensorDict:
+        if self._teacher_unembed is not None:
+            data["teacher_unembed"] = NonTensorData(self._teacher_unembed)
         output = self.actor.train_mini_batch(data=data)
         return output.cpu() if output is not None else None
 

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -93,6 +93,13 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
         data["teacher_logprobs"] = teacher_logprobs_nested
         data["teacher_ids"] = teacher_ids_nested
 
+    # (bsz, seqlen, D_t) -- Nitrobrew teacher hidden states
+    teacher_hidden_states = data.get("teacher_hidden_states", None)
+    if teacher_hidden_states is not None:
+        ths_rmpad = index_first_axis(teacher_hidden_states.unsqueeze(-1).flatten(0, 1), indices)
+        ths_nested = torch.nested.nested_tensor_from_jagged(ths_rmpad.squeeze(-1), offsets=cu_seqlens)
+        data["teacher_hidden_states"] = ths_nested
+
     return data
 
 


### PR DESCRIPTION
### What does this PR do?

Adds **Nitrobrew**, a new on-policy distillation loss mode that estimates forward / reverse KL against the full teacher distribution **without ever materializing the `[N, V]` student-vs-teacher logit tensor** and **without communicating top-k logits**. Read our blogpost detailing the approach: [Nitrobrew: Fast, Lossless Distillation for Free](https://blog.tilderesearch.com/blog/nitrobrew).

Builds on the on-policy distillation infrastructure from #5041, #5723, #5745, #5997, #6051.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Amerged+distillation
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

**CPU unit tests** (`tests/experimental/teacher_loop/`)
- `test_nitrobrew_kernel_on_cpu.py`: chunked forward / reverse KL match a naive reference; autograd backward matches `torch.autograd.grad` on the reference.
- `test_nitrobrew_svd_on_cpu.py`: SVD round-trip and rank truncation, plus single-file / sharded / tied-embedding safetensors.

**GPU integration test**
- `tests/experimental/teacher_loop/test_nitrobrew_async_llm.py`: launches a `NitrobrewTeacherWorker` on Ray with `Qwen/Qwen3-0.6B`, runs end-to-end SVD → `AsyncLLM.encode` → on-actor projection, asserts shape `[S, d_comp]` and `bfloat16` dtype. Wired into `.github/workflows/vllm.yml`.

**End-to-end training experiment** — student `Qwen3-0.6B-Base`, teacher `Qwen3-4B`, dataset DAPO-Math-17k, 100 steps, 4 nodes × 8 GPUs each. Three runs at matched compute:

| Run | `loss_mode` | Communication budget per token |
|---|---|---|
| Nitrobrew (lossless, `d_comp = D`) | `nitrobrew` | 2560 floats |
| Top-k matched (`k = D`) | `forward_kl_topk` | 2 × 2560 floats (index + logprob) |
| Top-k practical (`k = 512`) | `forward_kl_topk` | 2 × 512 floats |

End-to-end step time:

> _[STEP TIME PLOT HERE — `nitrobrew-verl/logs/nitrobrew_e2e/step_time.png`]_

Headline: **Nitrobrew at full `d_model` is [SPEEDUP HERE]× faster end-to-end than the matched top-k baseline (k = 2560), and [SPEEDUP HERE]× faster than the practical top-k baseline (k = 512), while remaining fully lossless.**

Per-component breakdown (rollout / teacher inference / actor update):

> _[PER-COMPONENT BREAKDOWN PLOT HERE — `nitrobrew-verl/logs/nitrobrew_e2e/breakdown.png`]_

Loss / training curves (sanity check that the student is learning):

> _[LOSS CURVE PLOT HERE — `nitrobrew-verl/logs/nitrobrew_e2e/loss.png`]_

Model behaviour after 100 steps converges to the same regime as the topk baselines on DAPO-Math validation:

> _[VAL CURVE / TABLE HERE]_

For comprehensive cross-scale profiling and convergence results (Qwen3 0.6B/8B, 1.7B/32B, 4B/32B; up to 14× speedup on the largest pair), see [the blogpost](https://blog.tilderesearch.com/blog/nitrobrew).

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

New `loss_mode` plus per-teacher PCA rank — fully backward-compatible (no existing config field renamed):

```yaml
distillation:
  enabled: true
  distillation_loss:
    loss_mode: nitrobrew                  # NEW: option for nitrobrew loss mode
  teacher_models:
    teacher_model:
      model_path: Qwen/Qwen3-32B
      nitrobrew_d_comp: 256               # NEW: compression rank for this teacher
      inference:
        name: vllm
        tensor_model_parallel_size: 4
        gpu_memory_utilization: 0.85
        max_num_seqs: 128
```

### Design & Code Changes
**New files**   
- `verl/trainer/distillation/fsdp/nitrobrew_loss.py`: chunked KL + reverse-KL kernels; FSDP-side reduction.
- `verl/trainer/distillation/megatron/nitrobrew_loss.py`: Megatron tensor-parallel variant (vocab-sharded W_up).
- `verl/experimental/teacher_loop/nitrobrew_teacher.py`: `NitrobrewTeacherWorker` (Ray actor wrapping `AsyncLLM` in pooling+embed+ALL mode), `NitrobrewAsyncTeacherManager` (round-robin client with `asyncio.Lock`), `NitrobrewTeacherModelManager` (driver-side SVD + actor pool).
- `examples/on_policy_distillation_trainer/run_qwen3_nitrobrew_dapo.sh`: end-to-end OPD example covering all three comparison modes.
- `tests/experimental/teacher_loop/test_nitrobrew_kernel_on_cpu.py`
- `tests/experimental/teacher_loop/test_nitrobrew_svd_on_cpu.py`
- `tests/experimental/teacher_loop/test_nitrobrew_async_llm.py`  

**Modified files**  
- `verl/trainer/distillation/losses.py`: register nitrobrew loss mode + settings (`use_hidden_states=True`).
- `verl/workers/config/distillation.py`: add `nitrobrew_d_comp: int | None` to `DistillationTeacherModelConfig`; require it when `use_hidden_states`.
- `verl/workers/engine_workers.py`: `set_teacher_unembed(W)` registers W_up on actor ranks (vocab-shards on Megatron); uses `verl.utils.device.get_device_id()`.
- `verl/workers/utils/padding.py`: pad/unpad helpers for `[S, d_comp]` hidden-state batches.
- `verl/experimental/agent_loop/agent_loop.py`: accept `nitrobrew_worker_handles`, dispatch to `NitrobrewAsyncTeacherManager` when use_hidden_states.
- `verl/trainer/ppo/ray_trainer.py`: instantiate `NitrobrewTeacherModelManager` and call `actor_rollout_wg.set_teacher_unembed(w_up)` on the hidden-states branch.
- `.github/workflows/vllm.yml`: trigger paths and pytest step for the new GPU integration test.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

***AI Disclosure:** LLM coding assistants were used to scaffold the evaluation and testing harnesses for this PR.All AI-generated content was reviewed, edited, and approved by the human authors (@tea-more, @dhruvbpai) before submission.*
