### PR TITLE
[algo,reward] fix: ignore masked reward tokens

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -22,8 +22,10 @@ import torch
 import verl.trainer.ppo.core_algos
 from verl.trainer.ppo.core_algos import (
     compute_gae_advantage_return,
+    compute_gdpo_outcome_advantage,
     compute_grpo_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
+    compute_opo_outcome_advantage,
     compute_rloo_outcome_advantage,
     compute_rloo_vectorized_outcome_advantage,
     get_adv_estimator_fn,
@@ -312,6 +314,64 @@ def test_grpo_and_vectorized_equivalence(batch_size: int, seq_len: int, num_grou
     assert ret1.shape == ret2.shape == (batch_size, seq_len)
     assert torch.allclose(adv1, adv2, rtol=1e-5, atol=1e-6)
     assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
+
+
+def test_grpo_ignores_rewards_on_masked_response_positions():
+    token_level_rewards = torch.tensor([[0.0, 0.0, 10.0], [0.0, 0.0, 0.0]])
+    response_mask = torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.float32)
+    index = np.array(["prompt", "prompt"], dtype=object)
+
+    adv, ret = compute_grpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+    adv_vec, ret_vec = compute_grpo_vectorized_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    assert torch.equal(adv, torch.zeros_like(adv))
+    assert torch.equal(ret, torch.zeros_like(ret))
+    assert torch.equal(adv_vec, torch.zeros_like(adv_vec))
+    assert torch.equal(ret_vec, torch.zeros_like(ret_vec))
+
+
+def test_gdpo_ignores_zero_length_component_rewards():
+    token_level_rewards = torch.zeros(2, 3, dtype=torch.float32)
+    response_mask = torch.tensor([[0, 0, 0], [1, 1, 0]], dtype=torch.float32)
+    batch = {
+        "prompts": torch.tensor([[11, 12], [11, 12]], dtype=torch.long),
+        "attention_mask": torch.tensor([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]], dtype=torch.long),
+    }
+    non_tensor_batch = {"accuracy_reward": np.array([10.0, 0.0], dtype=np.float32)}
+
+    adv, ret = compute_gdpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=np.array(["prompt", "prompt"], dtype=object),
+        config={"gdpo_reward_keys": ["accuracy_reward"]},
+        non_tensor_batch=non_tensor_batch,
+        batch=batch,
+    )
+
+    assert torch.equal(adv, torch.zeros_like(adv))
+    assert torch.equal(ret, torch.zeros_like(ret))
+
+
+def test_opo_all_zero_length_group_is_finite():
+    token_level_rewards = torch.tensor([[0.0, 10.0, 0.0], [0.0, 5.0, 0.0]])
+    response_mask = torch.zeros_like(token_level_rewards)
+
+    adv, ret = compute_opo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=np.array(["prompt", "prompt"], dtype=object),
+    )
+
+    assert torch.equal(adv, torch.zeros_like(adv))
+    assert torch.equal(ret, torch.zeros_like(ret))
 
 
 @pytest.mark.parametrize(

--- a/tests/workers/reward_manager/test_zero_length_response_on_cpu.py
+++ b/tests/workers/reward_manager/test_zero_length_response_on_cpu.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.experimental.reward_loop.reward_manager.base import RewardManagerBase
+from verl.workers.reward_manager.naive import NaiveRewardManager
+
+
+class Tokenizer:
+    pad_token_id = 0
+
+    def decode(self, ids, skip_special_tokens=True):
+        if hasattr(ids, "tolist"):
+            ids = ids.tolist()
+        return " ".join(str(token) for token in ids if token != self.pad_token_id)
+
+
+def _make_data() -> DataProto:
+    return DataProto(
+        batch=TensorDict(
+            {
+                "prompts": torch.tensor([[11, 12], [11, 12]], dtype=torch.long),
+                "responses": torch.tensor([[0, 0, 0], [101, 102, 0]], dtype=torch.long),
+                "attention_mask": torch.tensor([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]], dtype=torch.long),
+            },
+            batch_size=2,
+        ),
+        non_tensor_batch={
+            "reward_model": np.array(
+                [{"ground_truth": "empty-high"}, {"ground_truth": "normal"}],
+                dtype=object,
+            ),
+            "data_source": np.array(["probe", "probe"], dtype=object),
+            "extra_info": np.array([{}, {}], dtype=object),
+        },
+    )
+
+
+def test_naive_reward_manager_does_not_write_reward_for_zero_length_response():
+    def compute_score(data_source, solution_str, ground_truth, extra_info):
+        return 10.0 if ground_truth == "empty-high" else 1.0
+
+    reward_tensor = NaiveRewardManager(
+        Tokenizer(),
+        num_examine=0,
+        compute_score=compute_score,
+    )(_make_data())
+
+    assert torch.equal(reward_tensor[0], torch.zeros_like(reward_tensor[0]))
+    assert torch.equal(reward_tensor[1], torch.tensor([0.0, 1.0, 0.0]))
+
+
+def test_reward_loop_assemble_rm_scores_skips_zero_length_response():
+    rm_scores = RewardManagerBase.assemble_rm_scores(_make_data(), [10.0, 1.0])
+
+    assert torch.equal(rm_scores[0], torch.zeros_like(rm_scores[0]))
+    assert torch.equal(rm_scores[1], torch.tensor([0.0, 1.0, 0.0]))

--- a/verl/experimental/reward_loop/reward_manager/base.py
+++ b/verl/experimental/reward_loop/reward_manager/base.py
@@ -76,7 +76,8 @@ class RewardManagerBase(ABC):
         prompt_length = data.batch["prompts"].size(1)
         valid_response_length = data.batch["attention_mask"][:, prompt_length:].sum(dim=1)
         rm_scores = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
-        rm_scores[torch.arange(rm_scores.size(0), device=rm_scores.device), valid_response_length - 1] = (
-            rm_scores.new_tensor(scores)
-        )
+        has_response = valid_response_length > 0
+        if has_response.any():
+            batch_idx = torch.arange(rm_scores.size(0), device=rm_scores.device)[has_response]
+            rm_scores[batch_idx, valid_response_length[has_response] - 1] = rm_scores.new_tensor(scores)[has_response]
         return rm_scores

--- a/verl/experimental/reward_loop/reward_manager/limited.py
+++ b/verl/experimental/reward_loop/reward_manager/limited.py
@@ -521,10 +521,11 @@ class RateLimitedRewardManager(RewardManagerBase):
             data_item = data[i]
             response_ids = data_item.batch["responses"]
             response_length = response_ids.shape[-1]
-            valid_response_length = data_item.batch["attention_mask"][-response_length:].sum()
+            valid_response_length = int(data_item.batch["attention_mask"][-response_length:].sum().item())
 
             reward = result["reward_score"]
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             # Collect extra info
             if "reward_extra_info" in result:

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -263,6 +263,10 @@ def compute_gae_advantage_return(
     return advantages, returns
 
 
+def _sum_token_level_rewards(token_level_rewards: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:
+    return (token_level_rewards * response_mask).sum(dim=-1)
+
+
 # NOTE(sgm): this implementation only consider outcome supervision, where the reward is a scalar.
 @register_adv_est(AdvantageEstimator.GRPO)  # or simply: @register_adv_est("grpo")
 def compute_grpo_outcome_advantage(
@@ -301,7 +305,7 @@ def compute_grpo_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape is (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -347,7 +351,7 @@ def compute_grpo_vectorized_outcome_advantage(
       then broadcast the scalar across the token dimension (multiplied by response_mask).。
     """
     with torch.no_grad():
-        scores = token_level_rewards.sum(dim=-1)
+        scores = _sum_token_level_rewards(token_level_rewards, response_mask)
         g = as_torch_index(index, device=scores.device)
         mean_g, std_g, _ = group_mean_std(scores, g, eps=epsilon, device=scores.device)
         if norm_adv_by_std_in_grpo:
@@ -417,7 +421,9 @@ def compute_gdpo_outcome_advantage(
         )
         device = token_level_rewards.device
         prompt_length = batch["prompts"].size(1)
-        valid_response_length = batch["attention_mask"][:, prompt_length:].sum(dim=1) - 1
+        valid_response_length = batch["attention_mask"][:, prompt_length:].sum(dim=1)
+        valid_response_idx = valid_response_length - 1
+        has_response = valid_response_length > 0
 
         score_list = []
         for key in gdpo_reward_keys:
@@ -429,7 +435,9 @@ def compute_gdpo_outcome_advantage(
             comp = non_tensor_batch[key]
             rm_score = torch.tensor(np.asarray(comp, dtype=np.float32), device=device)
             rm_scores = torch.zeros_like(response_mask, dtype=torch.float32)
-            rm_scores[torch.arange(rm_scores.size(0), device=device), valid_response_length] = rm_score
+            if has_response.any():
+                batch_idx = torch.arange(rm_scores.size(0), device=device)[has_response]
+                rm_scores[batch_idx, valid_response_idx[has_response]] = rm_score[has_response]
             score_list.append(rm_scores)
 
         gdpo_weights = config.get("gdpo_reward_weights", None)
@@ -498,7 +506,7 @@ def compute_grpo_passk_outcome_advantage(
     assert config is not None
     # if True, normalize advantage by std within group
     norm_adv_by_std_in_grpo = config.get("norm_adv_by_std_in_grpo", True)
-    scores = token_level_rewards.sum(dim=-1)  # (bs,)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)  # (bs,)
     advantages = torch.zeros_like(scores)
 
     id2scores = defaultdict(list)
@@ -559,7 +567,7 @@ def compute_reinforce_plus_plus_baseline_outcome_advantage(
             shape: (bs, response_length)
     """
     response_length = token_level_rewards.shape[-1]
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -609,7 +617,7 @@ def compute_rloo_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -662,7 +670,7 @@ def compute_opo_outcome_advantage(
             shape: (bs, response_length)
     """
     response_length = response_mask.sum(dim=-1)
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2len = defaultdict(list)
@@ -680,7 +688,11 @@ def compute_opo_outcome_advantage(
             elif len(id2score[idx]) > 1:
                 score_tensor = torch.stack(id2score[idx])
                 len_tensor = torch.stack(id2len[idx])
-                id2bsl[idx] = (len_tensor * score_tensor).sum() / len_tensor.sum()
+                total_len = len_tensor.sum()
+                if total_len > 0:
+                    id2bsl[idx] = (len_tensor * score_tensor).sum() / total_len
+                else:
+                    id2bsl[idx] = torch.tensor(0.0, device=score_tensor.device, dtype=score_tensor.dtype)
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
@@ -797,7 +809,7 @@ def compute_gpg_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -853,7 +865,7 @@ def compute_rloo_vectorized_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _sum_token_level_rewards(token_level_rewards, response_mask)
 
     with torch.no_grad():
         inv = torch.from_numpy(np.unique(index, return_inverse=True)[1]).to(scores.device)

--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -107,7 +107,8 @@ class BatchRewardManager(AbstractRewardManager):
                 reward = score
 
             rewards.append(reward)
-            reward_tensor[i, length - 1] = reward
+            if length > 0:
+                reward_tensor[i, length - 1] = reward
 
             data_source = data_sources[i]
             if already_printed.get(data_source, 0) < self.num_examine:

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -79,7 +79,7 @@ class DAPORewardManager(AbstractRewardManager):
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
+            valid_response_length = int(data_item.batch["attention_mask"][prompt_length:].sum().item())
             valid_response_ids = response_ids[:valid_response_length]
 
             # decode
@@ -129,7 +129,8 @@ class DAPORewardManager(AbstractRewardManager):
                     reward_extra_info["overlong_reward"].append(overlong_reward)
                     reward_extra_info["overlong"].append(overlong_reward < 0)
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -67,7 +67,7 @@ class NaiveRewardManager(AbstractRewardManager):
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
+            valid_response_length = int(data_item.batch["attention_mask"][prompt_length:].sum().item())
             valid_response_ids = response_ids[:valid_response_length]
 
             # decode
@@ -97,7 +97,8 @@ class NaiveRewardManager(AbstractRewardManager):
             else:
                 reward = score
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -174,7 +174,9 @@ class PrimeRewardManager(AbstractRewardManager):
 
         for i in range(len(data)):
             data_source = data_sources[i]
-            reward_tensor[i, valid_response_length[i].item() - 1] = scores[i]
+            length = valid_response_length[i].item()
+            if length > 0:
+                reward_tensor[i, length - 1] = scores[i]
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0


### PR DESCRIPTION
### What does this PR do?

This PR fixes a quiet reward/advantage corruption when a rollout sample has zero valid response tokens.

Before this change, several reward managers wrote scalar reward to `valid_response_length - 1`. For a zero-length response this becomes `-1`, so the reward is stored on the last padded response token. GRPO-style outcome estimators then summed `token_level_rewards` without applying `response_mask`, allowing masked/padded rewards to affect group statistics and peer advantages.

The fix:

- skips scalar reward placement when a sample has no valid response tokens;
- applies `response_mask` when reducing token-level rewards into per-response outcome scores;
- guards GDPO and experimental reward-loop reward assembly against zero-length response indexing;
- adds CPU regressions for zero-length response reward placement and masked reward reduction.

Related RL-Sentinel evidence:

- Original failing recipe: `verl.white_box.empty_response_reward_pad_leak`
- Symptom before fix: empty sample had `token_level_rewards = [0.0, 0.0, 10.0]` with `response_mask = [0, 0, 0]`, and its peer received non-zero GRPO advantages.
- Validation after fix: the same RL-Sentinel recipe passes with `violation_count = 0`, empty sample reward stays all-zero, and peer advantages stay all-zero.

### Checklist Before Starting

- [x] Search for similar PRs. Query links:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+empty+response+reward+mask+GRPO+reward_manager
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+valid_response_length+reward_tensor+response_mask
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+token_level_rewards+response_mask+sum+advantage
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Duplicate-check note: no open PR with the same fix was found. The closest search hit was #5615, which is about missing `old_log_probs` for OTB estimators and is unrelated to reward-mask placement.

### Test

```bash
/usr/bin/python3 -m pytest -q \
  tests/trainer/ppo/test_core_algos_on_cpu.py \
  tests/workers/reward_manager/test_zero_length_response_on_cpu.py
```

Result:

```text
27 passed, 2 warnings in 7.83s
```

```bash
/usr/bin/python3 -m ruff check \
  verl/trainer/ppo/core_algos.py \
  verl/workers/reward_manager/naive.py \
  verl/workers/reward_manager/batch.py \
  verl/workers/reward_manager/dapo.py \
  verl/workers/reward_manager/prime.py \
  verl/experimental/reward_loop/reward_manager/base.py \
  verl/experimental/reward_loop/reward_manager/limited.py \
  tests/trainer/ppo/test_core_algos_on_cpu.py \
  tests/workers/reward_manager/test_zero_length_response_on_cpu.py
```

Result:

```text
All checks passed!
```

```bash
pre-commit run --files \
  verl/trainer/ppo/core_algos.py \
  verl/workers/reward_manager/naive.py \
  verl/workers/reward_manager/batch.py \
  verl/workers/reward_manager/dapo.py \
  verl/workers/reward_manager/prime.py \
  verl/experimental/reward_loop/reward_manager/base.py \
  verl/experimental/reward_loop/reward_manager/limited.py \
  tests/trainer/ppo/test_core_algos_on_cpu.py \
  tests/workers/reward_manager/test_zero_length_response_on_cpu.py
```

Result: all hooks passed, including ruff, ruff format, mypy, config generation, docs checks, license checks, DataProto checks, test-structure checks, naming checks, and Python compilation.

RL-Sentinel validation against this branch:

```bash
uv run python -m rl_infra_harness.cli run-recipe \
  --recipe-file recipes/agentic/verl/white_box_runtime/empty_response_reward_pad_leak.json \
  --repo-root /mlx_devbox/users/mahaoyang/playground/myverl \
  --scenario-file /tmp/rl_sentinel_empty_response_reward_myverl_fixed_scenario.json \
  --run-output-dir /tmp/rl_sentinel_empty_response_reward_myverl_fixed_runtime \
  --output-dir artifacts/recipe-runs/empty-response-reward-pad-leak-myverl-fixed \
  --no-use-env-profile-runtime \
  --timeout-s 120
```

Result: passed. `RolloutCorrectnessOracle` reported `violation_count = 0`.

### API and Usage Example

No public API or config change.

### Design & Code Changes

- `verl/workers/reward_manager/{naive,batch,dapo,prime}.py`: only place scalar reward at the last response token when `valid_response_length > 0`.
- `verl/experimental/reward_loop/reward_manager/{base,limited}.py`: apply the same zero-length guard in experimental reward-loop reward assembly.
- `verl/trainer/ppo/core_algos.py`: add a masked reward-sum helper and use it for outcome score reductions, so padded reward values cannot affect GRPO, vectorized GRPO, GRPO-Pass@k, RF++ baseline, RLOO, OPO, GPG, or vectorized RLOO. Also guard OPO's length-weighted baseline when a group has zero total valid response length.
- Tests cover the original quiet failure shape:
  - reward managers do not write reward for all-zero response masks;
  - GRPO/vectorized GRPO ignore reward values on masked positions;
  - GDPO ignores zero-length component rewards;
  - OPO all-zero-length groups stay finite and all-zero.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks on changed files.
- [x] Add unit tests covering the fix.
- [x] Documentation update not needed because this is an internal correctness fix with no user-facing API/config change.
- [ ] CI request not sent yet.
- [x] Not related to the `recipe` submodule.

### AI-Assisted Contribution Statement

AI assistance was used to help identify the failing edge case, implement the patch, and draft this PR description.