### PR TITLE
[tool, rollout] fix: preserve exact-fit tool responses in agent loop

### DIFF
--- a/tests/experimental/agent_loop/test_tool_agent_loop_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_agent_loop_on_cpu.py
@@ -1,0 +1,85 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for ToolAgentLoop state transitions."""
+
+import unittest
+from types import SimpleNamespace
+
+from verl.experimental.agent_loop.tool_agent_loop import AgentData, AgentState, ToolAgentLoop
+from verl.tools.schemas import ToolResponse
+
+
+def _make_agent_data() -> AgentData:
+    agent_data = AgentData(
+        messages=[],
+        image_data=[],
+        video_data=[],
+        metrics={},
+        request_id="test-request",
+        tools_kwargs={},
+    )
+    agent_data.prompt_ids = [11, 12, 101, 102]
+    agent_data.response_mask = [1, 1]
+    agent_data.response_logprobs = [0.1, 0.2]
+    agent_data.tool_calls = [SimpleNamespace(name="lookup", arguments="{}")]
+    return agent_data
+
+
+def _make_tool_agent_loop(tool_response_ids: list[int], response_length: int) -> ToolAgentLoop:
+    loop = ToolAgentLoop.__new__(ToolAgentLoop)
+    loop.max_parallel_calls = 1
+    loop.response_length = response_length
+    loop.tool_parser_name = "hermes"
+    loop.processor = None
+
+    async def _call_tool(tool_call, tools_kwargs, agent_data):
+        return ToolResponse(text="tool result"), None, {}
+
+    async def apply_chat_template(*args, **kwargs):
+        return tool_response_ids
+
+    loop._call_tool = _call_tool
+    loop.apply_chat_template = apply_chat_template
+    return loop
+
+
+class TestToolAgentLoopStateTransitions(unittest.IsolatedAsyncioTestCase):
+    async def test_tool_response_exact_fit_is_appended_before_termination(self):
+        loop = _make_tool_agent_loop(tool_response_ids=[201, 202], response_length=4)
+        agent_data = _make_agent_data()
+
+        state = await loop._handle_processing_tools_state(agent_data)
+
+        assert state is AgentState.TERMINATED
+        assert agent_data.prompt_ids == [11, 12, 101, 102, 201, 202]
+        assert agent_data.response_mask == [1, 1, 0, 0]
+        assert agent_data.response_logprobs == [0.1, 0.2, 0.0, 0.0]
+        assert agent_data.user_turns == 1
+
+    async def test_tool_response_overflow_still_terminates_without_appending(self):
+        loop = _make_tool_agent_loop(tool_response_ids=[201, 202, 203], response_length=4)
+        agent_data = _make_agent_data()
+
+        state = await loop._handle_processing_tools_state(agent_data)
+
+        assert state is AgentState.TERMINATED
+        assert agent_data.prompt_ids == [11, 12, 101, 102]
+        assert agent_data.response_mask == [1, 1]
+        assert agent_data.response_logprobs == [0.1, 0.2]
+        assert agent_data.user_turns == 0
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -355,7 +355,7 @@ class ToolAgentLoop(AgentLoopBase):
                 remove_system_prompt=True,
             )
 
-        if len(agent_data.response_mask) + len(response_ids) >= self.response_length:
+        if len(agent_data.response_mask) + len(response_ids) > self.response_length:
             return AgentState.TERMINATED
         # Update prompt_ids and response_mask
 
@@ -372,6 +372,8 @@ class ToolAgentLoop(AgentLoopBase):
         if agent_data.response_logprobs:
             agent_data.response_logprobs += [0.0] * len(response_ids)
         agent_data.user_turns += 1
+        if len(agent_data.response_mask) >= self.response_length:
+            return AgentState.TERMINATED
         return AgentState.GENERATING
 
     async def _call_tool(


### PR DESCRIPTION
# [tool, rollout] fix: preserve exact-fit tool responses in agent loop

### What does this PR do?

Fixes a quiet multi-turn tool-agent truncation boundary case in `ToolAgentLoop._handle_processing_tools_state`.

When a tool response tokenization exactly fills the remaining response budget, the previous `>= response_length` check returned `TERMINATED` before appending the tool response into `prompt_ids`, `response_mask`, and `response_logprobs`. That silently dropped the tool response from rollout state even though it fit within the configured response length.

This PR changes the overflow guard to only reject tool responses that exceed the remaining response budget, then terminates after appending when the exact-fit case reaches `response_length`.

Problem example:

- Configured response length is `4`.
- The assistant has already generated two response tokens: `response_ids=[101, 102]`, `response_mask=[1, 1]`.
- The assistant calls a tool, and the tool response tokenizes to exactly two tokens: `[201, 202]`.
- Since the tool response exactly fills the remaining budget, the expected final rollout state is:

```python
prompt_ids = [..., 101, 102, 201, 202]
response_mask = [1, 1, 0, 0]
state = TERMINATED
```

Before this fix, the `>= response_length` check returned before appending the tool response, so the rollout state stayed:

```python
prompt_ids = [..., 101, 102]
response_mask = [1, 1]
state = TERMINATED
```

The symptom is quiet: the run terminates normally, but the tool response that should be present in the conversation history is silently dropped from the rollout state.

Similar PR checks:

- https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ToolAgentLoop+tool+response+exact+fit+response_mask
- https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+tool_agent_loop+response_length+response_ids+response_mask
- https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+_handle_processing_tools_state+response_length

No open duplicate PR was found with these searches.

AI assistance: OpenAI Codex helped identify and prepare this patch.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ToolAgentLoop+tool+response+exact+fit+response_mask
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Targeted checks run locally:

```bash
python3 tests/experimental/agent_loop/test_tool_agent_loop_on_cpu.py
python3 tests/experimental/agent_loop/test_call_tool_on_cpu.py
uvx ruff check verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_on_cpu.py
uvx ruff format --check verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_tool_agent_loop_on_cpu.py
```

I also reproduced the original exact-fit failure with a focused runtime probe against upstream `main`, then reran the same probe against this branch. After the fix, the probe returns:

```json
{
  "response_ids": [101, 102, 201, 202],
  "response_mask": [1, 1, 0, 0],
  "agent_state": "terminated"
}
```

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Update the tool-response overflow check from `>= response_length` to `> response_length`, so an exact-fit tool response is appended instead of being dropped.
- Return `TERMINATED` after appending when the response budget is exactly filled.
- Add a CPU regression test covering both exact-fit and overflow behavior for `_handle_processing_tools_state`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Targeted `ruff check` and `ruff format --check` were run on changed files.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not applicable: this is an internal bug fix with no user-facing API/config change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable: this PR does not touch the `recipe` submodule.
