### PR TITLE
[rollout] feat: support suffix speculative decoding in vLLM rollout

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -291,6 +291,30 @@ checkpoint_engine:
   # in CheckpointEngineRegistry.
   custom_backend_module: null
 
+# Configuration for speculative decoding
+speculative:
+
+  # Target class for speculative config
+  _target_: verl.workers.config.SpeculativeConfig
+
+  # whether enable speculative in rollout
+  enable: False
+
+  # The speculative decoding method to use (e.g., "suffix")
+  method: suffix
+
+  # Number of draft tokens to generate in one speculative step
+  num_speculative_tokens: 3
+
+  # Path to the draft model checkpoint; if empty, not used (suffix doesn't need it)
+  draft_model_path: ""
+
+  # Maximum speculation factor for suffix decoding
+  suffix_decoding_max_spec_factor: 1.0
+
+  # Maximum number of cached requests for suffix decoding
+  suffix_decoding_max_cached_requests: 10000
+
 # trace rollout data
 trace:
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -32,6 +32,7 @@ __all__ = [
     "PrometheusConfig",
     "RolloutConfig",
     "CheckpointEngineConfig",
+    "SpeculativeConfig",
     "SkipConfig",
 ]
 
@@ -158,6 +159,16 @@ class CheckpointEngineConfig(BaseConfig):
 
 
 @dataclass
+class SpeculativeConfig(BaseConfig):
+    enable: bool = False
+    method: str = "suffix"
+    num_speculative_tokens: int = 5
+    draft_model_path: Optional[str] = ""
+    suffix_decoding_max_spec_factor: float = 1.0
+    suffix_decoding_max_cached_requests: int = 10000
+
+
+@dataclass
 class RolloutConfig(BaseConfig):
     _mutable_fields = {
         "max_model_len",
@@ -276,6 +287,8 @@ class RolloutConfig(BaseConfig):
     enable_sleep_mode: bool = True
 
     mtp: MtpConfig = field(default_factory=MtpConfig)
+
+    speculative: SpeculativeConfig = field(default_factory=SpeculativeConfig)
 
     qat: Optional[dict] = None
 

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -297,6 +297,25 @@ class vLLMHttpServer:
             }
             args["speculative_config"] = speculative_config
 
+        if self.config.speculative.enable:
+            assert not self.config.mtp.enable, (
+                "MTP speculative decoding and suffix speculative decoding cannot be enabled at the same time."
+            )
+            speculative_config = {
+                "method": self.config.speculative.method,
+                "num_speculative_tokens": self.config.speculative.num_speculative_tokens,
+            }
+            if self.config.speculative.method == "suffix":
+                speculative_config["suffix_decoding_max_spec_factor"] = (
+                    self.config.speculative.suffix_decoding_max_spec_factor
+                )
+                speculative_config["suffix_decoding_max_cached_requests"] = (
+                    self.config.speculative.suffix_decoding_max_cached_requests
+                )
+            if self.config.speculative.draft_model_path:
+                speculative_config["model"] = self.config.speculative.draft_model_path
+            args["speculative_config"] = speculative_config
+
         if self.config.data_parallel_size > 1:
             assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
                 "gpus_per_node should be divisible by tensor_model_parallel_size"


### PR DESCRIPTION
Introduce SpeculativeConfig under RolloutConfig and wire it through the vLLM async server so suffix-based speculative decoding from vLLM can be enabled via rollout.speculative.* in rollout.yaml. Asserts mutual exclusion with MTP speculative decoding.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

We compared the performance of suffix_decoding and the baseline using the GRPO algorithm and the dapo-math-17kdataset on the Ascend910C platform.
The accuracy has been aligned and the performance has been improved by 10%+.
<img width="1064" height="588" alt="image" src="https://github.com/user-attachments/assets/d34840c6-570e-4cf3-a6ff-b642818595e4" />
<img width="1065" height="590" alt="image" src="https://github.com/user-attachments/assets/ea7208a0-9395-41b2-93eb-d62d0fa76566" />
<img width="1071" height="586" alt="image" src="https://github.com/user-attachments/assets/24cd93ef-442d-41dd-b55d-44f3208e7b41" />
<img width="1058" height="583" alt="image" src="https://github.com/user-attachments/assets/44010579-5e59-46a8-bb61-3b89fb2aea44" />


### API and Usage Example

You can enable this feature by using the following parameters

actor_rollout_ref.rollout.speculative.enable=True
actor_rollout_ref.rollout.speculative.method="suffix"
actor_rollout_ref.rollout.speculative.num_speculative_tokens=3

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
