### PR TITLE
[worker] feat: QAT with FP8 (w8a8 & w8a16)

### DIFF
--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -2,12 +2,14 @@
 
 Last updated: 04/02/2026
 
-verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quantization during training so the model learns to tolerate NVFP4 quantization error. At rollout time, weights are packed into real NVFP4 format for vLLM inference. This closes the precision gap between training and inference, preventing KL divergence explosion.
+verl supports NVFP4 and FP8 Quantization-Aware Training (QAT), which applies fake quantization during training so the model learns to tolerate rollout-time quantization error. At rollout time, NVFP4 weights are packed into real NVFP4 format and FP8 weights use vLLM's blockwise FP8 loader. This closes the precision gap between training and inference, preventing KL divergence explosion.
 
 | Training Backend | Training Precision | Rollout Precision | vLLM Quant Method |
 |---|---|---|---|
 | **FSDP** | BF16 + fake quantization | NVFP4 W4A16 | `compressed-tensors` |
 | **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
+| **FSDP** | BF16 + fake quantization | FP8 W8A8/W8A16 | `fp8` |
+| **Megatron** | BF16 + fake quantization | FP8 W8A8/W8A16 | `fp8` |
 
 > [!TIP]
 > For ready-to-run scripts, environment setup, and experimental results, see the [QAT recipe](https://github.com/verl-project/verl-recipe/tree/main/qat).
@@ -26,8 +28,9 @@ actor_rollout_ref:
     fsdp_config:
       qat:
         enable: true
-        mode: "w4a16"
+        mode: "w4a16"  # or "fp8", "w8a8", "w8a16"
         group_size: 16
+        weight_block_size: null  # defaults to [128, 128] for FP8
         ignore_patterns:
           - "lm_head"
           - "embed_tokens"
@@ -40,8 +43,9 @@ actor_rollout_ref:
 | `fsdp_config.qat.enable` | Enable QAT | `False` |
 | `fsdp_config.qat.mode` | Quantization mode | `"w4a16"` |
 | `fsdp_config.qat.group_size` | Quantization group size | `16` |
+| `fsdp_config.qat.weight_block_size` | FP8 2D weight block size. Used when `mode` is FP8 | `null` (`[128, 128]`) |
 | `fsdp_config.qat.ignore_patterns` | Layers to skip. Supports `re:` prefix for regex, otherwise substring match | `["lm_head", "embed_tokens", "re:.*mlp.gate$"]` |
-| `fsdp_config.qat.quantization_config_path` | vLLM quantization config JSON path | Required |
+| `fsdp_config.qat.quantization_config_path` | vLLM quantization config JSON path. Required for NVFP4; optional for FP8 | Required for NVFP4 |
 
 ### Megatron Backend
 
@@ -53,8 +57,9 @@ actor_rollout_ref:
     megatron:
       qat:
         enable: true
-        mode: "w4a16"
+        mode: "w4a16"  # or "fp8", "w8a8", "w8a16"
         group_size: 16
+        weight_block_size: null  # defaults to [128, 128] for FP8
         ignore_patterns:
           - "lm_head"
           - "*mlp.gate"
@@ -66,16 +71,19 @@ actor_rollout_ref:
 | `megatron.qat.enable` | Enable QAT | `False` |
 | `megatron.qat.mode` | Quantization mode | `"w4a16"` |
 | `megatron.qat.group_size` | Quantization group size | `16` |
+| `megatron.qat.weight_block_size` | FP8 2D weight block size. Used when `mode` is FP8 | `null` (`[128, 128]`) |
 | `megatron.qat.ignore_patterns` | Layers to skip. Uses `fnmatch` glob syntax | `["lm_head", "*mlp.gate"]` |
-| `megatron.qat.quantization_config_path` | vLLM quantization config JSON path | Required |
+| `megatron.qat.quantization_config_path` | vLLM quantization config JSON path. Required for NVFP4; optional for FP8 | Required for NVFP4 |
 
 ---
 
 ## Support Matrix
 
 - NVFP4 W4A16 (weight-only FP4 quantization)
+- FP8 W8A8 (`mode: "fp8"` or `"w8a8"`) and FP8 W8A16 (`mode: "w8a16"`)
 - Dense models and MoE models
 - FSDP and Megatron training backends
+- LoRA adapter training. Base weights are quantized during rollout sync; adapter-only updates remain unquantized.
 - Full quantization and FFN-only quantization strategies
 - Verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base
 

--- a/scripts/print_cfg.py
+++ b/scripts/print_cfg.py
@@ -11,10 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import argparse
+import sys
+
 try:
     import hydra
 except ImportError as e:
     raise ImportError("Please install hydra-core via 'pip install hydra-core' and retry.") from e
+
+
+if sys.version_info >= (3, 14):
+    # Hydra 1.3 passes a lazy help object; Python 3.14 argparse validates help
+    # strings during add_argument and expects a real string.
+    original_expand_help = argparse.HelpFormatter._expand_help
+
+    def _expand_help(self, action):
+        if action.help is not None and not isinstance(action.help, str):
+            action.help = repr(action.help)
+        return original_expand_help(self, action)
+
+    argparse.HelpFormatter._expand_help = _expand_help
 
 
 @hydra.main(config_path="../verl/trainer/config", config_name="ppo_trainer", version_base=None)

--- a/tests/utils/test_qat_fp8.py
+++ b/tests/utils/test_qat_fp8.py
@@ -14,7 +14,8 @@
 
 import asyncio
 import os
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -378,6 +379,63 @@ def test_te_grouped_weight_calibration_skips_original_plain_weight_lookup(monkey
 
     assert [id(weight) for weight in grouped.quantized_weights] == [id(grouped.weight0), id(grouped.weight1)]
     assert model_calib.weight_attr_names is _bad_weight_attr_names
+
+
+def test_detect_parallelism_patch_uses_modelopt_linear_class(monkeypatch):
+    from verl.utils.modelopt.megatron_qat_patch import (
+        apply_detect_parallelism_type_patch,
+        revert_detect_parallelism_type_patch,
+    )
+
+    class AutoMapping:
+        def __init__(self, megatron_param="linear.weight"):
+            self.megatron_param = megatron_param
+
+        def _detect_parallelism_type(self, module):
+            return "original"
+
+    class Linear(torch.nn.Module):
+        pass
+
+    Linear.__module__ = "renamed.modelopt.layers"
+
+    class DynamicLinear(torch.nn.Module):
+        def get_original_cls_by_level(self, level=0):
+            assert level == 0
+            return Linear
+
+    def package(name):
+        module = ModuleType(name)
+        module.__path__ = []
+        return module
+
+    fake_modules = {
+        "megatron": package("megatron"),
+        "megatron.bridge": package("megatron.bridge"),
+        "megatron.bridge.models": package("megatron.bridge.models"),
+        "megatron.bridge.models.conversion": package("megatron.bridge.models.conversion"),
+        "megatron.core": package("megatron.core"),
+        "megatron.core.post_training": package("megatron.core.post_training"),
+        "megatron.core.post_training.modelopt": package("megatron.core.post_training.modelopt"),
+    }
+    param_mapping = ModuleType("megatron.bridge.models.conversion.param_mapping")
+    param_mapping.AutoMapping = AutoMapping
+    layers = ModuleType("megatron.core.post_training.modelopt.layers")
+    layers.Linear = Linear
+    fake_modules[param_mapping.__name__] = param_mapping
+    fake_modules[layers.__name__] = layers
+
+    for name, module in fake_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    try:
+        apply_detect_parallelism_type_patch()
+
+        assert AutoMapping()._detect_parallelism_type(Linear()) == "replicated"
+        assert AutoMapping()._detect_parallelism_type(DynamicLinear()) == "replicated"
+        assert AutoMapping()._detect_parallelism_type(torch.nn.Module()) == "original"
+    finally:
+        revert_detect_parallelism_type_patch()
 
 
 def test_fp8_module_lookup_unwraps_lora_fused_moe(monkeypatch):

--- a/tests/utils/test_qat_fp8.py
+++ b/tests/utils/test_qat_fp8.py
@@ -1,0 +1,525 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from verl.utils.fp8_utils import FP8QuantizerHelper
+from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
+from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter, _QuantMeta
+from verl.utils.modelopt.quantize import build_quantize_config
+from verl.utils.qat import QATConfig, is_fp8_qat_mode, load_quantization_config
+from verl.utils.qat.linear import QATLinear, QATMode, fp8_fake_quant_blockwise
+from verl.utils.qat.quantizer import QATQuantizer
+
+
+class _FakeModel:
+    def load_weights(self, weights):
+        return [name for name, _ in weights]
+
+
+def _make_worker(model):
+    from verl.workers.rollout.vllm_rollout.utils import vLLMColocateWorkerExtension
+
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = SimpleNamespace(model=model)
+    return worker
+
+
+def test_load_quantization_config_builds_default_fp8_config_without_file():
+    config = load_quantization_config(QATConfig(enable=True, mode="fp8"))
+
+    assert config["quant_method"] == "fp8"
+    assert config["activation_scheme"] == "dynamic"
+    assert config["weight_block_size"] == [128, 128]
+    assert is_fp8_qat_mode("fp8")
+
+
+def test_contains_serialized_fp8_weights_detects_qat_exported_tensors():
+    from verl.workers.rollout.vllm_rollout.utils import _contains_serialized_fp8_weights
+
+    assert _contains_serialized_fp8_weights(
+        [
+            ("model.layers.0.self_attn.q_proj.weight", torch.empty(1, dtype=torch.float8_e4m3fn)),
+        ]
+    )
+    assert _contains_serialized_fp8_weights(
+        [
+            ("model.layers.0.self_attn.q_proj.weight_scale_inv", torch.empty(1)),
+        ]
+    )
+    assert not _contains_serialized_fp8_weights(
+        [
+            ("model.layers.0.self_attn.q_proj.weight", torch.empty(1, dtype=torch.bfloat16)),
+        ]
+    )
+
+
+def test_update_weights_chooses_serialized_loader_for_fp8_qat_bucket(monkeypatch):
+    import verl.workers.rollout.vllm_rollout.utils as worker_utils
+
+    calls = []
+
+    monkeypatch.setattr(worker_utils, "is_fp8_model", lambda vllm_config: True)
+    monkeypatch.setattr(
+        worker_utils,
+        "load_serialized_fp8_weights",
+        lambda weights, model_runner: calls.append(("serialized", weights)) or ["weight"],
+    )
+    monkeypatch.setattr(
+        worker_utils,
+        "load_quanted_weights",
+        lambda weights, model_runner: calls.append(("quantize", weights)) or ["weight"],
+    )
+
+    worker = _make_worker(_FakeModel())
+    worker.model_runner.vllm_config = SimpleNamespace(quant_config=SimpleNamespace())
+
+    worker._update_weights(
+        [("model.layers.0.self_attn.q_proj.weight_scale_inv", torch.empty(1))],
+        peft_config=None,
+        base_sync_done=False,
+    )
+    worker._update_weights(
+        [("model.layers.0.self_attn.q_proj.weight", torch.empty(1, dtype=torch.bfloat16))],
+        peft_config=None,
+        base_sync_done=False,
+    )
+
+    assert [loader for loader, _ in calls] == ["serialized", "quantize"]
+
+
+def test_qat_linear_fp8_forward_backward_on_cpu():
+    layer = QATLinear(8, 4, mode=QATMode.W8A8, weight_block_size=[4, 4])
+    x = torch.randn(2, 3, 8, requires_grad=True)
+
+    loss = layer(x).sum()
+    loss.backward()
+
+    assert x.grad is not None
+    assert layer.weight.grad is not None
+
+
+def test_scaled_fp8_blockwise_supports_rectangular_cpu_blocks():
+    x = torch.randn(3, 5)
+
+    q, descale = scaled_fp8_blockwise(x, weight_block_size=(1, 4))
+    y = fp8_fake_quant_blockwise(x, (1, 4))
+
+    assert q.shape == x.shape
+    assert descale.shape == (3, 2, 1)
+    assert y.shape == x.shape
+    assert y.dtype == x.dtype
+
+
+def test_scaled_fp8_blockwise_cpu_does_not_mutate_input():
+    x = torch.randn(6, 8)
+    original = x.clone()
+
+    scaled_fp8_blockwise(x, weight_block_size=(1, 4))
+
+    torch.testing.assert_close(x, original)
+
+
+def test_fp8_quantizer_helper_preserves_2d_scale_with_single_column(monkeypatch):
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+
+    async def collect():
+        helper = FP8QuantizerHelper({"weight_block_size": [128, 128]})
+        weights = [("model.layers.0.self_attn.q_proj.weight", torch.randn(4, 4))]
+        return [item async for item in helper.quant_weights_by_name(weights, dtype=torch.float32)]
+
+    output = dict(asyncio.run(collect()))
+
+    assert output["model.layers.0.self_attn.q_proj.weight_scale_inv"].shape == (1, 1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA for Triton FP8 path")
+def test_fp8_fake_quant_uses_cuda_path_backward():
+    x = torch.randn(9, 17, device="cuda", dtype=torch.bfloat16)
+
+    y = fp8_fake_quant_blockwise(x, (4, 8))
+
+    assert y.shape == x.shape
+    assert y.dtype == x.dtype
+
+    layer = QATLinear(17, 4, mode=QATMode.W8A8, weight_block_size=[4, 8]).to(device="cuda", dtype=torch.bfloat16)
+    x = x.detach().requires_grad_(True)
+    layer(x).sum().backward()
+    assert x.grad is not None
+    assert layer.weight.grad is not None
+
+
+def test_modelopt_fp8_config_uses_weight_block_size():
+    config = build_quantize_config("fp8", weight_block_size=[64, 128])
+    weight_quantizer = config["quant_cfg"]["*weight_quantizer"]
+
+    assert weight_quantizer["num_bits"] == (4, 3)
+    assert weight_quantizer["block_sizes"] == {-1: 128, -2: 64}
+    assert config["quant_cfg"]["*input_quantizer"]["enable"] is True
+
+
+def test_modelopt_fp8_qat_disables_lora_adapter_quantizers():
+    import modelopt.torch.quantization as mtq
+    import torch.nn as nn
+
+    class AdapterModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base = nn.Linear(2048, 64, bias=False)
+            self.adapter = nn.Module()
+            self.adapter.linear_out = nn.Linear(2048, 8, bias=False)
+            nn.init.zeros_(self.adapter.linear_out.weight)
+
+    model = AdapterModel()
+    config = build_quantize_config("w8a16", weight_block_size=[64, 64])
+
+    mtq.quantize(model, config)
+
+    assert model.base.weight_quantizer.is_enabled
+    assert not model.adapter.linear_out.weight_quantizer.is_enabled
+    output = model.adapter.linear_out(torch.randn(2, 2048))
+    assert torch.isfinite(output).all()
+
+
+def test_qat_local_name_patch_skips_modelopt_quantizer_params(monkeypatch):
+    import megatron.bridge.models.conversion.model_bridge as bridge_module
+
+    from verl.utils.modelopt.megatron_qat_patch import (
+        apply_local_name_to_global_patch,
+        revert_local_name_to_global_patch,
+    )
+
+    if getattr(bridge_module, "_local_name_to_global_patched", False):
+        revert_local_name_to_global_patch()
+
+    def _raise_for_quantizer_params(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("quantizer params must not enter Bridge local-to-global conversion")
+
+    param_name = "decoder.layers.0.mlp.experts.linear_fc1.weight_quantizer._amax"
+    monkeypatch.setattr(bridge_module, "_megatron_local_name_to_global", _raise_for_quantizer_params)
+
+    try:
+        apply_local_name_to_global_patch()
+        assert bridge_module._megatron_local_name_to_global(None, None, param_name) == param_name
+    finally:
+        revert_local_name_to_global_patch()
+
+
+def test_qat_weight_exporter_serializes_fp8_from_qat_metadata():
+    exporter = QATWeightExporter.__new__(QATWeightExporter)
+    exporter.qat_mode = "w8a8"
+    weight = torch.randn(3, 5)
+    meta = _QuantMeta(
+        qformat="fp8_pb_wo",
+        block_size=4,
+        block_sizes={-1: 4, -2: 2},
+        weight_amax=None,
+    )
+
+    output = dict(exporter._quantize_fp8_blockwise("linear.weight", weight, meta))
+
+    assert output["linear.weight"].dtype == torch.float8_e4m3fn
+    assert output["linear.weight"].shape == weight.shape
+    assert output["linear.weight_scale_inv"].shape == (2, 2)
+
+
+def test_qat_weight_exporter_dequantizes_fp8_for_w8a16_rollout():
+    exporter = QATWeightExporter.__new__(QATWeightExporter)
+    exporter.qat_mode = "w8a16"
+    weight = torch.randn(3, 5, dtype=torch.bfloat16)
+    meta = _QuantMeta(
+        qformat="fp8_pb_wo",
+        block_size=4,
+        block_sizes={-1: 4, -2: 2},
+        weight_amax=None,
+    )
+
+    output = dict(exporter._quantize_fp8_blockwise("linear.weight", weight, meta))
+
+    assert set(output) == {"linear.weight"}
+    assert output["linear.weight"].dtype == weight.dtype
+    assert output["linear.weight"].shape == weight.shape
+    assert torch.isfinite(output["linear.weight"]).all()
+
+
+def test_qat_quantizer_skips_lora_adapter_weights():
+    quantizer = QATQuantizer(mode="w4a16", device=torch.device("cpu"))
+
+    assert not quantizer._should_quantize(
+        "model.layers.0.self_attn.q_proj.lora_A.default.weight",
+        torch.empty(4, 16),
+    )
+
+
+def test_serialized_fp8_loader_restores_param_class_on_error():
+    from verl.utils.vllm.vllm_fp8_utils import load_serialized_fp8_weights
+
+    class _ParamSubclass(torch.nn.Parameter):
+        pass
+
+    class _FailingModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.ones(1))
+            self.weight.subclass_type = _ParamSubclass
+
+        def load_weights(self, weights):
+            del weights
+            raise RuntimeError("load failed")
+
+    model = _FailingModel()
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        load_serialized_fp8_weights([], SimpleNamespace(model=model))
+
+    assert model.weight.__class__ is torch.nn.Parameter
+
+
+def test_vllm19_fp8_linear_processing_preserves_refit_param_metadata():
+    from verl.utils.vllm.vllm_fp8_utils import process_weights_after_loading_for_vllm14
+
+    class _WeightParam(torch.nn.Parameter):
+        pass
+
+    class _ScaleParam(torch.nn.Parameter):
+        pass
+
+    class _Fp8Linear:
+        def process_weights_after_loading(self, layer):
+            layer.weight = torch.nn.Parameter(layer.weight.detach().clone(), requires_grad=False)
+            layer.weight_scale_inv = torch.nn.Parameter(
+                layer.weight_scale_inv.detach().clone(),
+                requires_grad=False,
+            )
+
+    layer = torch.nn.Module()
+    layer.weight = _WeightParam(torch.ones(1, 1), requires_grad=False)
+    layer.weight.weight_loader = lambda *args, **kwargs: None
+    layer.weight.output_dim = 0
+    layer.weight.input_dim = 1
+    layer.weight_scale_inv = _ScaleParam(torch.ones(1, 1), requires_grad=False)
+    layer.weight_scale_inv.weight_loader = lambda *args, **kwargs: None
+    layer.weight_scale_inv.output_dim = 0
+    layer.weight_scale_inv.input_dim = 1
+
+    quant_config = SimpleNamespace(is_checkpoint_fp8_serialized=True, activation_scheme="dynamic")
+    method = SimpleNamespace(block_quant=True, quant_config=quant_config, fp8_linear=_Fp8Linear())
+
+    process_weights_after_loading_for_vllm14(method, layer)
+
+    assert layer.input_scale is None
+    assert layer.weight.subclass_type is _WeightParam
+    assert layer.weight.output_dim == 0
+    assert layer.weight.input_dim == 1
+    assert hasattr(layer.weight, "weight_loader")
+    assert layer.weight_scale_inv.subclass_type is _ScaleParam
+    assert layer.weight_scale_inv.output_dim == 0
+    assert layer.weight_scale_inv.input_dim == 1
+    assert hasattr(layer.weight_scale_inv, "weight_loader")
+
+
+def test_te_grouped_weight_calibration_skips_original_plain_weight_lookup(monkeypatch):
+    import contextlib
+
+    import modelopt.torch.quantization.model_calib as model_calib
+
+    from verl.utils.modelopt.megatron_qat_patch import (
+        apply_te_grouped_weight_calibration_patch,
+        revert_te_grouped_weight_calibration_patch,
+    )
+
+    class _GroupedLinear(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_gemms = 2
+            self.weight0 = torch.nn.Parameter(torch.ones(1))
+            self.weight1 = torch.nn.Parameter(torch.ones(1) * 2)
+            self.quantized_weights = []
+
+        def weight_quantizer(self, weight):
+            self.quantized_weights.append(weight)
+
+    grouped = _GroupedLinear()
+
+    def _bad_weight_attr_names(module):
+        if module is grouped:
+            yield "weight"
+
+    monkeypatch.setattr(model_calib, "weight_attr_names", _bad_weight_attr_names)
+    monkeypatch.setattr(
+        model_calib,
+        "enable_weight_access_and_writeback",
+        lambda module, model: contextlib.nullcontext(),
+    )
+
+    revert_te_grouped_weight_calibration_patch()
+    try:
+        apply_te_grouped_weight_calibration_patch()
+        model_calib.weight_only_quantize(grouped)
+    finally:
+        revert_te_grouped_weight_calibration_patch()
+
+    assert [id(weight) for weight in grouped.quantized_weights] == [id(grouped.weight0), id(grouped.weight1)]
+    assert model_calib.weight_attr_names is _bad_weight_attr_names
+
+
+def test_fp8_module_lookup_unwraps_lora_fused_moe(monkeypatch):
+    import verl.utils.vllm.vllm_fp8_utils as fp8_utils
+
+    class _FakeFusedMoE:
+        pass
+
+    class FusedMoEWithLoRA:
+        def __init__(self, base_layer):
+            self.base_layer = base_layer
+
+    monkeypatch.setattr(fp8_utils, "FusedMoE", _FakeFusedMoE)
+
+    fused_moe = _FakeFusedMoE()
+    root = torch.nn.Module()
+    root.packed_modules_mapping = {}
+    root.model = torch.nn.Module()
+    root.model.layers = torch.nn.ModuleList(torch.nn.Module() for _ in range(27))
+    root.model.layers[26].mlp = torch.nn.Module()
+    root.model.layers[26].mlp.experts = FusedMoEWithLoRA(fused_moe)
+
+    assert (
+        fp8_utils.get_module_from_param_name(
+            root,
+            "model.layers.26.mlp.experts.3.down_proj.base_layer.weight",
+        )
+        is fused_moe
+    )
+
+
+def test_fp8_module_lookup_applies_packed_mapping_before_base_layer():
+    import verl.utils.vllm.vllm_fp8_utils as fp8_utils
+
+    base_layer = torch.nn.Linear(4, 4)
+    gate_up_proj = torch.nn.Module()
+    gate_up_proj.base_layer = base_layer
+
+    root = torch.nn.Module()
+    root.packed_modules_mapping = {"gate_up_proj": ["gate_proj", "up_proj"]}
+    root.model = torch.nn.Module()
+    root.model.layers = torch.nn.ModuleList(torch.nn.Module() for _ in range(19))
+    root.model.layers[18].mlp = torch.nn.Module()
+    root.model.layers[18].mlp.shared_experts = torch.nn.Module()
+    root.model.layers[18].mlp.shared_experts.gate_up_proj = gate_up_proj
+
+    assert (
+        fp8_utils.get_module_from_param_name(
+            root,
+            "model.layers.18.mlp.shared_experts.gate_proj.base_layer.weight",
+        )
+        is base_layer
+    )
+    assert (
+        fp8_utils.get_module_from_param_name(
+            root,
+            "model.layers.18.mlp.shared_experts.up_proj.base_layer.weight",
+        )
+        is base_layer
+    )
+
+
+def test_update_weights_from_ipc_skips_qat_base_processing_for_lora_only_sync(monkeypatch):
+    import verl.utils.qat as qat_utils
+    import verl.workers.rollout.vllm_rollout.bucketed_weight_transfer as bucketed_weight_transfer
+
+    class _FakeBucketReceiver:
+        def __init__(self, zmq_handle, device, use_shm):
+            del zmq_handle, device, use_shm
+
+        def receive_weights(self, on_bucket_received):
+            on_bucket_received(
+                [("layers.0.self_attn.q_proj.lora_A.weight", torch.ones(1))],
+            )
+
+    def _raise_qat_base_processing(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("adapter-only LoRA sync must not process QAT base weights")
+
+    monkeypatch.setattr(bucketed_weight_transfer, "BucketedWeightReceiver", _FakeBucketReceiver)
+    monkeypatch.setattr(qat_utils, "prepare_qat_for_load_weights", _raise_qat_base_processing)
+    monkeypatch.setattr(qat_utils, "manual_process_weights_after_loading", _raise_qat_base_processing)
+
+    worker = _make_worker(_FakeModel())
+    worker.model_runner.vllm_config = SimpleNamespace()
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker._is_qat_model = True
+    worker._is_modelopt_qat = False
+    worker._get_zmq_handle = lambda: "ipc:///tmp/test-bucketed-lora-qAT.sock"
+    worker.remove_lora = lambda lora_id: None
+    worker.add_lora = lambda lora_request: True
+
+    worker.update_weights_from_ipc(peft_config={"r": 1}, base_sync_done=True)
+
+
+def _make_vllm_http_server_for_fp8_validation(moe_intermediate_size=1408, tp_size=2):
+    from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+
+    server = vLLMHttpServer.__new__(vLLMHttpServer)
+    server.config = SimpleNamespace(tensor_model_parallel_size=tp_size)
+    server.model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            moe_intermediate_size=moe_intermediate_size,
+        )
+    )
+    return server
+
+
+def test_fp8_weight_block_validation_rejects_unaligned_moonlight_moe_shard():
+    server = _make_vllm_http_server_for_fp8_validation()
+
+    with pytest.raises(ValueError, match="intermediate_size_per_partition=704.*block_n=128"):
+        server._validate_fp8_weight_block_size([128, 128])
+
+
+def test_fp8_weight_block_validation_accepts_moonlight_tp2_64_blocks():
+    server = _make_vllm_http_server_for_fp8_validation()
+
+    server._validate_fp8_weight_block_size([64, 64])
+
+
+def test_w8a16_qat_rollout_uses_bf16_quantization_path(monkeypatch):
+    from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+
+    monkeypatch.setenv("VERL_VLLM_FP8_QUANT_ENABLED", "1")
+
+    server = _make_vllm_http_server_for_fp8_validation()
+    server.config = SimpleNamespace(
+        quantization=None,
+        quantization_config_file=None,
+        tensor_model_parallel_size=2,
+        qat={
+            "enable": True,
+            "mode": "w8a16",
+            "weight_block_size": [64, 64],
+            "quantization_config_path": None,
+        },
+    )
+
+    quantization, hf_overrides = vLLMHttpServer._apply_quantization(server)
+
+    assert quantization is None
+    assert "quantization_config" not in hf_overrides
+    assert "VERL_VLLM_FP8_QUANT_ENABLED" not in os.environ

--- a/tests/utils/test_qat_fp8.py
+++ b/tests/utils/test_qat_fp8.py
@@ -20,10 +20,9 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
+from verl.utils.device import is_torch_npu_available
 from verl.utils.fp8_utils import FP8QuantizerHelper
 from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
-from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter, _QuantMeta
-from verl.utils.modelopt.quantize import build_quantize_config
 from verl.utils.qat import QATConfig, is_fp8_qat_mode, load_quantization_config
 from verl.utils.qat.linear import QATLinear, QATMode, fp8_fake_quant_blockwise
 from verl.utils.qat.quantizer import QATQuantizer
@@ -32,6 +31,26 @@ from verl.utils.qat.quantizer import QATQuantizer
 class _FakeModel:
     def load_weights(self, weights):
         return [name for name, _ in weights]
+
+
+def _import_modelopt_quantize():
+    pytest.importorskip("modelopt.torch.quantization.config")
+    from verl.utils.modelopt.quantize import build_quantize_config
+
+    return build_quantize_config
+
+
+def _import_modelopt_exporter():
+    for module in (
+        "modelopt.torch.export.quant_utils",
+        "modelopt.torch.quantization.qtensor.fp8_tensor",
+        "modelopt.torch.quantization.qtensor.nvfp4_tensor",
+    ):
+        pytest.importorskip(module)
+
+    from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter, _QuantMeta
+
+    return QATWeightExporter, _QuantMeta
 
 
 def _make_worker(model):
@@ -150,7 +169,10 @@ def test_fp8_quantizer_helper_preserves_2d_scale_with_single_column(monkeypatch)
     assert output["model.layers.0.self_attn.q_proj.weight_scale_inv"].shape == (1, 1)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA for Triton FP8 path")
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or is_torch_npu_available(check_device=False),
+    reason="requires CUDA for Triton FP8 path",
+)
 def test_fp8_fake_quant_uses_cuda_path_backward():
     x = torch.randn(9, 17, device="cuda", dtype=torch.bfloat16)
 
@@ -167,6 +189,8 @@ def test_fp8_fake_quant_uses_cuda_path_backward():
 
 
 def test_modelopt_fp8_config_uses_weight_block_size():
+    build_quantize_config = _import_modelopt_quantize()
+
     config = build_quantize_config("fp8", weight_block_size=[64, 128])
     weight_quantizer = config["quant_cfg"]["*weight_quantizer"]
 
@@ -176,8 +200,10 @@ def test_modelopt_fp8_config_uses_weight_block_size():
 
 
 def test_modelopt_fp8_qat_disables_lora_adapter_quantizers():
-    import modelopt.torch.quantization as mtq
     import torch.nn as nn
+
+    mtq = pytest.importorskip("modelopt.torch.quantization")
+    build_quantize_config = _import_modelopt_quantize()
 
     class AdapterModel(nn.Module):
         def __init__(self):
@@ -224,6 +250,8 @@ def test_qat_local_name_patch_skips_modelopt_quantizer_params(monkeypatch):
 
 
 def test_qat_weight_exporter_serializes_fp8_from_qat_metadata():
+    QATWeightExporter, _QuantMeta = _import_modelopt_exporter()
+
     exporter = QATWeightExporter.__new__(QATWeightExporter)
     exporter.qat_mode = "w8a8"
     weight = torch.randn(3, 5)
@@ -242,6 +270,8 @@ def test_qat_weight_exporter_serializes_fp8_from_qat_metadata():
 
 
 def test_qat_weight_exporter_dequantizes_fp8_for_w8a16_rollout():
+    QATWeightExporter, _QuantMeta = _import_modelopt_exporter()
+
     exporter = QATWeightExporter.__new__(QATWeightExporter)
     exporter.qat_mode = "w8a16"
     weight = torch.randn(3, 5, dtype=torch.bfloat16)
@@ -339,7 +369,7 @@ def test_vllm19_fp8_linear_processing_preserves_refit_param_metadata():
 def test_te_grouped_weight_calibration_skips_original_plain_weight_lookup(monkeypatch):
     import contextlib
 
-    import modelopt.torch.quantization.model_calib as model_calib
+    model_calib = pytest.importorskip("modelopt.torch.quantization.model_calib")
 
     from verl.utils.modelopt.megatron_qat_patch import (
         apply_te_grouped_weight_calibration_patch,

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -71,6 +71,7 @@ actor_rollout_ref:
         enable: false
         mode: w4a16
         group_size: 16
+        weight_block_size: null
         ignore_patterns:
         - lm_head
         - '*mlp.gate'
@@ -162,6 +163,7 @@ actor_rollout_ref:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - embed_tokens
@@ -252,6 +254,7 @@ actor_rollout_ref:
         enable: false
         mode: w4a16
         group_size: 16
+        weight_block_size: null
         ignore_patterns:
         - lm_head
         - '*mlp.gate'
@@ -560,6 +563,7 @@ critic:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - '*mlp.gate'

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -133,6 +133,7 @@ actor_rollout_ref:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - embed_tokens

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -50,6 +50,7 @@ actor_rollout_ref:
         enable: false
         mode: w4a16
         group_size: 16
+        weight_block_size: null
         ignore_patterns:
         - lm_head
         - embed_tokens
@@ -142,6 +143,7 @@ actor_rollout_ref:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - embed_tokens
@@ -223,6 +225,7 @@ actor_rollout_ref:
         enable: false
         mode: w4a16
         group_size: 16
+        weight_block_size: null
         ignore_patterns:
         - lm_head
         - embed_tokens
@@ -513,6 +516,7 @@ critic:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - embed_tokens

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -136,6 +136,7 @@ actor_rollout_ref:
       enable: false
       mode: w4a16
       group_size: 16
+      weight_block_size: null
       ignore_patterns:
       - lm_head
       - embed_tokens

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -286,9 +286,9 @@ router_replay:
 # QAT (Quantization-Aware Training) configuration
 # When enabled:
 #   - QAT is automatically applied to actor model during training
-#   - Fused scales (QKV/GateUp) are automatically enabled for training-inference consistency
-#   - Fast quantization is used when syncing weights to vLLM rollout
-# Supported modes: "w4a16" (NVFP4 weight-only)
+#   - Fused scales (QKV/GateUp) are automatically enabled for NVFP4 training-inference consistency
+#   - Fast quantization is used when syncing NVFP4 weights to vLLM rollout
+# Supported modes: "w4a16", "w4a4", "fp8"/"w8a8", and "w8a16"
 # Note: "w4a4" mode is included in the code but currently has KL divergence issues and is NOT recommended for use.
 # For usage examples, see: https://github.com/verl-project/verl-recipe/blob/main/qat/README.md
 qat:
@@ -296,11 +296,15 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only). "w4a4" is experimental and not recommended.
+  # Quantization mode: "w4a16" (weight-only FP4), "w4a4" (FP4 weight + activation),
+  # "fp8"/"w8a8" (FP8 weight + activation), or "w8a16" (weight-only FP8).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)
   group_size: 16
+
+  # 2D FP8 weight block size. Defaults to [128, 128] when mode is FP8.
+  weight_block_size: null
 
   # Patterns to ignore (e.g., lm_head, embed_tokens)
   ignore_patterns:

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -71,11 +71,15 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only). "w4a4" is experimental and not recommended.
+  # Quantization mode: "w4a16" (weight-only FP4), "w4a4" (FP4 weight + activation),
+  # "fp8"/"w8a8" (FP8 weight + activation), or "w8a16" (weight-only FP8).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)
   group_size: 16
+
+  # 2D FP8 weight block size. Defaults to [128, 128] when mode is FP8.
+  weight_block_size: null
 
   # Patterns to ignore (e.g., lm_head, embed_tokens)
   ignore_patterns:

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -126,10 +126,13 @@ qat:
   _target_: verl.workers.config.QATEngineConfig
   # Whether to enable QAT
   enable: false
-  # Quantization mode: "w4a16" (weight-only FP4) or "w4a4" (weight + activation FP4)
+  # Quantization mode: "w4a16" (weight-only FP4) or "w4a4" (weight + activation FP4),
+  # "fp8"/"w8a8" (FP8 weight + activation), or "w8a16" (weight-only FP8)
   mode: "w4a16"
   # Group size for blockwise quantization (NVFP4 requires 16)
   group_size: 16
+  # 2D FP8 weight block size. Defaults to [128, 128] when mode is FP8.
+  weight_block_size: null
   # Module name patterns to exclude from quantization (fnmatch style for Megatron)
   ignore_patterns:
     - "lm_head"

--- a/verl/utils/kernel/fp8_kernel.py
+++ b/verl/utils/kernel/fp8_kernel.py
@@ -271,8 +271,14 @@ def _scaled_fp8_blockwise_pytorch(
     data_hp = data_hp.reshape(blk_m, block_size0, blk_n, block_size1)
     data_hp = data_hp.permute(0, 2, 1, 3).contiguous()
 
-    # Flatten to (BLK_M, BLK_N, BLOCK_SIZE_M * BLOCK_SIZE_N) in float32 for precision
-    data_hp = data_hp.to(dtype=torch.float32, copy=True).flatten(start_dim=2)
+    # Flatten to (BLK_M, BLK_N, BLOCK_SIZE_M * BLOCK_SIZE_N) in float32 for precision.
+    # Float32 inputs need an explicit clone because the in-place scale/clamp below
+    # must not mutate the caller tensor when contiguous() can keep a view.
+    if data_hp.dtype == torch.float32:
+        data_hp = data_hp.clone()
+    else:
+        data_hp = data_hp.to(dtype=torch.float32)
+    data_hp = data_hp.flatten(start_dim=2)
 
     # Calculate max absolute value per block - use fused abs+amax
     max_abs = data_hp.abs().amax(dim=-1, keepdim=True)

--- a/verl/utils/kernel/fp8_kernel.py
+++ b/verl/utils/kernel/fp8_kernel.py
@@ -219,9 +219,8 @@ def scaled_fp8_blockwise_triton(
     if pad_dim0 > 0 or pad_dim1 > 0:
         fp_data = fp_data[: original_shape[0], : original_shape[1]].contiguous()
 
-    # Return scale as descale (the Triton kernel returns scale, we need to return it as-is
-    # since it's already the inverse scale format expected by vLLM/SGLang)
-    return fp_data, scale
+    # Keep the public scale layout consistent with the PyTorch fallback.
+    return fp_data, scale.unsqueeze(-1)
 
 
 def _scaled_fp8_blockwise_pytorch(
@@ -246,7 +245,6 @@ def _scaled_fp8_blockwise_pytorch(
     """
     block_size0 = weight_block_size[0]
     block_size1 = weight_block_size[1]
-    assert block_size0 == block_size1, "Block sizes must be equal"
 
     # Save unpadded shape for later cropping
     original_shape = data_hp.shape
@@ -274,7 +272,7 @@ def _scaled_fp8_blockwise_pytorch(
     data_hp = data_hp.permute(0, 2, 1, 3).contiguous()
 
     # Flatten to (BLK_M, BLK_N, BLOCK_SIZE_M * BLOCK_SIZE_N) in float32 for precision
-    data_hp = data_hp.to(torch.float32).flatten(start_dim=2)
+    data_hp = data_hp.to(dtype=torch.float32, copy=True).flatten(start_dim=2)
 
     # Calculate max absolute value per block - use fused abs+amax
     max_abs = data_hp.abs().amax(dim=-1, keepdim=True)
@@ -334,7 +332,7 @@ def scaled_fp8_blockwise(
     assert len(data_hp.shape) == 2, "Only 2d input tensor is supported"
 
     # Use Triton kernel if available and not disabled
-    if _TRITON_AVAILABLE and not _DISABLE_TRITON_FP8:
+    if _TRITON_AVAILABLE and data_hp.is_cuda and not _DISABLE_TRITON_FP8:
         return scaled_fp8_blockwise_triton(data_hp, weight_block_size)
 
     # PyTorch fallback implementation (memory-optimized)

--- a/verl/utils/modelopt/__init__.py
+++ b/verl/utils/modelopt/__init__.py
@@ -15,36 +15,29 @@
 
 """ModelOpt integration for NVFP4 quantization with Megatron QAT training and vLLM inference."""
 
-from verl.utils.modelopt.megatron_qat_patch import (
-    apply_qat_patch,
-    revert_qat_patch,
-)
-from verl.utils.modelopt.qat_utils import (
-    apply_qat_to_modules,
-    export_qat_weights,
-    patch_provider_for_qat,
-)
-from verl.utils.modelopt.qat_weight_exporter import QATWeightExporter
-from verl.utils.modelopt.quantize import (
-    apply_qat,
-    build_quantize_config,
-)
-from verl.utils.modelopt.vllm_modelopt_patch import (
-    apply_modelopt_nvfp4_patches,
-    modelopt_process_weights_after_loading,
-    prepare_modelopt_for_weight_reload,
-)
+from importlib import import_module
 
-__all__ = [
-    "build_quantize_config",
-    "apply_qat",
-    "QATWeightExporter",
-    "apply_modelopt_nvfp4_patches",
-    "prepare_modelopt_for_weight_reload",
-    "modelopt_process_weights_after_loading",
-    "apply_qat_patch",
-    "revert_qat_patch",
-    "patch_provider_for_qat",
-    "apply_qat_to_modules",
-    "export_qat_weights",
-]
+_EXPORTS = {
+    "megatron_qat_patch": ("apply_qat_patch", "revert_qat_patch"),
+    "qat_utils": ("patch_provider_for_qat", "apply_qat_to_modules", "export_qat_weights"),
+    "qat_weight_exporter": ("QATWeightExporter",),
+    "quantize": ("build_quantize_config", "apply_qat"),
+    "vllm_modelopt_patch": (
+        "apply_modelopt_nvfp4_patches",
+        "prepare_modelopt_for_weight_reload",
+        "modelopt_process_weights_after_loading",
+    ),
+}
+_MODULE_BY_ATTR = {attr: f"verl.utils.modelopt.{module}" for module, attrs in _EXPORTS.items() for attr in attrs}
+
+__all__ = list(_MODULE_BY_ATTR)
+
+
+def __getattr__(name):
+    module_name = _MODULE_BY_ATTR.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    attr = getattr(import_module(module_name), name)
+    globals()[name] = attr
+    return attr

--- a/verl/utils/modelopt/megatron_qat_patch.py
+++ b/verl/utils/modelopt/megatron_qat_patch.py
@@ -23,6 +23,10 @@ from typing import Optional
 import torch
 
 
+def _is_modelopt_quantizer_param_name(param_name: str) -> bool:
+    return "_quantizer" in param_name
+
+
 def apply_swiglu_sharded_factory_patch():
     """Patch ``apply_swiglu_sharded_factory`` to support ``singleton_local_shards``."""
     import megatron.core.transformer.mlp as mlp_module
@@ -282,6 +286,9 @@ def apply_local_name_to_global_patch():
     _orig_fn = bridge_module._megatron_local_name_to_global
 
     def _patched_megatron_local_name_to_global(models, config, param_name, vp_stage=None):
+        if _is_modelopt_quantizer_param_name(param_name):
+            return param_name
+
         param_name = _orig_fn(models, config, param_name, vp_stage)
 
         ep_group = parallel_state.get_expert_model_parallel_group()
@@ -326,7 +333,7 @@ def apply_skip_quantizer_params_patch():
     def _patched_is_adapter_param_name(self, param_name: str) -> bool:
         if _orig(self, param_name):
             return True
-        return "_quantizer" in param_name
+        return _is_modelopt_quantizer_param_name(param_name)
 
     MegatronModelBridge._is_adapter_param_name = _patched_is_adapter_param_name
 
@@ -353,6 +360,8 @@ def apply_detect_parallelism_type_patch():
 
     def _patched_detect_parallelism_type(self, module):
         module_type = type(module).__name__
+        if module_type == "Linear" and type(module).__module__ == "megatron.core.post_training.modelopt.layers":
+            return "replicated"
         if "LayerNormColumnParallelLinear" in module_type:
             if self.megatron_param and (
                 self.megatron_param.endswith("layer_norm_weight") or self.megatron_param.endswith("layer_norm_bias")
@@ -374,6 +383,59 @@ def revert_detect_parallelism_type_patch():
     AutoMapping._detect_parallelism_patched = False
 
 
+def apply_te_grouped_weight_calibration_patch():
+    """Patch ModelOpt weight-only calibration for TE grouped linear weights."""
+    import modelopt.torch.quantization.model_calib as model_calib
+
+    if getattr(model_calib, "_te_grouped_weight_calib_patched", False):
+        return
+    model_calib._te_grouped_weight_calib_patched = True
+    model_calib._original_weight_only_quantize = model_calib.weight_only_quantize
+
+    def _te_grouped_weight_names(module):
+        if not hasattr(module, "weight_quantizer"):
+            return []
+        if not hasattr(module, "num_gemms"):
+            return []
+        weight_names = [name for name, _ in module.named_parameters(recurse=False) if re.fullmatch(r"weight\d+", name)]
+        return sorted(weight_names, key=lambda name: int(name.removeprefix("weight")))
+
+    def _patched_weight_only_quantize(model):
+        for _, module in model.named_modules():
+            grouped_weight_names = _te_grouped_weight_names(module)
+            if not grouped_weight_names:
+                continue
+
+            with model_calib.enable_weight_access_and_writeback(module, model):
+                for weight_name in grouped_weight_names:
+                    module.weight_quantizer(getattr(module, weight_name))
+
+        original_weight_attr_names = model_calib.weight_attr_names
+
+        def _skip_te_grouped_weight_names(module):
+            if _te_grouped_weight_names(module):
+                return
+            yield from original_weight_attr_names(module)
+
+        try:
+            model_calib.weight_attr_names = _skip_te_grouped_weight_names
+            model_calib._original_weight_only_quantize(model)
+        finally:
+            model_calib.weight_attr_names = original_weight_attr_names
+
+    model_calib.weight_only_quantize = _patched_weight_only_quantize
+
+
+def revert_te_grouped_weight_calibration_patch():
+    """Revert the TE grouped linear weight-only calibration patch."""
+    import modelopt.torch.quantization.model_calib as model_calib
+
+    if not getattr(model_calib, "_te_grouped_weight_calib_patched", False):
+        return
+    model_calib.weight_only_quantize = model_calib._original_weight_only_quantize
+    model_calib._te_grouped_weight_calib_patched = False
+
+
 def apply_qat_patch():
     """Apply all QAT-related patches."""
     apply_swiglu_sharded_factory_patch()
@@ -382,6 +444,7 @@ def apply_qat_patch():
     apply_local_name_to_global_patch()
     apply_skip_quantizer_params_patch()
     apply_detect_parallelism_type_patch()
+    apply_te_grouped_weight_calibration_patch()
 
 
 def revert_qat_patch():
@@ -392,3 +455,4 @@ def revert_qat_patch():
     revert_local_name_to_global_patch()
     revert_skip_quantizer_params_patch()
     revert_detect_parallelism_type_patch()
+    revert_te_grouped_weight_calibration_patch()

--- a/verl/utils/modelopt/megatron_qat_patch.py
+++ b/verl/utils/modelopt/megatron_qat_patch.py
@@ -27,6 +27,22 @@ def _is_modelopt_quantizer_param_name(param_name: str) -> bool:
     return "_quantizer" in param_name
 
 
+def _module_matches_class(module, expected_cls: type) -> bool:
+    if isinstance(module, expected_cls):
+        return True
+
+    get_original_cls = getattr(module, "get_original_cls_by_level", None)
+    if not callable(get_original_cls):
+        return False
+
+    try:
+        original_cls = get_original_cls(level=0)
+    except TypeError:
+        original_cls = get_original_cls(0)
+
+    return isinstance(original_cls, type) and issubclass(original_cls, expected_cls)
+
+
 def apply_swiglu_sharded_factory_patch():
     """Patch ``apply_swiglu_sharded_factory`` to support ``singleton_local_shards``."""
     import megatron.core.transformer.mlp as mlp_module
@@ -353,6 +369,11 @@ def apply_detect_parallelism_type_patch():
     ``LayerNormColumnParallelLinear`` variants via substring matching."""
     from megatron.bridge.models.conversion.param_mapping import AutoMapping
 
+    try:
+        from megatron.core.post_training.modelopt.layers import Linear as ModelOptLinear
+    except ImportError:
+        ModelOptLinear = None
+
     if getattr(AutoMapping, "_detect_parallelism_patched", False):
         return
     AutoMapping._detect_parallelism_patched = True
@@ -360,7 +381,7 @@ def apply_detect_parallelism_type_patch():
 
     def _patched_detect_parallelism_type(self, module):
         module_type = type(module).__name__
-        if module_type == "Linear" and type(module).__module__ == "megatron.core.post_training.modelopt.layers":
+        if ModelOptLinear is not None and _module_matches_class(module, ModelOptLinear):
             return "replicated"
         if "LayerNormColumnParallelLinear" in module_type:
             if self.megatron_param and (

--- a/verl/utils/modelopt/qat_utils.py
+++ b/verl/utils/modelopt/qat_utils.py
@@ -19,11 +19,11 @@
 def patch_provider_for_qat(provider):
     """Patch the Megatron-Bridge provider to support QAT quantized layers."""
     from megatron.bridge.models.conversion.param_mapping import AutoMapping
-    from megatron.bridge.models.gpt_provider import quantization_layer_spec
+    from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec
 
     from verl.utils.modelopt.megatron_qat_patch import apply_qat_patch
 
-    provider.transformer_layer_spec = quantization_layer_spec
+    provider.transformer_layer_spec = modelopt_transformer_layer_spec
     apply_qat_patch()
     AutoMapping.register_module_type("QuantColumnParallelLinear", "column")
     AutoMapping.register_module_type("QuantRowParallelLinear", "row")
@@ -41,12 +41,18 @@ def apply_qat_to_modules(modules, qat_config):
     from verl.utils.modelopt.quantize import apply_qat
 
     qat_mode = _get_qat_field(qat_config, "mode", "w4a16")
+    weight_block_size = _get_qat_field(qat_config, "weight_block_size", None)
     ignore_patterns = _get_qat_field(qat_config, "ignore_patterns", None)
     if ignore_patterns is not None:
         ignore_patterns = list(ignore_patterns)
 
     for i in range(len(modules)):
-        modules[i] = apply_qat(modules[i], qat_mode, ignore_patterns=ignore_patterns)
+        modules[i] = apply_qat(
+            modules[i],
+            qat_mode,
+            ignore_patterns=ignore_patterns,
+            weight_block_size=weight_block_size,
+        )
     return modules
 
 

--- a/verl/utils/modelopt/qat_weight_exporter.py
+++ b/verl/utils/modelopt/qat_weight_exporter.py
@@ -21,12 +21,15 @@ from typing import Any, Iterator, Optional
 
 import torch
 from modelopt.torch.export.quant_utils import (
+    QUANTIZATION_FP8_PB_REAL,
+    QUANTIZATION_FP8_PB_WO,
     QUANTIZATION_NONE,
     QUANTIZATION_NVFP4,
     get_quantization_format,
     get_weight_block_size,
     to_quantized_weight,
 )
+from modelopt.torch.quantization.qtensor.fp8_tensor import FP8QTensor
 from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
 
 from verl.utils.megatron_utils import unwrap_model
@@ -41,13 +44,14 @@ class _QuantMeta:
 
     qformat: str
     block_size: int
+    block_sizes: Optional[dict[int, int]]
     weight_amax: Optional[torch.Tensor]
     input_amax: Optional[torch.Tensor] = None
     input_quantizer: Any = None
 
 
 class QATWeightExporter:
-    """Export QAT-trained bf16 weights as quantized weights (e.g. NVFP4)."""
+    """Export QAT-trained weights in the format expected by rollout workers."""
 
     def __init__(
         self,
@@ -96,8 +100,12 @@ class QATWeightExporter:
             if meta is None:
                 yield (hf_name, weight)
             else:
-                assert meta.qformat == QUANTIZATION_NVFP4, f"Unsupported qformat: {meta.qformat}"
-                yield from self._quantize_nvfp4(hf_name, weight, meta)
+                if meta.qformat == QUANTIZATION_NVFP4:
+                    yield from self._quantize_nvfp4(hf_name, weight, meta)
+                elif meta.qformat in {QUANTIZATION_FP8_PB_REAL, QUANTIZATION_FP8_PB_WO}:
+                    yield from self._quantize_fp8_blockwise(hf_name, weight, meta)
+                else:
+                    raise AssertionError(f"Unsupported qformat: {meta.qformat}")
 
     @staticmethod
     def _get_mapping_registry(bridge):
@@ -134,10 +142,12 @@ class QATWeightExporter:
                 i_q = getattr(submodule, "input_quantizer", None)
                 w_amax = w_q._amax.clone().cpu() if w_q and getattr(w_q, "_amax", None) is not None else None
                 i_amax = i_q._amax.clone().cpu() if i_q and getattr(i_q, "_amax", None) is not None else None
+                block_sizes = dict(w_q.block_sizes) if w_q and getattr(w_q, "block_sizes", None) else None
 
                 meta = _QuantMeta(
                     qformat=qformat,
                     block_size=block_size,
+                    block_sizes=block_sizes,
                     weight_amax=w_amax,
                     input_amax=i_amax,
                     input_quantizer=i_q,
@@ -178,6 +188,7 @@ class QATWeightExporter:
             name: {
                 "qformat": m.qformat,
                 "block_size": m.block_size,
+                "block_sizes": m.block_sizes,
                 "weight_amax": m.weight_amax,
                 "input_amax": m.input_amax,
             }
@@ -196,6 +207,7 @@ class QATWeightExporter:
                 self._metadata[name] = _QuantMeta(
                     qformat=info["qformat"],
                     block_size=info["block_size"],
+                    block_sizes=info["block_sizes"],
                     weight_amax=info["weight_amax"],
                     input_amax=info["input_amax"],
                     input_quantizer=None,
@@ -245,6 +257,30 @@ class QATWeightExporter:
         if input_scale is not None:
             yield (_derive_scale_name(name, "input_scale"), input_scale)
 
+    def _quantize_fp8_blockwise(
+        self,
+        name: str,
+        weight: torch.Tensor,
+        meta: _QuantMeta,
+    ) -> Iterator[tuple[str, torch.Tensor]]:
+        """Export FP8 QAT weights for vLLM rollout.
+
+        W8A8 rollout consumes serialized FP8 blockwise weights and scales.
+        W8A16 rollout stays BF16 and consumes the dequantized fake-quant weight
+        so rollout matches the actor-side QAT numerics without FP8 activation
+        quantization.
+        """
+        if meta.block_sizes is None:
+            raise ValueError(f"FP8 blockwise export requires block_sizes for {name}")
+
+        quantized, scale = FP8QTensor.quantize(weight, block_sizes=meta.block_sizes)
+        if str(getattr(self, "qat_mode", "")).lower() == "w8a16":
+            yield (name, _dequantize_fp8_blockwise(quantized._quantized_data, scale, meta.block_sizes, weight.dtype))
+            return
+
+        yield (name, quantized._quantized_data)
+        yield (_derive_scale_name(name, "weight_scale_inv"), scale)
+
 
 def _iter_hf_to_megatron_matches(registry, hf_name: str):
     """Yield all resolved mappings whose HF pattern matches *hf_name*."""
@@ -273,6 +309,23 @@ def _iter_hf_to_megatron_matches(registry, hf_name: str):
 def _derive_scale_name(weight_name: str, suffix: str) -> str:
     result = weight_name.replace(".weight", f".{suffix}")
     return result if result != weight_name else f"{weight_name}_{suffix}"
+
+
+def _dequantize_fp8_blockwise(
+    quantized_weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_sizes: dict[int, int],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    block_m = int(block_sizes[-2])
+    block_n = int(block_sizes[-1])
+    if scale.dim() == 3 and scale.shape[-1] == 1:
+        scale = scale.squeeze(-1)
+
+    expanded_scale = scale.to(device=quantized_weight.device, dtype=torch.float32)
+    expanded_scale = expanded_scale.repeat_interleave(block_m, dim=0).repeat_interleave(block_n, dim=1)
+    expanded_scale = expanded_scale[: quantized_weight.shape[0], : quantized_weight.shape[1]]
+    return (quantized_weight.to(torch.float32) * expanded_scale).to(dtype)
 
 
 def _compute_input_scale(meta: _QuantMeta) -> Optional[torch.Tensor]:

--- a/verl/utils/modelopt/qat_weight_exporter.py
+++ b/verl/utils/modelopt/qat_weight_exporter.py
@@ -20,19 +20,6 @@ from dataclasses import dataclass
 from typing import Any, Iterator, Optional
 
 import torch
-from modelopt.torch.export.quant_utils import (
-    QUANTIZATION_FP8_PB_REAL,
-    QUANTIZATION_FP8_PB_WO,
-    QUANTIZATION_NONE,
-    QUANTIZATION_NVFP4,
-    get_quantization_format,
-    get_weight_block_size,
-    to_quantized_weight,
-)
-from modelopt.torch.quantization.qtensor.fp8_tensor import FP8QTensor
-from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-
-from verl.utils.megatron_utils import unwrap_model
 
 # NVFP4 two-level scaling denominator: FP4_MAX (6.0) * FP8_MAX (448.0).
 _NVFP4_AMAX_DENOMINATOR = 6.0 * 448.0
@@ -95,14 +82,19 @@ class QATWeightExporter:
         quantized weight plus its scaling factors when the parameter is
         quantized, or the original tensor unchanged otherwise.
         """
+        from modelopt.torch.export import quant_utils
+
         for hf_name, weight in per_tensor_param:
             meta = self._resolve_quant_metadata(hf_name)
             if meta is None:
                 yield (hf_name, weight)
             else:
-                if meta.qformat == QUANTIZATION_NVFP4:
+                if meta.qformat == quant_utils.QUANTIZATION_NVFP4:
                     yield from self._quantize_nvfp4(hf_name, weight, meta)
-                elif meta.qformat in {QUANTIZATION_FP8_PB_REAL, QUANTIZATION_FP8_PB_WO}:
+                elif meta.qformat in {
+                    quant_utils.QUANTIZATION_FP8_PB_REAL,
+                    quant_utils.QUANTIZATION_FP8_PB_WO,
+                }:
                     yield from self._quantize_fp8_blockwise(hf_name, weight, meta)
                 else:
                     raise AssertionError(f"Unsupported qformat: {meta.qformat}")
@@ -113,11 +105,15 @@ class QATWeightExporter:
 
     @staticmethod
     def _get_model_config(actor_module):
+        from verl.utils.megatron_utils import unwrap_model
+
         model = unwrap_model(actor_module[0])
         return getattr(model, "config", None)
 
     @staticmethod
     def _count_local_experts(actor_module) -> int:
+        from verl.utils.megatron_utils import unwrap_model
+
         indices: set[int] = set()
         for module in actor_module:
             model = unwrap_model(module)
@@ -128,13 +124,17 @@ class QATWeightExporter:
         return max(indices) + 1 if indices else 0
 
     def _collect_metadata(self, actor_module: list) -> None:
+        from modelopt.torch.export import quant_utils
+
+        from verl.utils.megatron_utils import unwrap_model
+
         for vpp_idx, module in enumerate(actor_module):
             model = unwrap_model(module)
             for name, submodule in model.named_modules():
-                qformat = get_quantization_format(submodule)
-                if qformat == QUANTIZATION_NONE:
+                qformat = quant_utils.get_quantization_format(submodule)
+                if qformat == quant_utils.QUANTIZATION_NONE:
                     continue
-                block_size = get_weight_block_size(submodule)
+                block_size = quant_utils.get_weight_block_size(submodule)
                 if block_size == 0:
                     continue
 
@@ -238,6 +238,9 @@ class QATWeightExporter:
           ``(weight_scale_2, global_scale_from_amax)``
           ``(input_scale, activation_scale)`` -- only when available
         """
+        from modelopt.torch.export.quant_utils import to_quantized_weight
+        from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
+
         w_amax = meta.weight_amax.to(weight.device)
         w_scale_2 = w_amax.float() / _NVFP4_AMAX_DENOMINATOR
 
@@ -272,6 +275,8 @@ class QATWeightExporter:
         """
         if meta.block_sizes is None:
             raise ValueError(f"FP8 blockwise export requires block_sizes for {name}")
+
+        from modelopt.torch.quantization.qtensor.fp8_tensor import FP8QTensor
 
         quantized, scale = FP8QTensor.quantize(weight, block_sizes=meta.block_sizes)
         if str(getattr(self, "qat_mode", "")).lower() == "w8a16":
@@ -329,6 +334,8 @@ def _dequantize_fp8_blockwise(
 
 
 def _compute_input_scale(meta: _QuantMeta) -> Optional[torch.Tensor]:
+    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
+
     if meta.input_quantizer is not None:
         if hasattr(NVFP4QTensor, "get_activation_scaling_factor"):
             return NVFP4QTensor.get_activation_scaling_factor(meta.input_quantizer)

--- a/verl/utils/modelopt/quantize.py
+++ b/verl/utils/modelopt/quantize.py
@@ -13,11 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""ModelOpt NVFP4 quantization config and application for Megatron QAT."""
+"""ModelOpt quantization config and application for Megatron QAT."""
+
+import copy
 
 import modelopt.torch.quantization as mtq
 import torch.nn as nn
-from modelopt.torch.quantization.config import _default_disabled_quantizer_cfg
+from modelopt.torch.quantization.config import FP8_2D_BLOCKWISE_WEIGHT_ONLY_CFG, _default_disabled_quantizer_cfg
+
+from verl.utils.qat.core import get_fp8_weight_block_size, is_fp8_qat_mode, normalize_qat_mode
 
 _NVFP4_W4A16_QUANTIZER_CFG = {
     "*weight_quantizer": {
@@ -31,7 +35,10 @@ _NVFP4_W4A16_QUANTIZER_CFG = {
 
 
 def _ignore_patterns_to_quant_cfg(ignore_patterns: list[str]) -> dict:
-    cfg = {}
+    cfg = {
+        "*adapter*": {"enable": False},
+        "*lora*": {"enable": False},
+    }
     mapping = {
         "lm_head": "*output_layer*",
         "*mlp.gate": "*router*",
@@ -48,21 +55,35 @@ def _ignore_patterns_to_quant_cfg(ignore_patterns: list[str]) -> dict:
 def build_quantize_config(
     qat_mode: str,
     ignore_patterns: list[str] | None = None,
+    weight_block_size: list[int] | None = None,
 ) -> dict:
     """Build a complete ModelOpt quantization config for ``mtq.quantize``."""
-    if qat_mode != "w4a16":
-        raise ValueError(f"Only 'w4a16' is supported, got: {qat_mode}")
-
     if ignore_patterns is None:
         ignore_patterns = []
 
     ignore_cfg = _ignore_patterns_to_quant_cfg(ignore_patterns)
 
-    quant_cfg = {
-        **_NVFP4_W4A16_QUANTIZER_CFG,
-        **_default_disabled_quantizer_cfg,
-        **ignore_cfg,
-    }
+    qat_mode = normalize_qat_mode(qat_mode)
+    if qat_mode == "w4a16":
+        quant_cfg = {
+            **_NVFP4_W4A16_QUANTIZER_CFG,
+            **_default_disabled_quantizer_cfg,
+            **ignore_cfg,
+        }
+    elif is_fp8_qat_mode(qat_mode):
+        fp8_cfg = copy.deepcopy(FP8_2D_BLOCKWISE_WEIGHT_ONLY_CFG["quant_cfg"])
+        fp8_block_m, fp8_block_n = get_fp8_weight_block_size(weight_block_size)
+        fp8_cfg["*weight_quantizer"]["block_sizes"] = {-1: fp8_block_n, -2: fp8_block_m}
+        if qat_mode == "w8a8":
+            fp8_cfg["*input_quantizer"] = {"num_bits": (4, 3), "axis": None, "enable": True}
+        quant_cfg = {
+            **fp8_cfg,
+            **_default_disabled_quantizer_cfg,
+            **ignore_cfg,
+        }
+    else:
+        raise ValueError(f"Unsupported QAT mode for Megatron ModelOpt: {qat_mode}")
+
     return {"quant_cfg": quant_cfg, "algorithm": "max"}
 
 
@@ -70,8 +91,9 @@ def apply_qat(
     model: nn.Module,
     qat_mode: str,
     ignore_patterns: list[str] | None = None,
+    weight_block_size: list[int] | None = None,
 ) -> nn.Module:
     """Apply Quantization-Aware Training to a Megatron model."""
-    config = build_quantize_config(qat_mode, ignore_patterns)
+    config = build_quantize_config(qat_mode, ignore_patterns, weight_block_size)
     mtq.quantize(model, config)
     return model

--- a/verl/utils/modelopt/quantize.py
+++ b/verl/utils/modelopt/quantize.py
@@ -17,9 +17,7 @@
 
 import copy
 
-import modelopt.torch.quantization as mtq
 import torch.nn as nn
-from modelopt.torch.quantization.config import FP8_2D_BLOCKWISE_WEIGHT_ONLY_CFG, _default_disabled_quantizer_cfg
 
 from verl.utils.qat.core import get_fp8_weight_block_size, is_fp8_qat_mode, normalize_qat_mode
 
@@ -58,6 +56,8 @@ def build_quantize_config(
     weight_block_size: list[int] | None = None,
 ) -> dict:
     """Build a complete ModelOpt quantization config for ``mtq.quantize``."""
+    from modelopt.torch.quantization.config import FP8_2D_BLOCKWISE_WEIGHT_ONLY_CFG, _default_disabled_quantizer_cfg
+
     if ignore_patterns is None:
         ignore_patterns = []
 
@@ -94,6 +94,8 @@ def apply_qat(
     weight_block_size: list[int] | None = None,
 ) -> nn.Module:
     """Apply Quantization-Aware Training to a Megatron model."""
+    import modelopt.torch.quantization as mtq
+
     config = build_quantize_config(qat_mode, ignore_patterns, weight_block_size)
     mtq.quantize(model, config)
     return model

--- a/verl/utils/qat/__init__.py
+++ b/verl/utils/qat/__init__.py
@@ -15,7 +15,7 @@
 """
 QAT (Quantization-Aware Training) module for verl.
 
-Supports NVFP4 (W4A4 and W4A16) quantization modes for FSDP training.
+Supports NVFP4 (W4A4 and W4A16) and FP8 QAT modes for FSDP training.
 
 Module Structure:
 - core.py: QATConfig, apply_qat, enable_qat_fuse (training setup)
@@ -33,9 +33,14 @@ Usage:
 from verl.utils.qat.core import (
     QATConfig,
     apply_qat,
+    build_fp8_quantization_config,
     enable_qat_fuse,
+    get_fp8_weight_block_size,
     invalidate_all_scales,
+    is_fp4_qat_mode,
+    is_fp8_qat_mode,
     load_quantization_config,
+    normalize_qat_mode,
 )
 from verl.utils.qat.vllm_patch import (
     apply_qat_patches,
@@ -48,6 +53,11 @@ __all__ = [
     "QATConfig",
     "apply_qat",
     "load_quantization_config",
+    "normalize_qat_mode",
+    "is_fp4_qat_mode",
+    "is_fp8_qat_mode",
+    "get_fp8_weight_block_size",
+    "build_fp8_quantization_config",
     "enable_qat_fuse",
     "invalidate_all_scales",
     # vLLM Patch

--- a/verl/utils/qat/core.py
+++ b/verl/utils/qat/core.py
@@ -34,22 +34,72 @@ class QATConfig(BaseConfig):
     enable: bool = False
     mode: str = "w4a16"
     group_size: int = 16
+    weight_block_size: Optional[list[int]] = None
     ignore_patterns: list[str] = field(default_factory=lambda: ["lm_head", "embed_tokens", "re:.*mlp.gate$"])
     activation_observer: str = "static_minmax"
     quantization_config_path: Optional[str] = None
 
 
+FP8_QAT_MODES = {"fp8", "w8a8", "w8a16"}
+FP4_QAT_MODES = {"w4a4", "w4a16"}
+DEFAULT_FP8_WEIGHT_BLOCK_SIZE = [128, 128]
+
+
+def normalize_qat_mode(mode: str) -> str:
+    """Normalize user-facing QAT mode aliases."""
+    mode = mode.lower()
+    if mode == "fp8":
+        return "w8a8"
+    return mode
+
+
+def is_fp8_qat_mode(mode: str) -> bool:
+    """Return True when *mode* is an FP8 QAT mode."""
+    return mode.lower() in FP8_QAT_MODES
+
+
+def is_fp4_qat_mode(mode: str) -> bool:
+    """Return True when *mode* is an NVFP4 QAT mode."""
+    return mode.lower() in FP4_QAT_MODES
+
+
+def get_fp8_weight_block_size(weight_block_size: Optional[list[int]] = None) -> list[int]:
+    """Return the 2D FP8 block size used by vLLM blockwise FP8."""
+    if weight_block_size is None:
+        return list(DEFAULT_FP8_WEIGHT_BLOCK_SIZE)
+    if len(weight_block_size) != 2:
+        raise ValueError(f"FP8 weight_block_size must have two entries, got: {weight_block_size}")
+    return [int(weight_block_size[0]), int(weight_block_size[1])]
+
+
+def build_fp8_quantization_config(weight_block_size: Optional[list[int]] = None) -> dict[str, Any]:
+    """Build the vLLM quantization config for FP8 QAT rollout."""
+    return {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "weight_block_size": get_fp8_weight_block_size(weight_block_size),
+    }
+
+
 def load_quantization_config(qat_config: QATConfig) -> dict[str, Any]:
     """Load quantization config JSON file from QATConfig."""
     if not qat_config.quantization_config_path:
-        raise ValueError("quantization_config_path is required when QAT is enabled")
+        if is_fp8_qat_mode(qat_config.mode):
+            return build_fp8_quantization_config(qat_config.weight_block_size)
+        raise ValueError("quantization_config_path is required when NVFP4 QAT is enabled")
 
     logger.info(f"Loading QAT quantization config from: {qat_config.quantization_config_path}")
 
     with open(qat_config.quantization_config_path) as f:
         quant_config = json.load(f)
 
-    if qat_config.ignore_patterns:
+    if quant_config.get("quant_method") == "fp8":
+        quant_config["weight_block_size"] = get_fp8_weight_block_size(
+            quant_config.get("weight_block_size") or qat_config.weight_block_size
+        )
+
+    if qat_config.ignore_patterns and quant_config.get("quant_method") in {"compressed-tensors", "modelopt"}:
         original_ignore = quant_config.get("ignore", [])
         quant_config["ignore"] = qat_config.ignore_patterns
         if original_ignore != qat_config.ignore_patterns:
@@ -64,6 +114,9 @@ def _should_quantize(name: str, module: nn.Module, config: QATConfig) -> bool:
     if not isinstance(module, nn.Linear):
         return False
 
+    if "lora_" in name or ".lora_" in name:
+        return False
+
     for pattern in config.ignore_patterns:
         if pattern.startswith("re:"):
             regex = pattern[3:]
@@ -75,7 +128,7 @@ def _should_quantize(name: str, module: nn.Module, config: QATConfig) -> bool:
                 logger.debug(f"Ignoring {name} due to pattern: {pattern}")
                 return False
 
-    if module.in_features % config.group_size != 0:
+    if is_fp4_qat_mode(config.mode) and module.in_features % config.group_size != 0:
         logger.warning(
             f"Skipping {name}: in_features={module.in_features} not divisible by group_size={config.group_size}"
         )
@@ -98,7 +151,7 @@ def apply_qat(
         logger.info("QAT is disabled, returning original model")
         return model
 
-    mode = QATMode(config.mode.lower())
+    mode = QATMode(normalize_qat_mode(config.mode))
     logger.info(f"Applying QAT with mode={mode.value}, group_size={config.group_size}")
 
     modules_to_replace = []
@@ -117,6 +170,7 @@ def apply_qat(
             module,
             mode=mode,
             group_size=config.group_size,
+            weight_block_size=config.weight_block_size,
             activation_observer=config.activation_observer,
         )
 

--- a/verl/utils/qat/linear.py
+++ b/verl/utils/qat/linear.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""QAT FakeQuantized Linear module for NVFP4 (W4A4/W4A16) with FSDP compatibility.
+"""QAT FakeQuantized Linear module for NVFP4 and FP8 with FSDP compatibility.
 
-Includes Triton kernels for high-performance FP4 quantization.
+Includes Triton kernels for high-performance FP4 and FP8 quantization.
 """
 
 from enum import Enum
@@ -30,6 +30,8 @@ __all__ = ["QATLinear", "QATMode"]
 import triton
 import triton.language as tl
 
+from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
+
 _TORCH_TO_TL_DTYPE = {
     torch.float32: tl.float32,
     torch.float16: tl.float16,
@@ -37,6 +39,7 @@ _TORCH_TO_TL_DTYPE = {
 }
 FP4_E2M1_MAX: float = 6.0
 FP8_E4M3_MAX: float = 448.0
+DEFAULT_FP8_WEIGHT_BLOCK_SIZE: tuple[int, int] = (128, 128)
 
 
 @triton.jit
@@ -185,11 +188,52 @@ class STEFP4QuantTriton(torch.autograd.Function):
         return grad_output, None, None
 
 
+def _dequantize_blockwise_fp8(
+    q: torch.Tensor,
+    descale: torch.Tensor,
+    block_size: tuple[int, int],
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize blockwise FP8 output from ``scaled_fp8_blockwise``."""
+    block_m, block_n = block_size
+    descale = descale.squeeze(-1)
+    descale = descale.to(torch.float32).repeat_interleave(block_m, dim=0).repeat_interleave(block_n, dim=1)
+    descale = descale[: q.shape[0], : q.shape[1]]
+    return (q.to(torch.float32) * descale).to(dtype)
+
+
+def fp8_fake_quant_blockwise(
+    x: torch.Tensor,
+    block_size: tuple[int, int],
+) -> torch.Tensor:
+    """Apply blockwise FP8 fake quantization and dequantize to the original dtype.
+
+    ``scaled_fp8_blockwise`` dispatches to Triton for CUDA tensors and uses its
+    PyTorch fallback otherwise.
+    """
+    q, descale = scaled_fp8_blockwise(x, weight_block_size=block_size)
+    return _dequantize_blockwise_fp8(q, descale, block_size, x.dtype)
+
+
+class STEFP8Quant(torch.autograd.Function):
+    """Straight-Through Estimator wrapper for FP8 blockwise fake quantization."""
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, block_m: int, block_n: int) -> torch.Tensor:
+        return fp8_fake_quant_blockwise(x, (block_m, block_n))
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple:
+        return grad_output, None, None
+
+
 class QATMode(str, Enum):
     """QAT quantization mode."""
 
     W4A4 = "w4a4"  # Weight 4-bit, Activation 4-bit (dynamic)
     W4A16 = "w4a16"  # Weight 4-bit, Activation 16-bit (weight only)
+    W8A8 = "w8a8"  # Weight 8-bit FP8, Activation 8-bit FP8 (dynamic)
+    W8A16 = "w8a16"  # Weight 8-bit FP8, Activation 16-bit (weight only)
 
 
 class QATLinear(nn.Linear):
@@ -204,6 +248,7 @@ class QATLinear(nn.Linear):
         bias: bool = True,
         mode: QATMode = QATMode.W4A4,
         group_size: int = 16,
+        weight_block_size: Optional[list[int] | tuple[int, int]] = None,
         activation_observer: str = "static_minmax",  # Observer strategy for activation global_scale
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
@@ -212,6 +257,9 @@ class QATLinear(nn.Linear):
 
         self.mode = mode
         self.group_size = group_size
+        self.weight_block_size = (
+            tuple(weight_block_size or DEFAULT_FP8_WEIGHT_BLOCK_SIZE) if self._is_fp8_mode() else None
+        )
         self.activation_observer = activation_observer
 
         self._weight_blockwise_scale: Optional[torch.Tensor] = None
@@ -238,6 +286,7 @@ class QATLinear(nn.Linear):
         linear: nn.Linear,
         mode: QATMode = QATMode.W4A4,
         group_size: int = 16,
+        weight_block_size: Optional[list[int] | tuple[int, int]] = None,
         activation_observer: str = "static_minmax",
     ) -> "QATLinear":
         """Create QATLinear from an existing nn.Linear."""
@@ -249,6 +298,7 @@ class QATLinear(nn.Linear):
             bias=has_bias,
             mode=mode,
             group_size=group_size,
+            weight_block_size=weight_block_size,
             activation_observer=activation_observer,
             device=linear.weight.device,
             dtype=linear.weight.dtype,
@@ -260,6 +310,9 @@ class QATLinear(nn.Linear):
                 new_linear.bias = nn.Parameter(linear.bias.clone())
 
         return new_linear
+
+    def _is_fp8_mode(self) -> bool:
+        return self.mode in {QATMode.W8A8, QATMode.W8A16}
 
     def _is_amax_initialized(self) -> bool:
         """Check if input_amax has been initialized."""
@@ -309,6 +362,10 @@ class QATLinear(nn.Linear):
 
     def _fake_quantize_weight(self, weight: torch.Tensor) -> torch.Tensor:
         """Apply fake quantization to weight tensor using Triton kernel."""
+        if self._is_fp8_mode():
+            block_m, block_n = self.weight_block_size or DEFAULT_FP8_WEIGHT_BLOCK_SIZE
+            return STEFP8Quant.apply(weight, block_m, block_n)
+
         with torch.no_grad():
             if self._cached_weight_amax is not None:
                 global_amax = self._cached_weight_amax
@@ -345,13 +402,18 @@ class QATLinear(nn.Linear):
         return result
 
     def _fake_quantize_activation(self, x: torch.Tensor) -> torch.Tensor:
-        """Apply fake quantization to activation tensor (W4A4 mode only)."""
+        """Apply fake quantization to activation tensor."""
         original_shape = x.shape
 
         if x.dim() == 3:
             x_2d = x.view(-1, x.shape[-1])
         else:
             x_2d = x
+
+        if self.mode == QATMode.W8A8:
+            _, block_n = self.weight_block_size or DEFAULT_FP8_WEIGHT_BLOCK_SIZE
+            result = STEFP8Quant.apply(x_2d, 1, block_n)
+            return result.view(original_shape)
 
         if self.training:
             self._update_input_global_scale(x_2d)
@@ -370,7 +432,7 @@ class QATLinear(nn.Linear):
 
         weight_fq = self._fake_quantize_weight(self.weight)
 
-        if self.mode == QATMode.W4A4:
+        if self.mode in {QATMode.W4A4, QATMode.W8A8}:
             x_fq = self._fake_quantize_activation(x)
         else:
             x_fq = x
@@ -381,5 +443,6 @@ class QATLinear(nn.Linear):
         return (
             f"in_features={self.in_features}, out_features={self.out_features}, "
             f"bias={self.bias is not None}, mode={self.mode.value}, "
-            f"group_size={self.group_size}, fake_quant_enabled={self.fake_quant_enabled}"
+            f"group_size={self.group_size}, weight_block_size={self.weight_block_size}, "
+            f"fake_quant_enabled={self.fake_quant_enabled}"
         )

--- a/verl/utils/qat/quantizer.py
+++ b/verl/utils/qat/quantizer.py
@@ -25,7 +25,7 @@ import re
 from typing import Generator, Iterable, Optional
 
 import torch
-from compressed_tensors.compressors.quantized_compressors.fp4_quantized import NVFP4PackedCompressor
+from compressed_tensors.compressors.nvfp4.base import NVFP4PackedCompressor
 from compressed_tensors.quantization.quant_args import (
     FP4_E2M1_DATA,
     FP8_E4M3_DATA,
@@ -36,6 +36,7 @@ from compressed_tensors.quantization.quant_args import (
 from compressed_tensors.quantization.utils.helpers import generate_gparam
 
 from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.qat.core import is_fp8_qat_mode
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -131,6 +132,7 @@ class QATQuantizer:
     ):
         self.mode = mode.lower()
         self._is_w4a4 = self.mode == "w4a4"  # W4A4 needs input_global_scale
+        self._is_fp8 = is_fp8_qat_mode(self.mode)
         self.group_size = group_size
         self.ignore_patterns = ignore_patterns or ["lm_head", "embed_tokens", "re:.*mlp.gate$"]
         self.device = device or torch.device(get_device_name())
@@ -150,7 +152,11 @@ class QATQuantizer:
         """Check if parameter should be quantized."""
         if not name.endswith(".weight"):
             return False
+        if "lora_" in name or ".lora_" in name:
+            return False
         if tensor.dim() != 2:
+            return False
+        if self._is_fp8:
             return False
         if tensor.shape[1] % self.group_size != 0:
             return False

--- a/verl/utils/qat/quantizer.py
+++ b/verl/utils/qat/quantizer.py
@@ -22,18 +22,10 @@ Includes scale computation utilities for weight quantization.
 import logging
 import os
 import re
+from functools import cache
 from typing import Generator, Iterable, Optional
 
 import torch
-from compressed_tensors.compressors.nvfp4.base import NVFP4PackedCompressor
-from compressed_tensors.quantization.quant_args import (
-    FP4_E2M1_DATA,
-    FP8_E4M3_DATA,
-    QuantizationArgs,
-    QuantizationStrategy,
-    QuantizationType,
-)
-from compressed_tensors.quantization.utils.helpers import generate_gparam
 
 from verl.utils.device import get_device_name, get_torch_device
 from verl.utils.qat.core import is_fp8_qat_mode
@@ -42,6 +34,46 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 _LAYER_IDX_RE = re.compile(r"layers\.(\d+)\.")
+_COMPRESSED_TENSORS_ERROR = (
+    "NVFP4 QAT weight quantization requires a compressed-tensors installation with NVFP4 support. "
+    "Install or upgrade compressed-tensors before syncing NVFP4 QAT weights to rollout."
+)
+
+
+@cache
+def _load_quant_args():
+    """Load compressed-tensors quantization helpers only when the NVFP4 path needs them."""
+    try:
+        from compressed_tensors.quantization.quant_args import (
+            FP4_E2M1_DATA,
+            FP8_E4M3_DATA,
+            QuantizationArgs,
+            QuantizationStrategy,
+            QuantizationType,
+        )
+        from compressed_tensors.quantization.utils.helpers import generate_gparam
+    except ImportError as exc:
+        raise ImportError(_COMPRESSED_TENSORS_ERROR) from exc
+
+    return (
+        FP4_E2M1_DATA,
+        FP8_E4M3_DATA,
+        QuantizationArgs,
+        QuantizationStrategy,
+        QuantizationType,
+        generate_gparam,
+    )
+
+
+@cache
+def _load_nvfp4_compressor():
+    """Load the NVFP4 compressor lazily so FP8-only tests do not require it at import time."""
+    try:
+        from compressed_tensors.compressors.nvfp4.base import NVFP4PackedCompressor
+    except ImportError as exc:
+        raise ImportError(_COMPRESSED_TENSORS_ERROR) from exc
+
+    return NVFP4PackedCompressor
 
 
 def compute_blockwise_scale(
@@ -52,6 +84,8 @@ def compute_blockwise_scale(
     """Compute blockwise scale using pre-computed global_scale (for fusion).
     Returns FP8 E4M3 blockwise scale tensor.
     """
+    FP4_E2M1_DATA, FP8_E4M3_DATA, _, _, _, _ = _load_quant_args()
+
     out_features, in_features = weight.shape
     num_groups = in_features // group_size
     weight_reshaped = weight.view(out_features, num_groups, group_size)
@@ -137,6 +171,16 @@ class QATQuantizer:
         self.ignore_patterns = ignore_patterns or ["lm_head", "embed_tokens", "re:.*mlp.gate$"]
         self.device = device or torch.device(get_device_name())
         self.param_dtype = param_dtype
+        self._compressor = None
+        self._quant_args = None
+
+    def _ensure_nvfp4_quantizer(self) -> None:
+        """Initialize compressed-tensors objects once the NVFP4 path is actually used."""
+        if self._compressor is not None and self._quant_args is not None:
+            return
+
+        _, FP8_E4M3_DATA, QuantizationArgs, QuantizationStrategy, QuantizationType, _ = _load_quant_args()
+        NVFP4PackedCompressor = _load_nvfp4_compressor()
 
         self._compressor = NVFP4PackedCompressor()
         self._quant_args = QuantizationArgs(
@@ -144,7 +188,7 @@ class QATQuantizer:
             type=QuantizationType.FLOAT,
             symmetric=True,
             strategy=QuantizationStrategy.TENSOR_GROUP,
-            group_size=group_size,
+            group_size=self.group_size,
             scale_dtype=FP8_E4M3_DATA.dtype,
         )
 
@@ -209,6 +253,9 @@ class QATQuantizer:
 
         if not layer_weights:
             return [(name, tensor.to(output_device)) for name, tensor in layer_passthrough.items()]
+
+        self._ensure_nvfp4_quantizer()
+        FP4_E2M1_DATA, FP8_E4M3_DATA, _, _, _, generate_gparam = _load_quant_args()
 
         # Move weights to GPU, compute global scales
         weights_on_gpu = {}

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -85,8 +85,7 @@ def get_module_from_param_name(model, name: str):
         for fused_name, original_names_list in packed_modules_mapping.items()
         for original_name in original_names_list
     }
-    if module_path[-1] in reversed_mapping.keys():
-        module_path[-1] = reversed_mapping[module_path[-1]]
+    module_path = [reversed_mapping.get(part, part) for part in module_path]
 
     current_module = model
     try:
@@ -94,6 +93,11 @@ def get_module_from_param_name(model, name: str):
         for part in module_path:
             if isinstance(current_module, FusedMoE):
                 return current_module
+            base_layer = getattr(current_module, "base_layer", None)
+            if current_module.__class__.__name__ in {"FusedMoEWithLoRA", "FusedMoE3DWithLoRA"} and isinstance(
+                base_layer, FusedMoE
+            ):
+                return base_layer
             elif isinstance(current_module, torch.nn.ModuleList):
                 current_module = current_module[int(part)]
             else:
@@ -331,6 +335,23 @@ def load_quanted_weights(weights, model_runner):
     return loaded_params
 
 
+def load_serialized_fp8_weights(weights, model_runner):
+    """Load already-serialized FP8 weights produced by QAT export."""
+    model = model_runner.model
+
+    swapped_params = []
+    for _, param in model.named_parameters():
+        if hasattr(param, "subclass_type"):
+            swapped_params.append((param, param.__class__))
+            param.__class__ = param.subclass_type
+
+    try:
+        return model.load_weights(weights)
+    finally:
+        for param, orig_type in swapped_params:
+            param.__class__ = orig_type
+
+
 def process_weights_after_loading_for_vllm10(self, layer) -> None:
     """This function is used to process the weights after loading for a Linear layer, it is used for vllm v0.10
 
@@ -457,20 +478,11 @@ def process_weights_after_loading_for_vllm14(self, layer) -> None:
     `subclass_type` attributes so that refit (repeated weight sync) works.
     """
     from torch.nn import Parameter
-    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-        maybe_post_process_fp8_weight_block,
-        process_fp8_weight_block_strategy,
-    )
-    from vllm.model_executor.parameter import (
-        BlockQuantScaleParameter,
-        ModelWeightParameter,
-    )
 
     assert self.block_quant and self.quant_config.is_checkpoint_fp8_serialized
     assert self.quant_config.activation_scheme == "dynamic"
 
-    def _create_param_from_subclass_attributes(custom_param):
-        param = Parameter(custom_param.data, requires_grad=False)
+    def _copy_param_metadata(param, custom_param):
         base_param_dir = dir(torch.nn.Parameter)
         custom_param_dir = dir(custom_param)
         custom_attributes = [
@@ -480,7 +492,38 @@ def process_weights_after_loading_for_vllm14(self, layer) -> None:
             setattr(param, attr, getattr(custom_param, attr))
 
         param.subclass_type = type(custom_param)
+
+    def _create_param_from_subclass_attributes(custom_param):
+        param = Parameter(custom_param.data, requires_grad=False)
+        _copy_param_metadata(param, custom_param)
         return param
+
+    def _restore_param_metadata(param_name, custom_param):
+        param = getattr(layer, param_name, None)
+        if isinstance(param, torch.nn.Parameter):
+            _copy_param_metadata(param, custom_param)
+
+    # vLLM 0.19 moved block-FP8 post-processing behind the selected linear
+    # kernel and removed maybe_post_process_fp8_weight_block.
+    if hasattr(self, "fp8_linear") and hasattr(self.fp8_linear, "process_weights_after_loading"):
+        weight = layer.weight
+        weight_scale_inv = layer.weight_scale_inv
+        if not hasattr(layer, "input_scale"):
+            layer.input_scale = None
+
+        self.fp8_linear.process_weights_after_loading(layer)
+        _restore_param_metadata("weight", weight)
+        _restore_param_metadata("weight_scale_inv", weight_scale_inv)
+        return
+
+    from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+        maybe_post_process_fp8_weight_block,
+        process_fp8_weight_block_strategy,
+    )
+    from vllm.model_executor.parameter import (
+        BlockQuantScaleParameter,
+        ModelWeightParameter,
+    )
 
     weight, weight_scale_inv = process_fp8_weight_block_strategy(layer.weight, layer.weight_scale_inv)
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -131,8 +131,9 @@ class QATEngineConfig(BaseConfig):
 
     Args:
         enable (bool): Whether to enable QAT, default False
-        mode (str): Quantization mode, "w4a16" or "w4a4", default "w4a16"
+        mode (str): Quantization mode, "w4a16", "w4a4", "fp8", "w8a8", or "w8a16", default "w4a16"
         group_size (int): Group size for blockwise quantization, default 16
+        weight_block_size (Optional[list[int]]): 2D FP8 block size for rollout quantization
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)
         quantization_config_path (Optional[str]): Path to quantization config JSON for vLLM
@@ -141,6 +142,7 @@ class QATEngineConfig(BaseConfig):
     enable: bool = False
     mode: str = "w4a16"
     group_size: int = 16
+    weight_block_size: Optional[list[int]] = None
     ignore_patterns: list[str] = field(default_factory=lambda: ["lm_head", "embed_tokens", "re:.*mlp.gate$"])
     activation_observer: str = "static_minmax"
     quantization_config_path: Optional[str] = None

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -480,21 +480,25 @@ class FSDPEngine(BaseEngine):
 
     def _apply_qat(self, module):
         """Apply QAT transformations to the model before FSDP wrapping."""
-        from verl.utils.qat.core import apply_qat, enable_qat_fuse
+        from verl.utils.qat.core import apply_qat, enable_qat_fuse, is_fp4_qat_mode, normalize_qat_mode
+
+        qat_mode = normalize_qat_mode(self._qat_config.mode)
 
         module = apply_qat(
             module,
             {
                 "enable": self._qat_config.enable,
-                "mode": self._qat_config.mode,
+                "mode": qat_mode,
                 "group_size": self._qat_config.group_size,
+                "weight_block_size": getattr(self._qat_config, "weight_block_size", None),
                 "ignore_patterns": list(self._qat_config.ignore_patterns),
                 "activation_observer": self._qat_config.activation_observer,
             },
         )
-        enable_qat_fuse(module)
+        if is_fp4_qat_mode(qat_mode):
+            enable_qat_fuse(module)
 
-        if self._qat_config.mode == "w4a4":
+        if qat_mode == "w4a4":
             self._restore_w4a4_input_scales(module, self.model_config.local_path)
 
         return module
@@ -832,6 +836,16 @@ class FSDPEngine(BaseEngine):
             )
 
         if self._qat_enabled:
+            from verl.utils.qat import is_fp8_qat_mode
+
+            if peft_config is not None and base_sync_done:
+                peft_config_dict = peft_config.to_dict()
+                return per_tensor_param, peft_config_dict
+
+            if is_fp8_qat_mode(self._qat_config.mode):
+                peft_config_dict = peft_config.to_dict() if peft_config is not None else None
+                return per_tensor_param, peft_config_dict
+
             from verl.utils.qat.quantizer import QATQuantizer
             from verl.utils.torch_dtypes import PrecisionType
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -734,7 +734,7 @@ class MegatronEngine(BaseEngine):
                 )
 
         # QAT: process weights through QATWeightExporter for quantized weight sync to vLLM
-        if self._qat_enabled:
+        if self._qat_enabled and not adapter_only:
             from verl.utils.modelopt import export_qat_weights
 
             per_tensor_param = export_qat_weights(per_tensor_param, self.module, self._qat_config.mode, self.bridge)

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -27,7 +27,12 @@ from vllm.outputs import RequestOutput
 from verl.utils.device import is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack
 from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
-from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
+from verl.utils.vllm.vllm_fp8_utils import (
+    apply_vllm_fp8_patches,
+    is_fp8_model,
+    load_quanted_weights,
+    load_serialized_fp8_weights,
+)
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -38,6 +43,14 @@ VLLM_LORA_NAME = "123"
 VLLM_LORA_PATH = "simon_lora_path"
 
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
+
+
+def _contains_serialized_fp8_weights(weights: list[tuple[str, torch.Tensor]]) -> bool:
+    """Return true when a bucket already contains vLLM FP8 checkpoint tensors."""
+    return any(
+        tensor.dtype == torch.float8_e4m3fn or name.endswith((".weight_scale", ".weight_scale_inv", "_scale_inv"))
+        for name, tensor in weights
+    )
 
 
 def set_death_signal():
@@ -169,21 +182,21 @@ class vLLMColocateWorkerExtension:
         if current_platform.device_type == "npu" and self.device is None:
             self.device = torch.device(f"npu:{self.local_rank}")
 
+        adapter_only = bool(peft_config and base_sync_done)
+
         # In async mode, make sure the old lora is removed before adding the new one
-        if peft_config and base_sync_done:
+        if adapter_only:
             self.remove_lora(VLLM_LORA_INT_ID)
 
-        use_standard_weight_load = not (peft_config and base_sync_done) and not is_fp8_model(
-            self.model_runner.vllm_config
-        )
+        use_standard_weight_load = not adapter_only and not is_fp8_model(self.model_runner.vllm_config)
 
-        if self._is_qat_model:
+        if self._is_qat_model and not adapter_only:
             # QAT (compressed-tensors): Prepare for weight loading BEFORE receiving any buckets
             from verl.utils.qat import prepare_qat_for_load_weights
 
             prepare_qat_for_load_weights(self.model_runner.model, device=self.device)
             logger.info("QAT: prepare_qat_for_load_weights completed")
-        elif self._is_modelopt_qat:
+        elif self._is_modelopt_qat and not adapter_only:
             from verl.utils.modelopt.vllm_modelopt_patch import prepare_modelopt_for_weight_reload
 
             prepare_modelopt_for_weight_reload(self.model_runner.model, device=self.device)
@@ -204,13 +217,13 @@ class vLLMColocateWorkerExtension:
             )
         )
 
-        if self._is_qat_model:
+        if self._is_qat_model and not adapter_only:
             # QAT (compressed-tensors): call process_weights_after_loading AFTER all buckets are received
             from verl.utils.qat import manual_process_weights_after_loading
 
             manual_process_weights_after_loading(self.model_runner.model)
             logger.info("QAT: process_weights_after_loading completed")
-        elif self._is_modelopt_qat:
+        elif self._is_modelopt_qat and not adapter_only:
             from verl.utils.modelopt.vllm_modelopt_patch import modelopt_process_weights_after_loading
 
             modelopt_process_weights_after_loading(self.model_runner.model)
@@ -240,8 +253,12 @@ class vLLMColocateWorkerExtension:
             # Check if FP8 quantization is enabled and apply appropriate weight loading
             if is_fp8_model(self.model_runner.vllm_config):
                 logger.info(f"FP8 model detected (async): {self.model_runner.vllm_config.quant_config}")
-                # Convert bf16 weights to fp8 format before loading
-                loaded_params = load_quanted_weights(weights, self.model_runner)
+                if _contains_serialized_fp8_weights(weights):
+                    # FP8 QAT exports fake-quantized weights and scales directly.
+                    loaded_params = load_serialized_fp8_weights(weights, self.model_runner)
+                else:
+                    # Online FP8 rollout quantization converts bf16 weights before loading.
+                    loaded_params = load_quanted_weights(weights, self.model_runner)
                 logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
             else:
                 logger.info("Loading standard weights (non-FP8, async)")

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -787,10 +787,17 @@ class vLLMHttpServer:
 
             check_vllm_ascend_before_server_launch()
 
+        os.environ.pop("VERL_VLLM_FP8_QUANT_ENABLED", None)
+
         # Handle QAT (Quantization-Aware Training) configuration
         qat_config_dict = getattr(self.config, "qat", {}) or {}
         if qat_config_dict.get("enable", False):
-            from verl.utils.qat import QATConfig, load_quantization_config
+            from verl.utils.qat import (
+                QATConfig,
+                get_fp8_weight_block_size,
+                load_quantization_config,
+                normalize_qat_mode,
+            )
 
             qat_config = QATConfig(**qat_config_dict)
             quantization_config_dict = load_quantization_config(qat_config)
@@ -806,11 +813,30 @@ class vLLMHttpServer:
 
                 apply_qat_patches()
                 quantization = "compressed-tensors"
+            elif quant_method == "fp8":
+                qat_mode = normalize_qat_mode(qat_config.mode)
+                if qat_mode == "w8a16":
+                    logger.info("FP8 w8a16 QAT uses BF16 rollout with dequantized fake-quant weights")
+                    quantization = None
+                else:
+                    quantization_config_dict.setdefault("activation_scheme", "dynamic")
+                    quantization_config_dict.setdefault("fmt", "e4m3")
+                    quantization_config_dict.setdefault(
+                        "weight_block_size", get_fp8_weight_block_size(qat_config.weight_block_size)
+                    )
+                    self._validate_fp8_weight_block_size(quantization_config_dict["weight_block_size"])
+                    quantization_config_dict.setdefault("ignored_layers", self._build_fp8_ignored_layers())
+                    apply_vllm_fp8_patches()
+                    os.environ["VERL_VLLM_FP8_QUANT_ENABLED"] = "1"
+                    quantization = "fp8"
             else:
                 raise ValueError(f"Unsupported quant_method: {quant_method}")
 
-            logger.info(f"QAT quantization config injected (quant_method={quant_method})")
-            hf_overrides["quantization_config"] = quantization_config_dict
+            if quantization is not None:
+                logger.info(f"QAT quantization config injected (quant_method={quant_method})")
+                hf_overrides["quantization_config"] = quantization_config_dict
+            else:
+                logger.info(f"QAT enabled without rollout quantization config (quant_method={quant_method})")
         elif quantization is not None:
             # Handle other quantization methods (fp8, torchao)
             _SUPPORTED_QUANTIZATION = ["fp8", "torchao", "ascend"]
@@ -819,16 +845,12 @@ class vLLMHttpServer:
 
             if quantization == "fp8":
                 # Ignore MoE router layers for FP8 quantization
-                all_mlp_gate_layers = []
-                for layer in range(self.model_config.hf_config.num_hidden_layers):
-                    all_mlp_gate_layers.append(f"model.layers.{layer}.mlp.gate")
-
                 FP8_BLOCK_QUANT_KWARGS = {
                     "activation_scheme": "dynamic",
                     "fmt": "e4m3",
                     "quant_method": "fp8",
                     "weight_block_size": [128, 128],
-                    "ignored_layers": all_mlp_gate_layers,
+                    "ignored_layers": self._build_fp8_ignored_layers(),
                 }
                 hf_overrides["quantization_config"] = dict(FP8_BLOCK_QUANT_KWARGS)
                 # Apply vllm fp8 patches
@@ -841,6 +863,33 @@ class vLLMHttpServer:
             hf_overrides["quantization_config_file"] = self.config.quantization_config_file
 
         return quantization, hf_overrides
+
+    def _build_fp8_ignored_layers(self) -> list[str]:
+        """Return vLLM FP8 ignored layer names for router/gate modules."""
+        return [
+            f"model.layers.{layer}.mlp.gate"
+            for layer in range(getattr(self.model_config.hf_config, "num_hidden_layers", 0))
+        ]
+
+    def _validate_fp8_weight_block_size(self, weight_block_size: list[int]) -> None:
+        """Validate FP8 block size against tensor-parallel MoE expert shards."""
+        if len(weight_block_size) != 2:
+            raise ValueError(f"FP8 weight_block_size must have two entries, got: {weight_block_size}")
+
+        hf_config = self.model_config.hf_config
+        moe_intermediate_size = getattr(hf_config, "moe_intermediate_size", None)
+        if moe_intermediate_size is None:
+            return
+
+        tp_size = int(getattr(self.config, "tensor_model_parallel_size", 1) or 1)
+        intermediate_size_per_partition = int(moe_intermediate_size) // tp_size
+        block_n = int(weight_block_size[1])
+        if intermediate_size_per_partition % block_n != 0:
+            raise ValueError(
+                "FP8 weight_block_size is incompatible with MoE expert tensor-parallel shards: "
+                f"intermediate_size_per_partition={intermediate_size_per_partition}, block_n={block_n}. "
+                "Set qat.weight_block_size so block_n divides the per-partition MoE intermediate size."
+            )
 
     def _get_worker_extension_cls(self) -> str:
         """Return the fully-qualified colocate worker extension class name."""


### PR DESCRIPTION
### What does this PR do?

Support w8a8 & w8a16 for QAT

Need https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/3612

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
