### PR TITLE
[data, rollout] feat: add audio data support

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -43,8 +43,10 @@ class _FakeServerManager:
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> TokenOutput:
-        del request_id, sampling_params, image_data, video_data
+        del request_id, sampling_params, image_data, video_data, audio_data, mm_processor_kwargs
         # Return a short, deterministic "generation" for testing.
         return TokenOutput(token_ids=prompt_ids[-1:] + [11, 12, 13], log_probs=[0.0, 0.0, 0.0, 0.0])
 
@@ -56,8 +58,10 @@ class _FakeServerManager:
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[list[int], list[float], bool]:
-        del request_id, sampling_params, image_data, video_data
+        del request_id, sampling_params, image_data, video_data, audio_data, mm_processor_kwargs
         # Return a short partial generation and "not cancelled".
         response_ids = prompt_ids[-1:] + [21, 22]
         response_logprobs = [0.0] * len(response_ids)
@@ -257,6 +261,7 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
     class _DummyWorker:
         _compute_multi_modal_inputs = AgentLoopWorker._compute_multi_modal_inputs
         _compute_position_ids = AgentLoopWorker._compute_position_ids
+        _get_mm_processor_kwargs = AgentLoopWorker._get_mm_processor_kwargs
         _compute_score = AgentLoopWorker._compute_score
         _compute_teacher_logprobs = AgentLoopWorker._compute_teacher_logprobs
         distillation_enabled = False
@@ -265,6 +270,7 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
             self.tokenizer = _FakeTokenizer()
             self.rollout_config = OmegaConf.create({"prompt_length": 4, "response_length": 4})
             self.processor = None
+            self.mm_processor_kwargs = {}
             self.reward_loop_worker_handles = None
 
     routed_experts = np.arange(8, dtype=np.int64).reshape(4, 2, 1)

--- a/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
+++ b/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/llm_server.py"
+VLLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/vllm_rollout/vllm_async_server.py"
+
+
+def _load_module_ast(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def test_async_server_manager_generate_accepts_audio_and_mm_kwargs() -> None:
+    module = _load_module_ast(LLM_SERVER_SOURCE)
+
+    generate_fn = None
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "LLMServerClient":
+            for inner in node.body:
+                if isinstance(inner, ast.AsyncFunctionDef) and inner.name == "generate":
+                    generate_fn = inner
+                    break
+
+    assert generate_fn is not None
+    arg_names = [arg.arg for arg in generate_fn.args.kwonlyargs]
+    assert "audio_data" in arg_names
+    assert "mm_processor_kwargs" in arg_names
+
+
+def test_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
+    source = LLM_SERVER_SOURCE.read_text(encoding="utf-8")
+    assert "audio_data=audio_data" in source
+    assert "mm_processor_kwargs=mm_processor_kwargs" in source
+
+
+def test_vllm_generate_includes_audio_and_mm_processor_kwargs() -> None:
+    source = VLLM_SERVER_SOURCE.read_text(encoding="utf-8")
+    assert 'multi_modal_data["audio"] = audio_data' in source
+    assert 'prompt_kwargs["mm_processor_kwargs"] = mm_processor_kwargs' in source

--- a/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
+++ b/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/llm_server.py"
+FULLY_ASYNC_ROLLOUTER_SOURCE = REPO_ROOT / "verl/experimental/fully_async_policy/fully_async_rollouter.py"
 VLLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/vllm_rollout/vllm_async_server.py"
 
 
@@ -45,6 +46,12 @@ def test_async_server_manager_generate_accepts_audio_and_mm_kwargs() -> None:
 
 def test_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
     source = LLM_SERVER_SOURCE.read_text(encoding="utf-8")
+    assert 'multimodal_kwargs["audio_data"] = audio_data' in source
+    assert 'multimodal_kwargs["mm_processor_kwargs"] = mm_processor_kwargs' in source
+
+
+def test_fully_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
+    source = FULLY_ASYNC_ROLLOUTER_SOURCE.read_text(encoding="utf-8")
     assert "audio_data=audio_data" in source
     assert "mm_processor_kwargs=mm_processor_kwargs" in source
 

--- a/tests/utils/test_audio_input_support_on_cpu.py
+++ b/tests/utils/test_audio_input_support_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import pytest
+import torch
+
+from verl.utils.model import extract_multi_modal_inputs
+from verl.utils.tokenizer import build_multimodal_processor_inputs
+
+
+def test_build_messages_replaces_audio_placeholder() -> None:
+    pytest.importorskip("datasets")
+    from verl.utils.dataset.rl_dataset import RLHFDataset
+
+    dataset = RLHFDataset.__new__(RLHFDataset)
+    dataset.prompt_key = "prompt"
+    dataset.image_key = "images"
+    dataset.video_key = "videos"
+    dataset.audio_key = "audios"
+    dataset.processor = object()
+
+    example = {
+        "prompt": [
+            {"role": "user", "content": "Listen to this: <audio> and answer."},
+        ],
+        "audios": ["/tmp/example.wav"],
+    }
+
+    messages = dataset._build_messages(example)
+    content = messages[0]["content"]
+    assert content == [
+        {"type": "text", "text": "Listen to this: "},
+        {"type": "audio", "audio": "/tmp/example.wav"},
+        {"type": "text", "text": " and answer."},
+    ]
+
+
+def test_build_multimodal_processor_inputs_includes_audio_sampling_rate() -> None:
+    captured = {}
+
+    class AudioProcessor:
+        def __init__(self):
+            self.feature_extractor = types.SimpleNamespace(sampling_rate=16000)
+
+        def __call__(self, **kwargs):
+            captured.update(kwargs)
+            return {"input_ids": torch.tensor([[1, 2, 3]])}
+
+    processor = AudioProcessor()
+    output = build_multimodal_processor_inputs(
+        processor,
+        text=["hello"],
+        images=None,
+        videos=None,
+        audio=["waveform"],
+        mm_processor_kwargs={"use_audio_in_video": True},
+    )
+
+    assert torch.equal(output["input_ids"], torch.tensor([[1, 2, 3]]))
+    assert captured["audio"] == ["waveform"]
+    assert captured["sampling_rate"] == 16000
+    assert captured["use_audio_in_video"] is True
+
+
+def test_extract_multi_modal_inputs_merges_variable_audio_fields() -> None:
+    first_features = torch.arange(6, dtype=torch.float32).view(1, 2, 3)
+    second_features = torch.arange(10, dtype=torch.float32).view(1, 2, 5)
+
+    merged = extract_multi_modal_inputs(
+        [
+            {
+                "input_features": first_features,
+                "feature_attention_mask": torch.tensor([[1, 1, 1]], dtype=torch.long),
+                "video_second_per_grid": torch.tensor([0.5]),
+            },
+            {
+                "input_features": second_features,
+                "feature_attention_mask": torch.tensor([[1, 1, 1, 1, 0]], dtype=torch.long),
+                "video_second_per_grid": torch.tensor([1.0]),
+            },
+        ]
+    )
+
+    assert merged["input_features"].shape == (2, 2, 5)
+    assert torch.equal(merged["input_features"][0, :, :3], first_features.squeeze(0))
+    assert torch.equal(merged["input_features"][0, :, 3:], torch.zeros(2, 2))
+    assert torch.equal(merged["input_features"][1], second_features.squeeze(0))
+    assert torch.equal(merged["feature_attention_mask"], torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]))
+    assert torch.equal(merged["video_second_per_grid"], torch.tensor([0.5, 1.0]))
+
+
+def test_extract_multi_modal_inputs_rejects_unknown_ragged_fields() -> None:
+    with pytest.raises(RuntimeError, match="extra_audio_field"):
+        extract_multi_modal_inputs(
+            [
+                {"extra_audio_field": torch.ones(1, 2, 3)},
+                {"extra_audio_field": torch.ones(1, 2, 5)},
+            ]
+        )

--- a/tests/utils/test_audio_input_support_on_cpu.py
+++ b/tests/utils/test_audio_input_support_on_cpu.py
@@ -39,7 +39,7 @@ def test_build_messages_replaces_audio_placeholder() -> None:
         "audios": ["/tmp/example.wav"],
     }
 
-    messages = dataset._build_messages(example)
+    messages = dataset._build_messages(example, key=dataset.prompt_key)
     content = messages[0]["content"]
     assert content == [
         {"type": "text", "text": "Listen to this: "},

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -59,7 +59,11 @@ from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
 )
-from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.tokenizer import (
+    build_multimodal_processor_inputs,
+    get_processor_token_id,
+    normalize_token_ids,
+)
 from verl.workers.config import (
     HFModelConfig,
     RolloutConfig,
@@ -104,6 +108,8 @@ class AgentLoopOutput(BaseModel):
     """Auxiliary performance metrics"""
     extra_fields: dict[str, Any] = {}
     """Extra fields for dynamic addition."""
+    mm_processor_kwargs: Optional[dict[str, Any]] = None
+    """Processor/backend kwargs that must stay aligned across rollout and training paths."""
 
     def as_dict(self) -> dict[str, Any]:
         """Convert agent loop output to a dictionary."""
@@ -216,27 +222,50 @@ class AgentLoopBase(ABC):
         self.dataset_cls = dataset_cls
         self.data_config = data_config.config
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
-        self.system_prompt = initialize_system_prompt(self.tokenizer, **self.apply_chat_template_kwargs)
+        self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
+        processing_class = self.processor if self.processor is not None else self.tokenizer
+        self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 
+    def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
+        mm_processor_kwargs = dict(self.mm_processor_kwargs or {})
+        if audio_data is not None and "sampling_rate" not in mm_processor_kwargs:
+            sampling_rate = getattr(getattr(self.processor, "feature_extractor", None), "sampling_rate", None)
+            if sampling_rate is not None:
+                mm_processor_kwargs["sampling_rate"] = int(sampling_rate)
+        return mm_processor_kwargs
+
     async def process_vision_info(self, messages: list[dict]) -> dict:
-        """Extract images and videos from messages.
+        """Backward-compatible wrapper for multi-modal extraction."""
+        return await self.process_multi_modal_info(messages)
+
+    async def process_multi_modal_info(self, messages: list[dict]) -> dict:
+        """Extract images, videos and audios from messages.
 
         Args:
             messages (list[dict]): Input messages.
 
         Returns:
-            dict: Multi-modal data with keys "images" and "videos".
+            dict: Multi-modal data with keys like "images", "videos" and "audios".
         """
         multi_modal_data = {}
         if self.processor is not None:
-            images, videos = await self.dataset_cls.process_vision_info(
-                messages, image_patch_size=self.processor.image_processor.patch_size, config=self.data_config
-            )
+            image_patch_size = getattr(getattr(self.processor, "image_processor", None), "patch_size", 14)
+            if hasattr(self.dataset_cls, "process_multi_modal_info"):
+                images, videos, audios = await self.dataset_cls.process_multi_modal_info(
+                    messages, image_patch_size=image_patch_size, config=self.data_config
+                )
+            else:
+                images, videos = await self.dataset_cls.process_vision_info(
+                    messages, image_patch_size=image_patch_size, config=self.data_config
+                )
+                audios = None
             if images is not None:
                 multi_modal_data["images"] = images
             if videos is not None:
                 multi_modal_data["videos"] = videos
+            if audios is not None:
+                multi_modal_data["audios"] = audios
 
         return multi_modal_data
 
@@ -246,6 +275,8 @@ class AgentLoopBase(ABC):
         tools: list[dict] = None,
         images: list[Image.Image] = None,
         videos: list[tuple[torch.Tensor, dict]] = None,
+        audios: list[Any] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         remove_system_prompt: bool = False,
     ):
         """Apply chat template to messages with optional tools, images, and videos.
@@ -273,20 +304,15 @@ class AgentLoopBase(ABC):
                 ),
             )
 
-            # split the videos and according metadatas
-            if videos is not None:
-                videos, video_metadatas = zip(*videos, strict=False)
-                videos, video_metadatas = list(videos), list(video_metadatas)
-            else:
-                video_metadatas = None
-
-            model_inputs = self.processor(
+            model_inputs = build_multimodal_processor_inputs(
+                self.processor,
                 text=[raw_prompt],
                 images=images,
                 videos=videos,
-                video_metadata=video_metadatas,
-                return_tensors="pt",
-                do_sample_frames=False,
+                audio=audios,
+                mm_processor_kwargs=mm_processor_kwargs
+                if mm_processor_kwargs is not None
+                else self._get_mm_processor_kwargs(audios),
             )
             prompt_ids = normalize_token_ids(model_inputs.pop("input_ids"))
         else:
@@ -636,7 +662,16 @@ class AgentLoopWorker:
             routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
 
         multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
-        position_ids = self._compute_position_ids(input_ids, attention_mask, multi_modal_inputs)
+        position_ids = self._compute_position_ids(
+            input_ids,
+            attention_mask,
+            multi_modal_inputs,
+            output.mm_processor_kwargs
+            if output.mm_processor_kwargs is not None
+            else self._get_mm_processor_kwargs(
+                output.multi_modal_data.get("audios") if output.multi_modal_data else None
+            ),
+        )
         await self._compute_score([output], kwargs=kwargs)
         await self._compute_teacher_logprobs(
             output,
@@ -674,6 +709,7 @@ class AgentLoopWorker:
             routed_experts=routed_experts,
             multi_modal_inputs=multi_modal_inputs,
             multi_modal_data=output.multi_modal_data,
+            mm_processor_kwargs=output.mm_processor_kwargs,
             teacher_logprobs=teacher_logprobs,
             teacher_ids=teacher_ids,
             reward_score=output.reward_score,
@@ -683,27 +719,26 @@ class AgentLoopWorker:
         )
 
     def _compute_multi_modal_inputs(self, output, input_ids) -> dict[str, torch.Tensor]:
-        """Compute multi-modal inputs with image and video."""
+        """Compute multi-modal inputs with image, video and audio."""
         multi_modal_inputs = {}
         if self.processor is None:
             return multi_modal_inputs
 
-        images = output.multi_modal_data.get("images")
-        videos = output.multi_modal_data.get("videos")
-        # split the videos and according metadatas
-        if videos is not None:
-            videos, video_metadatas = zip(*videos, strict=False)
-            videos, video_metadatas = list(videos), list(video_metadatas)
-        else:
-            video_metadatas = None
+        multi_modal_data = output.multi_modal_data or {}
+        images = multi_modal_data.get("images")
+        videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
         current_text = self.tokenizer.decode(input_ids.squeeze(0), skip_special_tokens=True)
-        multi_modal_inputs = self.processor(
+
+        multi_modal_inputs = build_multimodal_processor_inputs(
+            self.processor,
             text=[current_text],
             images=images,
             videos=videos,
-            video_metadata=video_metadatas,
-            return_tensors="pt",
-            do_sample_frames=False,
+            audio=audios,
+            mm_processor_kwargs=output.mm_processor_kwargs
+            if output.mm_processor_kwargs is not None
+            else self._get_mm_processor_kwargs(audios),
         )
         multi_modal_inputs.pop("input_ids", None)
         multi_modal_inputs.pop("attention_mask", None)
@@ -717,7 +752,13 @@ class AgentLoopWorker:
             multi_modal_inputs["images_seqlens"] = images_seqlens
         return multi_modal_inputs
 
-    def _compute_position_ids(self, input_ids, attention_mask, multi_modal_inputs) -> torch.Tensor:
+    def _compute_position_ids(
+        self,
+        input_ids,
+        attention_mask,
+        multi_modal_inputs,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
+    ) -> torch.Tensor:
         """Compute position ids for multi-modal inputs."""
         if self.processor is None:
             return compute_position_id_with_mask(attention_mask)  # (1, seq_len)
@@ -729,8 +770,12 @@ class AgentLoopWorker:
         # For transformers>=5.3.0, mm_token_type_ids is only used to calculate position ids.
         if multi_modal_inputs.pop("mm_token_type_ids", None) is not None:
             mm_token_type_ids = torch.zeros_like(input_ids)
-            mm_token_type_ids[0][input_ids[0] == self.processor.image_token_id] = 1
-            mm_token_type_ids[0][input_ids[0] == self.processor.video_token_id] = 2
+            image_token_id = get_processor_token_id(self.processor, "image")
+            video_token_id = get_processor_token_id(self.processor, "video")
+            if image_token_id is not None:
+                mm_token_type_ids[0][input_ids[0] == image_token_id] = 1
+            if video_token_id is not None:
+                mm_token_type_ids[0][input_ids[0] == video_token_id] = 2
             multi_modal_kwargs["mm_token_type_ids"] = mm_token_type_ids
 
         # Model's get_rope_index has been dynamically bind to the processor.
@@ -764,7 +809,14 @@ class AgentLoopWorker:
                     attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
                     multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
                     position_ids = self._compute_position_ids(
-                        input_ids.unsqueeze(0), attention_mask.unsqueeze(0), multi_modal_inputs
+                        input_ids.unsqueeze(0),
+                        attention_mask.unsqueeze(0),
+                        multi_modal_inputs,
+                        output.mm_processor_kwargs
+                        if output.mm_processor_kwargs is not None
+                        else self._get_mm_processor_kwargs(
+                            output.multi_modal_data.get("audios") if output.multi_modal_data else None
+                        ),
                     ).squeeze(0)
                     all_prompts.append(prompts)
                     all_responses.append(responses)
@@ -824,6 +876,7 @@ class AgentLoopWorker:
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
                 sequence_ids=prompt_ids + response_ids,
                 multi_modal_data=output.multi_modal_data,
+                mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,
             )
             output.extra_fields["teacher_ids"] = teacher_ids

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -396,6 +396,7 @@ class AgentLoopWorker:
         self.dataset_cls = get_dataset_class(config.data)
         self.tokenizer = self.model_config.tokenizer
         self.processor = self.model_config.processor
+        self.mm_processor_kwargs = config.data.get("mm_processor_kwargs", {})
 
         # Online policy distillation
         self.distillation_enabled = is_distillation_enabled(config.distillation)
@@ -436,6 +437,15 @@ class AgentLoopWorker:
             trace_config.get("token2text", False),
             trace_config.get("max_samples_per_step_per_worker", None),
         )
+
+    def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
+        """Return multimodal processor kwargs with audio sampling-rate defaults."""
+        mm_processor_kwargs = dict(self.mm_processor_kwargs or {})
+        if audio_data is not None and "sampling_rate" not in mm_processor_kwargs:
+            sampling_rate = getattr(getattr(self.processor, "feature_extractor", None), "sampling_rate", None)
+            if sampling_rate is not None:
+                mm_processor_kwargs["sampling_rate"] = int(sampling_rate)
+        return mm_processor_kwargs
 
     async def generate_sequences(self, batch: DataProto) -> DataProto:
         """Generate sequences from agent loop.

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -38,16 +38,20 @@ class SingleTurnAgentLoop(AgentLoopBase):
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
 
-        # 1. extract images and videos from messages
-        multi_modal_data = await self.process_vision_info(messages)
+        # 1. extract multimodal inputs from messages
+        multi_modal_data = await self.process_multi_modal_info(messages)
         images = multi_modal_data.get("images")
         videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
+        mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
         prompt_ids = await self.apply_chat_template(
             messages,
             images=images,
             videos=videos,
+            audios=audios,
+            mm_processor_kwargs=mm_processor_kwargs,
         )
 
         # 3. generate sequences
@@ -59,6 +63,8 @@ class SingleTurnAgentLoop(AgentLoopBase):
                 sampling_params=sampling_params,
                 image_data=images,
                 video_data=videos,
+                audio_data=audios,
+                mm_processor_kwargs=mm_processor_kwargs,
             )
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
@@ -75,6 +81,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
                 else None
             ),
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             num_turns=2,
             metrics=metrics,
             extra_fields=output.extra_fields,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -56,6 +56,8 @@ class AgentData:
         messages: list[dict[str, Any]],
         image_data: list[Image.Image],
         video_data: list[tuple[torch.Tensor, dict[str, Any]]],
+        audio_data: Optional[list[Any]],
+        mm_processor_kwargs: Optional[dict[str, Any]],
         metrics: dict[str, Any],
         request_id: str,
         tools_kwargs: dict[str, Any],
@@ -63,6 +65,8 @@ class AgentData:
         self.messages = messages
         self.image_data = image_data
         self.video_data = video_data
+        self.audio_data = audio_data
+        self.mm_processor_kwargs = mm_processor_kwargs or {}
         self.metrics = metrics
         self.request_id = request_id
         self.tools_kwargs = tools_kwargs
@@ -115,10 +119,12 @@ class ToolAgentLoop(AgentLoopBase):
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
 
-        # extract images and videos from messages
-        multi_modal_data = await self.process_vision_info(messages)
+        # extract multimodal inputs from messages
+        multi_modal_data = await self.process_multi_modal_info(messages)
         images = multi_modal_data.get("images")
         videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
+        mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         metrics = {}
         request_id = uuid4().hex
@@ -128,6 +134,8 @@ class ToolAgentLoop(AgentLoopBase):
             messages=messages,
             image_data=images,
             video_data=videos,
+            audio_data=audios,
+            mm_processor_kwargs=mm_processor_kwargs,
             metrics=metrics,
             request_id=request_id,
             tools_kwargs=tools_kwargs,
@@ -167,12 +175,15 @@ class ToolAgentLoop(AgentLoopBase):
             multi_modal_data["images"] = agent_data.image_data
         if agent_data.video_data is not None:
             multi_modal_data["videos"] = agent_data.video_data
+        if agent_data.audio_data is not None:
+            multi_modal_data["audios"] = agent_data.audio_data
 
         output: AgentLoopOutput = AgentLoopOutput(
             prompt_ids=prompt_ids,
             response_ids=response_ids[: self.response_length],
             response_mask=agent_data.response_mask[: self.response_length],
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=agent_data.mm_processor_kwargs,
             response_logprobs=agent_data.response_logprobs[: self.response_length]
             if agent_data.response_logprobs
             else None,
@@ -196,6 +207,8 @@ class ToolAgentLoop(AgentLoopBase):
             tools=schemas,
             images=agent_data.image_data,
             videos=agent_data.video_data,
+            audios=agent_data.audio_data,
+            mm_processor_kwargs=agent_data.mm_processor_kwargs,
         )
         agent_data.prompt_ids = prompt_ids
         return AgentState.GENERATING
@@ -211,6 +224,8 @@ class ToolAgentLoop(AgentLoopBase):
                 sampling_params=sampling_params,
                 image_data=agent_data.image_data,
                 video_data=agent_data.video_data,
+                audio_data=agent_data.audio_data,
+                mm_processor_kwargs=agent_data.mm_processor_kwargs,
             )
         # first time to set num_preempted
         if agent_data.metrics.get("num_preempted") is None:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -62,6 +62,8 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
 
@@ -71,6 +73,8 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             sampling_params (Dict[str, Any]): Sampling parameters for the chat completion.
             image_data (Optional[List[Any]]): Image data for the chat completion.
             video_data (Optional[List[Any]]): Video data for the chat completion.
+            audio_data (Optional[List[Any]]): Audio data for the chat completion.
+            mm_processor_kwargs (Optional[Dict[str, Any]]): Multimodal processor kwargs.
 
         Returns:
             TokenOutput: token output
@@ -99,6 +103,8 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                 sampling_params=sampling_params,
                 image_data=image_data,
                 video_data=video_data,
+                audio_data=audio_data,
+                mm_processor_kwargs=mm_processor_kwargs,
             )
 
             # 2. merge output into final_output

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -103,6 +103,7 @@ class AsyncTeacherLLMServerManager:
         self,
         sequence_ids: list[int],
         multi_modal_data: Optional[dict[str, Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         routing_key: Optional[str] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute teacher log probabilities for a single unpadded sequence."""
@@ -116,6 +117,8 @@ class AsyncTeacherLLMServerManager:
             sampling_params=_get_teacher_sampling_params(teacher_model_config, self.distillation_loss_config),
             image_data=multi_modal_data.get("images"),
             video_data=multi_modal_data.get("videos"),
+            audio_data=multi_modal_data.get("audios"),
+            mm_processor_kwargs=mm_processor_kwargs,
         )
         # Shapes: # S, (1 or K), where S is the response length, K is either 1 or topk depending on
         # the distillation loss settings.

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -489,12 +489,14 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.McoreOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -454,12 +454,14 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.TorchtitanOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -461,12 +461,14 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.FSDPOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -443,12 +443,14 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
     name: null
   return_multi_modal_inputs: true
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.VeOmniOptimizerConfig

--- a/verl/trainer/config/data/legacy_data.yaml
+++ b/verl/trainer/config/data/legacy_data.yaml
@@ -94,6 +94,9 @@ image_key: images
 # The field in the multi-modal dataset where the video is located.
 video_key: videos
 
+# The field in the multi-modal dataset where the audio is located.
+audio_key: audios
+
 # If the remote tokenizer has a Python file, this flag determines whether to allow using it.
 trust_remote_code: False
 
@@ -111,3 +114,6 @@ return_multi_modal_inputs: True
 
 # Additional kwargs when calling tokenizer.apply_chat_template
 apply_chat_template_kwargs: {}
+
+# Additional kwargs passed to multimodal processors/backends.
+mm_processor_kwargs: {}

--- a/verl/utils/__init__.py
+++ b/verl/utils/__init__.py
@@ -15,11 +15,23 @@
 from . import config, tokenizer
 from .config import omega_conf_to_dataclass, validate_config
 from .groupwise import as_torch_index, group_mean_std
-from .tokenizer import hf_processor, hf_tokenizer, normalize_token_ids
+from .tokenizer import (
+    get_processor_token_id,
+    hf_processor,
+    hf_tokenizer,
+    normalize_token_ids,
+)
 
 __all__ = (
     tokenizer.__all__
     + config.__all__
-    + ["hf_processor", "hf_tokenizer", "normalize_token_ids", "omega_conf_to_dataclass", "validate_config"]
+    + [
+        "get_processor_token_id",
+        "hf_processor",
+        "hf_tokenizer",
+        "normalize_token_ids",
+        "omega_conf_to_dataclass",
+        "validate_config",
+    ]
     + ["as_torch_index", "group_mean_std"]
 )

--- a/verl/utils/__init__.py
+++ b/verl/utils/__init__.py
@@ -16,6 +16,7 @@ from . import config, tokenizer
 from .config import omega_conf_to_dataclass, validate_config
 from .groupwise import as_torch_index, group_mean_std
 from .tokenizer import (
+    build_multimodal_processor_inputs,
     get_processor_token_id,
     hf_processor,
     hf_tokenizer,
@@ -26,6 +27,7 @@ __all__ = (
     tokenizer.__all__
     + config.__all__
     + [
+        "build_multimodal_processor_inputs",
         "get_processor_token_id",
         "hf_processor",
         "hf_tokenizer",

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -21,7 +21,7 @@ import re
 import traceback
 from collections import defaultdict
 from io import BytesIO
-from typing import Optional
+from typing import Any, Optional
 
 import datasets
 import numpy as np
@@ -32,7 +32,7 @@ from torch.utils.data import Dataset
 from transformers import PreTrainedTokenizer, ProcessorMixin
 
 from verl.utils.import_utils import load_extern_object
-from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.tokenizer import build_multimodal_processor_inputs, normalize_token_ids
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,7 @@ class RLHFDataset(Dataset):
         self.prompt_key = config.get("prompt_key", "prompt")
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
+        self.audio_key = config.get("audio_key", "audios")
         self.image_patch_size = config.get("image_patch_size", 14)
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
@@ -114,6 +115,7 @@ class RLHFDataset(Dataset):
         self.truncation = config.get("truncation", "error")
         self.filter_overlong_prompts = config.get("filter_overlong_prompts", True)
         self.apply_chat_template_kwargs = config.get("apply_chat_template_kwargs", {})
+        self.mm_processor_kwargs = config.get("mm_processor_kwargs", {})
 
         # Mirror AgentLoopWorker's tool loading so length filtering sees the
         # same schemas the rollout will.
@@ -195,11 +197,8 @@ class RLHFDataset(Dataset):
             tokenizer = self.tokenizer
             processor = self.processor
             prompt_key = self.prompt_key
-            image_key = self.image_key
-            video_key = self.video_key
 
             if processor is not None:
-                from verl.utils.dataset.vision_utils import process_image, process_video
 
                 def doc2len(doc) -> int:
                     try:
@@ -212,31 +211,10 @@ class RLHFDataset(Dataset):
                         raw_prompt = self.processor.apply_chat_template(
                             messages, add_generation_prompt=True, tokenize=False, **apply_kwargs
                         )
-                        if image_key in doc and doc[image_key]:
-                            images = [
-                                process_image(image, image_patch_size=self.image_patch_size) for image in doc[image_key]
-                            ]
-                        else:
-                            images = None
-
-                        if video_key in doc and doc[video_key]:
-                            videos, video_metadata = zip(
-                                *[
-                                    process_video(
-                                        video, image_patch_size=self.image_patch_size, return_video_metadata=True
-                                    )
-                                    for video in doc[video_key]
-                                ],
-                                strict=True,
-                            )
-                            videos = list(videos)
-                            video_metadata = list(video_metadata)
-                            videos_kwargs = {"video_metadata": video_metadata, "do_sample_frames": False}
-                        else:
-                            videos = None
-                            videos_kwargs = {}
-
-                        if images is None and videos is None:
+                        images, videos, audios = self._process_multi_modal_info(
+                            messages, self.image_patch_size, self.config
+                        )
+                        if images is None and videos is None and audios is None:
                             # only text prompt
                             return len(
                                 processor.tokenizer(
@@ -248,9 +226,14 @@ class RLHFDataset(Dataset):
                         else:
                             # multi-modal prompt
                             return len(
-                                processor(text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs)[
-                                    "input_ids"
-                                ][0]
+                                build_multimodal_processor_inputs(
+                                    processor,
+                                    text=[raw_prompt],
+                                    images=images,
+                                    videos=videos,
+                                    audio=audios,
+                                    mm_processor_kwargs=self.mm_processor_kwargs,
+                                )["input_ids"][0]
                             )
                     except Exception:
                         print("Error processing one of the samples, skipping...")
@@ -311,10 +294,12 @@ class RLHFDataset(Dataset):
         return len(self.dataframe)
 
     def _build_messages(self, example: dict, key: str):
-        """Replace <image> and <video> placeholder in messages with corresponding image and video
-        which is required by processor.apply_chat_template.
+        """Replace multimodal placeholders in messages with structured content.
+
+        This is required by processor.apply_chat_template.
         - <image>: {"type": "image", **image}
         - <video>: {"type": "video", **video}
+        - <audio>: {"type": "audio", **audio}
 
         Args:
             example: Row dictionary from dataframe.
@@ -323,22 +308,23 @@ class RLHFDataset(Dataset):
             messages: List of messages with replaced placeholder.
         """
         messages: list = example[key]
-        # When concatenating image and video datasets, get will return None for image or video sample
+        # When concatenating multimodal datasets, get will return None for samples without a modality column.
         images = example.get(self.image_key, None) or []
         videos = example.get(self.video_key, None) or []
+        audios = example.get(self.audio_key, None) or []
 
-        image_offset, video_offset = 0, 0
+        image_offset, video_offset, audio_offset = 0, 0, 0
         for message in messages:
-            if not images and not videos:
+            if not images and not videos and not audios:
                 continue
-            assert self.processor is not None, "processor is needed to process image and video"
+            assert self.processor is not None, "processor is needed to process multimodal data"
 
             content = message["content"]
             if not isinstance(content, str):
                 continue
 
             content_list = []
-            segments = re.split("(<image>|<video>)", content)
+            segments = re.split("(<image>|<video>|<audio>)", content)
             segments = [item for item in segments if item != ""]
             for segment in segments:
                 if segment == "<image>":
@@ -358,12 +344,25 @@ class RLHFDataset(Dataset):
                     assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
                     content_list.append({"type": "video", **videos[video_offset]})
                     video_offset += 1
+                elif segment == "<audio>":
+                    assert audio_offset < len(audios), f"audio_offset {audio_offset} >= len(audios) {len(audios)}"
+                    audio = audios[audio_offset]
+                    if isinstance(audio, dict):
+                        payload = dict(audio)
+                        payload["type"] = "audio"
+                        if "audio" not in payload and "audio_url" not in payload:
+                            payload = {"type": "audio", "audio": audio}
+                        content_list.append(payload)
+                    else:
+                        content_list.append({"type": "audio", "audio": audio})
+                    audio_offset += 1
                 else:
                     content_list.append({"type": "text", "text": segment})
             message["content"] = content_list
 
         assert image_offset == len(images), f"image_offset {image_offset} != len(images) {len(images)}"
         assert video_offset == len(videos), f"video_offset {video_offset} != len(videos) {len(videos)}"
+        assert audio_offset == len(audios), f"audio_offset {audio_offset} != len(audios) {len(audios)}"
         return messages
 
     def __getitem__(self, item):
@@ -373,6 +372,7 @@ class RLHFDataset(Dataset):
 
         row_dict.pop(self.image_key, None)
         row_dict.pop(self.video_key, None)
+        row_dict.pop(self.audio_key, None)
 
         # TODO(wuxibin): We still need a dummy tensor to make sure DataProto.batch is not empty.
         # Remove this after deprecate DataProto by TensorDict.
@@ -383,11 +383,13 @@ class RLHFDataset(Dataset):
             row_dict["extra_info"] = dict()
         index = row_dict.get("extra_info", {}).get("index", 0)
         tools_kwargs = row_dict.get("extra_info", {}).get("tools_kwargs", {})
+        interaction_kwargs = row_dict.get("extra_info", {}).get("interaction_kwargs", {})
         need_tools_kwargs = row_dict.get("extra_info", {}).get("need_tools_kwargs", self.need_tools_kwargs)
         if need_tools_kwargs and not tools_kwargs:
             logger.warning("tools_kwargs is empty for index %s, data source: %s", index, row_dict["data_source"])
         row_dict["index"] = index
         row_dict["tools_kwargs"] = tools_kwargs
+        row_dict["interaction_kwargs"] = interaction_kwargs
         return row_dict
 
     @classmethod
@@ -423,6 +425,56 @@ class RLHFDataset(Dataset):
 
         images, videos = process_vision_info(messages, image_patch_size=image_patch_size, return_video_metadata=True)
         return images, videos
+
+    @classmethod
+    def _extract_audio_info(cls, messages: list[dict]) -> list[Any]:
+        audios = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "audio":
+                    continue
+                if "audio" in item:
+                    audios.append(item["audio"])
+                elif "audio_url" in item:
+                    audios.append(item["audio_url"])
+                else:
+                    audios.append({k: v for k, v in item.items() if k != "type"})
+        return audios or None
+
+    @classmethod
+    def _process_multi_modal_info(
+        cls,
+        messages: list[dict],
+        image_patch_size,
+        config: DictConfig,
+    ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        has_visual = any(
+            isinstance(message.get("content"), list)
+            and any(isinstance(item, dict) and item.get("type") in {"image", "video"} for item in message["content"])
+            for message in messages
+        )
+        if has_visual:
+            from qwen_vl_utils import process_vision_info
+
+            images, videos = process_vision_info(
+                messages, image_patch_size=image_patch_size, return_video_metadata=True
+            )
+        else:
+            images, videos = None, None
+        audios = cls._extract_audio_info(messages)
+        return images, videos, audios
+
+    @classmethod
+    async def process_multi_modal_info(
+        cls,
+        messages: list[dict],
+        image_patch_size,
+        config: DictConfig,
+    ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        return cls._process_multi_modal_info(messages, image_patch_size=image_patch_size, config=config)
 
     def split(self, num_splits: int):
         """

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -56,6 +56,8 @@ from verl.utils.transformers_compat import get_auto_model_for_vision2seq
 
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
+_VARLEN_MULTI_MODAL_KEYS = {"input_features", "feature_attention_mask"}
+
 
 class LambdaLayer(nn.Module):
     def __init__(self, fn):
@@ -710,6 +712,43 @@ def get_hf_auto_model_class(hf_config):
     return actor_module_class
 
 
+def _pad_last_dim_and_cat(values: list[torch.Tensor], key: str) -> torch.Tensor:
+    if not values:
+        raise ValueError(f"Cannot merge empty multi-modal input list for key {key!r}.")
+
+    def _format_tensor_shapes(values: list[torch.Tensor]) -> str:
+        return ", ".join(str(tuple(value.shape)) for value in values)
+
+    rank = values[0].dim()
+    if rank < 2:
+        raise RuntimeError(
+            f"Cannot pad multi-modal input {key!r} with rank {rank}; shapes: {_format_tensor_shapes(values)}"
+        )
+
+    middle_shape = values[0].shape[1:-1]
+    for value in values:
+        if value.dim() != rank or value.shape[1:-1] != middle_shape:
+            raise RuntimeError(
+                f"Cannot pad multi-modal input {key!r}; expected matching rank and non-batch/non-time "
+                f"dimensions, got shapes: {_format_tensor_shapes(values)}"
+            )
+
+    max_len = max(value.shape[-1] for value in values)
+    if all(value.shape[-1] == max_len for value in values):
+        return torch.cat(values, dim=0)
+
+    padded_values = []
+    for value in values:
+        if value.shape[-1] == max_len:
+            padded_values.append(value)
+            continue
+        padded_value = value.new_zeros((*value.shape[:-1], max_len))
+        padded_value[..., : value.shape[-1]] = value
+        padded_values.append(padded_value)
+
+    return torch.cat(padded_values, dim=0)
+
+
 def extract_multi_modal_inputs(
     batch_data: list[dict[str, torch.Tensor]],
     indices: Optional[list[int]] = None,
@@ -749,8 +788,16 @@ def extract_multi_modal_inputs(
     for key, values in multi_modal_inputs_collected.items():
         if has_image_bound:  # minicpm-o logic
             multi_modal_inputs[key] = values
+        elif key in _VARLEN_MULTI_MODAL_KEYS:
+            # some multi-modal keys with variable length are put in non-tensor batch,
+            # so we need to pad them manually.
+            multi_modal_inputs[key] = _pad_last_dim_and_cat(values, key)
         else:
-            multi_modal_inputs[key] = torch.cat(values, dim=0)
+            try:
+                multi_modal_inputs[key] = torch.cat(values, dim=0)
+            except RuntimeError as e:
+                shapes = ", ".join(str(tuple(value.shape)) for value in values)
+                raise RuntimeError(f"Failed to concatenate multi-modal input {key!r}; shapes: {shapes}") from e
 
     return multi_modal_inputs
 

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -16,7 +16,13 @@
 import types
 import warnings
 
-__all__ = ["hf_tokenizer", "hf_processor", "normalize_token_ids"]
+__all__ = [
+    "hf_tokenizer",
+    "hf_processor",
+    "normalize_token_ids",
+    "build_multimodal_processor_inputs",
+    "get_processor_token_id",
+]
 
 
 def normalize_token_ids(tokenized_output) -> list[int]:
@@ -54,6 +60,78 @@ def normalize_token_ids(tokenized_output) -> list[int]:
         except (TypeError, ValueError) as e:
             raise TypeError(f"token_id must be int-convertible, got {type(token_id).__name__}: {token_id!r}") from e
     return normalized_ids
+
+
+def get_processor_token_id(processor, token_name: str) -> int | None:
+    """Resolve a multimodal special token id from a processor.
+
+    Newer processors may expose ``image_token``/``video_token`` strings instead
+    of ``image_token_id``/``video_token_id`` integers. Fall back to tokenizer
+    conversion so rollout code can stay processor-agnostic.
+    """
+
+    if processor is None:
+        return None
+
+    token_id_attr = f"{token_name}_token_id"
+    token_id = getattr(processor, token_id_attr, None)
+    if token_id is not None:
+        return int(token_id)
+
+    token_attr = f"{token_name}_token"
+    token = getattr(processor, token_attr, None)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if token is not None and tokenizer is not None:
+        converted = tokenizer.convert_tokens_to_ids(token)
+        if converted is not None:
+            return int(converted)
+
+    return None
+
+
+def _split_videos_and_metadata(videos):
+    if videos is None:
+        return None, None
+    videos = list(videos)
+    if len(videos) > 0 and isinstance(videos[0], tuple):
+        video_values, video_metadata = zip(*videos, strict=False)
+        return list(video_values), list(video_metadata)
+    return videos, None
+
+
+def build_multimodal_processor_inputs(
+    processor,
+    *,
+    text,
+    images=None,
+    videos=None,
+    audio=None,
+    mm_processor_kwargs=None,
+    return_tensors: str = "pt",
+):
+    """Build kwargs for multimodal processor calls.
+
+    This keeps the existing VL flow intact while extending it with audio-aware
+    paths for processors that accept audio inputs.
+    """
+    processor_kwargs = dict(mm_processor_kwargs or {})
+    if audio is not None and "sampling_rate" not in processor_kwargs:
+        sampling_rate = getattr(getattr(processor, "feature_extractor", None), "sampling_rate", None)
+        if sampling_rate is not None:
+            processor_kwargs["sampling_rate"] = int(sampling_rate)
+
+    videos, video_metadata = _split_videos_and_metadata(videos)
+    processor_kwargs.setdefault("return_tensors", return_tensors)
+
+    if video_metadata is not None:
+        processor_kwargs.setdefault("video_metadata", video_metadata)
+        processor_kwargs.setdefault("do_sample_frames", False)
+
+    processor_inputs = {"text": text, "images": images, "videos": videos, **processor_kwargs}
+    if audio is not None:
+        processor_inputs["audio"] = audio
+
+    return processor(**processor_inputs)
 
 
 def set_pad_token_id(tokenizer):
@@ -124,7 +202,7 @@ def hf_processor(name_or_path, **kwargs):
 
         config = AutoConfig.from_pretrained(name_or_path, **kwargs)
 
-        # Bind vlm model's get_rope_index method to processor
+        # Bind vlm model's get_rope_index method to processor.
         processor.config = config
         model_class = None
         match processor.__class__.__name__:
@@ -162,4 +240,5 @@ def hf_processor(name_or_path, **kwargs):
     # https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/models/auto/processing_auto.py#L344
     if processor is not None and "Processor" not in processor.__class__.__name__:
         processor = None
+
     return processor

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -218,6 +218,7 @@ class LLMServerClient:
         finally:
             self._release_server(server_id)
 
+
 class LLMServerManager:
     """LLMServerManager is responsible for:
     - Launch server replicas

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -184,6 +184,8 @@ class LLMServerClient:
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
@@ -198,18 +200,23 @@ class LLMServerClient:
         """
         server_id, server = await self._acquire_server(request_id)
         try:
+            multimodal_kwargs = {}
+            if audio_data is not None:
+                multimodal_kwargs["audio_data"] = audio_data
+            if mm_processor_kwargs:
+                multimodal_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
             output: TokenOutput = await server.generate.remote(
                 request_id=uuid4().hex,  # use new request_id for each turn
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=image_data,
                 video_data=video_data,
+                **multimodal_kwargs,
                 **kwargs,
             )
             return output
         finally:
             self._release_server(server_id)
-
 
 class LLMServerManager:
     """LLMServerManager is responsible for:

--- a/verl/workers/rollout/schemas.py
+++ b/verl/workers/rollout/schemas.py
@@ -24,6 +24,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, Processor
 
 from verl.tools.schemas import OpenAIFunctionToolCall, OpenAIFunctionToolSchema, ToolResponse
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.tokenizer import build_multimodal_processor_inputs
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -90,6 +91,7 @@ class AsyncRolloutRequest(BaseModel):
     multi_modal_keys: Optional[list[str]] = None
     multi_modal_data: Optional[dict[str, Any]] = None
     multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None
+    mm_processor_kwargs: Optional[dict[str, Any]] = None
     tool_schemas: Optional[list[OpenAIFunctionToolSchema]] = None
     tools_kwargs: dict[str, Any] = {}
     input_ids: Optional[torch.Tensor] = None
@@ -130,9 +132,9 @@ class AsyncRolloutRequest(BaseModel):
 
         values["messages"] = [Message.model_validate(msg) for msg in messages]
 
-        # If there is no multi_modal_keys, we assume the multi-modal data is image and video.
+        # If there is no multi_modal_keys, we assume the multi-modal data is image, video and audio.
         if not values.get("multi_modal_keys"):
-            values["multi_modal_keys"] = ["image", "video"]
+            values["multi_modal_keys"] = ["image", "video", "audio"]
         if not values.get("multi_modal_data"):
             values["multi_modal_data"] = {key: [] for key in values["multi_modal_keys"]}
         else:
@@ -142,16 +144,20 @@ class AsyncRolloutRequest(BaseModel):
                     values["multi_modal_data"][key] = []
         if not values.get("multi_modal_inputs"):
             values["multi_modal_inputs"] = {}
+        if not values.get("mm_processor_kwargs"):
+            values["mm_processor_kwargs"] = {}
 
         tools = (
             [tool.model_dump() for tool in tool_schemas] if (tool_schemas := values.get("tool_schemas", [])) else None
         )
 
         multi_modal_data = values["multi_modal_data"]
+        mm_processor_kwargs = values["mm_processor_kwargs"]
         tokens_without_prompt = cls._handle_apply_chat_template(
             processing_class,
             messages,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -165,6 +171,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=multi_modal_data,
+                mm_processor_kwargs=mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -193,7 +200,11 @@ class AsyncRolloutRequest(BaseModel):
             values["multi_modal_inputs"] = multi_modal_inputs
 
             values["position_ids"] = values["prompt_position_ids"] = cls._get_position_ids(
-                processing_class, values["input_ids"], values["attention_mask"], multi_modal_inputs
+                processing_class,
+                values["input_ids"],
+                values["attention_mask"],
+                multi_modal_inputs,
+                mm_processor_kwargs=mm_processor_kwargs,
             )
 
         values["prompt_ids"], values["prompt_attention_mask"] = values["input_ids"], values["attention_mask"]
@@ -203,6 +214,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             BASE_CHAT_HISTORY,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -212,6 +224,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             BASE_CHAT_HISTORY,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=True,
             tokenize=True,
@@ -224,6 +237,7 @@ class AsyncRolloutRequest(BaseModel):
         processing_class: PreTrainedTokenizer | PreTrainedTokenizerFast | ProcessorMixin,
         messages: list[Message],
         multi_modal_data: dict[str, Any],
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[list[OpenAIFunctionToolSchema]] = None,
         add_generation_prompt: bool = False,
         tokenize: bool = False,
@@ -242,13 +256,22 @@ class AsyncRolloutRequest(BaseModel):
                 )
             model_inputs = processing_class(text=[raw_prompt], return_tensors="pt")
         elif isinstance(processing_class, ProcessorMixin):
-            # When we update multi_model_keys, we also need to update this logic
             images = images if len(images := multi_modal_data.get("image", [])) > 0 else None
             videos = videos if len(videos := multi_modal_data.get("video", [])) > 0 else None
-            model_inputs = processing_class(text=[raw_prompt], images=images, videos=videos, return_tensors="pt")
+            audio = audio if len(audio := multi_modal_data.get("audio", [])) > 0 else None
+            model_inputs = build_multimodal_processor_inputs(
+                processing_class,
+                text=[raw_prompt],
+                images=images,
+                videos=videos,
+                audio=audio,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
         else:
             raise ValueError(f"Unsupported processing class type: {type(processing_class)}")
 
+        if hasattr(model_inputs, "convert_to_tensors"):
+            model_inputs = model_inputs.convert_to_tensors("pt")
         model_inputs = dict(model_inputs)
         if return_dict:
             return model_inputs
@@ -261,6 +284,7 @@ class AsyncRolloutRequest(BaseModel):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> torch.Tensor:
         # special case for qwen2vl
         is_qwen2vl = (
@@ -315,7 +339,11 @@ class AsyncRolloutRequest(BaseModel):
             self._update_multi_modal_inputs(new_multi_modal_inputs)
 
         new_position_ids = self._get_position_ids(
-            processing_class, new_input_ids, attention_mask, new_multi_modal_inputs
+            processing_class,
+            new_input_ids,
+            attention_mask,
+            new_multi_modal_inputs,
+            mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
         last_pos = self.position_ids[..., -1:]
@@ -366,6 +394,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=self.multi_modal_data,
+                mm_processor_kwargs=self.mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -386,7 +415,13 @@ class AsyncRolloutRequest(BaseModel):
         # We don't need to pass multi_modal_data here because we don't have any multi-modal data from Engine
         # Inference, it is pure text.
         content_ids = self._handle_apply_chat_template(
-            processing_class, messages, multi_modal_data={}, tools=tools, add_generation_prompt=False, tokenize=True
+            processing_class,
+            messages,
+            multi_modal_data={},
+            mm_processor_kwargs={},
+            tools=tools,
+            add_generation_prompt=False,
+            tokenize=True,
         )[..., self.base_conv_wo_gen_prompt_end_pos :]
         self._update_input_ids(processing_class, content_ids, attention_mask=True, loss_mask=False)
 
@@ -405,7 +440,13 @@ class AsyncRolloutRequest(BaseModel):
             # We don't need to pass multi_modal_data here because we don't have any multi-modal data from Engine
             # Inference, it is pure text.
             content_ids = self._handle_apply_chat_template(
-                processing_class, messages, multi_modal_data={}, tools=tools, add_generation_prompt=False, tokenize=True
+                processing_class,
+                messages,
+                multi_modal_data={},
+                mm_processor_kwargs={},
+                tools=tools,
+                add_generation_prompt=False,
+                tokenize=True,
             )[..., self.base_conv_with_gen_prompt_end_pos :]
         self._update_input_ids(processing_class, content_ids, attention_mask=True, loss_mask=True)
 
@@ -447,6 +488,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             messages,
             multi_modal_data=delta_multi_modal_data,
+            mm_processor_kwargs=self.mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -571,6 +613,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=self.multi_modal_data,
+                mm_processor_kwargs=self.mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=False,
                 tokenize=True,

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -317,6 +317,8 @@ class TRTLLMHttpServer:
         request_id: str,
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> TokenOutput:
         from tensorrt_llm.llmapi import SamplingParams
 
@@ -337,6 +339,9 @@ class TRTLLMHttpServer:
         sampling_params.update(self.sampling_args)
 
         trt_llm_sampling_params = SamplingParams(**sampling_params)
+        if audio_data is not None:
+            raise NotImplementedError("TRT-LLM rollout does not support audio inputs yet.")
+
         await self._generation_allowed.wait()
         if self.is_vlm_model and (image_data or video_data):
             deduped_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
@@ -344,7 +349,7 @@ class TRTLLMHttpServer:
             input_dict = {
                 "prompt": org_prompt,
                 "multi_modal_data": {},
-                "mm_processor_kwargs": {},
+                "mm_processor_kwargs": dict(mm_processor_kwargs or {}),
             }
             if image_data:
                 input_dict["multi_modal_data"]["image"] = image_data

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -55,6 +55,7 @@ from verl.workers.rollout.vllm_rollout.utils import (
 
 _VLLM_VERSION = version.parse(vllm.__version__)
 
+
 if _VLLM_VERSION > version.parse("0.11.0"):
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -450,6 +451,8 @@ class vLLMHttpServer:
         request_id: str,
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         priority: int = 0,
     ) -> TokenOutput:
         """Generate sequence with token-in-token-out."""
@@ -493,8 +496,16 @@ class vLLMHttpServer:
             multi_modal_data["image"] = image_data
         if video_data is not None:
             multi_modal_data["video"] = video_data
+        if audio_data is not None:
+            multi_modal_data["audio"] = audio_data
 
-        prompt = TokensPrompt(prompt_token_ids=prompt_ids, multi_modal_data=multi_modal_data)
+        prompt_kwargs = {"prompt_token_ids": prompt_ids, "multi_modal_data": multi_modal_data}
+        if mm_processor_kwargs:
+            prompt_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
+        try:
+            prompt = TokensPrompt(**prompt_kwargs)
+        except TypeError:
+            prompt = prompt_kwargs
 
         # Add lora request
         lora_request = None


### PR DESCRIPTION
## Summary

Split from #6118. This PR adds generic audio data plumbing without adding Qwen3-Omni model-specific behavior:

- add `data.audio_key` support in `RLHFDataset` and carry audio payloads as `audio_data`
- thread `audio_data` and `mm_processor_kwargs` through agent loop, teacher loop, rollout schemas, and vLLM async server request paths
- extend multimodal processor input construction to include audio payloads and processor sampling rate
- make TRT-LLM fail explicitly for audio inputs because the async TRT-LLM path does not support audio yet
- add CPU tests for audio dataset processing and the agent-loop server contract

## Rebase / CI Update

Rebased onto latest `main` at `d324b014` on 2026-05-12. The merge conflict was in `verl/workers/rollout/llm_server.py`; the resolution keeps the latest `main` rollout-client layout where fully async resume generation lives in `verl/experimental/fully_async_policy/fully_async_rollouter.py`, while preserving this PR's `audio_data` / `mm_processor_kwargs` propagation through both the generic and fully async LLM server clients.

The old head `571a5760` had GitHub CI failures only in Ascend/self-hosted jobs. The relevant logs pointed to runner/environment/resource failures rather than this PR's audio path:

- `e2e_ascend`: one job could not resolve `setuptools>=61.0` during install; another failed with HCCL TCPStore wait timeout / `ERR02005 DIST internal error`.
- `e2e_one_step_off_policy_ascend`: Megatron Ascend job failed with NPU OOM while allocating a 1 GiB checkpoint-transfer buffer.
- `e2e_ppo_trainer_megatron_vllm_2_ascend`: FSDP/vLLM Ascend job exited with code 137 and then reported `container not found` during cleanup.

After the latest rebase push, GitHub currently reports the PR as mergeable. No checks have been reported yet for head `11df606c`; repository-side workflow approval may still be needed for this fork PR before CI executes.

## Duplicate-Work Check

No linked issue is used for this split PR. Duplicate searches run before this update:

- `gh pr list --repo verl-project/verl --state open --search "audio data support in:title,body"`
- `gh pr list --repo verl-project/verl --state open --search "audio_data mm_processor_kwargs in:body"`
- `gh pr list --repo verl-project/verl --state open --search "qwen3 omni audio in:title,body"`

Result: `audio_data mm_processor_kwargs` only finds this PR. The broader search finds #6118, #6277, and #3297, but they are materially different: #6118 is the original mixed PR being split, #6277 is the dependent Qwen3-Omni thinker follow-up, and #3297 is an older WIP/Draft model-specific Omni PR rather than this generic audio-data plumbing slice.

## Validation

- `git diff --check`
- `PYTHONPATH=. python -m py_compile verl/experimental/fully_async_policy/fully_async_rollouter.py verl/workers/rollout/llm_server.py`
- `PYTHONPATH=. python tests/special_sanity/check_api_docs.py verl` (passed; optional dependency warnings only)
- `PYTHONPATH=. pytest -q tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py tests/utils/test_audio_input_support_on_cpu.py` (`10 passed`)
- `pre-commit run --files $(git diff --name-only upstream/main...HEAD)` (passed)

AI assistance was used to prepare and update this PR. The human submitter should review every changed line and the CI status before merge.
