### PR TITLE
[fsdp] fix: FSDP2 silently drops fsdp_config.forward_prefetch

### DIFF
--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -563,13 +563,14 @@ def apply_fsdp2(model, fsdp_kwargs, config):
     # Honor `forward_prefetch` config to match the FSDP1 path. Depth=1 mirrors
     # PyTorch FSDP1's hardcoded `forward_prefetch_limit=1`. Static-graph models
     # only (see PyTorch FSDP1's docstring on `forward_prefetch`).
+    # `set_modules_to_forward_prefetch` was introduced in PyTorch 2.5; guard with
+    # `hasattr` so users on PyTorch 2.4 silently fall back to the no-prefetch
+    # behavior (same as before this PR — no regression).
     if config.get("forward_prefetch", False):
-        from torch.distributed.fsdp import FSDPModule
-
         fsdp_modules = [m for m in modules if isinstance(m, FSDPModule)]
         for i, m in enumerate(fsdp_modules):
             next_targets = fsdp_modules[i + 1 : i + 2]  # depth=1, mirrors FSDP1's forward_prefetch_limit=1
-            if next_targets:
+            if next_targets and hasattr(m, "set_modules_to_forward_prefetch"):
                 m.set_modules_to_forward_prefetch(next_targets)
 
 

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -560,6 +560,18 @@ def apply_fsdp2(model, fsdp_kwargs, config):
     with maybe_patch_fsdp_module(model):
         fully_shard(model, **fsdp_kwargs)  # fsdp2 will not reshard_after_forward for root module
 
+    # Honor `forward_prefetch` config to match the FSDP1 path. Depth=1 mirrors
+    # PyTorch FSDP1's hardcoded `forward_prefetch_limit=1`. Static-graph models
+    # only (see PyTorch FSDP1's docstring on `forward_prefetch`).
+    if config.get("forward_prefetch", False):
+        from torch.distributed.fsdp import FSDPModule
+
+        fsdp_modules = [m for m in modules if isinstance(m, FSDPModule)]
+        for i, m in enumerate(fsdp_modules):
+            next_targets = fsdp_modules[i + 1 : i + 2]  # depth=1, mirrors FSDP1's forward_prefetch_limit=1
+            if next_targets:
+                m.set_modules_to_forward_prefetch(next_targets)
+
 
 def get_shard_placement_fn(fsdp_size):
     """Choose the dimension that can divide fsdp_size to avoid padding"""


### PR DESCRIPTION
### What does this PR do?

FSDP2 path's `apply_fsdp2()` silently drops the user-set `fsdp_config.forward_prefetch` config. The FSDP1 wrap path in the same file (`verl/workers/engine/fsdp/transformer_impl.py`) already passes this flag through to PyTorch's `FullyShardedDataParallel`, but the FSDP2 wrap path doesn't honor it. It seems like a bug with FSDP2 backend.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

I ran 4 verification configurations on Qwen3-32B (2 node × 8 H200, FSDP2 + vLLM colocate, DP=16) using `torch.profiler` to capture one `train_batch` step's FSDP phase breakdown. (The profile code was written with the help of Claude Code).

| Config | Step time baseline (s/rk) | Step time with this PR (s/rk) | Δ |
|---|---:|---:|---:|
| w.o. offload | 44.03 | 43.27 | -0.76 s **(-1.7%)** |
| w/ offload  | 61.31 | 59.27 | -2.04 s **(-3.3%)** |

The step time is slightly reduced due to the communication-computation overlap. However, with prefetch on, forward compute slows down ~8-14% due to concurrent AG/compute HBM bandwidth contention, which is expected.

Here is a more detailed result:

| (s/rk) | w.o. offload (baseline) | w.o. offload (fixed) | w/ offload (baseline) | w/ offload (fixed) |
|---|---:|---:|---:|---:|
| Forward AG kernel (combined) | 2.99 | 0.13+6.08=6.21 | 3.10 | 0.41+5.19=5.60 |
| Forward AG exposed (combined) | 2.99 | 1.40 (-53%) | 3.10 | 1.34 (-57%) |
| Forward compute | 8.54 | 9.74 (+14%) | 8.41 | 9.11 (+8.3%) |
| Backward AG kernel | 3.41 | 3.61 | 22.85 | 22.13 |
| Backward AG exposed | 1.51 | 1.72 | 6.15 | 4.92 |
| Backward RS kernel | 5.85 | 5.41 | 17.06 | 17.56 |
| Backward compute | 23.67 | 23.62 | 24.87 | 24.92 |
| Step time total | 44.03 | 43.27 | 61.31 | 59.27 |
| Delta | — | -0.76 s (-1.7%) | — | -2.04 s (-3.3%) |

### API and Usage Example

No new API. Same opt-in flag the FSDP1 path already honors.

```python
python -m verl.trainer.main_ppo \
    actor_rollout_ref.actor.strategy=fsdp2 \
    actor_rollout_ref.actor.fsdp_config.forward_prefetch=True \ # add support with fsdp2 in this pr
    actor_rollout_ref.actor.fsdp_config.offload_policy=False \  # or True, for testing
```

### Design & Code Changes

We strictly mirror PyTorch FSDP1's behavior on the FSDP2 path:

- FSDP1's `FullyShardedDataParallel(forward_prefetch=True, ...)` hardcodes `forward_prefetch_limit=1` (`torch/distributed/fsdp/fully_sharded_data_parallel.py`).
- FSDP2 exposes `FSDPModule.set_modules_to_forward_prefetch([next_module])` for the same 1-layer-ahead overlap.

So I added 12 lines at the end of `apply_fsdp2()`: after every wrap target has been `fully_shard`, walk the wrap-target list in registration order and chain `set_modules_to_forward_prefetch` on each module pointing at the next.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (No change: Just a fix to align the behavior that documentation claimed)
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: It's just a bug fix, I have tested it with real recipes (see Section Test above).
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.