### PR TITLE
[reward] fix: compute correct rollout world size

### DIFF
--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -48,7 +48,11 @@ class RewardModelManager:
             self.sleep()
 
     def _initialize_llm_servers(self):
-        rollout_world_size = self.config.rollout.tensor_model_parallel_size
+        rollout_world_size = (
+            self.config.rollout.tensor_model_parallel_size
+            * self.config.rollout.data_parallel_size
+            * self.config.rollout.pipeline_model_parallel_size
+        )
         world_size = (
             self.resource_pool.world_size
             if self.resource_pool  # colocate mode


### PR DESCRIPTION
### What does this PR do?

In `RewardModelManager._initialize_llm_servers`, `rollout_world_size` was computed as only `tensor_model_parallel_size`, ignoring `data_parallel_size` and `pipeline_model_parallel_size`. This caused `num_replicas = world_size // rollout_world_size` to be overcounted whenever DP > 1 or PP > 1, leading to too many reward model replicas being created and incorrect resource pool splits.

Fix: multiply all three parallelism dimensions together, consistent with how `rollout_world_size` is computed in `llm_server.py` and `vllm_rollout.py`.

No related issues found.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/volcengine/verl/pulls?q=rollout+world+size+in%3Atitle%2Cbody — no duplicates found.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

Tested by manually starting runs with DP > 1.

### API and Usage Example

No API changes.

```python
# No usage example needed — internal fix only
```

### Design & Code Changes

- `verl/experimental/reward_loop/reward_model.py`: multiply `tensor_model_parallel_size * data_parallel_size * pipeline_model_parallel_size` to get the true per-replica GPU count, consistent with `llm_server.py:295-299` and `vllm_rollout.py:79-83`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/volcengine/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/volcengine/verl/tree/main/docs). (not necessary)
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/volcengine/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why:
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main` (not applicable)