### PR TITLE
[model, fsdp] fix: honor SP-rolled labels in fused kernels (#6068)

### DIFF
--- a/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
+++ b/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
@@ -11,58 +11,64 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Regression test for issue #6068.
+"""Regression test for issue #6068 (use_fused_kernels=True + ulysses_sp>1).
 
-When `use_fused_kernels=True` is combined with `ulysses_sequence_parallel_size > 1`,
-the fused-forward functions in `verl/models/transformers/*.py` were computing
+Under Ulysses sequence parallelism, the fused-kernel forward functions in
+`verl/models/transformers/*.py` were computing
 `rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)` *after* Ulysses had
-already SP-sliced the input. `torch.roll` wraps around the local-shard boundary
-rather than the global sequence, so the last position on every SP rank ended up
-predicting the wrong label (the first token of the rank's local shard instead of
-the global next-token). This biased ~1 position per rank per micro-batch and
-manifested as a slow training-quality regression at SP > 1 (issue #6068).
-
-The non-fused path was always correct because the FSDP engine pre-computes a
-globally-rolled `input_ids_rmpad_rolled`, then SP-slices *that* (see
-`verl/workers/engine/fsdp/transformer_impl.py:951-984`), and feeds it to
-`logprobs_from_logits` directly.
+already SP-sliced the input. `torch.roll` wraps around the local-shard
+boundary rather than the global sequence, so the last position on every SP
+rank ended up predicting the wrong label. This biased ~1 position per rank
+per micro-batch and manifested as a slow training-quality regression at
+SP > 1 (issue #6068).
 
 The fix plumbs the engine's pre-rolled `input_ids_rmpad_rolled` into the fused
-forward functions via a new `shift_labels` kwarg, mirroring what the veomni
-engine already does (see `verl/workers/engine/veomni/transformer_impl.py:659`).
+forwards via a new `shift_labels` kwarg, mirroring what the veomni engine
+already does at `verl/workers/engine/veomni/transformer_impl.py:659`.
 
-These tests run on CPU and do not require any GPUs.
+These tests:
+  1. Demonstrate the root cause directly (no model needed) — slice-then-roll
+     diverges from roll-then-slice at every shard boundary.
+  2. Verify each adapter's fused-forward (torch + triton backends) honors
+     the new `shift_labels` kwarg — i.e., the *routing* fix.
+
+The fused kernels themselves are Triton + CUDA only, so we patch them out
+for the CPU tests; their numerical correctness is covered by
+`tests/utils/test_linear_cross_entropy.py`. The end-to-end SP=2 integration
+test in `tests/special_distributed/test_fused_kernels_ulysses_sp.py`
+exercises the full path on 2 GPUs.
 """
 
+import contextlib
+from unittest import mock
+
+import pytest
 import torch
 
-from verl.models.transformers import dense_common, qwen2_vl, qwen3_5, qwen3_vl
+from verl.models.transformers import dense_common, glm4v, qwen2_vl, qwen3_5, qwen3_vl
+
+
+# ---------------------------------------------------------------------------
+# 1. Root-cause demonstration: slice-then-local-roll != global-roll-then-slice.
+# ---------------------------------------------------------------------------
 
 
 def _global_then_slice(input_ids: torch.Tensor, sp_size: int) -> list[torch.Tensor]:
-    """The correct behavior: roll on the full sequence, then SP-slice.
-
-    Mirrors the engine's `input_ids_rmpad_rolled` -> `ulysses_pad_and_slice_inputs`
-    pipeline in `verl/workers/engine/fsdp/transformer_impl.py`.
+    """Correct behavior: roll on the full sequence, then SP-slice. Mirrors the
+    engine's `input_ids_rmpad_rolled` -> `ulysses_pad_and_slice_inputs` path.
     """
     rolled = torch.roll(input_ids, shifts=-1, dims=-1)
     return list(torch.chunk(rolled, sp_size, dim=-1))
 
 
 def _slice_then_local_roll(input_ids: torch.Tensor, sp_size: int) -> list[torch.Tensor]:
-    """The buggy behavior: SP-slice first, then roll on the local shard.
-
-    Reproduces what `torch.roll(input_ids, shifts=-1, dims=-1)` did inside the
-    fused-forward functions when SP > 1.
-    """
+    """Buggy behavior: SP-slice first, then roll on the local shard."""
     sliced = list(torch.chunk(input_ids, sp_size, dim=-1))
     return [torch.roll(s, shifts=-1, dims=-1) for s in sliced]
 
 
 def test_local_roll_diverges_from_global_roll_under_sp():
-    """Demonstrates the root cause of #6068.
-
-    For SP > 1, slice-then-local-roll produces different labels than
+    """For SP > 1, slice-then-local-roll produces different labels than
     global-roll-then-slice at exactly the shard-boundary position on every rank.
     """
     torch.manual_seed(0)
@@ -72,136 +78,204 @@ def test_local_roll_diverges_from_global_roll_under_sp():
     correct_shards = _global_then_slice(input_ids, sp_size)
     buggy_shards = _slice_then_local_roll(input_ids, sp_size)
 
-    # Assertion 1: every interior position matches.
+    # Interior positions match — the bug is only at the shard boundary.
     for correct, buggy in zip(correct_shards, buggy_shards, strict=True):
         torch.testing.assert_close(correct[..., :-1], buggy[..., :-1])
 
-    # Assertion 2: the last position of every shard is wrong under buggy.
-    # On every rank the buggy version wraps to its local shard's first token;
-    # the correct version uses the next shard's first token (or the global
-    # first token on the final rank).
+    # Last position of every shard differs — that's the bias term that
+    # accumulates across training steps.
     for rank in range(sp_size):
         correct_last = correct_shards[rank][..., -1]
         buggy_last = buggy_shards[rank][..., -1]
         assert not torch.equal(correct_last, buggy_last), (
-            f"rank {rank}: expected divergence at shard boundary but got {correct_last}=={buggy_last}"
+            f"rank {rank}: expected divergence at shard boundary but got "
+            f"{correct_last}=={buggy_last}"
         )
 
 
-def _make_fake_lm(hidden_size: int, vocab_size: int):
-    """Minimal stand-in for the language-model wrapper expected by the fused forwards.
+# ---------------------------------------------------------------------------
+# 2. Adapter routing tests: each fused-forward (torch + triton) must use
+#    `shift_labels` verbatim when the engine passes it, and must fall back to
+#    local roll when it's absent (preserves SP=1 behavior).
+# ---------------------------------------------------------------------------
 
-    The fused forward functions only touch `self.model(...)` (returns hidden states)
-    and `self.lm_head.weight`, so we don't need a real transformer here.
+
+HIDDEN_SIZE = 8
+VOCAB_SIZE = 64
+
+
+class _FakeConfig:
+    """Minimal stand-in for `model.config` used by `forward_base_model`."""
+
+    output_attentions = False
+    output_hidden_states = False
+
+
+class _FakeBaseOutput:
+    """Mimics the HF model output: tuple-indexable and attribute-accessible."""
+
+    def __init__(self, hidden: torch.Tensor):
+        self._hidden = hidden
+        self.hidden_states = None
+        self.past_key_values = None
+        self.attentions = None
+
+    def __getitem__(self, idx):
+        if idx == 0:
+            return self._hidden
+        raise IndexError(idx)
+
+
+def _make_fake_lm() -> torch.nn.Module:
+    """Minimal stand-in for the language-model wrapper used by every adapter.
+
+    Provides `self.config`, `self.model(...)`, and `self.lm_head`. The fake
+    base model accepts the full kwarg set that `forward_base_model` passes.
     """
 
     class FakeBaseModel(torch.nn.Module):
-        def __init__(self, hidden):
+        def __init__(self):
             super().__init__()
-            self.embed = torch.nn.Embedding(vocab_size, hidden)
+            self.embed = torch.nn.Embedding(VOCAB_SIZE, HIDDEN_SIZE)
 
-        def forward(self, input_ids, **kwargs):
-            # Return a tuple so `outputs[0]` works (mirrors HF convention).
-            hidden_states = self.embed(input_ids).to(torch.float32)
-            return (hidden_states,)
+        def forward(self, input_ids=None, **_kwargs):
+            hidden = self.embed(input_ids).to(torch.float32)
+            return _FakeBaseOutput(hidden)
 
     class FakeLM(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.model = FakeBaseModel(hidden_size)
-            self.lm_head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+            self.config = _FakeConfig()
+            self.model = FakeBaseModel()
+            self.lm_head = torch.nn.Linear(HIDDEN_SIZE, VOCAB_SIZE, bias=False)
 
     torch.manual_seed(42)
     return FakeLM()
 
 
-def _run_fused_forward(forward_fn, model, input_ids, shift_labels):
-    """Invoke a fused forward, passing both `input_ids` and the new `shift_labels`."""
-    return forward_fn(
-        model,
-        input_ids=input_ids,
-        labels=None,
-        temperature=1.0,
-        shift_labels=shift_labels,
-        return_dict=True,
-    )
-
-
-def _assert_fused_forward_uses_shift_labels(forward_fn):
-    """Contract: when `shift_labels` is provided, the fused forward must use it
-    verbatim (i.e. not re-roll). We verify by feeding `shift_labels` that point
-    to a deliberately wrong vocab id and checking the resulting log-prob
-    matches what the kernel would produce for that wrong id, not for the
-    locally-rolled id.
+@contextlib.contextmanager
+def _patch_fused_kernels():
+    """Patch the fused kernels (Triton, CUDA-only) and the VLM body wrappers
+    so the CPU test exercises only the routing layer. Yields a dict that
+    captures the `input_ids` arg the kernel would have received.
     """
-    hidden_size, vocab_size = 8, 64
-    seq_len = 4
-    model = _make_fake_lm(hidden_size, vocab_size)
+    captured: dict[str, torch.Tensor] = {}
 
-    # Pick input_ids and a `shift_labels` that disagrees with torch.roll(input_ids).
-    # If the fix is in place, log_probs target `shift_labels`. If not, they target
-    # torch.roll(input_ids), which differs on the last position.
-    input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
-    shift_labels = torch.tensor([[20, 30, 40, 50]], dtype=torch.long)  # != torch.roll(input_ids)
+    def _fake_log_probs_and_entropy(input_ids: torch.Tensor):
+        if input_ids.dim() == 1:
+            shape = input_ids.shape
+        else:
+            shape = input_ids.shape  # already (B, T)
+        log_probs = torch.zeros(shape, dtype=torch.float32)
+        entropy = torch.zeros(shape, dtype=torch.float32)
+        return log_probs, entropy
 
-    out_with_shift = _run_fused_forward(forward_fn, model, input_ids, shift_labels)
+    def fake_fused_linear_forward(self, hidden_states, vocab_weights, input_ids, temperature=1.0):
+        captured["input_ids"] = input_ids.detach().clone()
+        return _fake_log_probs_and_entropy(input_ids)
 
-    # Recompute log_probs "by hand" using the same fused kernel against the
-    # explicit labels to nail down the expected value.
-    from verl.utils.experimental.torch_functional import FusedLinearForPPO
+    def fake_linear_ce(hidden_states, vocab_weights, input_ids, temperature, reduction):
+        captured["input_ids"] = input_ids.detach().clone()
+        return _fake_log_probs_and_entropy(input_ids)
 
-    with torch.no_grad():
-        hidden = model.model(input_ids)[0]
-        ref_log_probs, _ = FusedLinearForPPO().forward(
-            hidden_states=hidden,
-            vocab_weights=model.lm_head.weight,
-            input_ids=shift_labels,
-            temperature=1.0,
+    def fake_qwen2_vl_forward(self, input_ids, **_kwargs):
+        # Bypass `process_position_ids` and the real VLM body; we only care
+        # about the routing layer that runs *after* the model forward.
+        return _FakeBaseOutput(
+            torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1])
         )
 
-    torch.testing.assert_close(out_with_shift.log_probs, ref_log_probs, atol=1e-5, rtol=1e-5)
+    def fake_glm4v_forward(self, input_ids, **_kwargs):
+        return _FakeBaseOutput(
+            torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1])
+        )
+
+    with (
+        mock.patch(
+            "verl.utils.experimental.torch_functional.FusedLinearForPPO.forward",
+            new=fake_fused_linear_forward,
+        ),
+        mock.patch(
+            "verl.utils.kernel.linear_cross_entropy.linear_cross_entropy",
+            new=fake_linear_ce,
+        ),
+        mock.patch(
+            "verl.models.transformers.qwen2_vl.qwen2_vl_forward",
+            new=fake_qwen2_vl_forward,
+        ),
+        mock.patch(
+            "verl.models.transformers.glm4v.glm4v_forward",
+            new=fake_glm4v_forward,
+        ),
+    ):
+        yield captured
 
 
-def test_dense_common_torch_backend_honors_shift_labels():
-    _assert_fused_forward_uses_shift_labels(dense_common.forward_with_torch_backend)
+ALL_ADAPTERS = [
+    dense_common.forward_with_torch_backend,
+    dense_common.forward_with_triton_backend,
+    qwen3_5.forward_with_torch_backend,
+    qwen3_5.forward_with_triton_backend,
+    qwen3_vl.forward_with_torch_backend,
+    qwen3_vl.forward_with_triton_backend,
+    qwen2_vl.forward_with_torch_backend,
+    qwen2_vl.forward_with_triton_backend,
+    glm4v.forward_with_torch_backend,
+    glm4v.forward_with_triton_backend,
+]
 
 
-def test_qwen3_5_torch_backend_honors_shift_labels():
-    _assert_fused_forward_uses_shift_labels(qwen3_5.forward_with_torch_backend)
+def _adapter_id(forward_fn) -> str:
+    return f"{forward_fn.__module__.rsplit('.', 1)[-1]}.{forward_fn.__name__}"
 
 
-def test_qwen2_vl_torch_backend_honors_shift_labels():
-    _assert_fused_forward_uses_shift_labels(qwen2_vl.forward_with_torch_backend)
-
-
-def test_qwen3_vl_torch_backend_honors_shift_labels():
-    _assert_fused_forward_uses_shift_labels(qwen3_vl.forward_with_torch_backend)
-
-
-def test_dense_common_falls_back_to_local_roll_when_shift_labels_absent():
-    """Backward-compat: callers that don't pass `shift_labels` see unchanged behavior
-    (local roll over the input). This preserves the SP=1 path and any non-engine callers.
+@pytest.mark.parametrize("forward_fn", ALL_ADAPTERS, ids=_adapter_id)
+def test_adapter_honors_shift_labels(forward_fn):
+    """When `shift_labels` is provided, every fused adapter must pass it
+    through to the kernel verbatim — no local re-rolling.
     """
-    hidden_size, vocab_size = 8, 64
-    model = _make_fake_lm(hidden_size, vocab_size)
+    model = _make_fake_lm()
     input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+    # Deliberately != torch.roll(input_ids); the only way these labels reach
+    # the kernel is if the adapter honors `shift_labels`.
+    shift_labels = torch.tensor([[20, 30, 40, 50]], dtype=torch.long)
 
-    out_no_shift = dense_common.forward_with_torch_backend(
-        model,
-        input_ids=input_ids,
-        labels=None,
-        temperature=1.0,
-        return_dict=True,
+    with _patch_fused_kernels() as captured:
+        forward_fn(
+            model,
+            input_ids=input_ids,
+            labels=None,
+            temperature=1.0,
+            shift_labels=shift_labels,
+            return_dict=True,
+        )
+
+    assert "input_ids" in captured, "fused kernel was never called"
+    assert torch.equal(captured["input_ids"], shift_labels), (
+        f"{_adapter_id(forward_fn)}: expected kernel to see {shift_labels.tolist()}, "
+        f"got {captured['input_ids'].tolist()}"
     )
 
-    # Equivalent: explicit shift_labels = torch.roll(input_ids, -1).
-    out_explicit = dense_common.forward_with_torch_backend(
-        model,
-        input_ids=input_ids,
-        labels=None,
-        temperature=1.0,
-        shift_labels=torch.roll(input_ids, shifts=-1, dims=-1),
-        return_dict=True,
-    )
 
-    torch.testing.assert_close(out_no_shift.log_probs, out_explicit.log_probs, atol=1e-5, rtol=1e-5)
+@pytest.mark.parametrize("forward_fn", ALL_ADAPTERS, ids=_adapter_id)
+def test_adapter_falls_back_to_local_roll_when_shift_labels_absent(forward_fn):
+    """Backward-compat: callers that don't pass `shift_labels` (e.g. the SP=1
+    code path or any non-engine consumer) see unchanged behavior.
+    """
+    model = _make_fake_lm()
+    input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+    expected = torch.roll(input_ids, shifts=-1, dims=-1)
+
+    with _patch_fused_kernels() as captured:
+        forward_fn(
+            model,
+            input_ids=input_ids,
+            labels=None,
+            temperature=1.0,
+            return_dict=True,
+        )
+
+    assert torch.equal(captured["input_ids"], expected), (
+        f"{_adapter_id(forward_fn)}: expected fallback to torch.roll(input_ids), "
+        f"got {captured['input_ids'].tolist()}"
+    )

--- a/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
+++ b/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression test for issue #6068.
+
+When `use_fused_kernels=True` is combined with `ulysses_sequence_parallel_size > 1`,
+the fused-forward functions in `verl/models/transformers/*.py` were computing
+`rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)` *after* Ulysses had
+already SP-sliced the input. `torch.roll` wraps around the local-shard boundary
+rather than the global sequence, so the last position on every SP rank ended up
+predicting the wrong label (the first token of the rank's local shard instead of
+the global next-token). This biased ~1 position per rank per micro-batch and
+manifested as a slow training-quality regression at SP > 1 (issue #6068).
+
+The non-fused path was always correct because the FSDP engine pre-computes a
+globally-rolled `input_ids_rmpad_rolled`, then SP-slices *that* (see
+`verl/workers/engine/fsdp/transformer_impl.py:951-984`), and feeds it to
+`logprobs_from_logits` directly.
+
+The fix plumbs the engine's pre-rolled `input_ids_rmpad_rolled` into the fused
+forward functions via a new `shift_labels` kwarg, mirroring what the veomni
+engine already does (see `verl/workers/engine/veomni/transformer_impl.py:659`).
+
+These tests run on CPU and do not require any GPUs.
+"""
+
+import torch
+
+from verl.models.transformers import dense_common, qwen2_vl, qwen3_5, qwen3_vl
+
+
+def _global_then_slice(input_ids: torch.Tensor, sp_size: int) -> list[torch.Tensor]:
+    """The correct behavior: roll on the full sequence, then SP-slice.
+
+    Mirrors the engine's `input_ids_rmpad_rolled` -> `ulysses_pad_and_slice_inputs`
+    pipeline in `verl/workers/engine/fsdp/transformer_impl.py`.
+    """
+    rolled = torch.roll(input_ids, shifts=-1, dims=-1)
+    return list(torch.chunk(rolled, sp_size, dim=-1))
+
+
+def _slice_then_local_roll(input_ids: torch.Tensor, sp_size: int) -> list[torch.Tensor]:
+    """The buggy behavior: SP-slice first, then roll on the local shard.
+
+    Reproduces what `torch.roll(input_ids, shifts=-1, dims=-1)` did inside the
+    fused-forward functions when SP > 1.
+    """
+    sliced = list(torch.chunk(input_ids, sp_size, dim=-1))
+    return [torch.roll(s, shifts=-1, dims=-1) for s in sliced]
+
+
+def test_local_roll_diverges_from_global_roll_under_sp():
+    """Demonstrates the root cause of #6068.
+
+    For SP > 1, slice-then-local-roll produces different labels than
+    global-roll-then-slice at exactly the shard-boundary position on every rank.
+    """
+    torch.manual_seed(0)
+    total_nnz, sp_size = 32, 4
+    input_ids = torch.randint(0, 10000, (1, total_nnz))
+
+    correct_shards = _global_then_slice(input_ids, sp_size)
+    buggy_shards = _slice_then_local_roll(input_ids, sp_size)
+
+    # Assertion 1: every interior position matches.
+    for correct, buggy in zip(correct_shards, buggy_shards, strict=True):
+        torch.testing.assert_close(correct[..., :-1], buggy[..., :-1])
+
+    # Assertion 2: the last position of every shard is wrong under buggy.
+    # On every rank the buggy version wraps to its local shard's first token;
+    # the correct version uses the next shard's first token (or the global
+    # first token on the final rank).
+    for rank in range(sp_size):
+        correct_last = correct_shards[rank][..., -1]
+        buggy_last = buggy_shards[rank][..., -1]
+        assert not torch.equal(correct_last, buggy_last), (
+            f"rank {rank}: expected divergence at shard boundary but got {correct_last}=={buggy_last}"
+        )
+
+
+def _make_fake_lm(hidden_size: int, vocab_size: int):
+    """Minimal stand-in for the language-model wrapper expected by the fused forwards.
+
+    The fused forward functions only touch `self.model(...)` (returns hidden states)
+    and `self.lm_head.weight`, so we don't need a real transformer here.
+    """
+
+    class FakeBaseModel(torch.nn.Module):
+        def __init__(self, hidden):
+            super().__init__()
+            self.embed = torch.nn.Embedding(vocab_size, hidden)
+
+        def forward(self, input_ids, **kwargs):
+            # Return a tuple so `outputs[0]` works (mirrors HF convention).
+            hidden_states = self.embed(input_ids).to(torch.float32)
+            return (hidden_states,)
+
+    class FakeLM(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = FakeBaseModel(hidden_size)
+            self.lm_head = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+
+    torch.manual_seed(42)
+    return FakeLM()
+
+
+def _run_fused_forward(forward_fn, model, input_ids, shift_labels):
+    """Invoke a fused forward, passing both `input_ids` and the new `shift_labels`."""
+    return forward_fn(
+        model,
+        input_ids=input_ids,
+        labels=None,
+        temperature=1.0,
+        shift_labels=shift_labels,
+        return_dict=True,
+    )
+
+
+def _assert_fused_forward_uses_shift_labels(forward_fn):
+    """Contract: when `shift_labels` is provided, the fused forward must use it
+    verbatim (i.e. not re-roll). We verify by feeding `shift_labels` that point
+    to a deliberately wrong vocab id and checking the resulting log-prob
+    matches what the kernel would produce for that wrong id, not for the
+    locally-rolled id.
+    """
+    hidden_size, vocab_size = 8, 64
+    seq_len = 4
+    model = _make_fake_lm(hidden_size, vocab_size)
+
+    # Pick input_ids and a `shift_labels` that disagrees with torch.roll(input_ids).
+    # If the fix is in place, log_probs target `shift_labels`. If not, they target
+    # torch.roll(input_ids), which differs on the last position.
+    input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+    shift_labels = torch.tensor([[20, 30, 40, 50]], dtype=torch.long)  # != torch.roll(input_ids)
+
+    out_with_shift = _run_fused_forward(forward_fn, model, input_ids, shift_labels)
+
+    # Recompute log_probs "by hand" using the same fused kernel against the
+    # explicit labels to nail down the expected value.
+    from verl.utils.experimental.torch_functional import FusedLinearForPPO
+
+    with torch.no_grad():
+        hidden = model.model(input_ids)[0]
+        ref_log_probs, _ = FusedLinearForPPO().forward(
+            hidden_states=hidden,
+            vocab_weights=model.lm_head.weight,
+            input_ids=shift_labels,
+            temperature=1.0,
+        )
+
+    torch.testing.assert_close(out_with_shift.log_probs, ref_log_probs, atol=1e-5, rtol=1e-5)
+
+
+def test_dense_common_torch_backend_honors_shift_labels():
+    _assert_fused_forward_uses_shift_labels(dense_common.forward_with_torch_backend)
+
+
+def test_qwen3_5_torch_backend_honors_shift_labels():
+    _assert_fused_forward_uses_shift_labels(qwen3_5.forward_with_torch_backend)
+
+
+def test_qwen2_vl_torch_backend_honors_shift_labels():
+    _assert_fused_forward_uses_shift_labels(qwen2_vl.forward_with_torch_backend)
+
+
+def test_qwen3_vl_torch_backend_honors_shift_labels():
+    _assert_fused_forward_uses_shift_labels(qwen3_vl.forward_with_torch_backend)
+
+
+def test_dense_common_falls_back_to_local_roll_when_shift_labels_absent():
+    """Backward-compat: callers that don't pass `shift_labels` see unchanged behavior
+    (local roll over the input). This preserves the SP=1 path and any non-engine callers.
+    """
+    hidden_size, vocab_size = 8, 64
+    model = _make_fake_lm(hidden_size, vocab_size)
+    input_ids = torch.tensor([[10, 20, 30, 40]], dtype=torch.long)
+
+    out_no_shift = dense_common.forward_with_torch_backend(
+        model,
+        input_ids=input_ids,
+        labels=None,
+        temperature=1.0,
+        return_dict=True,
+    )
+
+    # Equivalent: explicit shift_labels = torch.roll(input_ids, -1).
+    out_explicit = dense_common.forward_with_torch_backend(
+        model,
+        input_ids=input_ids,
+        labels=None,
+        temperature=1.0,
+        shift_labels=torch.roll(input_ids, shifts=-1, dims=-1),
+        return_dict=True,
+    )
+
+    torch.testing.assert_close(out_no_shift.log_probs, out_explicit.log_probs, atol=1e-5, rtol=1e-5)

--- a/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
+++ b/tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
@@ -47,7 +47,6 @@ import torch
 
 from verl.models.transformers import dense_common, glm4v, qwen2_vl, qwen3_5, qwen3_vl
 
-
 # ---------------------------------------------------------------------------
 # 1. Root-cause demonstration: slice-then-local-roll != global-roll-then-slice.
 # ---------------------------------------------------------------------------
@@ -88,8 +87,7 @@ def test_local_roll_diverges_from_global_roll_under_sp():
         correct_last = correct_shards[rank][..., -1]
         buggy_last = buggy_shards[rank][..., -1]
         assert not torch.equal(correct_last, buggy_last), (
-            f"rank {rank}: expected divergence at shard boundary but got "
-            f"{correct_last}=={buggy_last}"
+            f"rank {rank}: expected divergence at shard boundary but got {correct_last}=={buggy_last}"
         )
 
 
@@ -181,14 +179,10 @@ def _patch_fused_kernels():
     def fake_qwen2_vl_forward(self, input_ids, **_kwargs):
         # Bypass `process_position_ids` and the real VLM body; we only care
         # about the routing layer that runs *after* the model forward.
-        return _FakeBaseOutput(
-            torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1])
-        )
+        return _FakeBaseOutput(torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1]))
 
     def fake_glm4v_forward(self, input_ids, **_kwargs):
-        return _FakeBaseOutput(
-            torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1])
-        )
+        return _FakeBaseOutput(torch.zeros(1, input_ids.shape[-1], self.lm_head.weight.shape[1]))
 
     with (
         mock.patch(
@@ -276,6 +270,5 @@ def test_adapter_falls_back_to_local_roll_when_shift_labels_absent(forward_fn):
         )
 
     assert torch.equal(captured["input_ids"], expected), (
-        f"{_adapter_id(forward_fn)}: expected fallback to torch.roll(input_ids), "
-        f"got {captured['input_ids'].tolist()}"
+        f"{_adapter_id(forward_fn)}: expected fallback to torch.roll(input_ids), got {captured['input_ids'].tolist()}"
     )

--- a/tests/special_distributed/test_fused_kernels_ulysses_sp.py
+++ b/tests/special_distributed/test_fused_kernels_ulysses_sp.py
@@ -135,9 +135,10 @@ def test_fused_kernels_log_probs_match_under_sp():
         input_ids_rmpad = input_ids  # (1, total_nnz), already "rmpadded"
         input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=1)
         # Slice both inputs and rolled labels exactly like the engine.
+        # `position_ids` is already (1, total_nnz); helper expects 2D, not 3D.
         sliced_input, sliced_pos, pad_size = ulysses_pad_and_slice_inputs(
             input_ids_rmpad,
-            position_ids_rmpad=position_ids.unsqueeze(0),
+            position_ids_rmpad=position_ids,
             sp_size=sp_size,
         )
         sliced_rolled, _, _ = ulysses_pad_and_slice_inputs(

--- a/tests/special_distributed/test_fused_kernels_ulysses_sp.py
+++ b/tests/special_distributed/test_fused_kernels_ulysses_sp.py
@@ -27,8 +27,6 @@ Run on 2 GPUs:
         tests/special_distributed/test_fused_kernels_ulysses_sp.py
 """
 
-import os
-
 import pytest
 import torch
 import torch.distributed

--- a/tests/special_distributed/test_fused_kernels_ulysses_sp.py
+++ b/tests/special_distributed/test_fused_kernels_ulysses_sp.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end regression test for issue #6068 (use_fused_kernels=True + ulysses_sp>1).
+
+Construction:
+1. Build a small Llama-style model patched with `use_fused_kernels=True` and SP=2.
+2. Run the fused forward through Ulysses (rank-local input_ids_rmpad slice + the
+   engine-style globally-rolled `shift_labels`) and compare its `log_probs`
+   against a single-GPU reference (SP=1, same fused kernel) gathered across ranks.
+3. Without the fix, every rank's last-position log_prob diverges from the
+   reference because the fused forward locally re-rolls the SP-sliced input.
+   With the fix, log_probs are bitwise close.
+
+Run on 2 GPUs:
+    torchrun --nproc_per_node=2 -m pytest -svv \
+        tests/special_distributed/test_fused_kernels_ulysses_sp.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed
+from torch.distributed import init_device_mesh
+from transformers import AutoModelForCausalLM, LlamaConfig
+
+from verl.models.transformers.monkey_patch import apply_monkey_patch
+from verl.utils.device import get_device_name, get_torch_device
+from verl.utils.distributed import initialize_global_process_group
+from verl.utils.ulysses import (
+    FSDPUlyssesShardingManager,
+    gather_outputs_and_unpad,
+    set_ulysses_sequence_parallel_group,
+    ulysses_pad_and_slice_inputs,
+)
+
+
+def _make_model(seed: int = 0):
+    config = LlamaConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=8,
+    )
+    torch.manual_seed(seed)
+    model = AutoModelForCausalLM.from_config(
+        config, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2"
+    )
+    return model, config
+
+
+def _broadcast_params(model):
+    for p in model.parameters():
+        torch.distributed.broadcast(p.data, src=0)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_dist():
+    if not torch.distributed.is_initialized():
+        initialize_global_process_group()
+    yield
+
+
+def test_fused_kernels_log_probs_match_under_sp():
+    """log_probs from fused-kernel + SP=2 must equal fused-kernel + SP=1.
+
+    This is the direct regression test for #6068. The bug was that the
+    fused-forward functions re-rolled the SP-sliced `input_ids` locally,
+    producing wrong labels at the shard boundary. The fix passes
+    `shift_labels` (engine-rolled, then SP-sliced) so the fused forward
+    uses correct labels.
+    """
+    assert get_torch_device().device_count() >= 2, "need at least 2 gpus"
+    sp_size = 2
+    device = get_device_name()
+
+    # Build identical model on every rank.
+    model, config = _make_model(seed=42)
+    apply_monkey_patch(
+        model,
+        ulysses_sp_size=sp_size,
+        use_remove_padding=True,
+        use_fused_kernels=True,
+        fused_kernels_backend="torch",
+    )
+    model = model.to(device=device, dtype=torch.bfloat16)
+    _broadcast_params(model)
+
+    # rank-0-authoritative input. total_nnz must be divisible by sp_size.
+    total_nnz = 32
+    if torch.distributed.get_rank() == 0:
+        input_ids = torch.randint(0, config.vocab_size, (1, total_nnz), device=device)
+    else:
+        input_ids = torch.empty((1, total_nnz), dtype=torch.long, device=device)
+    torch.distributed.broadcast(input_ids, src=0)
+    position_ids = torch.arange(total_nnz, device=device).unsqueeze(0)  # (1, total_nnz)
+
+    # ---- SP=1 reference: full sequence, fused forward, on rank 0 only ----
+    set_ulysses_sequence_parallel_group(None)
+    if torch.distributed.get_rank() == 0:
+        ref_out = model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            use_cache=False,
+            return_dict=True,
+            temperature=1.0,
+        )
+        ref_log_probs = ref_out.log_probs.detach().clone()  # (1, total_nnz)
+    else:
+        ref_log_probs = torch.empty((1, total_nnz), device=device, dtype=torch.float32)
+    torch.distributed.broadcast(ref_log_probs, src=0)
+
+    # ---- SP=2 path: each rank gets a slice; engine plumbs shift_labels ----
+    world_size = torch.distributed.get_world_size()
+    assert world_size % sp_size == 0
+    dp_size = world_size // sp_size
+    device_mesh = init_device_mesh(device_type=device, mesh_shape=(dp_size, sp_size), mesh_dim_names=("dp", "sp"))
+    sharding_manager = FSDPUlyssesShardingManager(device_mesh)
+
+    with sharding_manager:
+        # Mimic the engine's preparation (transformer_impl.py ~951-984).
+        input_ids_rmpad = input_ids  # (1, total_nnz), already "rmpadded"
+        input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=1)
+        # Slice both inputs and rolled labels exactly like the engine.
+        sliced_input, sliced_pos, pad_size = ulysses_pad_and_slice_inputs(
+            input_ids_rmpad,
+            position_ids_rmpad=position_ids.unsqueeze(0),
+            sp_size=sp_size,
+        )
+        sliced_rolled, _, _ = ulysses_pad_and_slice_inputs(
+            input_ids_rmpad_rolled, position_ids_rmpad=None, sp_size=sp_size
+        )
+        sp_out = model(
+            input_ids=sliced_input,
+            position_ids=sliced_pos,
+            use_cache=False,
+            return_dict=True,
+            temperature=1.0,
+            shift_labels=sliced_rolled,
+        )
+        # log_probs is (1, total_nnz/sp + pad). Gather across SP ranks → (1, total_nnz).
+        sp_log_probs_local = sp_out.log_probs  # (1, local_len)
+        sp_log_probs = gather_outputs_and_unpad(
+            sp_log_probs_local.squeeze(0),
+            gather_dim=0,
+            unpad_dim=0,
+            padding_size=pad_size,
+        ).unsqueeze(0)  # (1, total_nnz)
+
+    # bf16 matmul + chunked fused kernel — keep tolerances loose enough to absorb
+    # numerical noise but strict enough to catch the off-by-one label bug, which
+    # produces O(1) errors in the affected positions.
+    torch.testing.assert_close(sp_log_probs, ref_log_probs, atol=1e-3, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-svv"])

--- a/verl/models/transformers/dense_common.py
+++ b/verl/models/transformers/dense_common.py
@@ -83,6 +83,7 @@ def forward_with_torch_backend(
     cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: int | torch.Tensor = 0,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **loss_kwargs,
 ) -> tuple | CausalLMOutputForPPO:
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
@@ -105,8 +106,13 @@ def forward_with_torch_backend(
     if not return_dict:
         raise NotImplementedError("forward_with_torch_backend has to return_dict")
 
-    # Loss calculations
-    if labels is not None:
+    # Loss calculations.
+    # When the engine has already prepared globally-rolled labels (e.g. the FSDP
+    # path under Ulysses SP, see issue #6068), it passes them as `shift_labels`
+    # so we don't redo `torch.roll` on a sequence-parallel-sliced shard.
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
@@ -145,6 +151,7 @@ def forward_with_triton_backend(
     cache_position: Optional[torch.LongTensor] = None,
     logits_to_keep: int | torch.Tensor = 0,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **loss_kwargs,
 ) -> tuple | CausalLMOutputForPPO:
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
@@ -168,8 +175,11 @@ def forward_with_triton_backend(
     if not return_dict:
         raise NotImplementedError("forward_with_triton_backend has to return_dict")
 
-    # Loss calculations
-    if labels is not None:
+    # Loss calculations. See `forward_with_torch_backend` for why `shift_labels`
+    # takes precedence over local `torch.roll` (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)

--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -477,6 +477,7 @@ def forward_with_torch_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Glm4vCausalLMOutputForPPO:
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
@@ -484,8 +485,11 @@ def forward_with_torch_backend(
     outputs = glm4v_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # See `dense_common.forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
@@ -511,6 +515,7 @@ def forward_with_triton_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Glm4vCausalLMOutputForPPO:
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
@@ -518,8 +523,11 @@ def forward_with_triton_backend(
     outputs = glm4v_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # See `dense_common.forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -492,6 +492,7 @@ def forward_with_torch_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Qwen2VLCausalLMOutputForPPO:
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
@@ -499,8 +500,11 @@ def forward_with_torch_backend(
     outputs = qwen2_vl_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # Loss calculations. See `dense_common.forward_with_torch_backend` for the
+    # `shift_labels` rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
@@ -526,6 +530,7 @@ def forward_with_triton_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Qwen2VLCausalLMOutputForPPO:
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
@@ -533,8 +538,11 @@ def forward_with_triton_backend(
     outputs = qwen2_vl_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # See `dense_common.forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -199,6 +199,7 @@ def forward_with_torch_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
@@ -206,8 +207,11 @@ def forward_with_torch_backend(
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # See `dense_common.forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
@@ -233,6 +237,7 @@ def forward_with_triton_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
@@ -240,8 +245,11 @@ def forward_with_triton_backend(
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # See `dense_common.forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -280,6 +280,7 @@ def forward_with_torch_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
@@ -287,8 +288,12 @@ def forward_with_torch_backend(
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # Loss calculations. `shift_labels` (when provided by the engine) is the
+    # globally-rolled, SP-sliced label tensor — using it avoids the local-roll
+    # bug in issue #6068 under Ulysses sequence parallel.
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
@@ -314,6 +319,7 @@ def forward_with_triton_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
@@ -321,8 +327,11 @@ def forward_with_triton_backend(
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 
-    # Loss calculations
-    if labels is not None:
+    # Loss calculations. See `forward_with_torch_backend` for the `shift_labels`
+    # rationale (issue #6068).
+    if shift_labels is not None:
+        rolled_labels = shift_labels
+    elif labels is not None:
         rolled_labels = torch.roll(labels, shifts=-1, dims=-1)
     elif input_ids is not None:
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1040,6 +1040,14 @@ class FSDPEngineWithLMHead(FSDPEngine):
         if use_fused_kernels:
             extra_args["temperature"] = temperature_item
             extra_args["return_dict"] = True
+            if use_remove_padding:
+                # We have already computed `input_ids_rmpad_rolled` from the *full*
+                # global sequence and (when SP>1) SP-sliced it. Pass it into the model
+                # so the fused forward uses these labels verbatim instead of redoing
+                # `torch.roll` on the local SP shard, which would wrap around the
+                # shard boundary rather than the global sequence (issue #6068). This
+                # mirrors what the veomni engine already does for fused kernels.
+                extra_args["shift_labels"] = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
 
         model_inputs.update(multi_modal_inputs)
         model_inputs.update(extra_args)


### PR DESCRIPTION
## Summary

Fixes #6068.

When `use_fused_kernels=True` is combined with `ulysses_sequence_parallel_size > 1`,
the fused-forward functions in `verl/models/transformers/*.py` were re-rolling
SP-sliced inputs locally:

```python
rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
```

The engine had already SP-sliced `input_ids` along the sequence dimension, so
`torch.roll` wraps at the local-shard boundary instead of the global sequence.
This corrupts exactly one label per SP rank per micro-batch — the last position
on each shard predicts that shard's first token (or the global first token on
the final rank) instead of the correct global next-token.

The bug is silent: shapes stay consistent, only the label values are wrong.
This biases the importance-sampling log-probs at those positions every step
and matches the slow training-quality regression curves the reporter shared.

## Why this isn't already covered

The non-fused path in `verl/workers/engine/fsdp/transformer_impl.py` is correct
because it uses `logprobs_from_logits(labels=input_ids_rmpad_rolled, ...)` —
the engine pre-computes a globally-rolled label tensor and SP-slices *it*
(see [transformer_impl.py:951-984](https://github.com/verl-project/verl/blob/main/verl/workers/engine/fsdp/transformer_impl.py#L951-L984)).
The veomni engine already plumbs that same tensor into its fused path
([veomni/transformer_impl.py:659](https://github.com/verl-project/verl/blob/main/verl/workers/engine/veomni/transformer_impl.py#L659)).
The FSDP engine never plumbed it, so its fused path silently re-rolled.

## The fix

1. Six model adapters (`dense_common`, `qwen2_vl`, `qwen3_vl`, `qwen3_5`, `glm4v`)
   accept a new `shift_labels` kwarg in both `forward_with_torch_backend` and
   `forward_with_triton_backend`. When provided, it's used verbatim. When
   absent, the existing `torch.roll(input_ids, ...)` fallback preserves SP=1
   behavior and any non-engine callers.
2. The FSDP engine plumbs `output_args[\"input_ids_rmpad_rolled\"]` into
   `extra_args[\"shift_labels\"]` when `use_fused_kernels=True` and
   `use_remove_padding=True` — mirroring veomni.

## Out of scope (intentional)

- **Megatron engine**: uses a different fused path
  (`get_mcore_forward_fused_model_engine_fn`) and Megatron's CP rather than
  Ulysses SP. Not affected by this bug; happy to file a follow-up if needed.
- **Non-rmpad fused path**: the bug requires the engine to have already
  SP-sliced `input_ids`. The non-rmpad path doesn't take the SP-slice route,
  so it's unaffected.

## Duplicate-work check (per CLAUDE.md)

Confirmed clean before opening:
- \`gh issue view 6068 --comments\`: no claimed PRs, no follow-ups.
- \`gh pr list --search \"6068 in:body\"\`: 0 results.
- \`gh pr list --search \"fused_kernels ulysses sequence_parallel\"\`: 0 related results.

## Test plan

### CPU unit test (\`tests/models/test_fused_kernels_ulysses_sp_on_cpu.py\`)

21 tests, runs in CI's CPU lane (\`_on_cpu.py\` suffix):
- 1 root-cause demonstration: slice-then-local-roll diverges from
  global-roll-then-slice at every shard boundary.
- 10 routing tests (5 model adapters × torch+triton backends): each adapter
  passes \`shift_labels\` through to the kernel verbatim. Fused kernels are
  mocked because they are CUDA/Triton-only; their numerical correctness is
  covered by \`tests/utils/test_linear_cross_entropy.py\`.
- 10 backward-compat tests: when \`shift_labels\` is absent, every adapter
  falls back to local roll (preserves SP=1 behavior).

\`\`\`bash
pytest -svv tests/models/test_fused_kernels_ulysses_sp_on_cpu.py
# 21 passed
\`\`\`

### 2-GPU integration test (\`tests/special_distributed/test_fused_kernels_ulysses_sp.py\`)

End-to-end: builds a small Llama, runs fused-kernel forward with SP=2 vs.
fused-kernel forward with SP=1 on the same input, asserts log-prob parity
across the full sequence. Run on 2× A10 24GB.

\`\`\`bash
torchrun --nproc_per_node=2 -m pytest -svv \\
    tests/special_distributed/test_fused_kernels_ulysses_sp.py
# 1 passed
\`\`\`

### Fail-on-main verification

To confirm the integration test catches the bug, I reverted the production
code while keeping the tests, then re-ran:

\`\`\`
FAILED ... AssertionError: Tensor-likes are not close!
Mismatched elements: 2 / 32 (6.2%)
Greatest absolute difference: 0.6552734375 at index (0, 15)
\`\`\`

That's exactly one position per SP rank failing (index 15 = boundary of the
rank-0 shard, with a corresponding mismatch at the rank-1 boundary that the
assertion didn't reach), with O(1) absolute error consistent with wrong-label
cross-entropy. The 30/32 interior positions stay within 1e-3 — confirming
the bug is precisely a one-position-per-shard label corruption and not a
general SP or kernel issue.

### No-regression checks

- \`tests/utils/test_linear_cross_entropy.py\` — unchanged behavior.
- \`tests/models/test_transformers_ulysses.py\` — unchanged behavior.

<details>
<summary>AI assistance disclosure (per CLAUDE.md)</summary>

This PR was drafted with AI assistance. The submitter reviewed every changed
line, set up the test environment, ran the fix + fail-on-main verification
end-to-end on a 2× A10 box, and confirmed both the failure pattern and the
restored green state.

</details>