### PR TITLE
[algo] fix: vectorized grpo low-variance scaling

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -260,6 +260,26 @@ def test_rloo_and_vectorized_equivalence(batch_size: int, seq_len: int, num_grou
     assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
 
 
+def test_grpo_vectorized_matches_original_for_low_variance_rewards():
+    token_level_rewards = torch.tensor([[1.0], [1.00001], [2.0], [2.00001]], dtype=torch.float32)
+    response_mask = torch.ones_like(token_level_rewards)
+    index = np.array(["prompt-a", "prompt-a", "prompt-b", "prompt-b"], dtype=object)
+
+    adv1, ret1 = compute_grpo_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+    adv2, ret2 = compute_grpo_vectorized_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    assert torch.allclose(adv1, adv2, rtol=1e-5, atol=1e-6)
+    assert torch.allclose(ret1, ret2, rtol=1e-5, atol=1e-6)
+
+
 @pytest.mark.parametrize(
     "batch_size,seq_len,num_groups,seed",
     [

--- a/tests/utils/test_groupwise.py
+++ b/tests/utils/test_groupwise.py
@@ -65,6 +65,18 @@ def test_group_mean_std_simple():
     assert pytest.approx(std_g[0].item(), rel=1e-6) == (2.0**0.5)
 
 
+def test_group_mean_std_low_variance_matches_torch_std():
+    scores = torch.tensor([1.0, 1.00001, 2.0, 2.00001], dtype=torch.float32)
+    gidx = as_torch_index(["prompt-a", "prompt-a", "prompt-b", "prompt-b"])
+
+    mean_g, std_g, cnt_g = group_mean_std(scores, gidx, eps=0.0)
+
+    assert torch.allclose(mean_g, torch.tensor([1.000005, 2.000005]), rtol=1e-5, atol=1e-6)
+    assert torch.equal(cnt_g, torch.tensor([2.0, 2.0]))
+    assert torch.allclose(std_g[0], torch.std(scores[:2]), rtol=1e-5, atol=1e-6)
+    assert torch.allclose(std_g[1], torch.std(scores[2:]), rtol=1e-5, atol=1e-6)
+
+
 def test_group_mean_std_empty():
     scores = torch.tensor([], dtype=torch.float32)
     gidx = torch.tensor([], dtype=torch.long)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -349,7 +349,7 @@ def compute_grpo_vectorized_outcome_advantage(
     with torch.no_grad():
         scores = token_level_rewards.sum(dim=-1)
         g = as_torch_index(index, device=scores.device)
-        mean_g, std_g, _ = group_mean_std(scores, g, eps=epsilon, device=scores.device)
+        mean_g, std_g, _ = group_mean_std(scores, g, eps=0.0, device=scores.device)
         if norm_adv_by_std_in_grpo:
             scalars = (scores - mean_g[g]) / (std_g[g] + epsilon)
         else:

--- a/verl/utils/groupwise.py
+++ b/verl/utils/groupwise.py
@@ -204,10 +204,9 @@ def group_mean_std(
 
     count = torch.zeros(G, device=target, dtype=torch.float32).index_add_(0, gidx, ones)
     s1 = torch.zeros(G, device=target, dtype=torch.float32).index_add_(0, gidx, scores)
-    s2 = torch.zeros(G, device=target, dtype=torch.float32).index_add_(0, gidx, scores * scores)
-
     mean = s1 / count.clamp_min(1.0)
-    var_num = s2 - (s1 * s1) / count.clamp_min(1.0)
+    centered = scores - mean[gidx]
+    var_num = torch.zeros(G, device=target, dtype=torch.float32).index_add_(0, gidx, centered * centered)
     denom = (count - 1.0).clamp_min(1.0)
     var = var_num / denom
     std = torch.sqrt(torch.clamp(var, min=eps))


### PR DESCRIPTION
# [algo] fix: preserve low-variance scaling in vectorized GRPO

## What Does This PR Do?

`compute_grpo_vectorized_outcome_advantage()` is intended to match the canonical GRPO advantage implementation while avoiding Python-side grouping overhead. For low-variance reward groups, the vectorized path could silently shrink the normalized advantages by orders of magnitude.

This PR makes the vectorized path match canonical GRPO by:

- computing grouped variance with a numerically stable centered-sum formula;
- avoiding a variance floor inside the vectorized GRPO std calculation, so the caller's existing `+ epsilon` behavior remains the only stabilizer.

## How This Bug Is Triggered

Use vectorized GRPO on reward groups whose sampled responses have close but not identical rewards.

Minimal example:

```text
algorithm.adv_estimator=grpo_vectorized
token_level_rewards: [[1.00000], [1.00001], [2.00000], [2.00001]]
uid:                 ["prompt-a", "prompt-a", "prompt-b", "prompt-b"]
```

Before the fix:

```text
canonical GRPO:  [-0.6196,  0.6196, -0.6196,  0.6196]
vectorized GRPO: [-0.0050,  0.0050, -0.0050,  0.0050]
```

The recipe does not crash and does not warn; it trains with a much smaller advantage scale in low-variance groups.

## Symptom

No explicit runtime symptom. Training proceeds, but the vectorized estimator applies a different normalization than canonical GRPO. This can reduce policy-gradient signal for prompts where sampled responses receive close rewards.

## Training Signal Validation

I also validated the issue with a real veRL rollout-to-update recipe on upstream `main` before the fix:

```text
model: /mnt/hdfs/mahaoyang/models/Qwen2.5-0.5B-Instruct
dataset: /mnt/hdfs/mahaoyang/datasets/gsm8k_modelscope_verl/train.parquet
entrypoint: python3 -m verl.trainer.main_ppo
rollout backend: vLLM async
device: CUDA_VISIBLE_DEVICES=0
train prompts: 4 GSM8K prompts
rollout.n: 2
generated responses: 8 real Qwen responses
max_response_length: 24
reward path: veRL custom reward function, reward_manager=naive, reward.num_workers=1
reward stress case: close but non-identical rewards per prompt group, delta=1e-5
path checked: rollout -> reward loop -> old_log_prob -> advantage -> actor update -> weight sync
```

The Qwen/GSM8K prompts, model loading, vLLM server, response generation, response logprobs, advantage calculation, actor update, and weight sync were all executed by veRL. The reward values were controlled with a custom veRL reward function to create low-variance groups, because this bug is specifically about vectorized GRPO normalization under close but non-identical rewards; sparse exact-match GSM8K rewards are not a reliable trigger for this numerical path.

The local reproduction helper I used is equivalent to the following. The model and dataset paths can be replaced with any local HF model and veRL-format parquet dataset:

```bash
#!/usr/bin/env bash
set -euo pipefail

MODEL_PATH="${MODEL_PATH:-/mnt/hdfs/mahaoyang/models/Qwen2.5-0.5B-Instruct}"
TRAIN_FILE="${TRAIN_FILE:-/mnt/hdfs/mahaoyang/datasets/gsm8k_modelscope_verl/train.parquet}"
VAL_FILE="${VAL_FILE:-/mnt/hdfs/mahaoyang/datasets/gsm8k_modelscope_verl/test.parquet}"
ADV_ESTIMATOR="${ADV_ESTIMATOR:-grpo_vectorized}"
REWARD_HOOK="${REWARD_HOOK:-/tmp/low_variance_reward.py}"

CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}" python3 -m verl.trainer.main_ppo \
  algorithm.adv_estimator="${ADV_ESTIMATOR}" \
  algorithm.use_kl_in_reward=False \
  data.train_files="${TRAIN_FILE}" \
  data.val_files="${VAL_FILE}" \
  data.train_max_samples=4 \
  data.val_max_samples=4 \
  data.train_batch_size=4 \
  data.max_prompt_length=256 \
  data.max_response_length=24 \
  data.filter_overlong_prompts=True \
  data.truncation=error \
  data.shuffle=False \
  data.dataloader_num_workers=0 \
  actor_rollout_ref.model.path="${MODEL_PATH}" \
  actor_rollout_ref.model.use_remove_padding=False \
  actor_rollout_ref.model.enable_gradient_checkpointing=False \
  actor_rollout_ref.actor.optim.lr=1e-6 \
  actor_rollout_ref.actor.ppo_mini_batch_size=4 \
  actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.actor.use_dynamic_bsz=False \
  actor_rollout_ref.actor.use_kl_loss=False \
  actor_rollout_ref.actor.use_torch_compile=False \
  actor_rollout_ref.rollout.name=vllm \
  actor_rollout_ref.rollout.mode=async \
  actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
  actor_rollout_ref.rollout.gpu_memory_utilization=0.35 \
  actor_rollout_ref.rollout.n=2 \
  actor_rollout_ref.rollout.temperature=1.0 \
  actor_rollout_ref.rollout.top_p=1.0 \
  actor_rollout_ref.rollout.max_num_batched_tokens=512 \
  actor_rollout_ref.rollout.max_num_seqs=16 \
  actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
  actor_rollout_ref.rollout.load_format=safetensors \
  reward.num_workers=1 \
  reward.reward_manager.name=naive \
  reward.custom_reward_function.path="${REWARD_HOOK}" \
  reward.custom_reward_function.name=compute_score \
  +reward.custom_reward_function.reward_kwargs.delta=1e-5 \
  trainer.logger='["console"]' \
  trainer.project_name=grpo_vectorized_low_variance_repro \
  trainer.experiment_name="real_rollout_${ADV_ESTIMATOR}" \
  trainer.n_gpus_per_node=1 \
  trainer.nnodes=1 \
  trainer.total_epochs=1 \
  trainer.total_training_steps=1 \
  trainer.val_before_train=False \
  trainer.save_freq=-1 \
  trainer.test_freq=-1
```

The reward hook used for the reproduction:

```python
from collections import defaultdict
from threading import Lock

_COUNTS = defaultdict(int)
_LOCK = Lock()


def _prompt_key(extra_info, fallback_index):
    if isinstance(extra_info, dict):
        for key in ("index", "uid", "question"):
            if key in extra_info:
                return str(extra_info[key])
    return str(fallback_index)


def compute_score(
    data_source=None,
    solution_str=None,
    ground_truth=None,
    extra_info=None,
    base_reward: float = 1.0,
    delta: float = 1e-5,
):
    key = _prompt_key(extra_info, 0)
    with _LOCK:
        offset = _COUNTS[key]
        _COUNTS[key] += 1
    return {"score": float(base_reward + delta * offset)}
```

Run the same recipe twice to compare vectorized GRPO against canonical GRPO:

```bash
ADV_ESTIMATOR=grpo_vectorized bash run_low_variance_grpo_repro.sh
ADV_ESTIMATOR=grpo bash run_low_variance_grpo_repro.sh
```

Observed on the same real recipe before the fix:

```text
algorithm.adv_estimator=grpo_vectorized
critic/score/min:        1.0
critic/score/max:        1.0000100135803223
critic/advantages/min:  -0.005001788027584553
critic/advantages/max:   0.005001788027584553
actor/grad_norm:        13.132572174072266

algorithm.adv_estimator=grpo
critic/score/min:        1.0
critic/score/max:        1.0000100135803223
critic/advantages/min:  -0.6196008324623108
critic/advantages/max:   0.6196008324623108
actor/grad_norm:        2075.186767578125

vectorized / canonical advantage scale: about 0.0081x
```

The vectorized path therefore trains with a much smaller advantage signal even though the recipe finishes normally. After the fix, vectorized GRPO matches canonical GRPO on the focused regression tests for the same low-variance grouped rewards.

## Root Cause

The vectorized path called:

```python
group_mean_std(scores, g, eps=epsilon)
```

`group_mean_std()` floored the variance at `epsilon`, and `compute_grpo_vectorized_outcome_advantage()` then divided by `std + epsilon`. That means the vectorized path used a variance floor that canonical GRPO does not use.

The helper also used the one-pass variance formula `sum2 - sum^2 / n`, which is susceptible to cancellation for low-variance float32 reward groups.

## Fix

- Use a centered two-pass variance calculation in `group_mean_std()`.
- Call `group_mean_std(..., eps=0.0)` from vectorized GRPO, then keep the existing `std + epsilon` denominator.

## Test

```bash
python3 -m pytest -q tests/trainer/ppo/test_core_algos_on_cpu.py::test_grpo_vectorized_matches_original_for_low_variance_rewards tests/trainer/ppo/test_core_algos_on_cpu.py::test_grpo_and_vectorized_equivalence tests/utils/test_groupwise.py
python3 -m pytest -q tests/trainer/ppo/test_core_algos_on_cpu.py tests/utils/test_groupwise.py
python3 -m ruff check verl/trainer/ppo/core_algos.py verl/utils/groupwise.py tests/trainer/ppo/test_core_algos_on_cpu.py tests/utils/test_groupwise.py
python3 -m ruff format --check verl/trainer/ppo/core_algos.py verl/utils/groupwise.py tests/trainer/ppo/test_core_algos_on_cpu.py tests/utils/test_groupwise.py
CUDA_VISIBLE_DEVICES=0 ADV_ESTIMATOR=grpo_vectorized artifacts/run_grpo_vectorized_low_variance_recipe.sh
CUDA_VISIBLE_DEVICES=0 ADV_ESTIMATOR=grpo artifacts/run_grpo_vectorized_low_variance_recipe.sh
```

Results:

- `10 passed, 1 warning in 7.51s`
- `30 passed, 1 warning in 7.71s`
- `All checks passed!`
- `4 files already formatted`
- Real veRL recipe completed with Qwen2.5-0.5B-Instruct rollouts on GSM8K prompts for both `grpo_vectorized` and canonical `grpo`.

## API and Usage Example

No API change.

## Design & Code Changes

- Keep `group_mean_std()` output API unchanged.
- Improve grouped variance stability using centered differences.
- Add regression tests for low-variance grouped std and vectorized GRPO equivalence.

## Duplicate Check

Searched open and closed PRs/issues with:

- `repo:verl-project/verl is:pr grpo_vectorized`
- `repo:verl-project/verl is:pr compute_grpo_vectorized_outcome_advantage`
- `repo:verl-project/verl is:pr group_mean_std`
- `repo:verl-project/verl is:pr "low variance" GRPO`
- `repo:verl-project/verl is:issue grpo_vectorized`
- `repo:verl-project/verl is:issue group_mean_std`

Relevant results:

- [#4598](https://github.com/verl-project/verl/pull/4598) is related but not a duplicate. It handles numerical residuals in the canonical GRPO path when all rewards in a group should be equal. It does not change `group_mean_std()` and does not address the vectorized GRPO low-variance scale mismatch.
- [#4677](https://github.com/verl-project/verl/pull/4677) is related but not a duplicate. It adds more vectorized advantage estimators and uses `group_mean_std()` in additional paths, but it does not fix vectorized GRPO's low-variance normalization.
- [#3635](https://github.com/verl-project/verl/pull/3635) introduced the vectorized GRPO path and helper; it is not a fix.
- [#4961](https://github.com/verl-project/verl/pull/4961), [#4962](https://github.com/verl-project/verl/pull/4962), and [#4967](https://github.com/verl-project/verl/pull/4967) are device-selection/device-mismatch fixes around `group_mean_std()`, not numerical scaling fixes.

No existing issue or PR directly addresses this vectorized GRPO low-variance scaling mismatch.

## Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Search for similar PRs.
- [x] Format the PR title as `[algo] fix: preserve low-variance scaling in vectorized GRPO`.
- [x] Add focused CPU tests.
- [x] Run ruff check and ruff format check on changed files.
- [ ] Run full pre-commit before opening the PR.
- [ ] Request CI when the PR is ready.

## AI Assistance

This change was prepared with AI assistance.
