### PR TITLE
[sft] fix: honor left truncation in no-padding dataset

### DIFF
--- a/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
@@ -249,6 +249,109 @@ def generate_image(description: str, size: str = "256x256"):
     ...
 
 
+class ToyChatTokenizer:
+    pad_token_id = 0
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        add_generation_prompt=False,
+        tokenize=True,
+        return_dict=False,
+        return_tensors=None,
+        tools=None,
+        **kwargs,
+    ):
+        role_tokens = {"user": 10, "assistant": 20, "tool": 30, "system": 40}
+        ids = []
+        for message in messages:
+            role = message["role"]
+            ids.append(role_tokens[role])
+            content = message.get("content", "")
+            if isinstance(content, str) and content:
+                ids.extend(int(token) for token in content.split())
+            ids.append(99)
+        if add_generation_prompt:
+            ids.append(role_tokens["assistant"])
+
+        if not tokenize:
+            return " ".join(map(str, ids))
+        if return_dict:
+            input_ids = torch.tensor([ids], dtype=torch.long)
+            return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
+        return ids
+
+    def decode(self, ids, *args, **kwargs):
+        if isinstance(ids, torch.Tensor):
+            ids = ids.tolist()
+        return " ".join(map(str, ids))
+
+
+def test_no_padding_sft_left_truncation_preserves_tail_supervision(tmp_path):
+    test_file = tmp_path / "toy_sft.parquet"
+    pd.DataFrame(
+        {
+            "messages": [
+                [
+                    {"role": "user", "content": "1 2 3"},
+                    {"role": "assistant", "content": "4 5 6 7"},
+                ]
+            ]
+        }
+    ).to_parquet(test_file)
+
+    dataset = MultiTurnSFTDataset(
+        parquet_files=str(test_file),
+        tokenizer=ToyChatTokenizer(),
+        processor=None,
+        config={
+            "max_length": 5,
+            "pad_mode": "no_padding",
+            "truncation": "left",
+            "messages_key": "messages",
+        },
+    )
+
+    item = dataset[0]
+
+    assert item["input_ids"].tolist() == [4, 5, 6, 7, 99]
+    assert item["loss_mask"].tolist() == [1, 1, 1, 1, 1]
+    assert item["position_ids"].tolist() == [6, 7, 8, 9, 10]
+
+
+def test_no_padding_sft_right_truncation_preserves_prefix_context(tmp_path):
+    test_file = tmp_path / "toy_sft.parquet"
+    pd.DataFrame(
+        {
+            "messages": [
+                [
+                    {"role": "user", "content": "1 2 3"},
+                    {"role": "assistant", "content": "4 5 6 7"},
+                ]
+            ]
+        }
+    ).to_parquet(test_file)
+
+    dataset = MultiTurnSFTDataset(
+        parquet_files=str(test_file),
+        tokenizer=ToyChatTokenizer(),
+        processor=None,
+        config={
+            "max_length": 5,
+            "pad_mode": "no_padding",
+            "truncation": "right",
+            "messages_key": "messages",
+        },
+    )
+
+    item = dataset[0]
+
+    assert item["input_ids"].tolist() == [10, 1, 2, 3, 99]
+    assert item["loss_mask"].tolist() == [0, 0, 0, 0, 0]
+    assert item["position_ids"].tolist() == [0, 1, 2, 3, 4]
+
+
 @pytest.fixture
 def vlm_data_file():
     test_data = [

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -400,16 +400,19 @@ class MultiTurnSFTDataset(Dataset):
                 res["multi_modal_inputs"] = multi_modal_inputs
             return res
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
-            if sequence_length > self.max_length and self.truncation == "error":
-                raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
-            if sequence_length > self.max_length and self.truncation == "left":
-                input_ids = input_ids[-self.max_length :]
-                loss_mask = loss_mask[-self.max_length :]
-                position_ids = position_ids[..., -self.max_length :]
-            elif sequence_length > self.max_length and self.truncation == "right":
-                input_ids = input_ids[: self.max_length]
-                loss_mask = loss_mask[: self.max_length]
-                position_ids = position_ids[..., : self.max_length]
+            if sequence_length > self.max_length:
+                if self.truncation == "left":
+                    input_ids = input_ids[-self.max_length :]
+                    loss_mask = loss_mask[-self.max_length :]
+                    position_ids = position_ids[..., -self.max_length :]
+                elif self.truncation == "right":
+                    input_ids = input_ids[: self.max_length]
+                    loss_mask = loss_mask[: self.max_length]
+                    position_ids = position_ids[..., : self.max_length]
+                elif self.truncation == "error":
+                    raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
+                else:
+                    raise ValueError(f"Unknown truncation method {self.truncation}")
 
             # return nested tensor with out padding
             res = {

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -402,8 +402,11 @@ class MultiTurnSFTDataset(Dataset):
         elif self.pad_mode == DatasetPadMode.NO_PADDING:
             if sequence_length > self.max_length and self.truncation == "error":
                 raise ValueError(f"{sequence_length=} is larger than {self.max_length=}")
-            # truncate input_ids if it is longer than max_length
-            if len(input_ids) > self.max_length:
+            if sequence_length > self.max_length and self.truncation == "left":
+                input_ids = input_ids[-self.max_length :]
+                loss_mask = loss_mask[-self.max_length :]
+                position_ids = position_ids[..., -self.max_length :]
+            elif sequence_length > self.max_length and self.truncation == "right":
                 input_ids = input_ids[: self.max_length]
                 loss_mask = loss_mask[: self.max_length]
                 position_ids = position_ids[..., : self.max_length]


### PR DESCRIPTION
### What does this PR do?

This PR fixes `MultiTurnSFTDataset` when it is configured with:

```yaml
data.pad_mode: no_padding
data.truncation: left
```

The no-padding branch accepted `truncation=left`, but when a sample exceeded `max_length` it always kept the prefix:

```python
input_ids = input_ids[: self.max_length]
loss_mask = loss_mask[: self.max_length]
position_ids = position_ids[..., : self.max_length]
```

That means no-padding SFT behaved as `right` truncation even when the user explicitly requested `left` truncation.

### Symptom and impact

The failure is quiet. The dataset item is still returned and training can continue, but the final assistant supervision can be silently dropped.

This affects a real SFT path, not just a custom corner configuration. The veRL SFT trainer default config sets `data.pad_mode: no_padding` in `verl/trainer/config/sft_trainer_engine.yaml`, and several SFT examples and e2e tests also run with `data.pad_mode=no_padding`. The full trigger still requires `data.truncation=left` and an overlength sample, but the no-padding dataset path itself is a first-class/default SFT path.

Minimal example with `max_length=5`:

```text
full input_ids: [10, 1, 2, 3, 99, 20, 4, 5, 6, 7, 99]
full loss_mask: [0,  0, 0, 0, 0,  0, 1, 1, 1, 1, 1]
```

With `pad_mode=no_padding` and `truncation=left`, the expected retained slice is the tail:

```text
input_ids: [4, 5, 6, 7, 99]
loss_mask: [1, 1, 1, 1, 1]
```

Current main keeps the prefix instead:

```text
input_ids: [10, 1, 2, 3, 99]
loss_mask: [0,  0, 0, 0, 0]
```

So a long multi-turn SFT sample can lose the supervised assistant answer even though the user selected left truncation specifically to preserve the tail.

### Root cause

The right-padding path has explicit branches for `left`, `right`, and `error` truncation. The no-padding path only checked `error` and then used a prefix slice for all non-error truncation modes.

### Fix

The no-padding branch now mirrors the truncation direction used by the right-padding branch:

- `left`: keep `[-max_length:]`
- `right`: keep `[:max_length]`
- `error`: raise when over length

The same slice is applied to `input_ids`, `loss_mask`, and `position_ids`.

### Upstream duplicate check

Checked upstream PRs in `verl-project/verl` before preparing this draft.

- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+MultiTurnSFTDataset+no_padding+truncation+left
  - Result: found #3567, which introduced no-padding support, but it does not fix left truncation in the no-padding SFT path.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+no_padding+SFT+truncation+left+loss_mask
  - Result: no matching PR.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+multiturn_sft_dataset+truncation+left
  - Result: no matching PR.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+pad_mode+no_padding+truncation
  - Result: found related SFT/no-padding/config PRs (#3567, #5057, #5550, #5768), but none fixes this semantic bug.

Also checked current `origin/main` after fetch. At `origin/main@5b8986b`, `MultiTurnSFTDataset` still prefix-slices the no-padding overlength path:

```python
if len(input_ids) > self.max_length:
    input_ids = input_ids[: self.max_length]
    loss_mask = loss_mask[: self.max_length]
    position_ids = position_ids[..., : self.max_length]
```

### Validation recipe

This is a dataset-boundary bug, so the validation does not require a model, rollout backend, or dataset download. The hook uses a deterministic tokenizer fixture only to construct the exact token and loss-mask geometry; the target under test is the real `verl.utils.dataset.multiturn_sft_dataset.MultiTurnSFTDataset`.

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "bug_id": "BUG-3EECA176FA74",
  "title": "no-padding SFT ignores left truncation and drops tail supervision",
  "target_infra": "verl",
  "validation_kind": "real_target_boundary_hook",
  "target_boundary": "verl.utils.dataset.multiturn_sft_dataset.MultiTurnSFTDataset.__getitem__",
  "requires_model_download": false,
  "requires_dataset_download": false,
  "environment": {
    "VERL_REPO": "path to the veRL checkout under test",
    "OUTPUT_DIR": "directory where validation JSON should be written",
    "PYTHON": "python3"
  },
  "constructed_scenario": {
    "data.pad_mode": "no_padding",
    "data.truncation": "left",
    "data.max_length": 5,
    "messages": [
      {"role": "user", "content": "1 2 3"},
      {"role": "assistant", "content": "4 5 6 7"}
    ],
    "full_input_ids": [10, 1, 2, 3, 99, 20, 4, 5, 6, 7, 99],
    "full_loss_mask": [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
    "expected_left_truncated_input_ids": [4, 5, 6, 7, 99],
    "expected_left_truncated_loss_mask": [1, 1, 1, 1, 1],
    "buggy_prefix_input_ids": [10, 1, 2, 3, 99],
    "buggy_prefix_loss_mask": [0, 0, 0, 0, 0]
  },
  "expected_unpatched_status": "confirmed",
  "expected_fixed_status": "not_triggered",
  "outputs": {
    "validation": "training_signal_validation.json"
  }
}
```

### Validation runner and hook

Run against an unpatched or fixed checkout:

```bash
VERL_REPO=/path/to/verl \
OUTPUT_DIR=/path/to/output \
EXPECTATION=confirmed \
./run_validation.sh

VERL_REPO=/path/to/patched-verl \
OUTPUT_DIR=/path/to/output \
EXPECTATION=not_triggered \
./run_validation.sh
```

Full portable runner:

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${VERL_REPO:?Set VERL_REPO to the veRL checkout under test}"
OUTPUT_DIR="${OUTPUT_DIR:-./BUG-3EECA176FA74-validation}"
PYTHON="${PYTHON:-python3}"
EXPECTATION="${EXPECTATION:-any}"

mkdir -p "${OUTPUT_DIR}"
export VERL_REPO OUTPUT_DIR EXPECTATION

"${PYTHON}" - <<'PY'
import json
import os
import sys
import tempfile
from pathlib import Path

repo = Path(os.environ["VERL_REPO"]).resolve()
output_dir = Path(os.environ["OUTPUT_DIR"]).resolve()
expectation = os.environ.get("EXPECTATION", "any")

sys.path.insert(0, str(repo))

import pandas as pd
import torch

from verl.utils.dataset.multiturn_sft_dataset import MultiTurnSFTDataset


class ToyChatTokenizer:
    pad_token_id = 0

    def apply_chat_template(
        self,
        messages,
        *,
        add_generation_prompt=False,
        tokenize=True,
        return_dict=False,
        return_tensors=None,
        tools=None,
        **kwargs,
    ):
        role_tokens = {"user": 10, "assistant": 20, "tool": 30, "system": 40}
        ids = []
        for message in messages:
            role = message["role"]
            ids.append(role_tokens[role])
            content = message.get("content", "")
            if isinstance(content, str) and content:
                ids.extend(int(token) for token in content.split())
            ids.append(99)
        if add_generation_prompt:
            ids.append(role_tokens["assistant"])

        if not tokenize:
            return " ".join(map(str, ids))
        if return_dict:
            input_ids = torch.tensor([ids], dtype=torch.long)
            return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
        return ids

    def decode(self, ids, *args, **kwargs):
        if isinstance(ids, torch.Tensor):
            ids = ids.tolist()
        return " ".join(map(str, ids))


def run_case(truncation: str):
    with tempfile.TemporaryDirectory(prefix=f"sft-{truncation}-", dir=output_dir) as tmp:
        test_file = Path(tmp) / "toy_sft.parquet"
        pd.DataFrame(
            {
                "messages": [
                    [
                        {"role": "user", "content": "1 2 3"},
                        {"role": "assistant", "content": "4 5 6 7"},
                    ]
                ]
            }
        ).to_parquet(test_file)

        dataset = MultiTurnSFTDataset(
            parquet_files=str(test_file),
            tokenizer=ToyChatTokenizer(),
            processor=None,
            config={
                "max_length": 5,
                "pad_mode": "no_padding",
                "truncation": truncation,
                "messages_key": "messages",
            },
        )
        item = dataset[0]
        return {
            "input_ids": item["input_ids"].tolist(),
            "loss_mask": item["loss_mask"].tolist(),
            "position_ids": item["position_ids"].tolist(),
        }


left = run_case("left")
right = run_case("right")

expected_left = {
    "input_ids": [4, 5, 6, 7, 99],
    "loss_mask": [1, 1, 1, 1, 1],
    "position_ids": [6, 7, 8, 9, 10],
}
buggy_prefix = {
    "input_ids": [10, 1, 2, 3, 99],
    "loss_mask": [0, 0, 0, 0, 0],
    "position_ids": [0, 1, 2, 3, 4],
}
expected_right = dict(buggy_prefix)

if left == buggy_prefix:
    status = "confirmed"
    finding = "left truncation behaved like right truncation and dropped all assistant supervision"
elif left == expected_left:
    status = "not_triggered"
    finding = "left truncation preserved the assistant tail supervision"
else:
    status = "unexpected"
    finding = "left truncation produced an unrecognized slice"

result = {
    "bug_id": "BUG-3EECA176FA74",
    "status": status,
    "finding": finding,
    "repo": str(repo),
    "target_module_file": str(sys.modules[MultiTurnSFTDataset.__module__].__file__),
    "scenario": {
        "pad_mode": "no_padding",
        "truncation": "left",
        "max_length": 5,
        "full_input_ids": [10, 1, 2, 3, 99, 20, 4, 5, 6, 7, 99],
        "full_loss_mask": [0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
    },
    "observed": {
        "left": left,
        "right": right,
    },
    "expected": {
        "left": expected_left,
        "right": expected_right,
    },
}

output_path = output_dir / "training_signal_validation.json"
output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
print(json.dumps(result, indent=2))

if expectation != "any" and status != expectation:
    raise SystemExit(f"expected status {expectation!r}, got {status!r}")
PY
```

### Validation output

Unpatched `origin/main@5b8986b`:

```json
{
  "bug_id": "BUG-3EECA176FA74",
  "status": "confirmed",
  "finding": "left truncation behaved like right truncation and dropped all assistant supervision",
  "observed": {
    "left": {
      "input_ids": [10, 1, 2, 3, 99],
      "loss_mask": [0, 0, 0, 0, 0],
      "position_ids": [0, 1, 2, 3, 4]
    }
  },
  "expected": {
    "left": {
      "input_ids": [4, 5, 6, 7, 99],
      "loss_mask": [1, 1, 1, 1, 1],
      "position_ids": [6, 7, 8, 9, 10]
    }
  }
}
```

Fixed branch commit `5fdedd98`:

```json
{
  "bug_id": "BUG-3EECA176FA74",
  "status": "not_triggered",
  "finding": "left truncation preserved the assistant tail supervision",
  "observed": {
    "left": {
      "input_ids": [4, 5, 6, 7, 99],
      "loss_mask": [1, 1, 1, 1, 1],
      "position_ids": [6, 7, 8, 9, 10]
    }
  }
}
```

### Test

```bash
python3 -m pytest -q \
  tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py::test_no_padding_sft_left_truncation_preserves_tail_supervision \
  tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py::test_no_padding_sft_right_truncation_preserves_prefix_context
# 2 passed, 1 warning in 7.85s

python3 -m ruff check \
  verl/utils/dataset/multiturn_sft_dataset.py \
  tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
# All checks passed!

python3 -m ruff format --check \
  verl/utils/dataset/multiturn_sft_dataset.py \
  tests/utils/dataset/test_multiturn_sft_dataset_on_cpu.py
# 2 files already formatted
```

### API and Usage Example

No API change. Existing `data.truncation=left` configs now behave as requested under `data.pad_mode=no_padding`.

### Checklist Before Starting

- [x] Searched for duplicate upstream PRs and included query links/results above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [ ] Apply full pre-commit checks. Focused `ruff` checks were run on changed files.
- [ ] Add / update documentation. Not needed; this is a bug fix for existing config semantics.
- [x] Add unit tests covering the changed behavior.
- [ ] Request CI after opening the PR.

AI assistance: OpenAI Codex was used for local investigation, validation, and patch drafting.
