### PR TITLE
[ci] feat: introduce uv to accelerate pip install

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -93,8 +93,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Download datasets
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -74,9 +74,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip install -r docs/requirements-docs.txt
+          pip install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system -r docs/requirements-docs.txt
 
       - name: Run doc make html
         run: |

--- a/.github/workflows/e2e_ascend.yml
+++ b/.github/workflows/e2e_ascend.yml
@@ -91,7 +91,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -146,7 +147,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps --no-build-isolation -e .
+          pip install uv
+          uv pip install --system --no-deps --no-build-isolation -e .
       - name: Check final pip list
         run: |
           pip list
@@ -201,7 +203,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_fully_async_policy.yml
+++ b/.github/workflows/e2e_fully_async_policy.yml
@@ -116,9 +116,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
@@ -144,10 +145,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
-          pip3 install git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
+          uv pip install --system git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_fully_async_policy_ascend.yml
+++ b/.github/workflows/e2e_fully_async_policy_ascend.yml
@@ -109,7 +109,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -153,7 +154,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_fully_async_policy_opd.yml
+++ b/.github/workflows/e2e_fully_async_policy_opd.yml
@@ -79,10 +79,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
-          pip3 install --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git@main
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
+          uv pip install --system --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git@main
       - name: Prepare datasets
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_fully_async_policy_trtllm.yml
+++ b/.github/workflows/e2e_fully_async_policy_trtllm.yml
@@ -110,11 +110,12 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==14.0.1
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==14.0.1
           # WAR: CI image predates mbridge cf71117 (removes `imp` for Python 3.12). Drop this line after CI image is refreshed.
-          pip3 install --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
+          uv pip install --system --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_one_step_off_policy.yml
+++ b/.github/workflows/e2e_one_step_off_policy.yml
@@ -116,9 +116,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
@@ -144,9 +145,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_one_step_off_policy_ascend.yml
+++ b/.github/workflows/e2e_one_step_off_policy_ascend.yml
@@ -109,7 +109,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -153,7 +154,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_ppo_grpo_trainer_trtllm.yml
+++ b/.github/workflows/e2e_ppo_grpo_trainer_trtllm.yml
@@ -128,12 +128,14 @@ jobs:
       - name: Reinstall FlashInfer for runtime GPU arch
         run: |
           unset TORCH_CUDA_ARCH_LIST
-          pip3 install --force-reinstall --no-deps flashinfer-python
+          pip3 install uv
+          uv pip install --system --force-reinstall --no-deps flashinfer-python
       - name: Install the current repository
         run: |
-          pip3 install pytest-asyncio
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system pytest-asyncio
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Run TRTLLM unit tests
         run: |
           unset TORCH_CUDA_ARCH_LIST  # Let TRT-LLM CUTLASS DSL auto-detect runtime GPU arch
@@ -166,13 +168,15 @@ jobs:
       - name: Reinstall FlashInfer for runtime GPU arch
         run: |
           unset TORCH_CUDA_ARCH_LIST
-          pip3 install --force-reinstall --no-deps flashinfer-python
+          pip3 install uv
+          uv pip install --system --force-reinstall --no-deps flashinfer-python
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
           # WAR: CI image predates mbridge cf71117 (removes `imp` for Python 3.12). Drop this line after CI image is refreshed.
-          pip3 install --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
+          uv pip install --system --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k --local_save_dir ${PWD}/data/gsm8k
@@ -219,15 +223,17 @@ jobs:
       - name: Reinstall FlashInfer for runtime GPU arch
         run: |
           unset TORCH_CUDA_ARCH_LIST
-          pip3 install --force-reinstall --no-deps flashinfer-python
+          pip3 install uv
+          uv pip install --system --force-reinstall --no-deps flashinfer-python
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install qwen_vl_utils
-          pip3 install mathruler
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system qwen_vl_utils
+          uv pip install --system mathruler
           # WAR: CI image predates mbridge cf71117 (removes `imp` for Python 3.12). Drop this line after CI image is refreshed.
-          pip3 install --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
+          uv pip install --system --force-reinstall --no-deps --no-build-isolation git+https://github.com/ISEEKYAN/mbridge.git
       - name: Prepare GEO3K dataset
         run: |
           python3 examples/data_preprocess/geo3k.py --local_dataset_path ${HOME}/models/hf_data/hiyouga/geometry3k --local_save_dir ${PWD}/data/geo3k

--- a/.github/workflows/e2e_ppo_trainer.yml
+++ b/.github/workflows/e2e_ppo_trainer.yml
@@ -66,8 +66,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install the current repository
         run: |
-          pip install pre-commit hydra-core
-          pip3 install --no-deps -e .
+          pip install uv
+          uv pip install --system pre-commit hydra-core
+          uv pip install --system --no-deps -e .
       - name: Set ruff --output-format=github
         run: |
           sed -i 's/--output-format=full/--output-format=github/' .pre-commit-config.yaml

--- a/.github/workflows/e2e_ppo_trainer_megatron_sglang.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_sglang.yml
@@ -121,10 +121,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install megatron-bridge --no-deps
-          pip3 install git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system megatron-bridge --no-deps
+          uv pip install --system git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
+          uv pip install --system --no-deps -e .
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
@@ -169,9 +170,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install megatron-bridge --no-deps
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system megatron-bridge --no-deps
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_ppo_trainer_megatron_sglang_2.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_sglang_2.yml
@@ -120,8 +120,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force
@@ -146,8 +147,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       # Geo3k
       - name: Prepare GEO3K dataset
         run: |

--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm.yml
@@ -122,11 +122,12 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps --force-reinstall .
-          pip3 install megatron-bridge --no-deps
-          pip3 install git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
-          pip3 install math-verify
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps --force-reinstall .
+          uv pip install --system megatron-bridge --no-deps
+          uv pip install --system git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
+          uv pip install --system math-verify
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
@@ -145,9 +146,10 @@ jobs:
       - name: clean up and install Megatron-Bridge
         run: |
           rm -rf checkpoints
-          pip3 install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@6259ae8 --no-deps --no-build-isolation
-          pip3 install git+https://github.com/NVIDIA/Megatron-LM.git@7ca9dc5 --no-deps --no-build-isolation
-          pip3 install "nvidia-modelopt[torch]>=0.37.0"
+          pip3 install uv
+          uv pip install --system git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@6259ae8 --no-deps --no-build-isolation
+          uv pip install --system git+https://github.com/NVIDIA/Megatron-LM.git@7ca9dc5 --no-deps --no-build-isolation
+          uv pip install --system "nvidia-modelopt[torch]>=0.37.0"
       - name: Running GSM8K E2E training tests with 3D parallelism on 8 L20 GPUs with Megatron, use Megatron-Bridge LoRA e2e to pre-load and save (Deepseek)
         run: |
           ray stop --force
@@ -178,10 +180,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install megatron-bridge --no-deps
-          pip3 install math-verify
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system megatron-bridge --no-deps
+          uv pip install --system math-verify
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_2.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_2.yml
@@ -121,11 +121,12 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps --force-reinstall .
-          pip3 install git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@6259ae8 --no-deps --no-build-isolation
-          pip3 install git+https://github.com/NVIDIA/Megatron-LM.git@7ca9dc5 --no-deps --no-build-isolation
-          pip3 install "nvidia-modelopt[torch]>=0.37.0"
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps --force-reinstall .
+          uv pip install --system git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@6259ae8 --no-deps --no-build-isolation
+          uv pip install --system git+https://github.com/NVIDIA/Megatron-LM.git@7ca9dc5 --no-deps --no-build-isolation
+          uv pip install --system "nvidia-modelopt[torch]>=0.37.0"
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
@@ -178,8 +179,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Prepare GSM8K dataset
         run: |
           ray stop --force
@@ -260,8 +262,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       # Geo3k
       - name: Prepare GEO3K dataset
         run: |

--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_2_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_2_ascend.yml
@@ -113,7 +113,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -189,8 +190,9 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
-          pip install trl==0.26.0
+          pip install uv
+          uv pip install --system --no-deps -e .
+          uv pip install --system trl==0.26.0
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -115,10 +115,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          uv pip install --system transformers==4.57.3
       - name: Prepare GSM8K dataset
         run: |
           ray stop --force

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
@@ -110,10 +110,11 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install -r requirements-npu.txt
-          pip install --no-deps -e .
-          pip install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip install transformers==4.57.3
+          pip install uv
+          uv pip install --system -r requirements-npu.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          uv pip install --system transformers==4.57.3
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_sft_llm.yml
+++ b/.github/workflows/e2e_sft_llm.yml
@@ -102,11 +102,12 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install peft
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install uv
+          uv pip install --system peft
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          uv pip install --system transformers==4.57.3
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force

--- a/.github/workflows/e2e_sft_llm_ascend.yml
+++ b/.github/workflows/e2e_sft_llm_ascend.yml
@@ -95,12 +95,13 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
-          pip install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip install transformers==4.57.3
-          pip install pandas==2.3.3
-          pip uninstall -y mbridge
-          pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10
+          pip install uv
+          uv pip install --system --no-deps -e .
+          uv pip install --system veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          uv pip install --system transformers==4.57.3
+          uv pip install --system pandas==2.3.3
+          uv pip uninstall mbridge
+          uv pip install --system git+https://github.com/ISEEKYAN/mbridge.git@89eb10
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_sft_vlm.yml
+++ b/.github/workflows/e2e_sft_vlm.yml
@@ -102,11 +102,12 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install peft
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install uv
+          uv pip install --system peft
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          uv pip install --system transformers==4.57.3
       - name: Prepare pokemon-gpt4o-captions dataset
         run: |
           ray stop --force

--- a/.github/workflows/gpu_unit_tests.yml
+++ b/.github/workflows/gpu_unit_tests.yml
@@ -105,12 +105,13 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install hf_transfer
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0 pytest-asyncio
-          pip3 install --ignore-installed blinker
-          pip3 install --ignore-installed mlflow "numpy<2.0"
+          pip3 install uv
+          uv pip install --system hf_transfer
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0 pytest-asyncio
+          uv pip install --system --ignore-installed blinker
+          uv pip install --system --ignore-installed mlflow "numpy<2.0"
       - name: Run all GPU unit tests
         run: |
           pytest -s -x --ignore-glob="*on_npu.py" --ignore-glob="*test_special_*.py" --ignore-glob='*on_cpu.py' --ignore-glob="*test_vllm*" --ignore-glob="*_sglang*" --ignore-glob="*_hf_rollout*" --ignore-glob="tests/models/" --ignore-glob='tests/special*' --ignore-glob="tests/experimental" --ignore-glob="tests/workers/reward_model" --ignore-glob="*test_shared_memory*" --ignore-glob="tests/workers/rollout/rollout_trtllm" --ignore-glob="*test_bucketed_weight_transfer*" tests/

--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -96,8 +96,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository and upgrade to latest transformers
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Running rmpad model tests on 8 L20 GPUs + flash_attn 2.5.8
         run: |
           pytest -s tests/models/test_transformer.py
@@ -112,14 +113,16 @@ jobs:
           torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
       - name: Running transformers ulysses tests on 8 L20 GPUs + transformers 4.54.1
         run: |
-          pip3 install transformers==4.54.1
+          pip3 install uv
+          uv pip install --system transformers==4.54.1
           torchrun --nproc_per_node=8 -m pytest tests/models/test_transformers_ulysses.py
       - name: Run distributed test
         run: |
           bash tests/special_distributed/run_all.sh
       - name: Clean up and recover transformers
         run: |
-          pip3 install --upgrade "transformers==5.3.0"
+          pip3 install uv
+          uv pip install --system --upgrade "transformers==5.3.0"
 
   # TODO: Move this back to model_rmpad once FSDP2 is stable.
   # NOTE: List as an independent job to make rerun easier.
@@ -138,8 +141,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository and upgrade to latest transformers/flash_attn
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Running FSDP2 rmpad model tests on 8 L20 GPUs + latest flash_attn
         run: |
           STRATEGY=fsdp2 torchrun --nproc_per_node=8 tests/special_distributed/test_fsdp_ckpt.py
@@ -159,9 +163,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install --upgrade "accelerate>=1.13.0"
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system --upgrade "accelerate>=1.13.0"
       - name: Download model config files
         run: |
           hf download Qwen/Qwen2.5-0.5B-Instruct --local-dir $HOME/models/Qwen/Qwen2.5-0.5B-Instruct

--- a/.github/workflows/model_ascend.yml
+++ b/.github/workflows/model_ascend.yml
@@ -87,7 +87,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .[test]
+          pip install uv
+          uv pip install --system --no-deps -e .[test]
       - name: Check final pip list
         run: |
           pip list
@@ -126,7 +127,8 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .[test]
+          pip install uv
+          uv pip install --system --no-deps -e .[test]
       - name: Prepare weights
         run: |
           ln -s /root/.cache/models ~/models

--- a/.github/workflows/nightly_ascend.yml
+++ b/.github/workflows/nightly_ascend.yml
@@ -71,7 +71,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -113,7 +114,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -155,7 +157,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list
@@ -198,8 +201,9 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install -r requirements-npu.txt
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system -r requirements-npu.txt
+          uv pip install --system --no-deps -e .
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/npu_unit_tests.yml
+++ b/.github/workflows/npu_unit_tests.yml
@@ -98,8 +98,9 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .[test]
-          pip install mlflow pytest-asyncio
+          pip install uv
+          uv pip install --system --no-deps -e .[test]
+          uv pip install --system mlflow pytest-asyncio
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,8 +31,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install the current repository
         run: |
-          pip install pre-commit hydra-core
-          pip install --no-deps -e .
+          pip install uv
+          uv pip install --system pre-commit hydra-core
+          uv pip install --system --no-deps -e .
       - name: Set ruff --output-format=github
         run: |
           sed -i 's/--output-format=full/--output-format=github/' .pre-commit-config.yaml

--- a/.github/workflows/precommit-autofix.yml
+++ b/.github/workflows/precommit-autofix.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          pip install pre-commit hydra-core
+          pip install uv
+          uv pip install --system pre-commit hydra-core
 
       - name: Run pre-commit
         run: |

--- a/.github/workflows/reward_model_sglang.yml
+++ b/.github/workflows/reward_model_sglang.yml
@@ -96,9 +96,10 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install sglang-router==0.2.2
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system sglang-router==0.2.2
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force

--- a/.github/workflows/reward_model_vllm.yml
+++ b/.github/workflows/reward_model_vllm.yml
@@ -96,8 +96,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force

--- a/.github/workflows/reward_model_vllm_ascend.yml
+++ b/.github/workflows/reward_model_vllm_ascend.yml
@@ -85,7 +85,8 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip install --no-deps -e .[test]
+          pip install uv
+          uv pip install --system --no-deps -e .[test]
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -72,10 +72,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install the current repository
         run: |
-          pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-          pip3 install -r requirements.txt
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          uv pip install --system -r requirements.txt
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       # Most sanity checks now run via pre-commit (see .pre-commit-config.yaml
       # and .github/workflows/pre-commit.yml). Only checks that need the full
       # verl installation or CI-only context remain here.

--- a/.github/workflows/sgl.yml
+++ b/.github/workflows/sgl.yml
@@ -111,10 +111,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install cupy-cuda12x==13.6.0 pytest-asyncio
-          pip3 install hf_transfer pytest-asyncio
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system cupy-cuda12x==13.6.0 pytest-asyncio
+          uv pip install --system hf_transfer pytest-asyncio
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force
@@ -141,10 +142,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install cupy-cuda12x==13.6.0 pytest-asyncio
-          pip3 install hf_transfer pytest-asyncio
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system cupy-cuda12x==13.6.0 pytest-asyncio
+          uv pip install --system hf_transfer pytest-asyncio
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       - name: Test SGLang ServerAdapter with Checkpoint Engine (NCCL)
         run: |
           ROLLOUT_NAME=sglang pytest -svvv tests/checkpoint_engine/test_special_server_adapter.py

--- a/.github/workflows/sgl_ascend.yml
+++ b/.github/workflows/sgl_ascend.yml
@@ -105,10 +105,11 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip3 install pytest pytest-asyncio
-          pip3 install megatron-bridge --no-deps
-          pip3 install git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
-          pip3 install --no-deps --no-build-isolation -e .
+          pip3 install uv
+          uv pip install --system pytest pytest-asyncio
+          uv pip install --system megatron-bridge --no-deps
+          uv pip install --system git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
+          uv pip install --system --no-deps --no-build-isolation -e .
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/type-coverage-check.yml
+++ b/.github/workflows/type-coverage-check.yml
@@ -20,9 +20,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-          pip3 install -r requirements.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          uv pip install --system -r requirements.txt
+          uv pip install --system --no-deps -e .
       - name: Run type annotation coverage check
         run: |
           python3 tests/special_sanity/type_coverage_check.py

--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -106,8 +106,9 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
+          pip3 install uv
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
       #      - name: Download Model to Use
       #        run: |
       #          hf download Qwen/Qwen2.5-0.5B-Instruct --local-dir ${HOME}/models/Qwen/Qwen2.5-0.5B-Instruct
@@ -141,10 +142,11 @@ jobs:
           fetch-depth: 0
       - name: Install the current repository
         run: |
-          pip3 install pytest-asyncio
-          pip3 install -r requirements-test.txt
-          pip3 install --no-deps -e .
-          pip3 install cupy-cuda12x==13.6.0
+          pip3 install uv
+          uv pip install --system pytest-asyncio
+          uv pip install --system -r requirements-test.txt
+          uv pip install --system --no-deps -e .
+          uv pip install --system cupy-cuda12x==13.6.0
       - name: Test vLLM ServerAdapter with Checkpoint Engine (NCCL)
         run: |
           ROLLOUT_NAME=vllm pytest -svvv tests/checkpoint_engine/test_special_server_adapter.py

--- a/.github/workflows/vllm_ascend.yml
+++ b/.github/workflows/vllm_ascend.yml
@@ -98,8 +98,9 @@ jobs:
           clean: true
       - name: Install the current repository
         run: |
-          pip3 install --no-deps -e .[test]
-          pip3 install pytest-asyncio
+          pip3 install uv
+          uv pip install --system --no-deps -e .[test]
+          uv pip install --system pytest-asyncio
       - name: Check final pip list
         run: |
           pip list

--- a/scripts/install_sglang_mcore_npu.sh
+++ b/scripts/install_sglang_mcore_npu.sh
@@ -4,17 +4,22 @@ NPU_DEVICE=${NPU_DEVICE:=A3}
 USE_MEGATRON=${USE_MEGATRON:-1}
 
 export MAX_JOBS=32
+export UV_NO_CACHE=true
+export UV_SYSTEM_PYTHON=true
+export UV_INDEX_STRATEGY=unsafe-best-match
+
+python3 -m pip install uv
 
 echo "1. install SGLang from source"
 git clone -b v0.5.8 https://github.com/sgl-project/sglang.git
 cd sglang
 mv python/pyproject_other.toml python/pyproject.toml
-pip install -e python[srt_npu]
+uv pip install -e python[srt_npu]
 cd ..
 
 echo "2. install torch & torch_npu & triton_ascend & other basic packages"
-pip install torch==2.7.1 torch_npu==2.7.1.post2 torchvision==0.22.1
-pip install pybind11 click==8.2.1 mbridge "numpy<2.0.0" cachetools
+uv pip install torch==2.7.1 torch_npu==2.7.1.post2 torchvision==0.22.1
+uv pip install pybind11 click==8.2.1 mbridge "numpy<2.0.0" cachetools
 
 
 echo "3. install sgl-kernel-npu form source, detailed readme in https://github.com/sgl-project/sgl-kernel-npu/blob/main/python/deep_ep/README.md"
@@ -28,10 +33,10 @@ fi
 if [ "$NPU_DEVICE" = "A2" ]; then
     bash build.sh -a deepep2
 fi
-pip install output/torch_memory_saver*.whl
-pip install output/sgl_kernel_npu*.whl
-pip install output/deep_ep*.whl
-cd "$(pip show deep-ep | grep -E '^Location:' | awk '{print $2}')" && ln -s deep_ep/deep_ep_cpp*.so && cd -
+uv pip install output/torch_memory_saver*.whl
+uv pip install output/sgl_kernel_npu*.whl
+uv pip install output/deep_ep*.whl
+cd "$(uv pip show deep-ep | grep -E '^Location:' | awk '{print $2}')" && ln -s deep_ep/deep_ep_cpp*.so && cd -
 python -c "import deep_ep; print(deep_ep.__path__)"
 cd ..
 # install sgl-kernel-npu from release whl
@@ -42,17 +47,18 @@ cd ..
 #     wget https://github.com/sgl-project/sgl-kernel-npu/releases/download/2026.01.21/sgl-kernel-npu_2026.01.21_8.5.0_910b.zip
 # fi
 # unzip sgl-kernel-npu*.zip
-# pip install output/torch_memory_saver*.whl
-# pip install output/sgl_kernel_npu*.whl
-# pip install output/deep_ep*.whl
+# uv pip install output/torch_memory_saver*.whl
+# uv pip install output/sgl_kernel_npu*.whl
+# uv pip install output/deep_ep*.whl
 
 if [ $USE_MEGATRON -eq 1 ]; then
     echo "4. install Megatron and MindSpeed"
-    git clone -b 2.3.0_core_r0.12.1 https://gitcode.com/Ascend/MindSpeed.git 
-    pip install -e MindSpeed 
-    pip install git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.12.1 
+    git clone -b 2.3.0_core_r0.12.1 https://gitcode.com/Ascend/MindSpeed.git
+    # GitCode does not support UV downloads
+    python3 -m pip install -e MindSpeed
+    uv pip install git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.12.1
 fi
 
 echo "5. May need to uninstall timm & triton"
-pip uninstall -y timm triton
+uv pip uninstall timm triton || true
 echo "Successfully installed all packages"

--- a/scripts/install_vllm_sglang_mcore.sh
+++ b/scripts/install_vllm_sglang_mcore.sh
@@ -4,52 +4,57 @@ USE_MEGATRON=${USE_MEGATRON:-1}
 USE_SGLANG=${USE_SGLANG:-1}
 
 export MAX_JOBS=32
+export UV_NO_CACHE=true
+export UV_SYSTEM_PYTHON=true
+export UV_INDEX_STRATEGY=unsafe-best-match
+
+python3 -m pip install uv
 
 echo "1. install inference frameworks and pytorch they need"
 if [ $USE_SGLANG -eq 1 ]; then
-    pip install "sglang[all]==0.5.2" --no-cache-dir && pip install torch-memory-saver --no-cache-dir
+    uv pip install "sglang[all]==0.5.2" && uv pip install torch-memory-saver
 fi
-pip install --no-cache-dir "vllm==0.11.0"
+uv pip install "vllm==0.11.0"
 
 echo "2. install basic packages"
-pip install "transformers[hf_xet]>=4.51.0" accelerate datasets peft hf-transfer \
+uv pip install "transformers[hf_xet]>=4.51.0" accelerate datasets peft hf-transfer \
     "numpy<2.0.0" "pyarrow>=15.0.0" pandas "tensordict>=0.8.0,<=0.10.0,!=0.9.0" torchdata \
     ray[default] codetiming hydra-core pylatexenc qwen-vl-utils wandb dill pybind11 liger-kernel mathruler \
-    pytest py-spy pre-commit ruff tensorboard 
+    pytest py-spy pre-commit ruff tensorboard
 
 echo "pyext is lack of maintainace and cannot work with python 3.12."
 echo "if you need it for prime code rewarding, please install using patched fork:"
-echo "pip install git+https://github.com/ShaohonChen/PyExt.git@py311support"
+echo "uv pip install git+https://github.com/ShaohonChen/PyExt.git@py311support"
 
-pip install "nvidia-ml-py>=12.560.30" "fastapi[standard]>=0.115.0" "optree>=0.13.0" "pydantic>=2.9" "grpcio>=1.62.1"
+uv pip install "nvidia-ml-py>=12.560.30" "fastapi[standard]>=0.115.0" "optree>=0.13.0" "pydantic>=2.9" "grpcio>=1.62.1"
 
 
 echo "3. install FlashAttention and FlashInfer"
 # Install flash-attn-2.8.1 (cxx11abi=False)
 wget -nv https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.1/flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl && \
-    pip install --no-cache-dir flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl
+    uv pip install flash_attn-2.8.1+cu12torch2.8cxx11abiFALSE-cp312-cp312-linux_x86_64.whl
 
-pip install --no-cache-dir flashinfer-python==0.3.1
+uv pip install flashinfer-python==0.3.1
 
 
 if [ $USE_MEGATRON -eq 1 ]; then
     echo "4. install TransformerEngine and Megatron"
     echo "Notice that TransformerEngine installation can take very long time, please be patient"
-    pip install "onnxscript==0.3.1"
-    NVTE_FRAMEWORK=pytorch pip3 install --no-deps git+https://github.com/NVIDIA/TransformerEngine.git@v2.6
-    pip3 install --no-deps git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.13.1
+    uv pip install "onnxscript==0.3.1"
+    NVTE_FRAMEWORK=pytorch uv pip install --no-deps git+https://github.com/NVIDIA/TransformerEngine.git@v2.6
+    uv pip install --no-deps git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.13.1
 fi
 
 
 echo "5. May need to fix opencv"
-pip install opencv-python
-pip install opencv-fixer && \
+uv pip install opencv-python
+uv pip install opencv-fixer && \
     python -c "from opencv_fixer import AutoFix; AutoFix()"
 
 
 if [ $USE_MEGATRON -eq 1 ]; then
     echo "6. Install cudnn python package (avoid being overridden)"
-    pip install nvidia-cudnn-cu12==9.10.2.21
+    uv pip install nvidia-cudnn-cu12==9.10.2.21
 fi
 
 echo "Successfully installed all packages"


### PR DESCRIPTION
### What does this PR do?

Integrate uv to significantly accelerate pip install execution in CI workflows and install scripts. Keep `python3 -m pip install` for GitCode-hosted packages that do not support UV downloads.


### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+uv
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

This change modifies CI workflows themselves. The effect can be verified by comparing the `Install dependencies` step duration between this PR's CI runs and previous main branch runs.

### API and Usage Example

N/A — CI infrastructure change only.

### Design & Code Changes

- `scripts/install_sglang_mcore_npu.sh` — Dual approach: `uv pip install` for regular packages, `python3 -m pip install` for GitCode (MindSpeed)
- `scripts/install_vllm_sglang_mcore.sh` — All pip install calls converted to `uv pip install`
- 37 CI workflow files — All `pip install` / `pip3 install` calls replaced with `uv pip install`, with `pip install uv` added before first uv usage in each job

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation. (N/A — CI infrastructure only)
- [ ] Add unit or end-to-end test(s). (Not feasible — this PR modifies the CI workflows themselves)
- [ ] Once your PR is ready for CI, send a message in the ci-request channel.
- [x] Recipe submodule: N/A