### PR TITLE
[npu] feat: add true_on_policy_npu runtime consistency patch package

### DIFF
--- a/verl/utils/true_on_policy_npu/README.md
+++ b/verl/utils/true_on_policy_npu/README.md
@@ -133,7 +133,6 @@ python -m verl.trainer.main_ppo ...
 - Model: `Qwen3-4B`
 - Train dataset: `dapo-math-17k.parquet`
 - Validation dataset: `dapo-math-17k.parquet`
-- Experiment name: `GSPO-Qwen3-30B-megatron`
 
 ### Runtime Topology (from test script)
 
@@ -145,10 +144,10 @@ python -m verl.trainer.main_ppo ...
 
 ### Dependency Revisions
 
-- `vllm`: `72506c9`
-- `vllm-ascend`: `1dee1509`
-- `Megatron-LM`: `a845aa7`
-- `MindSpeed`: `674226a1`
+- `vllm`: release `v0.13.0` (commit `72506c9`)
+- `vllm-ascend`: release `v0.13.0rc3` (commit `1dee1509`)
+- `Megatron-LM`: release `core_v0.12.1` (commit `a845aa7`)
+- `MindSpeed`: release `v2.3.0_core_r0.12.1` (commit `674226a1`)
 
 ## Complete File Modification Checklist
 

--- a/verl/utils/true_on_policy_npu/README.md
+++ b/verl/utils/true_on_policy_npu/README.md
@@ -1,0 +1,234 @@
+# Train-Inference Consistency Patch System for VERL (NPU)
+
+This module ensures consistency between training (Megatron/MindSpeed) and inference (vLLM) backends when running on Ascend NPU.
+
+## Usage
+
+### 1. Enable Runtime Patches
+
+```bash
+export TRAIN_INFER_CONSIST=1
+```
+
+### 2. Apply Source Code Fixes (Required)
+
+Before running, these files **must** be directly modified in their respective repositories:
+
+**vllm/vllm/model_executor/layers/linear.py:**
+```python
+# Lines 1407-1426: Change all-reduce to reduce-scatter + all-gather
+if self.reduce_results and self.tp_size > 1:
+    # Split all-reduce into reduce-scatter + all-gather to match training
+    pad_size = (self.tp_size - (output_parallel.shape[0] % self.tp_size)) % self.tp_size
+    if pad_size > 0:
+        output_parallel = torch.nn.functional.pad(output_parallel, (0, 0, 0, pad_size))
+    scattered = tensor_model_parallel_reduce_scatter(output_parallel, dim=0)
+    output = tensor_model_parallel_all_gather(scattered, dim=0)
+    if pad_size > 0:
+        output = output[:-pad_size]
+```
+
+**vllm-ascend/vllm_ascend/ops/fused_moe/moe_mlp.py:**
+```python
+# Import order fix (lines 17-30)
+from typing import Optional
+
+import torch
+import torch.nn.functional as F  # Must come before torch_npu
+import torch_npu
+from torch.nn.functional import pad
+...
+```
+
+**vllm-ascend/vllm_ascend/ops/activation.py:**
+```python
+# Lines 43-44: SwiGLU using SiLU
+else:
+    d = x.shape[-1] // 2
+    return F.silu(x[..., :d]) * x[..., d:]
+```
+
+**vllm-ascend/vllm_ascend/ascend_forward_context.py:**
+```python
+# Lines 284-285: Force ALLTOALL when TRAIN_INFER_CONSIST=1
+if os.environ.get("TRAIN_INFER_CONSIST", "0") == "1":
+    moe_comm_type = MoECommType.ALLTOALL
+```
+
+**vllm-ascend/vllm_ascend/attention/attention_v1.py:**
+```python
+# Lines 590-660: Batch invariant FlashAttention handling
+if os.environ.get("VLLM_BATCH_INVARIANT", "0") == "1":
+    # Handle tokens with FlashAttention
+    ...
+```
+
+**vllm-ascend/vllm_ascend/ops/fused_moe/token_dispatcher.py:**
+```python
+# Import order fix (lines 23-36)
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+import torch_npu
+from vllm.config import get_current_vllm_config
+from vllm.distributed.parallel_state import get_ep_group
+
+from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.ops.fused_moe.comm_utils import (
+    async_all_to_all, gather_from_sequence_parallel_region)
+
+# TokenDispatcherWithAll2AllV.token_dispatch() additions:
+# Line 443: num_permuted calculation for weights processing
+num_permuted = permutated_local_input_tokens.shape[0]
+
+# Lines 460-469: topk_weights scatter logic
+flat_weights = topk_weights.view(-1)
+permuted_weights = torch.zeros(num_permuted, 1, dtype=flat_weights.dtype, device=flat_weights.device)
+permuted_weights.scatter_(
+    0,
+    reversed_local_input_permutation_mapping.unsqueeze(-1).long(),
+    flat_weights.unsqueeze(-1))
+
+# Lines 475-483: AllToAll for weights + token permute
+_, global_weights, weights_handle = async_all_to_all(
+    permuted_weights, output_splits, input_splits, self.ep_group)
+weights_handle.wait()
+if self.num_local_experts > 1 and global_input_tokens_local_experts_indices is not None:
+    global_weights, _ = torch_npu.npu_moe_token_permute(
+        global_weights, global_input_tokens_local_experts_indices)
+
+# Line 503: Return with topk_scales
+topk_scales=global_weights,
+
+# Line 645: _combine_postprocess with topk_weights
+probs=torch.ones_like(context_metadata["topk_weights"]),
+```
+
+**MindSpeed/mindspeed/core/transformer/flash_attention/flash_attention/adaptor.py:**
+```python
+# Import order fix (lines 4-16)
+import math
+import os
+from typing import Optional
+
+import torch
+from torch import Tensor
+import torch_npu
+from flash_attn import flash_attn_varlen_func
+...
+```
+
+### 3. Run VERL
+
+```bash
+python -m verl.trainer.main_ppo ...
+```
+
+## Tested Configuration
+
+### Model and Dataset
+
+- Model: `Qwen3-4B`
+- Train dataset: `dapo-math-17k.parquet`
+- Validation dataset: `dapo-math-17k.parquet`
+- Experiment name: `GSPO-Qwen3-30B-megatron`
+
+### Runtime Topology (from test script)
+
+- Device: NPU (`trainer.device=npu`)
+- Nodes / NPUs: `NNODES=1`, `NPUS_PER_NODE=16`
+- Training backend: Megatron (`pipeline_model_parallel_size=4`, `tensor_model_parallel_size=4`, `context_parallel_size=1`)
+- Inference backend: vLLM (`tensor_model_parallel_size=4`, `VLLM_USE_V1=1`)
+- Key flags: `TRAIN_INFER_CONSIST=1`, `VLLM_BATCH_INVARIANT=1`
+
+### Dependency Revisions
+
+- `vllm`: `72506c9`
+- `vllm-ascend`: `1dee1509`
+- `Megatron-LM`: `a845aa7`
+- `MindSpeed`: `674226a1`
+
+## Complete File Modification Checklist
+
+### 详细修改清单
+vLLM-Ascend modifications are maintained in local notes (not included in this MR).
+
+### vllm (Inference Backend)
+- [x] `vllm/model_executor/layers/linear.py` - RowParallelLinear RS+AG (lines 1407-1426)
+
+### vllm-ascend (NPU Inference) - 核心修改
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/token_dispatcher.py` - **5处修改** (lines 443, 460-469, 475-483, 503, 645)
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/moe_mlp.py` - Import顺序 (line 20-21)
+- [x] `vllm-ascend/vllm_ascend/ops/activation.py` - SwiGLU SiLU-based (lines 43-44)
+- [x] `vllm-ascend/vllm_ascend/ascend_forward_context.py` - MoE ALLTOALL强制 (lines 284-285)
+- [x] `vllm-ascend/vllm_ascend/attention/attention_v1.py` - FlashAttention batch invariant (lines 590-660)
+
+### vllm-ascend (NPU Inference) - 其他修改
+- [x] `vllm-ascend/vllm_ascend/worker/worker.py` - init_batch_invariance调用 (line 530-532)
+- [x] `vllm-ascend/vllm_ascend/distributed/parallel_state.py` - 额外进程组
+- [x] `vllm-ascend/vllm_ascend/distributed/utils.py` - 通信工具函数
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/fused_moe.py` - 通信模式
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/moe_comm_method.py` - 通信方法选择
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/comm_utils.py` - AllToAll实现
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/prepare_finalize.py` - Prepare/Finalize逻辑
+- [x] `vllm-ascend/vllm_ascend/ops/fused_moe/experts_selector.py` - tid2eid支持
+- [x] `vllm-ascend/vllm_ascend/ops/linear_op.py` - RS+AG模式
+- [x] `vllm-ascend/vllm_ascend/ops/vocab_parallel_embedding.py` - TP通信组
+- [x] `vllm-ascend/vllm_ascend/batch_invariant.py` - 批不变性初始化
+
+### MindSpeed (Training Backend)
+- [x] `MindSpeed/mindspeed/core/transformer/flash_attention/flash_attention/adaptor.py` - Import order
+
+### Megatron-LM (Training Backend)
+- [x] No source modifications - all handled via runtime environment variables
+
+## Architecture
+
+```
+verl/utils/true_on_policy_npu/
+├── __init__.py          # Entry point and patch orchestration
+├── vllm_patch.py        # RowParallelLinear RS+AG patch
+├── vllm_ascend_patch.py # Batch invariant + SwiGLU patches
+├── megatron_patch.py    # Communication determinism env vars
+├── mindspeed_patch.py   # Documentation placeholder
+└── README.md            # This file
+```
+
+## Runtime Patches (Auto-applied)
+
+| Patch | File | Description |
+|-------|------|-------------|
+| RowParallelLinear | vllm_patch.py | RS+AG instead of all-reduce |
+| Batch Invariant | vllm_ascend_patch.py | Deterministic operators |
+| AscendSiluAndMul | vllm_ascend_patch.py | SiLU-based SwiGLU |
+| Attention | vllm_ascend_patch.py | Batch invariant handling |
+| TokenDispatcher | vllm_ascend_patch.py | topk_weights AllToAll handling |
+| Communication | megatron_patch.py | HCCL/NCCL determinism |
+
+## Important Notes
+
+1. **Source code fixes cannot be runtime patched** - Import order and some conditional logic must be in source
+2. **Runtime patches are idempotent** - Can be safely applied multiple times
+3. **Patches are backend-specific** - Only apply when training=megatron-like + inference=vllm + device=npu
+4. **Reference implementation** - MindSpeed's `layernorm_column_parallel_linear.py` shows correct RS+AG pattern
+
+## Debugging
+
+```bash
+export VERL_LOGGING_LEVEL=DEBUG
+export TRAIN_INFER_CONSIST=1
+```
+
+## Why Separate Source and Runtime Fixes?
+
+**Source fixes required for:**
+- Import statement ordering (executes at module load time)
+- Conditional logic based on module-level state
+- Complex function modifications that depend on internal imports
+
+**Runtime patches for:**
+- Method body modifications (can be monkey-patched)
+- Environment variable setup
+- Logging and instrumentation

--- a/verl/utils/true_on_policy_npu/__init__.py
+++ b/verl/utils/true_on_policy_npu/__init__.py
@@ -1,0 +1,265 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Train-Inference Consistency Patch System for VERL (NPU Environment)
+
+This module applies patches to ensure consistency between training (Megatron/MindSpeed)
+and inference (vLLM) backends when running on Ascend NPU.
+
+Usage:
+    Set environment variable before running verl:
+    export TRAIN_INFER_CONSIST=1
+
+    The patches will be automatically applied when:
+    1. TRAIN_INFER_CONSIST=1 is set
+    2. Training backend is Megatron (or MindSpeed)
+    3. Inference backend is vLLM
+    4. Running on NPU device
+
+Environment Variables:
+    TRAIN_INFER_CONSIST: Set to "1" to enable train-inference consistency patches
+    VERL_INFER_BACKEND: (Optional) Override inference backend detection (e.g., "vllm", "sglang")
+    VERL_TRAIN_BACKEND: (Optional) Override training backend detection (e.g., "megatron", "fsdp")
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+TRAIN_INFER_CONSIST_ENV = "TRAIN_INFER_CONSIST"
+INFER_BACKEND_ENV = "VERL_INFER_BACKEND"
+TRAIN_BACKEND_ENV = "VERL_TRAIN_BACKEND"
+
+_PATCHES_APPLIED = False
+_DETECTED_TRAINING_BACKEND: str | None = None
+_DETECTED_INFERENCE_BACKEND: str | None = None
+
+
+def is_train_infer_consist_enabled() -> bool:
+    """Check if train-inference consistency mode is enabled via environment variable."""
+    return os.getenv(TRAIN_INFER_CONSIST_ENV, "0") == "1"
+
+
+def get_inference_backend() -> str | None:
+    """
+    Get inference backend from environment variable or return None.
+
+    Returns:
+        Inference backend name (e.g., "vllm", "sglang") or None if not set
+    """
+    return os.getenv(INFER_BACKEND_ENV, None)
+
+
+def get_training_backend() -> str | None:
+    """
+    Get training backend from environment variable or return None.
+
+    Returns:
+        Training backend name (e.g., "megatron", "fsdp") or None if not set
+    """
+    return os.getenv(TRAIN_BACKEND_ENV, None)
+
+
+def apply_train_infer_consist_patches(
+    training_backend: str | None = None,
+    inference_backend: str | None = None,
+    device: str | None = None,
+    force: bool = False,
+) -> bool:
+    """Apply runtime patches once all required conditions are met."""
+    global _PATCHES_APPLIED
+    global _DETECTED_TRAINING_BACKEND
+    global _DETECTED_INFERENCE_BACKEND
+
+    if not is_train_infer_consist_enabled():
+        return False
+
+    if training_backend:
+        _DETECTED_TRAINING_BACKEND = training_backend.lower()
+        os.environ[TRAIN_BACKEND_ENV] = _DETECTED_TRAINING_BACKEND
+    if inference_backend:
+        _DETECTED_INFERENCE_BACKEND = inference_backend.lower()
+        os.environ[INFER_BACKEND_ENV] = _DETECTED_INFERENCE_BACKEND
+
+    training_backend = (
+        (training_backend.lower() if training_backend else None)
+        or (_DETECTED_TRAINING_BACKEND.lower()
+            if _DETECTED_TRAINING_BACKEND else None)
+        or (get_training_backend().lower()
+            if get_training_backend() else None)
+    )
+    inference_backend = (
+        (inference_backend.lower() if inference_backend else None)
+        or (_DETECTED_INFERENCE_BACKEND.lower()
+            if _DETECTED_INFERENCE_BACKEND else None)
+        or (get_inference_backend().lower()
+            if get_inference_backend() else None)
+    )
+
+    if not training_backend or not inference_backend:
+        # Two-phase init is expected: train side and inference side may report
+        # their backends at different times.
+        return False
+
+    if _PATCHES_APPLIED and not force:
+        return False
+
+    if device is None:
+        try:
+            from verl.utils.device import get_device_name
+            device = get_device_name()
+        except Exception:
+            device = "npu"
+
+    if device != "npu":
+        return False
+
+    # User requirement: megatron training + vllm inference only.
+    if training_backend != "megatron" or inference_backend != "vllm":
+        return False
+
+    logger.info(
+        "Applying train-infer-consistency patches "
+        "(device=%s, train=%s, infer=%s).",
+        device,
+        training_backend,
+        inference_backend,
+    )
+    _apply_vllm_ascend_patches()
+    _apply_vllm_patches()
+    _apply_megatron_patches()
+    _apply_mindspeed_patches()
+    _PATCHES_APPLIED = True
+    logger.info("Train-infer-consistency patches applied.")
+    return True
+
+
+def _apply_vllm_ascend_patches() -> None:
+    """Apply patches to vllm-ascend for train-inference consistency."""
+    try:
+        from .vllm_ascend_patch import apply_vllm_ascend_train_infer_consist_patches
+
+        apply_vllm_ascend_train_infer_consist_patches()
+        logger.debug("vllm-ascend train-inference consistency patches applied.")
+    except Exception as e:
+        logger.warning(f"Failed to apply vllm-ascend patches: {e}")
+
+
+def apply_training_batch_invariance_patches(
+    training_backend: str | None = None,
+    device: str | None = None,
+) -> bool:
+    """
+    Apply batch-invariant operator replacements for training-side workers.
+
+    This can run before two-phase backend detection is complete so that
+    Megatron training workers enable deterministic batch-invariant kernels
+    as early as possible.
+    """
+    if not is_train_infer_consist_enabled():
+        return False
+
+    training_backend = (training_backend or get_training_backend() or "").lower()
+    if training_backend != "megatron":
+        return False
+
+    if device is None:
+        try:
+            from verl.utils.device import get_device_name
+            device = get_device_name()
+        except Exception:
+            device = "npu"
+
+    if device != "npu":
+        return False
+
+    try:
+        from .vllm_ascend_patch import apply_batch_invariance_runtime_patches
+        apply_batch_invariance_runtime_patches()
+        logger.debug("training-side batch-invariance patches applied.")
+        return True
+    except Exception as e:
+        logger.warning("Failed to apply training-side batch-invariance patches: %s", e)
+        return False
+
+
+def _apply_vllm_patches() -> None:
+    """Apply patches to vllm for train-inference consistency."""
+    try:
+        from .vllm_patch import apply_vllm_train_infer_consist_patches
+
+        apply_vllm_train_infer_consist_patches()
+        logger.debug("vllm train-inference consistency patches applied.")
+    except Exception as e:
+        logger.warning(f"Failed to apply vllm patches: {e}")
+
+
+def _apply_megatron_patches() -> None:
+    """Apply patches to megatron for train-inference consistency."""
+    try:
+        from .megatron_patch import apply_megatron_train_infer_consist_patches
+
+        apply_megatron_train_infer_consist_patches()
+        logger.debug("megatron train-inference consistency patches applied.")
+    except Exception as e:
+        logger.warning(f"Failed to apply megatron patches: {e}")
+
+
+def _apply_mindspeed_patches() -> None:
+    """Apply patches to mindspeed for train-inference consistency."""
+    try:
+        from .mindspeed_patch import apply_mindspeed_train_infer_consist_patches
+
+        apply_mindspeed_train_infer_consist_patches()
+        logger.debug("mindspeed train-inference consistency patches applied.")
+    except Exception as e:
+        logger.warning(f"Failed to apply mindspeed patches: {e}")
+
+
+# Convenience function for quick check
+def maybe_apply_patches_for_worker(
+    worker_type: str,
+    backend: str,
+    device: str | None = None,
+) -> bool:
+    """
+    Convenience function to apply patches from worker contexts.
+
+    This is meant to be called from worker __init__ methods.
+
+    Args:
+        worker_type: "training" or "inference"
+        backend: The backend name (e.g., "megatron", "vllm")
+        device: Device type, auto-detected if None
+
+    Returns:
+        True if patches were applied
+    """
+    if worker_type == "training":
+        return apply_train_infer_consist_patches(
+            training_backend=backend,
+            inference_backend=get_inference_backend(),
+            device=device,
+        )
+    elif worker_type == "inference":
+        return apply_train_infer_consist_patches(
+            training_backend=get_training_backend(),
+            inference_backend=backend,
+            device=device,
+        )
+    else:
+        logger.warning(f"Unknown worker_type: {worker_type}")
+        return False

--- a/verl/utils/true_on_policy_npu/megatron_patch.py
+++ b/verl/utils/true_on_policy_npu/megatron_patch.py
@@ -1,0 +1,122 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime patches mirroring local Megatron-LM modifications."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def apply_megatron_train_infer_consist_patches() -> None:
+    """Apply train-inference consistency patches for Megatron."""
+    logger.info("Applying Megatron train-inference consistency patches...")
+    _patch_vocab_parallel_cross_entropy_forward()
+
+
+def _patch_vocab_parallel_cross_entropy_forward() -> None:
+    """Patch _VocabParallelCrossEntropy.forward with local NPU-safe logic."""
+    try:
+        import torch
+        from megatron.core.tensor_parallel.cross_entropy import (
+            _VocabParallelCrossEntropy,
+        )
+        from megatron.core.tensor_parallel.utils import VocabUtility
+        from megatron.core.parallel_state import (
+            get_tensor_model_parallel_group,
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+
+        if hasattr(_VocabParallelCrossEntropy, "_orig_forward_train_infer_consist"):
+            return
+
+        original_forward = _VocabParallelCrossEntropy.forward
+
+        @staticmethod
+        def _patched_forward(ctx, vocab_parallel_logits, target, label_smoothing=0.0):
+            partition_vocab_size = vocab_parallel_logits.size(-1)
+            world_size = get_tensor_model_parallel_world_size()
+            rank = get_tensor_model_parallel_rank()
+
+            tensor_list = [torch.empty_like(vocab_parallel_logits) for _ in range(world_size)]
+            torch.distributed.all_gather(
+                tensor_list,
+                vocab_parallel_logits,
+                group=get_tensor_model_parallel_group(),
+            )
+            full_vocab_logits = torch.cat(tensor_list, dim=-1)
+
+            log_probs = torch.log_softmax(full_vocab_logits, dim=-1)
+            gathered_log_probs = torch.gather(
+                log_probs, dim=-1, index=target.unsqueeze(-1)).squeeze(-1)
+            loss = -gathered_log_probs
+
+            if label_smoothing > 0:
+                assert 1.0 > label_smoothing > 0.0
+                full_vocab_size = full_vocab_logits.size(-1)
+                smoothing = label_smoothing * full_vocab_size / (full_vocab_size - 1)
+                mean_log_probs = log_probs.mean(dim=-1)
+                loss = (1.0 - smoothing) * loss - smoothing * mean_log_probs
+
+                logits_max = torch.max(vocab_parallel_logits, dim=-1, keepdim=True)[0]
+                torch.distributed.all_reduce(
+                    logits_max,
+                    op=torch.distributed.ReduceOp.MAX,
+                    group=get_tensor_model_parallel_group(),
+                )
+                vocab_parallel_logits_stable = vocab_parallel_logits - logits_max
+
+                get_vocab_range = VocabUtility.vocab_range_from_per_partition_vocab_size
+                vocab_start_index, vocab_end_index = get_vocab_range(
+                    partition_vocab_size, rank, world_size)
+                target_mask = (target < vocab_start_index) | (target >= vocab_end_index)
+                masked_target = target.clone() - vocab_start_index
+                masked_target[target_mask] = 0
+
+                batch_dim = torch.arange(
+                    vocab_parallel_logits_stable.size(0),
+                    device=vocab_parallel_logits_stable.device,
+                ).view(-1, 1)
+                seq_dim = torch.arange(
+                    vocab_parallel_logits_stable.size(1),
+                    device=vocab_parallel_logits_stable.device,
+                ).view(1, -1)
+                predicted_logits = vocab_parallel_logits_stable[
+                    batch_dim, seq_dim, masked_target
+                ]
+                predicted_logits = predicted_logits * (~target_mask).float()
+
+                exp_logits = torch.exp(vocab_parallel_logits_stable)
+                sum_exp_logits = exp_logits.sum(dim=-1)
+                torch.distributed.all_reduce(
+                    predicted_logits,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=get_tensor_model_parallel_group(),
+                )
+                torch.distributed.all_reduce(
+                    sum_exp_logits,
+                    op=torch.distributed.ReduceOp.SUM,
+                    group=get_tensor_model_parallel_group(),
+                )
+                softmax_output = exp_logits / sum_exp_logits.unsqueeze(-1)
+                ctx.label_smoothing = label_smoothing
+                ctx.vocab_size = full_vocab_logits.size(-1)
+                ctx.save_for_backward(softmax_output, target_mask, masked_target.view(-1))
+            return loss
+
+        _VocabParallelCrossEntropy._orig_forward_train_infer_consist = original_forward
+        _VocabParallelCrossEntropy.forward = _patched_forward
+    except Exception as e:
+        logger.warning("Failed to patch Megatron cross entropy: %s", e)

--- a/verl/utils/true_on_policy_npu/mindspeed_patch.py
+++ b/verl/utils/true_on_policy_npu/mindspeed_patch.py
@@ -1,0 +1,124 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime patches mirroring local MindSpeed modifications."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def apply_mindspeed_train_infer_consist_patches() -> None:
+    logger.info("Applying MindSpeed train-inference consistency patches...")
+    _patch_flash_attention_adaptor()
+    _patch_layernorm_column_parallel_linear()
+
+
+def _patch_flash_attention_adaptor() -> None:
+    """Patch adaptor.dot_product_attention_forward_impl with FA3 branch."""
+    try:
+        import os
+        import torch
+        from flash_attn import flash_attn_varlen_func
+        import mindspeed.core.transformer.flash_attention.flash_attention.adaptor as adaptor
+
+        if hasattr(adaptor, "_orig_dot_product_attention_forward_impl_train_infer_consist"):
+            return
+
+        original_impl = adaptor.dot_product_attention_forward_impl
+
+        def _patched_impl(self, query, key, value, attention_mask,
+                          attn_mask_type=None, attention_bias=None,
+                          packed_seq_params=None):
+            if packed_seq_params is not None and os.environ.get("VLLM_BATCH_INVARIANT", "0") == "1":
+                scale = self.softmax_scale
+                cu_seqlens_q = torch.tensor(
+                    packed_seq_params.cu_seqlens_q, dtype=torch.int32).npu()
+                cu_seqlens_k = torch.tensor(
+                    packed_seq_params.cu_seqlens_kv, dtype=torch.int32).npu()
+                max_seqlen_q = int((cu_seqlens_q[1:] - cu_seqlens_q[:-1]).max())
+                max_seqlen_k = int((cu_seqlens_k[1:] - cu_seqlens_k[:-1]).max())
+
+                q_fa = query.detach().clone()
+                k_fa = key.detach().clone()
+                v_fa = value.detach().clone()
+                q_fa.requires_grad = True
+                k_fa.requires_grad = True
+                v_fa.requires_grad = True
+                return flash_attn_varlen_func(
+                    q_fa,
+                    k_fa,
+                    v_fa,
+                    cu_seqlens_q,
+                    cu_seqlens_k,
+                    max_seqlen_q,
+                    max_seqlen_k,
+                    dropout_p=self.attention_dropout.p,
+                    softmax_scale=scale,
+                    causal=True,
+                    window_size=(-1, -1),
+                    alibi_slopes=None,
+                    deterministic=False,
+                    return_attn_probs=False,
+                    block_table=None,
+                )
+            return original_impl(
+                self,
+                query,
+                key,
+                value,
+                attention_mask,
+                attn_mask_type=attn_mask_type,
+                attention_bias=attention_bias,
+                packed_seq_params=packed_seq_params,
+            )
+
+        adaptor._orig_dot_product_attention_forward_impl_train_infer_consist = original_impl
+        adaptor.dot_product_attention_forward_impl = _patched_impl
+    except Exception as e:
+        logger.warning("Failed to patch MindSpeed adaptor: %s", e)
+
+
+def _patch_layernorm_column_parallel_linear() -> None:
+    """Patch te_return_bias and _rmsnorm behavior."""
+    try:
+        import torch_npu
+        from mindspeed.te.pytorch.module.layernorm_column_parallel_linear import (
+            MindSpeedTELayerNormColumnParallelLinear,
+        )
+
+        if hasattr(MindSpeedTELayerNormColumnParallelLinear, "_patched_train_infer_consist"):
+            return
+
+        original_init = MindSpeedTELayerNormColumnParallelLinear.__init__
+        original_rmsnorm = MindSpeedTELayerNormColumnParallelLinear._rmsnorm
+
+        def _patched_init(self, *args, **kwargs):
+            original_init(self, *args, **kwargs)
+            # Align with local modification:
+            # self.te_return_bias = (not self.skip_bias_add) and bias
+            self.te_return_bias = (not self.skip_bias_add) and (self.bias is not None)
+
+        def _patched_rmsnorm(self, inp):
+            return torch_npu.npu_rms_norm(
+                inp, self.layer_norm_weight, epsilon=self.config.layernorm_epsilon
+            )[0]
+
+        MindSpeedTELayerNormColumnParallelLinear.__init__ = _patched_init
+        MindSpeedTELayerNormColumnParallelLinear._rmsnorm = _patched_rmsnorm
+        MindSpeedTELayerNormColumnParallelLinear._orig_init_train_infer_consist = original_init
+        MindSpeedTELayerNormColumnParallelLinear._orig_rmsnorm_train_infer_consist = original_rmsnorm
+        MindSpeedTELayerNormColumnParallelLinear._patched_train_infer_consist = True
+    except Exception as e:
+        logger.warning("Failed to patch layernorm_column_parallel_linear: %s", e)

--- a/verl/utils/true_on_policy_npu/vllm_ascend_patch.py
+++ b/verl/utils/true_on_policy_npu/vllm_ascend_patch.py
@@ -1,0 +1,581 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Train-Inference Consistency Patches for vLLM-Ascend (NPU)
+
+This module applies runtime patches to ensure vLLM-Ascend inference behavior
+matches Megatron/MindSpeed training behavior.
+
+Source code fixes required in vllm-ascend:
+1. vllm_ascend/ops/fused_moe/moe_mlp.py - Import order fix (torch.nn.functional as F before torch_npu)
+2. vllm_ascend/ops/activation.py - SwiGLU implementation (SiLU-based, lines 43-44)
+3. vllm_ascend/ascend_forward_context.py - MoE ALLTOALL override (lines 284-285)
+4. vllm_ascend/attention/attention_v1.py - FlashAttention with batch invariant (lines 590-660)
+5. vllm_ascend/ops/fused_moe/token_dispatcher.py - Import order and AllToAll communication patterns
+"""
+
+import logging
+import os
+
+import torch
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+def apply_batch_invariance_runtime_patches() -> None:
+    """
+    Apply vllm-ascend batch-invariant runtime patches.
+
+    This mirrors the local vllm_ascend/batch_invariant.py behavior and can be
+    called from both training and inference side.
+    """
+    os.environ["VLLM_BATCH_INVARIANT"] = "1"
+
+    _patch_batch_invariant_module()
+
+    try:
+        from vllm_ascend.batch_invariant import init_batch_invariance
+        init_batch_invariance()
+    except Exception as e:
+        logger.warning("init_batch_invariance failed: %s", e)
+
+
+def apply_vllm_ascend_train_infer_consist_patches() -> None:
+    """Apply runtime patches that mirror local vllm-ascend changes."""
+    apply_batch_invariance_runtime_patches()
+
+    _patch_ascend_forward_context()
+    _patch_swiglu_activation()
+    _patch_moe_mlp_unquant_apply_mlp()
+    _patch_attention_impl()
+    _patch_token_dispatcher_weights()
+
+
+def _patch_batch_invariant_module() -> None:
+    """Patch vllm_ascend.batch_invariant to include newly added operators."""
+    try:
+        import torch_npu
+        import vllm_ascend.batch_invariant as bi
+
+        if hasattr(bi, "_patched_batch_invariant_train_infer_consist"):
+            return
+
+        original_torch_sum = torch.sum
+        original_tensor_sum = torch.Tensor.sum
+
+        has_ascendc_batch_invariant = False
+        try:
+            import batch_invariant_ops  # type: ignore[import-not-found] # noqa: F401
+            has_ascendc_batch_invariant = True
+        except Exception:
+            has_ascendc_batch_invariant = False
+
+        def add_rms_norm(x: torch.Tensor,
+                         residual: torch.Tensor,
+                         weight: torch.Tensor,
+                         eps: float):
+            x_ = x + residual
+            residual_ = x_
+            x_, _ = torch_npu.npu_rms_norm(x_, weight, eps)
+            return x_, None, residual_
+
+        def reduce_sum_adapter(x: torch.Tensor, dim=None, keepdim=False,
+                               dtype=None, **kwargs):
+            if "axis" in kwargs:
+                dim = kwargs.pop("axis")
+
+            should_use_batch_invariant = (
+                x.device.type == "npu"
+                and x.dtype.is_floating_point
+                and dim is not None
+                and has_ascendc_batch_invariant
+            )
+            if should_use_batch_invariant:
+                if isinstance(dim, (tuple, list)):
+                    if len(dim) == 1:
+                        dim = dim[0]
+                    else:
+                        return original_tensor_sum(
+                            x, dim=dim, keepdim=keepdim, dtype=dtype, **kwargs
+                        )
+                return torch.ops.batch_invariant_ops.npu_reduce_sum_batch_invariant(
+                    x, dim, keepdim
+                )
+
+            return original_tensor_sum(x, dim=dim, keepdim=keepdim, dtype=dtype, **kwargs)
+
+        def softmax_adapter(x, dim, dtype=None):
+            return torch.ops.batch_invariant_ops.npu_softmax_batch_invariant(x, dim)
+
+        def log_softmax_adapter(x, dim, dtype=None):
+            return torch.ops.batch_invariant_ops.npu_log_softmax_batch_invariant(x, dim)
+
+        def override_envs_for_invariance():
+            os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
+            os.environ["HCCL_DETERMINISTIC"] = "strict"
+            os.environ["LCCL_DETERMINISTIC"] = "1"
+
+        def enable_batch_invariant_mode():
+            bi._batch_invariant_LIB = torch.library.Library("aten", "IMPL")
+
+            if getattr(bi, "HAS_TRITON", False):
+                bi._batch_invariant_LIB.impl("aten::addmm", bi.addmm_batch_invariant, "NPU")
+                bi._batch_invariant_LIB.impl("aten::bmm", bi.bmm_batch_invariant, "NPU")
+
+            if has_ascendc_batch_invariant:
+                bi._batch_invariant_LIB.impl(
+                    "aten::mm",
+                    torch.ops.batch_invariant_ops.npu_mm_batch_invariant,
+                    "NPU",
+                )
+                bi._batch_invariant_LIB.impl(
+                    "aten::matmul",
+                    torch.ops.batch_invariant_ops.npu_matmul_batch_invariant,
+                    "NPU",
+                )
+                bi._batch_invariant_LIB.impl("aten::softmax", softmax_adapter, "NPU")
+                bi._batch_invariant_LIB.impl("aten::_softmax", softmax_adapter, "NPU")
+                bi._batch_invariant_LIB.impl("aten::_log_softmax", log_softmax_adapter, "NPU")
+                bi._batch_invariant_LIB.impl("aten::log_softmax", log_softmax_adapter, "NPU")
+                torch_npu.npu_fused_infer_attention_score = (
+                    torch.ops.batch_invariant_ops.npu_fused_infer_attention_score_batch_invariant
+                )
+                torch_npu.npu_add_rms_norm = add_rms_norm
+                torch.sum = reduce_sum_adapter
+                torch.Tensor.sum = reduce_sum_adapter
+            elif getattr(bi, "HAS_TRITON", False):
+                bi._batch_invariant_LIB.impl("aten::mm", bi.mm_batch_invariant, "NPU")
+                bi._batch_invariant_LIB.impl("aten::matmul", bi.matmul_batch_invariant, "NPU")
+                bi._batch_invariant_LIB.impl("aten::linear", bi.linear_batch_invariant, "NPU")
+
+        def init_batch_invariance():
+            if bi.vllm_is_batch_invariant():
+                if getattr(bi, "HAS_TRITON", False) or has_ascendc_batch_invariant:
+                    logger.info("Enabling batch-invariant mode for vLLM on Ascend NPU.")
+                    override_envs_for_invariance()
+                    enable_batch_invariant_mode()
+                else:
+                    logger.warning(
+                        "Batch-invariant mode requested but Triton/Ascend batch-invariant "
+                        "ops are unavailable, skipping initialization."
+                    )
+
+        bi._orig_torch_sum_train_infer_consist = original_torch_sum
+        bi._orig_tensor_sum_train_infer_consist = original_tensor_sum
+        bi.HAS_ASCENDC_BATCH_INVARIANT = has_ascendc_batch_invariant
+        bi.add_rms_norm = add_rms_norm
+        bi.reduce_sum_adapter = reduce_sum_adapter
+        bi.softmax_adapter = softmax_adapter
+        bi.log_softmax_adapter = log_softmax_adapter
+        bi.override_envs_for_invariance = override_envs_for_invariance
+        bi.enable_batch_invariant_mode = enable_batch_invariant_mode
+        bi.init_batch_invariance = init_batch_invariance
+        bi._patched_batch_invariant_train_infer_consist = True
+    except Exception as e:
+        logger.warning("Failed to patch batch_invariant module: %s", e)
+
+
+def _patch_swiglu_activation() -> None:
+    """
+    Patch AscendSiluAndMul to use SiLU-based SwiGLU matching training behavior.
+
+    Source code location: vllm_ascend/ops/activation.py lines 43-44
+    """
+    try:
+        from vllm_ascend.ops.activation import AscendSiluAndMul
+
+        if hasattr(AscendSiluAndMul, '_patched_for_train_infer_consist'):
+            return
+
+        original_forward_oot = AscendSiluAndMul.forward_oot
+
+        def _patched_forward_oot(self, x):
+            d = x.shape[-1] // 2
+            return F.silu(x[..., :d]) * x[..., d:]
+
+        AscendSiluAndMul.forward_oot = _patched_forward_oot
+        AscendSiluAndMul._patched_for_train_infer_consist = True
+        AscendSiluAndMul._original_forward_oot = original_forward_oot
+
+    except Exception as e:
+        logger.warning("Failed to patch AscendSiluAndMul: %s", e)
+
+
+def _patch_moe_mlp_unquant_apply_mlp() -> None:
+    """Patch moe_mlp.unquant_apply_mlp non-310P path to SiLU split form."""
+    try:
+        import vllm_ascend.ops.fused_moe.moe_mlp as moe_mlp
+        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+        if hasattr(moe_mlp, "_orig_unquant_apply_mlp_train_infer_consist"):
+            return
+
+        original = moe_mlp.unquant_apply_mlp
+
+        def _patched_unquant_apply_mlp(hidden_states, w1, w2, group_list,
+                                       group_list_type=1, topk_scales=None,
+                                       need_trans=True):
+            if need_trans:
+                w1_local = w1.transpose(1, 2)
+                w2_local = w2.transpose(1, 2)
+            else:
+                w1_local = w1
+                w2_local = w2
+
+            import torch_npu
+            gate_up_out = torch_npu.npu_grouped_matmul(
+                x=[hidden_states],
+                weight=[w1_local],
+                split_item=2,
+                group_list_type=group_list_type,
+                group_type=0,
+                group_list=group_list,
+            )[0]
+            if get_ascend_device_type() == AscendDeviceType._310P:
+                gate_up_out = torch_npu.npu_swiglu(
+                    gate_up_out.to(torch.float32)).to(torch.float16)
+            else:
+                d = gate_up_out.shape[-1] // 2
+                gate_up_out = F.silu(gate_up_out[..., :d]) * gate_up_out[..., d:]
+
+            if topk_scales is not None:
+                gate_up_out *= topk_scales
+
+            out = torch_npu.npu_grouped_matmul(
+                x=[gate_up_out],
+                weight=[w2_local],
+                split_item=2,
+                group_list_type=group_list_type,
+                group_type=0,
+                group_list=group_list,
+            )[0]
+            return out
+
+        moe_mlp._orig_unquant_apply_mlp_train_infer_consist = original
+        moe_mlp.unquant_apply_mlp = _patched_unquant_apply_mlp
+    except Exception as e:
+        logger.warning("Failed to patch moe_mlp.unquant_apply_mlp: %s", e)
+
+
+def _patch_ascend_forward_context() -> None:
+    """Force ALLTOALL when TRAIN_INFER_CONSIST=1."""
+    try:
+        import vllm_ascend.ascend_forward_context as afc
+
+        if hasattr(afc, "_orig_select_moe_comm_method_train_infer_consist"):
+            return
+
+        original = afc.select_moe_comm_method
+
+        def _patched_select_moe_comm_method(num_tokens, vllm_config,
+                                            is_draft_model=False):
+            moe_comm_type = original(num_tokens, vllm_config, is_draft_model)
+            if os.environ.get("TRAIN_INFER_CONSIST", "0") == "1":
+                return afc.MoECommType.ALLTOALL
+            return moe_comm_type
+
+        afc._orig_select_moe_comm_method_train_infer_consist = original
+        afc.select_moe_comm_method = _patched_select_moe_comm_method
+    except Exception as e:
+        logger.warning("Failed to patch ascend_forward_context: %s", e)
+
+
+def _patch_attention_impl() -> None:
+    """Patch forward_fused_infer_attention with FA3 path for batch-invariant mode."""
+    try:
+        import vllm_ascend.attention.attention_v1 as attention_v1
+        AscendAttentionBackendImpl = attention_v1.AscendAttentionBackendImpl
+
+        if hasattr(AscendAttentionBackendImpl,
+                   "_patched_forward_fused_train_infer_consist"):
+            return
+
+        original_forward = AscendAttentionBackendImpl.forward_fused_infer_attention
+
+        def _patched_forward_fused_infer_attention(
+            self, query, key, value, attn_metadata, output
+        ):
+            import torch_npu
+
+            forward_context = attention_v1.get_forward_context()
+            if getattr(forward_context, "capturing", False):
+                attn_output, num_tokens = self.full_graph_fia(
+                    query, key, value, attn_metadata, output)
+                output[:num_tokens] = attn_output[:num_tokens]
+                return output
+
+            if (
+                attn_metadata.attn_state == attention_v1.AscendAttentionState.DecodeOnly
+                and self.sliding_window is not None
+                and attn_metadata.seq_lens.shape[0] == query.size(0)
+            ):
+                return self._forward_fia_slidingwindow(query, attn_metadata, output)
+
+            if (
+                attn_metadata.attn_state == attention_v1.AscendAttentionState.PrefillNoCache
+                and self.attn_type != attention_v1.AttentionType.ENCODER_DECODER
+                and os.environ.get("VLLM_BATCH_INVARIANT", "0") == "1"
+            ):
+                num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+                query = query[:num_tokens]
+                key = key[:num_tokens]
+                value = value[:num_tokens]
+
+                num_decodes = attn_metadata.num_decodes
+                num_decode_tokens = attn_metadata.num_decode_tokens
+                num_prefills = attn_metadata.num_prefills
+                attn_output_fa_decode = None
+                attn_output_fa_prefill = None
+
+                if num_decodes > 0:
+                    seq_lens_list_qa = attn_metadata.seq_lens_list[:num_decodes]
+                    actual_seq_lengths_fa = attn_metadata.query_start_loc[:num_decodes + 1]
+                    max_seq_len = max(seq_lens_list_qa)
+                    attn_output_fa_decode = self._foward_fa3(
+                        query[:num_decode_tokens],
+                        attn_metadata.block_tables[:num_decodes, :],
+                        actual_seq_lengths_fa,
+                        seq_lens_list_qa,
+                        False,
+                        max_seq_len,
+                    )
+
+                if num_prefills > 0:
+                    seq_lens_list_qa = attn_metadata.seq_lens_list[num_decodes:]
+                    actual_seq_lengths_fa = attn_metadata.query_start_loc[num_decodes:]
+                    max_seq_len = max(seq_lens_list_qa)
+                    attn_output_fa_prefill = self._foward_fa3(
+                        query[num_decode_tokens:],
+                        attn_metadata.block_tables[num_decode_tokens:, :],
+                        actual_seq_lengths_fa,
+                        seq_lens_list_qa,
+                        True,
+                        max_seq_len,
+                    )
+
+                outputs = []
+                if attn_output_fa_decode is not None:
+                    outputs.append(attn_output_fa_decode)
+                if attn_output_fa_prefill is not None:
+                    outputs.append(attn_output_fa_prefill)
+                if len(outputs) == 0:
+                    raise ValueError("No attention output available")
+                attn_output_fa = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+                output[:num_tokens] = attn_output_fa[:num_tokens]
+                return output
+
+            key, value, block_size, block_table, actual_seq_lengths_kv = self._get_fia_params(
+                key, value, attn_metadata)
+            num_tokens = attn_metadata.actual_seq_lengths_q[-1]
+            query = query[:num_tokens]
+            attn_output, _ = torch_npu.npu_fused_infer_attention_score(
+                query=query,
+                key=key,
+                value=value,
+                atten_mask=attn_metadata.attn_mask,
+                block_table=block_table,
+                input_layout="TND",
+                block_size=block_size,
+                actual_seq_lengths=attn_metadata.actual_seq_lengths_q,
+                actual_seq_lengths_kv=actual_seq_lengths_kv,
+                num_key_value_heads=self.num_kv_heads,
+                num_heads=self.num_heads,
+                scale=self.scale,
+                sparse_mode=3,
+            )
+            attn_output = attn_output.view(num_tokens, self.num_heads, self.head_size)
+            output[:num_tokens] = attn_output[:num_tokens]
+            return output
+
+        def _patched_foward_fa3(
+            self, query, block_table, actual_seq_lengths_fa, seq_lens_list_qa, is_causal, max_seq_len
+        ):
+            from flash_attn_v3 import flash_attn_with_kvcache
+
+            window_size_left = -1
+            window_size_right = -1
+            num_splits = 0
+            rotary_cos = None
+            rotary_sin = None
+            cache_batch_idx = None
+            leftpad_k = None
+            num_block, block_size, _, _ = self.key_cache.shape
+            key_fa_blk = self.key_cache.view(num_block, block_size, self.num_kv_heads, self.head_size)
+            value_fa_blk = self.value_cache.view(num_block, block_size, self.num_kv_heads, self.head_size)
+            kv_seqlen_list = torch.tensor(seq_lens_list_qa, dtype=torch.int32).npu()
+            return flash_attn_with_kvcache(
+                query,
+                key_fa_blk,
+                value_fa_blk,
+                None,
+                None,
+                None,
+                rotary_cos=rotary_cos,
+                rotary_sin=rotary_sin,
+                cache_seqlens=kv_seqlen_list,
+                cache_batch_idx=cache_batch_idx,
+                cache_leftpad=leftpad_k,
+                page_table=block_table,
+                cu_seqlens_q=actual_seq_lengths_fa,
+                cu_seqlens_k_new=None,
+                max_seqlen_q=max_seq_len,
+                rotary_seqlens=None,
+                q_descale=None,
+                k_descale=None,
+                v_descale=None,
+                softmax_scale=None,
+                causal=is_causal,
+                window_size=[window_size_left, window_size_right],
+                attention_chunk=0,
+                softcap=0.0,
+                rotary_interleaved=False,
+                scheduler_metadata=None,
+                num_splits=num_splits,
+                pack_gqa=None,
+                sm_margin=0,
+                return_softmax_lse=False,
+            )
+
+        AscendAttentionBackendImpl._orig_forward_fused_infer_attention_train_infer_consist = (
+            original_forward
+        )
+        AscendAttentionBackendImpl.forward_fused_infer_attention = (
+            _patched_forward_fused_infer_attention
+        )
+        AscendAttentionBackendImpl._orig_foward_fa3_train_infer_consist = getattr(
+            AscendAttentionBackendImpl, "_foward_fa3", None
+        )
+        AscendAttentionBackendImpl._foward_fa3 = _patched_foward_fa3
+        AscendAttentionBackendImpl._patched_forward_fused_train_infer_consist = True
+    except Exception as e:
+        logger.warning("Failed to patch attention impl: %s", e)
+
+
+def _patch_token_dispatcher_weights() -> None:
+    """
+    Patch TokenDispatcherWithAll2AllV to handle topk_weights via AllToAll.
+
+    This ensures topk weights are properly permuted and communicated alongside
+    hidden states to match training behavior.
+
+    """
+    try:
+        from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithAll2AllV
+
+        if hasattr(TokenDispatcherWithAll2AllV, '_patched_for_weights'):
+            return
+
+        original_token_dispatch = TokenDispatcherWithAll2AllV.token_dispatch
+
+        def _patched_token_dispatch(self, hidden_states, topk_weights, topk_ids,
+                                    expert_map=None, global_redundant_expert_num=0,
+                                    mc2_mask=None, apply_router_weight_on_input=False,
+                                    with_quant=False, dynamic_eplb=False,
+                                    pertoken_scale=None):
+            """Patched dispatch with topk_weights handling via AllToAll."""
+            from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all
+            import torch_npu
+
+            self.with_quant = with_quant
+            self.hidden_shape = hidden_states.shape
+
+            permutated_local_input_tokens, reversed_local_input_permutation_mapping, \
+                tokens_per_expert, input_splits, output_splits, \
+                num_global_tokens_per_local_expert, global_input_tokens_local_experts_indices = \
+                self._dispatch_preprocess(hidden_states, topk_ids)
+
+            num_permuted = permutated_local_input_tokens.shape[0]
+
+            dynamic_scale_after_all2all = None
+            if self.with_quant:
+                permutated_local_input_tokens, dynamic_scale = torch_npu.npu_dynamic_quant(
+                    permutated_local_input_tokens)
+                _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
+                    dynamic_scale, output_splits, input_splits, self.ep_group)
+                permute2_ep_all_to_all_handle.wait()
+                dynamic_scale.untyped_storage().resize_(0)
+
+            _, global_input_tokens, permute1_ep_all_to_all_handle = async_all_to_all(
+                permutated_local_input_tokens, output_splits, input_splits, self.ep_group)
+            permute1_ep_all_to_all_handle.wait()
+            permutated_local_input_tokens.untyped_storage().resize_(0)
+
+            flat_weights = topk_weights.view(-1)
+            permuted_weights = torch.zeros(
+                num_permuted, 1,
+                dtype=flat_weights.dtype,
+                device=flat_weights.device)
+            permuted_weights.scatter_(
+                0,
+                reversed_local_input_permutation_mapping.unsqueeze(-1).long(),
+                flat_weights.unsqueeze(-1))
+
+            global_input_tokens, dynamic_scale_final, reversed_global_input_permutation_mapping = \
+                self._dispatch_postprocess(
+                    global_input_tokens, dynamic_scale_after_all2all,
+                    global_input_tokens_local_experts_indices)
+
+            _, global_weights, weights_handle = async_all_to_all(
+                permuted_weights, output_splits, input_splits, self.ep_group)
+            weights_handle.wait()
+            permuted_weights.untyped_storage().resize_(0)
+
+            if self.num_local_experts > 1 and global_input_tokens_local_experts_indices is not None:
+                global_weights, _ = torch_npu.npu_moe_token_permute(
+                    global_weights, global_input_tokens_local_experts_indices)
+
+            context_metadata = {
+                "input_splits": input_splits,
+                "output_splits": output_splits,
+                "topk_weights": topk_weights,
+                "reversed_local_input_permutation_mapping": reversed_local_input_permutation_mapping,
+                "reversed_global_input_permutation_mapping": reversed_global_input_permutation_mapping
+            }
+
+            from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatchResult
+            return TokenDispatchResult(
+                hidden_states=global_input_tokens,
+                dynamic_scale=dynamic_scale_final,
+                group_list=tokens_per_expert,
+                group_list_type=1,
+                context_metadata=context_metadata,
+                topk_scales=global_weights,
+            )
+
+        TokenDispatcherWithAll2AllV.token_dispatch = _patched_token_dispatch
+        TokenDispatcherWithAll2AllV._patched_for_weights = True
+        TokenDispatcherWithAll2AllV._original_token_dispatch = original_token_dispatch
+
+        original_combine_postprocess = TokenDispatcherWithAll2AllV._combine_postprocess
+
+        def _patched_combine_postprocess(self, permutated_local_input_tokens, context_metadata):
+            import torch_npu
+
+            output = torch_npu.npu_moe_token_unpermute(
+                permuted_tokens=permutated_local_input_tokens,
+                sorted_indices=context_metadata[
+                    "reversed_local_input_permutation_mapping"].to(torch.int32),
+                probs=torch.ones_like(context_metadata["topk_weights"]),
+                restore_shape=self.hidden_shape_before_permute,
+            )
+            output = output.view(self.hidden_shape)
+            return output
+
+        TokenDispatcherWithAll2AllV._combine_postprocess = _patched_combine_postprocess
+        TokenDispatcherWithAll2AllV._original_combine_postprocess = original_combine_postprocess
+
+    except Exception as e:
+        logger.warning("Failed to patch TokenDispatcherWithAll2AllV: %s", e)

--- a/verl/utils/true_on_policy_npu/vllm_patch.py
+++ b/verl/utils/true_on_policy_npu/vllm_patch.py
@@ -1,0 +1,102 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Train-Inference Consistency Patches for vLLM
+
+Patches applied:
+1. RowParallelLinear.forward() - Change all-reduce to reduce-scatter + all-gather
+
+Source code location: vllm/model_executor/layers/linear.py lines 1407-1426
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def apply_vllm_train_infer_consist_patches() -> None:
+    """Apply all train-inference consistency patches for vLLM."""
+    logger.info("Applying vLLM train-inference consistency patches...")
+
+    _patch_row_parallel_linear()
+
+    logger.info("vLLM train-inference consistency patches applied.")
+
+
+def _patch_row_parallel_linear() -> None:
+    """
+    Patch RowParallelLinear to use reduce-scatter + all-gather instead of all-reduce.
+
+    This matches MindSpeed's layernorm_column_parallel_linear.py training pattern.
+    """
+    try:
+        from vllm.model_executor.layers.linear import RowParallelLinear
+        from vllm.distributed import (
+            tensor_model_parallel_reduce_scatter,
+            tensor_model_parallel_all_gather,
+        )
+        import torch.nn.functional as F
+
+        if hasattr(RowParallelLinear, '_patched_for_train_infer_consist'):
+            logger.debug("RowParallelLinear already patched.")
+            return
+
+        RowParallelLinear._original_forward = RowParallelLinear.forward
+
+        def _patched_forward(self, input_):
+            """Patched forward using RS+AG pattern."""
+            # Input handling
+            if self.input_is_parallel:
+                input_parallel = input_
+            else:
+                from vllm.model_executor.layers.linear import split_tensor_along_last_dim
+                splitted_input = split_tensor_along_last_dim(
+                    input_, num_partitions=self.tp_size
+                )
+                input_parallel = splitted_input[self.tp_rank].contiguous()
+
+            # Matrix multiply
+            bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
+            output_parallel = self.quant_method.apply(self, input_parallel, bias_)
+
+            # MODIFIED: Use reduce-scatter + all-gather instead of all-reduce
+            if self.reduce_results and self.tp_size > 1:
+                # Calculate padding for divisibility
+                pad_size = (self.tp_size - (output_parallel.shape[0] % self.tp_size)) % self.tp_size
+
+                if pad_size > 0:
+                    output_parallel = F.pad(output_parallel, (0, 0, 0, pad_size))
+
+                scattered = tensor_model_parallel_reduce_scatter(output_parallel, dim=0)
+                output = tensor_model_parallel_all_gather(scattered, dim=0)
+
+                if pad_size > 0:
+                    output = output[:-pad_size]
+            else:
+                output = output_parallel
+
+            output_bias = self.bias if self.skip_bias_add else None
+
+            if not self.return_bias:
+                return output
+            return output, output_bias
+
+        RowParallelLinear.forward = _patched_forward
+        RowParallelLinear._patched_for_train_infer_consist = True
+
+        logger.info("Patched RowParallelLinear to use reduce-scatter + all-gather.")
+
+    except Exception as e:
+        logger.warning(f"Failed to patch RowParallelLinear: {e}")

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -89,10 +89,6 @@ class TrainingWorker(Worker, DistProfilerExtension):
         if is_npu_available:
             os.environ["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:True"
 
-        initialize_global_process_group_ray(timeout_second=None)
-
-        set_numa_affinity()
-
         self.config = config
         self.model_config = self.config.model_config
         self.engine_config = self.config.engine_config
@@ -111,6 +107,32 @@ class TrainingWorker(Worker, DistProfilerExtension):
             self.engine_config, self.optimizer_config = self.config.auto_select_engine_optim_fn(
                 self.model_config, self.device_name
             )
+
+        # Apply train-inference consistency patches for NPU when enabled.
+        # This includes batch-invariant operators and other alignment patches.
+        # Must run before distributed init so HCCL determinism env vars take effect.
+        from verl.utils.true_on_policy_npu import (
+            TRAIN_INFER_CONSIST_ENV,
+            apply_train_infer_consist_patches,
+            apply_training_batch_invariance_patches,
+        )
+
+        if os.getenv(TRAIN_INFER_CONSIST_ENV, "0") == "1":
+            # Training side should enable batch-invariant operator replacement
+            # immediately (before distributed init), even before inference backend
+            # is discovered in two-phase patch orchestration.
+            apply_training_batch_invariance_patches(
+                training_backend=self.engine_config.strategy,
+                device=self.device_name,
+            )
+            apply_train_infer_consist_patches(
+                training_backend=self.engine_config.strategy,
+                device=self.device_name,
+            )
+
+        initialize_global_process_group_ray(timeout_second=None)
+
+        set_numa_affinity()
 
         # we use the one defined in model
         # TODO: this is not elegant and should refactor later

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -110,6 +110,20 @@ class vLLMHttpServer:
         os.environ[get_visible_devices_keyword()] = cuda_visible_devices
         os.environ["VERL_REPLICA_RANK"] = str(replica_rank)
 
+        # Apply train-inference consistency patches when enabled.
+        # This ensures vLLM inference behavior matches Megatron training.
+        from verl.utils.true_on_policy_npu import (
+            TRAIN_INFER_CONSIST_ENV,
+            apply_train_infer_consist_patches,
+        )
+
+        if os.getenv(TRAIN_INFER_CONSIST_ENV, "0") == "1":
+            device = "npu" if is_torch_npu_available() else "cuda"
+            apply_train_infer_consist_patches(
+                inference_backend="vllm",
+                device=device,
+            )
+
         self.config = self._init_config(config)
         self.model_config = self._init_model_config(model_config)
         self._validate_configs()


### PR DESCRIPTION
## Summary
- Introduce `verl/utils/true_on_policy_npu/` as an NPU train-infer consistency runtime patch package, gated by `TRAIN_INFER_CONSIST=1`.
- Add conditional patch orchestration for the required path only: `device=npu`, `training_backend=megatron`, `inference_backend=vllm`, with idempotent apply behavior.
- Wire training/inference worker entrypoints to invoke this patch flow during initialization, and align vLLM-Ascend/vLLM/Megatron/MindSpeed runtime behavior to local consistency fixes.

## Motivation
In NPU deployments we observed train-inference mismatch between Megatron training and vLLM(+vLLM-Ascend) inference.  
This change introduces a runtime-patch integration path in VERL so users can enable consistency alignment without hard-forking upstream code paths.

## What is included
- New package:
  - `verl/utils/true_on_policy_npu/__init__.py`
  - `verl/utils/true_on_policy_npu/vllm_ascend_patch.py`
  - `verl/utils/true_on_policy_npu/vllm_patch.py`
  - `verl/utils/true_on_policy_npu/megatron_patch.py`
  - `verl/utils/true_on_policy_npu/mindspeed_patch.py`
  - docs:
    - `README.md`
    - `VLLM_ASCEND_MODIFICATIONS.md`
- Worker integration:
  - `verl/workers/engine_workers.py`
  - `verl/workers/rollout/vllm_rollout/vllm_async_server.py`

## Experiment
<img width="1549" height="160" alt="image001" src="https://github.com/user-attachments/assets/19f69eae-0e70-4759-8b0d-63d9e7e44208" />



## Risks / Notes
- Runtime monkey patches can be sensitive to upstream API changes in dependent projects; this is mitigated by guarded imports and conditional activation.
- The package includes detailed mapping docs for vLLM-Ascend local changes to support future maintenance and review.