### PR TITLE
[trainer] perf: async generation dump with exception propagation and streaming write

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -449,7 +449,7 @@ class RayPPOTrainer:
                 k: (v.tolist() if isinstance(v, np.ndarray) else v) for k, v in reward_extra_infos_dict.items()
             }
             if "request_id" in batch.non_tensor_batch:
-                reward_extra_infos_dict.setdefault(
+                reward_extra_infos_to_dump.setdefault(
                     "request_id",
                     batch.non_tensor_batch["request_id"].tolist(),
                 )

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -22,6 +22,7 @@ import json
 import os
 import uuid
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from pprint import pprint
 from typing import Any, Optional
@@ -318,6 +319,8 @@ class RayPPOTrainer:
         self._create_dataloader(train_dataset, val_dataset, collate_fn, train_sampler)
 
         self.checkpoint_manager = None
+        self._dump_executor = ThreadPoolExecutor(max_workers=1)
+        self._dump_futures = []  # track pending async dump tasks
 
     def _create_dataloader(self, train_dataset, val_dataset, collate_fn, train_sampler: Optional[Sampler]):
         """
@@ -401,10 +404,11 @@ class RayPPOTrainer:
         except Exception as e:
             print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
 
-    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
-        """Dump rollout/validation samples as JSONL."""
+    @staticmethod
+    def _write_generations(inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path, global_steps):
+        """Write generation samples as JSONL (runs in background thread)."""
         os.makedirs(dump_path, exist_ok=True)
-        filename = os.path.join(dump_path, f"{self.global_steps}.jsonl")
+        filename = os.path.join(dump_path, f"{global_steps}.jsonl")
 
         n = len(inputs)
         base_data = {
@@ -412,22 +416,36 @@ class RayPPOTrainer:
             "output": outputs,
             "gts": gts,
             "score": scores,
-            "step": [self.global_steps] * n,
+            "step": [global_steps] * n,
         }
 
         for k, v in reward_extra_infos_dict.items():
             if len(v) == n:
                 base_data[k] = v
 
-        lines = []
-        for i in range(n):
-            entry = {k: v[i] for k, v in base_data.items()}
-            lines.append(json.dumps(entry, ensure_ascii=False, default=str))
-
         with open(filename, "w") as f:
-            f.write("\n".join(lines) + "\n")
+            for i in range(n):
+                entry = {k: v[i] for k, v in base_data.items()}
+                f.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
 
         print(f"Dumped generations to {filename}")
+
+    def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
+        """Dump rollout/validation samples as JSONL asynchronously."""
+        global_steps = self.global_steps
+        future = self._dump_executor.submit(
+            self._write_generations,
+            inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path, global_steps,
+        )
+        self._dump_futures.append(future)
+        # Clean up completed futures and surface any exceptions early
+        still_pending = []
+        for f in self._dump_futures:
+            if f.done():
+                f.result()  # re-raises if the write failed
+            else:
+                still_pending.append(f)
+        self._dump_futures = still_pending
 
     def _log_rollout_data(
         self, batch: DataProto, reward_extra_infos_dict: dict, timing_raw: dict, rollout_data_dir: str
@@ -1657,6 +1675,11 @@ class RayPPOTrainer:
                 if is_last_step:
                     if hasattr(self.actor_rollout_wg, "async_calls_finalize_fn_exec"):
                         self.actor_rollout_wg.async_calls_finalize_fn_exec(blocking=True)
+                    # Check all remaining dump futures for exceptions before shutdown
+                    for f in self._dump_futures:
+                        f.result()
+                    self._dump_futures.clear()
+                    self._dump_executor.shutdown(wait=True)
                     pprint(f"Final validation metrics: {last_val_metrics}")
                     progress_bar.close()
                     return


### PR DESCRIPTION
## Summary

Fixes #6254
Closes #6250 (supersedes #6251, which is included as the first commit)

Make generation dump in `RayPPOTrainer` asynchronous with exception propagation and streaming writes, resolving:

1. **Synchronous I/O blocks the training loop** — dump runs on the main thread, blocking rollout with large batches
2. **I/O errors silently dropped** — disk full and other exceptions go unnoticed
3. **High peak memory** — `"\n".join(lines)` builds a large string before writing

## Changes

- **Extract `_write_generations` static method**: Lift the inline write logic into a `@staticmethod` so the background thread doesn't capture `self`, ensuring thread safety.
- **Async dump**: Submit write tasks via `ThreadPoolExecutor(max_workers=1)`; the main thread returns immediately without blocking training.
- **Exception propagation**: Track submitted futures in `_dump_futures`. On each call, remove completed futures and call `.result()` to surface I/O errors early.
- **Streaming write**: Replace `"\n".join(lines)` + single `f.write()` with per-line `f.write()`, reducing peak memory.
- **Drain pending futures**: Before `_dump_executor.shutdown(wait=True)`, iterate all remaining futures and call `.result()` so no write errors are lost at training end.
- **Fix `request_id` dict bug** (commit 2, same as #6251): Write `request_id` to `reward_extra_infos_to_dump` instead of `reward_extra_infos_dict`.

## Testing

- [x] Local PPO training runs correctly, generation data written to JSONL files as expected
- [x] Simulated I/O error (read-only directory): exception propagates correctly on the next `_dump_generations` call
- [x] All pending dumps complete at training end, no data loss

## Note on Training Correctness

This change does not affect training precision:
1. Generation dump is purely observational/logging — written data does not participate in loss computation
2. Async write ordering is guaranteed by `global_steps` in the filename, no confusion
3. If an I/O error occurs, the exception propagates to the main training loop — training fails rather than silently losing data

## Why this is not duplicating an existing PR

Searched open PRs for `async dump`, `dump_generations`, `ThreadPoolExecutor` — no existing PR addresses async generation dump. PR #6251 fixes the `request_id` dict bug only and is included here as the first commit.

## AI Assistance

AI assistance was used to implement this change and draft this PR (CodeBuddy). The submitter has reviewed every changed line and confirms correctness.
