### PR TITLE
[megatron] fix: fix bugs when using position_ids in cp

### DIFF
--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -288,7 +288,7 @@ def gptmodel_forward_model_engine(
         output_orig = model(
             input_ids=input_ids_rmpad,
             attention_mask=attention_mask,
-            position_ids=position_ids_rmpad if not vision_model else None,  # vision models will calculate position_ids
+            position_ids=position_ids_rmpad if mtp_enable_train else None,  # position_ids is only needed for MTP
             packed_seq_params=packed_seq_params,
             **model_kwargs,
         )

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -371,6 +371,7 @@ def preprocess_thd_engine(
                 continue
 
             seqlen_padded_i = seqlens_in_batch_padded_cpu[i]
+            seqlen_orig_i = seqlens_in_batch_cpu[i]
             seqlen = seqlen_padded_i // cp_size
             half_seqlen = seqlen // 2
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
@@ -406,10 +407,14 @@ def preprocess_thd_engine(
                 input_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + remain_len] = d[
                     remain_start:remain_end
                 ]
-                # Build position_ids for the remaining chunk
-                position_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + remain_len] = torch.arange(
-                    seqlen_padded_i - remain_len, seqlen_padded_i, dtype=torch.long, device=input_ids.device
-                )
+                # Build position_ids for the remaining chunk: use remain_start as base,
+                # clamped to original seqlen to avoid exceeding seqlen-1 for padded positions
+                pos_end = min(remain_start + remain_len, seqlen_orig_i)
+                valid_pos_len = pos_end - remain_start
+                if valid_pos_len > 0:
+                    position_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + valid_pos_len] = (
+                        torch.arange(remain_start, pos_end, dtype=torch.long, device=input_ids.device)
+                    )
 
             if need_roll:
                 # Handle roll for cp_size > 1 case

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -409,7 +409,7 @@ def preprocess_thd_engine(
                 ]
                 # Build position_ids for the remaining chunk: use remain_start as base,
                 # clamped to original seqlen to avoid exceeding seqlen-1 for padded positions
-                pos_end = min(remain_start + remain_len, seqlen_orig_i)
+                pos_end = min(remain_end, seqlen_orig_i)
                 valid_pos_len = pos_end - remain_start
                 if valid_pos_len > 0:
                     position_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + valid_pos_len] = (


### PR DESCRIPTION
### What does this PR do?

基于https://github.com/verl-project/verl/pull/5561

目前的position_ids有两个bug：
1. cp=2时position_ids错了一位
<img width="2804" height="307" alt="image" src="https://github.com/user-attachments/assets/76600cbd-ed5f-4817-af85-c105a7b0e4c2" />
2. cp=2的情况下rank=1的后半段position_ids还是错的
<img width="1630" height="130" alt="image" src="https://github.com/user-attachments/assets/689866e5-2ac7-416c-a6c0-289149b00115" />
+ 总长4803，此时正确的position_ids应该是[1201-3602]

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

+ 为什么input_ids的写法没问题，但是position_ids就错了？

+ 因为 remain_start 和 position 的语义不同：
input_ids 用 remain_start 作为数据索引 — 是从 d[remain_start:remain_end]取数据，这里 remain_start = seqlen_padded_i - half_seqlen*(cp_rank+1)，对于 CP=2：
  - cp_rank 0: remain_start = 4804 - 1201 = 3603，取 d[3603:4804] → 这就是 slice 3
  的数据 ✓
  - cp_rank 1: remain_start = 4804 - 2402 = 2402，取 d[2402:3603] → 这就是 slice 2
  的数据 ✓
数据索引和位置恰好是同一个值（因为 zigzag 切分后，slice k 的数据就在d[k*half_seqlen : (k+1)*half_seqlen]），所以 remain_start 同时也是正确的 position起点。
但原来的 position_ids 没用 remain_start，而是用了 seqlen_padded_i - remain_len：
  torch.arange(seqlen_padded_i - remain_len, seqlen_padded_i)
这个公式隐含假设 "back chunk 总是序列末尾"，即 position 总是 [seqlen - remain_len,seqlen)。对 cp_rank 0 碰巧成立（slice 3 确实是最后一段），但对 cp_rank 1（slice 2是中间段）就错了

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
