### PR TITLE
[data] fix: forward apply_chat_template_kwargs to system prompt measurement

### DIFF
--- a/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
@@ -236,6 +236,78 @@ def test_multiturn_sft_dataset(model_path: str, ignore_input_ids_mismatch: bool)
     print("Starting test...")
 
 
+@pytest.mark.parametrize(
+    "model_path, apply_chat_template_kwargs",
+    [
+        ("openai/gpt-oss-20b", {"model_identity": "You are a helpful assistant."}),
+    ],
+)
+def test_multiturn_sft_dataset_with_chat_template_kwargs(model_path: str, apply_chat_template_kwargs: dict):
+    """Test that custom apply_chat_template_kwargs are forwarded to system prompt
+    measurement so the loss mask is not shifted when kwargs change tokenization.
+
+    Some chat templates embed configurable fields (e.g. model_identity) in the
+    system prompt. If these kwargs are not forwarded to system prompt length
+    measurement, the per-turn strip length is wrong, causing role markers to be
+    removed and the loss mask to shift.
+    """
+    test_data = {
+        "messages": [
+            [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "2+2 equals 4."},
+            ],
+            [
+                {"role": "user", "content": "Tell me a joke."},
+                {"role": "assistant", "content": "Why did the chicken cross the road?"},
+            ],
+        ]
+    }
+
+    os.makedirs("test_data", exist_ok=True)
+    test_file = "test_data/test_kwargs.parquet"
+    df = pd.DataFrame(test_data)
+    df.to_parquet(test_file)
+
+    tokenizer = hf_tokenizer(model_path)
+
+    config = {
+        "max_length": 1024,
+        "truncation": "error",
+        "pad_mode": "no_padding",
+        "apply_chat_template_kwargs": apply_chat_template_kwargs,
+    }
+    dataset = MultiTurnSFTDataset(parquet_files=test_file, tokenizer=tokenizer, processor=None, config=config)
+
+    for idx in range(len(dataset)):
+        item = dataset[idx]
+        input_ids = item["input_ids"]
+        loss_mask = item["loss_mask"]
+
+        assistant_text = tokenizer.decode(input_ids[loss_mask == 1])
+        non_assistant_text = tokenizer.decode(input_ids[loss_mask == 0])
+
+        for msg in test_data["messages"][idx]:
+            if msg["role"] == "assistant":
+                assert msg["content"] in assistant_text, (
+                    f"Assistant message '{msg['content']}' not found in masked text. "
+                    f"This may indicate system prompt length mismatch when using "
+                    f"custom chat_template_kwargs."
+                )
+                assert msg["content"] not in non_assistant_text, (
+                    f"Assistant message '{msg['content']}' found in non-assistant text"
+                )
+            elif msg["role"] in ["system", "user"]:
+                assert msg["content"] in non_assistant_text, (
+                    f"{msg['role'].title()} message '{msg['content']}' not found in non-assistant text"
+                )
+                assert msg["content"] not in assistant_text, (
+                    f"{msg['role'].title()} message '{msg['content']}' found in assistant text"
+                )
+
+    print("All chat_template_kwargs tests passed!")
+
+
 def generate_image(description: str, size: str = "256x256"):
     """Generate a simple image based on description.
 

--- a/verl/utils/chat_template.py
+++ b/verl/utils/chat_template.py
@@ -22,28 +22,44 @@ def initialize_system_prompt(tokenizer, **apply_chat_template_kwargs) -> list[in
         List of token IDs for the system prompt, or empty list if not supported
     """
     token1 = normalize_token_ids(
-        tokenizer.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True)
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
+        )
     )
     token2 = normalize_token_ids(
-        tokenizer.apply_chat_template([{"role": "user", "content": ""}] * 2, add_generation_prompt=False, tokenize=True)
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}] * 2,
+            add_generation_prompt=False,
+            tokenize=True,
+            **apply_chat_template_kwargs,
+        )
     )
     # get system prompt tokens
     system_prompt = token1[: -(len(token2) - len(token1))]
     return system_prompt
 
 
-def extract_system_prompt_and_generation(tokenizer):
+def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs):
     token1 = normalize_token_ids(
-        tokenizer.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True)
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
+        )
     )
     token2 = normalize_token_ids(
-        tokenizer.apply_chat_template([{"role": "user", "content": ""}] * 2, add_generation_prompt=False, tokenize=True)
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}] * 2,
+            add_generation_prompt=False,
+            tokenize=True,
+            **apply_chat_template_kwargs,
+        )
     )
     # get system prompt tokens
     system_prompt = token1[: -(len(token2) - len(token1))]
     # get generate prompt tokens
     token3 = normalize_token_ids(
-        tokenizer.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=True, tokenize=True)
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}], add_generation_prompt=True, tokenize=True, **apply_chat_template_kwargs
+        )
     )
     generate_prompt = token3[len(token1) :]
 

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -177,7 +177,9 @@ class MultiTurnSFTDataset(Dataset):
 
         # system prompt: <|im_start|>system\nYou are a helpful assistant.<|im_end|>\n
         # generation prompt: <|im_start|>assistant\n
-        self.system_prompt, self.generation_prompt = extract_system_prompt_and_generation(self.tokenizer)
+        self.system_prompt, self.generation_prompt = extract_system_prompt_and_generation(
+            self.tokenizer, **self.apply_chat_template_kwargs
+        )
 
     def __len__(self):
         return len(self.messages)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where `extract_system_prompt_and_generation` and `initialize_system_prompt` in `verl/utils/chat_template.py` did not forward `apply_chat_template_kwargs` to their internal `apply_chat_template()` calls. This caused the system prompt length to be measured using default kwargs while per-turn tokenization used custom kwargs, resulting in incorrect token stripping and a shifted loss mask.

Any SFT run using `apply_chat_template_kwargs` with a model whose chat template embeds configurable fields in the system prompt (e.g., `model_identity` on `openai/gpt-oss-20b`) would trigger the `sanity_check` assertion error. Bypassing it via `ignore_input_ids_mismatch=True` would result in training on silently malformed data (shifted loss mask, missing role markers).

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+extract_system_prompt
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+chat_template_kwargs
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

```bash
pytest tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py::test_multiturn_sft_dataset_with_chat_template_kwargs -v
```

Result: PASSES with fix, FAILS without fix (sanity check catches the system prompt length mismatch).

### API and Usage Example

No API changes. Existing config usage now works correctly:

```yaml
data:
  apply_chat_template_kwargs:
    model_identity: "You are a helpful assistant."
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
