### PR TITLE
[fsdp] fix: lenient resolution of _no_split_modules in get_fsdp_wrap_policy

### DIFF
--- a/tests/utils/test_fsdp_wrap_policy_on_cpu.py
+++ b/tests/utils/test_fsdp_wrap_policy_on_cpu.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for ``get_fsdp_wrap_policy``.
+
+These tests cover the lenient resolution of ``_no_split_modules``: HF
+``transformers`` sometimes ships forward-compat names alongside concrete
+classes (e.g. Qwen3.5 lists ``Qwen3_5TextDecoderLayer`` next to the real
+``Qwen3_5DecoderLayer``). The wrap policy should succeed as long as at least
+one name resolves and only fail when none do.
+"""
+
+import pytest
+import torch.nn as nn
+
+from verl.utils.fsdp_utils import get_fsdp_wrap_policy
+
+
+class _RealLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+
+class _PartiallyResolvableModel(nn.Module):
+    """Mirrors the Qwen3.5 case: one valid layer name + one unknown name."""
+
+    _no_split_modules = ["_RealLayer", "_NonExistentLayer"]
+
+    def __init__(self):
+        super().__init__()
+        self.layer = _RealLayer()
+
+
+class _AllUnresolvableModel(nn.Module):
+    _no_split_modules = ["_GhostLayerA", "_GhostLayerB"]
+
+    def __init__(self):
+        super().__init__()
+        self.layer = _RealLayer()
+
+
+def test_wrap_policy_skips_missing_layer_class_names(caplog):
+    """A single missing name in ``_no_split_modules`` must not break wrapping."""
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="verl.utils.fsdp_utils")
+
+    policy = get_fsdp_wrap_policy(_PartiallyResolvableModel())
+    assert policy is not None, "wrap policy should be built from the resolvable name"
+
+    # The user should be told which names were skipped.
+    assert any("_NonExistentLayer" in record.message for record in caplog.records), (
+        "Expected a warning listing the skipped layer class names"
+    )
+
+
+def test_wrap_policy_raises_when_no_layer_classes_resolve():
+    """If no name resolves, raise -- otherwise FSDP would silently no-op."""
+    with pytest.raises(Exception, match="Could not find any of the transformer layer classes"):
+        get_fsdp_wrap_policy(_AllUnresolvableModel())
+
+
+def test_wrap_policy_explicit_config_overrides_no_split_modules():
+    """Explicit ``transformer_layer_cls_to_wrap`` config takes precedence."""
+    model = _PartiallyResolvableModel()
+    config = {"transformer_layer_cls_to_wrap": ["_RealLayer"]}
+    policy = get_fsdp_wrap_policy(model, config=config)
+    assert policy is not None

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -15,6 +15,7 @@
 import functools
 import itertools
 import json
+import logging
 import math
 import os
 from abc import ABC
@@ -34,6 +35,8 @@ from transformers.trainer_pt_utils import get_module_class_from_name
 
 from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.model import check_exclude_modules, check_target_modules
+
+logger = logging.getLogger(__name__)
 
 if version.parse(torch.__version__) >= version.parse("2.6"):
     from torch.distributed.fsdp import CPUOffloadPolicy, FSDPModule, MixedPrecisionPolicy, fully_shard
@@ -124,12 +127,29 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
         policies.append(size_policy)
     elif fsdp_transformer_layer_cls_to_wrap is not None:
         transformer_cls_to_wrap = set()
+        missing_classes = []
         for layer_class in fsdp_transformer_layer_cls_to_wrap:
             transformer_cls = get_module_class_from_name(module, layer_class)
             if transformer_cls is None:
-                raise Exception("Could not find the transformer layer class to wrap in the model.")
+                # Some HF transformers releases expose names in `_no_split_modules` that are not
+                # (yet) concrete classes -- e.g. Qwen3.5 lists `Qwen3_5TextDecoderLayer` alongside
+                # the real `Qwen3_5DecoderLayer`. Skip such names and only fail if none resolve,
+                # so a single forward-compat name does not break the whole FSDP wrap policy.
+                missing_classes.append(layer_class)
             else:
                 transformer_cls_to_wrap.add(transformer_cls)
+
+        if not transformer_cls_to_wrap:
+            raise Exception(
+                f"Could not find any of the transformer layer classes to wrap in the model: "
+                f"{list(fsdp_transformer_layer_cls_to_wrap)}"
+            )
+        if missing_classes:
+            logger.warning(
+                "FSDP wrap policy: skipped missing layer class names %s, wrapping %s",
+                missing_classes,
+                sorted(c.__name__ for c in transformer_cls_to_wrap),
+            )
 
         transformer_policy = functools.partial(
             transformer_auto_wrap_policy,


### PR DESCRIPTION
### What does this PR do?

Fix `get_fsdp_wrap_policy` so that it tolerates partial resolution of `_no_split_modules`.

Today the loop demands every name in `_no_split_modules` resolve to a class on the model and raises `Exception("Could not find the transformer layer class to wrap in the model.")` on the first miss. HF `transformers` ships `_no_split_modules` lists that may include forward-compat / not-yet-exported names. As a concrete example, Qwen3.5-9B has:

```python
model._no_split_modules
# ['Qwen3_5DecoderLayer', 'Qwen3_5VisionBlock', 'Qwen3_5TextDecoderLayer']
```

…but `Qwen3_5TextDecoderLayer` is not yet a concrete class in `transformers==5.2.0`. The first two are real and would suffice for a correct FSDP wrap policy, but the strict loop raises before we get there.

This change:
- Skips names that don't resolve.
- Raises only if **none** of the names resolve (with a clearer message that includes the full list).
- Emits a `logger.warning` listing the skipped names and the classes that were actually wrapped, so the behavior is visible in logs.

Closes #6289.

### Checklist Before Starting

- [x] Search for similar PRs. Queried [`fsdp_utils transformer layer`](https://github.com/verl-project/verl/pulls?q=is%3Apr+fsdp_utils+transformer+layer), [`Could not find the transformer layer`](https://github.com/verl-project/verl/issues?q=Could+not+find+the+transformer+layer), and [`_no_split_modules`](https://github.com/verl-project/verl/issues?q=_no_split_modules) — none match.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

A new CPU unit test `tests/utils/test_fsdp_wrap_policy_on_cpu.py` covers:

1. `_no_split_modules = ["_RealLayer", "_NonExistentLayer"]` — wrap policy is built from the resolvable name and a warning is logged listing the skipped name.
2. `_no_split_modules = ["_GhostLayerA", "_GhostLayerB"]` — raises with the new descriptive message.
3. Explicit `transformer_layer_cls_to_wrap` config still overrides `_no_split_modules`.

The test is suffixed `_on_cpu.py` so it is picked up by `cpu_unit_tests.yml` (no GPU needed).

### API and Usage Example

No public API change. Models whose `_no_split_modules` previously caused

```
Exception: Could not find the transformer layer class to wrap in the model.
```

now train successfully as long as at least one listed name resolves, and emit a single warning like:

```
WARNING verl.utils.fsdp_utils: FSDP wrap policy: skipped missing layer class names ['Qwen3_5TextDecoderLayer'], wrapping ['Qwen3_5DecoderLayer', 'Qwen3_5VisionBlock']
```

### Design & Code Changes

- `verl/utils/fsdp_utils.py`: collect missing names, raise only when the resulting set is empty, warn otherwise. Added a module-level `logger`.
- `tests/utils/test_fsdp_wrap_policy_on_cpu.py`: new CPU unit test (3 cases).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks: `ruff check` + `ruff format --check` pass on changed files.
- [ ] Add / Update the documentation. *(Not needed — internal behavior change, no public API.)*
- [x] Add unit test(s) to the CI workflow (CPU unit test under `tests/utils/`).
