### PR TITLE
[trainer] fix: dump all outputs in validation in main_ppo_sync

### DIFF
--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -856,6 +856,10 @@ class PPOTrainer:
         sample_turns = []
         data_sources = []
         reward_extra_infos_dict: dict[str, list] = defaultdict(list)
+        dump_all_inputs: list[str] = []
+        dump_all_outputs: list[str] = []
+        dump_all_keys: list[str] = []
+        session_to_sample_idx: dict[str, int] = {}
 
         for batch_dict in self.val_dataloader:
             # 1. put batch to agent loop manager
@@ -879,7 +883,6 @@ class PPOTrainer:
             # 4. collect necessary data for logging
             # For multi-output agent loops, only use the final output per session for metrics.
             # Keys have format {uid}_{session_id}_{index}; keep only the highest index per session.
-            final_indices = []
             session_max: dict[str, tuple[int, int]] = {}  # session_key -> (max_index, position)
             for pos, key in enumerate(batch.keys):
                 parts = key.rsplit("_", 2)
@@ -890,28 +893,28 @@ class PPOTrainer:
                         session_max[session_key] = (index, pos)
                 else:
                     session_max[key] = (0, pos)
-            final_indices = sorted(pos for _, pos in session_max.values())
+            sorted_sessions = sorted(session_max.items(), key=lambda x: x[1][1])
+            final_indices = [pos for _, (_, pos) in sorted_sessions]
             final_keys = [batch.keys[i] for i in final_indices]
+            base_offset = len(sample_scores)
+            session_to_sample_idx.update(
+                {session_key: base_offset + j for j, (session_key, _) in enumerate(sorted_sessions)}
+            )
 
-            fields = [
-                "uid",
-                "prompts",
-                "responses",
-                "rm_scores",
-                "num_turns",
-                "reward_model",
-                "data_source",
-                "extra_fields",
-            ]
+            text_data = tq.kv_batch_get(
+                keys=batch.keys, partition_id=batch.partition_id, select_fields=["prompts", "responses"]
+            )
+            text_data["prompts"] = text_data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            text_data["responses"] = text_data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            all_inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["prompts"]]
+            all_outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["responses"]]
+
+            fields = ["uid", "rm_scores", "num_turns", "reward_model", "data_source", "extra_fields"]
             data = tq.kv_batch_get(keys=final_keys, partition_id=batch.partition_id, select_fields=fields)
-            data["prompts"] = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
-            data["responses"] = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
 
             sample_uids.extend(data.pop("uid").tolist())
-            output_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["responses"]]
-            sample_outputs.extend(output_texts)
-            input_texts = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in data["prompts"]]
-            sample_inputs.extend(input_texts)
+            sample_outputs.extend(all_outputs[i] for i in final_indices)
+            sample_inputs.extend(all_inputs[i] for i in final_indices)
             scores = data["rm_scores"].sum(dim=1).tolist()
             sample_scores.extend(scores)
             sample_turns.extend(data.pop("num_turns").tolist())
@@ -937,13 +940,17 @@ class PPOTrainer:
             if reward_model is not None:
                 sample_gts.extend([item.get("ground_truth", None) for item in reward_model.tolist()])
             else:
-                sample_gts.extend([None] * len(batch))
+                sample_gts.extend([None] * len(final_indices))
 
             data_source = data.pop("data_source", None)
             if data_source is not None:
                 data_sources.extend(data_source.tolist())
             else:
-                data_sources.extend(["unknown"] * len(batch))
+                data_sources.extend(["unknown"] * len(final_indices))
+
+            dump_all_inputs.extend(all_inputs)
+            dump_all_outputs.extend(all_outputs)
+            dump_all_keys.extend(batch.keys)
 
             # 5. cleanup transfer queue and replay buffer
             tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
@@ -955,19 +962,33 @@ class PPOTrainer:
         # dump to local dir
         val_data_dir = self.config.trainer.get("validation_data_dir", None)
         if val_data_dir:
-            sorted_indices = sorted(range(len(sample_uids)), key=lambda i: sample_uids[i])
-            dump_inputs = [sample_inputs[i] for i in sorted_indices]
-            dump_outputs = [sample_outputs[i] for i in sorted_indices]
-            dump_gts = [sample_gts[i] for i in sorted_indices]
-            dump_scores = [sample_scores[i] for i in sorted_indices]
-            dump_extra = {k: [v[i] for i in sorted_indices] for k, v in reward_extra_infos_dict.items()}
-            dump_extra["uid"] = [sample_uids[i] for i in sorted_indices]
+            # Sort according to uid (so that generations in the same rollout are together)
+            sort_keys = []
+            for key in dump_all_keys:
+                parts = key.rsplit("_", 2)
+                sort_keys.append((parts[0], int(parts[1]), int(parts[2])) if len(parts) == 3 else (key, 0, 0))
+            sorted_indices = sorted(range(len(dump_all_keys)), key=lambda i: sort_keys[i])
+            dump_all_inputs = [dump_all_inputs[i] for i in sorted_indices]
+            dump_all_outputs = [dump_all_outputs[i] for i in sorted_indices]
+            dump_all_keys = [dump_all_keys[i] for i in sorted_indices]
+
+            # For ground truths, scores and reward extra infos, find the values in the
+            # lists for the final samples of each session
+            dump_all_sessions = [
+                f"{parts[0]}_{parts[1]}" if len(parts) == 3 else key
+                for key in dump_all_keys
+                for parts in [key.rsplit("_", 2)]
+            ]
+            session_final_indices = [session_to_sample_idx[session] for session in dump_all_sessions]
             self._dump_generations(
-                inputs=dump_inputs,
-                outputs=dump_outputs,
-                gts=dump_gts,
-                scores=dump_scores,
-                reward_extra_infos_dict=dump_extra,
+                inputs=dump_all_inputs,
+                outputs=dump_all_outputs,
+                gts=[sample_gts[i] for i in session_final_indices],
+                scores=[sample_scores[i] for i in session_final_indices],
+                reward_extra_infos_dict={
+                    k: [v[i] for i in session_final_indices] for k, v in reward_extra_infos_dict.items()
+                }
+                | {"uid": dump_all_keys},
                 dump_path=val_data_dir,
             )
 


### PR DESCRIPTION
### What does this PR do?

In `_validate` in `main_ppo_sync.py`, when `validation_data_dir` is set, the dump only included the final output per session. For multi-turn or multi-output rollouts, all intermediate and alternative outputs were silently discarded. This PR fixes `_validate` to fetch prompts/responses for all keys and include every output in the dump, while mapping each entry back to its session's final score/ground-truth. Follows up on #6101.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=all+outputs+in+validation https://github.com/verl-project/verl/pulls?q=main_ppo_sync+validation+outputs
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

This change only affects the file dump path (when `trainer.validation_data_dir` is set). No CI test covers this code path — it requires a full training run with multi-output rollouts.

### API and Usage Example

No API changes.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

- Fetch prompts/responses for **all** batch keys (not just final ones per session) using a separate `kv_batch_get` call, so every output is captured in the dump.
- `dump_all_inputs`, `dump_all_outputs`, `dump_all_keys` accumulate all entries across batches.
- `session_to_sample_idx` maps session keys to their position in the per-session lists, so scores/ground-truths can be looked up correctly when writing the dump.
- Remove `prompts`/`responses` from the `fields` list of the final-key `kv_batch_get` (fetched separately above).
- Sort the dump by `(uid, session_id, index)` so outputs from the same rollout are grouped together.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always` — passed (naming convention failures are pre-existing in third-party packages, not in changed files).
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). No docs needed — internal dump behavior only.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Not feasible — the validation dump path has no CI coverage and requires a full training run with multi-output rollouts to exercise.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.