### PR TITLE
[doc] fix: router_replay is now under megatron

### DIFF
--- a/examples/router_replay/README.md
+++ b/examples/router_replay/README.md
@@ -35,15 +35,16 @@ Add the following to your training configuration:
 
 ```yaml
 actor:
-  router_replay:
-    mode: "R2"
+  megatron:
+    router_replay:
+      mode: "R2"
 ```
 
 #### Command Line Method
 Enable R2 mode via command-line parameters:
 
 ```bash
-actor_rollout_ref.actor.router_replay.mode="R2"
+actor_rollout_ref.actor.megatron.router_replay.mode="R2"
 ```
 
 ### Enabling R3 Mode
@@ -52,19 +53,22 @@ actor_rollout_ref.actor.router_replay.mode="R2"
 Configure both actor and rollout settings:
 
 ```yaml
-# Actor configuration
-router_replay:
-  mode: "R3"
+# Actor configuration for megatron
+actor:
+  megatron:
+    router_replay:
+      mode: "R3"
 
-# Rollout configuration  
-enable_rollout_routing_replay: True
+# Rollout configuration
+rollout:
+  enable_rollout_routing_replay: True
 ```
 
 #### Command Line Method
 Enable R3 mode via command-line parameters:
 
 ```bash
-actor_rollout_ref.actor.router_replay.mode="R3"
+actor_rollout_ref.actor.megatron.router_replay.mode="R3"
 actor_rollout_ref.rollout.enable_rollout_routing_replay=True
 ```
 


### PR DESCRIPTION
### What does this PR do?

`router_replay` configuration key has been moved under `megatron` key, but the documentation hasn't reflected this correctly.

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
