### PR TITLE
[veomni] feat: add MoE router replay (R2/R3) support

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -117,8 +117,8 @@ jobs:
         run: |
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install transformers==5.3.0
       - name: Prepare GSM8K dataset
         run: |
           ray stop --force

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
@@ -112,8 +112,8 @@ jobs:
         run: |
           pip install -r requirements-npu.txt
           pip install --no-deps -e .
-          pip install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip install transformers==4.57.3
+          pip install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip install transformers==5.3.0
       - name: Check final pip list
         run: |
           pip list

--- a/.github/workflows/e2e_sft_llm.yml
+++ b/.github/workflows/e2e_sft_llm.yml
@@ -105,8 +105,8 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install transformers==5.3.0
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force

--- a/.github/workflows/e2e_sft_llm_ascend.yml
+++ b/.github/workflows/e2e_sft_llm_ascend.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Install the current repository
         run: |
           pip install --no-deps -e .
-          pip install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip install transformers==4.57.3
+          pip install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip install transformers==5.3.0
           pip install pandas==2.3.3
           pip uninstall -y mbridge
           pip install git+https://github.com/ISEEKYAN/mbridge.git@89eb10

--- a/.github/workflows/e2e_sft_vlm.yml
+++ b/.github/workflows/e2e_sft_vlm.yml
@@ -105,8 +105,8 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.9a5 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
-          pip3 install transformers==4.57.3
+          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install transformers==5.3.0
       - name: Prepare pokemon-gpt4o-captions dataset
         run: |
           ray stop --force

--- a/examples/router_replay/README.md
+++ b/examples/router_replay/README.md
@@ -28,6 +28,11 @@ router_replay:
 
 ## Quick Start Guide
 
+The config path differs by engine: `actor.megatron.router_replay.mode` for the
+Megatron engine, `actor.veomni.router_replay.mode` for the VeOmni engine.
+Examples below use `<engine>` as a placeholder — substitute `megatron` or
+`veomni`.
+
 ### Enabling R2 Mode
 
 #### Configuration File Method
@@ -35,7 +40,7 @@ Add the following to your training configuration:
 
 ```yaml
 actor:
-  megatron:
+  <engine>:
     router_replay:
       mode: "R2"
 ```
@@ -44,7 +49,7 @@ actor:
 Enable R2 mode via command-line parameters:
 
 ```bash
-actor_rollout_ref.actor.megatron.router_replay.mode="R2"
+actor_rollout_ref.actor.<engine>.router_replay.mode="R2"
 ```
 
 ### Enabling R3 Mode
@@ -53,13 +58,11 @@ actor_rollout_ref.actor.megatron.router_replay.mode="R2"
 Configure both actor and rollout settings:
 
 ```yaml
-# Actor configuration for megatron
 actor:
-  megatron:
+  <engine>:
     router_replay:
       mode: "R3"
 
-# Rollout configuration
 rollout:
   enable_rollout_routing_replay: True
 ```
@@ -68,7 +71,7 @@ rollout:
 Enable R3 mode via command-line parameters:
 
 ```bash
-actor_rollout_ref.actor.megatron.router_replay.mode="R3"
+actor_rollout_ref.actor.<engine>.router_replay.mode="R3"
 actor_rollout_ref.rollout.enable_rollout_routing_replay=True
 ```
 

--- a/examples/router_replay/run_qwen3_5_35b_a3b_veomni.sh
+++ b/examples/router_replay/run_qwen3_5_35b_a3b_veomni.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# GRPO training of Qwen3.5-35B-A3B using VeOmniEngine with MoE Router Replay (RR).
+#
+# Router Replay (R2/R3) makes the MoE expert selection deterministic across the
+# log-prob forward pass and the policy-update forward/backward pass within a
+# training step. Without RR, the R2/R3 recompute path can see different top-k
+# decisions from the original logits (e.g. due to floating-point drift or
+# activation-checkpointing recompute), which introduces extra noise into the
+# RL policy gradient.
+#
+# VeOmni's RR implementation is indices-only: the controller substitutes top-k
+# expert indices during REPLAY, while model-specific post-topk weight math
+# (gather, renorm, scaling, dtype cast) stays inside the per-family
+# SparseMoeBlock patch. This keeps the REPLAY forward bit-identical to what the
+# native forward would have produced given those replayed indices.
+#
+# Modes:
+#   - R2: record indices during compute_log_prob (forward-only), replay them in
+#         the actor update forward+backward. No rollout coordination required.
+#         This is the minimal, most-widely-compatible form.
+#   - R3: record indices at the rollout (inference) stage and replay them in
+#         both compute_log_prob and the actor update. Closes the loop end-to-end
+#         and requires rollout backend support for returning top-k indices
+#         (sglang via ``rollout.enable_rollout_routing_replay=True``).
+#
+# Environment (same as run_qwen3_5-35b-a3b_veomni.sh):
+#   - transformers==5.3.0
+#   - sglang==0.5.9
+#   - flash-linear-attention==0.4.1
+#   - veomni==0.1.10  # contains the maybe_replay_indices hook wired for Qwen3.5-MoE
+# Tested configuration:
+#   - Model: Qwen3.5-35B-A3B
+#   - Sequence Parallel (SP): sp=2 (ulysses_parallel_size)
+#   - Expert Parallel (EP): tested with ep=1 and ep=2 (expert_parallel_size)
+
+set -xeuo pipefail
+
+data_path=${data_path:-$HOME/data/geo3k}
+model_path=${model_path:-$HOME/model/Qwen3.5-35B-A3B}
+usp_size=${usp_size:-2}
+expert_size=${expert_size:-1}
+nnodes=${nnodes:-2}
+
+# ===================================== Router Replay =====================================
+# Default: R2 — safe everywhere, no rollout changes needed.
+# To try R3, switch to "R3" and flip ENABLE_ROLLOUT_ROUTING_REPLAY below.
+ROUTING_REPLAY_MODE=${ROUTING_REPLAY_MODE:-R2}
+
+if [ "$ROUTING_REPLAY_MODE" = "R3" ]; then
+    ENABLE_ROLLOUT_ROUTING_REPLAY=True
+else
+    ENABLE_ROLLOUT_ROUTING_REPLAY=False
+fi
+
+backend=fsdp2
+model_engine=veomni
+project_name='verl_grpo_qwen3_5_35b_a3b_geo3k'
+exp_name="qwen3_5_35b_a3b_veomni_sp2_rr_${ROUTING_REPLAY_MODE}"
+
+
+# ===================================== Algorithm =====================================
+adv_estimator=grpo
+loss_mode=gspo
+
+use_kl_in_reward=False
+kl_coef=0.001
+use_kl_loss=False
+kl_loss_coef=0.001
+
+clip_ratio_low=3e-4
+clip_ratio_high=4e-4
+
+actor_lr=1e-6
+critic_lr=2e-6
+gae_gamma=1.0
+gae_lam=0.95
+critic_warmup=0
+
+# ===================================== Data/Model =====================================
+train_files=$data_path/train.parquet
+test_files=$data_path/test.parquet
+
+actor_model_path=$model_path
+
+max_prompt_length=$((1024 * 1))
+max_response_length=$((1024 * 2))
+
+train_batch_size=128
+ppo_mini_batch_size=32
+n_resp_per_prompt=8
+n_resp_per_prompt_val=1
+
+use_remove_padding=True
+use_dynamic_bsz=False
+
+# ===================================== Training =====================================
+actor_max_token_len_per_gpu=$(((max_prompt_length + max_response_length) * 8))
+ppo_micro_batch_size_per_gpu=1
+
+# VeOmni config — note the `router_replay.mode` entry.
+# The path mirrors the Megatron example (`actor.megatron.router_replay.mode`):
+# the RR config lives on the per-strategy engine config
+# (VeOmniEngineConfig inherits `router_replay` from the shared `EngineConfig`
+# base), and verl's engine_worker reads `actor.veomni.router_replay.mode`.
+ACTOR_VEOMNI_CONFIG="
+    actor_rollout_ref.actor.veomni.param_offload=True \
+    actor_rollout_ref.actor.veomni.optimizer_offload=True \
+    actor_rollout_ref.actor.veomni.enable_full_shard=True \
+    actor_rollout_ref.actor.veomni.ulysses_parallel_size=$usp_size \
+    actor_rollout_ref.actor.veomni.expert_parallel_size=$expert_size \
+    actor_rollout_ref.actor.veomni.attn_implementation=flash_attention_2 \
+    actor_rollout_ref.actor.veomni.moe_implementation=fused_triton \
+    actor_rollout_ref.actor.veomni.cross_entropy_loss_implementation=liger_kernel \
+    actor_rollout_ref.actor.veomni.router_replay.mode=${ROUTING_REPLAY_MODE}"
+
+ACTOR_CONFIG="
+    actor_rollout_ref.actor.optim.lr=$actor_lr \
+    actor_rollout_ref.model.path=$actor_model_path \
+    actor_rollout_ref.model.use_remove_padding=$use_remove_padding \
+    actor_rollout_ref.actor.use_kl_loss=$use_kl_loss \
+    actor_rollout_ref.actor.kl_loss_coef=$kl_loss_coef \
+    actor_rollout_ref.actor.clip_ratio_low=$clip_ratio_low \
+    actor_rollout_ref.actor.clip_ratio_high=$clip_ratio_high \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    actor_rollout_ref.actor.use_dynamic_bsz=$use_dynamic_bsz \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$ppo_mini_batch_size \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_max_token_len_per_gpu} \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=$ppo_micro_batch_size_per_gpu"
+
+CONFIG_NAME=ppo_trainer
+ACTOR_CONFIG="$ACTOR_CONFIG $ACTOR_VEOMNI_CONFIG"
+CRITIC_CONFIG=""
+
+# ===================================== Inference =====================================
+rollout_name=sglang
+infer_tp=4
+infer_dp=1
+infer_ep=1
+gpu_memory_utilization=0.6
+
+# For R3, enable_rollout_routing_replay tells the rollout backend to return the
+# top-k indices it selected at generation time, so compute_log_prob and the
+# actor update can replay against the same indices. R2 leaves this off (rollout
+# unchanged; RR only ties log-prob and update forwards together).
+ROLLOUT_CONFIG="
+    actor_rollout_ref.rollout.name=$rollout_name \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$infer_tp \
+    actor_rollout_ref.rollout.data_parallel_size=$infer_dp \
+    actor_rollout_ref.rollout.expert_parallel_size=$infer_ep \
+    actor_rollout_ref.rollout.gpu_memory_utilization=$gpu_memory_utilization \
+    actor_rollout_ref.rollout.n=$n_resp_per_prompt \
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.7 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.n=$n_resp_per_prompt_val \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=False \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.enable_rollout_routing_replay=${ENABLE_ROLLOUT_ROUTING_REPLAY}"
+
+python -m verl.trainer.main_ppo \
+    --config-path=./config \
+    --config-name=$CONFIG_NAME \
+    model_engine=$model_engine \
+    algorithm.adv_estimator=$adv_estimator \
+    algorithm.use_kl_in_reward=$use_kl_in_reward \
+    algorithm.kl_ctrl.kl_coef=$kl_coef \
+    algorithm.gamma=$gae_gamma \
+    algorithm.lam=$gae_lam \
+    data.train_files="$train_files" \
+    data.val_files="$test_files" \
+    data.return_raw_chat=True \
+    data.train_batch_size=$train_batch_size \
+    data.max_prompt_length=$max_prompt_length \
+    data.max_response_length=$max_response_length \
+    data.filter_overlong_prompts=True \
+    data.filter_overlong_prompts_workers=64 \
+    data.truncation='error' \
+    trainer.critic_warmup=$critic_warmup \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name=$project_name \
+    trainer.experiment_name=$exp_name \
+    trainer.n_gpus_per_node=8 \
+    trainer.nnodes=$nnodes \
+    trainer.val_before_train=False \
+    trainer.log_val_generations=100 \
+    trainer.save_freq=-1 \
+    trainer.test_freq=10 \
+    trainer.total_epochs=10 \
+    trainer.total_training_steps=500 \
+    $ACTOR_CONFIG \
+    $CRITIC_CONFIG \
+    $ROLLOUT_CONFIG

--- a/tests/utils/veomni/test_router_replay_on_cpu.py
+++ b/tests/utils/veomni/test_router_replay_on_cpu.py
@@ -1,0 +1,396 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``verl.utils.veomni.router_replay.VeOmniRouterReplay``.
+
+Pure-CPU coverage for the controller state machine. The patched
+``SparseMoeBlock`` integration (the actual end-to-end forward through a
+real router) lives in VeOmni's invariant test suite; the engine-driver
+glue (snapshot side-channel + nested rebuild) lives in
+``tests/workers/test_router_replay_engine_helpers_on_cpu.py``.
+
+What's covered
+--------------
+* RECORD lifecycle (single mb, multi-mb).
+* Recompute under whole-model AND per-layer activation checkpointing.
+  Per-layer checkpointing fires backward recompute for each layer
+  *independently in reverse order* — the failure mode that breaks any
+  monotonic-cursor design.
+* REPLAY first step (R3 case): set_microbatch_targets must work
+  before any RECORD has populated the id table.
+* REPLAY strict missing-target error path.
+* Snapshot clone semantics.
+* id-mapping stability across micro-batches.
+* ``install`` / ``uninstall`` against a stubbed VeOmni hook surface.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from verl.utils.veomni.router_replay import RouterReplayAction, VeOmniRouterReplay
+
+# ----------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def ctrl():
+    """Fresh controller per test. Does NOT call ``install()`` — that
+    would need a stubbed ``veomni.utils.moe_router_replay`` module.
+    The controller's ``on_router_forward`` / ``begin_*`` / ``clear``
+    methods do not depend on ``install()`` having been called, so most
+    tests don't need it. The ``install`` / ``uninstall`` paths get
+    their own dedicated tests below."""
+    return VeOmniRouterReplay()
+
+
+# Each FakeRouter is a distinct nn.Module so ``id(router)`` is unique
+# and stable for the test's lifetime — exactly what the production code
+# relies on for FSDP2-wrapped MoE routers.
+class _FakeRouter(nn.Module):
+    pass
+
+
+@pytest.fixture
+def routers():
+    """Three distinct router instances, mimicking three MoE layers."""
+    return [_FakeRouter() for _ in range(3)]
+
+
+# Toy shapes — small enough that any failure prints readable tensors.
+_NNZ = 16
+_TOPK = 2
+
+
+def _scores():
+    return torch.randn(_NNZ, 8)
+
+
+def _idx():
+    """Return ``[_NNZ, _TOPK]`` int indices with DISTINCT entries per
+    row. Distinct-per-row matters for tests that assert REPLAY returns
+    the target verbatim — the duplicate-detection fallback in
+    ``on_router_forward`` would otherwise treat duplicate-top-k rows
+    as corrupted and return native instead. Real router top-k output
+    always picks distinct experts, so this matches production
+    semantics."""
+    # Random distinct top-k per row via sampling without replacement.
+    return torch.stack(
+        [torch.randperm(8)[:_TOPK] for _ in range(_NNZ)],
+        dim=0,
+    ).to(torch.int64)
+
+
+def _fire_all(ctrl, routers):
+    """Fire each router once in order and return the controller's outputs."""
+    return [ctrl.on_router_forward(r, _scores(), _idx()) for r in routers]
+
+
+# ===========================================================
+# RECORD lifecycle
+# ===========================================================
+
+
+def test_record_multiple_microbatches(ctrl, routers):
+    """advance_record_microbatch bumps the slot fill count without
+    touching the id mapping. The id table must persist across mbs in
+    the same step (recompute detection in on_router_forward depends on
+    ``len(slot) == _mb_index + 1``, which only holds with stable ids)."""
+    ctrl.begin_record()
+    n_mb = 3
+    for mb in range(n_mb):
+        if mb > 0:
+            ctrl.advance_record_microbatch()
+        _fire_all(ctrl, routers)
+    assert all(len(slot) == n_mb for slot in ctrl._recorded)
+    assert ctrl.action is RouterReplayAction.RECORD
+
+
+# ===========================================================
+# Activation-checkpointing recompute (the bug class id-keying solves)
+# ===========================================================
+
+
+def test_record_recompute_per_layer_reverse(ctrl, routers):
+    """Per-layer checkpointing: backward replays each layer independently
+    in REVERSE order. This is the realistic VeOmni MoE training case
+    that breaks any monotonic-cursor design. Subsumes whole-model
+    recompute (which is just sequential forward order)."""
+    ctrl.begin_record()
+    _fire_all(ctrl, routers)  # forward layer 0..L-1
+    for r in reversed(routers):  # backward recompute, reverse order
+        ctrl.on_router_forward(r, _scores(), _idx())
+    assert all(len(slot) == 1 for slot in ctrl._recorded), (
+        f"per-layer reverse recompute leaked: {[len(s) for s in ctrl._recorded]}"
+    )
+
+
+# ===========================================================
+# REPLAY
+# ===========================================================
+
+
+def test_replay_first_step_without_prior_discovery(ctrl, routers):
+    """R3 first step: REPLAY runs before any RECORD has populated the id
+    table. set_microbatch_targets just stashes the list; lookup happens
+    lazily during forward."""
+    ctrl.begin_replay()
+    targets = [_idx() for _ in routers]
+    ctrl.set_microbatch_targets(targets)
+    returned = _fire_all(ctrl, routers)
+    for i, ret in enumerate(returned):
+        assert torch.equal(ret, targets[i]), f"REPLAY layer {i} returned wrong target"
+
+
+def test_replay_per_layer_reverse_recompute(ctrl, routers):
+    """REPLAY recompute under per-layer checkpointing: same id ->
+    same target, regardless of fire order."""
+    ctrl.begin_replay()
+    targets = [_idx() for _ in routers]
+    ctrl.set_microbatch_targets(targets)
+    _fire_all(ctrl, routers)  # forward populates id mapping
+    # backward recompute in reverse — each layer must hit its OWN target
+    for r, want_pos in zip(reversed(routers), reversed(range(len(routers))), strict=True):
+        ret = ctrl.on_router_forward(r, _scores(), _idx())
+        assert torch.equal(ret, targets[want_pos]), f"REPLAY recompute layer {want_pos} returned wrong target"
+
+
+def test_replay_strict_missing_target_raises(ctrl, routers):
+    """Layer position with no target must raise — no silent fallback."""
+    ctrl.begin_replay()
+    ctrl.set_microbatch_targets([_idx()])  # only 1 target for 3 layers
+    ctrl.on_router_forward(routers[0], _scores(), _idx())  # pos 0 OK
+    with pytest.raises(RuntimeError, match="pos=1.*no target"):
+        ctrl.on_router_forward(routers[1], _scores(), _idx())
+
+
+def test_replay_with_mask_substitutes_only_masked_tokens(ctrl, routers):
+    """R3 prompt-token regression: when ``replay_mask`` is provided,
+    only tokens with mask=True get the recorded target; mask=False
+    tokens fall through to native indices.
+
+    This is what prevents R3 from sending all prompt tokens to expert 0
+    (the rollout backend writes zeros for prompt tokens because it
+    never captured prefill-time routing). Without the mask, those
+    zeros would be substituted, corrupting the EP all-to-all and
+    surfacing as ``RuntimeError: Split sizes doesn't match total dim
+    0 size`` mid-forward.
+    """
+    ctrl.begin_replay()
+    # 16 tokens; first 10 are "prompt" (mask=False), last 6 are "response" (mask=True).
+    mask = torch.tensor([False] * 10 + [True] * 6)
+    targets = [torch.zeros(_NNZ, _TOPK, dtype=torch.int64) for _ in routers]
+    # Fill response-portion of each target with DISTINCT-per-slot nonzero
+    # values so they (a) differ from the native sentinel, (b) don't
+    # contain duplicate top-k slots that would trigger the duplicate
+    # fallback.
+    for layer_pos, t in enumerate(targets):
+        for k in range(_TOPK):
+            t[10:, k] = layer_pos * 10 + k + 1  # e.g., layer 0 row: [1, 2], layer 1 row: [11, 12]
+    ctrl.set_microbatch_targets(targets, replay_mask=mask)
+
+    for layer_pos, r in enumerate(routers):
+        # Native values must also be distinct per slot so they don't
+        # themselves trigger the duplicate fallback.
+        native = torch.stack(
+            [torch.full((_NNZ,), 90 + k, dtype=torch.int64) for k in range(_TOPK)],
+            dim=-1,
+        )  # row pattern: [90, 91]
+        out = ctrl.on_router_forward(r, _scores(), native)
+
+        # First 10 rows (prompt, mask=False): native values preserved.
+        assert torch.equal(out[:10], native[:10]), (
+            f"layer {layer_pos}: prompt rows must keep native indices, got {out[:10]}"
+        )
+        # Last 6 rows (response, mask=True): substituted with the target.
+        assert torch.equal(out[10:], targets[layer_pos][10:]), (
+            f"layer {layer_pos}: response rows must use replay target"
+        )
+
+
+def test_replay_duplicate_topk_falls_back_to_native(ctrl, routers):
+    """R3 robustness regression: rows where the substituted top-k
+    contains duplicates (e.g. a placeholder ``[0, 0, 0, ...]`` that
+    slipped through the mask, or any rollout-side corruption) must
+    fall through to native routing.
+
+    Without this fallback, VeOmni's MoE expert dispatch silently
+    dedupes the duplicate top-k slots inside ``permute()``, while
+    ``input_splits`` keeps counting all of them — the EP all-to-all
+    then crashes with ``Split sizes doesn't match total dim 0 size``
+    several layers deep.
+    """
+    ctrl.begin_replay()
+    # All-True mask — exercise the fallback purely on duplicate detection.
+    mask = torch.ones(_NNZ, dtype=torch.bool)
+
+    # Build a target with two corruption patterns:
+    #   row 0: all-zeros (extreme duplicate — every slot is expert 0)
+    #   row 1: partial duplicate (slots 0 and 1 both expert 5)
+    # The other rows are clean (distinct top-k).
+    targets = []
+    for _ in routers:
+        t = torch.stack(
+            [torch.arange(_NNZ, dtype=torch.int64) + k for k in range(_TOPK)],
+            dim=-1,
+        )  # row i: [i, i+1] — distinct
+        t[0] = 0  # all-zero row
+        t[1, 0] = 5
+        t[1, 1] = 5  # duplicate row
+        targets.append(t)
+    ctrl.set_microbatch_targets(targets, replay_mask=mask)
+
+    for r, t in zip(routers, targets, strict=True):
+        # Native: distinct per row, distinct per slot.
+        native = torch.stack(
+            [torch.arange(_NNZ, dtype=torch.int64) + 100 + k for k in range(_TOPK)],
+            dim=-1,
+        )
+        out = ctrl.on_router_forward(r, _scores(), native)
+
+        # Corrupted rows fall back to native.
+        assert torch.equal(out[0], native[0]), "all-zero row must fall back to native"
+        assert torch.equal(out[1], native[1]), "partial-duplicate row must fall back to native"
+        # Clean rows substitute normally.
+        for i in range(2, _NNZ):
+            assert torch.equal(out[i], t[i]), f"clean row {i} must use replay target"
+
+
+def test_replay_mask_shape_mismatch_raises(ctrl, routers):
+    """Defensive: a mask sliced with a different SP rule than the
+    targets would silently corrupt routing. The controller refuses
+    rather than broadcast."""
+    ctrl.begin_replay()
+    targets = [_idx() for _ in routers]
+    bad_mask = torch.ones(_NNZ + 4, dtype=torch.bool)  # too long
+    ctrl.set_microbatch_targets(targets, replay_mask=bad_mask)
+    with pytest.raises(RuntimeError, match="replay_mask has .* rows but top_indices"):
+        ctrl.on_router_forward(routers[0], _scores(), _idx())
+
+
+def test_replay_set_targets_outside_replay_mode_raises(ctrl):
+    """set_microbatch_targets is REPLAY-only."""
+    ctrl.begin_record()
+    with pytest.raises(RuntimeError, match="requires REPLAY"):
+        ctrl.set_microbatch_targets([_idx()])
+
+
+# ===========================================================
+# State management
+# ===========================================================
+
+
+def test_advance_record_microbatch_outside_record_raises(ctrl):
+    """advance_record_microbatch is RECORD-only."""
+    ctrl.begin_replay()
+    with pytest.raises(RuntimeError, match="requires RECORD"):
+        ctrl.advance_record_microbatch()
+
+
+def test_clear_resets_state(ctrl, routers):
+    """clear() is the always-safe reset; state must be empty after."""
+    ctrl.begin_record()
+    _fire_all(ctrl, routers)
+    assert ctrl.action is RouterReplayAction.RECORD
+    assert ctrl._recorded
+    ctrl.clear()
+    assert ctrl.action is RouterReplayAction.DISABLED
+    assert ctrl._recorded == []
+    assert ctrl._targets == []
+    assert ctrl._id_to_pos == {}
+
+
+# ===========================================================
+# Snapshot clone semantics
+# ===========================================================
+
+
+def test_record_snapshot_independent_of_source_tensor(ctrl, routers):
+    """The captured tensor must NOT alias the source — otherwise
+    autograd-graph mutations would corrupt recorded indices."""
+    ctrl.begin_record()
+    src = _idx()
+    ctrl.on_router_forward(routers[0], _scores(), src)
+    src.fill_(99)
+    captured = ctrl._recorded[0][0]
+    assert (captured != 99).all(), "snapshot must be independent of the source tensor (.detach().clone())"
+
+
+# ===========================================================
+# Disabled state
+# ===========================================================
+
+
+def test_disabled_passes_through_indices(ctrl, routers):
+    """When no begin_*() has been called (DISABLED), on_router_forward
+    is a no-op pass-through."""
+    src = _idx()
+    out = ctrl.on_router_forward(routers[0], _scores(), src)
+    assert torch.equal(out, src)
+    assert ctrl._recorded == []
+    assert ctrl._targets == []
+
+
+# ===========================================================
+# install / uninstall against a stubbed VeOmni hook surface
+# ===========================================================
+
+
+def _make_veomni_stub():
+    """Return a (stub_module, captured_state) tuple where ``stub_module``
+    is the fake ``veomni.utils.moe_router_replay`` and
+    ``captured_state['active']`` records the last value passed to
+    ``set_active_replay``."""
+    stub = MagicMock()
+    captured = {"active": None}
+
+    def _set(x):
+        captured["active"] = x
+
+    stub.set_active_replay.side_effect = _set
+    stub.get_active_replay.side_effect = lambda: captured["active"]
+    stub.validate_model_for_replay.return_value = None
+    return stub, captured
+
+
+def test_install_uninstall_roundtrip(ctrl):
+    """install() registers the controller in VeOmni's global slot and
+    runs the model validator; uninstall() clears the slot back to None."""
+    stub, captured = _make_veomni_stub()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setitem(sys.modules, "veomni.utils.moe_router_replay", stub)
+        ctrl.install(nn.Linear(1, 1))
+        assert captured["active"] is ctrl
+        stub.validate_model_for_replay.assert_called_once()
+        ctrl.uninstall()
+        assert captured["active"] is None
+
+
+def test_install_without_veomni_raises(ctrl):
+    """If the VeOmni hook surface is missing, install() must raise a
+    typed RuntimeError pointing the user at the dependency, not a raw
+    ImportError."""
+    with pytest.MonkeyPatch.context() as mp:
+        # Drop both the package and the submodule from sys.modules to
+        # force a real ImportError inside install().
+        mp.delitem(sys.modules, "veomni.utils.moe_router_replay", raising=False)
+        mp.delitem(sys.modules, "veomni.utils", raising=False)
+        mp.delitem(sys.modules, "veomni", raising=False)
+        # Also poison the import path so a fresh import attempt fails.
+        mp.setattr("sys.path", [p for p in sys.path if "veomni" not in p.lower()])
+        with pytest.raises(RuntimeError, match="VeOmni build"):
+            ctrl.install(nn.Linear(1, 1))

--- a/tests/workers/test_router_replay_engine_helpers_on_cpu.py
+++ b/tests/workers/test_router_replay_engine_helpers_on_cpu.py
@@ -1,0 +1,375 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Engine-driver glue tests for VeOmni router replay.
+
+Complements ``tests/utils/veomni/test_router_replay_on_cpu.py`` (which
+covers the controller state machine in isolation). This file tests the
+engine-side glue helpers in ``verl/workers/engine/veomni/transformer_impl.py``:
+
+* ``VeOmniEngineWithLMHead._maybe_push_router_replay_state`` — the
+  per-micro-batch snapshot side-channel (pad_size + cu_seqlens) pushed
+  back from ``prepare_model_inputs`` to ``forward_backward_batch``,
+  plus the jagged-NestedTensor input assertion and the strict
+  missing-routed_experts error path in REPLAY mode.
+
+The real production helpers are imported here (not mirrored) — the
+``veomni.*`` package surfaces that ``transformer_impl`` needs at module
+load are stubbed with ``MagicMock`` via ``sys.modules`` patching, the
+same pattern the rest of the verl test suite uses for optional deps
+(see ``test_rollout_trace_on_cpu.py`` for the ``weave`` precedent).
+
+Out of scope (covered by manual GPU smoke + the e2e shell scripts):
+real ``VeOmniEngineWithLMHead`` instantiation, FSDP wrapping,
+multi-rank SP all-gather, end-to-end forward through the patched
+``SparseMoeBlock``.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+# ----------------------------------------------------------------- veomni stub
+#
+# ``transformer_impl.py`` imports several ``veomni.*`` submodules at
+# module top level (``OpsImplementationConfig``, ``parallel_state``,
+# ``build_foundation_model`` etc.). MagicMock auto-creates any
+# attribute on access, so a single stub per submodule is enough to let
+# the import succeed in environments without VeOmni installed (which is
+# the standard verl CPU-unit-tests image — VeOmni is only present in
+# the e2e_*.yml workflows). On environments where VeOmni IS installed,
+# ``setdefault`` is a no-op and the real package is used.
+
+for _mod in (
+    "veomni",
+    "veomni.arguments",
+    "veomni.distributed",
+    "veomni.distributed.offloading",
+    "veomni.distributed.torch_parallelize",
+    "veomni.models",
+    "veomni.models.auto",
+    "veomni.optim",
+    "veomni.utils",
+    "veomni.utils.moe_router_replay",
+    "veomni.utils.seqlen_pos_transform_utils",
+):
+    sys.modules.setdefault(_mod, MagicMock())
+
+
+from verl.utils.veomni.router_replay import RouterReplayAction, VeOmniRouterReplay  # noqa: E402
+from verl.workers.engine.veomni.transformer_impl import VeOmniEngineWithLMHead  # noqa: E402
+
+# ----------------------------------------------------------------- helpers
+
+
+def _make_jagged_input_ids(seq_lens: list[int]) -> torch.Tensor:
+    """Build a jagged NestedTensor mimicking what ``left_right_2_no_padding``
+    produces for ``input_ids``."""
+    pieces = [torch.randint(0, 100, (s,), dtype=torch.int64) for s in seq_lens]
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def _make_jagged_routed_experts(seq_lens: list[int], L: int, topk: int) -> torch.Tensor:
+    """Build a jagged NestedTensor mimicking the trainer-side
+    ``routed_experts`` shape: ``[bs, jagged_seq, L, topk]``."""
+    pieces = [torch.randint(0, 8, (s, L, topk), dtype=torch.int64) for s in seq_lens]
+    return torch.nested.as_nested_tensor(pieces, layout=torch.jagged)
+
+
+def _make_engine_with_controller(
+    controller: VeOmniRouterReplay,
+    mode: str = "R2",
+) -> VeOmniEngineWithLMHead:
+    """Build a bare ``VeOmniEngineWithLMHead`` instance without invoking
+    its ``__init__`` (which requires a torch.distributed process group,
+    parallel_state init, etc.). Only the controller and the mode string
+    (used to gate R3-specific replay-mask construction) are needed for
+    the helper methods exercised here."""
+    engine = VeOmniEngineWithLMHead.__new__(VeOmniEngineWithLMHead)
+    engine._router_replay = controller
+    engine._router_replay_mode = mode
+    return engine
+
+
+@pytest.fixture
+def controller():
+    return VeOmniRouterReplay()
+
+
+# ===========================================================
+# _maybe_push_router_replay_state
+# ===========================================================
+
+
+class TestMaybePushRouterReplayState:
+    """The per-mb side-channel + REPLAY input prep glue. Exercised on a
+    bare-instance ``VeOmniEngineWithLMHead`` (no real init needed —
+    the method only reads ``self._router_replay``)."""
+
+    def test_pad_and_cu_seqlens_snapshot_population(self, controller):
+        """The two snapshot sinks should receive one entry per call,
+        in the order ``prepare_model_inputs`` ran."""
+        controller.begin_record()
+        engine = _make_engine_with_controller(controller)
+
+        pad_sink: list[int] = []
+        cu_sink: list[torch.Tensor] = []
+
+        for mb in range(3):
+            mb_lens = [3 + mb, 5 + mb]
+            input_ids = _make_jagged_input_ids(mb_lens)
+            td = TensorDict({"input_ids": input_ids}, batch_size=[len(mb_lens)])
+            td.set_non_tensor("_router_replay_pad_size_out", pad_sink)
+            td.set_non_tensor("_router_replay_cu_seqlens_out", cu_sink)
+            output_args = {"pad_size": mb}  # pretend ulysses pad varies
+            engine._maybe_push_router_replay_state(td, output_args)
+
+        assert pad_sink == [0, 1, 2]
+        assert len(cu_sink) == 3
+        # Each cu_seqlens entry should reflect input_ids offsets at the
+        # time of capture (cloned, not aliased to the now-freed mb).
+        assert cu_sink[0].tolist() == [0, 3, 8]
+        assert cu_sink[1].tolist() == [0, 4, 10]
+        assert cu_sink[2].tolist() == [0, 5, 12]
+
+    def test_side_channel_list_can_be_stashed_on_micro_batch(self):
+        """Regression: ``forward_backward_batch`` stashes the snapshot
+        list via ``tu.assign_non_tensor_data(...)`` onto a micro_batch
+        that has a non-empty batch_size. The original code used
+        ``tu.assign_non_tensor`` (auto-dispatch), which detects the
+        value as a list and routes to ``assign_non_tensor_stack``,
+        producing a ``NonTensorStack`` with ``batch_size=[len(list)]``.
+        For an empty list (``[]``), the stack has ``batch_size=[0]``,
+        which mismatches the micro_batch's ``batch_size=[1]`` and
+        triggers ``RuntimeError: ... Modifying the batch size of a
+        lazy representation of a tensordict is not permitted`` because
+        ``NonTensorStack`` is itself a lazy TD.
+
+        The fix: use ``assign_non_tensor_data`` (singular), which wraps
+        the entire list as one ``NonTensorData(val)`` regardless of type
+        — the list IS the value, not a per-sample sequence to stack.
+        """
+        from verl.utils import tensordict_utils as tu
+
+        # Plain TensorDict with batch_size=[1] — same shape that
+        # prepare_micro_batches yields for a 1-sample micro-batch.
+        td = TensorDict({}, batch_size=[1])
+
+        # Sanity: the OLD (broken) auto-dispatch path raises on empty list.
+        with pytest.raises(RuntimeError, match="lazy representation"):
+            tu.assign_non_tensor(td, _broken_sink=[])
+
+        # The fixed singular API tolerates any value, including an empty
+        # list, by wrapping it as a single NonTensorData.
+        sink: list[int] = []
+        tu.assign_non_tensor_data(td, "_sink", sink)
+
+        # Mutate via reference and read back — the side-channel contract
+        # the engine driver relies on.
+        sink.append(7)
+        sink.append(11)
+        recovered = tu.get_non_tensor_data(td, "_sink", default=None)
+        assert recovered == [7, 11], f"side-channel list lost mutations: {recovered}"
+
+    def test_non_jagged_input_ids_raises(self, controller):
+        """The engine init guard rejects use_remove_padding=False, but
+        the per-mb assertion catches future bypass paths — a dense
+        tensor would otherwise fail mid-step on .offsets() with an
+        opaque AttributeError."""
+        controller.begin_record()
+        engine = _make_engine_with_controller(controller)
+        td = TensorDict(
+            {"input_ids": torch.randint(0, 100, (2, 8), dtype=torch.int64)},
+            batch_size=[2],
+        )
+        with pytest.raises(RuntimeError, match="must be a jagged NestedTensor"):
+            engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+
+    def test_replay_missing_routed_experts_raises(self, controller):
+        """Strict mode: REPLAY without routed_experts on the micro_batch
+        is a plumbing bug (compute_log_prob → update_actor lost the
+        field), not a soft fallback."""
+        controller.begin_replay()
+        engine = _make_engine_with_controller(controller)
+        td = TensorDict({"input_ids": _make_jagged_input_ids([3, 5])}, batch_size=[2])
+        with pytest.raises(RuntimeError, match="missing 'routed_experts'"):
+            engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+
+    def test_replay_with_routed_experts_feeds_targets(self, controller):
+        """Successful R2 REPLAY path: routed_experts.values() is sliced
+        per-layer and forwarded to set_microbatch_targets. The
+        controller's ``_targets`` should then contain L per-layer
+        tensors. R2 must NOT build a replay_mask — RECORD captured
+        full-sequence routing, so REPLAY substitutes uniformly."""
+        L, topk = 3, 2
+        controller.begin_replay()
+        engine = _make_engine_with_controller(controller, mode="R2")
+
+        seq_lens = [4, 6]
+        routed = _make_jagged_routed_experts(seq_lens, L, topk)
+        td = TensorDict(
+            {
+                "input_ids": _make_jagged_input_ids(seq_lens),
+                "routed_experts": routed,
+                # R2 must ignore response_mask even when present —
+                # gating prompt tokens out would re-introduce routing
+                # divergence on prompt tokens that propagates through
+                # attention KV into response logits/grad.
+                "response_mask": torch.tensor([[1, 1, 0, 0], [1, 1, 1, 0]], dtype=torch.int64),
+            },
+            batch_size=[2],
+        )
+        engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+        assert len(controller._targets) == L
+        for t in controller._targets:
+            assert t.shape == (sum(seq_lens), topk)
+        assert controller._replay_mask is None, "R2 must NOT build a replay_mask"
+
+    def test_r3_with_response_mask_builds_per_token_mask(self, controller):
+        """Regression: R3 must build a per-rmpad-token mask from
+        ``response_mask`` (strided ``(bs, max_response_len)``) via
+        per-sample length arithmetic — calling ``response_mask.values()``
+        directly raises ``RuntimeError: values expected sparse tensor
+        layout but got Strided``.
+
+        Layout the test mimics: 2 samples with total lens [5, 7], where
+        the last 2 / 3 tokens of each are response. The expected flat
+        mask is ``[0,0,0,1,1, 0,0,0,0,1,1,1]``.
+        """
+        L, topk = 2, 1
+        controller.begin_replay()
+        engine = _make_engine_with_controller(controller, mode="R3")
+
+        # Sample 0: 5 tokens (3 prompt + 2 response).
+        # Sample 1: 7 tokens (4 prompt + 3 response).
+        seq_lens = [5, 7]
+        max_response_len = 4  # padded; sample 0 has 2 response tokens, sample 1 has 3
+        response_mask = torch.zeros(2, max_response_len, dtype=torch.int64)
+        response_mask[0, :2] = 1  # sample 0: 2 response tokens
+        response_mask[1, :3] = 1  # sample 1: 3 response tokens
+
+        routed = _make_jagged_routed_experts(seq_lens, L, topk)
+        td = TensorDict(
+            {
+                "input_ids": _make_jagged_input_ids(seq_lens),
+                "routed_experts": routed,
+                "response_mask": response_mask,
+            },
+            batch_size=[2],
+        )
+        engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+
+        assert controller._replay_mask is not None, "R3 must build a replay_mask"
+        expected = torch.tensor(
+            [
+                False,
+                False,
+                False,
+                True,
+                True,  # sample 0: 3 prompt + 2 response
+                False,
+                False,
+                False,
+                False,
+                True,
+                True,
+                True,  # sample 1: 4 prompt + 3 response
+            ],
+            dtype=torch.bool,
+        )
+        assert torch.equal(controller._replay_mask, expected), (
+            f"replay_mask mismatch: got {controller._replay_mask.tolist()}, expected {expected.tolist()}"
+        )
+
+    def test_r3_missing_response_mask_raises(self, controller):
+        """R3 needs response_mask to know which tokens to substitute.
+        Missing it is a plumbing bug, not a soft-fallback case."""
+        L, topk = 2, 1
+        controller.begin_replay()
+        engine = _make_engine_with_controller(controller, mode="R3")
+        seq_lens = [3, 4]
+        td = TensorDict(
+            {
+                "input_ids": _make_jagged_input_ids(seq_lens),
+                "routed_experts": _make_jagged_routed_experts(seq_lens, L, topk),
+            },
+            batch_size=[2],
+        )
+        with pytest.raises(RuntimeError, match="R3.*missing 'response_mask'"):
+            engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+
+    def test_r3_response_longer_than_total_raises(self, controller):
+        """Defensive: if response_mask describes more tokens than the
+        actor's input, prompt_lens goes negative — fail-fast with a
+        typed error instead of letting repeat_interleave produce a
+        malformed mask that surfaces later as the EP all-to-all crash."""
+        L, topk = 2, 1
+        controller.begin_replay()
+        engine = _make_engine_with_controller(controller, mode="R3")
+        # Sample 0: 3 tokens but response_mask claims 5 → prompt_lens = -2.
+        seq_lens = [3, 4]
+        response_mask = torch.zeros(2, 6, dtype=torch.int64)
+        response_mask[0, :5] = 1  # impossible: 5 response > 3 total
+        response_mask[1, :2] = 1
+        td = TensorDict(
+            {
+                "input_ids": _make_jagged_input_ids(seq_lens),
+                "routed_experts": _make_jagged_routed_experts(seq_lens, L, topk),
+                "response_mask": response_mask,
+            },
+            batch_size=[2],
+        )
+        with pytest.raises(RuntimeError, match="response_mask sum exceeds total token"):
+            engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+
+    def test_record_does_not_consume_routed_experts(self, controller):
+        """RECORD path doesn't read routed_experts (it's the *output*,
+        not an input). Even if the micro_batch happens to carry one,
+        it must not be touched."""
+        L, topk = 2, 1
+        controller.begin_record()
+        engine = _make_engine_with_controller(controller)
+        seq_lens = [3, 4]
+        td = TensorDict(
+            {
+                "input_ids": _make_jagged_input_ids(seq_lens),
+                "routed_experts": _make_jagged_routed_experts(seq_lens, L, topk),
+            },
+            batch_size=[2],
+        )
+        engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+        # No targets set — RECORD ignores the field entirely.
+        assert controller._targets == []
+
+    def test_no_controller_is_a_noop(self):
+        """If router_replay is disabled on the engine, the helper is a
+        pure no-op even when the micro_batch is malformed."""
+        engine = _make_engine_with_controller(controller=None)
+        # Deliberately broken micro_batch — would raise if the helper
+        # progressed past the early ``return``.
+        td = TensorDict(
+            {"input_ids": torch.randint(0, 100, (2, 8), dtype=torch.int64)},
+            batch_size=[2],
+        )
+        engine._maybe_push_router_replay_state(td, {"pad_size": 0})
+        # No raise = pass.
+
+
+def _silence_unused_action_import():
+    """``RouterReplayAction`` is imported for symmetry with the engine
+    code that consumes it; silence the lint warning in tests."""
+    _ = RouterReplayAction

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -51,6 +51,9 @@ actor_rollout_ref:
       force_use_huggingface: false
       activation_gpu_limit: 0.0
       moe_load_balance_monitor_interval: 0
+      router_replay:
+        _target_: verl.workers.config.EngineRouterReplayConfig
+        mode: disabled
     _target_: verl.workers.config.VeOmniActorConfig
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: veomni
@@ -217,6 +220,9 @@ actor_rollout_ref:
       force_use_huggingface: false
       activation_gpu_limit: 0.0
       moe_load_balance_monitor_interval: 0
+      router_replay:
+        _target_: verl.workers.config.EngineRouterReplayConfig
+        mode: disabled
     _target_: verl.workers.config.VeOmniActorConfig
   rollout:
     _target_: verl.workers.config.RolloutConfig
@@ -501,6 +507,9 @@ critic:
     force_use_huggingface: false
     activation_gpu_limit: 0.0
     moe_load_balance_monitor_interval: 0
+    router_replay:
+      _target_: verl.workers.config.EngineRouterReplayConfig
+      mode: disabled
   _target_: verl.workers.config.VeOmniCriticConfig
   rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
   strategy: veomni

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -147,6 +147,7 @@ actor_rollout_ref:
       - re:.*mlp.gate$
       activation_observer: static_minmax
       quantization_config_path: null
+    use_remove_padding: ${oc.select:actor_rollout_ref.model.use_remove_padding,false}
   ref:
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: veomni

--- a/verl/trainer/config/actor/veomni_actor.yaml
+++ b/verl/trainer/config/actor/veomni_actor.yaml
@@ -14,3 +14,5 @@ defaults:
 _target_: verl.workers.config.VeOmniActorConfig
 
 strategy: veomni
+
+use_remove_padding: ${oc.select:actor_rollout_ref.model.use_remove_padding,false}

--- a/verl/trainer/config/engine/veomni.yaml
+++ b/verl/trainer/config/engine/veomni.yaml
@@ -69,3 +69,17 @@ activation_gpu_limit: 0.0
 # MoE expert-load monitor interval. When > 0, attach VeOmni's MoERouterMonitor.
 # Scalar metrics flow through Tracking; heatmap images go to wandb on rank 0.
 moe_load_balance_monitor_interval: 0
+
+router_replay:
+
+  # Target dataclass for this configuration
+  _target_: verl.workers.config.EngineRouterReplayConfig
+
+  # Router replay mode: disabled, R2, R3
+  # - R2: record top-k indices in compute_log_prob (forward-only) and
+  #       replay them in the actor update. No rollout-side change required.
+  # - R3: record top-k indices at the rollout backend and replay them in
+  #       both compute_log_prob and the actor update. Requires
+  #       ``rollout.enable_rollout_routing_replay=True`` and rollout backend
+  #       support for returning the selected indices.
+  mode: disabled

--- a/verl/utils/veomni/__init__.py
+++ b/verl/utils/veomni/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/verl/utils/veomni/router_replay.py
+++ b/verl/utils/veomni/router_replay.py
@@ -1,0 +1,539 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VeOmni-flavored MoE router replay.
+
+Self-contained record/replay controller for verl's VeOmni engine. Tapped
+into VeOmni's MoE ``SparseMoeBlock.forward`` via
+``veomni.utils.moe_router_replay.set_active_replay`` (a module-level
+singleton slot); the patched forward calls
+``maybe_replay_indices(module, routing_scores, top_indices)`` on each MoE
+layer, which delegates to :meth:`VeOmniRouterReplay.on_router_forward`.
+
+Lifecycle (per ``forward_backward_batch``)::
+
+    # Outside every micro-batch loop:
+    replay.begin_record()      # R2 compute_log_prob
+        or replay.begin_replay()  # R2 actor update, or R3 everywhere
+
+    # Inside the micro-batch loop, before each forward:
+    replay.set_microbatch_targets(per_layer_targets)  # REPLAY only
+
+    # After every micro-batch finishes:
+    # (nothing — state carries across recompute-in-backward too)
+
+    # After the whole step:
+    routed_experts = replay.collect_recorded(...)     # RECORD only
+    replay.clear()
+
+Layer indexing
+--------------
+RR uses **id-keyed positional** indexing. The first time each MoE router
+fires, we assign the next position (``len(_id_to_pos)``) to ``id(module)``;
+every subsequent call for that module reuses the same position. This is
+the key correctness property under **activation checkpointing**: backward
+recompute fires the same router modules again (in any order — per-layer
+checkpoint segments differentiate from L-1 down to 0), and the id-keyed
+lookup gives the correct position regardless of the order. A
+monotonically-incremented cursor would walk past ``len(_targets)`` (REPLAY
+crash) or grow phantom slots in ``_recorded`` (RECORD corruption).
+
+Layer position L is learned implicitly from input shapes:
+    * RECORD: ``len(_recorded)`` after the first full forward establishes L.
+    * REPLAY: ``set_microbatch_targets`` stashes a list of length L — no
+      prior id-mapping discovery needed (this is what unblocks R3 step 1,
+      where REPLAY runs *before* any RECORD has populated the id table).
+
+Parallelism scope
+-----------------
+VeOmni uses **FSDP2 + optional Ulysses SP**, with no pipeline parallelism.
+The state machine therefore gets away with a simple RECORD / REPLAY
+two-action model and a single ``_targets`` slot per layer — the same
+target carries across forward + recompute-in-backward because forward
+and its backward are not interleaved with other micro-batches' forwards.
+Engines with pipeline-parallel interleaved schedules (Megatron, mindspeed)
+need a richer state model (separate REPLAY_FORWARD / REPLAY_BACKWARD
+actions + a FIFO queue of pending targets, so late-arriving backwards can
+still recover their microbatch's target after later forwards have
+overwritten the "current target" slot). That lives in
+:mod:`verl.utils.megatron.router_replay_patch`; the two implementations
+are intentionally kept separate because their state models answer
+different parallelism constraints, not stylistic differences.
+
+The cross-rank aggregation for RECORD (Ulysses SP all-gather, pad trim)
+lives in :meth:`_all_gather_recorded` / :meth:`collect_recorded` here,
+and :meth:`slice_microbatch_replay_targets` handles the symmetric
+pad+slice on the REPLAY input path. Both delegate to
+``verl.utils.ulysses`` primitives so the pad/slice rule stays
+bit-identical to the one ``super().prepare_model_inputs`` applies to
+``input_ids``.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
+import torch.distributed as dist
+
+from verl.utils.ulysses import all_gather_tensor, slice_input_tensor
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+
+__all__ = ["RouterReplayAction", "VeOmniRouterReplay"]
+
+
+class RouterReplayAction(Enum):
+    DISABLED = "disabled"
+    RECORD = "record"
+    REPLAY = "replay"
+
+
+class VeOmniRouterReplay:
+    """Router replay controller for VeOmni (FSDP2 + optional Ulysses SP).
+
+    Single self-contained class: state machine, layer discovery, RECORD /
+    REPLAY forward dispatch, cross-rank aggregation, and the VeOmni-side
+    install/uninstall hookup all live here. No abstract base — see the
+    module docstring for why VeOmni and Megatron/mindspeed intentionally
+    keep separate RR implementations.
+    """
+
+    # ------------------------------------------------------------ lifecycle
+
+    def __init__(self, sp_group: dist.ProcessGroup | None = None) -> None:
+        self._sp_group = sp_group
+        self._action: RouterReplayAction = RouterReplayAction.DISABLED
+        # id(router_module) -> position. Populated lazily on first sight
+        # of each router; stable across the lifetime of the controller
+        # (FSDP2 / LoRA wrappers don't mutate module identity per forward).
+        # Re-discovered between RECORD and REPLAY phases (cleared by
+        # ``begin_record`` / ``begin_replay``); this is just an optimization
+        # bookkeeping reset — the same model produces the same id table.
+        self._id_to_pos: dict[int, int] = {}
+        # RECORD: per-layer-position list of [local_nnz, topk] tensors, one
+        # per micro-batch. Inner list length == num_micro_batches at collect
+        # time; outer list grows as new routers fire on the *first*
+        # micro-batch. Recompute-in-backward (which fires the same routers
+        # again, in any order under per-layer checkpointing) is detected via
+        # ``len(_recorded[pos]) == _mb_index + 1`` and skipped.
+        self._recorded: list[list[torch.Tensor]] = []
+        # REPLAY: positional list of target tensors for the *current*
+        # micro-batch. Re-built per micro-batch by ``set_microbatch_targets``.
+        self._targets: list[torch.Tensor] = []
+        # REPLAY only: optional per-token mask of shape ``[local_nnz]``,
+        # bool, True where the recorded targets are valid (substitute) and
+        # False where they are placeholders (fall through to native
+        # routing). Populated by ``set_microbatch_targets``. R3 needs this
+        # because the rollout backend only captures response-token routing
+        # and writes zeros for prompt tokens; substituting all tokens with
+        # those zeros sends every prompt token's topk slots to expert 0,
+        # which corrupts the EP all-to-all token distribution.
+        self._replay_mask: torch.Tensor | None = None
+        # RECORD only: which micro-batch is currently being recorded. Bumped
+        # by ``advance_record_microbatch`` between micro-batches; used both
+        # to detect recompute (slot already filled for this mb) and to
+        # validate the per-layer slot list is dense (no skipped mbs).
+        self._mb_index: int = 0
+        # Env-gated shape sanity check.
+        self._debug: bool = os.environ.get("VERL_ROUTER_REPLAY_DEBUG") == "1"
+        self._installed: bool = False
+
+    @property
+    def action(self) -> RouterReplayAction:
+        return self._action
+
+    @property
+    def num_layers(self) -> int:
+        """Number of MoE layers discovered so far. RECORD: established by the
+        first full forward (``len(_recorded)``). REPLAY: known directly from
+        ``set_microbatch_targets`` input length (``len(_targets)``)."""
+        return max(len(self._recorded), len(self._targets))
+
+    # -------------------------------------------------------- install/uninstall
+
+    def install(self, model: nn.Module) -> None:
+        """Register this controller with VeOmni's global ``set_active_replay`` slot.
+
+        After returning, every MoE router forward in ``model`` should reach
+        :meth:`on_router_forward` via ``maybe_replay_indices``.
+        """
+        try:
+            from veomni.utils.moe_router_replay import set_active_replay, validate_model_for_replay  # type: ignore
+        except ImportError as e:
+            raise RuntimeError(
+                "router_replay.mode != 'disabled' requires a VeOmni build that "
+                "exposes `veomni.utils.moe_router_replay.set_active_replay`. "
+                "Either upgrade VeOmni or set router_replay.mode='disabled'."
+            ) from e
+        # Fail fast if this model family has not been wired for replay
+        # (would otherwise surface as a cryptic mid-forward error from the
+        # controller's collect/set_microbatch_targets path).
+        validate_model_for_replay(model)
+        set_active_replay(self)
+        self._installed = True
+
+    def uninstall(self) -> None:
+        """Reverse :meth:`install`. Idempotent."""
+        if not self._installed:
+            return
+        try:
+            from veomni.utils.moe_router_replay import set_active_replay  # type: ignore
+
+            set_active_replay(None)
+        except ImportError:
+            pass
+        self._installed = False
+
+    # ----------------------------------------------------- router-side entry
+
+    def on_router_forward(
+        self,
+        module: nn.Module,
+        routing_scores: torch.Tensor,
+        top_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Called from each MoE router forward via VeOmni's hook surface.
+
+        Indices-only: records ``top_indices`` in RECORD mode or returns
+        substituted target indices in REPLAY mode. All model-specific
+        post-topk weight math (gather, renorm, scaling, dtype cast) lives
+        in the per-family patched ``SparseMoeBlock.forward``, not here —
+        that keeps the controller model-agnostic across MoE families
+        (softmax/sigmoid gating, group topk, expert bias, scaling factors,
+        etc.). ``routing_scores`` is accepted for optional debug inspection
+        but NOT used to derive weights.
+
+        Position assignment is keyed on ``id(module)`` so backward recompute
+        under activation checkpointing (which fires routers again, possibly
+        in non-sequential order under per-layer checkpoint segments) lands
+        on the same position as the original forward.
+        """
+        mid = id(module)
+        if mid in self._id_to_pos:
+            pos = self._id_to_pos[mid]
+            new_layer = False
+        else:
+            pos = len(self._id_to_pos)
+            self._id_to_pos[mid] = pos
+            new_layer = True
+
+        if self._debug:
+            # Cheap shape sanity check — cross-family safe (no weight math).
+            # Env-gated; off by default.
+            if routing_scores.dim() != 2 or top_indices.dim() != 2:
+                raise AssertionError(
+                    f"router_replay: expected 2D tensors, got routing_scores "
+                    f"{tuple(routing_scores.shape)} and top_indices "
+                    f"{tuple(top_indices.shape)}."
+                )
+            if routing_scores.shape[0] != top_indices.shape[0]:
+                raise AssertionError(
+                    f"router_replay: routing_scores / top_indices row count "
+                    f"mismatch: {routing_scores.shape[0]} vs {top_indices.shape[0]}."
+                )
+
+        if self._action is RouterReplayAction.RECORD:
+            if new_layer:
+                # First time we've seen this router — grow the slot list.
+                # Must be on the first micro-batch; later mbs would see the
+                # router already mapped.
+                self._recorded.append([])
+            slot = self._recorded[pos]
+            # Recompute detection: this layer has already been captured for
+            # the current mb. Skip the append (re-recording would duplicate
+            # an already-deterministic value). Snapshot was via
+            # ``.detach().clone()`` so the originally captured tensor is
+            # independent of the autograd graph that produced it.
+            if len(slot) == self._mb_index + 1:
+                return top_indices
+            if len(slot) != self._mb_index:
+                # Should never happen — would indicate skipped or extra
+                # micro-batches earlier in the step.
+                raise RuntimeError(
+                    f"router_replay RECORD invariant violated at layer pos={pos}: "
+                    f"slot has {len(slot)} entries, expected {self._mb_index} "
+                    f"before appending mb {self._mb_index}. Possible cause: "
+                    "router fired in some micro-batches but not others."
+                )
+            slot.append(top_indices.detach().clone())
+            return top_indices
+
+        if self._action is RouterReplayAction.REPLAY:
+            # Strict: every layer position must have a target. There is no
+            # silent fallback — a missing target indicates a real plumbing
+            # bug (routed_experts not propagated, layer count mismatch
+            # between RECORD and REPLAY models, or the engine forgot to call
+            # set_microbatch_targets before this forward).
+            if pos >= len(self._targets):
+                raise RuntimeError(
+                    f"router_replay REPLAY: layer pos={pos} has no target "
+                    f"(only {len(self._targets)} targets set for this "
+                    "micro-batch). Likely cause: model has more MoE layers "
+                    "than the recorded routed_experts tensor describes, or "
+                    "set_microbatch_targets was not called before forward."
+                )
+            target = self._targets[pos]
+            if self._replay_mask is None:
+                substituted = target
+            else:
+                # Per-token gated substitution: where the mask is True the
+                # recorded target is valid (substitute); where False the
+                # target is a placeholder and we must fall through to native
+                # routing. R3 needs this to skip prompt tokens that the
+                # rollout backend wrote zeros for.
+                mask = self._replay_mask
+                if mask.shape[0] != top_indices.shape[0]:
+                    raise RuntimeError(
+                        f"router_replay REPLAY: replay_mask has {mask.shape[0]} rows "
+                        f"but top_indices has {top_indices.shape[0]}. The mask must "
+                        "be sliced with the same Ulysses SP rule as the targets."
+                    )
+                substituted = torch.where(mask.unsqueeze(-1), target, top_indices)
+
+            # Defensive duplicate-detection.
+            #
+            # VeOmni's MoE expert dispatch (``permute()`` in
+            # ``veomni/distributed/moe/moe_utils.py``) builds the permuted
+            # tensor via ``routing_map.bool().masked_select(...)``, which
+            # collapses duplicate top-k slots within one token to a single
+            # entry. ``input_splits`` keeps counting every slot, so the two
+            # diverge whenever ANY token has duplicate top-k experts and the
+            # EP all-to-all crashes with
+            # ``RuntimeError: Split sizes doesn't match total dim 0 size``.
+            #
+            # Recorded targets can contain such duplicate rows when the
+            # rollout backend writes zero placeholders (e.g. left/right pad,
+            # or capture regions that don't match the response_mask). The
+            # mask filters most of these, but the exact contract differs
+            # across backends — fall back to native routing for any row whose
+            # substituted top-k contains a duplicate. Native indices are
+            # always distinct top-k choices, so this is correct regardless
+            # of what the rollout produces.
+            sorted_sub, _ = substituted.sort(dim=-1)
+            has_duplicate = (sorted_sub[:, 1:] == sorted_sub[:, :-1]).any(dim=-1)
+            return torch.where(has_duplicate.unsqueeze(-1), top_indices, substituted)
+
+        return top_indices
+
+    # --------------------------------------------------- engine-side drivers
+
+    def begin_record(self) -> None:
+        """Enter RECORD mode. Must be called before the micro-batch loop."""
+        self._action = RouterReplayAction.RECORD
+        self._recorded = []
+        self._targets = []
+        self._replay_mask = None
+        self._id_to_pos = {}
+        self._mb_index = 0
+
+    def begin_replay(self) -> None:
+        """Enter REPLAY mode. Must be called before the micro-batch loop."""
+        self._action = RouterReplayAction.REPLAY
+        self._targets = []
+        self._replay_mask = None
+        self._id_to_pos = {}
+        # _mb_index is unused in REPLAY (recompute is detected via id-keyed
+        # lookup hitting an already-mapped module, not via mb counters).
+        self._mb_index = 0
+
+    def advance_record_microbatch(self) -> None:
+        """Mark the start of a new RECORD micro-batch.
+
+        Call this in the engine driver immediately after the previous
+        micro-batch's forward+backward returns and before the next one
+        starts. Bumps ``_mb_index`` so :meth:`on_router_forward` knows which
+        slot to fill on the next router fire. Recompute-in-backward (which
+        fires within the *same* micro-batch's backward) does NOT call this —
+        it's detected via id-keyed lookup hitting a slot whose length already
+        equals ``_mb_index + 1``.
+        """
+        if self._action is not RouterReplayAction.RECORD:
+            raise RuntimeError(f"advance_record_microbatch requires RECORD action, got {self._action}")
+        self._mb_index += 1
+
+    def set_microbatch_targets(
+        self,
+        per_layer_targets: list[torch.Tensor],
+        replay_mask: torch.Tensor | None = None,
+    ) -> None:
+        """Load per-layer target indices for the upcoming micro-batch forward.
+
+        ``per_layer_targets[i]`` is ``[local_nnz, topk]`` int64 on device,
+        ordered by layer position (matches the order in which routers fire
+        during forward — established when each router gets its position
+        assigned in :meth:`on_router_forward`). Strict: REPLAY mode must
+        already be active. ``L`` is taken from the input list length — no
+        prior id-mapping discovery is required, which is what unblocks R3
+        step 1 where REPLAY runs before any RECORD has populated the table.
+
+        ``replay_mask`` (optional, ``[local_nnz]`` bool): per-token gate.
+        Where True, substitute with the recorded target. Where False, fall
+        through to the native router output. Required for R3, where the
+        rollout backend captures only response-token routing and writes
+        zeros for prompt tokens — without the mask, those zeros would be
+        substituted, sending every prompt token's topk slots to expert 0
+        and corrupting the EP all-to-all token distribution.
+
+        The mask must be in the rmpad ``[local_nnz]`` layout (same SP
+        slice rule as ``per_layer_targets``). The engine driver builds it
+        from ``response_mask`` (strided ``(bs, max_response_len)``) plus
+        ``input_ids.offsets()`` via per-sample length arithmetic, then
+        runs it through :meth:`slice_microbatch_replay_mask`. Callers
+        should not pass the strided ``response_mask`` / ``loss_mask``
+        directly — they have neither the right shape nor a valid
+        ``.values()`` for a strided layout.
+
+        R2 callers should pass ``None`` (uniform substitution): R2
+        RECORD captures the actor's full-sequence routing (prompt +
+        response), so applying a response-only gate would leak prompt-
+        token routing divergence into the bit-equal forward guarantee.
+        """
+        if self._action is not RouterReplayAction.REPLAY:
+            raise RuntimeError(f"set_microbatch_targets requires REPLAY action, got {self._action}")
+        self._targets = list(per_layer_targets)
+        self._replay_mask = replay_mask.bool() if replay_mask is not None else None
+
+    def clear(self) -> None:
+        """Reset the state machine between steps."""
+        self._action = RouterReplayAction.DISABLED
+        self._recorded = []
+        self._targets = []
+        self._replay_mask = None
+        self._id_to_pos = {}
+        self._mb_index = 0
+
+    # ---------------------------------------------------- cross-rank gather
+
+    def _all_gather_recorded(self, local: torch.Tensor) -> torch.Tensor:
+        """All-gather a ``[local_nnz, L, topk]`` tensor along Ulysses SP.
+
+        Returns ``[nnz_padded, L, topk]`` where
+        ``nnz_padded = local_nnz * sp_size``. The caller trims the ulysses
+        pad suffix.
+        """
+        if self._sp_group is None or dist.get_world_size(self._sp_group) == 1:
+            return local
+        return all_gather_tensor(local.contiguous(), group=self._sp_group)
+
+    def collect_recorded(
+        self,
+        pad_size_per_mb: list[int],
+        num_micro_batches: int,
+    ) -> list[torch.Tensor]:
+        """Aggregate recorded indices across ranks and unpack per micro-batch.
+
+        For each micro-batch:
+          * Stack per-layer-position [local_nnz, topk] into [local_nnz, L, topk]
+          * All-gather along Ulysses SP to restore full nnz+pad
+          * Trim the ulysses pad suffix
+
+        Returns a list of length ``num_micro_batches``, each element a
+        ``[total_nnz_mb, L, topk]`` int tensor. The caller (engine) is
+        responsible for (a) reordering micro-batches back to batch order
+        using the indices returned by ``prepare_micro_batches``, and (b)
+        converting to the nested/jagged layout expected by the trainer.
+        """
+        if self._action is not RouterReplayAction.RECORD:
+            raise RuntimeError(f"collect_recorded requires RECORD action, got {self._action}")
+        if not self._recorded:
+            raise RuntimeError("collect_recorded called before any router fired.")
+        if len(pad_size_per_mb) != num_micro_batches:
+            raise ValueError(f"pad_size_per_mb length {len(pad_size_per_mb)} != {num_micro_batches}")
+        # Sanity: every recorded layer should have the same number of entries.
+        for pos, slot in enumerate(self._recorded):
+            if len(slot) != num_micro_batches:
+                raise RuntimeError(
+                    f"Router layer pos={pos} recorded {len(slot)} micro-batches, "
+                    f"expected {num_micro_batches}. Possible causes: "
+                    "router skipped on some micro-batches, or forward failed mid-step."
+                )
+
+        per_mb: list[torch.Tensor] = []
+        for mb in range(num_micro_batches):
+            per_layer = [slot[mb] for slot in self._recorded]
+            local = torch.stack(per_layer, dim=1)  # [local_nnz, L, topk]
+            gathered = self._all_gather_recorded(local)
+            pad = pad_size_per_mb[mb]
+            if pad > 0:
+                gathered = gathered[:-pad]
+            per_mb.append(gathered)
+        return per_mb
+
+    # ---------------------------------------------------- replay input prep
+
+    def slice_microbatch_replay_targets(self, batch_routed_experts: torch.Tensor) -> list[torch.Tensor]:
+        """Prepare per-layer replay targets from a micro-batch's routed_experts.
+
+        Reuses :func:`verl.utils.ulysses.slice_input_tensor` so the pad+split
+        rule matches the one ``super().prepare_model_inputs`` already applies
+        to ``input_ids``. The SP rank/world_size are derived from
+        ``self._sp_group`` internally — we never dig into ``parallel_state``
+        here.
+
+        Args:
+            batch_routed_experts: ``[mb_nnz, L, topk]`` int tensor, flattened
+                across the micro-batch (the ``.values()`` of the nested
+                jagged ``routed_experts``).
+
+        Returns:
+            List of length ``L``, each ``[mb_nnz_local, topk]`` int64 tensor,
+            ready to feed :meth:`set_microbatch_targets`.
+        """
+        if batch_routed_experts.dim() != 3:
+            raise ValueError(f"routed_experts must be [mb_nnz, L, topk], got {batch_routed_experts.shape}")
+        idx = batch_routed_experts.to(torch.int64)
+        if self._sp_group is not None and dist.get_world_size(self._sp_group) > 1:
+            idx = slice_input_tensor(idx, dim=0, padding=True, group=self._sp_group)
+        return list(idx.unbind(dim=1))
+
+    def slice_microbatch_replay_mask(self, batch_mask: torch.Tensor) -> torch.Tensor:
+        """Prepare a per-token replay mask using the same pad+slice rule as
+        :meth:`slice_microbatch_replay_targets`.
+
+        Used to feed the optional ``replay_mask`` of
+        :meth:`set_microbatch_targets`. The input is a flat
+        ``[mb_nnz]`` bool/int tensor in the same rmpad layout as
+        ``input_ids.values()`` — it is NOT the engine's
+        ``response_mask`` directly (which is a strided
+        ``(bs, max_response_len)`` tensor and has the wrong shape).
+        The engine driver constructs the flat layout via per-sample
+        prompt/response length arithmetic (see
+        ``VeOmniEngineWithLMHead._maybe_push_router_replay_state``)
+        before calling this helper.
+
+        Padding values (added by ``slice_input_tensor`` to make the tensor
+        SP-divisible) are filled with zero, matching the "no recorded data"
+        semantics — pad rows shouldn't be substituted regardless.
+        """
+        if batch_mask.dim() != 1:
+            raise ValueError(f"replay_mask must be 1-D [mb_nnz], got {batch_mask.shape}")
+        m = batch_mask.to(torch.int64)
+        if self._sp_group is not None and dist.get_world_size(self._sp_group) > 1:
+            m = slice_input_tensor(m, dim=0, padding=True, group=self._sp_group)
+        return m.bool()
+
+    # --------------------------------------------------------- debug helpers
+
+    def assert_layer_count(self, expected: int) -> None:
+        """Assert the discovered layer count matches the model config."""
+        if self.num_layers != expected:
+            raise AssertionError(
+                f"router_replay discovered {self.num_layers} MoE layers, "
+                f"model config says {expected}. Layer discovery is broken."
+            )

--- a/verl/utils/veomni/router_replay.py
+++ b/verl/utils/veomni/router_replay.py
@@ -57,27 +57,10 @@ Layer position L is learned implicitly from input shapes:
 
 Parallelism scope
 -----------------
-VeOmni uses **FSDP2 + optional Ulysses SP**, with no pipeline parallelism.
-The state machine therefore gets away with a simple RECORD / REPLAY
-two-action model and a single ``_targets`` slot per layer — the same
-target carries across forward + recompute-in-backward because forward
-and its backward are not interleaved with other micro-batches' forwards.
-Engines with pipeline-parallel interleaved schedules (Megatron, mindspeed)
-need a richer state model (separate REPLAY_FORWARD / REPLAY_BACKWARD
-actions + a FIFO queue of pending targets, so late-arriving backwards can
-still recover their microbatch's target after later forwards have
-overwritten the "current target" slot). That lives in
-:mod:`verl.utils.megatron.router_replay_patch`; the two implementations
-are intentionally kept separate because their state models answer
-different parallelism constraints, not stylistic differences.
-
-The cross-rank aggregation for RECORD (Ulysses SP all-gather, pad trim)
-lives in :meth:`_all_gather_recorded` / :meth:`collect_recorded` here,
-and :meth:`slice_microbatch_replay_targets` handles the symmetric
-pad+slice on the REPLAY input path. Both delegate to
-``verl.utils.ulysses`` primitives so the pad/slice rule stays
-bit-identical to the one ``super().prepare_model_inputs`` applies to
-``input_ids``.
+VeOmni uses FSDP2 + optional Ulysses SP, no pipeline parallelism. The
+RECORD all-gather and REPLAY pad+slice both go through
+``verl.utils.ulysses`` so the SP layout matches what
+``super().prepare_model_inputs`` applies to ``input_ids``.
 """
 
 from __future__ import annotations

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -352,6 +352,14 @@ class VeOmniActorConfig(ActorConfig):
         """Validate VeOmni actor configuration parameters."""
         super().__post_init__()
         self.engine = self.veomni
+        if self.veomni.router_replay.mode != "disabled" and not self.use_remove_padding:
+            raise RuntimeError(
+                "router_replay requires use_remove_padding=True. In VeOmni engine, "
+                "the non-remove-padding path also disables Ulysses SP slicing and "
+                "the fused-kernel log_probs path, and is not a tested production "
+                "configuration for MoE routing replay. Set "
+                "actor.use_remove_padding=True or router_replay.mode='disabled'."
+            )
 
 
 @dataclass

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -186,9 +186,8 @@ class VeOmniEngine(FSDPEngine):
         self._init_moe_monitor()
 
         if self.enable_routing_replay:
-            # Defense in depth: the worker-side check at
-            # ``ActorRolloutRefWorker.__init__`` is the primary fail-fast
-            # point and runs *before* engine init. By the time we get here,
+            # Defense in depth: the VeOmniActorConfig check is the primary
+            # fail-fast point and runs *before* engine init. By the time we get here,
             # ``_build_model_optimizer()`` has already finished — this
             # second check exists to catch direct ``VeOmniEngine``
             # instantiation paths that bypass the worker (e.g. unit tests,

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -41,6 +41,7 @@ from verl.utils.ulysses import (
     get_ulysses_sequence_parallel_group,
     set_ulysses_sequence_parallel_group,
 )
+from verl.utils.veomni.router_replay import RouterReplayAction, VeOmniRouterReplay
 from verl.workers.config import HFModelConfig, VeOmniEngineConfig, VeOmniOptimizerConfig
 
 from ..base import BaseEngineCtx, EngineRegistry
@@ -163,6 +164,14 @@ class VeOmniEngine(FSDPEngine):
             else entropy_from_logits
         )
 
+        # Router replay (R2 / R3) for MoE models. Controller is attached in
+        # initialize() after the model is built; here we only record intent.
+        self._router_replay_mode: str = self.engine_config.router_replay.mode
+        self.enable_routing_replay: bool = self._router_replay_mode != "disabled"
+        self._router_replay: VeOmniRouterReplay | None = None
+        if self.enable_routing_replay:
+            logger.info("VeOmniEngine: router_replay enabled, mode=%s", self._router_replay_mode)
+
     def initialize(self):
         """
         Build the model, optimizer, and learning rate scheduler under VeOmni.
@@ -175,6 +184,31 @@ class VeOmniEngine(FSDPEngine):
 
         self._build_model_optimizer()
         self._init_moe_monitor()
+
+        if self.enable_routing_replay:
+            # Defense in depth: the worker-side check at
+            # ``ActorRolloutRefWorker.__init__`` is the primary fail-fast
+            # point and runs *before* engine init. By the time we get here,
+            # ``_build_model_optimizer()`` has already finished — this
+            # second check exists to catch direct ``VeOmniEngine``
+            # instantiation paths that bypass the worker (e.g. unit tests,
+            # standalone debug scripts) so the user gets a typed config
+            # error instead of an opaque mid-step ``AttributeError`` on
+            # ``input_ids.offsets()``.
+            if not self.engine_config.use_remove_padding:
+                raise RuntimeError(
+                    "router_replay requires use_remove_padding=True. In VeOmni engine, "
+                    "the non-remove-padding path also disables Ulysses SP slicing and "
+                    "the fused-kernel log_probs path, and is not a tested production "
+                    "configuration for MoE routing replay. Set "
+                    "actor.model.use_remove_padding=True or "
+                    "router_replay.mode='disabled'."
+                )
+            self._router_replay = VeOmniRouterReplay(sp_group=self.ulysses_parallel_group)
+            # Fails loudly if the VeOmni build in the environment does not
+            # export `set_active_replay` yet (plan requires upgrading VeOmni
+            # or disabling router_replay).
+            self._router_replay.install(self.module)
 
         self.checkpoint_manager = FSDPCheckpointManager(
             model=self.module,
@@ -395,26 +429,97 @@ class VeOmniEngine(FSDPEngine):
             data=data, dp_group=self.get_data_parallel_group(), same_micro_num_in_dp=True
         )
 
-        output_lst = []
+        # Router replay state machine: decide RECORD vs REPLAY for this step.
+        # RECORD: R2 compute_log_prob (forward_only=True).
+        # REPLAY: R2 actor update, or R3 always (forward_only=True and False).
+        rr_active = self.enable_routing_replay and tu.get_non_tensor_data(data, "enable_routing_replay", default=False)
+        if rr_active:
+            assert self._router_replay is not None
+            if self._router_replay_mode == "R2" and forward_only:
+                self._router_replay.begin_record()
+            else:
+                self._router_replay.begin_replay()
 
-        for micro_batch in micro_batches:
-            with self.model_fwd_context:
-                loss, meta_info = self.forward_step(micro_batch, loss_function=loss_function, forward_only=forward_only)
-            if not forward_only:
-                with self.model_bwd_context:
-                    loss.backward()
+        # Wrap the per-step body in try/finally so the controller is always
+        # reset to DISABLED even if forward / backward / postprocess raises.
+        # Without this, an exception leaves _recorded / _targets pinned
+        # (GPU memory) until the next successful step's begin_record/replay
+        # clears them, which may never happen if the caller (Ray actor) tears
+        # down the worker after the failure.
+        try:
+            output_lst = []
+            # Per-microbatch metadata for RECORD aggregation (pad_size for SP pad trim,
+            # cu_seqlens for per-sample split). Collected via side-channel on the
+            # micro_batch TensorDict during prepare_model_inputs.
+            pad_size_per_mb: list[int] = []
+            cu_seqlens_per_mb: list[torch.Tensor] = []
 
-            output_lst.append(meta_info)
+            for micro_batch in micro_batches:
+                if rr_active:
+                    # Singular form: stash the entire list as one NonTensorData.
+                    # The plural ``assign_non_tensor`` auto-dispatches lists to a
+                    # NonTensorStack (batch_size=[len(list)]), which mutates the
+                    # lazy-stacked micro_batch's batch_size and is rejected.
+                    tu.assign_non_tensor_data(micro_batch, "_router_replay_pad_size_out", pad_size_per_mb)
+                    tu.assign_non_tensor_data(micro_batch, "_router_replay_cu_seqlens_out", cu_seqlens_per_mb)
 
-        result = postprocess_batch_func(output_lst=output_lst, indices=indices, data=data)
+                with self.model_fwd_context:
+                    loss, meta_info = self.forward_step(
+                        micro_batch, loss_function=loss_function, forward_only=forward_only
+                    )
+                if not forward_only:
+                    with self.model_bwd_context:
+                        loss.backward()
 
-        if not forward_only and self._moe_monitor is not None:
-            self._moe_monitor_step += 1
-            interval = self.engine_config.moe_load_balance_monitor_interval
-            if interval > 0 and self._moe_monitor_step % interval == 0:
-                self._log_moe_metrics(result)
+                output_lst.append(meta_info)
 
-        return result
+                # Advance the per-mb counter on the controller. RECORD bumps
+                # ``_mb_index`` so the next micro-batch's first router fire writes
+                # into the next slot (recompute-in-backward of *this* mb has
+                # already finished by here, so its detection window is closed).
+                # Skip the bump after the last micro-batch: collect_recorded
+                # cross-checks that every layer has exactly num_micro_batches
+                # entries, so we must not advance past the last one.
+                if rr_active and self._router_replay.action is RouterReplayAction.RECORD:
+                    if len(output_lst) < len(micro_batches):
+                        self._router_replay.advance_record_microbatch()
+
+            if rr_active and self._router_replay.action is RouterReplayAction.RECORD:
+                # ``collect_recorded`` already checks pad_size_per_mb internally;
+                # cu_seqlens_per_mb is engine-local, so we cross-check here for
+                # a clear error if anything (e.g. a deep-copying TD op) breaks
+                # the by-reference side-channel contract.
+                n_mb = len(micro_batches)
+                if not (len(pad_size_per_mb) == len(cu_seqlens_per_mb) == n_mb):
+                    raise RuntimeError(
+                        f"router_replay RECORD aggregation: side-channel lengths "
+                        f"diverge — pad_size_per_mb={len(pad_size_per_mb)}, "
+                        f"cu_seqlens_per_mb={len(cu_seqlens_per_mb)}, "
+                        f"num_micro_batches={n_mb}."
+                    )
+                # Per-microbatch recorded indices -> per-sample nested tensors,
+                # attached to each output_lst entry so postprocess_batch_func can
+                # unbind + restore the original batch order, matching log_probs /
+                # entropy flow.
+                per_mb_flat = self._router_replay.collect_recorded(
+                    pad_size_per_mb=pad_size_per_mb,
+                    num_micro_batches=n_mb,
+                )
+                for i, (flat, cu) in enumerate(zip(per_mb_flat, cu_seqlens_per_mb, strict=True)):
+                    output_lst[i].setdefault("model_output", {})["routed_experts"] = (
+                        torch.nested.nested_tensor_from_jagged(flat, offsets=cu)
+                    )
+
+            result = postprocess_batch_func(output_lst=output_lst, indices=indices, data=data)
+            if not forward_only and self._moe_monitor is not None:
+                self._moe_monitor_step += 1
+                interval = self.engine_config.moe_load_balance_monitor_interval
+                if interval > 0 and self._moe_monitor_step % interval == 0:
+                    self._log_moe_metrics(result)
+            return result
+        finally:
+            if rr_active:
+                self._router_replay.clear()
 
     def get_data_parallel_rank(self):
         return parallel_state.get_parallel_state().device_mesh.get_local_rank("dp")
@@ -749,7 +854,148 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             model_inputs["shift_labels"] = shift_labels
             model_inputs["return_log_probs"] = True
 
+        # Router replay plumbing. Two responsibilities:
+        #   (1) snapshot the ulysses pad_size for this micro-batch so
+        #       forward_backward_batch can trim it during RECORD aggregation;
+        #   (2) during REPLAY, slice this micro-batch's routed_experts along
+        #       the same pad+SP rule that super().prepare_model_inputs used
+        #       for input_ids, then feed per-layer targets to the controller.
+        self._maybe_push_router_replay_state(micro_batch, output_args)
+
         return model_inputs, output_args
+
+    def _maybe_push_router_replay_state(self, micro_batch: TensorDict, output_args: dict) -> None:
+        rr = self._router_replay
+        if rr is None:
+            return
+
+        # RR's pack/unpack rule assumes ``input_ids`` is a jagged NestedTensor
+        # built by ``left_right_2_no_padding`` — both the cu_seqlens snapshot
+        # below and ``slice_microbatch_replay_targets`` rely on the same
+        # pad+slice rule that ``super().prepare_model_inputs`` applies to it.
+        # The engine-init guard already rejects ``use_remove_padding=False``,
+        # but this check defends against future callers that bypass the guard
+        # (debug tools, sub-engine instantiations) and converts an opaque
+        # ``AttributeError: 'Tensor' object has no attribute 'offsets'`` into
+        # a clear invariant failure.
+        input_ids = micro_batch["input_ids"]
+        if not (isinstance(input_ids, torch.Tensor) and input_ids.is_nested):
+            raise RuntimeError(
+                "router_replay: micro_batch['input_ids'] must be a jagged "
+                "NestedTensor (produced by left_right_2_no_padding). Got "
+                f"type={type(input_ids).__name__}, is_nested="
+                f"{getattr(input_ids, 'is_nested', False)}. RR currently "
+                "supports only the use_remove_padding=True data path."
+            )
+
+        pad_sink = tu.get_non_tensor_data(micro_batch, "_router_replay_pad_size_out", default=None)
+        if pad_sink is not None:
+            pad_sink.append(int(output_args.get("pad_size", 0)))
+
+        # Snapshot cu_seqlens for per-sample split during RECORD aggregation.
+        cu_sink = tu.get_non_tensor_data(micro_batch, "_router_replay_cu_seqlens_out", default=None)
+        if cu_sink is not None:
+            cu_sink.append(input_ids.offsets().clone())
+
+        if rr.action is RouterReplayAction.REPLAY:
+            routed = micro_batch.get("routed_experts", None)
+            if routed is None:
+                # Strict: no silent fallback. A missing routed_experts in
+                # REPLAY means the trainer-side plumbing (compute_log_prob ->
+                # update_actor for R2, or rollout -> compute_log_prob for R3)
+                # has dropped the field somewhere upstream — silently running
+                # the actor update on native router decisions would re-introduce
+                # exactly the floating-point divergence RR is meant to remove.
+                raise RuntimeError(
+                    "router_replay REPLAY: micro_batch missing 'routed_experts'. "
+                    "Verify that compute_log_prob (R2) or the rollout path (R3) "
+                    "attached routed_experts to the batch before this engine "
+                    "call, and that left_right_2_no_padding preserved it."
+                )
+            # Nested-jagged [bs, seq, L, topk] → rmpad values [mb_nnz, L, topk].
+            # slice_microbatch_replay_targets reuses slice_input_tensor to
+            # mirror the exact pad+slice rule super().prepare_model_inputs
+            # already applied to input_ids.
+            flat = routed.values() if hasattr(routed, "values") else routed
+            per_layer = rr.slice_microbatch_replay_targets(flat)
+
+            # Per-token replay mask — R3 only.
+            #
+            # R2 RECORD captures the actor's full-sequence routing
+            # (prompt + response) in compute_log_prob, so REPLAY
+            # substitutes uniformly. Applying a response-only mask
+            # would let prompt tokens fall through to a fresh native
+            # call — atomic-add nondeterminism in the fused MoE
+            # experts means that call may pick different indices than
+            # RECORD, breaking the bit-equal forward guarantee R2
+            # exists for. The divergence then propagates through
+            # attention KV into response logits and gradients.
+            #
+            # R3 RECORD runs at the rollout backend, which only
+            # captures response-token routing during generation;
+            # prefill is not instrumented and prompt-token positions
+            # carry zero placeholders. Substituting those zeros sends
+            # every prompt token's topk slots to expert 0, corrupting
+            # the EP all-to-all token distribution. R3 must mask
+            # prompt tokens out and let them go through native routing.
+            replay_mask = None
+            if self._router_replay_mode == "R3":
+                response_mask = micro_batch.get("response_mask", None)
+                if response_mask is None:
+                    raise RuntimeError(
+                        "router_replay R3: micro_batch missing 'response_mask'. "
+                        "R3 needs the response_mask to know which tokens have "
+                        "real recorded routing (response) vs. zero placeholders "
+                        "(prompt). Verify left_right_2_no_padding preserved it."
+                    )
+                # Build a per-rmpad-token bool mask in the SAME [total_nnz]
+                # layout as ``input_ids.values()`` (also matches
+                # ``routed_experts.values()`` since they share the same
+                # ``index_first_axis(unpad_input(input_ids).indices)``
+                # transform): per sample i, ``prompt_lens[i]`` zeros
+                # followed by ``response_lens[i]`` ones.
+                #
+                # We CANNOT use ``micro_batch['loss_mask']`` directly —
+                # after ``left_right_2_no_padding`` it's still a strided
+                # ``(bs, max_response_len)`` tensor (not nested), which
+                # neither has the right shape nor a valid ``.values()``
+                # for a strided layout.
+                total_lens = input_ids.offsets().diff()  # (bs,)
+                response_lens = response_mask.sum(dim=-1).to(total_lens.dtype)  # (bs,)
+                prompt_lens = total_lens - response_lens  # (bs,)
+                # Defensive: response_lens > total_lens means the
+                # response_mask describes more tokens than the input has,
+                # which is data corruption. Failing here surfaces a clear
+                # message instead of letting repeat_interleave silently
+                # produce a malformed mask.
+                if torch.any(prompt_lens < 0):
+                    raise RuntimeError(
+                        f"router_replay R3: response_mask sum exceeds total token "
+                        f"count for some samples — prompt_lens={prompt_lens.tolist()}. "
+                        "Likely cause: response_mask was not aligned with the "
+                        "input_ids the actor sees (rollout/trainer plumbing bug)."
+                    )
+                bs = total_lens.size(0)
+                # values=[0, 1, 0, 1, ...] (length 2*bs), counts=[p_0, r_0, p_1, r_1, ...]
+                values = torch.tensor([False, True], dtype=torch.bool, device=total_lens.device).repeat(bs)
+                counts = torch.stack([prompt_lens, response_lens], dim=1).flatten()
+                mask_flat = torch.repeat_interleave(values, counts)
+                # Defensive: the constructed mask must align with
+                # routed_experts at the rmpad layer, otherwise the
+                # downstream ``torch.where(mask, target, native)`` would
+                # silently misalign and the EP all-to-all would still
+                # blow up. Fail-fast here with a clearer message.
+                if mask_flat.numel() != flat.size(0):
+                    raise RuntimeError(
+                        f"router_replay R3: constructed replay_mask has "
+                        f"{mask_flat.numel()} entries but routed_experts.values() "
+                        f"has {flat.size(0)}. response_mask + input_ids.offsets() "
+                        "do not describe the same total token count."
+                    )
+                # Mirror the same pad+slice rule used for routed_experts.
+                replay_mask = rr.slice_microbatch_replay_mask(mask_flat)
+
+            rr.set_microbatch_targets(per_layer, replay_mask=replay_mask)
 
 
 @EngineRegistry.register(model_type="value_model", backend=["veomni"], device=["cuda", "npu"])

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -483,24 +483,6 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             rr_mode = "disabled"
         self.enable_routing_replay = rr_mode != "disabled"
 
-        # Fail fast on the (router_replay enabled) + (use_remove_padding=False)
-        # combination for the veomni engine. We do this here, at config-
-        # coherence-check time, rather than inside the engine's initialize()
-        # so the user gets the error before any expensive model build.
-        if (
-            self.enable_routing_replay
-            and actor_strategy == "veomni"
-            and not self.config.model.get("use_remove_padding", False)
-        ):
-            raise RuntimeError(
-                "router_replay requires use_remove_padding=True. In VeOmni engine, "
-                "the non-remove-padding path also disables Ulysses SP slicing and "
-                "the fused-kernel log_probs path, and is not a tested production "
-                "configuration for MoE routing replay. Set "
-                "actor.model.use_remove_padding=True or "
-                "router_replay.mode='disabled'."
-            )
-
         DistProfilerExtension.__init__(
             self, DistProfiler(rank=self.rank, config=profiler_config, tool_config=tool_config)
         )

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -471,9 +471,35 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         else:
             tool_config = None
 
-        self.enable_routing_replay = (
-            self.config.actor.strategy == "megatron" and self.config.actor.megatron.router_replay.mode != "disabled"
-        )
+        # Router replay is supported on the megatron engine and on the veomni
+        # engine. Both expose `router_replay` on their per-strategy engine
+        # config (the field lives on the shared `EngineConfig` base).
+        actor_strategy = self.config.actor.strategy
+        if actor_strategy == "megatron":
+            rr_mode = self.config.actor.megatron.router_replay.mode
+        elif actor_strategy == "veomni":
+            rr_mode = self.config.actor.veomni.router_replay.mode
+        else:
+            rr_mode = "disabled"
+        self.enable_routing_replay = rr_mode != "disabled"
+
+        # Fail fast on the (router_replay enabled) + (use_remove_padding=False)
+        # combination for the veomni engine. We do this here, at config-
+        # coherence-check time, rather than inside the engine's initialize()
+        # so the user gets the error before any expensive model build.
+        if (
+            self.enable_routing_replay
+            and actor_strategy == "veomni"
+            and not self.config.model.get("use_remove_padding", False)
+        ):
+            raise RuntimeError(
+                "router_replay requires use_remove_padding=True. In VeOmni engine, "
+                "the non-remove-padding path also disables Ulysses SP slicing and "
+                "the fused-kernel log_probs path, and is not a tested production "
+                "configuration for MoE routing replay. Set "
+                "actor.model.use_remove_padding=True or "
+                "router_replay.mode='disabled'."
+            )
 
         DistProfilerExtension.__init__(
             self, DistProfiler(rank=self.rank, config=profiler_config, tool_config=tool_config)


### PR DESCRIPTION

### What does this PR do?

Wires VeOmni's `maybe_replay_indices` hook into the verl actor pipeline
so MoE routing decisions can be recorded during `compute_log_prob` and
replayed during the actor update (R2), or recorded at rollout time and
replayed in both `compute_log_prob` and the update (R3). Removes the
floating-point drift between rollout and actor router decisions that
otherwise contaminates the RL policy gradient on MoE models.

Wired today for `qwen3_moe` and `qwen3_5_moe` (the families with the
hook installed in their patched `SparseMoeBlock` on the VeOmni side).

### Design & Code Changes

- Indices-only contract: all model-specific weight math (gather, renorm,
  scaling, dtype cast) stays in the per-family `SparseMoeBlock` patch
  on the VeOmni side. The verl-side controller is model-agnostic.
- Id-keyed positional indexing: each MoE router gets its position
  assigned the first time it fires (`id(module) -> pos`); subsequent
  fires (under any backward order) hit the same position via dict
  lookup. This is what makes RR correct under per-layer activation
  checkpointing recompute, where backward replays each layer's forward
  independently in reverse order.
- Strict REPLAY: missing `routed_experts` on the batch, or missing
  target for any layer position, raises with a typed message. No silent
  fallback to native router decisions.
- R3-only response mask: R2 RECORD captures full-sequence routing in
  compute_log_prob, so REPLAY substitutes uniformly. R3 RECORD runs at
  the rollout backend and only captures response-token routing, so
  prompt-token positions carry zero placeholders — REPLAY must mask
  them out and let them go through native routing or every prompt
  token's topk slots get sent to expert 0.
- Defensive duplicate-row fallback: VeOmni's expert dispatch collapses
  duplicate top-k slots in `permute()` while `input_splits` keeps
  counting them, so any token with duplicate substituted experts
  crashes the EP all-to-all. Rows whose substituted top-k contains a
  duplicate fall back to native indices.
- `try / finally` lifecycle in `forward_backward_batch` so an exception
  during forward / backward / postprocess never pins GPU memory in the
  controller across steps.
- Requires `use_remove_padding=True`. The non-rmpad VeOmni MoE path
  also loses Ulysses SP slicing and the fused-kernel log_probs path,
  and is not a tested production configuration; checked at
  config-coherence time in `ActorRolloutRefWorker.__init__` with a
  defense-in-depth guard at engine init.

Files:
- `verl/utils/veomni/router_replay.py` — `VeOmniRouterReplay` controller
  (state machine, RECORD aggregation w/ Ulysses SP all-gather, REPLAY
  per-mb target slicing).
- `verl/workers/engine/veomni/transformer_impl.py` — RECORD/REPLAY
  driver in `forward_backward_batch`; snapshot side-channel + jagged
  NestedTensor invariant assertion + R3 per-token mask construction in
  `prepare_model_inputs`.
- `verl/workers/engine_workers.py` — wires
  `actor.veomni.router_replay.mode` through the worker; fail-fast on
  the rmpad constraint.
- `verl/experimental/agent_loop/agent_loop.py` — narrow `routed_experts`
  carrier dtype from int64 to int32 (expert ids fit comfortably; halves
  the R3 payload through DataProto).
- `verl/trainer/config/engine/veomni.yaml` + regenerated
  `_generated_ppo_veomni_trainer.yaml` — exposes the `router_replay`
  block on the veomni engine schema (mirrors megatron's structure).
- `examples/router_replay/run_qwen3_5_35b_a3b_veomni.sh` — GRPO
  Qwen3.5-35B-A3B demo with `ROUTING_REPLAY_MODE` env toggle.
- `tests/utils/veomni/test_router_replay_on_cpu.py` (15 tests) —
  controller state machine: RECORD/REPLAY lifecycle, per-layer reverse-
  order activation-checkpointing recompute, R3 first-step (REPLAY
  before any RECORD), per-token mask substitution, duplicate-row
  fallback, install/uninstall against a stubbed VeOmni hook.
- `tests/workers/test_router_replay_engine_helpers_on_cpu.py` (14
  tests) — engine-driver glue: flat→nested unpacker, side-channel
  list-stash regression, R2/R3 mask construction, strict missing-input
  error paths.

### API and Usage Example

```bash
# R2: record indices in compute_log_prob, replay in actor update.
ROUTING_REPLAY_MODE=R2 \
  bash examples/router_replay/run_qwen3_5_35b_a3b_veomni.sh

# R3: record at rollout, replay in both compute_log_prob and update.
ROUTING_REPLAY_MODE=R3 \
  bash examples/router_replay/run_qwen3_5_35b_a3b_veomni.sh
```

Or via Hydra override:
```
actor_rollout_ref.actor.veomni.router_replay.mode=R2
```

### Test

- AST + `ruff check` clean on the modified files.
- 29 CPU unit tests across the two test files above; all pass. Coverage
  includes the per-layer reverse-order activation-checkpointing case
  (the realistic VeOmni MoE training pattern that breaks any monotonic
  cursor design) and the R3 first-step case (REPLAY runs before any
  RECORD has populated the layer table).
- GPU end-to-end on Qwen3.5-35B-A3B GRPO, R2 mode: actor metrics show
  the expected reduction in actor↔rollout router divergence —
  `actor/ppo_kl` ~5.5e-5 (R2) vs ~9e-5 (disabled), and
  `actor/pg_clipfrac` ~28.6% vs ~35.9% (≈20% reduction). Effect is
  diluted by the per-step PPO mini-batch averaging; raw per-mb effect
  is larger.
- qwen3.5_35ba3b_grpo_geo3k_sp2_ep1
<img width="2214" height="1404" alt="image" src="https://github.com/user-attachments/assets/a9703cb7-71fa-42bf-b1da-1dedcaf30fe3" />

### Dependencies

Requires the VeOmni-side hook (`set_active_replay`,
`maybe_replay_indices`) to be present and wired into the patched
`SparseMoeBlock.forward` for the target MoE family. 
