### PR TITLE
[trainer] feat: add set_expandable_segments support for npu

### DIFF
--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -148,7 +148,9 @@ def set_expandable_segments(enable: bool) -> None:
         try:
             torch.npu.memory._set_allocator_settings(f"expandable_segments:{enable}")
         except Exception:
-            logger.warning("Current version of torch-npu does not support `_set_allocator_settings`, please upgrade torch-npu to 2.9.0 or later")
+            logger.warning(
+                "Current version of torch-npu does not support `_set_allocator_settings`, please upgrade torch-npu to 2.9.0 or later"
+            )
             
 
 

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -144,6 +144,12 @@ def set_expandable_segments(enable: bool) -> None:
     """
     if is_cuda_available:
         torch.cuda.memory._set_allocator_settings(f"expandable_segments:{enable}")
+    elif is_npu_available:
+        try:
+            torch.npu.memory._set_allocator_settings(f"expandable_segments:{enable}")
+        except Exception:
+            logger.warning("Current version of torch-npu does not support `_set_allocator_settings`, please upgrade torch-npu to 2.9.0 or later")
+            
 
 
 def auto_set_device(config) -> None:

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -149,8 +149,9 @@ def set_expandable_segments(enable: bool) -> None:
             torch.npu.memory._set_allocator_settings(f"expandable_segments:{enable}")
         except Exception:
             logger.warning(
-                "Current version of torch-npu does not support `_set_allocator_settings`, please upgrade torch-npu to 2.9.0 or later"
-            )  
+                "Current version of torch-npu does not support `_set_allocator_settings`, "
+                "please upgrade torch-npu to 2.9.0 or later"
+            )
 
 
 def auto_set_device(config) -> None:

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -150,8 +150,7 @@ def set_expandable_segments(enable: bool) -> None:
         except Exception:
             logger.warning(
                 "Current version of torch-npu does not support `_set_allocator_settings`, please upgrade torch-npu to 2.9.0 or later"
-            )
-            
+            )  
 
 
 def auto_set_device(config) -> None:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -85,11 +85,6 @@ class TrainingWorker(Worker, DistProfilerExtension):
 
         from verl.workers.engine import BaseEngine, EngineRegistry
 
-        # TODO(jhz): Switch to `set_expandable_segments` when the torch_npu library
-        # supports `torch.npu.memory._set_allocator_settings`
-        if is_npu_available:
-            os.environ["PYTORCH_NPU_ALLOC_CONF"] = "expandable_segments:True"
-
         initialize_global_process_group_ray(timeout_second=None)
 
         set_numa_affinity()

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -33,7 +33,7 @@ from verl.single_controller.base.decorator import Dispatch, make_nd_compute_data
 from verl.trainer.distillation import distillation_ppo_loss, is_distillation_enabled
 from verl.utils import tensordict_utils as tu
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import get_device_name, get_torch_device, is_npu_available, set_expandable_segments
+from verl.utils.device import get_device_name, get_torch_device, set_expandable_segments
 from verl.utils.distributed import initialize_global_process_group_ray, set_numa_affinity
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.import_utils import import_external_libs


### PR DESCRIPTION
### What does this PR do?

as title.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
