### PR TITLE
[trainer] fix: write request_id to reward_extra_infos_to_dump instead of reward_extra_infos_dict

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -449,7 +449,7 @@ class RayPPOTrainer:
                 k: (v.tolist() if isinstance(v, np.ndarray) else v) for k, v in reward_extra_infos_dict.items()
             }
             if "request_id" in batch.non_tensor_batch:
-                reward_extra_infos_dict.setdefault(
+                reward_extra_infos_to_dump.setdefault(
                     "request_id",
                     batch.non_tensor_batch["request_id"].tolist(),
                 )


### PR DESCRIPTION
## What does this PR do?

Fixes #6250

In `_log_rollout_data`, `request_id` was being written to `reward_extra_infos_dict` instead of `reward_extra_infos_to_dump`. Since `reward_extra_infos_to_dump` is created from `reward_extra_infos_dict` **before** the `request_id` insertion and is the dict passed to `_dump_generations()`, the `request_id` was never included in dumped rollout data.

### Change

```diff
 if "request_id" in batch.non_tensor_batch:
-    reward_extra_infos_dict.setdefault(
+    reward_extra_infos_to_dump.setdefault(
         "request_id",
         batch.non_tensor_batch["request_id"].tolist(),
     )
```

### Why this is not duplicating an existing PR

Searched upstream open PRs for `request_id`, `reward_extra_infos_dict`, and `dump_generations` — no existing PR addresses this bug.

### Test

This is a one-line variable name fix. Verified by code inspection:

1. `reward_extra_infos_to_dump` is created from `reward_extra_infos_dict` at L448-450 (before the `request_id` insertion)
2. `reward_extra_infos_to_dump` is passed to `_dump_generations()` at L465
3. Writing to `reward_extra_infos_dict` after the copy means `request_id` is never in the dump output

No unit test exists for `_log_rollout_data` dump output content. The fix is trivially correct by code inspection.

### AI Assistance

AI assistance was used to identify the bug and draft this PR. The submitter has reviewed every changed line and confirms the fix is correct.
