### PR TITLE
[trainer] mask kl reward nans

### DIFF
--- a/tests/trainer/ppo/test_kl_reward_on_cpu.py
+++ b/tests/trainer/ppo/test_kl_reward_on_cpu.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from tensordict import TensorDict
+
+from verl import DataProto
+from verl.trainer.ppo.core_algos import FixedKLController
+from verl.trainer.ppo.ray_trainer import apply_kl_penalty
+
+
+def test_apply_kl_penalty_masks_invalid_logprob_nans_on_cpu():
+    data = DataProto(
+        batch=TensorDict(
+            {
+                "response_mask": torch.tensor([[1, 0]], dtype=torch.long),
+                "token_level_scores": torch.tensor([[1.0, 0.0]], dtype=torch.float32),
+                "old_log_probs": torch.tensor([[0.0, float("nan")]], dtype=torch.float32),
+                "ref_log_prob": torch.tensor([[0.0, float("nan")]], dtype=torch.float32),
+            },
+            batch_size=1,
+        )
+    )
+
+    data, metrics = apply_kl_penalty(data, kl_ctrl=FixedKLController(kl_coef=0.1), kl_penalty="kl")
+
+    assert torch.isfinite(data.batch["token_level_rewards"]).all()
+    assert data.batch["token_level_rewards"].tolist() == [[1.0, 0.0]]
+    assert metrics["actor/reward_kl_penalty"] == 0.0

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -97,7 +97,7 @@ def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, 
     kld = core_algos.kl_penalty(
         data.batch["old_log_probs"], data.batch["ref_log_prob"], kl_penalty=kl_penalty
     )  # (batch_size, response_length)
-    kld = kld * response_mask
+    kld = torch.where(response_mask.bool(), kld, torch.zeros_like(kld))
     beta = kl_ctrl.value
 
     token_level_rewards = token_level_scores - beta * kld


### PR DESCRIPTION
# [trainer] mask invalid KL values before KL-in-reward reduction

## How This Bug Is Triggered

Enable KL-in-reward:

```text
algorithm.use_kl_in_reward=true
```

and process a batch where a non-trainable response position has invalid logprob values:

```text
response_mask: [1, 0]
old_log_probs: [0.0, NaN]
ref_log_prob:  [0.0, NaN]
```

Masked-out positions can come from padding, tool observations, rejected rollout-correction tokens, or backend outputs that do not define logprobs for non-policy tokens.

## Symptom

There is no local crash at the masking line. The masked-out NaN survives and can later appear as NaN `token_level_rewards` or NaN `actor/reward_kl_penalty`.

The focused regression test builds a two-token batch with a NaN on the masked token. Before the fix, `NaN * 0` keeps the NaN. After the fix, rewards stay finite and the KL metric is `0.0`.

## Training Signal Validation

I also validated this with a real rollout-to-update path using Qwen2.5-0.5B-Instruct and GSM8K prompts. The validation script loads real prompts, generates real model responses, computes response logprobs with the model, applies a narrow controlled perturbation at the KL reward boundary, then compares buggy and fixed-equivalent reward/advantage behavior through one LM-head SGD update.

The recipe, runner, and relevant output content used for validation are included
below. Local machine paths are parameterized with environment variables.

Recipe content:

```json
{
  "name": "verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun",
  "target_bugs": [
    "BUG-F0C9A4E8D11B",
    "BUG-F61D0D8A9C2E"
  ],
  "script": "RL-Sentinel/scripts/verl_training_attack_validation.py",
  "runner": "${OUTPUT_DIR}/run_validation.sh",
  "model_path": "${MODEL_PATH}",
  "dataset_path": "${DATASET_PATH}",
  "device": "cuda:0",
  "seed": 20260515,
  "prompt_count": 2,
  "num_return_sequences": 2,
  "max_new_tokens": 24,
  "validation_path": [
    "load real GSM8K prompts",
    "generate real Qwen2.5-0.5B responses",
    "compute response logprobs with the model",
    "apply narrow controlled perturbations at the target reward/mask boundary",
    "compare buggy and fixed-equivalent reward/advantage behavior",
    "run one LM-head SGD update and record loss, grad_norm, and delta_norm"
  ],
  "outputs": {
    "training_attack_validation": "${OUTPUT_DIR}/training_attack_validation.json"
  }
}
```

Runner content:

```bash
#!/usr/bin/env bash
set -euo pipefail

MODEL_PATH="${MODEL_PATH:?set MODEL_PATH to a local Qwen2.5-0.5B-Instruct path}"
DATASET_PATH="${DATASET_PATH:?set DATASET_PATH to a local veRL-format GSM8K train.parquet path}"
OUTPUT_DIR="${OUTPUT_DIR:-./artifacts/training-attack-validation/verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun}"
CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"

CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
python3 RL-Sentinel/scripts/verl_training_attack_validation.py \
  --model-path "${MODEL_PATH}" \
  --dataset-path "${DATASET_PATH}" \
  --output-dir "${OUTPUT_DIR}" \
  --prompt-count 2 \
  --num-return-sequences 2 \
  --max-new-tokens 24 \
  --seed 20260515
```

Portable rerun command:

```bash
export MODEL_PATH="<local-Qwen2.5-0.5B-Instruct-path>"
export DATASET_PATH="<local-verl-format-gsm8k-train.parquet>"

CUDA_VISIBLE_DEVICES=0 \
python3 RL-Sentinel/scripts/verl_training_attack_validation.py \
  --model-path "${MODEL_PATH}" \
  --dataset-path "${DATASET_PATH}" \
  --output-dir ./artifacts/training-attack-validation/verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun \
  --prompt-count 2 \
  --num-return-sequences 2 \
  --max-new-tokens 24 \
  --seed 20260515
```

Observed before the fix:

```text
buggy_has_nonfinite_rewards: true
buggy_advantages_finite: false
buggy update: loss=nan, grad_norm=nan, delta_norm=nan
```

Observed on the fixed-equivalent path:

```text
fixed_has_nonfinite_rewards: false
fixed_advantages_finite: true
fixed update: loss=0.0005615507252514362, grad_norm=0.29667991399765015, delta_norm=2.8506510716397315e-06
```

Relevant output content:

```json
"BUG-F0C9A4E8D11B_kl_reward_masked_nan": {
  "attack_assessment": {
    "fixed_path_finite": true,
    "primary_risk": "masked invalid KL values make rewards/advantages/loss nonfinite",
    "quiet_reward_contamination": true,
    "training_signal_breaks": true
  },
  "beta": 0.1,
  "buggy_advantages_finite": false,
  "buggy_has_nonfinite_rewards": true,
  "buggy_masked_kld_tail": [
    "nan",
    "nan",
    "nan",
    "nan"
  ],
  "buggy_reward_tail": [
    "nan",
    "nan",
    "nan",
    "nan"
  ],
  "buggy_update": {
    "delta_norm": "nan",
    "delta_norm_isfinite": false,
    "grad_norm": "nan",
    "grad_norm_isfinite": false,
    "loss": "nan",
    "loss_isfinite": false
  },
  "controlled_perturbation": "append one response_mask=0 tail slot and set old/ref logprobs at that slot to NaN",
  "fixed_advantages_finite": true,
  "fixed_has_nonfinite_rewards": false,
  "fixed_masked_kld_tail": [
    0.0,
    0.0,
    0.0,
    0.0
  ],
  "fixed_reward_tail": [
    0.0,
    0.0,
    0.0,
    0.0
  ],
  "fixed_update": {
    "delta_norm": 2.8506510716397315e-06,
    "delta_norm_isfinite": true,
    "grad_norm": 0.29667991399765015,
    "grad_norm_isfinite": true,
    "loss": 0.0005615507252514362,
    "loss_isfinite": true
  },
  "mask_tail": [
    0.0,
    0.0,
    0.0,
    0.0
  ]
}
```

## Root Cause

`apply_kl_penalty()` computed raw KL values over all response positions and then used multiplication for masking:

```python
kld = kld * response_mask
```

In PyTorch, multiplying a NaN by zero still yields NaN. Masking invalid numerical values requires selecting the valid branch with a boolean mask.

## Fix

Use `torch.where(response_mask.bool(), kld, torch.zeros_like(kld))` so masked-out KL values are replaced before they can contaminate rewards or metrics.

## Related Fix

Related fix: https://github.com/verl-project/verl/pull/6349#discussion_r3242298119

That PR is related because it fixes the same masked-NaN failure family: invalid values must be removed by mask-aware selection before they enter a reduction or training signal. In #6349, the bug appears in sequence-level actor loss aggregation after `loss_mat` has already been built. This PR fixes the earlier KL-in-reward path, where invalid masked old/ref logprobs can create NaN KL values before `token_level_rewards`, advantages, and actor loss are computed.

The two fixes are therefore related, but not duplicates: #6349 protects `agg_loss()`; this PR protects `apply_kl_penalty()`.

## Tests

```bash
python3 -m pytest -q tests/trainer/ppo/test_kl_reward_on_cpu.py
python3 -m ruff check verl/trainer/ppo/ray_trainer.py tests/trainer/ppo/test_kl_reward_on_cpu.py
python3 -m ruff format --check verl/trainer/ppo/ray_trainer.py tests/trainer/ppo/test_kl_reward_on_cpu.py
```

Results:

- `1 passed, 3 warnings in 9.05s`
- `All checks passed!`
- `2 files already formatted`

## Duplicate Check

Searched open and closed PRs/issues with:

- `apply_kl_penalty response_mask NaN old_log_probs ref_log_prob`
- `reward_kl_penalty masked NaN response_mask`
- `apply_kl_penalty kld response_mask`
- `old_log_probs ref_log_prob NaN response_mask`

No existing issue or PR directly addresses this masked-NaN KL reward bug. PR #6349 is a related masked-NaN fix in sequence-level actor loss aggregation, but it does not cover the KL-in-reward path.

## AI Assistance

This change was prepared with AI assistance.
