### PR TITLE
[trainer] fix: keep rollout-rejected samples out of advantage baselines

### DIFF
--- a/tests/trainer/ppo/test_rollout_corr_integration.py
+++ b/tests/trainer/ppo/test_rollout_corr_integration.py
@@ -16,10 +16,13 @@
 import pytest
 import torch
 
+from verl import DataProto
 from verl.trainer.config.algorithm import RolloutCorrectionConfig
-from verl.trainer.ppo.core_algos import compute_policy_loss_vanilla
+from verl.trainer.ppo.core_algos import AdvantageEstimator, compute_policy_loss_vanilla
+from verl.trainer.ppo.ray_trainer import compute_advantage
 from verl.trainer.ppo.rollout_corr_helper import (
     compute_offpolicy_metrics,
+    compute_rollout_correction_and_add_to_batch,
     compute_rollout_correction_and_rejection_mask,
 )
 from verl.workers.config.actor import ActorConfig
@@ -267,6 +270,44 @@ class TestRolloutISIntegration:
         assert metrics["rollout_corr/rollout_is_oob_ratio"] == pytest.approx(1.0 / 3.0, abs=1e-6)
         torch.testing.assert_close(rollout_is_weights, expected_weights, atol=1e-6, rtol=1e-6)
         torch.testing.assert_close(pg_loss, expected_loss, atol=1e-6, rtol=1e-6)
+
+    def test_rejected_sequences_do_not_pollute_group_advantage(self):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        seq_length = 3
+        old_log_prob = torch.tensor([[-2.0] * seq_length, [-2.0] * seq_length], device=device)
+        rollout_log_prob = torch.tensor(
+            [
+                [-1.0] * seq_length,  # ratio below lower threshold, rejected
+                [-2.5] * seq_length,  # ratio inside threshold, accepted
+            ],
+            device=device,
+        )
+        response_mask = torch.ones(2, seq_length, device=device)
+        token_level_rewards = torch.tensor([[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]], device=device)
+
+        batch = DataProto.from_dict(
+            tensors={
+                "old_log_probs": old_log_prob,
+                "rollout_log_probs": rollout_log_prob,
+                "response_mask": response_mask,
+                "token_level_scores": token_level_rewards.clone(),
+                "token_level_rewards": token_level_rewards.clone(),
+            },
+            non_tensors={"uid": ["same_prompt", "same_prompt"]},
+        )
+        config = RolloutCorrectionConfig(rollout_rs="token_k1", rollout_rs_threshold="0.5_2.0")
+
+        batch, _ = compute_rollout_correction_and_add_to_batch(batch, config)
+        batch = compute_advantage(
+            batch,
+            adv_estimator=AdvantageEstimator.GRPO,
+            norm_adv_by_std_in_grpo=False,
+        )
+
+        assert torch.all(batch.batch["response_mask"][0] == 0)
+        assert torch.all(batch.batch["token_level_rewards"][0] == 0)
+        torch.testing.assert_close(batch.batch["advantages"][0], torch.zeros(seq_length, device=device))
+        torch.testing.assert_close(batch.batch["advantages"][1], torch.ones(seq_length, device=device))
 
 
 class TestRolloutCorrectionConfigNormalization:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -132,6 +132,19 @@ def compute_response_mask(data: DataProto):
     return attention_mask[:, -response_length:]
 
 
+def _isolate_fully_masked_response_groups(index: np.ndarray, response_mask: torch.Tensor) -> np.ndarray:
+    """Keep rollout-rejected samples out of prompt-level advantage baselines."""
+    valid_response = response_mask.sum(dim=-1) > 0
+    if torch.all(valid_response):
+        return index
+
+    isolated_index = np.asarray(index, dtype=object).copy()
+    invalid_positions = (~valid_response).nonzero(as_tuple=False).flatten().cpu().tolist()
+    for pos in invalid_positions:
+        isolated_index[pos] = f"__fully_masked_response_{pos}_{isolated_index[pos]}"
+    return isolated_index
+
+
 def compute_advantage(
     data: DataProto,
     adv_estimator: AdvantageEstimator,
@@ -183,12 +196,13 @@ def compute_advantage(
     elif adv_estimator == AdvantageEstimator.GRPO:
         # Initialize the mask for GRPO calculation
         grpo_calculation_mask = data.batch["response_mask"]
+        index = _isolate_fully_masked_response_groups(data.non_tensor_batch["uid"], grpo_calculation_mask)
 
         # Call compute_grpo_outcome_advantage with parameters matching its definition
         advantages, returns = core_algos.compute_grpo_outcome_advantage(
             token_level_rewards=data.batch["token_level_rewards"],
             response_mask=grpo_calculation_mask,
-            index=data.non_tensor_batch["uid"],
+            index=index,
             norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
         )
         data.batch["advantages"] = advantages
@@ -202,7 +216,9 @@ def compute_advantage(
             "config": config,
         }
         if "uid" in data.non_tensor_batch:  # optional
-            adv_kwargs["index"] = data.non_tensor_batch["uid"]
+            adv_kwargs["index"] = _isolate_fully_masked_response_groups(
+                data.non_tensor_batch["uid"], data.batch["response_mask"]
+            )
         if "reward_baselines" in data.batch:  # optional
             adv_kwargs["reward_baselines"] = data.batch["reward_baselines"]
         # GDPO: pass raw data for per-dimension reward extraction

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -1052,6 +1052,9 @@ def compute_rollout_correction_and_add_to_batch(
 
     # ALWAYS update response_mask with rejection applied
     batch.batch["response_mask"] = modified_response_mask
+    for reward_key in ("token_level_scores", "token_level_rewards"):
+        if reward_key in batch.batch:
+            batch.batch[reward_key] = batch.batch[reward_key] * modified_response_mask
 
     # Add IS weights to batch if computed
     if rollout_is_weights is not None:


### PR DESCRIPTION
### What does this PR do?

This PR fixes a quiet rollout-correction advantage leak. When rollout rejection
sampling rejects a response, veRL updates `response_mask`, but the rejected row
can still keep its reward tensors and original prompt `uid`. Prompt-group
advantage estimators such as GRPO/RLOO can then use the rejected sibling while
computing baselines for accepted siblings from the same prompt.

Example trigger:

```text
algorithm.adv_estimator=grpo
algorithm.rollout_correction.rollout_rs=token_k1
algorithm.rollout_correction.rollout_rs_threshold=0.5_2.0
actor_rollout_ref.rollout.calculate_log_probs=True
```

Concrete two-sibling shape:

```text
uid:                 ["same_prompt", "same_prompt"]
initial response_mask: [[1, 1, 1], [1, 1, 1]]
old_log_probs:         [[-2, -2, -2], [-2, -2, -2]]
rollout_log_probs:     [[-1, -1, -1], [-2.5, -2.5, -2.5]]
token_level_rewards:   [[ 0,  0, 100], [ 0,   0,    1]]
```

Rollout correction rejects the first row, so its `response_mask` becomes all
zero. Before this fix, that rejected row still had reward `100` and stayed in
the `same_prompt` GRPO group. The accepted row then received advantages
`[-49.5, -49.5, -49.5]` instead of `[1.0, 1.0, 1.0]`.

The failure is silent: training continues, but a rejected response changes the
policy gradient for an accepted response.

### Root Cause

`compute_rollout_correction_and_add_to_batch()` updated only `response_mask`
after rejection sampling. It did not clear `token_level_scores` or
`token_level_rewards` on rejected tokens.

Then `compute_advantage()` passed the original `uid` array into group-based
advantage estimators. A fully rejected response therefore stayed in the same
prompt group as accepted sibling responses.

### Fix

This PR makes rejection sampling consistently remove rejected samples from
subsequent training signals:

- after updating `response_mask`, zero `token_level_scores` and
  `token_level_rewards` on rejected tokens;
- isolate fully masked responses from their original prompt group before
  computing group-based advantages.

Normal non-rejected samples keep the same behavior.

### Duplicate Check

I checked upstream PRs/issues before preparing this draft.

- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout+correction+rejected+response_mask+advantage+token_level_rewards
  - Result: found related PR #6362, but no exact duplicate for fully rejected
    sibling group-baseline pollution.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout+rejection+sampling+GRPO+advantage+response_mask
  - Result: found related PR #6362.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+fully+masked+response+uid+group+advantage+baseline+GRPO
  - Result: no matching PR.
- Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+rejected+sequences+pollute+group+advantage+baseline+uid
  - Result: no matching PR.
- Query: https://github.com/verl-project/verl/issues?q=is%3Aissue+fully+masked+response+uid+group+advantage+baseline+GRPO
  - Result: no matching open issue.

Related but not duplicate: #6362 masks rewards inside outcome estimators so a
reward on a rejected token does not enter `token_level_rewards.sum(...)`.
This PR fixes the next lifecycle boundary: after rollout correction mutates
`response_mask`, a fully rejected response must also be removed from the prompt
group used to compute accepted siblings' baselines. Without this fix, even a
zero-reward fully rejected row can still dilute a same-prompt group baseline.

### Validation Recipe

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "schema_version": 1,
  "bug_id": "BUG-8E34B7A19D20",
  "title": "Rollout-rejected samples pollute group advantage baselines",
  "target": "verl",
  "validation_mode": "real_target_boundary_hook",
  "target_boundaries": [
    "verl.trainer.ppo.rollout_corr_helper.compute_rollout_correction_and_add_to_batch",
    "verl.trainer.ppo.ray_trainer.compute_advantage"
  ],
  "requires_model_download": false,
  "requires_dataset_download": false,
  "environment": {
    "VERL_REPO": "path to the veRL checkout under test",
    "OUTPUT_DIR": "directory where validation JSON should be written",
    "EXPECTATION": "confirmed for unpatched, not_triggered for fixed",
    "PYTHON": "python3"
  },
  "constructed_scenario": {
    "algorithm.adv_estimator": "grpo",
    "algorithm.rollout_correction.rollout_rs": "token_k1",
    "algorithm.rollout_correction.rollout_rs_threshold": "0.5_2.0",
    "response_mask_before_correction": [[1, 1, 1], [1, 1, 1]],
    "uid": ["same_prompt", "same_prompt"],
    "old_log_probs": [[-2.0, -2.0, -2.0], [-2.0, -2.0, -2.0]],
    "rollout_log_probs": [[-1.0, -1.0, -1.0], [-2.5, -2.5, -2.5]],
    "token_level_rewards": [[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]]
  },
  "expected_unpatched": {
    "status": "confirmed",
    "rejected_row_response_mask": [0.0, 0.0, 0.0],
    "rejected_row_rewards_still_present": true,
    "accepted_advantages": [-49.5, -49.5, -49.5]
  },
  "expected_fixed": {
    "status": "not_triggered",
    "rejected_row_response_mask": [0.0, 0.0, 0.0],
    "rejected_row_rewards_zeroed": true,
    "accepted_advantages": [1.0, 1.0, 1.0]
  },
  "outputs": {
    "validation": "training_signal_validation.json"
  }
}
```

### Validation Runner

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${VERL_REPO:?Set VERL_REPO to the veRL checkout under test}"
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/output}"
PYTHON="${PYTHON:-python3}"
EXPECTATION="${EXPECTATION:-any}"

mkdir -p "${OUTPUT_DIR}"

export VERL_REPO OUTPUT_DIR EXPECTATION
export PYTHONPATH="${VERL_REPO}${PYTHONPATH:+:${PYTHONPATH}}"

"${PYTHON}" "${SCRIPT_DIR}/rollout_rejection_advantage_hook.py"
```

Run against an unpatched and a fixed checkout:

```bash
VERL_REPO=/path/to/unpatched-verl \
OUTPUT_DIR=./BUG-8E34B7A19D20-unpatched \
EXPECTATION=confirmed \
./run_validation.sh

VERL_REPO=/path/to/fixed-verl \
OUTPUT_DIR=./BUG-8E34B7A19D20-fixed \
EXPECTATION=not_triggered \
./run_validation.sh
```

### Boundary Hook

```python
from __future__ import annotations

import json
import os
import subprocess
import sys
from pathlib import Path

import torch


BUG_ID = "BUG-8E34B7A19D20"
TITLE = "Rollout-rejected samples pollute group advantage baselines"


def _git_commit(repo: Path) -> str | None:
    try:
        return subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
    except Exception:
        return None


def _tolist(tensor: torch.Tensor) -> list:
    return tensor.detach().cpu().tolist()


def _write_json(path: Path, payload: dict) -> None:
    path.parent.mkdir(parents=True, exist_ok=True)
    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")


def main() -> None:
    repo = Path(os.environ["VERL_REPO"]).resolve()
    output_dir = Path(os.environ["OUTPUT_DIR"]).resolve()
    expectation = os.environ.get("EXPECTATION", "any")

    if str(repo) not in sys.path:
        sys.path.insert(0, str(repo))

    from verl import DataProto
    from verl.trainer.config.algorithm import RolloutCorrectionConfig
    from verl.trainer.ppo.core_algos import AdvantageEstimator
    from verl.trainer.ppo.ray_trainer import compute_advantage
    from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch

    device = "cuda" if torch.cuda.is_available() else "cpu"
    seq_length = 3
    old_log_probs = torch.tensor([[-2.0] * seq_length, [-2.0] * seq_length], dtype=torch.float32, device=device)
    rollout_log_probs = torch.tensor(
        [
            [-1.0] * seq_length,
            [-2.5] * seq_length,
        ],
        dtype=torch.float32,
        device=device,
    )
    response_mask = torch.ones(2, seq_length, dtype=torch.float32, device=device)
    token_level_rewards = torch.tensor(
        [[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]], dtype=torch.float32, device=device
    )

    batch = DataProto.from_dict(
        tensors={
            "old_log_probs": old_log_probs,
            "rollout_log_probs": rollout_log_probs,
            "response_mask": response_mask,
            "token_level_scores": token_level_rewards.clone(),
            "token_level_rewards": token_level_rewards.clone(),
        },
        non_tensors={"uid": ["same_prompt", "same_prompt"]},
    )
    config = RolloutCorrectionConfig(rollout_rs="token_k1", rollout_rs_threshold="0.5_2.0")

    corrected, rollout_metrics = compute_rollout_correction_and_add_to_batch(batch, config)
    corrected = compute_advantage(
        corrected,
        adv_estimator=AdvantageEstimator.GRPO,
        norm_adv_by_std_in_grpo=False,
    )

    rejected_mask = corrected.batch["response_mask"][0]
    rejected_rewards = corrected.batch["token_level_rewards"][0]
    accepted_advantages = corrected.batch["advantages"][1]

    rejected_row_is_masked = bool(torch.all(rejected_mask == 0).item())
    rejected_rewards_zeroed = bool(torch.all(rejected_rewards == 0).item())
    accepted_isolated = bool(torch.allclose(accepted_advantages, torch.ones_like(accepted_advantages), atol=1e-6))
    accepted_contaminated = bool(
        torch.allclose(accepted_advantages, torch.full_like(accepted_advantages, -49.5), atol=1e-6)
    )

    if rejected_row_is_masked and (not rejected_rewards_zeroed) and accepted_contaminated:
        status = "confirmed"
        finding = "rollout-rejected sibling kept reward/group membership and contaminated accepted GRPO advantages"
    elif rejected_row_is_masked and rejected_rewards_zeroed and accepted_isolated:
        status = "not_triggered"
        finding = "rollout-rejected sibling was removed from reward tensors and prompt-group baseline"
    else:
        status = "unexpected"
        finding = "rollout rejection produced an unrecognized advantage shape"

    payload = {
        "kind": "rl_sentinel_training_signal_validation",
        "bug_id": BUG_ID,
        "title": TITLE,
        "status": status,
        "finding": finding,
        "commit": _git_commit(repo),
        "target_boundaries": [
            "verl.trainer.ppo.rollout_corr_helper.compute_rollout_correction_and_add_to_batch",
            "verl.trainer.ppo.ray_trainer.compute_advantage",
        ],
        "scenario": {
            "adv_estimator": "grpo",
            "rollout_rs": "token_k1",
            "rollout_rs_threshold": "0.5_2.0",
            "uid": ["same_prompt", "same_prompt"],
            "old_log_probs": [[-2.0, -2.0, -2.0], [-2.0, -2.0, -2.0]],
            "rollout_log_probs": [[-1.0, -1.0, -1.0], [-2.5, -2.5, -2.5]],
            "token_level_rewards_before_correction": [[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]],
        },
        "observed": {
            "response_mask_after_correction": _tolist(corrected.batch["response_mask"]),
            "token_level_rewards_after_correction": _tolist(corrected.batch["token_level_rewards"]),
            "advantages": _tolist(corrected.batch["advantages"]),
            "returns": _tolist(corrected.batch["returns"]),
            "rollout_metrics": rollout_metrics,
        },
    }

    output_path = output_dir / "training_signal_validation.json"
    _write_json(output_path, payload)
    print(json.dumps(payload, indent=2))

    if expectation != "any" and status != expectation:
        raise SystemExit(f"expected status {expectation!r}, got {status!r}")


if __name__ == "__main__":
    main()
```

### Validation Output

Unpatched `origin/main@5b8986b`:

```json
{
  "bug_id": "BUG-8E34B7A19D20",
  "status": "confirmed",
  "finding": "rollout-rejected sibling kept reward/group membership and contaminated accepted GRPO advantages",
  "observed": {
    "response_mask_after_correction": [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
    "token_level_rewards_after_correction": [[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]],
    "advantages": [[0.0, 0.0, 0.0], [-49.5, -49.5, -49.5]],
    "returns": [[0.0, 0.0, 0.0], [-49.5, -49.5, -49.5]]
  }
}
```

Fixed branch commit `c59fa352`:

```json
{
  "bug_id": "BUG-8E34B7A19D20",
  "status": "not_triggered",
  "finding": "rollout-rejected sibling was removed from reward tensors and prompt-group baseline",
  "observed": {
    "response_mask_after_correction": [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
    "token_level_rewards_after_correction": [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
    "advantages": [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
    "returns": [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
  }
}
```

### Test

```bash
python3 -m pytest -q tests/trainer/ppo/test_rollout_corr_integration.py::TestRolloutISIntegration::test_rejected_sequences_do_not_pollute_group_advantage
python3 -m pytest -q tests/trainer/ppo/test_rollout_corr_integration.py tests/trainer/ppo/test_rollout_corr.py
python3 -m ruff check verl/trainer/ppo/rollout_corr_helper.py verl/trainer/ppo/ray_trainer.py tests/trainer/ppo/test_rollout_corr_integration.py
python3 -m ruff format --check verl/trainer/ppo/rollout_corr_helper.py verl/trainer/ppo/ray_trainer.py tests/trainer/ppo/test_rollout_corr_integration.py
```

Results:

- `1 passed, 3 warnings in 9.91s`
- `30 passed, 4 warnings in 9.17s`
- `All checks passed!`
- `3 files already formatted`

### API and Usage Example

No public API or configuration change. Existing rollout-correction configs now
remove fully rejected responses from downstream reward tensors and group
advantage baselines.

### Checklist Before Starting

- [x] Searched upstream PRs/issues and documented exact/related results above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Added a CPU regression test for rejected-sequence group leakage.
- [x] Ran focused pytest and ruff checks.
- [ ] Request CI after opening the PR.

AI assistance: OpenAI Codex was used for local investigation, validation, and patch drafting.
