### PR TITLE
[model] fix: Ulysses SP support for Qwen3.5/Qwen3.5-MoE

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -137,6 +137,7 @@ def _ulysses_flash_attention_forward(
         # https://github.com/huggingface/transformers/pull/33932
 
         # (bsz, seq_len/n) -> (bsz, seq_len)
+        position_ids = position_ids.contiguous()
         position_ids_list = [torch.empty_like(position_ids) for _ in range(ulysses_sp_size)]
         torch.distributed.all_gather(position_ids_list, position_ids, group=get_ulysses_sequence_parallel_group())
         position_ids = torch.concat(position_ids_list, dim=-1)
@@ -494,11 +495,13 @@ def apply_monkey_patch(
         from transformers.models.qwen3_5.modeling_qwen3_5 import (
             Qwen3_5ForConditionalGeneration,
             Qwen3_5Model,
+            Qwen3_5TextModel,
             Qwen3_5VisionModel,
         )
         from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
             Qwen3_5MoeForConditionalGeneration,
             Qwen3_5MoeModel,
+            Qwen3_5MoeTextModel,
             Qwen3_5MoeVisionModel,
         )
 
@@ -517,6 +520,11 @@ def apply_monkey_patch(
         # Step 2: patch vision model to fix fsdp2 cpu_offload bug.
         Qwen3_5VisionModel.fast_pos_embed_interpolate = fast_pos_embed_interpolate
         Qwen3_5MoeVisionModel.fast_pos_embed_interpolate = fast_pos_embed_interpolate
+
+        # Step 3: patch input for multimodal sequence parallelism
+        if ulysses_sp_size > 1:
+            patch_vlm_for_ulysses_input_slicing(Qwen3_5TextModel)
+            patch_vlm_for_ulysses_input_slicing(Qwen3_5MoeTextModel)
 
     if use_remove_padding or ulysses_sp_size > 1:
         if hasattr(module, "_flash_attention_forward"):  # transformers <= 4.47.1 or legacy models


### PR DESCRIPTION
## Fix

Two bugs prevent Ulysses Sequence Parallelism (SP > 1) from working
with Qwen3.5 / Qwen3.5-MoE models:

1. `_ulysses_flash_attention_forward` passes sliced `position_ids`
   (a non-contiguous view) directly to `all_gather`, which requires
   contiguous tensors. Crashes with
   `RuntimeError: Tensors must be contiguous` at step 0.

2. `patch_vlm_for_ulysses_input_slicing` was never registered for
   `Qwen3_5TextModel` / `Qwen3_5MoeTextModel`. Other VLMs (Qwen2.5VL,
   Qwen3VL, GLM4V) all have this Step 3 registration; Qwen3.5 was
   the only one missing it. Without it, `inputs_embeds` and
   `position_ids` are not sliced per SP rank, causing shape mismatch
   in the forward pass.

## Relation to #5957 and #6094

#5957 reports shape mismatch (`logits_rmpad` vs `temperature_rmpad`)
on NPU with Qwen3.5 + SP > 1. #6094 reports SP works for Qwen-3 but
fails for Qwen-3.5 with tensor shape mismatch. Both share the same
root cause: missing `patch_vlm_for_ulysses_input_slicing` for Qwen3.5.

## Duplicate-work check

```
gh pr list --repo verl-project/verl --state open --search "patch_vlm_for_ulysses"
gh pr list --repo verl-project/verl --state open --search "position_ids contiguous"
```

First query returns no results. Second returns #5886 and #5829 which
address different issues (nested tensor / mrope), not the Ulysses SP
`all_gather` path.

## Test plan

- Qwen3.5-35B-A3B GRPO + Ulysses SP=2 + FSDP2 param_offload,
  10x Ascend 910B.
- Without fix 1: `RuntimeError: Tensors must be contiguous` at step 0
  `compute_log_prob`.
- Without fix 2: shape mismatch -- `inputs_embeds` not sliced per rank.
- With both fixes: training completes step 1 with correct metrics.
- `pre-commit run --files verl/models/transformers/monkey_patch.py`:
  all hooks pass.

## AI-assisted disclosure

AI assistance (Claude) used. Submitter reviewed every changed line.