### PR TITLE
[rollout] fix: skip_tokenizer_init=True for OPD teacher

### DIFF
--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -868,7 +868,7 @@ distillation:
         enable_chunked_prefill: true
         enable_prefix_caching: true
         disable_log_stats: true
-        skip_tokenizer_init: false
+        skip_tokenizer_init: true
         prompt_length: ${oc.select:actor_rollout_ref.rollout.prompt_length}
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -804,7 +804,7 @@ distillation:
         enable_chunked_prefill: true
         enable_prefix_caching: true
         disable_log_stats: true
-        skip_tokenizer_init: false
+        skip_tokenizer_init: true
         prompt_length: ${oc.select:actor_rollout_ref.rollout.prompt_length}
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -824,7 +824,7 @@ distillation:
         enable_chunked_prefill: true
         enable_prefix_caching: true
         disable_log_stats: true
-        skip_tokenizer_init: false
+        skip_tokenizer_init: true
         prompt_length: ${oc.select:actor_rollout_ref.rollout.prompt_length}
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -796,7 +796,7 @@ distillation:
         enable_chunked_prefill: true
         enable_prefix_caching: true
         disable_log_stats: true
-        skip_tokenizer_init: false
+        skip_tokenizer_init: true
         prompt_length: ${oc.select:actor_rollout_ref.rollout.prompt_length}
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -104,7 +104,7 @@ teacher_models:
       enable_chunked_prefill: true
       enable_prefix_caching: true
       disable_log_stats: true
-      skip_tokenizer_init: false
+      skip_tokenizer_init: true
       prompt_length: ${oc.select:actor_rollout_ref.rollout.prompt_length}
       response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
       temperature: ${oc.select:actor_rollout_ref.rollout.temperature}


### PR DESCRIPTION
### What does this PR do?

OPD teacher should skip tokenizer initialization to enable `Token-In-Token-Out`.
