### PR TITLE
Fix PPO dataloader worker teardown

### DIFF
--- a/tests/utils/test_dataloader_lifecycle_on_cpu.py
+++ b/tests/utils/test_dataloader_lifecycle_on_cpu.py
@@ -1,0 +1,85 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from verl.utils.dataloader import shutdown_dataloader_workers, shutdown_dataloaders
+
+
+class _FakeIterator:
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def _shutdown_workers(self):
+        self.shutdown_calls += 1
+
+
+class _FailingIterator:
+    def _shutdown_workers(self):
+        raise RuntimeError("shutdown failed")
+
+
+class _FakeDataLoader:
+    def __init__(self, iterator=None):
+        self._iterator = iterator
+
+
+def test_shutdown_dataloader_workers_calls_iterator_shutdown():
+    iterator = _FakeIterator()
+    dataloader = _FakeDataLoader(iterator)
+
+    assert shutdown_dataloader_workers(dataloader) is True
+
+    assert iterator.shutdown_calls == 1
+    assert dataloader._iterator is None
+
+
+def test_shutdown_dataloader_workers_is_noop_without_iterator():
+    dataloader = _FakeDataLoader()
+
+    assert shutdown_dataloader_workers(dataloader) is False
+    assert dataloader._iterator is None
+
+
+def test_shutdown_dataloaders_skips_none_and_clears_iterators():
+    iterator = _FakeIterator()
+    dataloader = _FakeDataLoader(iterator)
+
+    shutdown_dataloaders(None, dataloader)
+
+    assert iterator.shutdown_calls == 1
+    assert dataloader._iterator is None
+
+
+def test_shutdown_dataloader_workers_does_not_raise_on_shutdown_error():
+    dataloader = _FakeDataLoader(_FailingIterator())
+
+    assert shutdown_dataloader_workers(dataloader) is False
+    assert dataloader._iterator is None
+
+
+def test_shutdown_stateful_dataloader_stops_worker_processes():
+    from torchdata.stateful_dataloader import StatefulDataLoader
+
+    dataloader = StatefulDataLoader(list(range(64)), batch_size=4, num_workers=2)
+    iterator = iter(dataloader)
+    next(iterator)
+    workers = list(getattr(iterator, "_workers", []))
+
+    assert workers
+    assert any(worker.is_alive() for worker in workers)
+    assert shutdown_dataloader_workers(dataloader) is True
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert dataloader._iterator is None
+    assert not any(worker.is_alive() for worker in workers)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -61,6 +61,7 @@ from verl.trainer.ppo.utils import (
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.dataloader import shutdown_dataloaders
 from verl.utils.debug import marked_timer
 from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.metric import reduce_metrics
@@ -400,6 +401,9 @@ class RayPPOTrainer:
                     self.config.critic.optim.total_training_steps = total_training_steps
         except Exception as e:
             print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
+
+    def _shutdown_dataloaders(self):
+        shutdown_dataloaders(getattr(self, "train_dataloader", None), getattr(self, "val_dataloader", None))
 
     def _dump_generations(self, inputs, outputs, gts, scores, reward_extra_infos_dict, dump_path):
         """Dump rollout/validation samples as JSONL."""
@@ -1307,6 +1311,7 @@ class RayPPOTrainer:
             pprint(f"Initial validation metrics: {val_metrics}")
             logger.log(data=val_metrics, step=self.global_steps)
             if self.config.trainer.get("val_only", False):
+                self._shutdown_dataloaders()
                 return
 
         if self.config.actor_rollout_ref.rollout.skip.get("enable", False):
@@ -1659,6 +1664,7 @@ class RayPPOTrainer:
                         self.actor_rollout_wg.async_calls_finalize_fn_exec(blocking=True)
                     pprint(f"Final validation metrics: {last_val_metrics}")
                     progress_bar.close()
+                    self._shutdown_dataloaders()
                     return
 
                 # this is experimental and may be changed/removed in the future
@@ -1666,3 +1672,6 @@ class RayPPOTrainer:
                 if hasattr(self.train_dataset, "on_batch_end"):
                     # The dataset may be changed after each training batch
                     self.train_dataset.on_batch_end(batch=batch)
+
+        progress_bar.close()
+        self._shutdown_dataloaders()

--- a/verl/utils/dataloader.py
+++ b/verl/utils/dataloader.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for DataLoader lifecycle management."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def shutdown_dataloader_workers(dataloader: Any) -> bool:
+    """Best-effort shutdown for multiprocessing DataLoader iterators.
+
+    PyTorch and torchdata keep worker processes on the active iterator. There
+    is no public close API, so this helper uses the same private shutdown hook
+    that the iterator destructor calls, but does it while the trainer is still
+    in a normal execution context instead of during Python/Ray teardown.
+    """
+    iterator = getattr(dataloader, "_iterator", None)
+    if iterator is None:
+        return False
+
+    shutdown_workers = getattr(iterator, "_shutdown_workers", None)
+    try:
+        if callable(shutdown_workers):
+            shutdown_workers()
+            return True
+        return False
+    except Exception:
+        logger.warning("Failed to shut down DataLoader workers", exc_info=True)
+        return False
+    finally:
+        if getattr(dataloader, "_iterator", None) is iterator:
+            dataloader._iterator = None
+
+
+def shutdown_dataloaders(*dataloaders: Any) -> None:
+    """Shut down active worker iterators for any initialized dataloaders."""
+    for dataloader in dataloaders:
+        if dataloader is None:
+            continue
+        shutdown_dataloader_workers(dataloader)


### PR DESCRIPTION
# [trainer] fix: shut down PPO DataLoader workers before final trainer return

### What does this PR do?

This PR makes PPO trainer shutdown a bit more explicit for `StatefulDataLoader` workers. In a short async vLLM run, I observed a successful training job return code 0 and then print a post-success `DataLoader worker ... is killed by signal: Killed` traceback during process teardown. The patch shuts down active DataLoader worker iterators before `RayPPOTrainer.fit()` returns.

AI assistance was used to help isolate the reproducer, inspect the lifecycle path, implement the fix, and draft this PR description.

### Checklist Before Starting

- [x] Search for similar PRs. Query checks:
  - `DataLoader worker teardown is:open`
  - `StatefulDataLoader worker is:open`
  - `dataloader_num_workers is:open`
  - `RayPPOTrainer dataloader is:open`
- [x] This does not duplicate an existing PR. The closest open result found was #2487, which fixes RLHFDataset pickling with multiple DataLoader workers; this PR instead fixes trainer shutdown of active DataLoader worker iterators after successful early return.
- [x] Suggested title format: `[trainer] fix: shut down PPO DataLoader workers before final trainer return`

## Reproduction And Symptom

I reproduced the symptom with a short async vLLM PPO run that exits through `trainer.total_training_steps` while using DataLoader multiprocessing:

- veRL commit: `b916f603613c1af30289964a560f13508dc675af`
- model: Qwen2.5-0.5B-Instruct
- dataset: GSM8K parquet in veRL RLHF format
- hardware: 2 x A100 80GB
- rollout: `actor_rollout_ref.rollout.name=vllm`, `actor_rollout_ref.rollout.mode=async`, `actor_rollout_ref.rollout.tensor_model_parallel_size=2`
- algorithm: `algorithm.adv_estimator=grpo`, `critic.enable=false`
- data: `data.train_batch_size=8`, `data.val_batch_size=8`, `data.max_prompt_length=2048`, `data.max_response_length=128`
- early-exit condition: `trainer.total_training_steps=2`, `trainer.val_before_train=false`
- DataLoader setting: default `data.dataloader_num_workers=8`

Observed symptom: the run reaches `training/global_step:2`, prints final training metrics, and returns code 0, but stderr then emits a post-success teardown traceback:

```text
Exception ignored in: <function _StatefulMultiProcessingDataLoaderIter.__del__ ...>
RuntimeError: DataLoader worker (pid <pid>) is killed by signal: Killed.
```

As a control, changing only `data.dataloader_num_workers=0` removed the traceback while preserving successful training.

## Root Cause

The likely cause is that `RayPPOTrainer.fit()` can return immediately after `trainer.total_training_steps` is reached, even if `self.train_dataloader` still has an active multiprocessing iterator. `torchdata.stateful_dataloader.StatefulDataLoader` stores that iterator on `dataloader._iterator`, and the iterator owns the worker processes. When the trainer returns without explicitly shutting down this iterator, cleanup is deferred to Python/Ray process teardown and weakref/destructor handling. At that point, PyTorch's worker-failure signal handler may observe workers being killed during shutdown and report `RuntimeError: DataLoader worker ... is killed by signal: Killed`, even though the training step itself succeeded.

## How This PR Fixes It

This PR adds a small best-effort DataLoader lifecycle helper that shuts down active multiprocessing iterators before the trainer returns. The helper checks whether a dataloader has an active `_iterator`, calls the iterator's `_shutdown_workers()` hook when available, and clears `dataloader._iterator` afterward so the same iterator is not cleaned up again during process teardown. `RayPPOTrainer.fit()` now calls this cleanup on successful `val_only` return and on the final-step return path after async rollout finalization and progress-bar close. This keeps normal training behavior unchanged while moving DataLoader worker shutdown into the trainer's controlled lifecycle.

### Test

- `pre-commit run --files verl/utils/dataloader.py verl/trainer/ppo/ray_trainer.py tests/utils/test_dataloader_lifecycle_on_cpu.py --show-diff-on-failure --color=always`
  - Result: passed
- `python -m py_compile verl/utils/dataloader.py verl/trainer/ppo/ray_trainer.py tests/utils/test_dataloader_lifecycle_on_cpu.py`
  - Result: passed
- Manual execution of `tests/utils/test_dataloader_lifecycle_on_cpu.py` test functions
  - Result: passed
- Real GPU reproduction on 2 x A100 80GB with async vLLM PPO and default `data.dataloader_num_workers=8`
  - Result: return code `0`, reached `training/global_step:2`, and no `RuntimeError`, `Traceback`, or `DataLoader worker ... killed`
  - Log: `/tmp/rl_sentinel_myverl_fix_BUG-8AB7B174EF13/default_workers.log`

### API and Usage Example

No public API or config change.

### Design & Code Changes

- Added a DataLoader lifecycle helper that best-effort shuts down active multiprocessing iterators and clears `dataloader._iterator`.
- Added `RayPPOTrainer._shutdown_dataloaders()`.
- Called `_shutdown_dataloaders()` on successful `val_only` return and final-step return.
- Added CPU tests covering no-op behavior, error-tolerant cleanup, fake iterator cleanup, and real `StatefulDataLoader(num_workers=2)` worker shutdown.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and `AGENTS.md`.
- [x] Applied relevant pre-commit checks to changed files.
- [x] Added unit coverage for the new helper.
- [x] Ran a real GPU reproduction for the bug scenario.
- [x] No docs update needed because this is an internal lifecycle fix with no user-facing API/config change.
