### PR TITLE
 [rollout, vllm, sglang] fix async sampling params reuse

### DIFF
--- a/tests/workers/rollout/test_async_sampling_params_on_cpu.py
+++ b/tests/workers/rollout/test_async_sampling_params_on_cpu.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+
+
+class _RolloutConfig:
+    max_model_len = 100
+    prompt_length = 16
+    response_length = 8
+    enable_rollout_routing_replay = False
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class _ModelConfig:
+    processor = None
+    lora_rank = 0
+    lora = {}
+
+
+class _LogProb:
+    def __init__(self, value: float):
+        self.logprob = value
+
+
+class _FakeVllmEngine:
+    def __init__(self):
+        self.calls = []
+        self.call_count = 0
+
+    def generate(self, **kwargs):
+        sampling_params = kwargs["sampling_params"]
+        self.calls.append(sampling_params)
+        self.call_count += 1
+
+        token_ids = [10 * self.call_count + 1, 10 * self.call_count + 2]
+        logprobs = None
+        if sampling_params.logprobs is not None:
+            logprobs = [
+                {token_ids[0]: _LogProb(-0.1 * self.call_count)},
+                {token_ids[1]: _LogProb(-0.2 * self.call_count)},
+            ]
+        output = SimpleNamespace(token_ids=token_ids, logprobs=logprobs, finish_reason="stop")
+        request_output = SimpleNamespace(outputs=[output])
+
+        async def _generator():
+            yield request_output
+
+        return _generator()
+
+    async def list_loras(self):
+        return []
+
+
+def _make_vllm_http_server():
+    server = vLLMHttpServer.__new__(vLLMHttpServer)
+    server.config = _RolloutConfig()
+    server.model_config = _ModelConfig()
+    server.engine = _FakeVllmEngine()
+    server.global_steps = 0
+    return server
+
+
+def test_vllm_generate_keeps_sampling_params_reusable_across_turns():
+    async def _run():
+        server = _make_vllm_http_server()
+        sampling_params = {"max_tokens": 2, "logprobs": True, "temperature": 0.0}
+
+        first = await vLLMHttpServer.generate(server, [1, 2, 3], sampling_params, "turn-1")
+        second = await vLLMHttpServer.generate(server, [1, 2, 3, 11, 12], sampling_params, "turn-2")
+
+        assert first.log_probs == [-0.1, -0.2]
+        assert second.log_probs == [-0.2, -0.4]
+        assert sampling_params == {"max_tokens": 2, "logprobs": True, "temperature": 0.0}
+        assert [call.max_tokens for call in server.engine.calls] == [2, 2]
+        assert [call.logprobs for call in server.engine.calls] == [0, 0]
+
+    asyncio.run(_run())

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -519,6 +519,8 @@ class SGLangHttpServer:
             _, decode_output = await asyncio.gather(prefill_coro, decode_coro)
             return decode_output
 
+        sampling_params = dict(sampling_params)
+
         # TODO(@wuxibin): switch to `/generate` http endpoint once multi-modal support ready.
         max_possible_tokens = self.config.max_model_len - len(prompt_ids) - 1
 

--- a/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
+++ b/verl/workers/rollout/trtllm_rollout/trtllm_async_server.py
@@ -320,6 +320,7 @@ class TRTLLMHttpServer:
     ) -> TokenOutput:
         from tensorrt_llm.llmapi import SamplingParams
 
+        sampling_params = dict(sampling_params)
         max_tokens = min(
             self.config.response_length,
             self.config.prompt_length + self.config.response_length - len(prompt_ids),

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -453,6 +453,7 @@ class vLLMHttpServer:
         priority: int = 0,
     ) -> TokenOutput:
         """Generate sequence with token-in-token-out."""
+        sampling_params = dict(sampling_params)
         prompt_ids = normalize_token_ids(prompt_ids)
 
         # Calculate the maximum possible new tokens based on available context space


### PR DESCRIPTION
### What does this PR do?

Fixes a quiet multi-turn rollout correctness issue in async rollout servers.

In tool/agent-loop rollout, the same `sampling_params` dict is reused across generation turns. The async vLLM, SGLang, and TensorRT-LLM server paths mutate that dict while translating generic sampling options into backend-specific arguments, for example by popping `max_tokens` / `max_new_tokens` and converting `logprobs=True` into backend-specific values.

Trigger recipe:

- Rollout mode: async multi-turn tool/agent loop.
- Backend: vLLM, SGLang, or TensorRT-LLM async server.
- Sampling config includes `logprobs=True` and an explicit generation budget such as `max_tokens=2`.
- The trajectory has at least two generation turns, e.g. assistant emits a tool call, veRL appends the tool response, then assistant generates again.

Symptom:

- First generation turn requests logprobs correctly.
- The server mutates the shared dict to backend-specific values.
- Second generation turn no longer requests output-token logprobs, and its max-token budget can drift back to the rollout default.
- The final response still marks second-turn model tokens as trainable with `response_mask=1`, but their rollout logprobs are missing and later padded as zeros.

This silently corrupts rollout-logprob alignment for multi-turn training and any path that relies on recorded rollout logprobs.

The fix is to copy `sampling_params` at each async server `generate()` boundary before backend-specific mutation. Caller-visible sampling config now remains reusable across turns.

AI assistance: OpenAI Codex helped identify and prepare this patch.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+sampling_params+logprobs+multi-turn
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+vllm+generate+logprobs+sampling_params
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ToolAgentLoop+logprobs
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Targeted checks run locally:

```bash
python3 -m pytest -q tests/workers/rollout/test_async_sampling_params_on_cpu.py
```

Result:

```text
1 passed, 4 warnings in 12.33s
```

Lint and format checks:

```bash
python3 -m ruff check verl/workers/rollout/vllm_rollout/vllm_async_server.py \
  verl/workers/rollout/sglang_rollout/async_sglang_server.py \
  verl/workers/rollout/trtllm_rollout/trtllm_async_server.py \
  tests/workers/rollout/test_async_sampling_params_on_cpu.py

python3 -m ruff format --check verl/workers/rollout/vllm_rollout/vllm_async_server.py \
  verl/workers/rollout/sglang_rollout/async_sglang_server.py \
  verl/workers/rollout/trtllm_rollout/trtllm_async_server.py \
  tests/workers/rollout/test_async_sampling_params_on_cpu.py
```

Results:

```text
All checks passed!
4 files already formatted
```

Real-backend rollout hook validation:

The hook uses a real Qwen0.5B model, real `vllm==0.10.2`
`AsyncLLMEngine`, and the real veRL
`verl.workers.rollout.vllm_rollout.vllm_async_server.vLLMHttpServer.generate`
boundary. It does not mock vLLM or the server. The only constructed scenario is
that two generation turns reuse the same caller-owned `sampling_params` dict:

```json
{"max_tokens": 2, "logprobs": true, "ignore_eos": true, "temperature": 0.0}
```

Recipe:

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "schema_version": 1,
  "bug_id": "BUG-ED96EC6A22AD",
  "title": "async rollout servers mutate reusable sampling params",
  "target": "verl",
  "validation_mode": "real_vllm_backend_hook",
  "requirements": {
    "verl_repo": "${VERL_REPO}",
    "output_dir": "${OUTPUT_DIR}",
    "model_id": "Qwen/Qwen2.5-0.5B-Instruct",
    "model_path": "${MODEL_PATH}",
    "backend": "vllm",
    "backend_version_tested": "0.10.2",
    "cuda_visible_devices": "${CUDA_VISIBLE_DEVICES}"
  },
  "preserved_infrastructure": [
    "real vllm package import",
    "real vLLM AsyncLLMEngine backend",
    "real model weights loaded by vLLM",
    "real veRL vLLMHttpServer class imported from VERL_REPO",
    "real vLLMHttpServer.generate boundary",
    "real SamplingParams translation inside generate",
    "real TokenOutput/logprob extraction path"
  ],
  "constructed_scenario": {
    "sampling_params": {
      "max_tokens": 2,
      "logprobs": true,
      "ignore_eos": true,
      "temperature": 0.0
    },
    "turns": [
      {
        "request_id": "turn-1",
        "prompt_ids": [1, 2, 3]
      },
      {
        "request_id": "turn-2",
        "prompt_ids": [1, 2, 3, 11, 12]
      }
    ]
  },
  "replaced_component": null,
  "expected_unpatched": {
    "status": "confirmed",
    "caller_params_mutated": true,
    "second_turn_loses_logprobs": true,
    "second_turn_uses_default_budget": true,
    "first_token_count": 2,
    "second_token_count": 8
  },
  "expected_fixed": {
    "status": "not_triggered",
    "caller_params_preserved": true,
    "second_turn_keeps_logprobs": true,
    "second_turn_keeps_budget": true,
    "first_token_count": 2,
    "second_token_count": 2
  },
  "outputs": [
    "training_signal_validation.json",
    "hook_validation.json",
    "bug_record.json"
  ]
}
```

Runner (`run_hook_validation.sh`):

```bash
#!/usr/bin/env bash
set -euo pipefail

SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

if [[ -z "${VERL_REPO:-}" ]]; then
  if [[ -d "${PWD}/verl" ]]; then
    VERL_REPO="${PWD}/verl"
  else
    echo "Set VERL_REPO to a real veRL checkout, or run from a workspace containing ./verl." >&2
    exit 2
  fi
fi

OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}}"
MODEL_ID="${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}"
mkdir -p "${OUTPUT_DIR}"

export VERL_REPO OUTPUT_DIR MODEL_ID
export PYTHONPATH="${VERL_REPO}${PYTHONPATH:+:${PYTHONPATH}}"

python3 "${SCRIPT_DIR}/real_vllm_hook.py"
```

Hook implementation (`real_vllm_hook.py`):

```python
from __future__ import annotations

import asyncio
import importlib
import json
import os
import subprocess
import sys
import traceback
from pathlib import Path


BUG_ID = "BUG-ED96EC6A22AD"
TITLE = "async rollout servers mutate reusable sampling params"
BOUNDARY = "verl.workers.rollout.vllm_rollout.vllm_async_server.vLLMHttpServer.generate"


def _jsonable(value):
    if isinstance(value, Path):
        return str(value)
    return value


def _write_json(path: Path, payload: dict) -> None:
    path.parent.mkdir(parents=True, exist_ok=True)
    path.write_text(json.dumps(payload, indent=2, default=_jsonable) + "\n", encoding="utf-8")


def _git_commit(repo: Path) -> str | None:
    try:
        return subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
    except Exception:
        return None


def _import_required(name: str, preflight: dict):
    try:
        module = importlib.import_module(name)
    except Exception as exc:
        preflight["imports"].append({"module": name, "ok": False, "error": repr(exc)})
        raise
    preflight["imports"].append(
        {
            "module": name,
            "ok": True,
            "file": getattr(module, "__file__", None),
            "version": getattr(module, "__version__", None),
        }
    )
    return module


def _is_under(path: str | None, root: Path) -> bool:
    if not path:
        return False
    try:
        Path(path).resolve().relative_to(root.resolve())
    except ValueError:
        return False
    return True


def _resolve_model_path(preflight: dict) -> Path:
    model_path = os.environ.get("MODEL_PATH")
    if model_path:
        path = Path(model_path).expanduser().resolve()
        preflight["model_source"] = "MODEL_PATH"
        preflight["model_path"] = str(path)
        return path

    from huggingface_hub import snapshot_download

    model_id = os.environ["MODEL_ID"]
    path = Path(snapshot_download(model_id, local_files_only=True)).resolve()
    preflight["model_source"] = "huggingface_cache"
    preflight["model_id"] = model_id
    preflight["model_path"] = str(path)
    return path


def _has_model_weights(model_path: Path) -> bool:
    for pattern in ("*.safetensors", "pytorch_model*.bin", "*.bin"):
        if any(model_path.glob(pattern)):
            return True
    return False


class _RolloutConfig:
    max_model_len = 64
    prompt_length = 16
    response_length = 8
    enable_rollout_routing_replay = False

    def get(self, key, default=None):
        return getattr(self, key, default)


class _ModelConfig:
    processor = None
    lora_rank = 0
    lora = {}


def _make_vllm_http_server(vllm_http_server_cls, engine):
    server = vllm_http_server_cls.__new__(vllm_http_server_cls)
    server.config = _RolloutConfig()
    server.model_config = _ModelConfig()
    server.engine = engine
    server.global_steps = 0
    return server


async def _build_real_vllm_engine(model_path: Path, preflight: dict):
    from vllm.engine.arg_utils import AsyncEngineArgs
    from vllm.engine.async_llm_engine import AsyncLLMEngine

    engine_args = AsyncEngineArgs(
        model=str(model_path),
        tokenizer=str(model_path),
        dtype="float16",
        max_model_len=64,
        max_num_seqs=2,
        gpu_memory_utilization=0.05,
        enforce_eager=True,
        disable_log_stats=True,
        trust_remote_code=False,
        enable_prefix_caching=False,
    )
    preflight["vllm_engine_args"] = {
        "model": str(model_path),
        "dtype": "float16",
        "max_model_len": 64,
        "max_num_seqs": 2,
        "gpu_memory_utilization": 0.05,
        "enforce_eager": True,
        "enable_prefix_caching": False,
    }
    engine = AsyncLLMEngine.from_engine_args(engine_args)
    preflight["vllm_engine_class"] = f"{engine.__class__.__module__}.{engine.__class__.__name__}"
    return engine


def _load_verl_boundary(repo: Path, preflight: dict):
    module = _import_required("verl.workers.rollout.vllm_rollout.vllm_async_server", preflight)
    module_file = getattr(module, "__file__", None)
    if not _is_under(module_file, repo):
        raise RuntimeError(f"target module did not import from VERL_REPO: {module_file}")
    return getattr(module, "vLLMHttpServer")


async def _run_generate_pair(vllm_http_server_cls, engine) -> dict:
    server = _make_vllm_http_server(vllm_http_server_cls, engine)
    sampling_params = {"max_tokens": 2, "logprobs": True, "ignore_eos": True, "temperature": 0.0}
    original = dict(sampling_params)

    first = await vllm_http_server_cls.generate(server, [1, 2, 3], sampling_params, "turn-1")
    params_after_first = dict(sampling_params)
    second = await vllm_http_server_cls.generate(server, [1, 2, 3, 11, 12], sampling_params, "turn-2")
    params_after_second = dict(sampling_params)

    second_turn_loses_logprobs = second.log_probs is None
    second_turn_uses_default_budget = len(second.token_ids) > original["max_tokens"]
    caller_params_mutated = params_after_second != original

    return {
        "original": original,
        "params_after_first": params_after_first,
        "params_after_second": params_after_second,
        "first_token_ids": first.token_ids,
        "second_token_ids": second.token_ids,
        "first_token_count": len(first.token_ids),
        "second_token_count": len(second.token_ids),
        "first_log_probs": first.log_probs,
        "second_log_probs": second.log_probs,
        "caller_params_mutated": caller_params_mutated,
        "second_turn_loses_logprobs": second_turn_loses_logprobs,
        "second_turn_uses_default_budget": second_turn_uses_default_budget,
        "caller_params_preserved": params_after_second == original,
        "second_turn_keeps_logprobs": second.log_probs is not None,
        "second_turn_keeps_budget": len(second.token_ids) == original["max_tokens"],
    }


def _make_bug_record() -> dict:
    return {
        "kind": "rl_sentinel_bug_record",
        "bug_id": BUG_ID,
        "title": TITLE,
        "status": "fix but not push",
        "severity": "high",
        "target": "verl",
        "signal": "rollout_logprob_alignment",
        "bug_type": "quiet rollout correctness bug",
        "summary": (
            "Async rollout server generate() mutates caller-owned sampling_params, "
            "so later multi-turn requests can lose logprobs and generation budget."
        ),
        "impact": "Second-turn trainable model tokens can be packed without valid rollout logprobs.",
        "tags": ["async-rollout", "multi-turn", "sampling-params", "logprobs", "real-vllm-hook"],
        "artifacts": {
            "hook_spec": "hook_spec.json",
            "runner": "run_hook_validation.sh",
            "output": "training_signal_validation.json",
        },
    }


async def _main_async() -> dict:
    repo = Path(os.environ["VERL_REPO"]).resolve()
    preflight = {
        "target_repo": str(repo),
        "target_commit": _git_commit(repo),
        "python": sys.executable,
        "cuda_visible_devices": os.environ.get("CUDA_VISIBLE_DEVICES"),
        "imports": [],
    }
    hook = {
        "hooked_boundary": BOUNDARY,
        "preserved_infrastructure": [
            "real vllm package import",
            "real vLLM AsyncLLMEngine backend",
            "real model weights loaded by vLLM",
            "real veRL vLLMHttpServer class imported from VERL_REPO",
            "real vLLMHttpServer.generate boundary",
            "real SamplingParams translation inside generate",
            "real TokenOutput/logprob extraction path",
        ],
        "constructed_scenario": {
            "reused_sampling_params": {"max_tokens": 2, "logprobs": True, "ignore_eos": True, "temperature": 0.0},
            "turn_count": 2,
            "prompt_token_ids": [[1, 2, 3], [1, 2, 3, 11, 12]],
        },
        "replaced_component": None,
    }

    _import_required("vllm", preflight)
    model_path = _resolve_model_path(preflight)
    if not _has_model_weights(model_path):
        raise RuntimeError(f"MODEL_PATH has no model weights: {model_path}")

    engine = await _build_real_vllm_engine(model_path, preflight)
    vllm_http_server_cls = _load_verl_boundary(repo, preflight)
    observed = await _run_generate_pair(vllm_http_server_cls, engine)

    status = (
        "confirmed"
        if observed["caller_params_mutated"]
        and observed["second_turn_loses_logprobs"]
        and observed["second_turn_uses_default_budget"]
        else "not_triggered"
    )
    return {
        "kind": "rl_sentinel_training_signal_validation",
        "schema_version": 2,
        "bug_id": BUG_ID,
        "title": TITLE,
        "target": "verl",
        "signal": "rollout_logprob_alignment",
        "validation_mode": "real_vllm_backend_hook",
        "status": status,
        "preflight": preflight,
        "hook": hook,
        "observed": observed,
        "attack_effect": (
            "A reused multi-turn sampling_params dict is mutated by the async server boundary, "
            "so later turns can lose rollout logprobs and drift from the explicit generation budget."
        ),
        "expected_unpatched": {
            "caller_params_mutated": True,
            "second_turn_loses_logprobs": True,
            "second_turn_uses_default_budget": True,
        },
        "expected_fixed": {
            "caller_params_preserved": True,
            "second_turn_keeps_logprobs": True,
            "second_turn_keeps_budget": True,
        },
    }


def main() -> int:
    out = Path(os.environ["OUTPUT_DIR"]).resolve()
    try:
        payload = asyncio.run(_main_async())
        _write_json(out / "training_signal_validation.json", payload)
        _write_json(out / "hook_validation.json", payload)
        _write_json(out / "bug_record.json", _make_bug_record())
        print(json.dumps(payload, indent=2))
        return 0
    except Exception as exc:
        payload = {
            "kind": "rl_sentinel_training_signal_validation",
            "schema_version": 2,
            "bug_id": BUG_ID,
            "title": TITLE,
            "target": "verl",
            "validation_mode": "real_vllm_backend_hook",
            "status": "blocked",
            "reason": "infrastructure_preflight_or_real_backend_failed",
            "error": repr(exc),
            "traceback": traceback.format_exc(),
        }
        _write_json(out / "training_signal_validation.json", payload)
        _write_json(out / "hook_validation.json", payload)
        print(json.dumps(payload, indent=2), file=sys.stderr)
        return 3


if __name__ == "__main__":
    raise SystemExit(main())
```

Unpatched upstream output excerpt:

```json
{
  "status": "confirmed",
  "target_commit": "802256a79d676215740e9545cf79be816afea78c",
  "caller_params_mutated": true,
  "second_turn_loses_logprobs": true,
  "second_turn_uses_default_budget": true,
  "first_token_count": 2,
  "second_token_count": 8
}
```

Fixed output excerpt:

```json
{
  "status": "not_triggered",
  "target_commit": "359294f619c6403be8dae65f3a4544c2345116f8",
  "caller_params_preserved": true,
  "second_turn_keeps_logprobs": true,
  "second_turn_keeps_budget": true,
  "first_token_count": 2,
  "second_token_count": 2
}
```

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Copy `sampling_params` at the start of vLLM async `generate()` before `pop` / `setdefault` mutations.
- Copy `sampling_params` in the SGLang async server after PD dispatch and before request-local mutation.
- Copy `sampling_params` at the start of TensorRT-LLM async `generate()` before backend-specific translation.
- Add a CPU regression test that calls the vLLM async server twice with the same sampling dict and verifies the caller dict, `max_tokens`, and `logprobs` remain stable across turns.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [ ] Apply full pre-commit checks.
  - Targeted `ruff check` and `ruff format --check` were run on changed files.
- [ ] Add / Update documentation.
  - Not applicable: this is an internal bug fix with no user-facing API/config change.
- [x] Add unit test coverage for the bug.
- [ ] Request CI when ready.
- [ ] If related to the `recipe` submodule, update it.
  - Not applicable: this PR does not touch the `recipe` submodule.
