### PR TITLE
[trainer, fsdp, megatron, veomni, torchtitan] feat: add freeze_module_pattern for partial parameter freezing

### DIFF
--- a/tests/utils/test_freeze_utils_on_cpu.py
+++ b/tests/utils/test_freeze_utils_on_cpu.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Individual Contributor: Wu Zehuan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import torch.nn as nn
+
+from verl.utils.freeze_utils import apply_freeze_to_module
+
+
+class DummyVLModel(nn.Module):
+    """Minimal model with a vision-like subtree and a language head."""
+
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.visual = nn.Module()
+        self.model.visual.encoder = nn.Linear(16, 16)
+        self.model.visual.merger = nn.Linear(16, 32)
+        self.model.language = nn.Linear(32, 64)
+        self.lm_head = nn.Linear(64, 10)
+
+
+class TestApplyFreezeToModule(unittest.TestCase):
+    def test_no_pattern_does_nothing(self):
+        model = DummyVLModel()
+        apply_freeze_to_module(model, None)
+        for p in model.parameters():
+            self.assertTrue(p.requires_grad)
+
+    def test_freeze_visual_subtree(self):
+        model = DummyVLModel()
+        apply_freeze_to_module(model, r"model\.visual\.")
+        self.assertFalse(model.model.visual.encoder.weight.requires_grad)
+        self.assertFalse(model.model.visual.merger.weight.requires_grad)
+        self.assertTrue(model.model.language.weight.requires_grad)
+        self.assertTrue(model.lm_head.weight.requires_grad)
+
+    def test_freeze_single_module(self):
+        model = DummyVLModel()
+        apply_freeze_to_module(model, r"model\.visual\.merger")
+        self.assertTrue(model.model.visual.encoder.weight.requires_grad)  # not matched
+        self.assertFalse(model.model.visual.merger.weight.requires_grad)
+
+    def test_invalid_regex_raises(self):
+        model = DummyVLModel()
+        with self.assertRaisesRegex(ValueError, "Invalid freeze_module_pattern"):
+            apply_freeze_to_module(model, r"[invalid")
+
+    def test_megatron_works(self):
+        model = DummyVLModel()
+        apply_freeze_to_module(model, r"visual")
+
+    def test_returns_frozen_count(self):
+        model = DummyVLModel()
+        count = apply_freeze_to_module(model, r"model\.visual\.")
+        # encoder.weight, encoder.bias, merger.weight, merger.bias = 4 params
+        self.assertEqual(count, 4)
+
+    def test_anchor_based_exact_parameter_match(self):
+        """Regex with ^...$ should match only the exact parameter."""
+        model = DummyVLModel()
+        apply_freeze_to_module(model, r"^model\.visual\.encoder\.weight$")
+        self.assertFalse(model.model.visual.encoder.weight.requires_grad)
+        self.assertTrue(model.model.visual.encoder.bias.requires_grad)  # not matched
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -408,6 +408,7 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
@@ -637,6 +638,7 @@ critic:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -373,6 +373,7 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
@@ -570,6 +571,7 @@ critic:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -380,6 +380,7 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
@@ -590,6 +591,7 @@ critic:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -362,6 +362,7 @@ actor_rollout_ref:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true
@@ -562,6 +563,7 @@ critic:
     custom_chat_template: null
     external_lib: null
     override_config: {}
+    freeze_module_pattern: null
     enable_gradient_checkpointing: true
     enable_activation_offload: false
     use_remove_padding: true

--- a/verl/trainer/config/model/hf_model.yaml
+++ b/verl/trainer/config/model/hf_model.yaml
@@ -30,6 +30,9 @@ external_lib: null
 # override hf config
 override_config: {}
 
+# regex pattern to freeze parameters. null means no freeze is applied.
+freeze_module_pattern: null
+
 # whether to enable gradient checkpointing. Only valid when we use hf model definition
 enable_gradient_checkpointing: True
 

--- a/verl/utils/freeze_utils.py
+++ b/verl/utils/freeze_utils.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Individual Contributor: Wu Zehuan
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Freeze module parameters by regex pattern.
+
+Used by both FSDP and Megatron engines to selectively freeze model
+parameters during training (e.g. freeze vision encoder in VLMs).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+def apply_freeze_to_module(
+    module: nn.Module,
+    freeze_pattern: str,
+) -> int:
+    """Freeze parameters whose fully-qualified name matches the regex pattern.
+
+    Sets ``requires_grad = False`` on matching parameters before FSDP
+    wrapping or Megatron/VeOmni/TorchTitan optimizer construction.
+
+    Args:
+        module: The loaded model (before FSDP/DDP wrapping).
+        freeze_pattern: Regex pattern to match against parameter names.
+            e.g. ``"model\\.visual"`` to match all visual model params.
+
+    Returns:
+        Number of parameters frozen.
+
+    Raises:
+        ValueError: If the regex pattern is invalid.
+    """
+    if not freeze_pattern:
+        return 0
+
+    try:
+        pattern = re.compile(freeze_pattern)
+    except re.error as exc:
+        raise ValueError(f"Invalid freeze_module_pattern regex: '{freeze_pattern}' — {exc}") from exc
+
+    frozen = 0
+    for name, param in module.named_parameters():
+        if pattern.search(name):
+            param.requires_grad = False
+            frozen += 1
+
+    if frozen == 0:
+        logger.warning(
+            "freeze_module_pattern '%s' matched 0 parameters. Check your regex.  Example parameter names: %s",
+            freeze_pattern,
+            ", ".join(n for i, (n, _) in enumerate(module.named_parameters()) if i < 5),
+        )
+    else:
+        logger.info(
+            "Freeze applied: %d parameters frozen (pattern: '%s')",
+            frozen,
+            freeze_pattern,
+        )
+
+    return frozen

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -113,6 +113,7 @@ class HFModelConfig(BaseConfig):
     external_lib: Optional[str] = None
 
     override_config: dict = field(default_factory=dict)
+    freeze_module_pattern: Optional[str] = None
 
     enable_gradient_checkpointing: bool = True
     enable_activation_offload: bool = False

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -442,7 +442,8 @@ class FSDPEngine(BaseEngine):
     def _build_optimizer(self, module):
         from verl.workers.config.optimizer import build_optimizer
 
-        optimizer = build_optimizer(module.parameters(), self.optimizer_config)
+        trainable_params = [p for p in module.parameters() if p.requires_grad]
+        optimizer = build_optimizer(trainable_params, self.optimizer_config)
 
         return optimizer
 
@@ -539,6 +540,14 @@ class FSDPEngine(BaseEngine):
         # Apply LoRA adapters if low-rank adaptation is enabled
         if self._is_lora:
             module = self._build_lora_module(module)
+
+        # Freeze policy (after LoRA, before FSDP wrapping)
+        if self.model_config.freeze_module_pattern:
+            from verl.utils.freeze_utils import apply_freeze_to_module
+            apply_freeze_to_module(
+                module,
+                self.model_config.freeze_module_pattern,
+            )
 
         # Apply QAT before FSDP wrapping (training only)
         if self._qat_enabled and not self.engine_config.forward_only:

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -377,6 +377,15 @@ class MegatronEngine(BaseEngine):
 
             self.module = apply_qat_to_modules(self.module, self._qat_config)
 
+        # Freeze policy (after model build, before optimizer)
+        if self.model_config.freeze_module_pattern:
+            from verl.utils.freeze_utils import apply_freeze_to_module
+            for model in self.module:
+                apply_freeze_to_module(
+                    model,
+                    self.model_config.freeze_module_pattern,
+                )
+
         self._maybe_enable_fused_kernels()
 
         if self.model_config.mtp.enable:

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -110,6 +110,19 @@ class TorchTitanEngine(BaseEngine):
         model_module = importlib.import_module(f"torchtitan.models.{torchtitan_name}")
         model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
 
+        # Freeze policy: wrap parallelize_fn to freeze before FSDP2 apply
+        if self.model_config.freeze_module_pattern:
+            from verl.utils.freeze_utils import apply_freeze_to_module
+
+            _orig_parallelize = model_spec.parallelize_fn
+            _freeze_pattern = self.model_config.freeze_module_pattern
+
+            def _parallelize_with_freeze(model, *args, **kwargs):
+                apply_freeze_to_module(model, _freeze_pattern)
+                return _orig_parallelize(model, *args, **kwargs)
+
+            model_spec.parallelize_fn = _parallelize_with_freeze
+
         optimizer = OptimizersContainer.Config(
             name=self.optimizer_config.name,
             lr=self.optimizer_config.lr,

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -237,6 +237,15 @@ class VeOmniEngine(FSDPEngine):
         )
         log_gpu_memory_usage("After parallelize model", logger=logger)
 
+        # Freeze policy (after model build, before optimizer)
+        if self.model_config.freeze_module_pattern:
+            from verl.utils.freeze_utils import apply_freeze_to_module
+
+            apply_freeze_to_module(
+                module,
+                self.model_config.freeze_module_pattern,
+            )
+
         if not self.engine_config.forward_only:
             # Initialize optimizer with model parameters and config settings
             optimizer = self._build_optimizer(module)


### PR DESCRIPTION
## Summary

Add a standardized mechanism to selectively freeze model parameters during RL training, configurable via a single regex pattern in `hf_model.yaml`.  Works on all four training engines: FSDP, Megatron, VeOmni, and TorchTitan.

Resolves #2526.

## Motivation

Currently verl has no built-in way to freeze specific model components (e.g., the vision encoder in VLMs) during full-parameter training.  Previous attempts:

- **PR #3178** added `freeze_vision_tower` to the legacy `fsdp_workers.py` path, but this has no effect on the current engine.  It silently overrides `use_orig_params` and is hardcoded to VL models only.

- **Community forks** (e.g., #6104) added Megatron-specific freeze callbacks that depend on model-specific `freeze()` methods.

This PR provides a single, engine-agnostic, model-agnostic solution.

Full design discussion: [issue #2526 comment](https://github.com/verl-project/verl/issues/2526)

## Design

### Config

```yaml
# hf_model.yaml
freeze_module_pattern: null   # null = no freeze (default)
```

When set, any parameter whose fully-qualified name matches the regex has `requires_grad` set to `False`.

Examples:
- `model\\.visual\\.` — freeze the entire vision tower
- `model\\.visual\\.merger` — freeze only the projection layer
- `model\\.visual|model\\.embed` — freeze multiple subtrees

### Key design decisions

- **Regex over exact paths**: Model-agnostic — each model's internal structure differs (e.g., Qwen3.5-VL uses `model.visual`, others use `vision_encoder`).
- **`re.search` semantics**: Partial match. Exact matching via `^` / `$` anchors.
- **No `unfreeze_module_pattern`**: Regex supports negation natively.
- **No fallback to legacy `freeze_vision_tower`**: Unused on current engine, hardcoded to `model.visual`. Cleanup is a separate task.

### Engine coverage

| Engine | Covered | Insertion point |
|--------|---------|-----------------|
| FSDP | ✅ | `_build_model_optimizer`: after LoRA, before FSDP wrap |
| Megatron | ✅ | `initialize()`: after `_build_megatron_module`, before optimizer |
| VeOmni | ✅ | `_build_model_optimizer`: after `build_parallelize_model`, before optimizer |
| TorchTitan | ✅ | `__init__`: wraps `model_spec.parallelize_fn` so freeze runs after model build, before FSDP2 parallelization |

### Implementation

**New file:** `verl/utils/freeze_utils.py`

```python
def apply_freeze_to_module(module, freeze_pattern):
    """Set requires_grad=False on params matching regex."""
    pattern = re.compile(freeze_pattern)
    for name, param in module.named_parameters():
        if pattern.search(name):
            param.requires_grad = False
```

### Engine-specific details

**FSDP**: Freeze call inserted in `_build_model_optimizer` after LoRA and before FSDP wrapping.

**Megatron**: Freeze call inserted in `initialize()` after `_build_megatron_module`. Megatron's distributed optimizer respects `requires_grad` natively.

**VeOmni**: Overrides `_build_model_optimizer` independently (does not inherit from FSDP). Freeze inserted after `build_parallelize_model`, before optimizer construction.

**TorchTitan**: Model construction happens inside TorchTitan's `Trainer.__init__` which uses a `ModelSpec` dataclass with replaceable callables.  We wrap `model_spec.parallelize_fn` so freeze runs after `model_config.build()` but before FSDP2 is applied.  No TorchTitan upstream changes needed.

### Safety checks

- **Zero-match warning**: Logs sample parameter names to help debug.
- **Invalid regex**: Raises `ValueError` immediately.

## Files changed

| File | Change |
|------|--------|
| `verl/utils/freeze_utils.py` | New — `apply_freeze_to_module()` |
| `tests/utils/test_freeze_utils_on_cpu.py` | New — 7 test cases |
| `verl/workers/config/model.py` | `HFModelConfig` +1 field |
| `verl/trainer/config/model/hf_model.yaml` | +1 config entry |
| `verl/trainer/config/_generated_ppo_*.yaml` (×4) | Auto-generated expansion |
| `verl/workers/engine/fsdp/transformer_impl.py` | Freeze call + optimizer filter |
| `verl/workers/engine/megatron/transformer_impl.py` | Freeze call |
| `verl/workers/engine/veomni/transformer_impl.py` | Freeze call |
| `verl/workers/engine/torchtitan/transformer_impl.py` | Wraps `model_spec.parallelize_fn` |

12 files, ~242 lines.

## Backward compatibility

- `freeze_module_pattern` defaults to `null` — no behavioral change.
- All existing configs and training scripts continue to work unchanged.

## Usage

```bash
# FSDP
python -m verl.trainer.main_ppo \
    actor_rollout_ref.actor.fsdp_config.use_orig_params=True \
    +actor_rollout_ref.model.freeze_module_pattern='model\\.visual\\.' \
    ...

# Megatron / VeOmni / TorchTitan (no use_orig_params constraint)
python -m verl.trainer.main_ppo \
    +actor_rollout_ref.model.freeze_module_pattern='model\\.visual\\.' \
    ...
```

## Checklist

- [x] PR title format: `[trainer, fsdp, megatron, veomni, torchtitan] feat: ...`
- [x] Search for similar PRs: #3178, #6104, #1346, #596, community fork
- [x] Pre-commit checks verified (ruff, mypy, autogen-trainer-cfg) on `cn-tj-verl`
- [x] Unit tests — `tests/utils/test_freeze_utils_on_cpu.py` (7 cases, CPU-only)
- [x] Covers all 4 training engines (FSDP, Megatron, VeOmni, TorchTitan)
- [ ] CI-request — to be posted in Slack/Feishu after CI is triggered
