### PR TITLE
[tool] feat: Memory snapshot collection, add functionality to clear history after collection.

### DIFF
--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import torch
 
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_torch_device, is_cuda_available
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -237,6 +237,16 @@ def enable_memory_visualize(
     rank = int(os.environ.get("RANK", "0") or 0)
     logger.info(f"[memory_visualize][rank {rank}] recording enabled ({mode}); args={used}")
 
+def clear_memory_history(trace_alloc_max_entries: int = 200_000, stack_depth: int = 32):
+    device = get_torch_device()
+    if not device.is_available():
+        logger.warning("[memory_visualize] Memory history recording is only available on accelerator devices")
+        return
+    try:
+        device.memory._record_memory_history(enabled=None)
+        enable_memory_visualize(trace_alloc_max_entries=trace_alloc_max_entries, stack_depth=stack_depth)
+    except Exception as e:
+        logger.warning(f"[memory_visualize] Failed to reset memory history: {e}")
 
 class MemorySnapshotSampler:
     """

--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import torch
 
-from verl.utils.device import get_torch_device, is_cuda_available
+from verl.utils.device import get_torch_device
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -237,6 +237,7 @@ def enable_memory_visualize(
     rank = int(os.environ.get("RANK", "0") or 0)
     logger.info(f"[memory_visualize][rank {rank}] recording enabled ({mode}); args={used}")
 
+
 def clear_memory_history(trace_alloc_max_entries: int = 200_000, stack_depth: int = 32):
     device = get_torch_device()
     if not device.is_available():
@@ -247,6 +248,7 @@ def clear_memory_history(trace_alloc_max_entries: int = 200_000, stack_depth: in
         enable_memory_visualize(trace_alloc_max_entries=trace_alloc_max_entries, stack_depth=stack_depth)
     except Exception as e:
         logger.warning(f"[memory_visualize] Failed to reset memory history: {e}")
+
 
 class MemorySnapshotSampler:
     """

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -15,7 +15,7 @@
 import functools
 from typing import Callable, Optional
 
-from ..memory_utils import MemorySnapshotSampler, enable_memory_visualize, clear_memory_history
+from ..memory_utils import MemorySnapshotSampler, clear_memory_history, enable_memory_visualize
 from .config import ProfilerConfig, TorchMemoryToolConfig
 
 
@@ -243,7 +243,9 @@ class TorchMemoryProfiler:
         # Best-effort enable memory history once
         if not TorchMemoryProfiler._memory_history_enabled:
             try:
-                enable_memory_visualize(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
+                enable_memory_visualize(
+                    trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth
+                )
             except Exception:
                 # silently ignore if not supported
                 pass

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -15,7 +15,7 @@
 import functools
 from typing import Callable, Optional
 
-from ..memory_utils import MemorySnapshotSampler, enable_memory_visualize
+from ..memory_utils import MemorySnapshotSampler, enable_memory_visualize, clear_memory_history
 from .config import ProfilerConfig, TorchMemoryToolConfig
 
 
@@ -234,16 +234,16 @@ class TorchMemoryProfiler:
 
         # Get parameters from tool_config, with fallback to defaults
         if tool_config:
-            trace_alloc_max_entries = tool_config.trace_alloc_max_entries
-            stack_depth = tool_config.stack_depth
+            self.trace_alloc_max_entries = tool_config.trace_alloc_max_entries
+            self.stack_depth = tool_config.stack_depth
         else:
-            trace_alloc_max_entries = 100_000
-            stack_depth = 32
+            self.trace_alloc_max_entries = 100_000
+            self.stack_depth = 32
 
         # Best-effort enable memory history once
         if not TorchMemoryProfiler._memory_history_enabled:
             try:
-                enable_memory_visualize(trace_alloc_max_entries=trace_alloc_max_entries, stack_depth=stack_depth)
+                enable_memory_visualize(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
             except Exception:
                 # silently ignore if not supported
                 pass
@@ -272,6 +272,9 @@ class TorchMemoryProfiler:
             self.sampler.dump_memory_snapshot(out_dir=out_dir, tag=tag, sub_dir=self.sub_dir)
         except Exception:
             pass
+        # Clear memory history
+        if TorchMemoryProfiler._memory_history_enabled:
+            clear_memory_history(trace_alloc_max_entries=self.trace_alloc_max_entries, stack_depth=self.stack_depth)
 
     def _should_profile_this_rank(self) -> bool:
         if self.config.all_ranks:


### PR DESCRIPTION
### What does this PR do?

Memory snapshot collection, add functionality to clear history after collection. This feature aligns verl's memory profiling capabilities with vLLM's memory snapshot mechanism, enabling better memory debugging on NPU devices (Ascend).
Related: NPU memory profiling for Ascend devices
Closes #6208

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pull/6216
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Tested on NPU device with the following command:
python3 -m verl.trainer.main_ppo \
    trainer.device=npu \
    global_profiler.tool=torch_memory \
    global_profiler.steps=[1,2,3] \
    actor_rollout_ref.actor.profiler.enable=True \
    actor_rollout_ref.actor.profiler.all_ranks=True 
Memory snapshots are successfully generated in the output directory with .pickle format. 

Before modification: Each collection is based on the memory usage from the beginning to the current step.
<img width="408" height="21" alt="image" src="https://github.com/user-attachments/assets/a1496c51-d828-47d6-8ea3-87b2651ef779" />
<img width="1297" height="609" alt="image" src="https://github.com/user-attachments/assets/d8e46f27-4d5f-4c36-aca0-e8f962a77eb5" />

After modification: Each collection only includes the memory usage from the last collection to the current step.
<img width="408" height="41" alt="image" src="https://github.com/user-attachments/assets/7e287454-5f8a-475d-a3e6-361aadec8f21" />
<img width="1310" height="512" alt="image" src="https://github.com/user-attachments/assets/dba105c3-0b22-405b-9843-e3be50be1ba3" />
<img width="1299" height="612" alt="image" src="https://github.com/user-attachments/assets/bc8e25eb-3299-4c7f-ab7f-a83bf7bfb0a6" />
<img width="1300" height="617" alt="image" src="https://github.com/user-attachments/assets/fa091a8f-f3d2-4b6b-bc99-6e43ea54b4c1" />


### API and Usage Example

python3 -m verl.trainer.main_ppo \
    trainer.device=npu \
    global_profiler.tool=torch_memory \
    global_profiler.steps=[1,5,10] \
    actor_rollout_ref.actor.profiler.enable=True \
    actor_rollout_ref.actor.profiler.all_ranks=True \
    global_profiler.global_tool_config.torch_memory.trace_alloc_max_entries=100000 \
    global_profiler.global_tool_config.torch_memory.stack_depth=32 \
    global_profiler.global_tool_config.torch_memory.context=all \
    global_profiler.global_tool_config.torch_memory.stacks=all \
    global_profiler.save_path=/path/to/output

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
