### PR TITLE
[algo] mask rewards in outcome estimators

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -20,16 +20,23 @@ import pytest
 import torch
 
 import verl.trainer.ppo.core_algos
+from verl.protocol import DataProto
+from verl.trainer.config.algorithm import RolloutCorrectionConfig
 from verl.trainer.ppo.core_algos import (
     compute_gae_advantage_return,
+    compute_gpg_outcome_advantage,
     compute_grpo_outcome_advantage,
+    compute_grpo_passk_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
+    compute_opo_outcome_advantage,
+    compute_reinforce_plus_plus_baseline_outcome_advantage,
     compute_rloo_outcome_advantage,
     compute_rloo_vectorized_outcome_advantage,
     get_adv_estimator_fn,
     kl_penalty,
     register_adv_est,
 )
+from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
 
 
 def mock_test_fn():
@@ -196,6 +203,60 @@ def test_multi_turn_compute_gae_advantage_return():
     assert torch.equal(adv1, adv2), f"{adv1=}, {adv2=}"
     assert torch.equal(ret1, ret2), f"{ret1=}, {ret2=}"
     print(f" [CORRECT] \n\n{adv1=}, \n\n{ret1=}")
+
+
+@pytest.mark.parametrize(
+    "adv_fn,kwargs",
+    [
+        (compute_grpo_outcome_advantage, {"norm_adv_by_std_in_grpo": False}),
+        (compute_grpo_vectorized_outcome_advantage, {"norm_adv_by_std_in_grpo": False}),
+        (compute_grpo_passk_outcome_advantage, {"config": {"norm_adv_by_std_in_grpo": False}}),
+        (compute_reinforce_plus_plus_baseline_outcome_advantage, {}),
+        (compute_rloo_outcome_advantage, {}),
+        (compute_opo_outcome_advantage, {}),
+        (compute_gpg_outcome_advantage, {}),
+        (compute_rloo_vectorized_outcome_advantage, {}),
+    ],
+)
+def test_outcome_advantage_estimators_ignore_masked_rewards(adv_fn, kwargs):
+    response_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
+    token_level_rewards = torch.tensor([[0.0, 1.0], [0.0, 0.0]])
+    index = np.array(["prompt", "prompt"], dtype=object)
+
+    advantages, returns = adv_fn(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+        **kwargs,
+    )
+
+    assert torch.count_nonzero(advantages).item() == 0
+    assert torch.count_nonzero(returns).item() == 0
+
+
+def test_rollout_rejection_masks_reward_before_grpo_advantage():
+    batch = DataProto.from_dict(
+        tensors={
+            "response_mask": torch.ones(2, 2),
+            "old_log_probs": torch.tensor([[-1.0, -6.0], [-1.0, -1.0]]),
+            "rollout_log_probs": torch.tensor([[-1.0, -1.0], [-1.0, -1.0]]),
+            "token_level_rewards": torch.tensor([[0.0, 1.0], [0.0, 0.0]]),
+        },
+        non_tensors={"uid": np.array(["prompt", "prompt"], dtype=object)},
+    )
+    config = RolloutCorrectionConfig(rollout_rs="token_k1", rollout_rs_threshold="0.8_1.25")
+
+    batch, _ = compute_rollout_correction_and_add_to_batch(batch, config)
+    advantages, returns = compute_grpo_outcome_advantage(
+        token_level_rewards=batch.batch["token_level_rewards"],
+        response_mask=batch.batch["response_mask"],
+        index=batch.non_tensor_batch["uid"],
+        norm_adv_by_std_in_grpo=False,
+    )
+
+    assert torch.equal(batch.batch["response_mask"], torch.tensor([[1.0, 0.0], [1.0, 1.0]]))
+    assert torch.count_nonzero(advantages).item() == 0
+    assert torch.count_nonzero(returns).item() == 0
 
 
 def _make_group_index(batch_size: int, num_groups: int) -> np.ndarray:

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -212,6 +212,10 @@ def get_kl_controller(kl_ctrl):
         raise NotImplementedError
 
 
+def _masked_reward_sum(token_level_rewards: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:
+    return (token_level_rewards * response_mask.to(dtype=token_level_rewards.dtype)).sum(dim=-1)
+
+
 @register_adv_est(AdvantageEstimator.GAE)  # or simply: @register_adv_est("gae")
 def compute_gae_advantage_return(
     token_level_rewards: torch.Tensor,
@@ -301,7 +305,7 @@ def compute_grpo_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape is (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -347,7 +351,7 @@ def compute_grpo_vectorized_outcome_advantage(
       then broadcast the scalar across the token dimension (multiplied by response_mask).。
     """
     with torch.no_grad():
-        scores = token_level_rewards.sum(dim=-1)
+        scores = _masked_reward_sum(token_level_rewards, response_mask)
         g = as_torch_index(index, device=scores.device)
         mean_g, std_g, _ = group_mean_std(scores, g, eps=epsilon, device=scores.device)
         if norm_adv_by_std_in_grpo:
@@ -498,7 +502,7 @@ def compute_grpo_passk_outcome_advantage(
     assert config is not None
     # if True, normalize advantage by std within group
     norm_adv_by_std_in_grpo = config.get("norm_adv_by_std_in_grpo", True)
-    scores = token_level_rewards.sum(dim=-1)  # (bs,)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)  # (bs,)
     advantages = torch.zeros_like(scores)
 
     id2scores = defaultdict(list)
@@ -559,7 +563,7 @@ def compute_reinforce_plus_plus_baseline_outcome_advantage(
             shape: (bs, response_length)
     """
     response_length = token_level_rewards.shape[-1]
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -609,7 +613,7 @@ def compute_rloo_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -662,7 +666,7 @@ def compute_opo_outcome_advantage(
             shape: (bs, response_length)
     """
     response_length = response_mask.sum(dim=-1)
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2len = defaultdict(list)
@@ -797,7 +801,7 @@ def compute_gpg_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -853,7 +857,7 @@ def compute_rloo_vectorized_outcome_advantage(
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
     """
-    scores = token_level_rewards.sum(dim=-1)
+    scores = _masked_reward_sum(token_level_rewards, response_mask)
 
     with torch.no_grad():
         inv = torch.from_numpy(np.unique(index, return_inverse=True)[1]).to(scores.device)


### PR DESCRIPTION
# [algo] mask rewards in outcome estimators

## How This Bug Is Triggered

Use rollout correction with token-level rejection sampling and an outcome-style advantage estimator such as GRPO:

```text
algorithm.adv_estimator=grpo
algorithm.rollout_correction.rollout_rs=token_k1
algorithm.rollout_correction.rollout_rs_threshold=0.8_1.25
```

A minimal reproducer is a same-prompt group with two responses. The first response has its scalar outcome reward on the final token, and that final token is rejected by rollout correction because its rollout/training logprob ratio is outside the configured trust region:

```text
initial response_mask: [[1, 1], [1, 1]]
old_log_probs:         [[-1, -6], [-1, -1]]
rollout_log_probs:     [[-1, -1], [-1, -1]]
token_level_rewards:   [[ 0,  1], [ 0,  0]]
modified response_mask after rollout_rs: [[1, 0], [1, 1]]
```

Before this patch, GRPO still produced nonzero advantages from the rejected reward token:

```text
advantages: [[ 0.7071, 0.0], [-0.7071, -0.7071]]
```

This is quiet: training continues without an exception, but rollout rejection no longer removes the rejected reward from the training signal.

## Root Cause

Several outcome-style estimators reduced token rewards with `token_level_rewards.sum(dim=-1)`. That ignores the current `response_mask`. Rollout correction explicitly updates `response_mask` to remove rejected tokens from training, and agent/tool rollouts also use `response_mask=0` for non-model observation tokens. The sequence-level outcome score should therefore be computed from masked rewards.

## How This Is Fixed

This patch adds a small `_masked_reward_sum()` helper and uses it in the outcome estimators that compute sequence scores: GRPO, vectorized GRPO, Pass@K, RF++ baseline, RLOO, OPO, GPG, and vectorized RLOO. The tests add:

- a regression that masked-only rewards do not affect outcome advantages across these estimators;
- an integration-style CPU test where rollout rejection masks the rewarded token before GRPO advantage computation.

## Training Signal Validation

I also validated this with a real rollout-to-update path using Qwen2.5-0.5B-Instruct and GSM8K prompts. The validation script loads real prompts, generates real model responses, computes response logprobs with the model, applies a narrow controlled perturbation that places a reward on one token removed by rollout rejection, then compares buggy and fixed-equivalent advantage/update behavior.

The recipe, runner, and relevant output content used for validation are included
below. Local machine paths are parameterized with environment variables.

Recipe content:

```json
{
  "name": "verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun",
  "target_bugs": [
    "BUG-F0C9A4E8D11B",
    "BUG-F61D0D8A9C2E"
  ],
  "script": "RL-Sentinel/scripts/verl_training_attack_validation.py",
  "runner": "${OUTPUT_DIR}/run_validation.sh",
  "model_path": "${MODEL_PATH}",
  "dataset_path": "${DATASET_PATH}",
  "device": "cuda:0",
  "seed": 20260515,
  "prompt_count": 2,
  "num_return_sequences": 2,
  "max_new_tokens": 24,
  "validation_path": [
    "load real GSM8K prompts",
    "generate real Qwen2.5-0.5B responses",
    "compute response logprobs with the model",
    "apply narrow controlled perturbations at the target reward/mask boundary",
    "compare buggy and fixed-equivalent reward/advantage behavior",
    "run one LM-head SGD update and record loss, grad_norm, and delta_norm"
  ],
  "outputs": {
    "training_attack_validation": "${OUTPUT_DIR}/training_attack_validation.json"
  }
}
```

Runner content:

```bash
#!/usr/bin/env bash
set -euo pipefail

MODEL_PATH="${MODEL_PATH:?set MODEL_PATH to a local Qwen2.5-0.5B-Instruct path}"
DATASET_PATH="${DATASET_PATH:?set DATASET_PATH to a local veRL-format GSM8K train.parquet path}"
OUTPUT_DIR="${OUTPUT_DIR:-./artifacts/training-attack-validation/verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun}"
CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"

CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES}" \
python3 RL-Sentinel/scripts/verl_training_attack_validation.py \
  --model-path "${MODEL_PATH}" \
  --dataset-path "${DATASET_PATH}" \
  --output-dir "${OUTPUT_DIR}" \
  --prompt-count 2 \
  --num-return-sequences 2 \
  --max-new-tokens 24 \
  --seed 20260515
```

Portable rerun command:

```bash
export MODEL_PATH="<local-Qwen2.5-0.5B-Instruct-path>"
export DATASET_PATH="<local-verl-format-gsm8k-train.parquet>"

CUDA_VISIBLE_DEVICES=0 \
python3 RL-Sentinel/scripts/verl_training_attack_validation.py \
  --model-path "${MODEL_PATH}" \
  --dataset-path "${DATASET_PATH}" \
  --output-dir ./artifacts/training-attack-validation/verl-qwen25-05b-gsm8k-f0c9-f61d-20260515-rerun \
  --prompt-count 2 \
  --num-return-sequences 2 \
  --max-new-tokens 24 \
  --seed 20260515
```

Observed before the fix:

```text
max_abs_buggy_vs_fixed: 0.5
buggy update: loss=0.004063721746206284, grad_norm=2.75504207611084, delta_norm=0.00022133989841677248
```

Observed on the fixed-equivalent path:

```text
fixed advantages stayed zero
fixed update: loss=0.0, grad_norm=0.0, delta_norm=0.0
```

Relevant output content:

```json
"BUG-F61D0D8A9C2E_rollout_rs_masked_reward_score": {
  "attack_assessment": {
    "fixed_path_suppresses_update": true,
    "masked_reward_changes_advantage": true,
    "primary_risk": "rollout-rejected reward changes accepted token policy gradient"
  },
  "buggy_advantage_sample": [
    [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.0],
    [-0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5]
  ],
  "buggy_update": {
    "delta_norm": 0.00022133989841677248,
    "delta_norm_isfinite": true,
    "grad_norm": 2.75504207611084,
    "grad_norm_isfinite": true,
    "loss": 0.004063721746206284,
    "loss_isfinite": true
  },
  "controlled_perturbation": "place reward on one token removed from response_mask by rollout rejection",
  "fixed_advantage_sample": [
    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
    [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  ],
  "fixed_update": {
    "delta_norm": 0.0,
    "delta_norm_isfinite": true,
    "grad_norm": 0.0,
    "grad_norm_isfinite": true,
    "loss": 0.0,
    "loss_isfinite": true
  },
  "max_abs_buggy_vs_fixed": 0.5,
  "rejected_sample": 0,
  "rejected_token": 23
}
```

## Duplicate Check

Searched open and closed PRs/issues with:

- `rollout correction response_mask token_level_rewards advantage GRPO masked reward`
- `rollout_rs reward response_mask core_algos`
- `rollout correction response_mask reward advantage`
- `token_level_rewards response_mask advantage`
- `rollout_rs token_level_rewards core_algos`

No existing issue or PR directly addresses rewards on rollout-rejected or otherwise masked tokens contaminating outcome-estimator advantages.

Related prior PR: https://github.com/verl-project/verl/pull/6310

That PR is related because it also touched masked reward reduction in outcome estimators, but it was framed around zero-length response reward placement and broad masked reward leakage. This PR is narrower: it targets rollout-correction rejected-token reward leakage, where rollout correction mutates `response_mask` after rollout and an already-populated reward on a rejected token still changes accepted-token advantages.

Validation:

```bash
python3 -m pytest -q tests/trainer/ppo/test_core_algos_on_cpu.py
python3 -m pytest -q tests/trainer/test_multi_trajectories_advantage.py tests/trainer/ppo/test_rollout_corr.py tests/trainer/ppo/test_rollout_corr_integration.py
python3 -m ruff check verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py
python3 -m ruff format --check verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py
```

Results:

- `31 passed, 1 warning in 6.65s`
- `31 passed, 4 warnings in 9.93s`
- `All checks passed!`
- `2 files already formatted`

AI assistance: this local draft and patch were prepared with Codex assistance and reviewed in the local workspace.
