### PR TITLE
[tool] fix: tool response truncate side

### DIFF
--- a/tests/experimental/agent_loop/test_call_tool_on_cpu.py
+++ b/tests/experimental/agent_loop/test_call_tool_on_cpu.py
@@ -64,14 +64,29 @@ class FakeFailingTool(FakeTool):
         raise RuntimeError("database connection failed")
 
 
-def _make_tool_agent_loop(tools: dict[str, Any]):
+class FakeLongResponseTool(FakeTool):
+    """A fake tool that returns a long response."""
+
+    def __init__(self, name: str, text: str):
+        super().__init__(name)
+        self.text = text
+
+    async def execute(self, instance_id, parameters, **kwargs):
+        return ToolResponse(text=self.text), 1.0, {}
+
+
+def _make_tool_agent_loop(
+    tools: dict[str, Any],
+    max_tool_response_length: int = 10000,
+    tool_response_truncate_side: str = "left",
+):
     """Create a minimal ToolAgentLoop instance with only the fields _call_tool needs."""
     from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
 
     mock = MagicMock(spec=ToolAgentLoop)
     mock.tools = tools
-    mock.max_tool_response_length = 10000
-    mock.tool_response_truncate_side = "left"
+    mock.max_tool_response_length = max_tool_response_length
+    mock.tool_response_truncate_side = tool_response_truncate_side
     # Bind the real _call_tool method to our mock
     mock._call_tool = ToolAgentLoop._call_tool.__get__(mock, ToolAgentLoop)
     return mock
@@ -136,6 +151,41 @@ class TestCallToolErrorHandling(unittest.IsolatedAsyncioTestCase):
         assert reward == 0.0
         assert "failing_tool" in response.text
         assert "database connection failed" in response.text
+
+    async def test_left_truncation_keeps_response_tail(self):
+        """Left truncation should drop the left side and preserve the response tail."""
+        tool_response = (
+            "Search results for capital of France:\n"
+            "1. Lyon is a major city with a long Roman history.\n"
+            "2. Marseille is a large port city in southern France.\n"
+            "3. The final retrieved snippet says the capital is Paris.\n"
+            "Final answer: Paris"
+        )
+        tools = {"search": FakeLongResponseTool("search", tool_response)}
+        loop = _make_tool_agent_loop(tools, max_tool_response_length=19, tool_response_truncate_side="left")
+        tool_call = FakeFunctionCall(name="search", arguments="{}")
+        response, reward, _ = await loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 1.0
+        assert response.text.startswith("(truncated)...")
+        assert response.text.endswith("Final answer: Paris")
+
+    async def test_right_truncation_keeps_response_head(self):
+        """Right truncation should drop the right side and preserve the response head."""
+        tool_response = (
+            "Search results for capital of France:\n"
+            "1. Lyon is a major city with a long Roman history.\n"
+            "2. Marseille is a large port city in southern France.\n"
+            "3. The final retrieved snippet says the capital is Paris.\n"
+            "Final answer: Paris"
+        )
+        tools = {"search": FakeLongResponseTool("search", tool_response)}
+        loop = _make_tool_agent_loop(tools, max_tool_response_length=19, tool_response_truncate_side="right")
+        tool_call = FakeFunctionCall(name="search", arguments="{}")
+        response, reward, _ = await loop._call_tool(tool_call, {}, self.agent_data)
+        assert reward == 1.0
+        assert response.text.startswith("Search results")
+        assert response.text.endswith("...(truncated)")
+        assert "Final answer: Paris" not in response.text
 
 
 if __name__ == "__main__":

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -416,9 +416,9 @@ class ToolAgentLoop(AgentLoopBase):
         tool_response_text = tool_execution_response.text
         if tool_response_text and len(tool_response_text) > self.max_tool_response_length:
             if self.tool_response_truncate_side == "left":
-                tool_response_text = tool_response_text[: self.max_tool_response_length] + "...(truncated)"
-            elif self.tool_response_truncate_side == "right":
                 tool_response_text = "(truncated)..." + tool_response_text[-self.max_tool_response_length :]
+            elif self.tool_response_truncate_side == "right":
+                tool_response_text = tool_response_text[: self.max_tool_response_length] + "...(truncated)"
             else:
                 length = self.max_tool_response_length // 2
                 tool_response_text = tool_response_text[:length] + "...(truncated)..." + tool_response_text[-length:]


### PR DESCRIPTION
### What does this PR do?

This PR fixes `tool_response_truncate_side` handling in `ToolAgentLoop._call_tool`.

`left` truncation is expected to drop the left side and keep the tail, matching existing veRL truncation behavior in `verl.utils.torch_functional.postprocess_data` and dataset truncation code. The tool response path currently does the opposite: `left` keeps the head and drops the tail, while `right` keeps the tail.

This is quiet for agentic rollout: no crash is raised, but a rollout configured with:

```yaml
actor_rollout_ref.rollout.multi_turn.enable: true
actor_rollout_ref.rollout.multi_turn.max_tool_response_length: 32
actor_rollout_ref.rollout.multi_turn.tool_response_truncate_side: left
```

can hide the most recent or terminal part of a long tool result from the model. The sample below mirrors common search/code/database tool output: the beginning contains verbose context, while the final line contains the result the model should use.

```text
Search results for capital of France:
1. Lyon is a major city with a long Roman history.
2. Marseille is a large port city in southern France.
3. The final retrieved snippet says the capital is Paris.
Final answer: Paris
```

Current `left` truncation can produce a model-visible tool message without `Final answer: Paris`:

```text
Search results for ...(truncated)
```

With the corrected left-truncation semantics, the final tool result remains visible:

```text
(truncated)...Final answer: Paris
```

### Symptom and impact

The symptom is silent prompt corruption in multi-turn tool rollouts:

- The rollout does not crash.
- The tool call succeeds and returns a long response.
- The configured `tool_response_truncate_side=left` unexpectedly keeps old prefix text and drops the response tail.
- The model receives a tool message that is missing the final tool result, so downstream answers, rewards, and training signals can be wrong without an obvious runtime error.

This matters for agent/tool tasks because tool responses commonly place the useful answer near the end: search summaries with final citations, execution logs with final status, database lookups with a final record, or code tools with the final result after verbose output.

### Minimal reproduction

The issue can be reproduced by calling the real `_call_tool` path with a long search-style tool response and `tool_response_truncate_side=left`.

```python
import asyncio
from dataclasses import dataclass, field
from unittest.mock import MagicMock

from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
from verl.tools.schemas import ToolResponse

TOOL_RESPONSE = (
    "Search results for capital of France:\n"
    "1. Lyon is a major city with a long Roman history.\n"
    "2. Marseille is a large port city in southern France.\n"
    "3. The final retrieved snippet says the capital is Paris.\n"
    "Final answer: Paris"
)


@dataclass
class FakeFunctionCall:
    name: str
    arguments: str


@dataclass
class FakeAgentData:
    tools_kwargs: dict = field(default_factory=dict)


class SearchTool:
    name = "search"

    async def create(self, create_kwargs=None):
        return "inst", ToolResponse()

    async def execute(self, instance_id, parameters, **kwargs):
        return ToolResponse(text=TOOL_RESPONSE), 1.0, {}

    async def release(self, instance_id):
        pass


async def main():
    for side in ["left", "right"]:
        loop = MagicMock(spec=ToolAgentLoop)
        loop.tools = {"search": SearchTool()}
        loop.max_tool_response_length = len("Final answer: Paris")
        loop.tool_response_truncate_side = side
        loop._call_tool = ToolAgentLoop._call_tool.__get__(loop, ToolAgentLoop)
        response, reward, _ = await loop._call_tool(FakeFunctionCall("search", "{}"), {}, FakeAgentData())
        print(side, repr(response.text), "contains_final_answer=", "Final answer: Paris" in response.text)


asyncio.run(main())
```

On current main before this fix, the output is:

```text
left  'Search results for ...(truncated)' contains_final_answer=False
right '(truncated)...Final answer: Paris' contains_final_answer=True
```

After this fix, the output is:

```text
left  '(truncated)...Final answer: Paris' contains_final_answer=True
right 'Search results for ...(truncated)' contains_final_answer=False
```

Related but not duplicate: #4918 discusses char-count versus token-count truncation. This PR only fixes the side semantics.

### Checklist Before Starting

- [x] Search for similar PRs. Query link: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+tool_response_truncate_side
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

```bash
python -m pytest -q tests/experimental/agent_loop/test_call_tool_on_cpu.py
# 8 passed, 2 warnings in 8.29s

python -m ruff check verl/experimental/agent_loop/tool_agent_loop.py tests/experimental/agent_loop/test_call_tool_on_cpu.py
# All checks passed!
```

I also ran a focused `_call_tool` reproduction before and after the fix. After the fix:

```text
left  '(truncated)...Final answer: Paris' contains_final_answer=True
right 'Search results for ...(truncated)' contains_final_answer=False
```

### API and Usage Example

No API change.

Existing configs using:

```yaml
actor_rollout_ref.rollout.multi_turn.tool_response_truncate_side: left
```

now follow the same left-truncation convention as other veRL truncation paths: drop left, keep tail.

### Design & Code Changes

- Swap the `left` and `right` branches in `ToolAgentLoop._call_tool` so side semantics match the rest of veRL.
- Add CPU unit tests covering:
  - `left` truncation preserves the response tail.
  - `right` truncation preserves the response head.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [ ] Apply full pre-commit checks. Focused `ruff check` was run on changed files.
- [ ] Add / update documentation. Not needed; this is a bug fix for existing config semantics.
- [x] Add unit test(s) to cover the changed behavior.
- [ ] Request CI after opening the PR.

AI assistance: OpenAI Codex was used for local investigation and patch drafting.
