### PR TITLE
[fsdp, ckpt] chore: fold drop_tied_target_keys into top-level import

### DIFF
--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -24,14 +24,9 @@ from accelerate import init_empty_weights
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForTokenClassification, GenerationConfig
 
 from verl.utils import hf_processor, hf_tokenizer
-from verl.utils.transformers_compat import get_auto_model_for_vision2seq
+from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
 
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
-
-
-# Re-export so existing callers that previously imported the symbol from this
-# module continue to work.
-from verl.utils.transformers_compat import drop_tied_target_keys as _drop_tied_target_keys  # noqa: E402
 
 
 def parse_args():
@@ -390,7 +385,7 @@ class BaseModelMerger(ABC):
         if lora_path:
             print(f"Saving lora adapter to {lora_path}")
 
-        _drop_tied_target_keys(state_dict, model, self.model_config)
+        drop_tied_target_keys(state_dict, model, self.model_config)
 
         print(f"Saving model to {self.config.target_dir}")
         model.save_pretrained(self.config.target_dir, state_dict=state_dict)

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -32,18 +32,13 @@ from verl.utils.device import is_cuda_available
 from verl.utils.fs import copy_to_local, is_non_local, local_mkdir_safe
 from verl.utils.fsdp_utils import fsdp_version, get_fsdp_full_state_dict, get_fsdp_state_ctx
 from verl.utils.logger import log_with_rank
-from verl.utils.transformers_compat import get_auto_model_for_vision2seq
+from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
 
 from .checkpoint_manager import BaseCheckpointManager
 
 # Setup logging
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
-
-
-# Re-export so existing callers that previously imported the symbol from this
-# module continue to work.
-from verl.utils.transformers_compat import drop_tied_target_keys as _drop_tied_target_keys  # noqa: E402
 
 
 @dataclass
@@ -344,7 +339,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                             f"in, using a generation config created from the model config when saving hf_model."
                         )
 
-                _drop_tied_target_keys(state_dict, save_model, model_config)
+                drop_tied_target_keys(state_dict, save_model, model_config)
 
                 save_model.save_pretrained(hf_local_path, state_dict=state_dict)
                 log_with_rank(


### PR DESCRIPTION
### What does this PR do?

Follow-up to #6334 per @wuxibin89's review comment that came in after the original PR was already merged.

The merged version left a separate late-import + alias block in both files:

\`\`\`python
# Re-export so existing callers that previously imported the symbol from
# this module continue to work.
from verl.utils.transformers_compat import drop_tied_target_keys as _drop_tied_target_keys  # noqa: E402
\`\`\`

The \`_drop_tied_target_keys\` alias was just back-compat scaffolding for a symbol that never lived in the merged tree — neither file exported it publicly before #6334, so nothing else can be importing it. Drop the alias, fold the helper into the existing top-level \`from verl.utils.transformers_compat import get_auto_model_for_vision2seq\` line, and use the public name at the call site.

No behavior change.

### Test plan
- [x] \`from verl.model_merger.base_model_merger import drop_tied_target_keys\` and \`from verl.utils.checkpoint.fsdp_checkpoint_manager import drop_tied_target_keys\` both resolve to the same function as \`verl.utils.transformers_compat.drop_tied_target_keys\` (smoke-checked locally).