### PR TITLE
[trainer] fix: combine REMAX sampled and greedy samples in one rollout request

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -433,6 +433,7 @@ class AgentLoopWorker:
             response_mask: | 1, 1, 1, ..., 1, 1 | 0, 0, .., 0, 0 | 1, 1, 1, ..., 1, 1 | 0, 0, ..., 0|
         """
         config = self.rollout_config
+        validate = batch.meta_info.get("validate", False)
         sampling_params = dict(
             temperature=config.temperature,
             top_p=config.top_p,
@@ -441,8 +442,13 @@ class AgentLoopWorker:
             logprobs=config.calculate_log_probs,
         )
 
+        def apply_greedy_sampling_params(params: dict[str, Any]) -> None:
+            params["top_p"] = 1.0
+            params["top_k"] = -1
+            params["temperature"] = 0
+
         # override sampling params for validation
-        if batch.meta_info.get("validate", False):
+        if validate:
             sampling_params["top_p"] = config.val_kwargs.top_p
             sampling_params["top_k"] = config.val_kwargs.top_k
             sampling_params["temperature"] = config.val_kwargs.temperature
@@ -477,13 +483,19 @@ class AgentLoopWorker:
             batch.meta_info.get("global_steps", -1), index.tolist(), batch.meta_info.get("validate", False)
         )
 
+        # NOTE: __do_sample__ is an internal per-sample override used by REMAX combined rollout.
+        # Do not forward it to concrete agent loops, which may reject unknown kwargs.
+        per_sample_do_sample = batch.non_tensor_batch.get("__do_sample__")
         tasks = []
         for i in range(len(batch)):
             trace_this_sample = i in traced_indices
-            kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items()}
+            kwargs = {k: v[i] for k, v in batch.non_tensor_batch.items() if k != "__do_sample__"}
+            sample_sampling_params = dict(sampling_params)
+            if not validate and per_sample_do_sample is not None and not bool(per_sample_do_sample[i]):
+                apply_greedy_sampling_params(sample_sampling_params)
             tasks.append(
                 asyncio.create_task(
-                    self._run_agent_loop(sampling_params, trajectory_info[i], trace=trace_this_sample, **kwargs)
+                    self._run_agent_loop(sample_sampling_params, trajectory_info[i], trace=trace_this_sample, **kwargs)
                 )
             )
         outputs = await asyncio.gather(*tasks)

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -20,7 +20,6 @@ This trainer supports model-agonistic model initialization with huggingface
 """
 
 import uuid
-from copy import deepcopy
 from pprint import pprint
 from typing import Any, Optional
 

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -437,22 +437,21 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
             gen_batch_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
         if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-            with marked_timer("gen_max", timing_raw, color="purple"):
-                gen_baseline_output = combined_gen_output.slice(num_sampled_prompts, None)
-                if "__do_sample__" in gen_baseline_output.non_tensor_batch:
-                    gen_baseline_output.pop(non_tensor_batch_keys=["__do_sample__"])
+            gen_baseline_output = combined_gen_output.slice(num_sampled_prompts, None)
+            if "__do_sample__" in gen_baseline_output.non_tensor_batch:
+                gen_baseline_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
-                # REMAX only needs one scalar baseline reward per original prompt.
-                # Agent-loop rollout outputs contain sample-specific non-tensor fields
-                # such as turns, tool rewards and extras; keep the baseline path isolated.
-                if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
-                    baseline_reward = self._compute_reward_colocate(gen_baseline_output)
-                    gen_baseline_output = gen_baseline_output.union(baseline_reward)
+            # REMAX only needs one scalar baseline reward per original prompt.
+            # Agent-loop rollout outputs contain sample-specific non-tensor fields
+            # such as turns, tool rewards and extras; keep the baseline path isolated.
+            if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
+                baseline_reward = self._compute_reward_colocate(gen_baseline_output)
+                gen_baseline_output = gen_baseline_output.union(baseline_reward)
 
-                reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
-                batch.batch["reward_baselines"] = reward_baseline_tensor
+            reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
+            batch.batch["reward_baselines"] = reward_baseline_tensor
 
-                del gen_baseline_output
+            del gen_baseline_output
         del combined_gen_batch, combined_gen_output
         # repeat to align with repeated responses in rollout
         batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -404,47 +404,56 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
         gen_batch = self._get_gen_batch(batch)
         # pass global_steps to trace
         gen_batch.meta_info["global_steps"] = self.global_steps
-        gen_batch_output = gen_batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
+        rollout_n = self.config.actor_rollout_ref.rollout.n
+        gen_batch_output = gen_batch.repeat(repeat_times=rollout_n, interleave=True)
+
+        if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+            # NOTE: REMAX needs one sampled rollout plus one greedy baseline per prompt.
+            # Keep them in a single agent-loop/vLLM request to avoid sending a second
+            # rollout after replicas have been put to sleep, which can leave async vLLM
+            # engines in an invalid state for multi-turn agent workloads.
+            gen_batch_output.non_tensor_batch["__do_sample__"] = np.ones(len(gen_batch_output), dtype=bool)
+            gen_baseline_batch = deepcopy(gen_batch)
+            gen_baseline_batch.non_tensor_batch["__do_sample__"] = np.zeros(len(gen_baseline_batch), dtype=bool)
+            combined_gen_batch = DataProto.concat([gen_batch_output, gen_baseline_batch])
+            num_sampled_prompts = len(gen_batch_output)
+        else:
+            combined_gen_batch = gen_batch_output
+            num_sampled_prompts = len(gen_batch_output)
 
         with marked_timer("gen", timing_raw, color="red"):
             if self.curr_step_profile:
                 self.async_rollout_manager.start_profile(global_step=self.global_steps)
-            gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
+            combined_gen_output = self.async_rollout_manager.generate_sequences(combined_gen_batch)
             self.checkpoint_manager.sleep_replicas()
             if self.curr_step_profile:
                 self.llm_server_manager.stop_profile()
 
-            timing_raw.update(gen_batch_output.meta_info["timing"])
-            gen_batch_output.meta_info.pop("timing", None)
+            timing_raw.update(combined_gen_output.meta_info["timing"])
+            combined_gen_output.meta_info.pop("timing", None)
+
+        gen_batch_output = combined_gen_output.slice(0, num_sampled_prompts)
+        if "__do_sample__" in gen_batch_output.non_tensor_batch:
+            gen_batch_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
         if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
             with marked_timer("gen_max", timing_raw, color="purple"):
-                gen_baseline_batch = deepcopy(gen_batch)
-                gen_baseline_batch.meta_info["do_sample"] = False
-                if self.curr_step_profile:
-                    self.llm_server_manager.start_profile()
-                gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
-                self.checkpoint_manager.sleep_replicas()
-                if self.curr_step_profile:
-                    self.llm_server_manager.stop_profile()
-                batch = batch.union(gen_baseline_output)
-                # compute reward model score on batch
-                rm_scores = None
-                if self.use_rm and "rm_scores" not in batch.batch.keys():
-                    batch_reward = self._compute_reward_colocate(batch)
-                    batch = batch.union(batch_reward)
+                gen_baseline_output = combined_gen_output.slice(num_sampled_prompts, None)
+                if "__do_sample__" in gen_baseline_output.non_tensor_batch:
+                    gen_baseline_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
-                # Compute or extract reward for REMAX baseline
-                reward_baseline_tensor = batch.batch["rm_scores"].sum(dim=-1)
+                # REMAX only needs one scalar baseline reward per original prompt.
+                # Agent-loop rollout outputs contain sample-specific non-tensor fields
+                # such as turns, tool rewards and extras; keep the baseline path isolated.
+                if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
+                    baseline_reward = self._compute_reward_colocate(gen_baseline_output)
+                    gen_baseline_output = gen_baseline_output.union(baseline_reward)
 
-                keys_to_pop = set(gen_baseline_output.batch.keys())
-                if rm_scores is not None:
-                    keys_to_pop.update(rm_scores.batch.keys())
-                batch.pop(batch_keys=list(keys_to_pop))
-
+                reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
                 batch.batch["reward_baselines"] = reward_baseline_tensor
 
-                del rm_scores, gen_baseline_batch, gen_baseline_output
+                del gen_baseline_output
+        del combined_gen_batch, combined_gen_output
         # repeat to align with repeated responses in rollout
         batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
         batch = batch.union(gen_batch_output)

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -413,7 +413,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
             # rollout after replicas have been put to sleep, which can leave async vLLM
             # engines in an invalid state for multi-turn agent workloads.
             gen_batch_output.non_tensor_batch["__do_sample__"] = np.ones(len(gen_batch_output), dtype=bool)
-            gen_baseline_batch = deepcopy(gen_batch)
+            gen_baseline_batch = gen_batch.slice(0, None)
             gen_baseline_batch.non_tensor_batch["__do_sample__"] = np.zeros(len(gen_baseline_batch), dtype=bool)
             combined_gen_batch = DataProto.concat([gen_batch_output, gen_baseline_batch])
             num_sampled_prompts = len(gen_batch_output)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1353,9 +1353,22 @@ class RayPPOTrainer:
 
                 # pass global_steps to trace
                 gen_batch.meta_info["global_steps"] = self.global_steps
-                gen_batch_output = gen_batch.repeat(
-                    repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True
-                )
+                rollout_n = self.config.actor_rollout_ref.rollout.n
+                gen_batch_output = gen_batch.repeat(repeat_times=rollout_n, interleave=True)
+
+                if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
+                    # NOTE: REMAX needs one sampled rollout plus one greedy baseline per prompt.
+                    # Keep them in a single agent-loop/vLLM request to avoid sending a second
+                    # rollout after replicas have been put to sleep, which can leave async vLLM
+                    # engines in an invalid state for multi-turn agent workloads.
+                    gen_batch_output.non_tensor_batch["__do_sample__"] = np.ones(len(gen_batch_output), dtype=bool)
+                    gen_baseline_batch = deepcopy(gen_batch)
+                    gen_baseline_batch.non_tensor_batch["__do_sample__"] = np.zeros(len(gen_baseline_batch), dtype=bool)
+                    combined_gen_batch = DataProto.concat([gen_batch_output, gen_baseline_batch])
+                    num_sampled_prompts = len(gen_batch_output)
+                else:
+                    combined_gen_batch = gen_batch_output
+                    num_sampled_prompts = len(gen_batch_output)
 
                 is_last_step = self.global_steps >= self.total_training_steps
                 with marked_timer("step", timing_raw):
@@ -1363,42 +1376,32 @@ class RayPPOTrainer:
                     with marked_timer("gen", timing_raw, color="red"):
                         if curr_step_profile:
                             self.llm_server_manager.start_profile()
-                        gen_batch_output = self.async_rollout_manager.generate_sequences(gen_batch_output)
+                        combined_gen_output = self.async_rollout_manager.generate_sequences(combined_gen_batch)
                         self.checkpoint_manager.sleep_replicas()
                         if curr_step_profile:
                             self.llm_server_manager.stop_profile()
 
-                        timing_raw.update(gen_batch_output.meta_info["timing"])
-                        gen_batch_output.meta_info.pop("timing", None)
+                        timing_raw.update(combined_gen_output.meta_info["timing"])
+                        combined_gen_output.meta_info.pop("timing", None)
+
+                    gen_batch_output = combined_gen_output.slice(0, num_sampled_prompts)
+                    if "__do_sample__" in gen_batch_output.non_tensor_batch:
+                        gen_batch_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
                     if self.config.algorithm.adv_estimator == AdvantageEstimator.REMAX:
-                        with marked_timer("gen_max", timing_raw, color="purple"):
-                            gen_baseline_batch = deepcopy(gen_batch)
-                            gen_baseline_batch.meta_info["do_sample"] = False
-                            if curr_step_profile:
-                                self.llm_server_manager.start_profile()
-                            gen_baseline_output = self.async_rollout_manager.generate_sequences(gen_baseline_batch)
-                            self.checkpoint_manager.sleep_replicas()
-                            if curr_step_profile:
-                                self.llm_server_manager.stop_profile()
-                            batch = batch.union(gen_baseline_output)
-                            # compute reward model score on batch
-                            rm_scores = None
-                            if self.use_rm and "rm_scores" not in batch.batch.keys():
-                                batch_reward = self._compute_reward_colocate(batch)
-                                batch = batch.union(batch_reward)
+                        gen_baseline_output = combined_gen_output.slice(num_sampled_prompts, None)
+                        if "__do_sample__" in gen_baseline_output.non_tensor_batch:
+                            gen_baseline_output.pop(non_tensor_batch_keys=["__do_sample__"])
 
-                            # Compute or extract reward for REMAX baseline
-                            reward_baseline_tensor = batch.batch["rm_scores"].sum(dim=-1)
+                        if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
+                            baseline_reward = self._compute_reward_colocate(gen_baseline_output)
+                            gen_baseline_output = gen_baseline_output.union(baseline_reward)
 
-                            keys_to_pop = set(gen_baseline_output.batch.keys())
-                            if rm_scores is not None:
-                                keys_to_pop.update(rm_scores.batch.keys())
-                            batch.pop(batch_keys=list(keys_to_pop))
+                        reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
+                        batch.batch["reward_baselines"] = reward_baseline_tensor
 
-                            batch.batch["reward_baselines"] = reward_baseline_tensor
-
-                            del rm_scores, gen_baseline_batch, gen_baseline_output
+                        del gen_baseline_output
+                    del combined_gen_batch, combined_gen_output
                     # repeat to align with repeated responses in rollout
                     batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1362,7 +1362,7 @@ class RayPPOTrainer:
                     # rollout after replicas have been put to sleep, which can leave async vLLM
                     # engines in an invalid state for multi-turn agent workloads.
                     gen_batch_output.non_tensor_batch["__do_sample__"] = np.ones(len(gen_batch_output), dtype=bool)
-                    gen_baseline_batch = deepcopy(gen_batch)
+                    gen_baseline_batch = gen_batch.slice(0, None)
                     gen_baseline_batch.non_tensor_batch["__do_sample__"] = np.zeros(len(gen_baseline_batch), dtype=bool)
                     combined_gen_batch = DataProto.concat([gen_batch_output, gen_baseline_batch])
                     num_sampled_prompts = len(gen_batch_output)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -22,7 +22,6 @@ import json
 import os
 import uuid
 from collections import defaultdict
-from copy import deepcopy
 from pprint import pprint
 from typing import Any, Optional
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes REMAX rollout for multi-turn agent workloads backed by async vLLM.

REMAX needs both sampled rollout samples and one greedy baseline sample per prompt. Previously, these were generated through two separate rollout requests. In the async vLLM agent-loop path, the second greedy-baseline request could be issued after rollout replicas were put to sleep, which may leave the vLLM engine in an invalid state and cause runtime failures.

This PR combines sampled samples and greedy baseline samples into one rollout request for REMAX, then splits the returned batch back into policy samples and baseline samples. The greedy baseline path is kept isolated and is only used to compute `reward_baselines`.

This should also fix #3027.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=REMAX+agent+loop+vLLM+greedy+baseline
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - Suggested title: `[rollout, trainer, vllm, algo] fix: combine REMAX sampled and greedy samples in one rollout request`
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Validated with local syntax and whitespace checks:

```bash
python3 -m py_compile \
  verl/experimental/agent_loop/agent_loop.py \
  verl/experimental/separation/ray_trainer.py \
  verl/trainer/ppo/ray_trainer.py

git diff --check -- \
  verl/experimental/agent_loop/agent_loop.py \
  verl/experimental/separation/ray_trainer.py \
  verl/trainer/ppo/ray_trainer.py
```

Also validated by running REMAX multi-turn training with local scripts/configs that are not included in this PR:

```bash
bash scripts/run_remax_multiturn.sh
```

The local validation used:

- `scripts/run_remax_multiturn.sh`
- `scripts/gsm8k_tool_config.yaml`
- `examples/remax_trainer/run_qwen3_8b_fsdp.sh`

<img width="323" height="305" alt="image" src="https://github.com/user-attachments/assets/98a80805-d1b0-4421-89a3-2416c2c2e4a2" />


Result: the previous async vLLM failure no longer reproduces. REMAX multi-turn rollout runs normally after combining sampled rollout samples and greedy baseline samples into one rollout request.

### API and Usage Example

No public API change is introduced.

No config schema change is required. Existing REMAX configs continue to work. For REMAX, the trainer internally combines sampled rollout samples and greedy baseline samples into one rollout request.

Example usage remains unchanged:

```bash
bash examples/remax_trainer/run_qwen3_8b_fsdp.sh
```

Internally, REMAX now uses a private per-sample control field, `__do_sample__`, to distinguish sampled requests from greedy-baseline requests inside the combined batch. This field is removed before downstream reward and training logic.

### Design & Code Changes

#### Workflow

Before this PR, REMAX used two rollout requests:

```text
sampled rollout request
-> sleep rollout replicas
-> greedy baseline rollout request
-> compute reward_baselines
```

This is fragile for async vLLM multi-turn agent workloads because the second request can happen after replica sleep / memory-state transition.

After this PR, REMAX uses one combined rollout request:

```text
sampled batch + greedy baseline batch
-> one rollout request
-> split sampled output and baseline output
-> compute reward_baselines from baseline output only
```

#### Call chain comparison

Previous REMAX path:

```text
RayPPOTrainer / SeparateRayPPOTrainer
-> generate sampled rollout
-> sleep_replicas()
-> generate greedy baseline rollout
-> union baseline output into batch
-> compute reward_baselines
-> pop baseline fields from batch
```

New REMAX path:

```text
RayPPOTrainer / SeparateRayPPOTrainer
-> build sampled batch with __do_sample__ = True
-> build greedy baseline batch with __do_sample__ = False
-> concat both batches
-> one rollout request
-> split combined output
-> compute reward_baselines from baseline output
-> keep baseline output isolated from the training batch
```

#### Specific changes

- `verl/experimental/agent_loop/agent_loop.py`
  - Adds support for an internal per-sample `__do_sample__` override.
  - Applies greedy sampling params only for rows where `__do_sample__` is `False`.
  - Filters `__do_sample__` before forwarding kwargs to concrete agent loops.
  - Keeps validation sampling behavior unchanged.
  - Adds a `NOTE` explaining that `__do_sample__` is an internal REMAX combined-rollout control field.

- `verl/trainer/ppo/ray_trainer.py`
  - For REMAX, concatenates sampled rollout batch and greedy baseline batch before rollout generation.
  - Uses one rollout request instead of two separate requests.
  - Splits the combined output into sampled output and baseline output.
  - Computes `reward_baselines` from the greedy baseline output only.
  - Avoids merging baseline output into the main training batch.

- `verl/experimental/separation/ray_trainer.py`
  - Applies the same REMAX combined-rollout logic to the separated trainer path.

#### Design trade-offs

- The combined batch is slightly larger for REMAX because it includes both sampled requests and greedy baseline requests in one rollout call.
- This is intentional: it avoids sending a second request after replica sleep, which is the failure-prone part in async vLLM agent-loop workloads.
- The implementation keeps the change REMAX-specific and avoids changing behavior for PPO / GRPO / other algorithms.
- The internal `__do_sample__` field is private and removed after rollout generation, so it does not become part of the downstream training data contract.

#### Backward compatibility

This PR does not introduce public API or config changes.

Non-REMAX algorithms keep the existing behavior. REMAX keeps the same algorithm-level semantics:

- sampled rollout count still follows `actor_rollout_ref.rollout.n`
- greedy baseline remains one sample per original prompt
- `reward_baselines` is still computed from the greedy baseline reward

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x]  Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x]  Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not updated in this PR because this is an internal REMAX rollout fix without user-facing API or config changes.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: 
  - this issue requires async vLLM multi-turn agent rollout with REMAX and is difficult to cover in the regular unit-test CI due to distributed runtime and GPU requirements. It was validated with local REMAX multi-turn training scripts/configs instead.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [`verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable. This PR does not touch the `recipe` submodule.