### PR TITLE
fix(ulysses): ensure position_ids is contiguous before all_gather

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -137,6 +137,9 @@ def _ulysses_flash_attention_forward(
         # https://github.com/huggingface/transformers/pull/33932
 
         # (bsz, seq_len/n) -> (bsz, seq_len)
+        # Ensure position_ids is contiguous before all_gather to avoid
+        # "Tensors must be contiguous" error from torch.distributed
+        position_ids = position_ids.contiguous()
         position_ids_list = [torch.empty_like(position_ids) for _ in range(ulysses_sp_size)]
         torch.distributed.all_gather(position_ids_list, position_ids, group=get_ulysses_sequence_parallel_group())
         position_ids = torch.concat(position_ids_list, dim=-1)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1191,6 +1191,14 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         )
                         sum_pi_squared_rmpad = torch.cat([t for t in sum_pi_squared.unbind()])
                         sum_pi_squared = torch.nested.nested_tensor_from_jagged(sum_pi_squared_rmpad, cu_seqlens)
+
+                    # compute distillation top-k when use_remove_padding=False
+                    if distillation_use_topk:
+                        outputs = logits_processor_func(student_logits=logits_rmpad.unsqueeze(0), data=micro_batch)
+                        for k, v in outputs.items():
+                            v = v.squeeze(0)
+                            assert v.shape == log_probs.shape, f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
+                            model_output[k] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
                 else:
                     raise NotImplementedError(f"pad_mode {pad_mode} not implemented")
 


### PR DESCRIPTION
Closing per verl AGENTS.md policy: pure code-agent PRs are not allowed. A human submitter must understand and defend the change end-to-end. Will re-submit with proper human review and test validation when ready.

Co-authored-by: Claude