### PR TITLE
[fsdp, ckpt] fix: drop tied target keys before HF save_pretrained

### DIFF
--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -29,24 +29,9 @@ from verl.utils.transformers_compat import get_auto_model_for_vision2seq
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
 
-def _drop_tied_target_keys(state_dict: dict, model, model_config) -> None:
-    """Drop tied alias keys (e.g. ``lm_head.weight``) from ``state_dict``.
-
-    The merger materialises one independent CPU tensor per state_dict key,
-    which defeats ``save_pretrained``'s storage-pointer-based dedup. When both
-    keys end up in safetensors, ``transformers>=5`` silently refuses to re-tie
-    on reload. Detects aliases by ``Parameter`` identity after ``tie_weights()``.
-    """
-    if not getattr(model_config, "tie_word_embeddings", False):
-        return
-    model.tie_weights()
-    seen: dict[int, str] = {}
-    for name, param in model.named_parameters(remove_duplicate=False):
-        pid = id(param)
-        if pid in seen:
-            state_dict.pop(name, None)
-        else:
-            seen[pid] = name
+# Re-export so existing callers that previously imported the symbol from this
+# module continue to work.
+from verl.utils.transformers_compat import drop_tied_target_keys as _drop_tied_target_keys  # noqa: E402
 
 
 def parse_args():

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -29,6 +29,26 @@ from verl.utils.transformers_compat import get_auto_model_for_vision2seq
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
 
+def _drop_tied_target_keys(state_dict: dict, model, model_config) -> None:
+    """Drop tied alias keys (e.g. ``lm_head.weight``) from ``state_dict``.
+
+    The merger materialises one independent CPU tensor per state_dict key,
+    which defeats ``save_pretrained``'s storage-pointer-based dedup. When both
+    keys end up in safetensors, ``transformers>=5`` silently refuses to re-tie
+    on reload. Detects aliases by ``Parameter`` identity after ``tie_weights()``.
+    """
+    if not getattr(model_config, "tie_word_embeddings", False):
+        return
+    model.tie_weights()
+    seen: dict[int, str] = {}
+    for name, param in model.named_parameters(remove_duplicate=False):
+        pid = id(param)
+        if pid in seen:
+            state_dict.pop(name, None)
+        else:
+            seen[pid] = name
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="verl model merger")
     subparsers = parser.add_subparsers(dest="operation", required=True, help="Specify 'merge' or 'test' operation.")
@@ -384,6 +404,8 @@ class BaseModelMerger(ABC):
         lora_path = self.save_lora_adapter(state_dict)
         if lora_path:
             print(f"Saving lora adapter to {lora_path}")
+
+        _drop_tied_target_keys(state_dict, model, self.model_config)
 
         print(f"Saving model to {self.config.target_dir}")
         model.save_pretrained(self.config.target_dir, state_dict=state_dict)

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -41,6 +41,26 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 
+def _drop_tied_target_keys(state_dict: dict, model, model_config) -> None:
+    """Drop tied alias keys (e.g. ``lm_head.weight``) from ``state_dict``.
+
+    FSDP gather produces independent CPU tensors per state_dict key, which
+    defeats ``save_pretrained``'s storage-pointer-based dedup. When both keys
+    end up in safetensors, ``transformers>=5`` silently refuses to re-tie on
+    reload. Detects aliases by ``Parameter`` identity after ``tie_weights()``.
+    """
+    if not getattr(model_config, "tie_word_embeddings", False):
+        return
+    model.tie_weights()
+    seen: dict[int, str] = {}
+    for name, param in model.named_parameters(remove_duplicate=False):
+        pid = id(param)
+        if pid in seen:
+            state_dict.pop(name, None)
+        else:
+            seen[pid] = name
+
+
 @dataclass
 class FSDPConfig:
     """Configuration for FSDP checkpointing.
@@ -338,6 +358,8 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                             f"Warning: {self.__class__.__name__}.save_checkpoint: Generation config file not found "
                             f"in, using a generation config created from the model config when saving hf_model."
                         )
+
+                _drop_tied_target_keys(state_dict, save_model, model_config)
 
                 save_model.save_pretrained(hf_local_path, state_dict=state_dict)
                 log_with_rank(

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -41,24 +41,9 @@ logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 
-def _drop_tied_target_keys(state_dict: dict, model, model_config) -> None:
-    """Drop tied alias keys (e.g. ``lm_head.weight``) from ``state_dict``.
-
-    FSDP gather produces independent CPU tensors per state_dict key, which
-    defeats ``save_pretrained``'s storage-pointer-based dedup. When both keys
-    end up in safetensors, ``transformers>=5`` silently refuses to re-tie on
-    reload. Detects aliases by ``Parameter`` identity after ``tie_weights()``.
-    """
-    if not getattr(model_config, "tie_word_embeddings", False):
-        return
-    model.tie_weights()
-    seen: dict[int, str] = {}
-    for name, param in model.named_parameters(remove_duplicate=False):
-        pid = id(param)
-        if pid in seen:
-            state_dict.pop(name, None)
-        else:
-            seen[pid] = name
+# Re-export so existing callers that previously imported the symbol from this
+# module continue to work.
+from verl.utils.transformers_compat import drop_tied_target_keys as _drop_tied_target_keys  # noqa: E402
 
 
 @dataclass

--- a/verl/utils/transformers_compat.py
+++ b/verl/utils/transformers_compat.py
@@ -90,3 +90,32 @@ def unpack_visual_output(visual_output):
         return visual_output
     else:
         return visual_output, None
+
+
+def drop_tied_target_keys(state_dict, model, model_config) -> None:
+    """Drop tied alias keys (e.g. ``lm_head.weight``) from ``state_dict``.
+
+    FSDP gather and the model merger materialise one independent CPU tensor
+    per state_dict key, which defeats ``save_pretrained``'s storage-pointer-
+    based dedup. When both keys end up in safetensors, ``transformers>=5``
+    silently refuses to re-tie on reload. Detects aliases by ``Parameter``
+    identity after ``tie_weights()``.
+
+    Only drops the alias when the canonical name has been confirmed to exist
+    in ``state_dict``; otherwise the alias is promoted to canonical so we
+    never accidentally remove every entry for a tied parameter.
+    """
+    if not getattr(model_config, "tie_word_embeddings", False):
+        return
+    model.tie_weights()
+    canonical_by_id: dict[int, str] = {}
+    for name, param in model.named_parameters(remove_duplicate=False):
+        pid = id(param)
+        if pid not in canonical_by_id:
+            canonical_by_id[pid] = name
+            continue
+        if canonical_by_id[pid] in state_dict:
+            state_dict.pop(name, None)
+        else:
+            # Canonical name absent: promote the alias instead of erasing it.
+            canonical_by_id[pid] = name


### PR DESCRIPTION
Credit to @nathanrchn for finding this bug and propose solution!

### What does this PR do?

FSDP gather un-aliases tied params (one independent CPU tensor per state_dict key), so `save_pretrained`'s storage-based dedup in `remove_tied_weights_from_state_dict` never fires for them. Both `model.embed_tokens.weight` and `lm_head.weight` end up in the safetensors with distinct (eventually-divergent) values.

On reload, `transformers>=5` detects the duplicate and silently refuses to tie (logs a warning, empties `all_tied_weights_keys`). The two heads then train as independent parameters in every subsequent stage, defeating `tie_word_embeddings=true` and quietly losing the `lm_head` learning that should have flowed through the embedding.

### Fix

Drop tied alias keys (e.g. `lm_head.weight`) from `state_dict` before `save_pretrained` in:

- `verl/utils/checkpoint/fsdp_checkpoint_manager.py` — auto-save path
- `verl/model_merger/base_model_merger.py` — CLI merger path

The drop uses `named_parameters(remove_duplicate=False)` after `tie_weights()` to detect aliases via `Parameter` identity. The first occurrence in iteration order is the canonical source; later occurrences are aliases and get dropped. Avoids relying on the `_tied_weights_keys` attribute, whose format and contents (list of aliases vs list of both source+aliases) vary across model classes and transformers versions.

### Verification

End-to-end on real Slurm training with `LiquidAI/LFM2.5-350M` (`tie_word_embeddings=True`) on MI300X:

| stage | verl | base ckpt | save outcome |
|---|---|---|---|
| pre-fix | this PR not applied | HF base (148 keys) | hf_model contains 149 keys (both `lm_head.weight` and `embed_tokens.weight`), bit-equal at step 1 |
| post-fix | this PR | HF base (148 keys) | hf_model contains 148 keys, `lm_head.weight` dropped |
| resume-from-broken | this PR not applied | pre-fix broken 149-key ckpt | `transformers 5.2.0` emits `we will NOT tie them` warning; FSDP wraps with two independent `FlatParameter`s; 10 grad steps produce `max_abs_diff=5.65e-4` on 99.87% of elements between `lm_head.weight` and `embed_tokens.weight` |

The resume-from-broken cascade quantified:

```
 step | max_diff  | mean_diff | %elements_diff
   2  | 2.00e-5   | 6.18e-7   | 99.19%
   4  | 1.18e-4   | 2.95e-6   | 99.78%
   6  | 2.56e-4   | 6.27e-6   | 99.84%
   8  | 4.08e-4   | 9.73e-6   | 99.86%
  10  | 5.65e-4   | 1.31e-5   | 99.87%
```

The `lm_head` and `embed_tokens` continue to silently train as independent params for the remainder of the run.


### Related

Same root cause as the long-standing pytorch/pytorch#77724 ("FSDP: enhanced shared parameter support") and pytorch/pytorch#85949 ("Loading distributed checkpoint with FSDP fails ... shared.weight"). PyTorch FSDP's gather contract doesn't preserve tied-parameter aliasing across the GPU→CPU materialisation, and HF `save_pretrained`'s dedup is storage-pointer-based, so the gap can only be closed at the user (verl) layer.

This fix lives in our internal fork at https://github.com/Liquid4All/verl/pull/62. Sharing upstream so other verl users don't hit the same silent corruption.