### PR TITLE
[trainer] fix: update TorchTitanEngine for latest torchtitan API

### DIFF
--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -29,6 +29,7 @@ from tensordict import TensorDict
 from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
+from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
@@ -107,12 +108,7 @@ class TorchTitanEngine(BaseEngine):
 
         # Get ModelSpec from model registry
         model_module = importlib.import_module(f"torchtitan.models.{torchtitan_name}")
-        model_spec = model_module.model_registry(torchtitan_flavor)
-
-        # Override attn_backend on the model config if needed
-        attn_type = self.engine_config.attn_type
-        if hasattr(model_spec.model, "layer") and hasattr(model_spec.model.layer, "attention"):
-            model_spec.model.layer.attention.attn_backend = attn_type
+        model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
 
         optimizer = OptimizersContainer.Config(
             name=self.optimizer_config.name,
@@ -141,7 +137,6 @@ class TorchTitanEngine(BaseEngine):
             pipeline_parallel_degree=self.engine_config.pipeline_parallel_size,
             context_parallel_degree=self.engine_config.context_parallel_size,
             expert_parallel_degree=self.engine_config.expert_parallel_size,
-            expert_tensor_parallel_degree=self.engine_config.expert_tensor_parallel_size,
         )
         checkpoint = CheckpointManager.Config(
             enable=True,
@@ -170,6 +165,9 @@ class TorchTitanEngine(BaseEngine):
             training=training,
             # Use a no-op dataloader since verl has its own data loading
             dataloader=NoOpDataLoader.Config(),
+            # Provide a concrete loss so Trainer.__init__ can build it;
+            # verl uses its own loss function and ignores this one.
+            loss=CrossEntropyLoss.Config(),
         )
         self.trainer = Trainer(self.config)
 
@@ -266,7 +264,6 @@ class TorchTitanEngine(BaseEngine):
             tp=self.engine_config.tensor_parallel_size,
             pp=self.engine_config.pipeline_parallel_size,
             ep=self.engine_config.expert_parallel_size,
-            etp=self.engine_config.expert_tensor_parallel_size,
             world_size=world_size,
         )
         self.device_mesh = self.parallel_dims.build_mesh()
@@ -366,8 +363,7 @@ class TorchTitanEngine(BaseEngine):
             # Non-PP forward
             assert len(model_parts) == 1
             with self.trainer.train_context():
-                with self.trainer.maybe_enable_amp:
-                    pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
+                pred = model_parts[0](inputs, **extra_inputs, **extra_kwargs)
 
         if isinstance(pred, DTensor):
             pred = pred.full_tensor()
@@ -596,7 +592,7 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
                 position_ids = position_ids.values().unsqueeze(0)
 
             labels = torch.roll(input_ids, shifts=-1, dims=1)
-            attn_type = self.trainer.model_config.layer.attention.attn_backend
+            attn_type = self.engine_config.attn_type
             attention_mask = get_attention_masks(
                 input_batch=input_ids,
                 positions=position_ids,

--- a/verl/workers/engine/torchtitan/utils.py
+++ b/verl/workers/engine/torchtitan/utils.py
@@ -104,16 +104,20 @@ def derive_torchtitan_name_and_flavor(hf_config) -> tuple[str, str]:
             f"Supported types: {list(_HF_MODEL_TYPE_TO_TORCHTITAN_NAME.keys())}."
         )
 
-    # Import the model package and find the configs dict
+    # Import the model package and use model_registry to build each flavor's config.
+    # model_registry has sensible defaults for all optional params (attn_backend, etc.).
     model_module = importlib.import_module(f"torchtitan.models.{name}")
-    model_configs = None
-    for attr in dir(model_module):
-        obj = getattr(model_module, attr)
-        if isinstance(obj, dict) and attr.endswith("_configs"):
-            model_configs = obj
+    model_registry = model_module.model_registry
+
+    # The configs dict name isn't derivable from the model name
+    # (e.g. gpt_oss -> gptoss_configs), so we find it by convention.
+    flavor_names = None
+    for attr, obj in vars(model_module).items():
+        if attr.endswith("_configs") and isinstance(obj, dict):
+            flavor_names = list(obj.keys())
             break
 
-    if model_configs is None:
+    if flavor_names is None:
         raise ValueError(
             f"Could not find model configs dict in torchtitan.models.{name}. "
             f"Expected a dict attribute ending with '_configs'."
@@ -123,11 +127,13 @@ def derive_torchtitan_name_and_flavor(hf_config) -> tuple[str, str]:
     num_layers = hf_config.num_hidden_layers
     vocab_size = hf_config.vocab_size
 
-    for flavor_name, model_cfg in model_configs.items():
+    for flavor_name in flavor_names:
+        cfg = model_registry(flavor_name).model
+        n_layers = getattr(cfg, "n_layers", None) or len(getattr(cfg, "layers", []))
         if (
-            getattr(model_cfg, "dim", None) == hidden_size
-            and getattr(model_cfg, "n_layers", None) == num_layers
-            and getattr(model_cfg, "vocab_size", None) == vocab_size
+            getattr(cfg, "dim", None) == hidden_size
+            and n_layers == num_layers
+            and getattr(cfg, "vocab_size", None) == vocab_size
         ):
             logger.info(
                 f"Auto-derived torchtitan name='{name}', flavor='{flavor_name}' from HF model_type='{model_type}'"
@@ -138,7 +144,7 @@ def derive_torchtitan_name_and_flavor(hf_config) -> tuple[str, str]:
         f"No matching torchtitan flavor found for model_type='{model_type}' "
         f"(hidden_size={hidden_size}, num_hidden_layers={num_layers}, "
         f"vocab_size={vocab_size}). "
-        f"Available flavors for '{name}': {list(model_configs.keys())}."
+        f"Available flavors for '{name}': {flavor_names}."
     )
 
 


### PR DESCRIPTION
## Summary
- Update TorchTitanEngine to align with torchtitan HEAD API changes: remove deleted `expert_tensor_parallel_degree`/`etp`/`maybe_enable_amp`, add concrete `CrossEntropyLoss.Config` for new abstract `BaseLoss`
- Fix `attn_type` being silently ignored (#6182): pass `attn_backend=` to `model_registry()` and fix wrong attribute path in `prepare_model_inputs`
- Fix `derive_torchtitan_name_and_flavor` to handle config factories (callables) and `len(layers)` fallback for layer count matching
- Fix test script: use `NUM_GPUS` for rollout TP size instead of hardcoded 8, fix misleading experiment name

Fixes #6182

## Test plan
- [ ] Verify `derive_torchtitan_name_and_flavor` correctly resolves Qwen3-0.6B flavor
- [ ] Run `tests/special_e2e/run_ppo_trainer_torchtitan.sh` with torchtitan HEAD
- [ ] Verify model builds with `attn_type=flex` (FlexAttention) as configured
```
BACKEND=torchtitan FSDP_SIZE=1 NUM_GPUS=1 MODEL_ID=Qwen/Qwen3-0.6B
   bash tests/special_e2e/sft/run_sft_engine.sh 
```