### PR TITLE
[docker,vllm] feat: Enable DeepEP in ARM stable image

### DIFF
--- a/docker/Dockerfile.stable.vllm
+++ b/docker/Dockerfile.stable.vllm
@@ -76,24 +76,24 @@ RUN NSIGHT_VERSION=2025.6.1_2025.6.1.190-1_$(if [ "$(uname -m)" = "aarch64" ]; t
     rm -rf /var/lib/apt/lists/*
 
 # =========================
-# Install DeepEP (x86_64 only)
+# Install DeepEP
 # =========================
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-        cd /home && mkdir -p dpsk_a2a && cd dpsk_a2a && \
-        git clone -b v2.5.1 https://github.com/NVIDIA/gdrcopy.git && \
-        cd gdrcopy && \
-        make prefix=/usr/local lib_install && \
-        cd .. && rm -rf gdrcopy && \
-        git clone -b hybrid-ep https://github.com/deepseek-ai/DeepEP.git && \
-        export NVSHMEM_DIR=/usr/local/lib/python3.12/dist-packages/nvidia/nvshmem && \
-        export LD_LIBRARY_PATH="${NVSHMEM_DIR}/lib:$LD_LIBRARY_PATH" && \
-        export PATH="${NVSHMEM_DIR}/bin:$PATH" && \
-        cd ${NVSHMEM_DIR}/lib && \
-        ln -sf libnvshmem_host.so.3 libnvshmem_host.so && \
-        cd /home/dpsk_a2a/DeepEP && \
-        export CPATH=/usr/local/cuda/targets/x86_64-linux/include/cccl:$CPATH && \
-        python setup.py install; \
-    fi
+RUN cd /home && mkdir -p dpsk_a2a && cd dpsk_a2a && \
+    git clone -b v2.5.1 https://github.com/NVIDIA/gdrcopy.git && \
+    cd gdrcopy && \
+    make prefix=/usr/local lib_install && \
+    cd .. && rm -rf gdrcopy && \
+    git clone -b hybrid-ep https://github.com/deepseek-ai/DeepEP.git && \
+    export NVSHMEM_DIR=/usr/local/lib/python3.12/dist-packages/nvidia/nvshmem && \
+    export LD_LIBRARY_PATH="${NVSHMEM_DIR}/lib:$LD_LIBRARY_PATH" && \
+    export PATH="${NVSHMEM_DIR}/bin:$PATH" && \
+    cd ${NVSHMEM_DIR}/lib && \
+    ln -sf libnvshmem_host.so.3 libnvshmem_host.so && \
+    cd /home/dpsk_a2a/DeepEP && \
+    git checkout 3f601f7ac1c062c46502646ff04c535013bfca00 && \
+    CUDA_TARGET=$(uname -m | sed 's/aarch64/sbsa-linux/;s/x86_64/x86_64-linux/') && \
+    export CPATH=/usr/local/cuda/targets/${CUDA_TARGET}/include/cccl:$CPATH && \
+    TORCH_CUDA_ARCH_LIST="9.0;10.0" python setup.py install
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then apt-get remove -y python3-jwt; fi && \
     pip install vllm==0.18.0


### PR DESCRIPTION
## What

Enable DeepEP in the stable vLLM Docker image on ARM64 while keeping x86_64 support.

## Validation

- `python3 -m pytest tests/experimental/agent_loop/test_standalone_rollout.py::test_hybrid_rollout_with_ep -s -rs` (`1 passed, 27 warnings in 2270.54s`)

## Note

For this GB200 validation, `test_hybrid_rollout_with_ep` needs to run unskipped on one 4-GPU node, use `/models/Qwen3-30B-A3B-Base`, set `nnodes=1`, and configure rollout as `TP=2, DP=2, EP=4`. The stale extra checkpoint block should also be removed/updated because `init_agent_loop_manager()` already handles replica sleep and weight update.
