### PR TITLE
[reward, trainer] feat: support multi-output trajectories in async reward scoring

### DIFF
--- a/docs/advance/reward_loop.rst
+++ b/docs/advance/reward_loop.rst
@@ -115,7 +115,6 @@ The rewards can be categorized as follows:
          return outputs
 
       async def compute_score(self, data: DataProto) -> dict:
-         assert len(data) == 1, "RewardLoopWorker only support single data item"
          if self.config.reward.custom_reward_function.path is not None:
             # directly use user-customized reward function
             return await self.reward_manager.run_single(data)
@@ -146,7 +145,8 @@ Users can also customize their own ``RewardManager``, inheriting from ``RewardMa
    @register("user_costomized")
    class UserCostomizedRewardManager(RewardManagerBase):
       async def run_single(self, data: DataProto) -> dict:
-         assert len(data) == 1, "Only support single data item"
+         data = data[-1:]  # for multi-sequence outputs, score only the last sequence
+         data_item = data[0]
          # your own reward manager
          ...
 

--- a/docs/advance/reward_loop.rst
+++ b/docs/advance/reward_loop.rst
@@ -122,7 +122,7 @@ The rewards can be categorized as follows:
             if self.config.reward.reward_model.enable:
                # we assume the rm is disrm
                # genrm must set custom_reward_function
-               return await self.compute_score_disrm(data)
+               return await self.compute_score_disrm(data[-1:])  # only pass the last output to discriminative reward model
             else:
                return await self.reward_manager.run_single(data)
 
@@ -145,12 +145,17 @@ Users can also customize their own ``RewardManager``, inheriting from ``RewardMa
    @register("user_costomized")
    class UserCostomizedRewardManager(RewardManagerBase):
       async def run_single(self, data: DataProto) -> dict:
-         data = data[-1:]  # for multi-sequence outputs, score only the last sequence
-         data_item = data[0]
+         data_item = data[-1]
          # your own reward manager
          ...
 
 After defining it, users can specify their custom reward manager by setting ``reward.reward_manager.name=user_costomized``.
+
+When trajectories consist of multiple output sequences (currently supported only by the ``main_ppo_sync`` trainer) reward managers may consider all outputs when computing their scores.
+In that case, the ``data`` argument passed to ``run_single`` will contain all outputs in the trajectory.
+However, the default reward managers (e.g. ``naive``, ``dapo``, etc.) will only consider the last sequence by default, as they are typically designed for single-output tasks.
+The same is true in the ``UserCostomizedRewardManager`` example above, as indicated by the line ``data_item = data[-1]``.
+
 
 Rule-Based Reward
 ~~~~~~~~~~~~~~~~~

--- a/tests/experimental/reward_loop/test_rate_limited_reward_manager_on_cpu.py
+++ b/tests/experimental/reward_loop/test_rate_limited_reward_manager_on_cpu.py
@@ -16,6 +16,7 @@ import asyncio
 import os.path
 import time
 
+import numpy as np
 import pytest
 import torch
 from omegaconf import DictConfig
@@ -134,8 +135,11 @@ def create_test_data_proto(tokenizer, response_text: str, ground_truth: str, dat
         }
     )
 
-    # Wrap non-tensor values in lists to match batch dimension
-    data.non_tensor_batch = {"data_source": [data_source], "reward_model": [{"ground_truth": ground_truth}]}
+    # Wrap non-tensor values in numpy arrays to match batch dimension
+    data.non_tensor_batch = {
+        "data_source": np.array([data_source], dtype=object),
+        "reward_model": np.array([{"ground_truth": ground_truth}], dtype=object),
+    }
 
     return data
 
@@ -489,7 +493,7 @@ class TestRateLimitedRewardManager:
         )
 
         data = create_test_data_proto(tokenizer, "answer", "answer")
-        data.non_tensor_batch["extra_info"] = [{"custom_field": "test_value"}]
+        data.non_tensor_batch["extra_info"] = np.array([{"custom_field": "test_value"}], dtype=object)
 
         await manager.run_single(data)
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -607,15 +607,7 @@ class AgentLoopWorker:
 
         multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
         position_ids = self._compute_position_ids(input_ids, attention_mask, multi_modal_inputs)
-        await self._compute_score(
-            output,
-            prompts=prompt_output["input_ids"],
-            responses=response_output["input_ids"],
-            attention_mask=attention_mask,
-            input_ids=input_ids,
-            position_ids=position_ids,
-            kwargs=kwargs,
-        )
+        await self._compute_score([output], kwargs=kwargs)
         await self._compute_teacher_logprobs(
             output,
             prompt_ids=output.prompt_ids,
@@ -726,27 +718,34 @@ class AgentLoopWorker:
         position_ids = torch.cat((text_position_ids, vision_position_ids), dim=1)  # (1, 4, seq_length)
         return position_ids
 
-    async def _compute_score(self, output, prompts, responses, attention_mask, input_ids, position_ids, kwargs):
-        """Compute reward score for single sample."""
+    async def _compute_score(self, outputs: list, kwargs: dict) -> None:
+        """Compute reward score for a list of agent loop outputs (scores outputs[-1])."""
         enable_async_reward = self.reward_loop_worker_handles is not None
 
-        if output.reward_score is None and enable_async_reward:
+        final_output = outputs[-1]
+        if final_output.reward_score is None and enable_async_reward:
             timing = {}
             with simple_timer("compute_score", timing):
+                prompts = torch.tensor(final_output.prompt_ids, dtype=torch.int64).unsqueeze(0)
+                responses = torch.tensor(final_output.response_ids, dtype=torch.int64).unsqueeze(0)
+                input_ids = torch.cat([prompts, responses], dim=1)
+                attention_mask = torch.ones_like(input_ids)
+                multi_modal_inputs = self._compute_multi_modal_inputs(final_output, input_ids.squeeze(0))
+                position_ids = self._compute_position_ids(input_ids, attention_mask, multi_modal_inputs)
                 batch = TensorDict(
                     {
-                        "prompts": prompts,  # [1, prompt_length]
-                        "responses": responses,  # [1, response_length]
-                        "attention_mask": attention_mask,  # [1, prompt_length + response_length]
-                        "input_ids": input_ids,  # [1, prompt_length + response_length]
+                        "prompts": prompts,
+                        "responses": responses,
+                        "attention_mask": attention_mask,
+                        "input_ids": input_ids,
                         "position_ids": position_ids,
                     },
                     batch_size=1,
                 )
                 non_tensor_batch = {
                     **{k: np.array([v]) for k, v in kwargs.items()},
-                    "__num_turns__": np.array([output.num_turns]),
-                    "tool_extra_fields": np.array([output.extra_fields], dtype=object),
+                    "__num_turns__": np.array([final_output.num_turns]),
+                    "tool_extra_fields": np.array([final_output.extra_fields], dtype=object),
                 }
 
                 data = DataProto(
@@ -755,9 +754,9 @@ class AgentLoopWorker:
                 )
                 selected_reward_loop_worker_handle = random.choice(self.reward_loop_worker_handles)
                 result = await selected_reward_loop_worker_handle.compute_score.remote(data)
-                output.reward_score = result["reward_score"]
-                output.extra_fields["reward_extra_info"] = result["reward_extra_info"]
-            output.metrics.compute_score = timing["compute_score"]
+                final_output.reward_score = result["reward_score"]
+                final_output.extra_fields["reward_extra_info"] = result["reward_extra_info"]
+            final_output.metrics.compute_score = timing["compute_score"]
 
     async def _compute_teacher_logprobs(
         self,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -718,34 +718,51 @@ class AgentLoopWorker:
         position_ids = torch.cat((text_position_ids, vision_position_ids), dim=1)  # (1, 4, seq_length)
         return position_ids
 
-    async def _compute_score(self, outputs: list, kwargs: dict) -> None:
-        """Compute reward score for a list of agent loop outputs (scores outputs[-1])."""
+    async def _compute_score(self, outputs: list[AgentLoopOutput], kwargs: dict) -> None:
+        """Compute reward score for all outputs in a trajectory; assigns result to outputs[-1]."""
         enable_async_reward = self.reward_loop_worker_handles is not None
 
         final_output = outputs[-1]
         if final_output.reward_score is None and enable_async_reward:
             timing = {}
             with simple_timer("compute_score", timing):
-                prompts = torch.tensor(final_output.prompt_ids, dtype=torch.int64).unsqueeze(0)
-                responses = torch.tensor(final_output.response_ids, dtype=torch.int64).unsqueeze(0)
-                input_ids = torch.cat([prompts, responses], dim=1)
-                attention_mask = torch.ones_like(input_ids)
-                multi_modal_inputs = self._compute_multi_modal_inputs(final_output, input_ids.squeeze(0))
-                position_ids = self._compute_position_ids(input_ids, attention_mask, multi_modal_inputs)
+                all_prompts, all_responses, all_input_ids, all_attention_mask, all_position_ids = [], [], [], [], []
+                for output in outputs:
+                    prompts = torch.tensor(output.prompt_ids, dtype=torch.int64)
+                    responses = torch.tensor(output.response_ids, dtype=torch.int64)
+                    input_ids = torch.cat([prompts, responses], dim=0)
+                    attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
+                    multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
+                    position_ids = self._compute_position_ids(
+                        input_ids.unsqueeze(0), attention_mask.unsqueeze(0), multi_modal_inputs
+                    ).squeeze(0)
+                    all_prompts.append(prompts)
+                    all_responses.append(responses)
+                    all_input_ids.append(input_ids)
+                    all_attention_mask.append(attention_mask)
+                    all_position_ids.append(position_ids)
+
+                n = len(outputs)
                 batch = TensorDict(
                     {
-                        "prompts": prompts,
-                        "responses": responses,
-                        "attention_mask": attention_mask,
-                        "input_ids": input_ids,
-                        "position_ids": position_ids,
+                        "prompts": torch.nn.utils.rnn.pad_sequence(all_prompts, batch_first=True, padding_value=0),
+                        "responses": torch.nn.utils.rnn.pad_sequence(all_responses, batch_first=True, padding_value=0),
+                        "attention_mask": torch.nn.utils.rnn.pad_sequence(
+                            all_attention_mask, batch_first=True, padding_value=0
+                        ),
+                        "input_ids": torch.nn.utils.rnn.pad_sequence(all_input_ids, batch_first=True, padding_value=0),
+                        "position_ids": torch.nn.utils.rnn.pad_sequence(
+                            all_position_ids, batch_first=True, padding_value=0
+                        ),
                     },
-                    batch_size=1,
+                    batch_size=n,
                 )
                 non_tensor_batch = {
-                    **{k: np.array([v]) for k, v in kwargs.items()},
-                    "__num_turns__": np.array([final_output.num_turns]),
-                    "tool_extra_fields": np.array([final_output.extra_fields], dtype=object),
+                    **{k: np.array([v] * n) for k, v in kwargs.items()},
+                    "__num_turns__": np.array([o.num_turns for o in outputs]),
+                    "tool_extra_fields": np.array([o.extra_fields for o in outputs], dtype=object),
+                    "prompt_len": np.array([len(o.prompt_ids) for o in outputs]),
+                    "response_len": np.array([len(o.response_ids) for o in outputs]),
                 }
 
                 data = DataProto(

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -144,7 +144,6 @@ class RewardLoopWorker:
         return outputs
 
     async def compute_score(self, data: DataProto) -> dict:
-        assert len(data) == 1, "RewardLoopWorker only support single data item"
         if self.config.reward.custom_reward_function.path is not None:
             # directly use user-customized reward function
             return await self.reward_manager.run_single(data)
@@ -152,7 +151,7 @@ class RewardLoopWorker:
             if self.config.reward.reward_model.enable:
                 # we assume the rm is disrm
                 # genrm must set custom_reward_function
-                return await self.compute_score_disrm(data)
+                return await self.compute_score_disrm(data[-1:])
             else:
                 return await self.reward_manager.run_single(data)
 

--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -50,7 +50,7 @@ class DAPORewardManager(RewardManagerBase):
             )
 
     async def run_single(self, data: DataProto) -> dict:
-        assert len(data) == 1, "Only support single data item"
+        data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]
         response_length = response_ids.shape[-1]

--- a/verl/experimental/reward_loop/reward_manager/gdpo.py
+++ b/verl/experimental/reward_loop/reward_manager/gdpo.py
@@ -33,7 +33,7 @@ class GDPORewardManager(RewardManagerBase):
         self.reward_model_tokenizer = reward_model_tokenizer
 
     async def run_single(self, data: DataProto) -> dict:
-        assert len(data) == 1, "Only support single data item"
+        data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]
         response_length = response_ids.shape[-1]

--- a/verl/experimental/reward_loop/reward_manager/limited.py
+++ b/verl/experimental/reward_loop/reward_manager/limited.py
@@ -396,7 +396,7 @@ class RateLimitedRewardManager(RewardManagerBase):
             )
 
     async def run_single(self, data: DataProto) -> dict:
-        assert len(data) == 1, "Only support single data item"
+        data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
 
         response_ids = data_item.batch["responses"]

--- a/verl/experimental/reward_loop/reward_manager/naive.py
+++ b/verl/experimental/reward_loop/reward_manager/naive.py
@@ -32,7 +32,7 @@ class NaiveRewardManager(RewardManagerBase):
         self.reward_model_tokenizer = reward_model_tokenizer
 
     async def run_single(self, data: DataProto) -> dict:
-        assert len(data) == 1, "Only support single data item"
+        data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]
         response_length = response_ids.shape[-1]

--- a/verl/experimental/reward_loop/reward_manager/remote.py
+++ b/verl/experimental/reward_loop/reward_manager/remote.py
@@ -73,7 +73,7 @@ class RemoteRewardManager(RewardManagerBase):
         return next(self.reward_worker_pool)
 
     async def run_single(self, data: DataProto) -> dict:
-        assert len(data) == 1, "Only support single data item"
+        data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]
         response_length = response_ids.shape[-1]

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -360,32 +360,13 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             logger.warning(f"Empty output for prompt {uid}_{session_id}")
             return
 
-        # NOTE: only use the last output to compute reward score, then assign reward score to all agent loop outputs.
-        # User can customize the reward score assignment strategy.
-        final_output = outputs[-1]
-        final_prompts = torch.tensor(final_output.prompt_ids, dtype=torch.int64)
-        final_responses = torch.tensor(final_output.response_ids, dtype=torch.int64)
-        final_input_ids = torch.cat([final_prompts, final_responses], dim=0)
-        final_attention_mask = torch.ones_like(final_input_ids, dtype=torch.int64)
-        final_multi_modal_inputs = self._compute_multi_modal_inputs(final_output, final_input_ids)
-        final_position_ids = self._compute_position_ids(
-            final_input_ids.unsqueeze(0), final_attention_mask.unsqueeze(0), final_multi_modal_inputs
-        ).squeeze(0)
-        await self._compute_score(
-            final_output,
-            prompts=final_prompts.unsqueeze(0),  # [1, prompt_length]
-            responses=final_responses.unsqueeze(0),  # [1, response_length]
-            attention_mask=final_attention_mask.unsqueeze(0),  # [1, seq_len]
-            input_ids=final_input_ids.unsqueeze(0),  # [1, seq_len]
-            position_ids=final_position_ids.unsqueeze(0),  # [1, seq_len] or [1, 4, seq_len]
-            kwargs=kwargs,
-        )
+        await self._compute_score(outputs, kwargs=kwargs)
 
-        # TODO: Support output:list[AgentLoopOutput]
+        final_output = outputs[-1]
         await self._compute_teacher_logprobs(
-            output,
-            prompt_ids=output.prompt_ids,
-            response_ids=output.response_ids,
+            final_output,
+            prompt_ids=final_output.prompt_ids,
+            response_ids=final_output.response_ids,
             validate=validate,
             sample_kwargs=kwargs,
         )

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -363,6 +363,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
         await self._compute_score(outputs, kwargs=kwargs)
 
         final_output = outputs[-1]
+        # TODO: Support output:list[AgentLoopOutput]
         await self._compute_teacher_logprobs(
             final_output,
             prompt_ids=final_output.prompt_ids,


### PR DESCRIPTION
### What does this PR do?

When using the TransferQueue trainer with multi-turn agent loops, each prompt may produce a list of `AgentLoopOutput`s. Previously `_compute_score` was called only on the final output, constructing a batch of size 1. This change passes all outputs to `_compute_score` so reward managers can be extended to score intermediate turns, while the default behaviour (scoring only the last output via `data[-1:]`) is preserved for all existing reward managers.

Also fixes a pre-existing bug in `AgentLoopWorkerTQ._agent_loop_postprocess` where `_compute_teacher_logprobs` was called with the raw `output` parameter (which may be a `list[AgentLoopOutput]`) instead of the resolved `final_output`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+multi-output+async+reward+scoring
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Manually ran trainings with:
- `main_ppo` with naive reward manager
- `main_ppo_sync` with single-output rollouts and naive reward manager
- `main_ppo_sync` with multi-output rollouts and a custom reward manager (that combines the outputs into a single sequence in a non-trivial way, and then delegates to the naive reward manager)

All runs could train for a few steps and compute validation without problems.

This behaviour is also covered by current end-to-end tests.

### API and Usage Example

```python
# Before
await self._compute_score(output, prompts=..., responses=..., attention_mask=..., input_ids=..., position_ids=..., kwargs=kwargs)

# After — outputs is list[AgentLoopOutput]
await self._compute_score(outputs, kwargs=kwargs)
```

### Design & Code Changes

- `_compute_score` now accepts `list[AgentLoopOutput]` and internally derives tensors from `outputs[-1]`
- All built-in reward managers (`naive`, `dapo`, `gdpo`, `limited`, `remote`) use `data[-1:]` instead of asserting `len(data) == 1`
- `RewardLoopWorker.compute_score` removes the single-item assertion
- `AgentLoopWorkerTQ._agent_loop_postprocess` simplified and the `_compute_teacher_logprobs` bug fixed
- Updated `docs/advance/reward_loop.rst` to reflect the new interface

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: covered by existing end-to-end tests.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote`: not applicable.