### PR TITLE
[rollout,vllm] fix: include Ray job id in colocated weight-transfer IPC path

### DIFF
--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -249,12 +249,16 @@ class vLLMColocateWorkerExtension:
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication.
-        Uses replica_rank + local_rank to form handle so it matches the sender side
-        regardless of CUDA_VISIBLE_DEVICES differences, and avoids collisions
-        when multiple replicas share the same node.
+        Uses Ray job id + replica_rank + local_rank to form the handle so it
+        matches the sender side regardless of CUDA_VISIBLE_DEVICES differences,
+        avoids collisions when multiple replicas share the same node, and is
+        unique per Ray job to avoid cross-job collisions on shared hosts. The
+        job id is forwarded by the vLLMHttpServer actor as VERL_RAY_JOB_ID and
+        inherited by this vLLM worker subprocess.
         """
         replica_rank = os.environ.get("VERL_REPLICA_RANK", "0")
-        return f"ipc:///tmp/rl-colocate-zmq-replica-{replica_rank}-rank-{self.local_rank}.sock"
+        job_id = os.environ.get("VERL_RAY_JOB_ID", "0")
+        return f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{self.local_rank}.sock"
 
 
 class SuppressSignalInThread:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -109,6 +109,13 @@ class vLLMHttpServer:
         """
         os.environ[get_visible_devices_keyword()] = cuda_visible_devices
         os.environ["VERL_REPLICA_RANK"] = str(replica_rank)
+        # Forward the Ray job id into the vLLM worker subprocess so the
+        # colocated weight-transfer IPC socket path is unique per Ray job.
+        # Without this, two concurrent verl jobs on the same node both bind
+        # the same /tmp/rl-colocate-zmq-replica-0-rank-0.sock and one fails
+        # with EADDRINUSE; a stale socket from a crashed run trips the same
+        # error on restart.
+        os.environ["VERL_RAY_JOB_ID"] = ray.get_runtime_context().get_job_id()
 
         self.config = self._init_config(config)
         self.model_config = self._init_model_config(model_config)

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -100,9 +100,12 @@ class ServerAdapter(BaseRollout):
         # when CUDA_VISIBLE_DEVICES differs between processes (common on ROCm/AMD).
         # Must use node-local rank (not rollout_rank) so it matches vLLM worker's
         # local_rank on every node. Include replica_rank to avoid collisions when
-        # multiple replicas share a node.
+        # multiple replicas share a node, and the Ray job id so two independent
+        # verl jobs on the same host (or a new run after a crashed one with a
+        # stale socket file) cannot collide on the shared /tmp namespace.
         local_rank = self.rollout_rank % local_world_size
-        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-replica-{self.replica_rank}-rank-{local_rank}.sock"
+        job_id = ray.get_runtime_context().get_job_id()
+        self.zmq_handle = f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{self.replica_rank}-rank-{local_rank}.sock"
 
         self.use_shm = not is_support_ipc()
         if self.use_shm:


### PR DESCRIPTION
### What does this PR do?

Closes #6233.

The colocated vLLM rollout uses an `ipc://...sock` path under `/tmp` shared by the trainer-side `ServerAdapter` and the vLLM worker subprocess. The current path is keyed only on `(replica_rank, local_rank)`, so two independent verl jobs on the same host both produce `replica-0/rank-0` for their first local GPU and try to `bind()` to the same `/tmp/rl-colocate-zmq-replica-0-rank-0.sock`. The second job fails with `zmq.error.ZMQError: Address already in use` from `BucketedWeightSender._init_socket` during the first `update_weights` call. The same failure mode appears after a crashed run leaves a stale socket file behind.

This PR mixes `ray.get_runtime_context().get_job_id()` into the path so each Ray job owns a disjoint set of socket files:

```
ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{local_rank}.sock
```

The id is naturally available in `ServerAdapter` (Ray actor) and forwarded into the vLLM worker subprocess via the existing env-var bridge in `vLLMHttpServer.__init__` that already plumbs `VERL_REPLICA_RANK`. PR #6062's replica/local-rank pairing is preserved for tensor-parallel and multi-replica layouts inside a single job.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+rl-colocate-zmq+in%3Abody+sort%3Acreated-desc and https://github.com/verl-project/verl/issues?q=is%3Aissue+rl-colocate-zmq — no overlapping work; full discussion at #6233.
- [x] Format the PR title as `[{modules}] {type}: {description}` — `[rollout,vllm] fix: include Ray job id in colocated weight-transfer IPC path`.

### Test

- `ruff check` and `ruff format --check` are clean on the three touched files.
- `tests/special_sanity/check_license.py` passes.
- Confirmed at runtime that `ray.get_runtime_context().get_job_id()` returns a short hex string (e.g. `'01000000'`) and is identical across the driver process and remote workers within a single `ray.init()` — so sender (Ray actor) and receiver (vLLM subprocess that inherits `VERL_RAY_JOB_ID`) derive matching paths.
- The change is a path-string modification only; the IPC protocol itself is untouched. `tests/utils/test_bucketed_weight_transfer.py` already exercises the bucketed roundtrip with arbitrary `ipc://` paths and is unaffected. Happy to add a focused unit test for `_get_zmq_handle` if reviewers prefer.

### API and Usage Example

No user-visible API or config changes. One internal forwarding env var (`VERL_RAY_JOB_ID`) is set automatically by `vLLMHttpServer` and consumed automatically by `vLLMColocateWorkerExtension._get_zmq_handle`; users do not set it.

```python
# Existing colocated-rollout entrypoint, unchanged for end users:
python -m verl.trainer.main_ppo  # ... your usual config

# What changed under the hood: each Ray job's IPC path now includes ray.get_runtime_context().get_job_id():
# Before: ipc:///tmp/rl-colocate-zmq-replica-0-rank-0.sock
# After:  ipc:///tmp/rl-colocate-zmq-01000000-replica-0-rank-0.sock
```

### Design & Code Changes

Three small edits, +20 / −6 lines total:

| File | Change |
|---|---|
| `verl/workers/rollout/vllm_rollout/vllm_async_server.py` | In `vLLMHttpServer.__init__`, set `os.environ["VERL_RAY_JOB_ID"] = ray.get_runtime_context().get_job_id()` next to the existing `VERL_REPLICA_RANK` line so the vLLM worker subprocess inherits it. |
| `verl/workers/rollout/vllm_rollout/vllm_rollout.py` | In `ServerAdapter.__init__` (sender, runs inside a Ray actor), include `ray.get_runtime_context().get_job_id()` directly in `self.zmq_handle`. |
| `verl/workers/rollout/vllm_rollout/utils.py` | In `vLLMColocateWorkerExtension._get_zmq_handle` (receiver, runs in the vLLM worker subprocess), read `os.environ.get("VERL_RAY_JOB_ID", "0")` and include it in the path. |

#### Why Ray's `get_job_id()` and not a new UUID?

A driver-side UUID propagated through Ray `runtime_env.env_vars` would also work but adds a new public env-var contract and modifies `constants_ppo.py`. Ray's job id is already authoritative and unique per `ray.init()`, so it's the smaller change with no new public contracts.

`$TMPDIR` was also considered; it doesn't cover same-user multiple concurrent jobs or stale-socket recovery.

#### Compatibility / edge cases

- No public config changes; no new documented env var.
- No behavior change for single-job runs: each `ray.init()` produces one job id, so paths are stable within a run.
- Sender/receiver pairing under TP/DP/multi-replica is unchanged: the `(replica_rank, local_rank)` pairing logic from #6062 is preserved.
- Multi-node jobs: `local_rank` stays node-local; `job_id` is identical across all nodes of one Ray job.
- Existing exact-path stale-socket cleanup before `bind()` and during teardown in `BucketedWeightSender` continues to work — and is now safe by construction because the path can never overlap with another concurrent job's path.
- Missing `VERL_RAY_JOB_ID` in the receiver: falls back to `"0"`, which produces a deterministic mismatch with the sender so the failure surfaces immediately as an EADDRINUSE / connect mismatch rather than a silent cross-job collision.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks: ran `ruff check` and `ruff format --check` on the touched files (clean), plus `tests/special_sanity/check_license.py` (clean). Will run the full `pre-commit run --all-files` and push any auto-fixes if requested.
- [ ] Add / Update the documentation. Not applicable — no user-visible API or config surface changes; the internal `VERL_RAY_JOB_ID` is set and consumed entirely within `verl/workers/rollout/vllm_rollout/`.
- [ ] Add unit or end-to-end test(s) to the CI workflow to cover all the code. Explanation: this PR is a path-string modification with no protocol or behavior change; `tests/utils/test_bucketed_weight_transfer.py` already exercises the bucketed IPC roundtrip with arbitrary handles and remains green. Happy to add a focused unit test asserting that `_get_zmq_handle` includes `VERL_RAY_JOB_ID` if reviewers prefer.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] If your PR is related to the `recipe` submodule. Not applicable.
