### PR TITLE
[fsdp] fix: build no-padding attention mask from input ids

### DIFF
--- a/tests/models/test_fsdp_no_padding_on_gpu.py
+++ b/tests/models/test_fsdp_no_padding_on_gpu.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GPU regression coverage for issue #6278.
+
+These tests exercise the FSDP language-model engine path with
+``pad_mode=NO_PADDING`` and ``use_remove_padding=False``. The issue was that
+the model attention mask was built from response-only ``loss_mask`` rows, then
+used as a full prompt+response sequence mask.
+"""
+
+import warnings
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+if not torch.cuda.is_available():
+    pytest.skip("Requires CUDA", allow_module_level=True)
+
+
+def _nested(rows: list[list[int]], device: str) -> torch.Tensor:
+    return torch.nested.as_nested_tensor(
+        [torch.tensor(row, device=device, dtype=torch.long) for row in rows],
+        layout=torch.jagged,
+    )
+
+
+def _make_micro_batch(device: str):
+    from tensordict import TensorDict
+
+    from verl.utils import tensordict_utils as tu
+    from verl.utils.dataset.dataset_utils import DatasetPadMode
+
+    input_ids = _nested([[11, 12, 13, 14, 15], [21, 22, 23]], device)
+    position_ids = _nested([[0, 1, 2, 3, 4], [0, 1, 2]], device)
+    prompts = _nested([[11, 12, 13], [21, 22]], device)
+    responses = _nested([[14, 15], [23]], device)
+
+    # This is intentionally response-only. The old attention-mask path used this
+    # tensor and produced masks of lengths [2, 1] instead of full sequence [5, 3].
+    loss_mask = torch.nested.as_nested_tensor(
+        [
+            torch.ones(2, device=device, dtype=torch.int64),
+            torch.ones(1, device=device, dtype=torch.int64),
+        ],
+        layout=torch.jagged,
+    )
+
+    micro_batch = TensorDict(
+        {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "prompts": prompts,
+            "responses": responses,
+            "loss_mask": loss_mask,
+            "temperature": torch.ones(2, device=device),
+        },
+        batch_size=[2],
+    )
+    tu.assign_non_tensor(
+        micro_batch,
+        use_remove_padding=False,
+        use_fused_kernels=False,
+        pad_mode=DatasetPadMode.NO_PADDING,
+        pad_token_id=0,
+        max_response_len=2,
+        max_response_length=2,
+    )
+    return micro_batch
+
+
+def _fsdp_engine_with_lm_head_cls():
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="NPU not support router replay for now.", category=UserWarning)
+        from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
+
+    return FSDPEngineWithLMHead
+
+
+def _legacy_attention_mask_from_response_loss_mask(
+    loss_mask: torch.Tensor, batch_size: int, max_seq_len: int
+) -> torch.Tensor:
+    """Mirror the pre-fix mask construction to make the regression explicit."""
+    attention_mask_list = [torch.ones_like(t, dtype=torch.int32) for t in loss_mask]
+    attention_mask = torch.nested.as_nested_tensor(attention_mask_list, layout=torch.jagged)
+    return torch.nested.to_padded_tensor(attention_mask, padding=0, output_size=(batch_size, max_seq_len))
+
+
+def test_prepare_model_inputs_uses_full_sequence_attention_mask_on_gpu():
+    device = "cuda"
+    FSDPEngineWithLMHead = _fsdp_engine_with_lm_head_cls()
+    engine = FSDPEngineWithLMHead.__new__(FSDPEngineWithLMHead)
+    micro_batch = _make_micro_batch(device)
+
+    model_inputs, output_args = engine.prepare_model_inputs(micro_batch)
+    legacy_attention_mask = _legacy_attention_mask_from_response_loss_mask(
+        loss_mask=micro_batch["loss_mask"],
+        batch_size=micro_batch.batch_size[0],
+        max_seq_len=model_inputs["input_ids"].shape[1],
+    )
+
+    expected_attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 0, 0],
+        ],
+        device=device,
+        dtype=torch.int32,
+    )
+    expected_legacy_attention_mask = torch.tensor(
+        [
+            [1, 1, 0, 0, 0],
+            [1, 0, 0, 0, 0],
+        ],
+        device=device,
+        dtype=torch.int32,
+    )
+
+    torch.testing.assert_close(legacy_attention_mask, expected_legacy_attention_mask)
+    assert not torch.equal(legacy_attention_mask, expected_attention_mask)
+    torch.testing.assert_close(model_inputs["attention_mask"], expected_attention_mask)
+    assert model_inputs["attention_mask"].device.type == "cuda"
+    assert model_inputs["attention_mask"].dtype == torch.int32
+    assert model_inputs["input_ids"].shape == (2, 5)
+    assert output_args["input_ids_rmpad_rolled"].shape == (8,)
+
+
+def test_prepare_model_outputs_can_be_sliced_back_to_response_shape_on_gpu():
+    from verl.utils.torch_functional import logprobs_from_logits
+    from verl.workers.utils.padding import no_padding_2_padding
+
+    device = "cuda"
+    FSDPEngineWithLMHead = _fsdp_engine_with_lm_head_cls()
+    engine = FSDPEngineWithLMHead.__new__(FSDPEngineWithLMHead)
+    micro_batch = _make_micro_batch(device)
+    _, output_args = engine.prepare_model_inputs(micro_batch)
+
+    torch.manual_seed(0)
+    vocab_size = 32
+    max_seq_len = 5
+    logits = torch.randn(2, max_seq_len, vocab_size, device=device)
+
+    model_output = engine.prepare_model_outputs(
+        output=SimpleNamespace(logits=logits.clone()),
+        output_args=output_args,
+        micro_batch=micro_batch,
+        logits_processor_func=None,
+    )
+    padded_log_probs = no_padding_2_padding(model_output["log_probs"], micro_batch)
+
+    flat_logits = torch.cat([logits[0, :5], logits[1, :3]], dim=0)
+    expected_full_log_probs = logprobs_from_logits(flat_logits, output_args["input_ids_rmpad_rolled"])
+    expected = torch.stack(
+        [
+            expected_full_log_probs[2:4],
+            F.pad(expected_full_log_probs[6:7], (0, 1)),
+        ],
+        dim=0,
+    )
+
+    assert model_output["log_probs"].is_nested
+    assert padded_log_probs.shape == (2, 2)
+    torch.testing.assert_close(padded_log_probs, expected)

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -17,6 +17,7 @@ import torch
 from tensordict import TensorDict
 
 from verl.workers.utils.padding import (
+    build_attention_mask_from_nested,
     embeds_padding_2_no_padding,
     left_right_2_no_padding,
     no_padding_2_padding,
@@ -243,6 +244,27 @@ def test_no_padding_2_padding_varying_lengths():
             msg=f"Batch {i} (prompt_len={prompt_lens[i]}, resp_len={resp_len}): values incorrect",
         )
     print("All varied length tests passed")
+
+
+def test_build_attention_mask_from_nested_uses_full_sequence_lengths():
+    input_ids = torch.nested.as_nested_tensor(
+        [
+            torch.tensor([11, 12, 13, 14, 15]),
+            torch.tensor([21, 22, 23]),
+        ],
+        layout=torch.jagged,
+    )
+
+    attention_mask = build_attention_mask_from_nested(input_ids, max_seq_len=5)
+
+    expected = torch.tensor(
+        [
+            [1, 1, 1, 1, 1],
+            [1, 1, 1, 0, 0],
+        ],
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(attention_mask.cpu(), expected)
 
 
 def test_embeds_padding_2_no_padding_varying_lengths():

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -70,6 +70,7 @@ from verl.utils.ulysses import (
     ulysses_pad_and_slice_inputs,
 )
 from verl.workers.config import FSDPEngineConfig, FSDPOptimizerConfig, HFModelConfig
+from verl.workers.utils.padding import build_attention_mask_from_nested
 
 from ..base import BaseEngine, BaseEngineCtx, EngineRegistry
 from ..utils import enable_full_determinism, postprocess_batch_func, prepare_micro_batches
@@ -996,12 +997,10 @@ class FSDPEngineWithLMHead(FSDPEngine):
             if pad_mode == DatasetPadMode.NO_PADDING:
                 input_ids = micro_batch["input_ids"]
                 position_ids = micro_batch["position_ids"]
-                loss_mask = micro_batch["loss_mask"]
-
                 pad_token_id = tu.get_non_tensor_data(data=micro_batch, key="pad_token_id", default=0)
                 batch_size = micro_batch.batch_size[0]
                 seq_len_effective = input_ids.offsets().diff()
-                max_seq_len = max(seq_len_effective)
+                max_seq_len = int(seq_len_effective.max().item())
 
                 input_ids_rmpad_rolled = torch.roll(input_ids.values(), shifts=-1, dims=0)
                 output_args["input_ids_rmpad_rolled"] = input_ids_rmpad_rolled
@@ -1021,10 +1020,8 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         position_ids, padding=0, output_size=(batch_size, max_seq_len)
                     )
 
-                attention_mask_list = [torch.ones_like(t, dtype=torch.int32) for t in loss_mask]
-                attention_mask = torch.nested.as_nested_tensor(attention_mask_list, layout=torch.jagged)
-                attention_mask = torch.nested.to_padded_tensor(
-                    attention_mask, padding=0, output_size=(batch_size, max_seq_len)
+                attention_mask = build_attention_mask_from_nested(
+                    input_ids=micro_batch["input_ids"], max_seq_len=max_seq_len
                 )
 
                 model_inputs = {

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -143,6 +143,17 @@ def no_padding_2_padding(tensor: torch.Tensor, data: TensorDict) -> torch.Tensor
     return output
 
 
+def build_attention_mask_from_nested(input_ids: torch.Tensor, max_seq_len: int | None = None) -> torch.Tensor:
+    """Build a padded full-sequence attention mask from nested input ids."""
+    assert input_ids.is_nested, "input_ids must be a nested tensor"
+    device = input_ids.values().device
+    seq_lens = input_ids.offsets().diff().to(device=device)
+    if max_seq_len is None:
+        max_seq_len = int(seq_lens.max().item())
+    positions = torch.arange(max_seq_len, device=device).unsqueeze(0)
+    return (positions < seq_lens.unsqueeze(1)).to(torch.int32)
+
+
 def embeds_padding_2_no_padding(data: TensorDict) -> TensorDict:
     """
     Convert TensorDict from prompt embeds with padding to no-padding format.


### PR DESCRIPTION
Fixes #6278

### What does this PR do?
When `pad_mode=NO_PADDING` and `use_remove_padding=False`, the FSDP LM engine pads jagged `input_ids` back to dense `[batch, max_seq_len]` before forwarding the model. The attention mask for that dense full sequence must therefore cover the whole prompt+response
  sequence.

  Before this change, this path built `attention_mask` from `loss_mask`. However, `loss_mask` is response-only, not prompt+response. For example, with full sequence lengths `[5, 3]` and response lengths `[2, 1]`, the old logic produced:

  ```python
  [[1, 1, 0, 0, 0],
   [1, 0, 0, 0, 0]]

  The correct full-sequence attention mask is:

  [[1, 1, 1, 1, 1],
   [1, 1, 1, 0, 0]]

  This explains the issue reporter's observation that KL / clipfrac can be abnormally high even before optimizer updates: the training-policy forward can attend to a different effective sequence than intended.

  This PR:

  - Adds build_attention_mask_from_nested() to construct full-sequence masks from jagged input_ids.
  - Uses that helper in the FSDP use_remove_padding=False + NO_PADDING path.
  - Adds CPU helper coverage and GPU regression coverage for the exact failure mode.
  - Adds GPU coverage for the downstream prepare_model_outputs -> no_padding_2_padding shape contract, because #6278 also called out this area.

  ### Checklist Before Starting

  - [x] Search for similar PRs.
      - 6278 in:body: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6278+in%3Abody
      - attention_mask fsdp use_remove_padding: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+attention_mask+fsdp+use_remove_padding
      - no_padding loss_mask attention_mask: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+no_padding+loss_mask+attention_mask
      - No duplicate open PRs found.
  - [x] Format the PR title as [{modules}] {type}: {description}.

### Test
  #### GPU regression test

  Test file:

  tests/models/test_fsdp_no_padding_on_gpu.py

  GPU environment:

  GPU: Tesla V100-SXM2-32GB
  GPU memory: 32768 MiB
  NVIDIA-SMI: 535.261.03
  CUDA reported by nvidia-smi: 12.6
  Python: /usr/bin/python3, Python 3.11.2
  PyTorch: 2.7.1
  torch.cuda.is_available(): True
  torch.cuda.device_count(): 1

  Command:

  python3 -c "import sys, torch; print('pytest torch', torch.__file__, torch.__version__, torch.cuda.is_available(), torch.cuda.device_count()); sys.path.insert(0, '/tmp/verl_warning_deps'); import pytest; raise SystemExit(pytest.main(['-q', 'tests/models/
  test_fsdp_no_padding_on_gpu.py']))"

  Result:

  pytest torch /usr/local/lib/python3.11/dist-packages/torch/__init__.py 2.7.1 True 1
  ..                                                                       [100%]
  2 passed in 9.59s

  What the GPU test verifies:

  1. It explicitly reconstructs the old response-only loss_mask behavior and confirms it produces the wrong mask:

  [[1, 1, 0, 0, 0],
   [1, 0, 0, 0, 0]]

  2. It verifies the fixed FSDP path passes the full prompt+response attention mask to the model:

  [[1, 1, 1, 1, 1],
   [1, 1, 1, 0, 0]]

  3. It verifies prepare_model_outputs() returns nested full-sequence log_probs that can be correctly sliced back to padded response shape via no_padding_2_padding().

  #### CPU helper test
  Command:
  python3 -c "import sys, torch; sys.path.insert(0, '/tmp/verl_report_deps_clean'); import pytest; raise SystemExit(pytest.main(['-q', 'tests/utils/test_padding_on_cpu.py::test_build_attention_mask_from_nested_uses_full_sequence_lengths']))"

  Result:  1 passed in 4.65s

  #### Syntax check
  Command:
  python3 -m py_compile tests/models/test_fsdp_no_padding_on_gpu.py
  Result:   PASS


### API and Usage Example

  No public API or config change.

  The existing config combination now behaves correctly:

  actor_rollout_ref:
    model:
      use_remove_padding: False
  data:
    pad_mode: no_padding
  actor_rollout_ref:
    actor:
      strategy: fsdp2

### Design & Code Changes
  - verl/workers/utils/padding.py
      - Adds build_attention_mask_from_nested(input_ids, max_seq_len=None).
      - Uses jagged input_ids.offsets().diff() to derive full sequence lengths.
      - Returns dense int32 attention mask on the same device as input_ids.
  - verl/workers/engine/fsdp/transformer_impl.py
      - Replaces response-only loss_mask-based mask construction with build_attention_mask_from_nested() in the non-remove-padding FSDP path.
  - tests/utils/test_padding_on_cpu.py
      - Adds CPU helper coverage for full-sequence mask construction.
  - tests/models/test_fsdp_no_padding_on_gpu.py
      - Adds CUDA regression tests for issue #6278.
      - Suppresses only the unrelated import-time MindSpeed/NPU warning around FSDP engine import, so the test report is clean.

### Checklist Before Submitting
  - [x] Search for duplicate PRs.
  - [x] Add unit/GPU regression tests for the changed behavior.
  - [x] No public API change.
  - [x] Documentation update not needed; this is an internal correctness fix.
  - [x] Run pre-commit before requesting review.
  - [x] Human submitter should review every changed line and confirm the test results.

### AI Assistance Disclosure

 Codex was used to draft the fix, add regression tests, and review this PR report.