### PR TITLE
[model, rollout] feat: add qwen3-omni thinker support

### DIFF
--- a/examples/data_preprocess/omniinstruct_to_verl.md
+++ b/examples/data_preprocess/omniinstruct_to_verl.md
@@ -1,0 +1,138 @@
+# OmniInstruct to verl Parquet Mapping
+
+This note describes a practical mapping from `m-a-p/OmniInstruct` into the
+multimodal parquet format consumed by the current `verl` data pipeline.
+
+## Why This Mapping Matches Current verl
+
+The recent multimodal updates in `verl` expect:
+
+- `prompt` to store chat messages
+- multimodal references to appear inside the user message as `<image>`,
+  `<video>`, and `<audio>` placeholders
+- `images` to be a list of dictionaries such as
+  `[{"image": "/abs/path/to/image.png"}]`
+- `audios` to be a list of audio payloads, where a local file path is the
+  simplest stable choice
+
+For Qwen3-Omni thinker style workloads, this gives a dataset shape that works
+with the audio-aware `RLHFDataset` path and with the new rollout-side
+`mm_processor_kwargs` support.
+
+## Source Schema
+
+`m-a-p/OmniInstruct` exposes the following raw fields on Hugging Face:
+
+| Raw field | Meaning |
+| --- | --- |
+| `question` | Instruction or question text |
+| `answer` | Reference answer |
+| `image` | Image payload |
+| `audio` | Audio payload |
+| `category` | Task/category label |
+| `category_id` | Numeric category id |
+| `id` | Sample id |
+| `video_id` | Original source video id |
+
+The public split names are `train` and `valid`.
+
+## Target verl Schema
+
+| verl field | Mapping | Notes |
+| --- | --- | --- |
+| `data_source` | Constant string, default `m-a-p/OmniInstruct` | Used by reward selection and logging |
+| `prompt` | `[{"role": "user", "content": "<image><audio>\n{question}"}]` | Placeholders are emitted only when the modality exists |
+| `images` | `[{"image": exported_image_path}]` | Use dict form because the current image path expects structured content |
+| `audios` | `[exported_audio_path]` | A local `.wav` path is the most stable export format |
+| `ability` | `category` by default, or a constant fallback | Keeps category-level observability in trainer logs |
+| `reward_model` | `{"style": "rule", "ground_truth": answer}` | Works for exact/heuristic answer checking |
+| `extra_info.split` | Output split name (`train` / `test`) | Matches existing `examples/data_preprocess` convention |
+| `extra_info.source_split` | Raw split name (`train` / `valid`) | Keeps provenance after renaming `valid -> test` |
+| `extra_info.raw_id` | `id` | Original sample identifier |
+| `extra_info.category_id` | `category_id` | Preserved metadata |
+| `extra_info.video_id` | `video_id` | Preserved metadata |
+| `extra_info.question` | `question` | Useful for debugging |
+| `extra_info.answer` | `answer` | Useful for debugging |
+
+## Prompt Layout Decision
+
+The converter uses the following user prompt layout:
+
+```text
+<image><audio>
+{question}
+```
+
+Rationale:
+
+- it keeps multimodal placeholders explicit and deterministic
+- it lets `RLHFDataset._build_messages()` inject the exported assets into the
+  message content list in the same order
+- it remains compatible with mixed-modality rows where only image or only audio
+  is present
+
+## Asset Export Decision
+
+The converter exports media into a local assets tree:
+
+```text
+${local_save_dir}/assets/train/images/*.png|*.jpg
+${local_save_dir}/assets/train/audios/*.wav
+${local_save_dir}/assets/test/images/*.png|*.jpg
+${local_save_dir}/assets/test/audios/*.wav
+```
+
+This avoids pointing parquet rows at transient Hugging Face cache locations.
+
+## Example Converted Row
+
+```json
+{
+  "data_source": "m-a-p/OmniInstruct",
+  "prompt": [
+    {
+      "role": "user",
+      "content": "<image><audio>\nWhat is happening in this clip?"
+    }
+  ],
+  "images": [
+    {
+      "image": "/abs/path/to/assets/train/images/00000042_42.png"
+    }
+  ],
+  "audios": [
+    "/abs/path/to/assets/train/audios/00000042_42.wav"
+  ],
+  "ability": "food/drink",
+  "reward_model": {
+    "style": "rule",
+    "ground_truth": "The speaker is cooking curry."
+  },
+  "extra_info": {
+    "split": "train",
+    "source_split": "train",
+    "index": 42,
+    "raw_id": 42,
+    "category": "food/drink",
+    "category_id": 7,
+    "video_id": 1234
+  }
+}
+```
+
+## Converter Script
+
+Use `examples/data_preprocess/omniinstruct_to_verl.py`.
+
+Example:
+
+```bash
+python examples/data_preprocess/omniinstruct_to_verl.py \
+  --local_save_dir ~/data/omniinstruct_verl
+```
+
+This produces:
+
+- `~/data/omniinstruct_verl/train.parquet`
+- `~/data/omniinstruct_verl/test.parquet`
+- exported image/audio assets under `~/data/omniinstruct_verl/assets`

--- a/examples/data_preprocess/omniinstruct_to_verl.py
+++ b/examples/data_preprocess/omniinstruct_to_verl.py
@@ -1,0 +1,510 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Convert OmniInstruct to verl parquet format.
+
+The exported parquet follows verl's current multimodal contract:
+- ``prompt`` stores chat messages with ``<image>`` / ``<audio>`` placeholders
+- ``images`` stores ``[{"image": "/abs/path/to/file"}]``
+- ``audios`` stores ``["/abs/path/to/file.wav"]``
+
+This format matches the recent audio-aware preprocessing path used by
+``RLHFDataset`` and the Qwen3-Omni thinker examples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import shutil
+import wave
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+DEFAULT_DATASET_NAME = "m-a-p/OmniInstruct"
+DEFAULT_DATA_SOURCE = "m-a-p/OmniInstruct"
+
+
+def _copy_to_hdfs(local_path: str, hdfs_dir: str) -> None:
+    from verl.utils.hdfs_io import copy, makedirs
+
+    makedirs(hdfs_dir)
+    copy(src=local_path, dst=hdfs_dir)
+
+
+def _sanitize_filename(value: Any, default: str = "sample") -> str:
+    text = str(value) if value is not None else default
+    text = re.sub(r"[^0-9A-Za-z._-]+", "_", text).strip("._")
+    return text or default
+
+
+def _normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _to_numpy(value: Any) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _normalize_waveform_and_channels(array: Any) -> tuple[np.ndarray, int]:
+    waveform = _to_numpy(array)
+    if waveform.ndim == 0:
+        raise ValueError("audio array is scalar")
+    if waveform.ndim > 2:
+        raise ValueError(f"audio array rank must be 1 or 2, got {waveform.ndim}")
+
+    if waveform.ndim == 1:
+        return waveform, 1
+
+    # TorchCodec returns channels-first tensors, while some other loaders use
+    # samples-first arrays. Heuristically treat the small dimension as channel.
+    if waveform.shape[0] <= waveform.shape[1] and waveform.shape[0] <= 8:
+        waveform = waveform.transpose(1, 0)
+    elif waveform.shape[1] <= 8:
+        pass
+    else:
+        # Fall back to mono when the layout is ambiguous.
+        waveform = waveform.mean(axis=-1)
+        return waveform, 1
+
+    num_channels = int(waveform.shape[1])
+    if num_channels <= 0:
+        raise ValueError(f"invalid channel count: {num_channels}")
+    return waveform, num_channels
+
+
+def _write_pcm_wav(array: Any, sampling_rate: int, output_path: Path) -> None:
+    waveform, num_channels = _normalize_waveform_and_channels(array)
+
+    if np.issubdtype(waveform.dtype, np.floating):
+        waveform = np.clip(waveform, -1.0, 1.0)
+        pcm = (waveform * np.iinfo(np.int16).max).astype(np.int16)
+    else:
+        pcm = waveform.astype(np.int16)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(output_path), "wb") as wav_file:
+        wav_file.setnchannels(num_channels)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(int(sampling_rate))
+        wav_file.writeframes(pcm.tobytes())
+
+
+def _decode_torchcodec_samples(audio_value: Any) -> tuple[Any, int] | None:
+    if not hasattr(audio_value, "get_all_samples"):
+        return None
+
+    samples = audio_value.get_all_samples()
+    data = getattr(samples, "data", None)
+    sample_rate = getattr(samples, "sample_rate", None)
+    if data is None or sample_rate is None:
+        raise ValueError("AudioDecoder.get_all_samples() did not provide both data and sample_rate")
+    return data, int(sample_rate)
+
+
+def _decode_audio_bytes_with_torchcodec(audio_bytes: bytes) -> tuple[Any, int]:
+    import importlib
+
+    audio_decoder_cls = importlib.import_module("torchcodec.decoders").AudioDecoder
+
+    samples = audio_decoder_cls(audio_bytes).get_all_samples()
+    data = getattr(samples, "data", None)
+    sample_rate = getattr(samples, "sample_rate", None)
+    if data is None or sample_rate is None:
+        raise ValueError("torchcodec decoder failed to provide data/sample_rate")
+    return data, int(sample_rate)
+
+
+def _save_image_object(image_obj: Any, output_stem: Path) -> Path:
+    if hasattr(image_obj, "filename") and getattr(image_obj, "filename", None):
+        filename = Path(image_obj.filename)
+        if filename.exists():
+            output_path = output_stem.with_suffix(filename.suffix or ".png")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(filename, output_path)
+            return output_path.resolve()
+
+    output_path = output_stem.with_suffix(".png")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image_obj.save(output_path)
+    return output_path.resolve()
+
+
+def export_audio_asset(audio_value: Any, output_stem: Path) -> str | None:
+    if audio_value is None:
+        return None
+
+    if isinstance(audio_value, str):
+        source_path = Path(audio_value)
+        if not source_path.exists():
+            raise FileNotFoundError(f"audio path does not exist: {audio_value}")
+        output_path = output_stem.with_suffix(source_path.suffix or ".wav")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, output_path)
+        return str(output_path.resolve())
+
+    decoded_audio = _decode_torchcodec_samples(audio_value)
+    if decoded_audio is not None:
+        array, sampling_rate = decoded_audio
+        output_path = output_stem.with_suffix(".wav")
+        _write_pcm_wav(array=array, sampling_rate=sampling_rate, output_path=output_path)
+        return str(output_path.resolve())
+
+    if not isinstance(audio_value, dict):
+        raise TypeError(f"unsupported audio payload type: {type(audio_value)!r}")
+
+    raw_path = audio_value.get("path")
+    if raw_path:
+        source_path = Path(raw_path)
+        if source_path.exists():
+            output_path = output_stem.with_suffix(source_path.suffix or ".wav")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, output_path)
+            return str(output_path.resolve())
+
+    array = audio_value.get("array")
+    sampling_rate = audio_value.get("sampling_rate")
+    if array is not None and sampling_rate is not None:
+        output_path = output_stem.with_suffix(".wav")
+        _write_pcm_wav(array=array, sampling_rate=int(sampling_rate), output_path=output_path)
+        return str(output_path.resolve())
+
+    audio_bytes = audio_value.get("bytes")
+    if audio_bytes is not None:
+        output_path = output_stem.with_suffix(".wav")
+        try:
+            decoded_array, decoded_sample_rate = _decode_audio_bytes_with_torchcodec(audio_bytes)
+        except Exception as exc:
+            raise ValueError(
+                "audio payload bytes could not be decoded; install a compatible torchcodec/ffmpeg stack "
+                "or provide a path-backed dataset"
+            ) from exc
+        _write_pcm_wav(array=decoded_array, sampling_rate=decoded_sample_rate, output_path=output_path)
+        return str(output_path.resolve())
+
+    raise ValueError(
+        "audio payload must contain a valid path, an AudioDecoder object, bytes, or both array and sampling_rate"
+    )
+
+
+def export_image_asset(image_value: Any, output_stem: Path) -> str | None:
+    if image_value is None:
+        return None
+
+    if isinstance(image_value, str):
+        source_path = Path(image_value)
+        if not source_path.exists():
+            raise FileNotFoundError(f"image path does not exist: {image_value}")
+        output_path = output_stem.with_suffix(source_path.suffix or ".png")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, output_path)
+        return str(output_path.resolve())
+
+    if isinstance(image_value, dict):
+        raw_path = image_value.get("path")
+        if raw_path:
+            source_path = Path(raw_path)
+            if source_path.exists():
+                output_path = output_stem.with_suffix(source_path.suffix or ".png")
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source_path, output_path)
+                return str(output_path.resolve())
+
+        if image_value.get("bytes") is not None:
+            from PIL import Image
+
+            image = Image.open(BytesIO(image_value["bytes"]))
+            return str(_save_image_object(image, output_stem))
+
+        if image_value.get("image") is not None:
+            return str(_save_image_object(image_value["image"], output_stem))
+
+    if hasattr(image_value, "save"):
+        return str(_save_image_object(image_value, output_stem))
+
+    raise TypeError(f"unsupported image payload type: {type(image_value)!r}")
+
+
+def build_prompt_messages(question: str, *, has_image: bool, has_audio: bool, system_prompt: str | None) -> list[dict]:
+    placeholders = ""
+    if has_image:
+        placeholders += "<image>"
+    if has_audio:
+        placeholders += "<audio>"
+
+    user_content = placeholders
+    if question:
+        user_content = f"{placeholders}\n{question}" if placeholders else question
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": user_content})
+    return messages
+
+
+def convert_example(
+    example: dict[str, Any],
+    *,
+    split_name: str,
+    output_split_name: str,
+    idx: int,
+    assets_root: Path,
+    data_source: str,
+    ability_mode: str,
+    default_ability: str,
+    system_prompt: str | None,
+) -> dict[str, Any]:
+    question = _normalize_text(example.get("question"))
+    answer = _normalize_text(example.get("answer"))
+    if not question:
+        raise ValueError("question is empty")
+    if not answer:
+        raise ValueError("answer is empty")
+
+    raw_id = example.get("id", example.get("index", idx))
+    stem_name = f"{idx:08d}_{_sanitize_filename(raw_id)}"
+
+    image_path = export_image_asset(
+        example.get("image"),
+        assets_root / output_split_name / "images" / stem_name,
+    )
+    audio_path = export_audio_asset(
+        example.get("audio"),
+        assets_root / output_split_name / "audios" / stem_name,
+    )
+
+    if ability_mode == "category":
+        ability = _normalize_text(example.get("category")) or default_ability
+    else:
+        ability = default_ability
+
+    modalities = []
+    if image_path is not None:
+        modalities.append("image")
+    if audio_path is not None:
+        modalities.append("audio")
+
+    extra_info = {
+        "split": output_split_name,
+        "source_split": split_name,
+        "index": idx,
+        "raw_id": raw_id,
+        "question": question,
+        "answer": answer,
+        "category": example.get("category"),
+        "category_id": example.get("category_id"),
+        "video_id": example.get("video_id"),
+        "modalities": modalities,
+        "exported_image_path": image_path,
+        "exported_audio_path": audio_path,
+    }
+
+    return {
+        "data_source": data_source,
+        "prompt": build_prompt_messages(
+            question,
+            has_image=image_path is not None,
+            has_audio=audio_path is not None,
+            system_prompt=system_prompt,
+        ),
+        "images": [{"image": image_path}] if image_path is not None else [],
+        "audios": [audio_path] if audio_path is not None else [],
+        "ability": ability,
+        "reward_model": {"style": "rule", "ground_truth": answer},
+        "extra_info": extra_info,
+    }
+
+
+def convert_split(
+    *,
+    dataset_source: str,
+    split_name: str,
+    output_split_name: str,
+    local_save_dir: Path,
+    data_source: str,
+    ability_mode: str,
+    default_ability: str,
+    system_prompt: str | None,
+    max_samples_per_split: int,
+    log_every: int,
+) -> None:
+    from datasets import Audio, Dataset, load_dataset
+
+    logger.info("Loading split %s from %s", split_name, dataset_source)
+    dataset = load_dataset(dataset_source, split=split_name)
+
+    if "audio" in dataset.column_names:
+        try:
+            dataset = dataset.cast_column("audio", Audio(decode=False))
+            logger.info("Casted audio column to decode=False for path/bytes-based export")
+        except Exception as exc:
+            logger.warning(
+                "Failed to cast audio column to decode=False, will handle decoded audio objects directly: %s",
+                exc,
+            )
+
+    if max_samples_per_split > 0:
+        sample_count = min(len(dataset), max_samples_per_split)
+        dataset = dataset.select(range(sample_count))
+        logger.info("Using first %s samples from split %s", sample_count, split_name)
+
+    processed_rows: list[dict[str, Any]] = []
+    skipped_rows = 0
+    assets_root = local_save_dir / "assets"
+
+    for idx, example in enumerate(dataset):
+        try:
+            processed_rows.append(
+                convert_example(
+                    example,
+                    split_name=split_name,
+                    output_split_name=output_split_name,
+                    idx=idx,
+                    assets_root=assets_root,
+                    data_source=data_source,
+                    ability_mode=ability_mode,
+                    default_ability=default_ability,
+                    system_prompt=system_prompt,
+                )
+            )
+        except Exception as exc:
+            skipped_rows += 1
+            logger.warning(
+                "Skipping split=%s idx=%s raw_id=%s because conversion failed: %s",
+                split_name,
+                idx,
+                example.get("id", example.get("index", idx)),
+                exc,
+            )
+        else:
+            if log_every > 0 and (idx + 1) % log_every == 0:
+                logger.info("Converted %s rows from split %s", idx + 1, split_name)
+
+    if not processed_rows:
+        raise ValueError(f"no rows were converted for split {split_name}")
+
+    output_path = local_save_dir / f"{output_split_name}.parquet"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    Dataset.from_list(processed_rows).to_parquet(str(output_path))
+    logger.info(
+        "Saved %s rows to %s (skipped=%s)",
+        len(processed_rows),
+        output_path,
+        skipped_rows,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert OmniInstruct to verl parquet with exported media assets.")
+    parser.add_argument("--dataset_name", default=DEFAULT_DATASET_NAME, help="Hugging Face dataset name to load.")
+    parser.add_argument(
+        "--data_source_name",
+        default=DEFAULT_DATA_SOURCE,
+        help="Value written to the verl parquet data_source column.",
+    )
+    parser.add_argument(
+        "--local_dataset_path",
+        default=None,
+        help=(
+            "Optional local dataset path. When provided, it is passed to datasets.load_dataset instead of dataset_name."
+        ),
+    )
+    parser.add_argument("--train_split", default="train", help="Source split written to train.parquet.")
+    parser.add_argument("--eval_split", default="valid", help="Source split written to test.parquet.")
+    parser.add_argument("--eval_output_name", default="test", help="Output parquet filename stem for the eval split.")
+    parser.add_argument("--local_dir", default=None)
+    parser.add_argument(
+        "--local_save_dir",
+        default="~/data/omniinstruct_verl",
+        help="Directory where parquet files and exported media assets are stored.",
+    )
+    parser.add_argument("--hdfs_dir", default=None, help="Optional HDFS destination directory.")
+    parser.add_argument("--system_prompt", default=None, help="Optional system prompt prepended to every sample.")
+    parser.add_argument(
+        "--ability_mode",
+        choices=("category", "constant"),
+        default="category",
+        help="How to populate the verl ability field.",
+    )
+    parser.add_argument(
+        "--default_ability",
+        default="omni",
+        help="Fallback ability when ability_mode=category and category is missing, or constant value otherwise.",
+    )
+    parser.add_argument(
+        "--max_samples_per_split",
+        type=int,
+        default=-1,
+        help="Optional upper bound for quick smoke tests. Use -1 for the full split.",
+    )
+    parser.add_argument("--log_every", type=int, default=500, help="Log progress every N converted rows.")
+    args = parser.parse_args()
+
+    local_save_dir = args.local_dir
+    if local_save_dir is not None:
+        logger.warning("Argument 'local_dir' is deprecated. Please use 'local_save_dir' instead.")
+    else:
+        local_save_dir = args.local_save_dir
+
+    output_dir = Path(local_save_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_source = args.local_dataset_path if args.local_dataset_path is not None else args.dataset_name
+
+    convert_split(
+        dataset_source=dataset_source,
+        split_name=args.train_split,
+        output_split_name="train",
+        local_save_dir=output_dir,
+        data_source=args.data_source_name,
+        ability_mode=args.ability_mode,
+        default_ability=args.default_ability,
+        system_prompt=args.system_prompt,
+        max_samples_per_split=args.max_samples_per_split,
+        log_every=args.log_every,
+    )
+
+    if args.eval_split:
+        convert_split(
+            dataset_source=dataset_source,
+            split_name=args.eval_split,
+            output_split_name=args.eval_output_name,
+            local_save_dir=output_dir,
+            data_source=args.data_source_name,
+            ability_mode=args.ability_mode,
+            default_ability=args.default_ability,
+            system_prompt=args.system_prompt,
+            max_samples_per_split=args.max_samples_per_split,
+            log_every=args.log_every,
+        )
+
+    if args.hdfs_dir is not None:
+        _copy_to_hdfs(local_path=str(output_dir), hdfs_dir=args.hdfs_dir)
+        logger.info("Copied converted dataset to HDFS: %s", args.hdfs_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gspo_trainer/qwen3_omni_thinker_assets.md
+++ b/examples/gspo_trainer/qwen3_omni_thinker_assets.md
@@ -1,0 +1,46 @@
+## Qwen3-Omni Thinker Assets
+
+Prepare these assets on the cluster before running `Qwen3-Omni Thinker` GSPO jobs.
+
+### Required paths
+
+| Variable | Description |
+| --- | --- |
+| `MODEL_PATH` | Local checkpoint directory for `Qwen3-Omni-30B-A3B-Thinking`. |
+| `TRAIN_FILE` | Training parquet with `<audio>` placeholders and an `audios` column. |
+| `TEST_FILE` | Validation parquet with the same schema as the training parquet. |
+| `RAY_DATA_HOME` | Root directory for models, data, and checkpoints on the cluster. |
+
+### Required runtime
+
+- `transformers` version that includes `Qwen3OmniMoeProcessor` and `Qwen3OmniMoeThinkerForConditionalGeneration`
+- `vllm` version with multimodal audio input support and `mm_processor_kwargs`
+- `qwen_omni_utils` when `use_audio_in_video=True`
+- Ray cluster with `ray` CLI available in `PATH`
+
+### Dataset schema expectations
+
+- `prompt` contains chat messages with `<audio>` placeholders
+- `audios` contains the audio payloads referenced by those placeholders
+- Optional `images` / `videos` columns may coexist for mixed-modality samples
+
+### Suggested validation flow
+
+1. Prepare `MODEL_PATH`, `TRAIN_FILE`, and `TEST_FILE`.
+2. Run a short smoke test:
+
+```bash
+MODEL_PATH=/path/to/Qwen3-Omni-30B-A3B-Thinking \
+TRAIN_FILE=/path/to/omniinstruct/train.parquet \
+TEST_FILE=/path/to/omniinstruct/test.parquet \
+TOTAL_TRAINING_STEPS=5 \
+bash examples/gspo_trainer/run_qwen3_omni_thinker_fsdp2.sh
+```
+
+3. For cluster execution, submit the same command through your Ray job launcher:
+
+```bash
+ray job submit --runtime-env=verl/trainer/runtime_env.yaml -- \
+  bash examples/gspo_trainer/run_qwen3_omni_thinker_fsdp2.sh \
+  trainer.total_training_steps=120
+```

--- a/examples/gspo_trainer/run_qwen3_omni_thinker_fsdp2.sh
+++ b/examples/gspo_trainer/run_qwen3_omni_thinker_fsdp2.sh
@@ -1,0 +1,136 @@
+set -euo pipefail
+
+# Required assets before cluster submission:
+# 1. MODEL_PATH points to a local Qwen3-Omni Thinker checkpoint directory.
+# 2. TRAIN_FILE / TEST_FILE point to parquet files whose prompts use <audio> placeholders
+#    and whose audio payload column is configured by data.audio_key (default: audios).
+# 3. The runtime environment must provide transformers with Qwen3-Omni support,
+#    vLLM with multimodal audio input support, Ray CLI, and qwen_omni_utils when
+#    use_audio_in_video=True is desired.
+
+if [ $# -gt 0 ] && [[ "$1" != *=* ]]; then
+  ENGINE=$1
+  shift
+else
+  ENGINE=${ENGINE:-vllm}
+fi
+
+: "${MODEL_PATH:?Set MODEL_PATH to a local Qwen3-Omni Thinker checkpoint directory.}"
+: "${TRAIN_FILE:?Set TRAIN_FILE to the converted OmniInstruct training parquet.}"
+: "${TEST_FILE:?Set TEST_FILE to the converted OmniInstruct validation parquet.}"
+
+PROJECT_NAME=${PROJECT_NAME:-"GSPO-Qwen3-Omni-Thinker"}
+EXP_NAME=${EXP_NAME:-"GSPO-Qwen3-Omni-Thinker-FSDP-${ENGINE}"}
+
+# Use Hydra interpolation so a ``trainer.experiment_name=...`` CLI override
+# automatically produces a per-experiment checkpoint directory. Without this,
+# parallel A/B runs would all share the same CKPTS_DIR and auto-resume would
+# try to load an unrelated run's state_dict (and fail on mesh mismatches such
+# as flat FSDP mesh (N,) vs HSDP mesh (nnodes, fsdp_size)).
+CKPTS_DIR=${CKPTS_DIR:-"checkpoints/\${trainer.project_name}/\${trainer.experiment_name}"}
+
+USE_AUDIO_IN_VIDEO=${USE_AUDIO_IN_VIDEO:-false}
+TOTAL_TRAINING_STEPS=${TOTAL_TRAINING_STEPS:-120}
+
+VAL_FILE="${TEST_FILE}"
+
+# Cluster geometry. Defaults reproduce the original 8-GPU setup; override when
+# splitting the cluster across two parallel runs (e.g. NNODES=4
+# N_GPUS_PER_NODE=8 for a 32-GPU job).
+NNODES=${NNODES:-2}
+N_GPUS_PER_NODE=${N_GPUS_PER_NODE:-8}
+# Keep FSDP sharding intra-node by default. With NNODES>1 this gives HSDP
+# (FSDP within a node, DP across nodes) which keeps all-gather/reduce-scatter
+# on NVLink instead of IB.
+FSDP_SIZE=${FSDP_SIZE:-${N_GPUS_PER_NODE}}
+# Rollout TP must fit within a node (NVLink). 4 is a sweet spot for 30B-A3B.
+GEN_TP=${GEN_TP:-4}
+SP_SIZE=${SP_SIZE:-1}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-32768}
+
+# Batch geometry. Override these values to match the target cluster size and
+# memory budget.
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-64}
+PPO_MINI_BATCH_SIZE=${PPO_MINI_BATCH_SIZE:-64}
+ROLLOUT_N=${ROLLOUT_N:-4}
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-24576}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-8192}
+LR=${LR:-5e-7}
+KL_LOSS_COEF=${KL_LOSS_COEF:-1e-3}
+GRAD_CLIP=${GRAD_CLIP:-0.5}
+
+python3 -m verl.trainer.main_ppo \
+    algorithm.adv_estimator=grpo \
+    actor_rollout_ref.actor.policy_loss.loss_mode=gspo \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    data.train_batch_size=${TRAIN_BATCH_SIZE} \
+    data.max_prompt_length=${MAX_PROMPT_LENGTH} \
+    data.max_response_length=${MAX_RESPONSE_LENGTH} \
+    data.filter_overlong_prompts=False \
+    data.filter_overlong_prompts_workers=64 \
+    data.val_max_samples=64 \
+    data.truncation='error' \
+    data.audio_key=audios \
+    data.shuffle=False \
+    +data.mm_processor_kwargs.use_audio_in_video=${USE_AUDIO_IN_VIDEO} \
+    actor_rollout_ref.model.path=${MODEL_PATH} \
+    actor_rollout_ref.model.trust_remote_code=True \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.optim.lr=${LR} \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.actor.grad_clip=${GRAD_CLIP} \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=${KL_LOSS_COEF} \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.ref.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=${FSDP_SIZE} \
+    actor_rollout_ref.actor.fsdp_config.model_dtype=bf16 \
+    actor_rollout_ref.ref.fsdp_config.model_dtype=bf16 \
+    actor_rollout_ref.actor.fsdp_config.reshard_after_forward=True \
+    actor_rollout_ref.ref.fsdp_config.reshard_after_forward=True \
+    actor_rollout_ref.actor.fsdp_config.entropy_checkpointing=True \
+    actor_rollout_ref.actor.entropy_from_logits_with_chunking=True \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=${SP_SIZE} \
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
+    actor_rollout_ref.actor.use_torch_compile=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \
+    actor_rollout_ref.ref.entropy_from_logits_with_chunking=True \
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=${SP_SIZE} \
+    actor_rollout_ref.rollout.name=${ENGINE} \
+    actor_rollout_ref.rollout.ignore_eos=False \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${GEN_TP} \
+    actor_rollout_ref.rollout.max_model_len=${MAX_MODEL_LEN} \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \
+    actor_rollout_ref.rollout.n=${ROLLOUT_N} \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=${MAX_MODEL_LEN} \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.enable_prefix_caching=True \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    algorithm.use_kl_in_reward=False \
+    trainer.use_legacy_worker_impl=disable \
+    trainer.critic_warmup=0 \
+    trainer.resume_mode=disable \
+    trainer.logger='["console","swanlab"]' \
+    trainer.project_name="${PROJECT_NAME}" \
+    trainer.experiment_name="${EXP_NAME}" \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.n_gpus_per_node=${N_GPUS_PER_NODE} \
+    trainer.nnodes=${NNODES} \
+    trainer.balance_batch=True \
+    trainer.val_before_train=False \
+    trainer.total_epochs=10 \
+    trainer.total_training_steps=${TOTAL_TRAINING_STEPS} \
+    trainer.save_freq=-1 \
+    trainer.test_freq=20 \
+    "$@"

--- a/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
+++ b/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/llm_server.py"
+VLLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/vllm_rollout/vllm_async_server.py"
+
+
+def _load_module_ast(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def test_async_server_manager_generate_accepts_audio_and_mm_kwargs() -> None:
+    module = _load_module_ast(LLM_SERVER_SOURCE)
+
+    generate_fn = None
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "LLMServerClient":
+            for inner in node.body:
+                if isinstance(inner, ast.AsyncFunctionDef) and inner.name == "generate":
+                    generate_fn = inner
+                    break
+
+    assert generate_fn is not None
+    arg_names = [arg.arg for arg in generate_fn.args.kwonlyargs]
+    assert "audio_data" in arg_names
+    assert "mm_processor_kwargs" in arg_names
+
+
+def test_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
+    source = LLM_SERVER_SOURCE.read_text(encoding="utf-8")
+    assert "audio_data=audio_data" in source
+    assert "mm_processor_kwargs=mm_processor_kwargs" in source
+
+
+def test_vllm_generate_includes_audio_and_mm_processor_kwargs() -> None:
+    source = VLLM_SERVER_SOURCE.read_text(encoding="utf-8")
+    assert 'multi_modal_data["audio"] = audio_data' in source
+    assert 'prompt_kwargs["mm_processor_kwargs"] = mm_processor_kwargs' in source

--- a/tests/models/transformers/test_qwen3_omni_get_rope_index_on_cpu.py
+++ b/tests/models/transformers/test_qwen3_omni_get_rope_index_on_cpu.py
@@ -1,0 +1,170 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU regression tests for ``verl.models.transformers.qwen3_omni_moe.get_rope_index``.
+
+HF's ``Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index`` gates the
+3D audio/image/video-aware branch on ``image_grid_thw is not None or
+video_grid_thw is not None``. Audio-only samples fall through to a 1D
+``cumsum`` broadcast to 3 axes in ``float32``. That makes the FSDP2 actor
+disagree with the vLLM rollout engine on audio-region tokens.
+
+These tests pin the verl helper's contract so the bug can't silently return.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from verl.models.transformers.qwen3_omni_moe import get_rope_index
+
+AUDIO_TOKEN_ID = 151675
+AUDIO_START_TOKEN_ID = 151669
+AUDIO_END_TOKEN_ID = 151670
+
+
+class _FakeQwen3OmniProcessor:
+    """Minimal stand-in for ``Qwen3OmniMoeProcessor`` — only the fields the
+    audio-aware branch of ``get_rope_index`` reads from.
+
+    ``get_rope_index`` on the real processor is dynamically bound by
+    ``verl.utils.tokenizer.hf_processor``; we don't need it here because the
+    verl helper's audio-only branch is self-contained (no delegation).
+    """
+
+    __class__name = "Qwen3OmniMoeProcessor"
+
+    def __init__(self):
+        self.config = SimpleNamespace(
+            audio_token_id=AUDIO_TOKEN_ID,
+            audio_start_token_id=AUDIO_START_TOKEN_ID,
+            audio_end_token_id=AUDIO_END_TOKEN_ID,
+        )
+        self.audio_token_id = AUDIO_TOKEN_ID
+        self.audio_start_token_id = AUDIO_START_TOKEN_ID
+        self.audio_end_token_id = AUDIO_END_TOKEN_ID
+
+
+def _build_row(audio_lens: list[int]):
+    """Build input_ids = [t t t] + (audio_start + audio_pad*L + audio_end + [t])*len + tail.
+
+    Audio length L is the post-Whisper token count produced by
+    ``_get_feat_extract_output_lengths``. For ``audio_seqlens = 1104`` the
+    formula gives ``L = 144``; for 1204 it gives 157; for 2002 it gives 261.
+    We pick audio_seqlens values that return the caller-supplied L.
+    """
+    # Inverse of _get_feat_extract_output_lengths for multiples of 100:
+    # L = 13 * (seq // 100)  when seq % 100 == 0
+    # so pass seq = L * 100 / 13 rounded up. Simpler: pick a fixed seq that
+    # we know produces L (see test_lengths fixture below).
+    pass  # helper removed — we inline the cases below
+
+
+def _feat_extract(seq):
+    """Mirror of transformers._get_feat_extract_output_lengths for audit."""
+    input_lengths_leave = seq % 100
+    feat_lengths = (input_lengths_leave - 1) // 2 + 1
+    return ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (seq // 100) * 13
+
+
+def test_audio_only_returns_long_not_float():
+    """Pre-fix the audio-only path returned ``float32``; after fix it must be
+    ``int64`` so HF rope embeddings (indexed by position) don't silently cast."""
+    processor = _FakeQwen3OmniProcessor()
+    audio_len = _feat_extract(1104)  # 144
+
+    row = [10, 11, 12, AUDIO_START_TOKEN_ID] + [AUDIO_TOKEN_ID] * audio_len + [AUDIO_END_TOKEN_ID, 20]
+    input_ids = torch.tensor([row], dtype=torch.long)
+    attn = torch.ones_like(input_ids)
+    audio_seqlens = torch.tensor([1104], dtype=torch.long)
+
+    pid, deltas = get_rope_index(
+        processor,
+        input_ids=input_ids,
+        attention_mask=attn,
+        audio_seqlens=audio_seqlens,
+    )
+
+    assert pid.dtype == torch.long
+    assert list(pid.shape) == [3, 1, input_ids.shape[-1]]
+
+
+def test_audio_only_positions_are_contiguous_and_cover_audio_block():
+    """The verl helper must emit ``[0, 1, ..., T-1]`` for a single-audio row
+    with no other text gaps — that's what HF's audio-aware branch does via
+    ``torch.arange(audio_len).view(1, -1).expand(3, -1)`` with ``st_idx``
+    bookkeeping. The pre-fix code produced the same *values* but as float32,
+    so we fix the dtype and *also* check the arithmetic stays right."""
+    processor = _FakeQwen3OmniProcessor()
+    audio_len = _feat_extract(1104)
+
+    row = [10, 11, 12, 13, 14, AUDIO_START_TOKEN_ID] + [AUDIO_TOKEN_ID] * audio_len + [AUDIO_END_TOKEN_ID, 20, 21, 22]
+    T = len(row)
+    input_ids = torch.tensor([row], dtype=torch.long)
+    attn = torch.ones_like(input_ids)
+    audio_seqlens = torch.tensor([1104], dtype=torch.long)
+
+    pid, _ = get_rope_index(
+        processor,
+        input_ids=input_ids,
+        attention_mask=attn,
+        audio_seqlens=audio_seqlens,
+    )
+
+    expected = torch.arange(T, dtype=torch.long)
+    assert torch.equal(pid[0, 0], expected)
+    assert torch.equal(pid[1, 0], expected)
+    assert torch.equal(pid[2, 0], expected)
+
+
+def test_two_audio_blocks_positions_cover_full_sequence():
+    processor = _FakeQwen3OmniProcessor()
+    audio_len = _feat_extract(1104)
+
+    block = [AUDIO_START_TOKEN_ID] + [AUDIO_TOKEN_ID] * audio_len + [AUDIO_END_TOKEN_ID]
+    row = [10, 11] + block + [30, 31] + block + [40]
+    T = len(row)
+    input_ids = torch.tensor([row], dtype=torch.long)
+    attn = torch.ones_like(input_ids)
+    audio_seqlens = torch.tensor([1104, 1104], dtype=torch.long)
+
+    pid, _ = get_rope_index(
+        processor,
+        input_ids=input_ids,
+        attention_mask=attn,
+        audio_seqlens=audio_seqlens,
+    )
+    expected = torch.arange(T, dtype=torch.long)
+    assert torch.equal(pid[0, 0], expected)
+
+
+def test_no_audio_no_vision_produces_long_dtype():
+    """Pure-text branch delegates to HF and casts to long. Uses a stubbed
+    ``get_rope_index`` on the processor since the verl helper only falls
+    through when ``audio_seqlens is None`` and no vision grids."""
+
+    class _Stub(_FakeQwen3OmniProcessor):
+        def get_rope_index(self, **kwargs):
+            T = kwargs["input_ids"].shape[-1]
+            # Mimic HF's text-only fallback: float cumsum broadcast to 3 axes.
+            pos = torch.arange(T, dtype=torch.float32).unsqueeze(0).expand(3, -1, -1)
+            return pos, torch.tensor([[0]])
+
+    processor = _Stub()
+    input_ids = torch.tensor([[10, 11, 12, 13, 14]], dtype=torch.long)
+    attn = torch.ones_like(input_ids)
+
+    pid, _ = get_rope_index(processor, input_ids=input_ids, attention_mask=attn)
+    assert pid.dtype == torch.long

--- a/tests/models/transformers/test_qwen3_omni_moe_patch_on_cpu.py
+++ b/tests/models/transformers/test_qwen3_omni_moe_patch_on_cpu.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from verl.models.transformers.qwen3_omni_moe import (
+    _DEFAULT_EXPERTS_IMPLEMENTATION,
+    _force_experts_implementation,
+    patch_qwen3_omni_moe_sparse_moe_block_forward,
+)
+
+
+def test_force_experts_implementation_sets_when_unset():
+    config = SimpleNamespace(_experts_implementation=None)
+
+    result = _force_experts_implementation(config, "batched_mm")
+
+    assert result == "batched_mm"
+    assert config._experts_implementation == "batched_mm"
+
+
+def test_force_experts_implementation_preserves_existing_value():
+    config = SimpleNamespace(_experts_implementation="eager")
+
+    result = _force_experts_implementation(config, "batched_mm")
+
+    assert result == "eager"
+    assert config._experts_implementation == "eager"
+
+
+def test_patch_configures_model_instance_when_unset():
+    model = SimpleNamespace(config=SimpleNamespace(_experts_implementation=None))
+
+    patch_qwen3_omni_moe_sparse_moe_block_forward(model=model)
+
+    assert model.config._experts_implementation == _DEFAULT_EXPERTS_IMPLEMENTATION
+
+
+def test_patch_is_noop_without_model_instance():
+    patch_qwen3_omni_moe_sparse_moe_block_forward()

--- a/tests/utils/reward_score/test_omniinstruct_on_cpu.py
+++ b/tests/utils/reward_score/test_omniinstruct_on_cpu.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.utils.reward_score import default_compute_score, omniinstruct
+
+
+def test_omniinstruct_exact_match_scores_one():
+    result = omniinstruct.compute_score("The man is cooking curry.", "The man is cooking curry.")
+
+    assert result["score"] == 1.0
+    assert result["exact_match"] == 1.0
+
+
+def test_omniinstruct_overlap_reward_is_soft():
+    result = omniinstruct.compute_score(
+        "A person is cooking in the kitchen.",
+        "The man is cooking curry.",
+    )
+
+    assert 0.0 < result["score"] < 1.0
+    assert result["token_f1"] > 0.0
+    assert result["rouge_l_f1"] > 0.0
+
+
+def test_default_compute_score_routes_omniinstruct():
+    result = default_compute_score(
+        "m-a-p/OmniInstruct",
+        "A person is chopping vegetables while speaking.",
+        "A person is chopping vegetables.",
+    )
+
+    assert isinstance(result, dict)
+    assert "score" in result
+    assert result["score"] > 0.0
+
+
+def test_long_rambling_with_short_ref_gets_no_substring_bonus():
+    """A long ramble that happens to embed the reference must not collect the
+    substring bonus. Without this guard the policy learns to keep generating
+    until it accidentally mentions the answer (observed as length blow-up
+    and reward collapse on the qwen3-omni GSPO run)."""
+    reference = "The man is cooking curry."
+    long_pred = (
+        "Honestly I have been thinking about this for a while because the audio "
+        "felt ambiguous and I wanted to triple check before answering. "
+        * 30
+        + " The man is cooking curry. "
+        + "Now let me explain why I think so for a few more paragraphs. " * 30
+    )
+
+    bounded = omniinstruct.compute_score(long_pred, reference)
+    raw = omniinstruct._substring_match(long_pred, [reference])
+
+    assert raw == 1.0, "raw substring detector should still trip"
+    assert bounded["substring_match_bounded"] == 0.0
+    # Lexical overlap on a 1000-token rambling against a 4-token reference
+    # is dominated by the precision penalty, so the resulting score is small.
+    assert bounded["score"] < 0.2
+
+
+def test_bounded_substring_match_grants_partial_credit():
+    """A short, on-topic answer that contains the reference still collects the
+    softened substring bonus."""
+    result = omniinstruct.compute_score(
+        "Yes, the man is cooking curry on the stove.",
+        "The man is cooking curry.",
+    )
+
+    assert result["substring_match_bounded"] == 1.0
+    assert result["score"] >= omniinstruct.DEFAULT_SUBSTRING_BONUS
+
+
+def test_substring_bonus_blocked_for_single_token_reference():
+    """Single-token MCQ references like 'B' would otherwise be trivially
+    contained in any verbose response. The bounded substring path requires
+    at least two reference tokens by default."""
+    # Note: 'A' would be removed by ``normalize_answer`` as an article, so we
+    # use 'B' which survives normalization and keeps the raw substring helper
+    # firing — proving that only the bounded path suppresses the bonus.
+    result = omniinstruct.compute_score(
+        "After listening carefully I believe the correct answer is B.",
+        "B",
+    )
+
+    assert result["substring_match_bounded"] == 0.0
+    # The raw containment metric still fires for diagnostic purposes.
+    assert result["substring_match"] == 1.0
+
+
+def test_format_bonus_added_when_answer_tag_present():
+    no_tag = omniinstruct.compute_score(
+        "The man is cooking curry on the stove.",
+        "The man is cooking curry.",
+    )
+    with_tag = omniinstruct.compute_score(
+        "<think>let me transcribe</think><answer>The man is cooking curry.</answer>",
+        "The man is cooking curry.",
+    )
+
+    assert with_tag["format_match"] == 1.0
+    assert no_tag["format_match"] == 0.0
+    # Exact answers already saturate at 1.0; the bonus only matters when the
+    # base score has headroom.
+    weak_no_tag = omniinstruct.compute_score(
+        "Cooking happens here.",
+        "The man is cooking curry.",
+    )
+    weak_with_tag = omniinstruct.compute_score(
+        "<answer>Cooking happens here.</answer>",
+        "The man is cooking curry.",
+    )
+    assert weak_with_tag["score"] > weak_no_tag["score"]
+
+
+def test_format_bonus_does_not_rescue_zero_score():
+    """If the base score is zero, the format bonus must not turn a wrong
+    answer into a positive reward."""
+    result = omniinstruct.compute_score(
+        "<answer>completely unrelated content</answer>",
+        "the man is cooking curry",
+    )
+    assert result["format_match"] == 1.0
+    assert result["score"] == 0.0
+
+
+def test_truncation_penalty_scales_score_down():
+    base = omniinstruct.compute_score(
+        "The man is cooking curry.",
+        "The man is cooking curry.",
+    )
+    truncated = omniinstruct.compute_score(
+        "The man is cooking curry.",
+        "The man is cooking curry.",
+        extra_info={"truncated": True},
+    )
+
+    assert base["score"] == 1.0
+    assert truncated["score"] == 0.5
+    # The override knob makes it possible to disable the penalty entirely.
+    disabled = omniinstruct.compute_score(
+        "The man is cooking curry.",
+        "The man is cooking curry.",
+        extra_info={"truncated": True, "truncation_penalty": 1.0},
+    )
+    assert disabled["score"] == 1.0
+
+
+def test_extra_info_overrides_pass_through_default_compute_score():
+    """extra_info must reach the omniinstruct scorer when routed through the
+    central default_compute_score dispatcher."""
+    result = default_compute_score(
+        "m-a-p/OmniInstruct",
+        "<answer>A person is chopping vegetables.</answer>",
+        "A person is chopping vegetables.",
+        extra_info={"truncated": True, "truncation_penalty": 0.0},
+    )
+    assert result["score"] == 0.0
+
+
+def test_score_bounds_remain_in_unit_interval():
+    cases = [
+        ("", "anything"),
+        ("anything", ""),
+        ("anything", None),
+        ("anything", []),
+        ("anything", ["", None]),
+        ("<answer>x</answer>", ["x"]),
+        ("a" * 5000, "the man is cooking curry"),
+    ]
+    for pred, ref in cases:
+        out = omniinstruct.compute_score(pred, ref)
+        assert 0.0 <= out["score"] <= 1.0, (pred[:30], ref, out["score"])

--- a/tests/utils/test_audio_input_support_on_cpu.py
+++ b/tests/utils/test_audio_input_support_on_cpu.py
@@ -51,7 +51,7 @@ def test_build_messages_replaces_audio_placeholder() -> None:
 def test_build_multimodal_processor_inputs_includes_audio_sampling_rate() -> None:
     captured = {}
 
-    class AudioProcessor:
+    class Qwen3OmniMoeProcessor:
         def __init__(self):
             self.feature_extractor = types.SimpleNamespace(sampling_rate=16000)
 
@@ -59,7 +59,7 @@ def test_build_multimodal_processor_inputs_includes_audio_sampling_rate() -> Non
             captured.update(kwargs)
             return {"input_ids": torch.tensor([[1, 2, 3]])}
 
-    processor = AudioProcessor()
+    processor = Qwen3OmniMoeProcessor()
     output = build_multimodal_processor_inputs(
         processor,
         text=["hello"],
@@ -75,7 +75,40 @@ def test_build_multimodal_processor_inputs_includes_audio_sampling_rate() -> Non
     assert captured["use_audio_in_video"] is True
 
 
-def test_extract_multi_modal_inputs_merges_variable_audio_fields() -> None:
+def test_qwen3_omni_position_ids_use_audio_feature_lengths() -> None:
+    pytest.importorskip("codetiming")
+    from verl.workers.rollout.schemas import AsyncRolloutRequest
+
+    captured = {}
+
+    class Qwen3OmniMoeProcessor:
+        def get_rope_index(self, **kwargs):
+            captured.update(kwargs)
+            return torch.arange(12, dtype=torch.long).view(3, 1, 4), torch.tensor([[0]])
+
+    processor = Qwen3OmniMoeProcessor()
+    multi_modal_inputs = {
+        "image_grid_thw": torch.tensor([[1, 1, 1]]),
+        "video_grid_thw": torch.tensor([[2, 1, 1]]),
+        "video_second_per_grid": torch.tensor([0.5]),
+        "feature_attention_mask": torch.tensor([[1, 1, 0], [1, 1, 1]], dtype=torch.long),
+    }
+
+    position_ids = AsyncRolloutRequest._get_position_ids(
+        processor,
+        input_ids=torch.tensor([[1, 2, 3, 4]], dtype=torch.long),
+        attention_mask=torch.tensor([[1, 1, 1, 1]], dtype=torch.long),
+        multi_modal_inputs=multi_modal_inputs,
+        mm_processor_kwargs={"use_audio_in_video": True},
+    )
+
+    assert position_ids.shape == (3, 4)
+    assert captured["use_audio_in_video"] is True
+    assert torch.equal(captured["audio_seqlens"], torch.tensor([2, 3]))
+    assert torch.equal(captured["second_per_grids"], torch.tensor([0.5]))
+
+
+def test_extract_multi_modal_inputs_merges_qwen3_omni_fields() -> None:
     first_features = torch.arange(6, dtype=torch.float32).view(1, 2, 3)
     second_features = torch.arange(10, dtype=torch.float32).view(1, 2, 5)
 

--- a/tests/utils/test_audio_input_support_on_cpu.py
+++ b/tests/utils/test_audio_input_support_on_cpu.py
@@ -1,0 +1,112 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import types
+
+import pytest
+import torch
+
+from verl.utils.model import extract_multi_modal_inputs
+from verl.utils.tokenizer import build_multimodal_processor_inputs
+
+
+def test_build_messages_replaces_audio_placeholder() -> None:
+    pytest.importorskip("datasets")
+    from verl.utils.dataset.rl_dataset import RLHFDataset
+
+    dataset = RLHFDataset.__new__(RLHFDataset)
+    dataset.prompt_key = "prompt"
+    dataset.image_key = "images"
+    dataset.video_key = "videos"
+    dataset.audio_key = "audios"
+    dataset.processor = object()
+
+    example = {
+        "prompt": [
+            {"role": "user", "content": "Listen to this: <audio> and answer."},
+        ],
+        "audios": ["/tmp/example.wav"],
+    }
+
+    messages = dataset._build_messages(example)
+    content = messages[0]["content"]
+    assert content == [
+        {"type": "text", "text": "Listen to this: "},
+        {"type": "audio", "audio": "/tmp/example.wav"},
+        {"type": "text", "text": " and answer."},
+    ]
+
+
+def test_build_multimodal_processor_inputs_includes_audio_sampling_rate() -> None:
+    captured = {}
+
+    class AudioProcessor:
+        def __init__(self):
+            self.feature_extractor = types.SimpleNamespace(sampling_rate=16000)
+
+        def __call__(self, **kwargs):
+            captured.update(kwargs)
+            return {"input_ids": torch.tensor([[1, 2, 3]])}
+
+    processor = AudioProcessor()
+    output = build_multimodal_processor_inputs(
+        processor,
+        text=["hello"],
+        images=None,
+        videos=None,
+        audio=["waveform"],
+        mm_processor_kwargs={"use_audio_in_video": True},
+    )
+
+    assert torch.equal(output["input_ids"], torch.tensor([[1, 2, 3]]))
+    assert captured["audio"] == ["waveform"]
+    assert captured["sampling_rate"] == 16000
+    assert captured["use_audio_in_video"] is True
+
+
+def test_extract_multi_modal_inputs_merges_variable_audio_fields() -> None:
+    first_features = torch.arange(6, dtype=torch.float32).view(1, 2, 3)
+    second_features = torch.arange(10, dtype=torch.float32).view(1, 2, 5)
+
+    merged = extract_multi_modal_inputs(
+        [
+            {
+                "input_features": first_features,
+                "feature_attention_mask": torch.tensor([[1, 1, 1]], dtype=torch.long),
+                "video_second_per_grid": torch.tensor([0.5]),
+            },
+            {
+                "input_features": second_features,
+                "feature_attention_mask": torch.tensor([[1, 1, 1, 1, 0]], dtype=torch.long),
+                "video_second_per_grid": torch.tensor([1.0]),
+            },
+        ]
+    )
+
+    assert merged["input_features"].shape == (2, 2, 5)
+    assert torch.equal(merged["input_features"][0, :, :3], first_features.squeeze(0))
+    assert torch.equal(merged["input_features"][0, :, 3:], torch.zeros(2, 2))
+    assert torch.equal(merged["input_features"][1], second_features.squeeze(0))
+    assert torch.equal(merged["feature_attention_mask"], torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 0]]))
+    assert torch.equal(merged["video_second_per_grid"], torch.tensor([0.5, 1.0]))
+
+
+def test_extract_multi_modal_inputs_rejects_unknown_ragged_fields() -> None:
+    with pytest.raises(RuntimeError, match="extra_audio_field"):
+        extract_multi_modal_inputs(
+            [
+                {"extra_audio_field": torch.ones(1, 2, 3)},
+                {"extra_audio_field": torch.ones(1, 2, 5)},
+            ]
+        )

--- a/tests/utils/test_maybe_fix_3d_position_ids_on_cpu.py
+++ b/tests/utils/test_maybe_fix_3d_position_ids_on_cpu.py
@@ -1,0 +1,167 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""CPU regression tests for 3D nested ``position_ids`` handling."""
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.utils.tensordict_utils import (
+    chunk_tensordict,
+    concat_tensordict,
+    index_select_tensor_dict,
+    maybe_fix_3d_position_ids,
+)
+
+
+def _make_ids(seq_lens):
+    return torch.nested.as_nested_tensor(
+        [torch.arange(seq_len, dtype=torch.long) for seq_len in seq_lens], layout=torch.jagged
+    )
+
+
+def _make_3d_position_ids(seq_lens, mrope=4):
+    samples = [torch.arange(mrope * seq_len, dtype=torch.long).view(mrope, seq_len) for seq_len in seq_lens]
+    values = torch.cat(samples, dim=-1)
+    offsets = torch.zeros(len(seq_lens) + 1, dtype=torch.long)
+    offsets[1:] = torch.cumsum(torch.tensor(seq_lens, dtype=torch.long), dim=0)
+    position_ids = torch.nested.nested_tensor_from_jagged(values, offsets=offsets)
+    position_ids._ragged_idx = 2
+    return position_ids
+
+
+def _assert_seq_ragged_position_ids(position_ids, seq_lens, mrope=4):
+    assert position_ids.is_nested
+    assert position_ids._ragged_idx == 2
+    assert position_ids.offsets().diff().tolist() == seq_lens
+    assert position_ids.values().shape == (mrope, sum(seq_lens))
+
+
+def test_noop_on_2d_position_ids():
+    seq_lens = [3, 5]
+    td = TensorDict(
+        {"input_ids": _make_ids(seq_lens), "position_ids": _make_ids(seq_lens)},
+        batch_size=[len(seq_lens)],
+    )
+    before = td["position_ids"]
+    maybe_fix_3d_position_ids(td)
+    # 2D nested tensor is unchanged.
+    assert td["position_ids"] is before
+    assert td["position_ids"].dim() == 2
+
+
+def test_fast_path_flips_ragged_idx_when_storage_is_seq_major():
+    seq_lens = [4, 7]
+    # Multi-sample case: as_nested_tensor picks ragged_idx=2 automatically.
+    samples = [torch.arange(4 * s, dtype=torch.long).view(4, s) for s in seq_lens]
+    nt = torch.nested.as_nested_tensor(samples, layout=torch.jagged)
+    assert nt._ragged_idx == 2  # sanity: upstream is fine
+    # Simulate the "label got flipped back to 1 during pickle round-trip".
+    nt._ragged_idx = 1
+    td = TensorDict({"input_ids": _make_ids(seq_lens), "position_ids": nt}, batch_size=[len(seq_lens)])
+    maybe_fix_3d_position_ids(td)
+    fixed = td["position_ids"]
+    assert fixed._ragged_idx == 2
+    # Storage layout either (total_seq, mrope) or (mrope, total_seq): both
+    # are valid as long as sum(seq_lens) appears somewhere in values.shape.
+    assert sum(seq_lens) in fixed.values().shape
+
+
+def test_single_sample_mislabeled_ragged_idx_is_fixed_by_label_flip():
+    """Single-sample 3D ``position_ids`` should keep the seq axis ragged.
+
+    ``as_nested_tensor([dense_3d], layout=jagged)`` picks ``_ragged_idx=1``
+    for a single-sample input, even though the storage is seq-major. The
+    downstream ``.values().unsqueeze(1)`` chain works correctly as long as
+    the label gets flipped back to 2.
+    """
+    seq_len = 1283
+    mrope = 4
+    sample = torch.arange(mrope * seq_len, dtype=torch.long).view(mrope, seq_len)
+    bad = torch.nested.as_nested_tensor([sample], layout=torch.jagged)
+    assert bad._ragged_idx == 1
+    assert bad.values().shape == (mrope, seq_len)
+
+    td = TensorDict(
+        {"input_ids": _make_ids([seq_len]), "position_ids": bad},
+        batch_size=[1],
+    )
+    maybe_fix_3d_position_ids(td)
+    fixed = td["position_ids"]
+    assert fixed._ragged_idx == 2
+    # Simulate the downstream reshape in FSDPEngine.prepare_model_inputs.
+    rmpad = fixed.values().unsqueeze(1)
+    assert rmpad.shape == (mrope, 1, seq_len)
+    # Content preserved: rmpad[:, 0, :] == sample.
+    assert torch.equal(rmpad[:, 0, :], sample)
+
+
+def test_rebuild_raises_when_seq_data_lost():
+    """If storage lost the seq dim (e.g. pickle dropped values), raise loudly.
+
+    If ``_values`` no longer contains the true seq length from ``input_ids``,
+    there is no way to reconstruct the original data.
+    """
+    fake_mrope_axes = 4
+    fake_seq = 32
+    true_seq = 1283
+    # Build a nested tensor whose per-sample shape (4, 32) doesn't match the
+    # sibling input_ids seq_len=1283.
+    bad_values = torch.arange(fake_mrope_axes * fake_seq, dtype=torch.float32).view(fake_mrope_axes, fake_seq)
+    broken = torch.nested.as_nested_tensor([bad_values], layout=torch.jagged)
+    td = TensorDict(
+        {"input_ids": _make_ids([true_seq]), "position_ids": broken},
+        batch_size=[1],
+    )
+    with pytest.raises(RuntimeError, match="Invalid 3D nested position_ids storage"):
+        maybe_fix_3d_position_ids(td)
+
+
+def test_index_select_keeps_equal_length_3d_position_ids_seq_ragged():
+    seq_lens = [1283] * 8
+    td = TensorDict(
+        {"input_ids": _make_ids(seq_lens), "position_ids": _make_3d_position_ids(seq_lens)},
+        batch_size=[len(seq_lens)],
+    )
+
+    selected = index_select_tensor_dict(td, list(range(len(seq_lens))))
+
+    _assert_seq_ragged_position_ids(selected["position_ids"], seq_lens)
+    maybe_fix_3d_position_ids(selected)
+
+
+def test_chunk_tensordict_keeps_equal_length_3d_position_ids_seq_ragged():
+    seq_lens = [1283] * 16
+    td = TensorDict(
+        {"input_ids": _make_ids(seq_lens), "position_ids": _make_3d_position_ids(seq_lens)},
+        batch_size=[len(seq_lens)],
+    )
+
+    chunks = chunk_tensordict(td, chunks=2)
+
+    assert len(chunks) == 2
+    for chunk in chunks:
+        _assert_seq_ragged_position_ids(chunk["position_ids"], [1283] * 8)
+        maybe_fix_3d_position_ids(chunk)
+
+
+def test_concat_tensordict_keeps_equal_length_3d_position_ids_seq_ragged():
+    seq_lens = [1283] * 4
+    td_a = TensorDict(
+        {"input_ids": _make_ids(seq_lens), "position_ids": _make_3d_position_ids(seq_lens)},
+        batch_size=[len(seq_lens)],
+    )
+    td_b = TensorDict(
+        {"input_ids": _make_ids(seq_lens), "position_ids": _make_3d_position_ids(seq_lens)},
+        batch_size=[len(seq_lens)],
+    )
+
+    merged = concat_tensordict([td_a, td_b])
+
+    _assert_seq_ragged_position_ids(merged["position_ids"], seq_lens + seq_lens)
+    maybe_fix_3d_position_ids(merged)

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -134,6 +134,50 @@ def test_padding_conversion_without_log_probs():
     assert "ref_log_prob" not in data_converted
 
 
+def test_left_right_2_no_padding_keeps_equal_length_3d_position_ids_seq_ragged(monkeypatch):
+    def fake_unpad_input(hidden_states, attention_mask):
+        valid_mask = attention_mask.bool()
+        indices = valid_mask.flatten().nonzero(as_tuple=False).flatten()
+        unpadded = hidden_states.reshape(-1, *hidden_states.shape[2:])[indices]
+        lengths = valid_mask.sum(dim=1, dtype=torch.long)
+        cu_seqlens = torch.zeros(lengths.numel() + 1, dtype=torch.long, device=hidden_states.device)
+        cu_seqlens[1:] = torch.cumsum(lengths, dim=0)
+        return unpadded, indices, cu_seqlens, int(lengths.max().item())
+
+    monkeypatch.setattr("verl.workers.utils.padding.unpad_input", fake_unpad_input)
+
+    batch_size = 8
+    max_seq_len = 1283
+    max_response_len = 64
+
+    input_ids = torch.arange(batch_size * max_seq_len, dtype=torch.long).view(batch_size, max_seq_len)
+    attention_mask = torch.ones(batch_size, max_seq_len, dtype=torch.long)
+    response_mask = torch.ones(batch_size, max_response_len, dtype=torch.long)
+    position_ids = torch.arange(batch_size * 4 * max_seq_len, dtype=torch.long).view(batch_size, 4, max_seq_len)
+
+    data = TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+        },
+        batch_size=[batch_size],
+    )
+
+    data_converted = left_right_2_no_padding(data)
+    position_ids_nested = data_converted["position_ids"]
+
+    assert position_ids_nested.is_nested
+    assert position_ids_nested._ragged_idx == 2
+    assert position_ids_nested.offsets().diff().tolist() == [max_seq_len] * batch_size
+    assert position_ids_nested.values().shape == (4, batch_size * max_seq_len)
+    assert position_ids_nested.values().unsqueeze(1).shape == (4, 1, batch_size * max_seq_len)
+
+    expected_values = torch.cat([position_ids[i] for i in range(batch_size)], dim=-1)
+    torch.testing.assert_close(position_ids_nested.values(), expected_values)
+
+
 def test_padding_roundtrip():
     """Test that converting from padding to nested and back preserves values in the response region"""
     batch_size = 2

--- a/tests/utils/test_qwen3_omni_thinker_patch_on_cpu.py
+++ b/tests/utils/test_qwen3_omni_thinker_patch_on_cpu.py
@@ -1,0 +1,205 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+PATCH_PATH = Path(__file__).resolve().parents[2] / "verl" / "utils" / "vllm" / "patch.py"
+
+
+def _load_patch_module():
+    # Load patch.py directly to bypass ``verl.utils.vllm.__init__`` which
+    # imports vllm at module load time.
+    spec = importlib.util.spec_from_file_location("verl_vllm_patch_under_test", PATCH_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def patch_mod():
+    return _load_patch_module()
+
+
+@pytest.fixture
+def stub_thinker_module(monkeypatch, patch_mod):
+    # WeightsMapper lookalike with the same prefix-rewrite semantics as vLLM's.
+    class WeightsMapper:
+        def __init__(self, orig_to_new_prefix):
+            self.orig_to_new_prefix = dict(orig_to_new_prefix)
+
+        def map_name(self, key: str) -> str:
+            for prefix, new_prefix in self.orig_to_new_prefix.items():
+                if key.startswith(prefix):
+                    key = new_prefix + key[len(prefix) :]
+            return key
+
+    class Qwen3OmniMoeThinkerForConditionalGeneration:
+        hf_to_vllm_mapper = WeightsMapper(
+            {
+                "thinker.lm_head.": "language_model.lm_head.",
+                "thinker.model.": "language_model.model.",
+                "thinker.": "",
+            }
+        )
+
+        def load_weights(self, weights):
+            return {self.hf_to_vllm_mapper.map_name(name): tuple(weight.shape) for name, weight in weights}
+
+    module = types.ModuleType("vllm.model_executor.models.qwen3_omni_moe_thinker")
+    module.Qwen3OmniMoeThinkerForConditionalGeneration = Qwen3OmniMoeThinkerForConditionalGeneration
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.models.qwen3_omni_moe_thinker", module)
+
+    patch_mod._QWEN3_OMNI_THINKER_MAPPER_PATCHED = False
+    return Qwen3OmniMoeThinkerForConditionalGeneration
+
+
+def test_patch_rewrites_bare_keys(patch_mod, stub_thinker_module):
+    patch_mod.apply_qwen3_omni_thinker_patches()
+
+    mapper = stub_thinker_module.hf_to_vllm_mapper
+    assert mapper.map_name("model.layers.0.self_attn.q_proj.weight") == (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+    assert mapper.map_name("lm_head.weight") == "language_model.lm_head.weight"
+    # audio_tower has no rewrite rule, stays as-is.
+    assert mapper.map_name("audio_tower.layers.0.conv.weight") == "audio_tower.layers.0.conv.weight"
+
+
+def test_patch_preserves_existing_thinker_rules(patch_mod, stub_thinker_module):
+    patch_mod.apply_qwen3_omni_thinker_patches()
+
+    mapper = stub_thinker_module.hf_to_vllm_mapper
+    # HF full-omni keys should still be rewritten through the original rules.
+    assert mapper.map_name("thinker.model.layers.0.self_attn.q_proj.weight") == (
+        "language_model.model.layers.0.self_attn.q_proj.weight"
+    )
+    assert mapper.map_name("thinker.lm_head.weight") == "language_model.lm_head.weight"
+    assert mapper.map_name("thinker.audio_tower.layers.0.conv.weight") == "audio_tower.layers.0.conv.weight"
+
+
+def test_patch_is_idempotent(patch_mod, stub_thinker_module):
+    patch_mod.apply_qwen3_omni_thinker_patches()
+    first = dict(stub_thinker_module.hf_to_vllm_mapper.orig_to_new_prefix)
+    patch_mod.apply_qwen3_omni_thinker_patches()
+    second = dict(stub_thinker_module.hf_to_vllm_mapper.orig_to_new_prefix)
+    assert first == second
+
+
+def test_patch_expands_packed_expert_weights_before_loading(patch_mod, stub_thinker_module):
+    patch_mod.apply_qwen3_omni_thinker_patches()
+
+    model = stub_thinker_module()
+    loaded = model.load_weights(
+        [
+            (
+                "model.layers.0.mlp.experts.gate_up_proj",
+                torch.empty(2, 6, 4),
+            ),
+            (
+                "thinker.model.layers.0.mlp.experts.down_proj",
+                torch.empty(2, 4, 3),
+            ),
+        ]
+    )
+
+    assert loaded == {
+        "language_model.model.layers.0.mlp.experts.0.gate_proj.weight": (3, 4),
+        "language_model.model.layers.0.mlp.experts.0.up_proj.weight": (3, 4),
+        "language_model.model.layers.0.mlp.experts.1.gate_proj.weight": (3, 4),
+        "language_model.model.layers.0.mlp.experts.1.up_proj.weight": (3, 4),
+        "language_model.model.layers.0.mlp.experts.0.down_proj.weight": (4, 3),
+        "language_model.model.layers.0.mlp.experts.1.down_proj.weight": (4, 3),
+    }
+
+
+def test_patch_noop_without_vllm_module(monkeypatch, patch_mod):
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.models.qwen3_omni_moe_thinker", None)
+    patch_mod._QWEN3_OMNI_THINKER_MAPPER_PATCHED = False
+    # Should not raise even if the module is unavailable.
+    patch_mod.apply_qwen3_omni_thinker_patches()
+
+
+def test_training_monkey_patch_matches_actual_qwen3_omni_model_type(monkeypatch):
+    from verl.models.transformers.monkey_patch import apply_monkey_patch
+
+    fake_module = types.ModuleType("fake_qwen3_omni_model")
+    monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
+
+    class Qwen3OmniMoeThinkerForConditionalGeneration:
+        __module__ = fake_module.__name__
+
+        def __init__(self):
+            self.set_experts_implementation_calls = []
+            self.config = types.SimpleNamespace(
+                model_type="qwen3_omni_moe",
+                num_attention_heads=8,
+                num_key_value_heads=8,
+                _experts_implementation=None,
+                text_config=types.SimpleNamespace(_experts_implementation=None),
+            )
+
+        def set_experts_implementation(self, implementation):
+            self.set_experts_implementation_calls.append(implementation)
+            self.config._experts_implementation = implementation
+            self.config.text_config._experts_implementation = implementation
+
+    model = Qwen3OmniMoeThinkerForConditionalGeneration()
+
+    apply_monkey_patch(model, use_remove_padding=False, use_fused_kernels=False)
+
+    assert model.set_experts_implementation_calls == []
+    assert model.config._experts_implementation == "batched_mm"
+
+
+def test_training_monkey_patch_does_not_override_existing_experts_implementation(monkeypatch):
+    from verl.models.transformers.monkey_patch import apply_monkey_patch
+
+    fake_module = types.ModuleType("fake_qwen3_omni_model_existing_impl")
+    monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
+
+    class Qwen3OmniMoeThinkerForConditionalGeneration:
+        __module__ = fake_module.__name__
+
+        def __init__(self):
+            self.set_experts_implementation_calls = []
+            self.config = types.SimpleNamespace(
+                model_type="qwen3_omni_moe",
+                num_attention_heads=8,
+                num_key_value_heads=8,
+                _experts_implementation="eager",
+                text_config=types.SimpleNamespace(_experts_implementation="eager"),
+            )
+
+        def set_experts_implementation(self, implementation):
+            self.set_experts_implementation_calls.append(implementation)
+            self.config._experts_implementation = implementation
+            self.config.text_config._experts_implementation = implementation
+
+    model = Qwen3OmniMoeThinkerForConditionalGeneration()
+
+    apply_monkey_patch(model, use_remove_padding=False, use_fused_kernels=False)
+
+    assert model.set_experts_implementation_calls == []
+    assert model.config._experts_implementation == "eager"
+    assert model.config.text_config._experts_implementation == "eager"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/workers/rollout/test_mm_placeholder_dedup_on_cpu.py
+++ b/tests/workers/rollout/test_mm_placeholder_dedup_on_cpu.py
@@ -1,0 +1,273 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the ``dedup_mm_placeholder_tokens`` rollout helper.
+
+The helper guards the verl → vLLM interface against a "double expansion"
+bug: training-side processors emit fully-expanded multimodal placeholder
+runs (N ``<|audio_pad|>`` tokens per audio clip, N ``<|image_pad|>`` per
+image region), but when vLLM then receives those pre-expanded tokens
+alongside the raw multimodal payload it expands the first placeholder
+*again*, producing a sequence of length roughly ``2N - 1`` and decoupling
+the rollout distribution from the training distribution.
+
+The helper collapses every consecutive run of placeholder tokens back
+down to one so vLLM's prompt replacement step fires exactly once.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROLLOUT_UTILS_PATH = Path(__file__).resolve().parents[3] / "verl/workers/rollout/utils.py"
+
+
+@pytest.fixture()
+def rollout_utils(monkeypatch):
+    uvicorn_mod = types.ModuleType("uvicorn")
+    uvicorn_mod.__spec__ = ModuleSpec("uvicorn", loader=None)
+
+    class _UvicornServer:
+        def __init__(self, config):
+            self.config = config
+            self.servers = []
+
+        async def serve(self):
+            return None
+
+        async def startup(self, sockets=None):
+            return None
+
+    class _UvicornConfig:
+        def __init__(self, app, host, port, log_level):
+            self.app = app
+            self.host = host
+            self.port = port
+            self.log_level = log_level
+
+    uvicorn_mod.Config = _UvicornConfig
+    uvicorn_mod.Server = _UvicornServer
+    monkeypatch.setitem(sys.modules, "uvicorn", uvicorn_mod)
+
+    fastapi_mod = types.ModuleType("fastapi")
+    fastapi_mod.__spec__ = ModuleSpec("fastapi", loader=None)
+    fastapi_mod.FastAPI = type("FastAPI", (), {})
+    monkeypatch.setitem(sys.modules, "fastapi", fastapi_mod)
+
+    yaml_mod = types.ModuleType("yaml")
+    yaml_mod.__spec__ = ModuleSpec("yaml", loader=None)
+    yaml_mod.dump = lambda *args, **kwargs: ""
+    monkeypatch.setitem(sys.modules, "yaml", yaml_mod)
+
+    config_pkg = types.ModuleType("verl.workers.config")
+    config_pkg.__path__ = []
+    rollout_config_mod = types.ModuleType("verl.workers.config.rollout")
+    rollout_config_mod.PrometheusConfig = object
+    monkeypatch.setitem(sys.modules, "verl.workers.config", config_pkg)
+    monkeypatch.setitem(sys.modules, "verl.workers.config.rollout", rollout_config_mod)
+
+    spec = importlib.util.spec_from_file_location("verl_rollout_utils_under_test", ROLLOUT_UTILS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.dedup_mm_placeholder_tokens, module.qwen2_5_vl_dedup_image_tokens
+
+
+IMAGE_TOKEN_ID = 151655
+VIDEO_TOKEN_ID = 151656
+AUDIO_TOKEN_ID = 151675
+VISION_START = 151652
+VISION_END = 151653
+AUDIO_START = 151669
+AUDIO_END = 151670
+
+
+def _make_qwen25_vl_processor():
+    """Mock processor that matches the Qwen2.5-VL image-processor gate."""
+    # The helper checks ``image_processor.__class__.__name__`` for the
+    # string ``Qwen2VLImageProcessor`` — the cheapest way to spoof that is
+    # to construct an actual instance of a dynamically created class with
+    # exactly that ``__name__``.
+    qwen_image_processor_cls = type("Qwen2VLImageProcessor", (), {})
+    return SimpleNamespace(
+        image_processor=qwen_image_processor_cls(),
+        image_token_id=IMAGE_TOKEN_ID,
+        video_token_id=VIDEO_TOKEN_ID,
+    )
+
+
+def _make_qwen3_omni_processor():
+    """Mock processor that matches the Qwen3-Omni gate.
+
+    ``is_qwen3_omni_processor`` checks ``__class__.__name__``, so we need
+    to fabricate an instance whose class is literally named
+    ``Qwen3OmniMoeProcessor``.
+    """
+
+    fake_cls = type("Qwen3OmniMoeProcessor", (), {})
+    instance = fake_cls()
+    instance.image_token_id = IMAGE_TOKEN_ID
+    instance.video_token_id = VIDEO_TOKEN_ID
+    instance.audio_token_id = AUDIO_TOKEN_ID
+    return instance
+
+
+def test_qwen25_vl_collapses_image_run_to_single_token(rollout_utils):
+    dedup_mm_placeholder_tokens, qwen2_5_vl_dedup_image_tokens = rollout_utils
+    processor = _make_qwen25_vl_processor()
+    prompt_ids = [
+        VISION_START,
+        *([IMAGE_TOKEN_ID] * 80),
+        VISION_END,
+        42,
+    ]
+
+    deduped = dedup_mm_placeholder_tokens(prompt_ids, processor)
+
+    # 80-token run collapses to one; surrounding tokens remain in place.
+    assert deduped == [VISION_START, IMAGE_TOKEN_ID, VISION_END, 42]
+    # Backwards-compatible alias routes to the same behaviour.
+    assert qwen2_5_vl_dedup_image_tokens(prompt_ids, processor) == deduped
+
+
+def test_qwen25_vl_collapses_video_run(rollout_utils):
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen25_vl_processor()
+    prompt_ids = [VISION_START, *([VIDEO_TOKEN_ID] * 5), VISION_END]
+
+    deduped = dedup_mm_placeholder_tokens(prompt_ids, processor)
+
+    assert deduped == [VISION_START, VIDEO_TOKEN_ID, VISION_END]
+
+
+def test_qwen25_vl_does_not_touch_audio_placeholder(rollout_utils):
+    """The Qwen2.5-VL gate intentionally ignores audio placeholders."""
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen25_vl_processor()
+    prompt_ids = [AUDIO_START, *([AUDIO_TOKEN_ID] * 3), AUDIO_END]
+
+    assert dedup_mm_placeholder_tokens(prompt_ids, processor) == prompt_ids
+
+
+def test_qwen3_omni_collapses_audio_and_image_runs(rollout_utils):
+    """Qwen3-Omni can emit long audio/image placeholder runs.
+
+    vLLM expands each placeholder token independently, so the helper must
+    collapse each run to a single token before rollout.
+    """
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen3_omni_processor()
+    prompt_ids = [
+        1,
+        VISION_START,
+        *([IMAGE_TOKEN_ID] * 80),
+        VISION_END,
+        2,
+        AUDIO_START,
+        *([AUDIO_TOKEN_ID] * 286),
+        AUDIO_END,
+        3,
+    ]
+
+    deduped = dedup_mm_placeholder_tokens(prompt_ids, processor)
+
+    assert deduped == [
+        1,
+        VISION_START,
+        IMAGE_TOKEN_ID,
+        VISION_END,
+        2,
+        AUDIO_START,
+        AUDIO_TOKEN_ID,
+        AUDIO_END,
+        3,
+    ]
+
+
+def test_qwen3_omni_handles_adjacent_mixed_modalities(rollout_utils):
+    """When an image run abuts an audio run, each run is still collapsed
+    independently: the boundary tokens separate the two placeholder
+    species, but the helper should not merge them even if they happen to
+    touch."""
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen3_omni_processor()
+    prompt_ids = [
+        *([IMAGE_TOKEN_ID] * 4),
+        *([AUDIO_TOKEN_ID] * 4),
+    ]
+
+    # No non-placeholder separator: both runs are "consecutive" in the
+    # placeholder mask, so the second, third, fourth image and the second,
+    # third, fourth audio tokens all get removed — but the transition
+    # image→audio does NOT get removed (they are different values but both
+    # placeholders, and we collapse *runs of the same placeholder class*).
+    # The helper's contract is "collapse consecutive placeholder tokens
+    # regardless of which placeholder species they are", matching the
+    # pre-existing Qwen2.5-VL behaviour. Encode that invariant here so we
+    # notice if anyone weakens it.
+    assert dedup_mm_placeholder_tokens(prompt_ids, processor) == [IMAGE_TOKEN_ID]
+
+
+def test_qwen3_omni_missing_audio_token_id_still_covers_image(rollout_utils):
+    """If the processor happens not to expose an audio token id (e.g. an
+    older build), we must still dedup image/video runs rather than bailing
+    out entirely."""
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen3_omni_processor()
+    processor.audio_token_id = None  # pretend the lookup failed
+
+    prompt_ids = [VISION_START, IMAGE_TOKEN_ID, IMAGE_TOKEN_ID, VISION_END]
+
+    assert dedup_mm_placeholder_tokens(prompt_ids, processor) == [
+        VISION_START,
+        IMAGE_TOKEN_ID,
+        VISION_END,
+    ]
+
+
+def test_empty_prompt_noops(rollout_utils):
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen3_omni_processor()
+    assert dedup_mm_placeholder_tokens([], processor) == []
+
+
+def test_no_placeholder_run_is_identity(rollout_utils):
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    processor = _make_qwen3_omni_processor()
+    prompt_ids = [1, 2, 3, IMAGE_TOKEN_ID, 4, AUDIO_TOKEN_ID, 5]
+
+    assert dedup_mm_placeholder_tokens(prompt_ids, processor) == prompt_ids
+
+
+def test_unknown_processor_passthrough(rollout_utils):
+    """Processors that match neither family must not mutate the prompt."""
+    dedup_mm_placeholder_tokens, _ = rollout_utils
+    prompt_ids = [
+        VISION_START,
+        IMAGE_TOKEN_ID,
+        IMAGE_TOKEN_ID,
+        AUDIO_TOKEN_ID,
+        AUDIO_TOKEN_ID,
+    ]
+
+    class RandomProcessor:
+        pass
+
+    assert dedup_mm_placeholder_tokens(prompt_ids, RandomProcessor()) == prompt_ids
+    assert dedup_mm_placeholder_tokens(prompt_ids, None) == prompt_ids

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -59,7 +59,11 @@ from verl.utils.rollout_trace import (
     RolloutTraceConfig,
     rollout_trace_attr,
 )
-from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.tokenizer import (
+    build_multimodal_processor_inputs,
+    get_processor_token_id,
+    normalize_token_ids,
+)
 from verl.workers.config import (
     HFModelConfig,
     RolloutConfig,
@@ -104,6 +108,8 @@ class AgentLoopOutput(BaseModel):
     """Auxiliary performance metrics"""
     extra_fields: dict[str, Any] = {}
     """Extra fields for dynamic addition."""
+    mm_processor_kwargs: Optional[dict[str, Any]] = None
+    """Processor/backend kwargs that must stay aligned across rollout and training paths."""
 
     def as_dict(self) -> dict[str, Any]:
         """Convert agent loop output to a dictionary."""
@@ -216,27 +222,50 @@ class AgentLoopBase(ABC):
         self.dataset_cls = dataset_cls
         self.data_config = data_config.config
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
-        self.system_prompt = initialize_system_prompt(self.tokenizer, **self.apply_chat_template_kwargs)
+        self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
+        processing_class = self.processor if self.processor is not None else self.tokenizer
+        self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 
+    def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
+        mm_processor_kwargs = dict(self.mm_processor_kwargs or {})
+        if audio_data is not None and "sampling_rate" not in mm_processor_kwargs:
+            sampling_rate = getattr(getattr(self.processor, "feature_extractor", None), "sampling_rate", None)
+            if sampling_rate is not None:
+                mm_processor_kwargs["sampling_rate"] = int(sampling_rate)
+        return mm_processor_kwargs
+
     async def process_vision_info(self, messages: list[dict]) -> dict:
-        """Extract images and videos from messages.
+        """Backward-compatible wrapper for multi-modal extraction."""
+        return await self.process_multi_modal_info(messages)
+
+    async def process_multi_modal_info(self, messages: list[dict]) -> dict:
+        """Extract images, videos and audios from messages.
 
         Args:
             messages (list[dict]): Input messages.
 
         Returns:
-            dict: Multi-modal data with keys "images" and "videos".
+            dict: Multi-modal data with keys like "images", "videos" and "audios".
         """
         multi_modal_data = {}
         if self.processor is not None:
-            images, videos = await self.dataset_cls.process_vision_info(
-                messages, image_patch_size=self.processor.image_processor.patch_size, config=self.data_config
-            )
+            image_patch_size = getattr(getattr(self.processor, "image_processor", None), "patch_size", 14)
+            if hasattr(self.dataset_cls, "process_multi_modal_info"):
+                images, videos, audios = await self.dataset_cls.process_multi_modal_info(
+                    messages, image_patch_size=image_patch_size, config=self.data_config
+                )
+            else:
+                images, videos = await self.dataset_cls.process_vision_info(
+                    messages, image_patch_size=image_patch_size, config=self.data_config
+                )
+                audios = None
             if images is not None:
                 multi_modal_data["images"] = images
             if videos is not None:
                 multi_modal_data["videos"] = videos
+            if audios is not None:
+                multi_modal_data["audios"] = audios
 
         return multi_modal_data
 
@@ -246,6 +275,8 @@ class AgentLoopBase(ABC):
         tools: list[dict] = None,
         images: list[Image.Image] = None,
         videos: list[tuple[torch.Tensor, dict]] = None,
+        audios: list[Any] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         remove_system_prompt: bool = False,
     ):
         """Apply chat template to messages with optional tools, images, and videos.
@@ -273,20 +304,15 @@ class AgentLoopBase(ABC):
                 ),
             )
 
-            # split the videos and according metadatas
-            if videos is not None:
-                videos, video_metadatas = zip(*videos, strict=False)
-                videos, video_metadatas = list(videos), list(video_metadatas)
-            else:
-                video_metadatas = None
-
-            model_inputs = self.processor(
+            model_inputs = build_multimodal_processor_inputs(
+                self.processor,
                 text=[raw_prompt],
                 images=images,
                 videos=videos,
-                video_metadata=video_metadatas,
-                return_tensors="pt",
-                do_sample_frames=False,
+                audio=audios,
+                mm_processor_kwargs=mm_processor_kwargs
+                if mm_processor_kwargs is not None
+                else self._get_mm_processor_kwargs(audios),
             )
             prompt_ids = normalize_token_ids(model_inputs.pop("input_ids"))
         else:
@@ -623,7 +649,16 @@ class AgentLoopWorker:
             routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
 
         multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
-        position_ids = self._compute_position_ids(input_ids, attention_mask, multi_modal_inputs)
+        position_ids = self._compute_position_ids(
+            input_ids,
+            attention_mask,
+            multi_modal_inputs,
+            output.mm_processor_kwargs
+            if output.mm_processor_kwargs is not None
+            else self._get_mm_processor_kwargs(
+                output.multi_modal_data.get("audios") if output.multi_modal_data else None
+            ),
+        )
         await self._compute_score(
             output,
             prompts=prompt_output["input_ids"],
@@ -669,6 +704,7 @@ class AgentLoopWorker:
             routed_experts=routed_experts,
             multi_modal_inputs=multi_modal_inputs,
             multi_modal_data=output.multi_modal_data,
+            mm_processor_kwargs=output.mm_processor_kwargs,
             teacher_logprobs=teacher_logprobs,
             teacher_ids=teacher_ids,
             reward_score=output.reward_score,
@@ -678,27 +714,26 @@ class AgentLoopWorker:
         )
 
     def _compute_multi_modal_inputs(self, output, input_ids) -> dict[str, torch.Tensor]:
-        """Compute multi-modal inputs with image and video."""
+        """Compute multi-modal inputs with image, video and audio."""
         multi_modal_inputs = {}
         if self.processor is None:
             return multi_modal_inputs
 
-        images = output.multi_modal_data.get("images")
-        videos = output.multi_modal_data.get("videos")
-        # split the videos and according metadatas
-        if videos is not None:
-            videos, video_metadatas = zip(*videos, strict=False)
-            videos, video_metadatas = list(videos), list(video_metadatas)
-        else:
-            video_metadatas = None
+        multi_modal_data = output.multi_modal_data or {}
+        images = multi_modal_data.get("images")
+        videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
         current_text = self.tokenizer.decode(input_ids.squeeze(0), skip_special_tokens=True)
-        multi_modal_inputs = self.processor(
+
+        multi_modal_inputs = build_multimodal_processor_inputs(
+            self.processor,
             text=[current_text],
             images=images,
             videos=videos,
-            video_metadata=video_metadatas,
-            return_tensors="pt",
-            do_sample_frames=False,
+            audio=audios,
+            mm_processor_kwargs=output.mm_processor_kwargs
+            if output.mm_processor_kwargs is not None
+            else self._get_mm_processor_kwargs(audios),
         )
         multi_modal_inputs.pop("input_ids", None)
         multi_modal_inputs.pop("attention_mask", None)
@@ -712,7 +747,13 @@ class AgentLoopWorker:
             multi_modal_inputs["images_seqlens"] = images_seqlens
         return multi_modal_inputs
 
-    def _compute_position_ids(self, input_ids, attention_mask, multi_modal_inputs) -> torch.Tensor:
+    def _compute_position_ids(
+        self,
+        input_ids,
+        attention_mask,
+        multi_modal_inputs,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
+    ) -> torch.Tensor:
         """Compute position ids for multi-modal inputs."""
         if self.processor is None:
             return compute_position_id_with_mask(attention_mask)  # (1, seq_len)
@@ -724,8 +765,12 @@ class AgentLoopWorker:
         # For transformers>=5.3.0, mm_token_type_ids is only used to calculate position ids.
         if multi_modal_inputs.pop("mm_token_type_ids", None) is not None:
             mm_token_type_ids = torch.zeros_like(input_ids)
-            mm_token_type_ids[0][input_ids[0] == self.processor.image_token_id] = 1
-            mm_token_type_ids[0][input_ids[0] == self.processor.video_token_id] = 2
+            image_token_id = get_processor_token_id(self.processor, "image")
+            video_token_id = get_processor_token_id(self.processor, "video")
+            if image_token_id is not None:
+                mm_token_type_ids[0][input_ids[0] == image_token_id] = 1
+            if video_token_id is not None:
+                mm_token_type_ids[0][input_ids[0] == video_token_id] = 2
             multi_modal_kwargs["mm_token_type_ids"] = mm_token_type_ids
 
         # Model's get_rope_index has been dynamically bind to the processor.
@@ -795,6 +840,7 @@ class AgentLoopWorker:
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
                 sequence_ids=prompt_ids + response_ids,
                 multi_modal_data=output.multi_modal_data,
+                mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,
             )
             output.extra_fields["teacher_ids"] = teacher_ids

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -62,6 +62,7 @@ from verl.utils.rollout_trace import (
 from verl.utils.tokenizer import (
     build_multimodal_processor_inputs,
     get_processor_token_id,
+    is_qwen3_omni_processor,
     normalize_token_ids,
 )
 from verl.workers.config import (
@@ -757,6 +758,42 @@ class AgentLoopWorker:
         """Compute position ids for multi-modal inputs."""
         if self.processor is None:
             return compute_position_id_with_mask(attention_mask)  # (1, seq_len)
+
+        mm_processor_kwargs = mm_processor_kwargs or {}
+        if is_qwen3_omni_processor(self.processor):
+            from verl.models.transformers.qwen3_omni_moe import get_rope_index as qwen3_omni_get_rope_index
+
+            audio_seqlens = None
+            feature_attention_mask = multi_modal_inputs.get("feature_attention_mask")
+            if feature_attention_mask is not None:
+                audio_seqlens = feature_attention_mask.sum(dim=-1)
+
+            position_ids, _ = qwen3_omni_get_rope_index(
+                self.processor,
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                image_grid_thw=multi_modal_inputs.get("image_grid_thw"),
+                video_grid_thw=multi_modal_inputs.get("video_grid_thw"),
+                use_audio_in_video=bool(mm_processor_kwargs.get("use_audio_in_video", False)),
+                audio_seqlens=audio_seqlens,
+                second_per_grids=multi_modal_inputs.get("video_second_per_grid"),
+            )
+            # HF ``Qwen3OmniMoeThinkerTextModel.forward`` expects a 4-axis
+            # position_ids tensor ``(text, T, H, W, bs, seq)``. Without the
+            # leading text axis it falls through the ``shape[0] == 4`` guard
+            # and feeds the 3-axis tensor straight into ``rotary_emb``,
+            # producing cos/sin whose seq dim ends up collapsing to
+            # ``mrope_section[0]`` and blowing up ``apply_rotary_pos_emb``.
+            # Mirror the Qwen3-VL rollout path (the ``multi_modal_kwargs``
+            # branch below) which prepends a cumsum-over-mask text row to
+            # reach the ``(1, 4, seq)`` layout verl's
+            # ``FSDPEngine.prepare_model_inputs`` expects.
+            vision_position_ids = position_ids.transpose(0, 1)  # (3, 1, S) -> (1, 3, S)
+            valid_mask = attention_mask[0].bool()
+            text_position_ids = torch.ones((1, input_ids.shape[1]), dtype=torch.long, device=input_ids.device)
+            text_position_ids[0, valid_mask] = torch.arange(int(valid_mask.sum().item()), device=input_ids.device)
+            text_position_ids = text_position_ids.unsqueeze(0)  # (1, 1, S)
+            return torch.cat((text_position_ids, vision_position_ids), dim=1)  # (1, 4, S)
 
         multi_modal_kwargs = {
             "image_grid_thw": multi_modal_inputs.get("image_grid_thw"),

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -38,16 +38,20 @@ class SingleTurnAgentLoop(AgentLoopBase):
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
 
-        # 1. extract images and videos from messages
-        multi_modal_data = await self.process_vision_info(messages)
+        # 1. extract multimodal inputs from messages
+        multi_modal_data = await self.process_multi_modal_info(messages)
         images = multi_modal_data.get("images")
         videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
+        mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
         prompt_ids = await self.apply_chat_template(
             messages,
             images=images,
             videos=videos,
+            audios=audios,
+            mm_processor_kwargs=mm_processor_kwargs,
         )
 
         # 3. generate sequences
@@ -59,6 +63,8 @@ class SingleTurnAgentLoop(AgentLoopBase):
                 sampling_params=sampling_params,
                 image_data=images,
                 video_data=videos,
+                audio_data=audios,
+                mm_processor_kwargs=mm_processor_kwargs,
             )
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
@@ -75,6 +81,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
                 else None
             ),
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             num_turns=2,
             metrics=metrics,
             extra_fields=output.extra_fields,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -57,6 +57,8 @@ class AgentData:
         messages: list[dict[str, Any]],
         image_data: list[Image.Image],
         video_data: list[tuple[torch.Tensor, dict[str, Any]]],
+        audio_data: Optional[list[Any]],
+        mm_processor_kwargs: Optional[dict[str, Any]],
         metrics: dict[str, Any],
         request_id: str,
         tools_kwargs: dict[str, Any],
@@ -64,6 +66,8 @@ class AgentData:
         self.messages = messages
         self.image_data = image_data
         self.video_data = video_data
+        self.audio_data = audio_data
+        self.mm_processor_kwargs = mm_processor_kwargs or {}
         self.metrics = metrics
         self.request_id = request_id
         self.tools_kwargs = tools_kwargs
@@ -131,10 +135,12 @@ class ToolAgentLoop(AgentLoopBase):
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
         messages = list(kwargs["raw_prompt"])
 
-        # extract images and videos from messages
-        multi_modal_data = await self.process_vision_info(messages)
+        # extract multimodal inputs from messages
+        multi_modal_data = await self.process_multi_modal_info(messages)
         images = multi_modal_data.get("images")
         videos = multi_modal_data.get("videos")
+        audios = multi_modal_data.get("audios")
+        mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         metrics = {}
         request_id = uuid4().hex
@@ -144,6 +150,8 @@ class ToolAgentLoop(AgentLoopBase):
             messages=messages,
             image_data=images,
             video_data=videos,
+            audio_data=audios,
+            mm_processor_kwargs=mm_processor_kwargs,
             metrics=metrics,
             request_id=request_id,
             tools_kwargs=tools_kwargs,
@@ -183,12 +191,15 @@ class ToolAgentLoop(AgentLoopBase):
             multi_modal_data["images"] = agent_data.image_data
         if agent_data.video_data is not None:
             multi_modal_data["videos"] = agent_data.video_data
+        if agent_data.audio_data is not None:
+            multi_modal_data["audios"] = agent_data.audio_data
 
         output: AgentLoopOutput = AgentLoopOutput(
             prompt_ids=prompt_ids,
             response_ids=response_ids[: self.response_length],
             response_mask=agent_data.response_mask[: self.response_length],
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=agent_data.mm_processor_kwargs,
             response_logprobs=agent_data.response_logprobs[: self.response_length]
             if agent_data.response_logprobs
             else None,
@@ -212,6 +223,8 @@ class ToolAgentLoop(AgentLoopBase):
             tools=schemas,
             images=agent_data.image_data,
             videos=agent_data.video_data,
+            audios=agent_data.audio_data,
+            mm_processor_kwargs=agent_data.mm_processor_kwargs,
         )
         agent_data.prompt_ids = prompt_ids
         return AgentState.GENERATING
@@ -227,6 +240,8 @@ class ToolAgentLoop(AgentLoopBase):
                 sampling_params=sampling_params,
                 image_data=agent_data.image_data,
                 video_data=agent_data.video_data,
+                audio_data=agent_data.audio_data,
+                mm_processor_kwargs=agent_data.mm_processor_kwargs,
             )
         # first time to set num_preempted
         if agent_data.metrics.get("num_preempted") is None:

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -103,6 +103,7 @@ class AsyncTeacherLLMServerManager:
         self,
         sequence_ids: list[int],
         multi_modal_data: Optional[dict[str, Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         routing_key: Optional[str] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute teacher log probabilities for a single unpadded sequence."""
@@ -116,6 +117,8 @@ class AsyncTeacherLLMServerManager:
             sampling_params=_get_teacher_sampling_params(teacher_model_config, self.distillation_loss_config),
             image_data=multi_modal_data.get("images"),
             video_data=multi_modal_data.get("videos"),
+            audio_data=multi_modal_data.get("audios"),
+            mm_processor_kwargs=mm_processor_kwargs,
         )
         # Shapes: # S, (1 or K), where S is the response length, K is either 1 or topk depending on
         # the distillation loss settings.

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -469,6 +469,15 @@ def apply_monkey_patch(
         if ulysses_sp_size > 1:
             patch_vlm_for_ulysses_input_slicing(Glm4vTextModel)
 
+    elif model.config.model_type in ["qwen3_omni_moe", "qwen3_omni_moe_thinker"]:
+        # Qwen3-Omni's concrete HF config reports ``model_type=qwen3_omni_moe``
+        # even for the Thinker model. Keep the historical thinker name here for
+        # compatibility with remote-code variants, but match the real config
+        # value as well so the Qwen3-Omni MoE patch is not silently skipped.
+        from verl.models.transformers.qwen3_omni_moe import patch_qwen3_omni_moe_sparse_moe_block_forward
+
+        patch_qwen3_omni_moe_sparse_moe_block_forward(model=model)
+
     elif model.config.model_type == "kimi_vl":
         if use_remove_padding or ulysses_sp_size > 1:
             # TODO: Changes need to be made when transformers are adapted.

--- a/verl/models/transformers/qwen3_omni_moe.py
+++ b/verl/models/transformers/qwen3_omni_moe.py
@@ -1,0 +1,249 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Monkey patches for the Qwen3-Omni MoE model family.
+
+Upstream ``Qwen3OmniMoeThinkerTextExperts.forward`` (and the Talker
+variant) can dispatch through different expert implementations depending on
+``config._experts_implementation``. The training monkey patch routes the real
+Qwen3-Omni model type here so configs that still have that value unset can opt
+into the configured implementation, while user- or transformers-provided
+values are left untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# Matches the keys registered in transformers.integrations.moe.ExpertsInterface.
+_DEFAULT_EXPERTS_IMPLEMENTATION = "batched_mm"
+
+
+def get_rope_index(
+    processor,
+    input_ids: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    image_grid_thw: Optional[torch.Tensor] = None,
+    video_grid_thw: Optional[torch.Tensor] = None,
+    use_audio_in_video: bool = False,
+    audio_seqlens: Optional[torch.Tensor] = None,
+    second_per_grids: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Audio-aware MRope for Qwen3-Omni.
+
+    HF's ``Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index`` gates
+    the 3D audio/image/video-aware branch on ``image_grid_thw is not None or
+    video_grid_thw is not None``. Audio-only samples fall through to a 1D
+    ``cumsum`` broadcast across 3 axes, which corrupts MRope at the audio
+    region and makes actor logprobs diverge from the rollout engine.
+
+    This helper reconstructs the audio-aware branch locally: when
+    ``audio_seqlens`` is present it walks the pre-expanded ``input_ids`` and
+    assigns per-axis MRope positions around ``audio_start / audio_pad*N /
+    audio_end`` blocks. When images/videos are present, it delegates back to
+    the processor's bound ``get_rope_index`` (which works correctly once at
+    least one vision grid is supplied, provided ``get_llm_pos_ids_for_vision``
+    is also bound by ``verl.utils.tokenizer.hf_processor``).
+
+    Returns ``(position_ids, mrope_position_deltas)`` matching HF's
+    signature: ``position_ids`` has shape ``(3, batch, seq_len)`` and
+    ``dtype=torch.long``. Callers that feed the result into
+    ``Qwen3OmniMoeThinkerTextModel.forward`` must prepend a text axis
+    (cumsum over the valid attention mask) to reach the
+    ``(4, bs, seq_len)`` layout HF's text model expects — see
+    ``verl.experimental.agent_loop.agent_loop.AgentLoopWorker._compute_position_ids``
+    for the concat recipe.
+    """
+
+    def _assert_shape(pos: torch.Tensor) -> torch.Tensor:
+        assert pos.dim() == 3 and pos.shape[0] == 3, (
+            f"qwen3_omni get_rope_index must return (3, bs, seq); got {tuple(pos.shape)}"
+        )
+        return pos
+
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        _get_feat_extract_output_lengths,
+    )
+
+    has_vision = image_grid_thw is not None or video_grid_thw is not None
+    has_audio = audio_seqlens is not None
+
+    # Vision branch: HF's bound implementation already works. Fall back to
+    # it when any vision grid is provided — the guard fires correctly.
+    if has_vision:
+        pos, deltas = processor.get_rope_index(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            use_audio_in_video=use_audio_in_video,
+            audio_seqlens=audio_seqlens,
+            second_per_grids=second_per_grids,
+        )
+        return _assert_shape(pos), deltas
+
+    # Pure-text branch: HF fallback is correct (the 1D linear cumsum is what
+    # a text-only sample needs). Cast to long for consistency.
+    if not has_audio:
+        pos, deltas = processor.get_rope_index(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            image_grid_thw=None,
+            video_grid_thw=None,
+            use_audio_in_video=use_audio_in_video,
+            audio_seqlens=None,
+            second_per_grids=second_per_grids,
+        )
+        return _assert_shape(pos.long()), deltas
+
+    # Audio-only branch: replicate HF's audio-aware loop but without the
+    # buggy guard. Mirrors transformers 4.57.1
+    # ``Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index``.
+    cfg = getattr(processor, "config", None)
+    audio_token_id = getattr(processor, "audio_token_id", None)
+    audio_start_token_id = getattr(processor, "audio_start_token_id", None)
+    audio_end_token_id = getattr(processor, "audio_end_token_id", None)
+    if cfg is not None:
+        audio_token_id = getattr(cfg, "audio_token_id", audio_token_id)
+        audio_start_token_id = getattr(cfg, "audio_start_token_id", audio_start_token_id)
+        audio_end_token_id = getattr(cfg, "audio_end_token_id", audio_end_token_id)
+    if audio_token_id is None or audio_start_token_id is None or audio_end_token_id is None:
+        raise RuntimeError(
+            "Qwen3-Omni audio MRope requires audio_token_id / audio_start_token_id / "
+            "audio_end_token_id on the processor; did hf_processor fail to initialize Qwen3-Omni attrs?"
+        )
+
+    if attention_mask is None:
+        attention_mask = torch.ones_like(input_ids)
+    batch_size, seq_len = input_ids.shape
+    position_ids = torch.zeros(3, batch_size, seq_len, dtype=torch.long, device=input_ids.device)
+    mrope_position_deltas = []
+
+    attn_bool = attention_mask == 1
+
+    audio_idx_global = 0
+    for i in range(batch_size):
+        row_ids = input_ids[i][attn_bool[i]]
+        row_tokens = row_ids.tolist()
+        row_len = len(row_tokens)
+
+        llm_pos_ids_list: list[torch.Tensor] = []
+        st = 0
+        remain_audios = int((row_ids == audio_start_token_id).sum())
+        bos_len, eos_len = 1, 1
+
+        for _ in range(remain_audios):
+            st_idx = int(llm_pos_ids_list[-1].max()) + 1 if llm_pos_ids_list else 0
+            try:
+                ed_audio_start = row_tokens.index(audio_start_token_id, st)
+            except ValueError:
+                break
+
+            # Text run before this audio block.
+            text_len = ed_audio_start - st
+            if text_len > 0:
+                llm_pos_ids_list.append(torch.arange(text_len, dtype=torch.long).view(1, -1).expand(3, -1) + st_idx)
+                st_idx += text_len
+
+            # audio_start (bos_len=1).
+            llm_pos_ids_list.append(torch.arange(bos_len, dtype=torch.long).view(1, -1).expand(3, -1) + st_idx)
+            st_idx += bos_len
+
+            # audio_pad*N_audio (N_audio from _get_feat_extract_output_lengths).
+            audio_len_t = _get_feat_extract_output_lengths(audio_seqlens[audio_idx_global])
+            audio_len = int(audio_len_t.item() if torch.is_tensor(audio_len_t) else audio_len_t)
+            llm_pos_ids_list.append(torch.arange(audio_len, dtype=torch.long).view(1, -1).expand(3, -1) + st_idx)
+
+            # advance st past text + audio_start + audio_pad*N + audio_end.
+            st += int(text_len + bos_len + audio_len + eos_len)
+            audio_idx_global += 1
+
+            # audio_end (eos_len=1).
+            st_idx = int(llm_pos_ids_list[-1].max()) + 1
+            llm_pos_ids_list.append(torch.arange(eos_len, dtype=torch.long).view(1, -1).expand(3, -1) + st_idx)
+
+        # Trailing text run.
+        if st < row_len:
+            st_idx = int(llm_pos_ids_list[-1].max()) + 1 if llm_pos_ids_list else 0
+            tail_len = row_len - st
+            llm_pos_ids_list.append(torch.arange(tail_len, dtype=torch.long).view(1, -1).expand(3, -1) + st_idx)
+        elif not llm_pos_ids_list:
+            # Attention-masked-to-zero or empty row.
+            llm_pos_ids_list.append(torch.zeros(3, row_len, dtype=torch.long))
+
+        llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+        position_ids[..., i, attn_bool[i]] = llm_positions.to(position_ids.device)
+        mrope_position_deltas.append(int(llm_positions.max()) + 1 - row_len)
+
+    mrope_position_deltas = torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+    return _assert_shape(position_ids), mrope_position_deltas
+
+
+def _force_experts_implementation(config, implementation: str) -> str:
+    """Set ``config._experts_implementation`` if it is not already configured.
+
+    ``PreTrainedConfig._experts_implementation`` has a setter that walks
+    ``sub_configs`` for us, so assigning on the outer composite config is
+    enough — both ``thinker_config`` and ``talker_config`` pick up the value.
+    If the user or transformers has already set it explicitly, we leave it
+    alone. In particular, forcing HF ``batched_mm`` on Qwen3-Omni long
+    sequences can materialize huge selected-weight tensors during actor
+    logprob forward.
+    """
+    current = getattr(config, "_experts_implementation", None)
+    if current is not None:
+        logger.debug(
+            "Skipping _experts_implementation override on %s (already set to %r).",
+            type(config).__name__,
+            current,
+        )
+        return current
+    config._experts_implementation = implementation
+
+    return getattr(config, "_experts_implementation", implementation)
+
+
+def patch_qwen3_omni_moe_sparse_moe_block_forward(
+    model: Optional[torch.nn.Module] = None,
+    implementation: str = _DEFAULT_EXPERTS_IMPLEMENTATION,
+) -> None:
+    """Configure Qwen3-Omni expert dispatch when it is still unset.
+
+    Both ``Qwen3OmniMoeThinkerTextExperts`` and ``Qwen3OmniMoeTalkerTextExperts``
+    already carry ``@use_experts_implementation`` in transformers >=5.3, so the
+    only thing we need is to flip ``config._experts_implementation`` away from
+    its ``None`` default. Already-instantiated models can carry a concrete
+    value such as ``eager``; this helper does not override those values.
+    """
+    if model is None:
+        logger.debug(
+            "Qwen3-Omni experts dispatch requires a model instance to set "
+            "config._experts_implementation; skipping (no-op)."
+        )
+        return
+
+    config = getattr(model, "config", None)
+    if config is None:
+        logger.warning("Qwen3-Omni experts dispatch: model has no .config attribute; skipping.")
+        return
+
+    applied_implementation = _force_experts_implementation(config, implementation)
+    logger.info(
+        "Qwen3-Omni config._experts_implementation=%s after sparse MoE patch.",
+        applied_implementation,
+    )

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -485,6 +485,7 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
@@ -497,6 +498,7 @@ data:
     path: null
     name: null
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.McoreOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -452,6 +452,7 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
@@ -464,6 +465,7 @@ data:
     path: null
     name: null
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.TorchtitanOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -459,6 +459,7 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
@@ -471,6 +472,7 @@ data:
     path: null
     name: null
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.FSDPOptimizerConfig

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -441,6 +441,7 @@ data:
   truncation: error
   image_key: images
   video_key: videos
+  audio_key: audios
   trust_remote_code: false
   custom_cls:
     path: null
@@ -453,6 +454,7 @@ data:
     path: null
     name: null
   apply_chat_template_kwargs: {}
+  mm_processor_kwargs: {}
 critic:
   optim:
     _target_: verl.workers.config.VeOmniOptimizerConfig

--- a/verl/trainer/config/data/legacy_data.yaml
+++ b/verl/trainer/config/data/legacy_data.yaml
@@ -91,6 +91,9 @@ image_key: images
 # The field in the multi-modal dataset where the video is located.
 video_key: videos
 
+# The field in the multi-modal dataset where the audio is located.
+audio_key: audios
+
 # If the remote tokenizer has a Python file, this flag determines whether to allow using it.
 trust_remote_code: False
 
@@ -129,3 +132,6 @@ datagen:
 
 # Additional kwargs when calling tokenizer.apply_chat_template
 apply_chat_template_kwargs: {}
+
+# Additional kwargs passed to multimodal processors/backends.
+mm_processor_kwargs: {}

--- a/verl/utils/__init__.py
+++ b/verl/utils/__init__.py
@@ -15,11 +15,23 @@
 from . import config, tokenizer
 from .config import omega_conf_to_dataclass, validate_config
 from .groupwise import as_torch_index, group_mean_std
-from .tokenizer import hf_processor, hf_tokenizer, normalize_token_ids
+from .tokenizer import (
+    get_processor_token_id,
+    hf_processor,
+    hf_tokenizer,
+    normalize_token_ids,
+)
 
 __all__ = (
     tokenizer.__all__
     + config.__all__
-    + ["hf_processor", "hf_tokenizer", "normalize_token_ids", "omega_conf_to_dataclass", "validate_config"]
+    + [
+        "get_processor_token_id",
+        "hf_processor",
+        "hf_tokenizer",
+        "normalize_token_ids",
+        "omega_conf_to_dataclass",
+        "validate_config",
+    ]
     + ["as_torch_index", "group_mean_std"]
 )

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -21,7 +21,7 @@ import re
 import traceback
 from collections import defaultdict
 from io import BytesIO
-from typing import Optional
+from typing import Any, Optional
 
 import datasets
 import numpy as np
@@ -32,7 +32,7 @@ from torch.utils.data import Dataset
 from transformers import PreTrainedTokenizer, ProcessorMixin
 
 from verl.utils.import_utils import load_extern_object
-from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.tokenizer import build_multimodal_processor_inputs, normalize_token_ids
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +107,7 @@ class RLHFDataset(Dataset):
         self.prompt_key = config.get("prompt_key", "prompt")
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
+        self.audio_key = config.get("audio_key", "audios")
         self.image_patch_size = config.get("image_patch_size", 14)
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
@@ -114,6 +115,7 @@ class RLHFDataset(Dataset):
         self.truncation = config.get("truncation", "error")
         self.filter_overlong_prompts = config.get("filter_overlong_prompts", True)
         self.apply_chat_template_kwargs = config.get("apply_chat_template_kwargs", {})
+        self.mm_processor_kwargs = config.get("mm_processor_kwargs", {})
 
         self.tool_config_path = config.get("tool_config_path", None)
         self.tool_schemas = None
@@ -185,11 +187,8 @@ class RLHFDataset(Dataset):
             tokenizer = self.tokenizer
             processor = self.processor
             prompt_key = self.prompt_key
-            image_key = self.image_key
-            video_key = self.video_key
 
             if processor is not None:
-                from verl.utils.dataset.vision_utils import process_image, process_video
 
                 def doc2len(doc) -> int:
                     try:
@@ -202,31 +201,10 @@ class RLHFDataset(Dataset):
                         raw_prompt = self.processor.apply_chat_template(
                             messages, add_generation_prompt=True, tokenize=False, **apply_kwargs
                         )
-                        if image_key in doc and doc[image_key]:
-                            images = [
-                                process_image(image, image_patch_size=self.image_patch_size) for image in doc[image_key]
-                            ]
-                        else:
-                            images = None
-
-                        if video_key in doc and doc[video_key]:
-                            videos, video_metadata = zip(
-                                *[
-                                    process_video(
-                                        video, image_patch_size=self.image_patch_size, return_video_metadata=True
-                                    )
-                                    for video in doc[video_key]
-                                ],
-                                strict=True,
-                            )
-                            videos = list(videos)
-                            video_metadata = list(video_metadata)
-                            videos_kwargs = {"video_metadata": video_metadata, "do_sample_frames": False}
-                        else:
-                            videos = None
-                            videos_kwargs = {}
-
-                        if images is None and videos is None:
+                        images, videos, audios = self._process_multi_modal_info(
+                            messages, self.image_patch_size, self.config
+                        )
+                        if images is None and videos is None and audios is None:
                             # only text prompt
                             return len(
                                 processor.tokenizer(
@@ -238,9 +216,14 @@ class RLHFDataset(Dataset):
                         else:
                             # multi-modal prompt
                             return len(
-                                processor(text=[raw_prompt], images=images, videos=videos, videos_kwargs=videos_kwargs)[
-                                    "input_ids"
-                                ][0]
+                                build_multimodal_processor_inputs(
+                                    processor,
+                                    text=[raw_prompt],
+                                    images=images,
+                                    videos=videos,
+                                    audio=audios,
+                                    mm_processor_kwargs=self.mm_processor_kwargs,
+                                )["input_ids"][0]
                             )
                     except Exception:
                         print("Error processing one of the samples, skipping...")
@@ -301,10 +284,12 @@ class RLHFDataset(Dataset):
         return len(self.dataframe)
 
     def _build_messages(self, example: dict, key: str):
-        """Replace <image> and <video> placeholder in messages with corresponding image and video
-        which is required by processor.apply_chat_template.
+        """Replace multimodal placeholders in messages with structured content.
+
+        This is required by processor.apply_chat_template.
         - <image>: {"type": "image", **image}
         - <video>: {"type": "video", **video}
+        - <audio>: {"type": "audio", **audio}
 
         Args:
             example: Row dictionary from dataframe.
@@ -313,22 +298,23 @@ class RLHFDataset(Dataset):
             messages: List of messages with replaced placeholder.
         """
         messages: list = example[key]
-        # When concatenating image and video datasets, get will return None for image or video sample
+        # When concatenating multimodal datasets, get will return None for samples without a modality column.
         images = example.get(self.image_key, None) or []
         videos = example.get(self.video_key, None) or []
+        audios = example.get(self.audio_key, None) or []
 
-        image_offset, video_offset = 0, 0
+        image_offset, video_offset, audio_offset = 0, 0, 0
         for message in messages:
-            if not images and not videos:
+            if not images and not videos and not audios:
                 continue
-            assert self.processor is not None, "processor is needed to process image and video"
+            assert self.processor is not None, "processor is needed to process multimodal data"
 
             content = message["content"]
             if not isinstance(content, str):
                 continue
 
             content_list = []
-            segments = re.split("(<image>|<video>)", content)
+            segments = re.split("(<image>|<video>|<audio>)", content)
             segments = [item for item in segments if item != ""]
             for segment in segments:
                 if segment == "<image>":
@@ -348,12 +334,25 @@ class RLHFDataset(Dataset):
                     assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
                     content_list.append({"type": "video", **videos[video_offset]})
                     video_offset += 1
+                elif segment == "<audio>":
+                    assert audio_offset < len(audios), f"audio_offset {audio_offset} >= len(audios) {len(audios)}"
+                    audio = audios[audio_offset]
+                    if isinstance(audio, dict):
+                        payload = dict(audio)
+                        payload["type"] = "audio"
+                        if "audio" not in payload and "audio_url" not in payload:
+                            payload = {"type": "audio", "audio": audio}
+                        content_list.append(payload)
+                    else:
+                        content_list.append({"type": "audio", "audio": audio})
+                    audio_offset += 1
                 else:
                     content_list.append({"type": "text", "text": segment})
             message["content"] = content_list
 
         assert image_offset == len(images), f"image_offset {image_offset} != len(images) {len(images)}"
         assert video_offset == len(videos), f"video_offset {video_offset} != len(videos) {len(videos)}"
+        assert audio_offset == len(audios), f"audio_offset {audio_offset} != len(audios) {len(audios)}"
         return messages
 
     def __getitem__(self, item):
@@ -363,6 +362,7 @@ class RLHFDataset(Dataset):
 
         row_dict.pop(self.image_key, None)
         row_dict.pop(self.video_key, None)
+        row_dict.pop(self.audio_key, None)
 
         # TODO(wuxibin): We still need a dummy tensor to make sure DataProto.batch is not empty.
         # Remove this after deprecate DataProto by TensorDict.
@@ -373,11 +373,13 @@ class RLHFDataset(Dataset):
             row_dict["extra_info"] = dict()
         index = row_dict.get("extra_info", {}).get("index", 0)
         tools_kwargs = row_dict.get("extra_info", {}).get("tools_kwargs", {})
+        interaction_kwargs = row_dict.get("extra_info", {}).get("interaction_kwargs", {})
         need_tools_kwargs = row_dict.get("extra_info", {}).get("need_tools_kwargs", self.need_tools_kwargs)
         if need_tools_kwargs and not tools_kwargs:
             logger.warning("tools_kwargs is empty for index %s, data source: %s", index, row_dict["data_source"])
         row_dict["index"] = index
         row_dict["tools_kwargs"] = tools_kwargs
+        row_dict["interaction_kwargs"] = interaction_kwargs
         return row_dict
 
     @classmethod
@@ -413,6 +415,56 @@ class RLHFDataset(Dataset):
 
         images, videos = process_vision_info(messages, image_patch_size=image_patch_size, return_video_metadata=True)
         return images, videos
+
+    @classmethod
+    def _extract_audio_info(cls, messages: list[dict]) -> list[Any]:
+        audios = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "audio":
+                    continue
+                if "audio" in item:
+                    audios.append(item["audio"])
+                elif "audio_url" in item:
+                    audios.append(item["audio_url"])
+                else:
+                    audios.append({k: v for k, v in item.items() if k != "type"})
+        return audios or None
+
+    @classmethod
+    def _process_multi_modal_info(
+        cls,
+        messages: list[dict],
+        image_patch_size,
+        config: DictConfig,
+    ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        has_visual = any(
+            isinstance(message.get("content"), list)
+            and any(isinstance(item, dict) and item.get("type") in {"image", "video"} for item in message["content"])
+            for message in messages
+        )
+        if has_visual:
+            from qwen_vl_utils import process_vision_info
+
+            images, videos = process_vision_info(
+                messages, image_patch_size=image_patch_size, return_video_metadata=True
+            )
+        else:
+            images, videos = None, None
+        audios = cls._extract_audio_info(messages)
+        return images, videos, audios
+
+    @classmethod
+    async def process_multi_modal_info(
+        cls,
+        messages: list[dict],
+        image_patch_size,
+        config: DictConfig,
+    ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        return cls._process_multi_modal_info(messages, image_patch_size=image_patch_size, config=config)
 
     def split(self, num_splits: int):
         """

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -307,7 +307,7 @@ class RLHFDataset(Dataset):
         for message in messages:
             if not images and not videos and not audios:
                 continue
-            assert self.processor is not None, "processor is needed to process multimodal data"
+            assert self.processor is not None, "processor is needed to process image and video"
 
             content = message["content"]
             if not isinstance(content, str):
@@ -435,17 +435,82 @@ class RLHFDataset(Dataset):
         return audios or None
 
     @classmethod
+    def _extract_image_info(cls, messages: list[dict]) -> list[Image.Image] | None:
+        """Load image payloads from messages as raw PIL images, skipping any
+        pre-resize.
+
+        Mirrors ``_build_messages``' image cases — dict with ``image`` pointing
+        at a filesystem path / PIL object / bytes — but returns the PIL object
+        straight through without calling ``qwen_omni_utils.fetch_image`` or
+        ``qwen_vl_utils.fetch_image``. Those helpers compute
+        ``smart_resize(...)`` and call ``PIL.Image.resize(...)`` *before* the
+        HF processor runs its own resize pass; the double pass can perturb
+        ``pixel_values`` and inflate rollout/actor logprob differences on
+        mixed image+audio samples.
+        """
+        images: list[Image.Image] = []
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict) or item.get("type") != "image":
+                    continue
+                payload = item.get("image")
+                if payload is None:
+                    payload = item.get("image_url") or item.get("path")
+                if isinstance(payload, Image.Image):
+                    images.append(payload.convert("RGB"))
+                elif isinstance(payload, str):
+                    images.append(Image.open(payload).convert("RGB"))
+                elif isinstance(payload, (bytes | bytearray)):
+                    images.append(Image.open(BytesIO(payload)).convert("RGB"))
+                elif isinstance(payload, dict) and "bytes" in payload:
+                    images.append(Image.open(BytesIO(payload["bytes"])).convert("RGB"))
+                else:
+                    return None  # unknown shape → let the legacy helper handle it
+        return images or None
+
+    @classmethod
     def _process_multi_modal_info(
         cls,
         messages: list[dict],
         image_patch_size,
         config: DictConfig,
     ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        use_audio_in_video = bool((config.get("mm_processor_kwargs", {}) or {}).get("use_audio_in_video", False))
+        has_audio = any(
+            isinstance(message.get("content"), list)
+            and any(isinstance(item, dict) and item.get("type") == "audio" for item in message["content"])
+            for message in messages
+        )
         has_visual = any(
             isinstance(message.get("content"), list)
             and any(isinstance(item, dict) and item.get("type") in {"image", "video"} for item in message["content"])
             for message in messages
         )
+        if has_audio or use_audio_in_video:
+            try:
+                from qwen_omni_utils import process_mm_info
+
+                audios, images, videos = process_mm_info(messages, use_audio_in_video=use_audio_in_video)
+                has_video = any(
+                    isinstance(m.get("content"), list)
+                    and any(isinstance(it, dict) and it.get("type") == "video" for it in m["content"])
+                    for m in messages
+                )
+                # ``qwen_omni_utils.fetch_image`` pre-resizes the image before
+                # the processor; the processor then resizes again. Skip the
+                # pre-resized images in favour of raw PIL objects when we have
+                # no video (video still needs fetch_video's frame-extraction).
+                if not has_video and not use_audio_in_video:
+                    raw_images = cls._extract_image_info(messages)
+                    if raw_images is not None:
+                        images = raw_images
+                return images, videos, audios
+            except Exception as e:
+                logger.warning("Failed to process audio inputs with qwen_omni_utils, fallback to generic path: %s", e)
+
         if has_visual:
             from qwen_vl_utils import process_vision_info
 

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -20,7 +20,7 @@ import os
 from abc import ABC
 from collections import OrderedDict
 from contextlib import contextmanager, nullcontext
-from typing import Optional, cast
+from typing import Any, Optional, cast
 
 import torch
 import torch.distributed as dist
@@ -30,6 +30,7 @@ from torch.distributed import DeviceMesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp._runtime_utils import _lazy_init
 from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
+from torch.distributed.utils import _apply_to_tensors
 from transformers.trainer_pt_utils import get_module_class_from_name
 
 from verl.utils.device import get_device_id, get_device_name, get_torch_device
@@ -48,6 +49,80 @@ elif version.parse(torch.__version__) >= version.parse("2.4"):
     fully_shard_module = torch.distributed._composable.fsdp
 else:
     fully_shard, MixedPrecisionPolicy, FSDPModule, CPUOffloadPolicy, fully_shard_module = None, None, None, None, None
+
+
+try:
+    from torch.distributed.fsdp._fully_shard._fsdp_common import (
+        _cast_fp_tensor as _torch_fsdp_cast_fp_tensor,
+    )
+except (ImportError, ModuleNotFoundError):
+
+    def _torch_fsdp_cast_fp_tensor(dtype: torch.dtype, x: torch.Tensor) -> torch.Tensor:
+        if not isinstance(x, torch.Tensor) or not torch.is_floating_point(x) or x.dtype == dtype:
+            return x
+        return x.to(dtype)
+
+
+# For some multi-modal model such as qwen3-omni, `position_ids` has type float,
+# which will be auto-cast to half by FSDP on default, so we need to skip it.
+_FSDP_FORWARD_INPUT_CAST_SKIP_NAMES = frozenset({"position_ids"})
+
+
+def _fsdp_forward_input_cast_skip_names() -> frozenset[str]:
+    raw = os.environ.get("VERL_FSDP_FORWARD_INPUT_CAST_SKIP_NAMES")
+    if raw is None:
+        return _FSDP_FORWARD_INPUT_CAST_SKIP_NAMES
+    return frozenset(name.strip() for name in raw.split(",") if name.strip())
+
+
+def _cast_fsdp_forward_input(
+    value: Any, dtype: torch.dtype, skip_names: frozenset[str], path: tuple[str, ...] = ()
+) -> Any:
+    if path and path[-1] in skip_names:
+        return value
+    cast_fn = functools.partial(_torch_fsdp_cast_fp_tensor, dtype)
+    if not skip_names:
+        return _apply_to_tensors(cast_fn, value)
+    if isinstance(value, dict):
+        return {
+            key: _cast_fsdp_forward_input(item, dtype, skip_names, (*path, str(key))) for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_cast_fsdp_forward_input(item, dtype, skip_names, (*path, str(idx))) for idx, item in enumerate(value)]
+    if isinstance(value, tuple):
+        return tuple(
+            _cast_fsdp_forward_input(item, dtype, skip_names, (*path, str(idx))) for idx, item in enumerate(value)
+        )
+    return _apply_to_tensors(cast_fn, value)
+
+
+def _register_filtered_forward_input_cast_hook(
+    module: torch.nn.Module, dtype: torch.dtype
+) -> torch.utils.hooks.RemovableHandle:
+    skip_names = _fsdp_forward_input_cast_skip_names()
+
+    def _pre_forward_cast_hook(_module: torch.nn.Module, args: tuple[Any, ...], kwargs: dict[str, Any]):
+        with torch.profiler.record_function("verl::fsdp_filtered_cast_forward_inputs"):
+            return (
+                _cast_fsdp_forward_input(args, dtype, skip_names),
+                _cast_fsdp_forward_input(kwargs, dtype, skip_names),
+            )
+
+    return module.register_forward_pre_hook(_pre_forward_cast_hook, with_kwargs=True)
+
+
+def register_filtered_forward_input_cast_hooks(
+    module: torch.nn.Module, dtype: torch.dtype, strategy: str
+) -> list[torch.utils.hooks.RemovableHandle]:
+    if dtype is None:
+        return []
+    if strategy == "fsdp2":
+        return [
+            _register_filtered_forward_input_cast_hook(submodule, dtype)
+            for submodule in module.modules()
+            if isinstance(submodule, FSDPModule)
+        ]
+    return [_register_filtered_forward_input_cast_hook(module, dtype)]
 
 
 def init_fn(x: torch.nn.Module):

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -56,6 +56,8 @@ from verl.utils.transformers_compat import get_auto_model_for_vision2seq
 
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
+_VARLEN_MULTI_MODAL_KEYS = {"input_features", "feature_attention_mask"}
+
 
 class LambdaLayer(nn.Module):
     def __init__(self, fn):
@@ -710,6 +712,43 @@ def get_hf_auto_model_class(hf_config):
     return actor_module_class
 
 
+def _pad_last_dim_and_cat(values: list[torch.Tensor], key: str) -> torch.Tensor:
+    if not values:
+        raise ValueError(f"Cannot merge empty multi-modal input list for key {key!r}.")
+
+    def _format_tensor_shapes(values: list[torch.Tensor]) -> str:
+        return ", ".join(str(tuple(value.shape)) for value in values)
+
+    rank = values[0].dim()
+    if rank < 2:
+        raise RuntimeError(
+            f"Cannot pad multi-modal input {key!r} with rank {rank}; shapes: {_format_tensor_shapes(values)}"
+        )
+
+    middle_shape = values[0].shape[1:-1]
+    for value in values:
+        if value.dim() != rank or value.shape[1:-1] != middle_shape:
+            raise RuntimeError(
+                f"Cannot pad multi-modal input {key!r}; expected matching rank and non-batch/non-time "
+                f"dimensions, got shapes: {_format_tensor_shapes(values)}"
+            )
+
+    max_len = max(value.shape[-1] for value in values)
+    if all(value.shape[-1] == max_len for value in values):
+        return torch.cat(values, dim=0)
+
+    padded_values = []
+    for value in values:
+        if value.shape[-1] == max_len:
+            padded_values.append(value)
+            continue
+        padded_value = value.new_zeros((*value.shape[:-1], max_len))
+        padded_value[..., : value.shape[-1]] = value
+        padded_values.append(padded_value)
+
+    return torch.cat(padded_values, dim=0)
+
+
 def extract_multi_modal_inputs(
     batch_data: list[dict[str, torch.Tensor]],
     indices: Optional[list[int]] = None,
@@ -749,8 +788,16 @@ def extract_multi_modal_inputs(
     for key, values in multi_modal_inputs_collected.items():
         if has_image_bound:  # minicpm-o logic
             multi_modal_inputs[key] = values
+        elif key in _VARLEN_MULTI_MODAL_KEYS:
+            # some multi-modal keys with variable length are put in non-tensor batch,
+            # so we need to pad them manually.
+            multi_modal_inputs[key] = _pad_last_dim_and_cat(values, key)
         else:
-            multi_modal_inputs[key] = torch.cat(values, dim=0)
+            try:
+                multi_modal_inputs[key] = torch.cat(values, dim=0)
+            except RuntimeError as e:
+                shapes = ", ".join(str(tuple(value.shape)) for value in values)
+                raise RuntimeError(f"Failed to concatenate multi-modal input {key!r}; shapes: {shapes}") from e
 
     return multi_modal_inputs
 

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -684,6 +684,11 @@ _architecture_to_auto_class = {
 
 
 def get_hf_auto_model_class(hf_config):
+    if getattr(hf_config, "model_type", None) == "qwen3_omni_moe":
+        from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+        return Qwen3OmniMoeThinkerForConditionalGeneration
+
     has_remote_code = hasattr(hf_config, "auto_map") and any(
         hf_config.architectures[0] in val for val in hf_config.auto_map.values()
     )

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -102,6 +102,10 @@ def default_compute_score(
         from . import search_r1_like_qa_em
 
         res = search_r1_like_qa_em.compute_score(solution_str, ground_truth)
+    elif data_source in ["m-a-p/OmniInstruct", "m-a-p/OmniInstruct_v1"]:
+        from . import omniinstruct
+
+        res = omniinstruct.compute_score(solution_str, ground_truth, extra_info=extra_info)
 
     else:
         raise NotImplementedError(f"Reward function is not implemented for {data_source=}")

--- a/verl/utils/reward_score/omniinstruct.py
+++ b/verl/utils/reward_score/omniinstruct.py
@@ -1,0 +1,306 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rule-based reward for OmniInstruct-style answer matching.
+
+Earlier versions combined a soft lexical-overlap score with a fixed
+``substring_bonus = 0.9`` whenever the normalized reference appeared inside
+the normalized prediction (or vice versa). On length-bounded RL training
+that interacts with two pathological dynamics:
+
+1. ``token_f1`` and ``rouge_l_f1`` both penalize long predictions through
+   their precision term, so the policy has every incentive to ramble until
+   the reference shows up by accident, then collect the flat 0.9 reward.
+2. Once the policy starts hitting ``data.max_response_length``, vLLM
+   truncates the response *before* the model can emit the answer,
+   reward collapses, and the resulting noisy gradient destabilizes
+   training (we observed this on a 300-step Qwen3-Omni Thinker GSPO run:
+   reward < 0.1 ↔ avg response length 1988, clip-to-cap ratio 94 percent).
+
+This implementation keeps the original ``compute_score`` signature and the
+public ``score`` / ``exact_match`` / ``substring_match`` / ``token_f1`` /
+``rouge_l_f1`` keys, but tightens the substring path:
+
+- the bonus applies only when the reference has at least
+  ``min_ref_tokens_for_substring`` tokens and the prediction stays within
+  ``length_factor`` of the reference;
+- the bonus value defaults to ``0.5`` (down from ``0.9``) so it cannot
+  dominate exact / lexical-overlap signals;
+- a small additive ``format_bonus`` rewards responses that use the expected
+  ``<answer>...</answer>`` schema, instead of leaving format adherence
+  unmeasured;
+- callers that know a response was hard-truncated by ``max_response_length``
+  can pass ``extra_info={"truncated": True}`` to scale the reward down.
+
+All knobs above can be overridden through ``extra_info`` so dataset-level
+tuning does not require touching this module.
+"""
+
+from __future__ import annotations
+
+import re
+import string
+from collections import Counter
+
+_THINK_TAG_RE = re.compile(r"<think>.*?</think>", flags=re.DOTALL)
+_ANSWER_TAG_RE = re.compile(r"<answer>(.*?)</answer>", flags=re.DOTALL)
+_OPEN_ANSWER_TAG_RE = re.compile(r"<answer>", flags=re.IGNORECASE)
+_PUNCT = set(string.punctuation)
+
+DEFAULT_SUBSTRING_BONUS = 0.5
+DEFAULT_FORMAT_BONUS = 0.1
+DEFAULT_LENGTH_FACTOR = 3.0
+DEFAULT_MIN_REF_TOKENS_FOR_SUBSTRING = 2
+DEFAULT_MIN_BOUNDED_TOKENS = 8
+DEFAULT_TRUNCATION_PENALTY = 0.5
+
+
+def _strip_reasoning(text: str) -> str:
+    text = _THINK_TAG_RE.sub(" ", text)
+    answer_matches = _ANSWER_TAG_RE.findall(text)
+    if answer_matches:
+        text = answer_matches[-1]
+    return text.strip()
+
+
+def _has_answer_tag(text: str) -> bool:
+    return bool(text) and _ANSWER_TAG_RE.search(text) is not None
+
+
+def normalize_answer(text: str) -> str:
+    text = _strip_reasoning(text)
+    text = text.lower()
+    text = "".join(ch for ch in text if ch not in _PUNCT)
+    text = re.sub(r"\b(a|an|the)\b", " ", text)
+    return " ".join(text.split())
+
+
+def _tokenize(text: str) -> list[str]:
+    normalized = normalize_answer(text)
+    return normalized.split() if normalized else []
+
+
+def _exact_match(prediction: str, references: list[str]) -> float:
+    normalized_prediction = normalize_answer(prediction)
+    return float(any(normalized_prediction == normalize_answer(reference) for reference in references))
+
+
+def _substring_match(prediction: str, references: list[str]) -> float:
+    """Plain string-containment match against the normalized text.
+
+    Kept for backwards-compatible logging only — ``compute_score`` itself
+    no longer derives reward from this metric directly.
+    """
+    normalized_prediction = normalize_answer(prediction)
+    if not normalized_prediction:
+        return 0.0
+    for reference in references:
+        normalized_reference = normalize_answer(reference)
+        if normalized_reference and (
+            normalized_reference in normalized_prediction or normalized_prediction in normalized_reference
+        ):
+            return 1.0
+    return 0.0
+
+
+def _bounded_substring_match(
+    prediction: str,
+    references: list[str],
+    *,
+    min_ref_tokens: int,
+    length_factor: float,
+    min_bounded_tokens: int,
+) -> tuple[float, float]:
+    """Length-aware substring match.
+
+    Returns ``(matched, max_length_ratio)``:
+
+    - ``matched`` is ``1.0`` when at least one reference has enough tokens
+      (``len(ref) >= min_ref_tokens``) AND the prediction stays within
+      ``max(min_bounded_tokens, length_factor * len(ref))`` tokens.
+    - ``max_length_ratio`` is the largest ``len(pred) / len(ref)`` observed
+      among references that string-matched, useful for diagnostics.
+    """
+    pred_tokens = _tokenize(prediction)
+    if not pred_tokens:
+        return 0.0, 0.0
+    pred_text = normalize_answer(prediction)
+
+    matched = 0.0
+    max_ratio = 0.0
+    for reference in references:
+        ref_tokens = _tokenize(reference)
+        if not ref_tokens or len(ref_tokens) < min_ref_tokens:
+            continue
+        ref_text = normalize_answer(reference)
+        if not ref_text or not (ref_text in pred_text or pred_text in ref_text):
+            continue
+        budget = max(min_bounded_tokens, int(length_factor * len(ref_tokens)))
+        ratio = len(pred_tokens) / max(1, len(ref_tokens))
+        max_ratio = max(max_ratio, ratio)
+        if len(pred_tokens) <= budget:
+            matched = 1.0
+    return matched, max_ratio
+
+
+def _token_f1(prediction: str, references: list[str]) -> float:
+    pred_tokens = _tokenize(prediction)
+    if not pred_tokens:
+        return 0.0
+
+    best = 0.0
+    pred_counter = Counter(pred_tokens)
+    for reference in references:
+        ref_tokens = _tokenize(reference)
+        if not ref_tokens:
+            continue
+        ref_counter = Counter(ref_tokens)
+        common = sum((pred_counter & ref_counter).values())
+        if common == 0:
+            continue
+        precision = common / len(pred_tokens)
+        recall = common / len(ref_tokens)
+        score = 2 * precision * recall / (precision + recall)
+        best = max(best, score)
+    return best
+
+
+def _lcs_length(a: list[str], b: list[str]) -> int:
+    if not a or not b:
+        return 0
+    prev = [0] * (len(b) + 1)
+    for token_a in a:
+        curr = [0]
+        for j, token_b in enumerate(b, start=1):
+            if token_a == token_b:
+                curr.append(prev[j - 1] + 1)
+            else:
+                curr.append(max(prev[j], curr[-1]))
+        prev = curr
+    return prev[-1]
+
+
+def _rouge_l_f1(prediction: str, references: list[str]) -> float:
+    pred_tokens = _tokenize(prediction)
+    if not pred_tokens:
+        return 0.0
+
+    best = 0.0
+    for reference in references:
+        ref_tokens = _tokenize(reference)
+        if not ref_tokens:
+            continue
+        lcs = _lcs_length(pred_tokens, ref_tokens)
+        if lcs == 0:
+            continue
+        precision = lcs / len(pred_tokens)
+        recall = lcs / len(ref_tokens)
+        score = 2 * precision * recall / (precision + recall)
+        best = max(best, score)
+    return best
+
+
+def compute_score(solution_str, ground_truth, extra_info=None):
+    """Length-aware OmniInstruct rule-based reward.
+
+    Args:
+        solution_str: model output (may include ``<think>`` and ``<answer>`` tags).
+        ground_truth: a single reference string or a list of acceptable references.
+        extra_info: optional dict with override knobs:
+
+            - ``substring_bonus`` (float, default 0.5)
+            - ``format_bonus`` (float, default 0.1) — added when the answer is
+              wrapped in ``<answer>...</answer>`` AND there is any positive
+              signal. Total score is capped to ``[0.0, 1.0]``.
+            - ``length_factor`` (float, default 3.0)
+            - ``min_ref_tokens_for_substring`` (int, default 2)
+            - ``min_bounded_tokens`` (int, default 8)
+            - ``truncated`` (bool, default False) — when the framework knows
+              the response was hard-truncated by ``max_response_length``,
+              set this to scale the reward down via ``truncation_penalty``.
+            - ``truncation_penalty`` (float, default 0.5) — multiplier when
+              ``truncated`` is True. Set to ``0.0`` for a hard zero,
+              ``1.0`` to disable.
+
+    Returns:
+        Dict with at least ``score`` (in ``[0, 1]``) plus the diagnostic
+        sub-metrics ``exact_match``, ``substring_match``,
+        ``substring_match_bounded``, ``token_f1``, ``rouge_l_f1``,
+        ``format_match``, ``pred_to_ref_length_ratio``.
+    """
+    extra_info = extra_info or {}
+    substring_bonus_value = float(extra_info.get("substring_bonus", DEFAULT_SUBSTRING_BONUS))
+    format_bonus_value = float(extra_info.get("format_bonus", DEFAULT_FORMAT_BONUS))
+    length_factor = float(extra_info.get("length_factor", DEFAULT_LENGTH_FACTOR))
+    min_ref_tokens = int(extra_info.get("min_ref_tokens_for_substring", DEFAULT_MIN_REF_TOKENS_FOR_SUBSTRING))
+    min_bounded_tokens = int(extra_info.get("min_bounded_tokens", DEFAULT_MIN_BOUNDED_TOKENS))
+    truncated = bool(extra_info.get("truncated", False))
+    truncation_penalty = float(extra_info.get("truncation_penalty", DEFAULT_TRUNCATION_PENALTY))
+
+    if isinstance(ground_truth, list):
+        references = [r for r in ground_truth if r is not None and str(r).strip()]
+    elif ground_truth is None:
+        references = []
+    else:
+        references = [ground_truth] if str(ground_truth).strip() else []
+
+    if not references:
+        return {
+            "score": 0.0,
+            "exact_match": 0.0,
+            "substring_match": 0.0,
+            "substring_match_bounded": 0.0,
+            "token_f1": 0.0,
+            "rouge_l_f1": 0.0,
+            "format_match": float(_has_answer_tag(solution_str)),
+            "pred_to_ref_length_ratio": 0.0,
+        }
+
+    exact_match = _exact_match(solution_str, references)
+    substring_match_raw = _substring_match(solution_str, references)
+    bounded_substring, length_ratio = _bounded_substring_match(
+        solution_str,
+        references,
+        min_ref_tokens=min_ref_tokens,
+        length_factor=length_factor,
+        min_bounded_tokens=min_bounded_tokens,
+    )
+    token_f1 = _token_f1(solution_str, references)
+    rouge_l_f1 = _rouge_l_f1(solution_str, references)
+
+    if exact_match:
+        score = 1.0
+    else:
+        lexical_overlap = 0.5 * token_f1 + 0.5 * rouge_l_f1
+        substring_contribution = substring_bonus_value if bounded_substring else 0.0
+        score = max(lexical_overlap, substring_contribution)
+
+    has_format = _has_answer_tag(solution_str)
+    if has_format and score > 0.0:
+        score = min(1.0, score + format_bonus_value)
+
+    if truncated:
+        score *= truncation_penalty
+
+    score = max(0.0, min(1.0, score))
+
+    return {
+        "score": float(score),
+        "exact_match": float(exact_match),
+        "substring_match": float(substring_match_raw),
+        "substring_match_bounded": float(bounded_substring),
+        "token_f1": float(token_f1),
+        "rouge_l_f1": float(rouge_l_f1),
+        "format_match": float(has_format),
+        "pred_to_ref_length_ratio": float(length_ratio),
+    }

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -330,10 +330,10 @@ def chunk_tensordict(td: TensorDict, chunks: int) -> list[TensorDict]:
             to <seq_len>, but got split_sizes=[4, 4, ...]
 
         2D jagged NestedTensors (e.g. ``input_ids``, ``loss_mask``) are
-        unaffected — ``unbind(dim=0)`` works correctly for them.
+        unaffected: ``unbind(dim=0)`` works correctly for them.
 
         The workaround: try ``unbind`` first (fast path for 2D); on failure,
-        fall back to ``to_padded_tensor`` → ``chunk`` → reconstruct per-chunk
+        fall back to ``to_padded_tensor`` -> ``chunk`` -> reconstruct per-chunk
         NestedTensors using the original ragged lengths from ``offsets``.
 
         See https://github.com/pytorch/pytorch/issues/153238
@@ -911,8 +911,24 @@ def maybe_fix_3d_position_ids(data: TensorDict):
     # note for tensordict with pickle/unpickle. nested tensor in tensordict after consolidate and pickle/unpickle
     # will incur indexing error for ragged tensor. This only happens when using 3D position ids in VLMs.
     # This is likely a bug in tensordict. As a workaround, we manually set _ragged_index.
-    if "position_ids" in data.keys() and data["position_ids"].dim() == 3 and data["position_ids"].is_nested:
-        data["position_ids"]._ragged_idx = 2
+    if "position_ids" not in data.keys():
+        return
+
+    position_ids = data["position_ids"]
+    if not (isinstance(position_ids, torch.Tensor) and position_ids.dim() == 3 and position_ids.is_nested):
+        return
+
+    input_ids = data.get("input_ids", None)
+    if isinstance(input_ids, torch.Tensor) and input_ids.is_nested:
+        total_seq_len = int(input_ids.offsets().diff().sum().item())
+        values_shape = tuple(position_ids.values().shape)
+        if total_seq_len not in values_shape:
+            raise RuntimeError(
+                "Invalid 3D nested position_ids storage: expected values shape to contain "
+                f"total sequence length {total_seq_len}, got {values_shape}."
+            )
+
+    position_ids._ragged_idx = 2
 
 
 def list_of_dict_to_tensordict(list_of_dicts: list[dict[str, Any]]) -> TensorDict:

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -16,7 +16,13 @@
 import types
 import warnings
 
-__all__ = ["hf_tokenizer", "hf_processor", "normalize_token_ids"]
+__all__ = [
+    "hf_tokenizer",
+    "hf_processor",
+    "normalize_token_ids",
+    "build_multimodal_processor_inputs",
+    "get_processor_token_id",
+]
 
 
 def normalize_token_ids(tokenized_output) -> list[int]:
@@ -54,6 +60,78 @@ def normalize_token_ids(tokenized_output) -> list[int]:
         except (TypeError, ValueError) as e:
             raise TypeError(f"token_id must be int-convertible, got {type(token_id).__name__}: {token_id!r}") from e
     return normalized_ids
+
+
+def get_processor_token_id(processor, token_name: str) -> int | None:
+    """Resolve a multimodal special token id from a processor.
+
+    Newer processors may expose ``image_token``/``video_token`` strings instead
+    of ``image_token_id``/``video_token_id`` integers. Fall back to tokenizer
+    conversion so rollout code can stay processor-agnostic.
+    """
+
+    if processor is None:
+        return None
+
+    token_id_attr = f"{token_name}_token_id"
+    token_id = getattr(processor, token_id_attr, None)
+    if token_id is not None:
+        return int(token_id)
+
+    token_attr = f"{token_name}_token"
+    token = getattr(processor, token_attr, None)
+    tokenizer = getattr(processor, "tokenizer", None)
+    if token is not None and tokenizer is not None:
+        converted = tokenizer.convert_tokens_to_ids(token)
+        if converted is not None:
+            return int(converted)
+
+    return None
+
+
+def _split_videos_and_metadata(videos):
+    if videos is None:
+        return None, None
+    videos = list(videos)
+    if len(videos) > 0 and isinstance(videos[0], tuple):
+        video_values, video_metadata = zip(*videos, strict=False)
+        return list(video_values), list(video_metadata)
+    return videos, None
+
+
+def build_multimodal_processor_inputs(
+    processor,
+    *,
+    text,
+    images=None,
+    videos=None,
+    audio=None,
+    mm_processor_kwargs=None,
+    return_tensors: str = "pt",
+):
+    """Build kwargs for multimodal processor calls.
+
+    This keeps the existing VL flow intact while extending it with audio-aware
+    paths for processors that accept audio inputs.
+    """
+    processor_kwargs = dict(mm_processor_kwargs or {})
+    if audio is not None and "sampling_rate" not in processor_kwargs:
+        sampling_rate = getattr(getattr(processor, "feature_extractor", None), "sampling_rate", None)
+        if sampling_rate is not None:
+            processor_kwargs["sampling_rate"] = int(sampling_rate)
+
+    videos, video_metadata = _split_videos_and_metadata(videos)
+    processor_kwargs.setdefault("return_tensors", return_tensors)
+
+    if video_metadata is not None:
+        processor_kwargs.setdefault("video_metadata", video_metadata)
+        processor_kwargs.setdefault("do_sample_frames", False)
+
+    processor_inputs = {"text": text, "images": images, "videos": videos, **processor_kwargs}
+    if audio is not None:
+        processor_inputs["audio"] = audio
+
+    return processor(**processor_inputs)
 
 
 def set_pad_token_id(tokenizer):
@@ -124,7 +202,7 @@ def hf_processor(name_or_path, **kwargs):
 
         config = AutoConfig.from_pretrained(name_or_path, **kwargs)
 
-        # Bind vlm model's get_rope_index method to processor
+        # Bind vlm model's get_rope_index method to processor.
         processor.config = config
         model_class = None
         match processor.__class__.__name__:
@@ -162,4 +240,5 @@ def hf_processor(name_or_path, **kwargs):
     # https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/models/auto/processing_auto.py#L344
     if processor is not None and "Processor" not in processor.__class__.__name__:
         processor = None
+
     return processor

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utils for tokenization."""
 
+import json
 import types
 import warnings
 
@@ -20,6 +21,7 @@ __all__ = [
     "hf_tokenizer",
     "hf_processor",
     "normalize_token_ids",
+    "is_qwen3_omni_processor",
     "build_multimodal_processor_inputs",
     "get_processor_token_id",
 ]
@@ -62,6 +64,11 @@ def normalize_token_ids(tokenized_output) -> list[int]:
     return normalized_ids
 
 
+def is_qwen3_omni_processor(processor) -> bool:
+    """Return True when ``processor`` is a Qwen3-Omni processor."""
+    return processor is not None and processor.__class__.__name__ == "Qwen3OmniMoeProcessor"
+
+
 def get_processor_token_id(processor, token_name: str) -> int | None:
     """Resolve a multimodal special token id from a processor.
 
@@ -89,6 +96,64 @@ def get_processor_token_id(processor, token_name: str) -> int | None:
     return None
 
 
+def _ensure_qwen3_omni_processor_attrs(processor):
+    """Populate processor attributes expected by Qwen3-Omni helper methods.
+
+    The bound ``get_rope_index`` implementation expects these values on the
+    processor instance. Treat the model config as the single source of truth and
+    fail fast when it does not expose the required fields.
+    """
+
+    if not is_qwen3_omni_processor(processor):
+        return processor
+
+    config = getattr(processor, "config", None)
+    thinker_config = getattr(config, "thinker_config", None)
+    talker_config = getattr(config, "talker_config", None)
+    vision_config = getattr(thinker_config, "vision_config", None) or getattr(config, "vision_config", None)
+
+    def _get_config_attr(attr_name: str, sources):
+        for source in sources:
+            if source is None:
+                continue
+            value = getattr(source, attr_name, None)
+            if value is not None:
+                return value
+        return None
+
+    required_config_attrs = {
+        "image_token_id": (config, thinker_config, talker_config),
+        "video_token_id": (config, thinker_config, talker_config),
+        "audio_token_id": (config, thinker_config, talker_config),
+        "vision_start_token_id": (config, talker_config, thinker_config),
+        "vision_end_token_id": (config, talker_config, thinker_config),
+        "audio_start_token_id": (config, talker_config, thinker_config),
+        "audio_end_token_id": (config, talker_config, thinker_config),
+        "position_id_per_seconds": (config, talker_config, thinker_config),
+    }
+    missing_attrs = []
+    for attr_name, sources in required_config_attrs.items():
+        value = _get_config_attr(attr_name, sources=sources)
+        if value is None:
+            missing_attrs.append(attr_name)
+        else:
+            setattr(processor, attr_name, value)
+
+    if missing_attrs:
+        raise ValueError(
+            "Qwen3-Omni processor is missing required config attributes: "
+            f"{', '.join(missing_attrs)}. Please use a model config that exposes these fields."
+        )
+
+    if vision_config is not None:
+        for attr_name in ("spatial_merge_size", "tokens_per_second"):
+            value = getattr(vision_config, attr_name, None)
+            if value is not None:
+                setattr(processor, attr_name, value)
+
+    return processor
+
+
 def _split_videos_and_metadata(videos):
     if videos is None:
         return None, None
@@ -112,7 +177,7 @@ def build_multimodal_processor_inputs(
     """Build kwargs for multimodal processor calls.
 
     This keeps the existing VL flow intact while extending it with audio-aware
-    paths for processors that accept audio inputs.
+    paths needed by Qwen3-Omni and generic audio-input processors.
     """
     processor_kwargs = dict(mm_processor_kwargs or {})
     if audio is not None and "sampling_rate" not in processor_kwargs:
@@ -123,15 +188,14 @@ def build_multimodal_processor_inputs(
     videos, video_metadata = _split_videos_and_metadata(videos)
     processor_kwargs.setdefault("return_tensors", return_tensors)
 
+    if is_qwen3_omni_processor(processor):
+        return processor(text=text, images=images, videos=videos, audio=audio, **processor_kwargs)
+
     if video_metadata is not None:
         processor_kwargs.setdefault("video_metadata", video_metadata)
         processor_kwargs.setdefault("do_sample_frames", False)
 
-    processor_inputs = {"text": text, "images": images, "videos": videos, **processor_kwargs}
-    if audio is not None:
-        processor_inputs["audio"] = audio
-
-    return processor(**processor_inputs)
+    return processor(text=text, images=images, videos=videos, **processor_kwargs)
 
 
 def set_pad_token_id(tokenizer):
@@ -147,6 +211,42 @@ def set_pad_token_id(tokenizer):
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
         warnings.warn(f"tokenizer.pad_token is None. Now set to {tokenizer.eos_token}", stacklevel=1)
+
+
+def _load_external_chat_template(name_or_path, **kwargs):
+    # Some HF model repos (e.g. Qwen3-Omni) keep ``chat_template`` in a
+    # standalone ``chat_template.json`` rather than ``tokenizer_config.json``.
+    # ``AutoTokenizer`` does not consume that file, so the resulting tokenizer
+    # has ``chat_template is None``. Load it here as a fallback.
+    try:
+        from transformers.utils import cached_file
+    except ImportError:
+        return None
+
+    cached_file_kwargs = {
+        k: kwargs[k]
+        for k in ("cache_dir", "revision", "token", "proxies", "local_files_only", "trust_remote_code")
+        if k in kwargs
+    }
+    try:
+        resolved = cached_file(
+            name_or_path,
+            "chat_template.json",
+            _raise_exceptions_for_missing_entries=False,
+            _raise_exceptions_for_connection_errors=False,
+            **cached_file_kwargs,
+        )
+    except Exception:
+        return None
+
+    if not resolved:
+        return None
+
+    try:
+        with open(resolved) as f:
+            return json.load(f).get("chat_template")
+    except (OSError, ValueError):
+        return None
 
 
 def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kwargs):
@@ -174,6 +274,10 @@ def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kw
         kwargs["eos_token"] = "<end_of_turn>"
         kwargs["eos_token_id"] = 107
     tokenizer = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
+    if getattr(tokenizer, "chat_template", None) is None:
+        external_template = _load_external_chat_template(name_or_path, **kwargs)
+        if external_template:
+            tokenizer.chat_template = external_template
     if correct_pad_token:
         set_pad_token_id(tokenizer)
     return tokenizer
@@ -203,7 +307,25 @@ def hf_processor(name_or_path, **kwargs):
         config = AutoConfig.from_pretrained(name_or_path, **kwargs)
 
         # Bind vlm model's get_rope_index method to processor.
-        processor.config = config
+        #
+        # For Qwen3-Omni, the bound ``get_rope_index`` is
+        # ``Qwen3OmniMoeThinkerForConditionalGeneration.get_rope_index`` and it
+        # reads ``self.config.vision_start_token_id`` / ``image_token_id`` /
+        # ``audio_start_token_id`` / ``position_id_per_seconds``. These attrs
+        # live on ``thinker_config``; the outer ``Qwen3OmniMoeConfig`` has
+        # ``im_start_token_id=151644`` which shadows ``vision_start_token_id``
+        # (151652) when used here. Binding the outer config makes the image
+        # branch of ``get_rope_index`` silently drop to the 1D-cumsum
+        # fallback: ``vision_start_indices`` points at ``<|im_start|>`` tokens
+        # instead of ``<|vision_start|>``, so ``image_nums`` evaluates to 0
+        # and 3D MRope for the image block is never applied. This leaves the
+        # actor forward disagreeing with the vLLM rollout (which uses the
+        # thinker config) and inflates ``rollout_probs_diff`` on image+audio
+        # samples by ~10x.
+        if processor.__class__.__name__ == "Qwen3OmniMoeProcessor":
+            processor.config = getattr(config, "thinker_config", config)
+        else:
+            processor.config = config
         model_class = None
         match processor.__class__.__name__:
             case "Qwen2VLProcessor":
@@ -218,6 +340,10 @@ def hf_processor(name_or_path, **kwargs):
                 from transformers.models.qwen3_vl import Qwen3VLModel
 
                 model_class = Qwen3VLModel
+            case "Qwen3OmniMoeProcessor":
+                from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+                model_class = Qwen3OmniMoeThinkerForConditionalGeneration
             case "Glm4vImageProcessor":
                 from transformers.models.glm4v import Glm4vModel
 
@@ -229,8 +355,14 @@ def hf_processor(name_or_path, **kwargs):
 
         if model_class is not None:
             processor.get_rope_index = types.MethodType(model_class.get_rope_index, processor)
-            if hasattr(model_class, "get_vision_position_ids"):
-                processor.get_vision_position_ids = types.MethodType(model_class.get_vision_position_ids, processor)
+            # Qwen3-Omni's get_rope_index internally calls
+            # self.get_llm_pos_ids_for_vision when images/videos are present;
+            # bind it so mixed audio+vision batches don't AttributeError.
+            for helper_name in ("get_vision_position_ids", "get_llm_pos_ids_for_vision"):
+                helper = getattr(model_class, helper_name, None)
+                if helper is not None:
+                    setattr(processor, helper_name, types.MethodType(helper, processor))
+            _ensure_qwen3_omni_processor_attrs(processor)
     except Exception as e:
         processor = None
         # TODO(haibin.lin): try-catch should be removed after adding transformer version req to setup.py to avoid
@@ -240,5 +372,10 @@ def hf_processor(name_or_path, **kwargs):
     # https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/models/auto/processing_auto.py#L344
     if processor is not None and "Processor" not in processor.__class__.__name__:
         processor = None
+
+    if processor is not None and getattr(processor, "chat_template", None) is None:
+        external_template = _load_external_chat_template(name_or_path, **kwargs)
+        if external_template:
+            processor.chat_template = external_template
 
     return processor

--- a/verl/utils/vllm/patch.py
+++ b/verl/utils/vllm/patch.py
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+from collections.abc import Iterable
+from functools import wraps
+
+import torch
+
 # To support different vLLM versions, we add the model into SUPPORTED_MOE_MODELS separately to avoid triggering
 # unsupported issues.
 SUPPORTED_MOE_MODELS = []
@@ -140,3 +146,78 @@ def patch_vllm_moe_model_weight_loader(model):
         for name, param in mlp.named_parameters():
             if "w13_weight" in name or "w2_weight" in name:
                 param.weight_loader = experts.weight_loader
+
+
+_QWEN3_OMNI_PACKED_EXPERT_RE = re.compile(
+    r"^(?P<prefix>(?:(?:thinker|language_model)\.)?model\.layers\.\d+\.mlp\.experts)\."
+    r"(?P<kind>gate_up_proj|down_proj)(?:\.weight)?$"
+)
+_QWEN3_OMNI_THINKER_MAPPER_PATCHED = False
+
+
+def _expand_qwen3_omni_packed_moe_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+) -> Iterable[tuple[str, torch.Tensor]]:
+    for name, tensor in weights:
+        match = _QWEN3_OMNI_PACKED_EXPERT_RE.match(name)
+        if match is None or tensor.dim() != 3:
+            yield name, tensor
+            continue
+
+        prefix = match.group("prefix")
+        if match.group("kind") == "gate_up_proj":
+            gate_proj, up_proj = tensor.chunk(2, dim=1)
+            for expert_idx in range(tensor.shape[0]):
+                yield f"{prefix}.{expert_idx}.gate_proj.weight", gate_proj[expert_idx]
+                yield f"{prefix}.{expert_idx}.up_proj.weight", up_proj[expert_idx]
+        else:
+            for expert_idx in range(tensor.shape[0]):
+                yield f"{prefix}.{expert_idx}.down_proj.weight", tensor[expert_idx]
+
+
+def _patch_qwen3_omni_thinker_load_weights(model_cls: type) -> None:
+    if getattr(model_cls, "_verl_packed_moe_load_weights_patched", False):
+        return
+
+    original_load_weights = model_cls.load_weights
+
+    @wraps(original_load_weights)
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        return original_load_weights(self, _expand_qwen3_omni_packed_moe_weights(weights))
+
+    model_cls.load_weights = load_weights
+    model_cls._verl_packed_moe_load_weights_patched = True
+
+
+def apply_qwen3_omni_thinker_patches() -> None:
+    # The training-side standalone thinker state_dict emits bare keys
+    # (``audio_tower.*``, ``model.*``, ``lm_head.*``), while vLLM's mapper
+    # only rewrites ``thinker.*`` prefixes. It also emits packed HF expert
+    # tensors that vLLM's generic Omni loader does not unpack itself. Patch
+    # both surfaces before rollout weight sync calls ``load_weights``.
+    global _QWEN3_OMNI_THINKER_MAPPER_PATCHED
+
+    try:
+        from vllm.model_executor.models.qwen3_omni_moe_thinker import (
+            Qwen3OmniMoeThinkerForConditionalGeneration,
+        )
+    except ImportError:
+        return
+
+    _patch_qwen3_omni_thinker_load_weights(Qwen3OmniMoeThinkerForConditionalGeneration)
+
+    if _QWEN3_OMNI_THINKER_MAPPER_PATCHED:
+        return
+
+    mapper = getattr(Qwen3OmniMoeThinkerForConditionalGeneration, "hf_to_vllm_mapper", None)
+    if mapper is None or not hasattr(mapper, "orig_to_new_prefix"):
+        return
+
+    extra = {
+        "lm_head.": "language_model.lm_head.",
+        "model.": "language_model.model.",
+    }
+    # Existing ``thinker.*`` rules run first (dict iteration order preserved);
+    # for bare keys those rules no-op and the new prefixes apply.
+    mapper.orig_to_new_prefix = {**mapper.orig_to_new_prefix, **extra}
+    _QWEN3_OMNI_THINKER_MAPPER_PATCHED = True

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -57,6 +57,7 @@ from verl.utils.fsdp_utils import (
     normalize_peft_param_name,
     offload_fsdp_model_to_cpu,
     offload_fsdp_optimizer,
+    register_filtered_forward_input_cast_hooks,
     replace_lora_wrapper,
 )
 from verl.utils.model import convert_weight_keys, extract_multi_modal_inputs
@@ -230,8 +231,18 @@ class FSDPEngine(BaseEngine):
 
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
+        # For composite configs like Qwen3-Omni (`model_type="qwen3_omni_moe"`), the
+        # outer config is only a container of sub-configs and does not expose common
+        # fields such as `tie_word_embeddings` (transformers>=5.3). Resolve the
+        # effective text/decoder config up-front so it is used both for meta-init
+        # gating and for `from_pretrained(config=...)`.
+        hf_effective_config = self.model_config.hf_config
+        if getattr(self.model_config.hf_config, "model_type", None) == "qwen3_omni_moe":
+            hf_effective_config = self.model_config.hf_config.thinker_config
+
         init_context = get_init_weight_context_manager(
-            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
+            use_meta_tensor=not getattr(hf_effective_config, "tie_word_embeddings", False),
+            mesh=self.device_mesh,
         )
 
         with init_context(), warnings.catch_warnings():
@@ -243,7 +254,7 @@ class FSDPEngine(BaseEngine):
                 module = auto_class.from_pretrained(
                     pretrained_model_name_or_path=self.model_config.local_path,
                     torch_dtype=torch_dtype,
-                    config=self.model_config.hf_config,
+                    config=hf_effective_config,
                     trust_remote_code=self.model_config.trust_remote_code,
                 )
             else:
@@ -344,7 +355,17 @@ class FSDPEngine(BaseEngine):
             reduce_dtype = torch.float32
             buffer_dtype = torch.float32
 
-        mixed_precision = MixedPrecision(param_dtype=param_dtype, reduce_dtype=reduce_dtype, buffer_dtype=buffer_dtype)
+        # Disable FSDP's blanket forward-input cast. verl installs a filtered
+        # replacement hook below so coordinate-like inputs (e.g. Qwen3-Omni
+        # fractional position_ids) can stay in fp32 while regular floating
+        # inputs are still cast to the parameter compute dtype.
+        mixed_precision = MixedPrecision(
+            param_dtype=param_dtype,
+            reduce_dtype=reduce_dtype,
+            buffer_dtype=buffer_dtype,
+            cast_forward_inputs=False,
+            cast_root_forward_inputs=False,
+        )
 
         self._autocast_dtype = param_dtype
         # fp16 training requires loss scaling to avoid gradient underflow. Mirror the pattern
@@ -399,7 +420,7 @@ class FSDPEngine(BaseEngine):
             # - ref: CPUOffloadPolicy(pin_memory=True)
             assert CPUOffloadPolicy is not None, "PyTorch version >= 2.4 is required for using fully_shard API (FSDP2)"
             mp_policy = MixedPrecisionPolicy(
-                param_dtype=param_dtype, reduce_dtype=reduce_dtype, cast_forward_inputs=True
+                param_dtype=param_dtype, reduce_dtype=reduce_dtype, cast_forward_inputs=False
             )
             offload_policy = None
             if self.engine_config.offload_policy or self.engine_config.forward_only:
@@ -418,6 +439,10 @@ class FSDPEngine(BaseEngine):
             fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
         else:
             raise NotImplementedError(f"Unknown strategy {self.engine_config.strategy}")
+
+        self._filtered_forward_input_cast_hook_handles = register_filtered_forward_input_cast_hooks(
+            module, param_dtype, self.engine_config.strategy
+        )
 
         if self.model_config.enable_activation_offload:
             enable_gradient_checkpointing = self.model_config.enable_gradient_checkpointing
@@ -784,7 +809,17 @@ class FSDPEngine(BaseEngine):
     def get_per_tensor_param(self, layered_summon=False, base_sync_done=False, **kwargs):
         log_gpu_memory_usage("Before load_fsdp_model_to_gpu", logger=logger)
 
-        load_fsdp_model_to_gpu(self.module)
+        # When FSDP2 is wrapped with CPUOffloadPolicy (engine_config.offload_policy=True),
+        # params are pinned on CPU and FSDP2 itself streams them to GPU during forward.
+        # Manually calling load_fsdp_model_to_gpu breaks that invariant: the next
+        # state_dict() triggers DTensor dispatch + return_and_correct_aliasing, which
+        # in torch>=2.4 strictly checks that local-tensor device matches DTensor metadata
+        # and raises "Attempted to set the storage of a tensor on device cpu to a storage
+        # on different device cuda:0". The per-param .to(device).full_tensor() below
+        # already all-gathers correctly, so only manually load when params were manually
+        # offloaded (mirrors the offload_fsdp_model_to_cpu gate below).
+        if self._is_offload_param:
+            load_fsdp_model_to_gpu(self.module)
 
         log_gpu_memory_usage("After load_fsdp_model_to_gpu", logger=logger)
 
@@ -985,7 +1020,6 @@ class FSDPEngineWithLMHead(FSDPEngine):
             output_args["temperature_rmpad"] = temperature_rmpad
 
             # only pass input_ids and position_ids to enable flash_attn_varlen
-
             model_inputs = {
                 "input_ids": input_ids_rmpad,
                 "attention_mask": None,
@@ -1046,7 +1080,13 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
         return model_inputs, output_args
 
-    def prepare_model_outputs(self, output, output_args, micro_batch: TensorDict, logits_processor_func):
+    def prepare_model_outputs(
+        self,
+        output,
+        output_args,
+        micro_batch: TensorDict,
+        logits_processor_func,
+    ):
         use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         pad_mode = tu.get_non_tensor_data(data=micro_batch, key="pad_mode", default=DatasetPadMode.NO_PADDING)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
@@ -1225,7 +1265,10 @@ class FSDPEngineWithLMHead(FSDPEngine):
             )  # prevent model thinks we are generating
 
             model_output = self.prepare_model_outputs(
-                output=raw_output, output_args=output_args, micro_batch=micro_batch, logits_processor_func=loss_function
+                output=raw_output,
+                output_args=output_args,
+                micro_batch=micro_batch,
+                logits_processor_func=loss_function,
             )
 
             if loss_function is not None:

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -130,6 +130,8 @@ class LLMServerClient:
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
@@ -144,12 +146,18 @@ class LLMServerClient:
         """
         server_id, server = await self._acquire_server(request_id)
         try:
+            multimodal_kwargs = {}
+            if audio_data is not None:
+                multimodal_kwargs["audio_data"] = audio_data
+            if mm_processor_kwargs:
+                multimodal_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
             output: TokenOutput = await server.generate.remote(
                 request_id=uuid4().hex,  # use new request_id for each turn
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=image_data,
                 video_data=video_data,
+                **multimodal_kwargs,
                 **kwargs,
             )
             return output
@@ -171,6 +179,9 @@ class FullyLLMServerClient(LLMServerClient):
         sampling_params: dict[str, Any],
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
 
@@ -208,6 +219,9 @@ class FullyLLMServerClient(LLMServerClient):
                 sampling_params=sampling_params,
                 image_data=image_data,
                 video_data=video_data,
+                audio_data=audio_data,
+                mm_processor_kwargs=mm_processor_kwargs,
+                **kwargs,
             )
 
             # 2. merge output into final_output

--- a/verl/workers/rollout/schemas.py
+++ b/verl/workers/rollout/schemas.py
@@ -24,6 +24,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, Processor
 
 from verl.tools.schemas import OpenAIFunctionToolCall, OpenAIFunctionToolSchema, ToolResponse
 from verl.utils.model import compute_position_id_with_mask
+from verl.utils.tokenizer import build_multimodal_processor_inputs
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -90,6 +91,7 @@ class AsyncRolloutRequest(BaseModel):
     multi_modal_keys: Optional[list[str]] = None
     multi_modal_data: Optional[dict[str, Any]] = None
     multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None
+    mm_processor_kwargs: Optional[dict[str, Any]] = None
     tool_schemas: Optional[list[OpenAIFunctionToolSchema]] = None
     tools_kwargs: dict[str, Any] = {}
     input_ids: Optional[torch.Tensor] = None
@@ -130,9 +132,9 @@ class AsyncRolloutRequest(BaseModel):
 
         values["messages"] = [Message.model_validate(msg) for msg in messages]
 
-        # If there is no multi_modal_keys, we assume the multi-modal data is image and video.
+        # If there is no multi_modal_keys, we assume the multi-modal data is image, video and audio.
         if not values.get("multi_modal_keys"):
-            values["multi_modal_keys"] = ["image", "video"]
+            values["multi_modal_keys"] = ["image", "video", "audio"]
         if not values.get("multi_modal_data"):
             values["multi_modal_data"] = {key: [] for key in values["multi_modal_keys"]}
         else:
@@ -142,16 +144,20 @@ class AsyncRolloutRequest(BaseModel):
                     values["multi_modal_data"][key] = []
         if not values.get("multi_modal_inputs"):
             values["multi_modal_inputs"] = {}
+        if not values.get("mm_processor_kwargs"):
+            values["mm_processor_kwargs"] = {}
 
         tools = (
             [tool.model_dump() for tool in tool_schemas] if (tool_schemas := values.get("tool_schemas", [])) else None
         )
 
         multi_modal_data = values["multi_modal_data"]
+        mm_processor_kwargs = values["mm_processor_kwargs"]
         tokens_without_prompt = cls._handle_apply_chat_template(
             processing_class,
             messages,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -165,6 +171,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=multi_modal_data,
+                mm_processor_kwargs=mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -193,7 +200,11 @@ class AsyncRolloutRequest(BaseModel):
             values["multi_modal_inputs"] = multi_modal_inputs
 
             values["position_ids"] = values["prompt_position_ids"] = cls._get_position_ids(
-                processing_class, values["input_ids"], values["attention_mask"], multi_modal_inputs
+                processing_class,
+                values["input_ids"],
+                values["attention_mask"],
+                multi_modal_inputs,
+                mm_processor_kwargs=mm_processor_kwargs,
             )
 
         values["prompt_ids"], values["prompt_attention_mask"] = values["input_ids"], values["attention_mask"]
@@ -203,6 +214,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             BASE_CHAT_HISTORY,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -212,6 +224,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             BASE_CHAT_HISTORY,
             multi_modal_data=multi_modal_data,
+            mm_processor_kwargs=mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=True,
             tokenize=True,
@@ -224,6 +237,7 @@ class AsyncRolloutRequest(BaseModel):
         processing_class: PreTrainedTokenizer | PreTrainedTokenizerFast | ProcessorMixin,
         messages: list[Message],
         multi_modal_data: dict[str, Any],
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         tools: Optional[list[OpenAIFunctionToolSchema]] = None,
         add_generation_prompt: bool = False,
         tokenize: bool = False,
@@ -242,13 +256,22 @@ class AsyncRolloutRequest(BaseModel):
                 )
             model_inputs = processing_class(text=[raw_prompt], return_tensors="pt")
         elif isinstance(processing_class, ProcessorMixin):
-            # When we update multi_model_keys, we also need to update this logic
             images = images if len(images := multi_modal_data.get("image", [])) > 0 else None
             videos = videos if len(videos := multi_modal_data.get("video", [])) > 0 else None
-            model_inputs = processing_class(text=[raw_prompt], images=images, videos=videos, return_tensors="pt")
+            audio = audio if len(audio := multi_modal_data.get("audio", [])) > 0 else None
+            model_inputs = build_multimodal_processor_inputs(
+                processing_class,
+                text=[raw_prompt],
+                images=images,
+                videos=videos,
+                audio=audio,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
         else:
             raise ValueError(f"Unsupported processing class type: {type(processing_class)}")
 
+        if hasattr(model_inputs, "convert_to_tensors"):
+            model_inputs = model_inputs.convert_to_tensors("pt")
         model_inputs = dict(model_inputs)
         if return_dict:
             return model_inputs
@@ -261,6 +284,7 @@ class AsyncRolloutRequest(BaseModel):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> torch.Tensor:
         # special case for qwen2vl
         is_qwen2vl = (
@@ -315,7 +339,11 @@ class AsyncRolloutRequest(BaseModel):
             self._update_multi_modal_inputs(new_multi_modal_inputs)
 
         new_position_ids = self._get_position_ids(
-            processing_class, new_input_ids, attention_mask, new_multi_modal_inputs
+            processing_class,
+            new_input_ids,
+            attention_mask,
+            new_multi_modal_inputs,
+            mm_processor_kwargs=self.mm_processor_kwargs,
         )
 
         last_pos = self.position_ids[..., -1:]
@@ -366,6 +394,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=self.multi_modal_data,
+                mm_processor_kwargs=self.mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=True,
                 tokenize=True,
@@ -386,7 +415,13 @@ class AsyncRolloutRequest(BaseModel):
         # We don't need to pass multi_modal_data here because we don't have any multi-modal data from Engine
         # Inference, it is pure text.
         content_ids = self._handle_apply_chat_template(
-            processing_class, messages, multi_modal_data={}, tools=tools, add_generation_prompt=False, tokenize=True
+            processing_class,
+            messages,
+            multi_modal_data={},
+            mm_processor_kwargs={},
+            tools=tools,
+            add_generation_prompt=False,
+            tokenize=True,
         )[..., self.base_conv_wo_gen_prompt_end_pos :]
         self._update_input_ids(processing_class, content_ids, attention_mask=True, loss_mask=False)
 
@@ -405,7 +440,13 @@ class AsyncRolloutRequest(BaseModel):
             # We don't need to pass multi_modal_data here because we don't have any multi-modal data from Engine
             # Inference, it is pure text.
             content_ids = self._handle_apply_chat_template(
-                processing_class, messages, multi_modal_data={}, tools=tools, add_generation_prompt=False, tokenize=True
+                processing_class,
+                messages,
+                multi_modal_data={},
+                mm_processor_kwargs={},
+                tools=tools,
+                add_generation_prompt=False,
+                tokenize=True,
             )[..., self.base_conv_with_gen_prompt_end_pos :]
         self._update_input_ids(processing_class, content_ids, attention_mask=True, loss_mask=True)
 
@@ -447,6 +488,7 @@ class AsyncRolloutRequest(BaseModel):
             processing_class,
             messages,
             multi_modal_data=delta_multi_modal_data,
+            mm_processor_kwargs=self.mm_processor_kwargs,
             tools=tools,
             add_generation_prompt=False,
             tokenize=True,
@@ -571,6 +613,7 @@ class AsyncRolloutRequest(BaseModel):
                 processing_class,
                 messages,
                 multi_modal_data=self.multi_modal_data,
+                mm_processor_kwargs=self.mm_processor_kwargs,
                 tools=tools,
                 add_generation_prompt=False,
                 tokenize=True,

--- a/verl/workers/rollout/schemas.py
+++ b/verl/workers/rollout/schemas.py
@@ -24,7 +24,7 @@ from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast, Processor
 
 from verl.tools.schemas import OpenAIFunctionToolCall, OpenAIFunctionToolSchema, ToolResponse
 from verl.utils.model import compute_position_id_with_mask
-from verl.utils.tokenizer import build_multimodal_processor_inputs
+from verl.utils.tokenizer import build_multimodal_processor_inputs, is_qwen3_omni_processor
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -286,6 +286,7 @@ class AsyncRolloutRequest(BaseModel):
         multi_modal_inputs: Optional[dict[str, torch.Tensor]] = None,
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> torch.Tensor:
+        mm_processor_kwargs = mm_processor_kwargs or {}
         # special case for qwen2vl
         is_qwen2vl = (
             hasattr(processing_class, "image_processor")
@@ -315,6 +316,39 @@ class AsyncRolloutRequest(BaseModel):
                 attention_mask=attention_mask.squeeze(0),
             )
             return new_position_ids  # (3, seq_len)
+        elif is_qwen3_omni_processor(processing_class):
+            from verl.models.transformers.qwen3_omni_moe import get_rope_index as qwen3_omni_get_rope_index
+
+            image_grid_thw = video_grid_thw = video_second_per_grid = feature_attention_mask = None
+            if multi_modal_inputs:
+                image_grid_thw = multi_modal_inputs.get("image_grid_thw")
+                video_grid_thw = multi_modal_inputs.get("video_grid_thw")
+                video_second_per_grid = multi_modal_inputs.get("video_second_per_grid")
+                feature_attention_mask = multi_modal_inputs.get("feature_attention_mask")
+
+            audio_seqlens = None
+            if feature_attention_mask is not None:
+                audio_seqlens = feature_attention_mask.sum(dim=-1)
+
+            new_position_ids, _ = qwen3_omni_get_rope_index(
+                processing_class,
+                input_ids=input_ids,
+                image_grid_thw=image_grid_thw,
+                video_grid_thw=video_grid_thw,
+                attention_mask=attention_mask,
+                use_audio_in_video=bool(mm_processor_kwargs.get("use_audio_in_video", False)),
+                audio_seqlens=audio_seqlens,
+                second_per_grids=video_second_per_grid,
+            )
+            # vLLM's Qwen3-Omni MRope consumes ``(3, seq_len)`` directly — do
+            # NOT prepend a text axis here. The training-side counterpart
+            # (``AgentLoopWorker._compute_position_ids``) adds the text axis so
+            # HF's ``Qwen3OmniMoeThinkerTextModel`` sees ``(4, bs, seq)``.
+            return (
+                new_position_ids.squeeze(1)
+                if new_position_ids.dim() == 3 and new_position_ids.shape[1] == 1
+                else new_position_ids
+            )
         else:
             return compute_position_id_with_mask(attention_mask)  # (1, seq_len)
 

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -317,6 +317,8 @@ class TRTLLMHttpServer:
         request_id: str,
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> TokenOutput:
         from tensorrt_llm.llmapi import SamplingParams
 
@@ -337,6 +339,9 @@ class TRTLLMHttpServer:
         sampling_params.update(self.sampling_args)
 
         trt_llm_sampling_params = SamplingParams(**sampling_params)
+        if audio_data is not None:
+            raise NotImplementedError("TRT-LLM rollout does not support audio inputs yet.")
+
         await self._generation_allowed.wait()
         if self.is_vlm_model and (image_data or video_data):
             deduped_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
@@ -344,7 +349,7 @@ class TRTLLMHttpServer:
             input_dict = {
                 "prompt": org_prompt,
                 "multi_modal_data": {},
-                "mm_processor_kwargs": {},
+                "mm_processor_kwargs": dict(mm_processor_kwargs or {}),
             }
             if image_data:
                 input_dict["multi_modal_data"]["image"] = image_data

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -29,7 +29,7 @@ from verl.utils.net_utils import is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
-from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
+from verl.workers.rollout.utils import dedup_mm_placeholder_tokens, get_max_position_embeddings, run_uvicorn
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.INFO)
@@ -344,7 +344,7 @@ class TRTLLMHttpServer:
 
         await self._generation_allowed.wait()
         if self.is_vlm_model and (image_data or video_data):
-            deduped_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
+            deduped_ids = dedup_mm_placeholder_tokens(prompt_ids, self.model_config.processor)
             org_prompt = self.llm.tokenizer.decode(deduped_ids)
             input_dict = {
                 "prompt": org_prompt,

--- a/verl/workers/rollout/utils.py
+++ b/verl/workers/rollout/utils.py
@@ -21,6 +21,7 @@ import uvicorn
 import yaml
 from fastapi import FastAPI
 
+from verl.utils.tokenizer import get_processor_token_id, is_qwen3_omni_processor
 from verl.workers.config.rollout import PrometheusConfig
 
 logger = logging.getLogger(__file__)
@@ -33,6 +34,14 @@ def get_max_position_embeddings(hf_config) -> int:
         text_config = getattr(hf_config, "text_config", None)
         if text_config is not None:
             max_len = getattr(text_config, "max_position_embeddings", None)
+    if max_len is None:
+        thinker_config = getattr(hf_config, "thinker_config", None)
+        if thinker_config is not None:
+            max_len = getattr(thinker_config, "max_position_embeddings", None)
+            if max_len is None:
+                text_config = getattr(thinker_config, "text_config", None)
+                if text_config is not None:
+                    max_len = getattr(text_config, "max_position_embeddings", None)
 
     if max_len is None:
         raise ValueError("max_position_embeddings not found in HFModelConfig!")
@@ -89,28 +98,93 @@ async def ensure_async_iterator(iterable):
             yield item
 
 
-def qwen2_5_vl_dedup_image_tokens(prompt_ids: list[int], processor):
-    """Deduplicate consecutive image tokens in prompt_ids for Qwen2.5-VL, since vLLM will replicate the
-    <|image_pad|> and <|video_pad|> token by image_data.
-    For example,
+def _has_qwen2_vl_image_processor(processor) -> bool:
+    return (
+        processor is not None
+        and hasattr(processor, "image_processor")
+        and "Qwen2VLImageProcessor" in processor.image_processor.__class__.__name__
+    )
+
+
+def _collapse_consecutive_ids(prompt_ids: list[int], placeholder_ids: set[int]) -> list[int]:
+    """Collapse each consecutive run of ``placeholder_ids`` down to one token.
+
+    Boundary tokens (``<|vision_start|>``, ``<|audio_end|>``, etc.) stay in
+    place because they are not in ``placeholder_ids``, so they act as
+    separators between independent runs.
+    """
+    if not placeholder_ids:
+        return prompt_ids
+
+    arr = np.asarray(prompt_ids)
+    if arr.size == 0:
+        return prompt_ids
+
+    is_placeholder = np.zeros(arr.size, dtype=bool)
+    for token_id in placeholder_ids:
+        is_placeholder |= arr == token_id
+
+    mask = np.ones(arr.size, dtype=bool)
+    mask[1:] &= ~(is_placeholder[1:] & is_placeholder[:-1])
+    return arr[mask].tolist()
+
+
+def dedup_mm_placeholder_tokens(prompt_ids: list[int], processor) -> list[int]:
+    """Collapse runs of multimodal placeholder tokens before sending to vLLM.
+
+    vLLM's multimodal prompt-replacement mechanism finds the *first* target
+    placeholder token in ``prompt_token_ids`` and replaces it with the full
+    expansion for that modality (e.g. N audio tokens). Any additional,
+    pre-expanded placeholder tokens that the training-side processor already
+    emitted would otherwise be left untouched, producing a doubly-expanded
+    sequence of length roughly ``2N`` and silently decoupling the rollout
+    distribution from the training distribution.
+
+    Example (Qwen2.5-VL / Qwen3-Omni image run):
+
     ```
     <|vision_start|><|image_pad|><|image_pad|>...<|image_pad|><|vision_end|>
     =>
     <|vision_start|><|image_pad|><|vision_end|>
     ```
+
+    For Qwen3-Omni the same collapse is also applied to the ``<|audio_pad|>``
+    run so audio and image rollouts stay aligned with the transformers
+    forward used by the actor / critic.
+
+    If the processor is not one of the supported families, the input is
+    returned unchanged.
     """
-    if (
-        processor is not None
-        and hasattr(processor, "image_processor")
-        and "Qwen2VLImageProcessor" in processor.image_processor.__class__.__name__
-    ):
-        prompt_ids = np.array(prompt_ids)
-        mask = np.ones(len(prompt_ids), dtype=bool)
-        is_value = (prompt_ids == processor.image_token_id) | (prompt_ids == processor.video_token_id)
-        mask[1:] &= ~(is_value[1:] & is_value[:-1])
-        return prompt_ids[mask].tolist()
+    if processor is None:
+        return prompt_ids
+
+    placeholder_ids: set[int] = set()
+
+    if is_qwen3_omni_processor(processor):
+        for token_name in ("image", "video", "audio"):
+            token_id = get_processor_token_id(processor, token_name)
+            if token_id is not None:
+                placeholder_ids.add(token_id)
+    elif _has_qwen2_vl_image_processor(processor):
+        image_token_id = get_processor_token_id(processor, "image")
+        video_token_id = get_processor_token_id(processor, "video")
+        if image_token_id is None or video_token_id is None:
+            return prompt_ids
+        placeholder_ids.update({image_token_id, video_token_id})
     else:
         return prompt_ids
+
+    return _collapse_consecutive_ids(prompt_ids, placeholder_ids)
+
+
+def qwen2_5_vl_dedup_image_tokens(prompt_ids: list[int], processor):
+    """Backwards-compatible alias for :func:`dedup_mm_placeholder_tokens`.
+
+    Kept so existing rollout engines (vLLM / TRT-LLM async servers) continue
+    to compile without import churn; new code should call
+    ``dedup_mm_placeholder_tokens`` directly.
+    """
+    return dedup_mm_placeholder_tokens(prompt_ids, processor)
 
 
 def update_prometheus_config(config: PrometheusConfig, server_addresses: list[str], rollout_name: str | None = None):

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -26,7 +26,10 @@ from vllm.outputs import RequestOutput
 
 from verl.utils.device import is_npu_available
 from verl.utils.vllm import TensorLoRARequest, VLLMHijack
-from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
+from verl.utils.vllm.patch import (
+    apply_qwen3_omni_thinker_patches,
+    patch_vllm_moe_model_weight_loader,
+)
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
 
 logger = logging.getLogger(__file__)
@@ -122,10 +125,12 @@ class vLLMColocateWorkerExtension:
 
         # 1. patch for Lora
         VLLMHijack.hijack()
-        # 2. patch online fp8 quant
+        # 2. patch Qwen3-Omni thinker weight loading for standalone thinker state_dicts
+        apply_qwen3_omni_thinker_patches()
+        # 3. patch online fp8 quant
         if os.environ.get("VERL_VLLM_FP8_QUANT_ENABLED", "0") == "1":
             apply_vllm_fp8_patches()
-        # 3. patch QAT (compressed-tensors NVFP4) for dynamic weight loading
+        # 4. patch QAT (compressed-tensors NVFP4) for dynamic weight loading
         vllm_config = kwargs.get("vllm_config")
         quant_config = getattr(vllm_config, "quant_config", None) if vllm_config else None
         _is_qat_model = getattr(quant_config, "quant_format", None) == "nvfp4-pack-quantized"
@@ -219,9 +224,8 @@ class vLLMColocateWorkerExtension:
             # Some post-load transforms are non-idempotent; run once after all buckets.
             from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
-            model = self.model_runner.model
             model_config = self.model_runner.vllm_config.model_config
-            process_weights_after_loading(model, model_config, self.device)
+            process_weights_after_loading(self.model_runner.model, model_config, self.device)
 
     def _update_weights(self, weights: list[tuple[str, torch.Tensor]], peft_config: dict, base_sync_done: bool):
         if peft_config and base_sync_done:
@@ -245,6 +249,7 @@ class vLLMColocateWorkerExtension:
                 logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
             else:
                 logger.info("Loading standard weights (non-FP8, async)")
+                apply_qwen3_omni_thinker_patches()
                 self.model_runner.model.load_weights(weights)
 
     def _get_zmq_handle(self) -> str:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -55,6 +55,7 @@ from verl.workers.rollout.vllm_rollout.utils import (
 
 _VLLM_VERSION = version.parse(vllm.__version__)
 
+
 if _VLLM_VERSION > version.parse("0.11.0"):
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -450,6 +451,8 @@ class vLLMHttpServer:
         request_id: str,
         image_data: Optional[list[Any]] = None,
         video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
         priority: int = 0,
     ) -> TokenOutput:
         """Generate sequence with token-in-token-out."""
@@ -493,8 +496,16 @@ class vLLMHttpServer:
             multi_modal_data["image"] = image_data
         if video_data is not None:
             multi_modal_data["video"] = video_data
+        if audio_data is not None:
+            multi_modal_data["audio"] = audio_data
 
-        prompt = TokensPrompt(prompt_token_ids=prompt_ids, multi_modal_data=multi_modal_data)
+        prompt_kwargs = {"prompt_token_ids": prompt_ids, "multi_modal_data": multi_modal_data}
+        if mm_processor_kwargs:
+            prompt_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
+        try:
+            prompt = TokensPrompt(**prompt_kwargs)
+        except TypeError:
+            prompt = prompt_kwargs
 
         # Add lora request
         lora_request = None

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -42,7 +42,7 @@ from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
-from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
+from verl.workers.rollout.utils import dedup_mm_placeholder_tokens, get_max_position_embeddings, run_uvicorn
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
     VLLM_LORA_NAME,
@@ -490,7 +490,7 @@ class vLLMHttpServer:
         sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
         sampling_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
-        prompt_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
+        prompt_ids = dedup_mm_placeholder_tokens(prompt_ids, self.model_config.processor)
         multi_modal_data = {}
         if image_data is not None:
             multi_modal_data["image"] = image_data

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -64,7 +64,12 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
         else:  # (4, seq_len)
             valid_ids = curr_pos_ids[:, curr_mask]
         position_ids_list.append(valid_ids)
-    position_ids_nested = torch.nested.as_nested_tensor(position_ids_list, layout=torch.jagged)
+    if position_ids_list[0].dim() == 1:
+        position_ids_nested = torch.nested.as_nested_tensor(position_ids_list, layout=torch.jagged)
+    else:
+        position_ids_values = torch.cat(position_ids_list, dim=-1)
+        position_ids_nested = torch.nested.nested_tensor_from_jagged(position_ids_values, offsets=cu_seqlens)
+        position_ids_nested._ragged_idx = 2
 
     data["input_ids"] = input_ids_nested
     data["position_ids"] = position_ids_nested


### PR DESCRIPTION
## Summary

Split from #6118 and stacked on #6276. This PR adds the Qwen3-Omni thinker-specific layer on top of the generic audio data support:

- add Qwen3-Omni thinker processor/model detection and monkey patch registration
- preserve Qwen3-Omni multimodal processor kwargs through dataset, actor/FSDP, and rollout paths
- handle Qwen3-Omni 3D `position_ids`, padding, and FSDP forward compatibility
- patch vLLM weight mapping and multimodal placeholder deduplication for Qwen3-Omni audio/image placeholder runs
- add OmniInstruct preprocessing/reward helpers and an FSDP2 GSPO example script
- add focused CPU regression tests for Qwen3-Omni patching, rope index behavior, padding, reward scoring, and rollout placeholder deduplication

## Dependency

Depends on #6276. This draft PR is opened against `main` because I cannot create an upstream PR whose base branch lives only in the fork. Until #6276 lands and this branch is rebased, the GitHub diff will include the audio-data-support commit as its base layer.

## Duplicate check

Per `AGENTS.md`, I checked for duplicate work before opening this split PR:

- `gh issue view 6118 --repo verl-project/verl --comments`
- `gh pr list --repo verl-project/verl --state open --search "6118 in:body"`
- `gh pr list --repo verl-project/verl --state open --search "qwen3 omni thinker"`
- `gh pr list --repo verl-project/verl --state open --search "qwen3 omni audio"`

The checks found #6238 and #3297. This PR is materially different from #6238: #6238 focuses on `vllm_omni` / `vllm_omni_ar`, LoRA/FSDP, and verl-omni registry integration, while this PR carries the Qwen3-Omni thinker support split from #6118 on top of generic audio data plumbing, including processor kwargs, 3D position ids, vLLM weight mapping, placeholder deduplication, OmniInstruct reward/preprocess utilities, and a concrete FSDP2 GSPO example. #3297 targets older Qwen2.5-Omni/audio support and does not cover this Qwen3-Omni thinker path.

## Tests

- `git diff --check`
- `PYTHONPATH=. python -m py_compile examples/data_preprocess/omniinstruct_to_verl.py tests/models/transformers/test_qwen3_omni_get_rope_index_on_cpu.py tests/models/transformers/test_qwen3_omni_moe_patch_on_cpu.py tests/utils/reward_score/test_omniinstruct_on_cpu.py tests/utils/test_maybe_fix_3d_position_ids_on_cpu.py tests/utils/test_qwen3_omni_thinker_patch_on_cpu.py tests/workers/rollout/test_mm_placeholder_dedup_on_cpu.py verl/models/transformers/qwen3_omni_moe.py verl/utils/reward_score/omniinstruct.py`
- `PYTHONPATH=. pytest -q tests/utils/test_audio_input_support_on_cpu.py tests/models/transformers/test_qwen3_omni_get_rope_index_on_cpu.py tests/models/transformers/test_qwen3_omni_moe_patch_on_cpu.py tests/utils/reward_score/test_omniinstruct_on_cpu.py tests/utils/test_maybe_fix_3d_position_ids_on_cpu.py tests/utils/test_qwen3_omni_thinker_patch_on_cpu.py tests/workers/rollout/test_mm_placeholder_dedup_on_cpu.py tests/utils/test_padding_on_cpu.py::test_left_right_2_no_padding_keeps_equal_length_3d_position_ids_seq_ragged` (`46 passed, 2 skipped`)
- pre-commit hooks run during commit: passed

Local limitation: running the full `tests/utils/test_padding_on_cpu.py` file in this environment hit existing padding tests that require `flash_attn`; the new Qwen3 3D position-id padding regression test passed directly.

## AI assistance

AI assistance was used to split the original #6118 patch into this focused stacked PR. The human submitter should review every changed line and rerun relevant tests before marking the PR ready for review.
