### PR TITLE
[algo] fix: convert K1 rollout rejection ratio bounds correctly

### DIFF
--- a/tests/trainer/ppo/test_rollout_corr.py
+++ b/tests/trainer/ppo/test_rollout_corr.py
@@ -191,6 +191,67 @@ def test_rollout_rs_multiple_options():
         assert key in metrics, f"Metrics missing for chained option {option}"
 
 
+def test_token_k1_respects_non_reciprocal_ratio_bounds():
+    """K1 rejection thresholds are ratio bounds, not raw -log(ratio) bounds."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    ratios = torch.tensor([[0.55, 0.65, 1.0, 1.35, 1.5]], device=device)
+    old_log_prob = torch.zeros_like(ratios)
+    rollout_log_prob = -torch.log(ratios)
+    response_mask = torch.ones_like(ratios)
+
+    _, modified_response_mask, metrics = compute_rollout_correction_and_rejection_mask(
+        old_log_prob=old_log_prob,
+        rollout_log_prob=rollout_log_prob,
+        response_mask=response_mask,
+        rollout_is=None,
+        rollout_rs="token_k1",
+        rollout_rs_threshold="0.6_1.4",
+    )
+
+    expected_mask = torch.tensor([[0.0, 1.0, 1.0, 1.0, 0.0]], device=device)
+    torch.testing.assert_close(modified_response_mask, expected_mask)
+    assert metrics["rollout_corr/rollout_rs_masked_fraction"] == pytest.approx(0.4, abs=1e-6)
+    assert metrics["rollout_corr/rollout_rs_token_k1_fraction_low"] == pytest.approx(0.2, abs=1e-6)
+    assert metrics["rollout_corr/rollout_rs_token_k1_fraction_high"] == pytest.approx(0.2, abs=1e-6)
+
+
+def test_seq_mean_k1_respects_non_reciprocal_geometric_ratio_bounds():
+    """Sequence K1 rejection should preserve the requested geometric ratio interval."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    ratios = torch.tensor(
+        [
+            [1.5, 1.5],
+            [0.65, 0.65],
+        ],
+        device=device,
+    )
+    old_log_prob = torch.zeros_like(ratios)
+    rollout_log_prob = -torch.log(ratios)
+    response_mask = torch.ones_like(ratios)
+
+    _, modified_response_mask, metrics = compute_rollout_correction_and_rejection_mask(
+        old_log_prob=old_log_prob,
+        rollout_log_prob=rollout_log_prob,
+        response_mask=response_mask,
+        rollout_is=None,
+        rollout_rs="seq_mean_k1",
+        rollout_rs_threshold="0.6_1.4",
+    )
+
+    expected_mask = torch.tensor(
+        [
+            [0.0, 0.0],
+            [1.0, 1.0],
+        ],
+        device=device,
+    )
+    torch.testing.assert_close(modified_response_mask, expected_mask)
+    assert metrics["rollout_corr/rollout_rs_masked_fraction"] == pytest.approx(0.5, abs=1e-6)
+    assert metrics["rollout_corr/rollout_rs_seq_mean_k1_seq_fraction_low"] == pytest.approx(0.5, abs=1e-6)
+
+
 def test_metrics_completeness():
     """Test that all expected metrics are returned."""
     print("\nTesting metrics completeness...")

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -192,6 +192,11 @@ def _parse_rollout_rs_thresholds(
     return thresholds
 
 
+def _k1_stat_bounds_from_ratio_bounds(lower_ratio: float, upper_ratio: float) -> tuple[float, float]:
+    """Convert K1 ratio bounds to bounds for the -log(ratio) statistic."""
+    return -math.log(upper_ratio), -math.log(lower_ratio)
+
+
 def compute_rollout_rejection_mask(
     log_ratio: torch.Tensor,
     response_mask: torch.Tensor,
@@ -287,16 +292,15 @@ def compute_rollout_rejection_mask(
         upper_value = thresholds_info["upper"]
         lower_value = thresholds_info["lower"]
         apply_lower_threshold = is_k1_option
-        lower_log: Optional[float] = None
-        upper_log: Optional[float] = None
+        lower_stat_threshold: Optional[float] = None
+        upper_stat_threshold: Optional[float] = None
 
         if is_k1_option:
             if lower_value is None or upper_value is None:
                 raise ValueError(
                     f"rollout_rs_threshold for option '{option_name}' must specify both lower and upper bounds."
                 )
-            lower_log = math.log(lower_value)
-            upper_log = math.log(upper_value)
+            lower_stat_threshold, upper_stat_threshold = _k1_stat_bounds_from_ratio_bounds(lower_value, upper_value)
         else:
             if upper_value is None:
                 raise ValueError(f"rollout_rs_threshold for option '{option_name}' must specify an upper bound.")
@@ -308,10 +312,10 @@ def compute_rollout_rejection_mask(
         token_keep_bool: torch.Tensor
 
         if option_name == "token_k1":
-            if lower_log is None:
+            if lower_stat_threshold is None or upper_stat_threshold is None:
                 raise ValueError("Threshold specification for token_k1 must include lower and upper bounds.")
             per_token_stat = token_k1
-            token_keep_bool = (per_token_stat >= lower_log) & (per_token_stat <= upper_log)
+            token_keep_bool = (per_token_stat >= lower_stat_threshold) & (per_token_stat <= upper_stat_threshold)
         elif option_name == "token_k2":
             per_token_stat = token_k2
             token_keep_bool = per_token_stat <= upper_value
@@ -320,12 +324,12 @@ def compute_rollout_rejection_mask(
             token_keep_bool = per_token_stat <= upper_value
         elif option_name.startswith("seq_sum"):
             if option_name.endswith("k1"):
-                if lower_log is None:
+                if lower_stat_threshold is None or upper_stat_threshold is None:
                     raise ValueError(
                         f"Threshold specification for option '{option_name}' must include lower and upper bounds."
                     )
                 seq_stat = _sequence_sum(token_k1)
-                seq_keep_bool_direct = (seq_stat >= lower_log) & (seq_stat <= upper_log)
+                seq_keep_bool_direct = (seq_stat >= lower_stat_threshold) & (seq_stat <= upper_stat_threshold)
             elif option_name.endswith("k2"):
                 seq_stat = _sequence_sum(token_k2)
                 seq_keep_bool_direct = seq_stat <= upper_value
@@ -339,12 +343,12 @@ def compute_rollout_rejection_mask(
             per_token_stat = seq_stat.unsqueeze(-1).expand_as(response_mask)
         elif option_name.startswith("seq_mean"):
             if option_name.endswith("k1"):
-                if lower_log is None:
+                if lower_stat_threshold is None or upper_stat_threshold is None:
                     raise ValueError(
                         f"Threshold specification for option '{option_name}' must include lower and upper bounds."
                     )
                 seq_stat = _sequence_mean(token_k1)
-                seq_keep_bool_direct = (seq_stat >= lower_log) & (seq_stat <= upper_log)
+                seq_keep_bool_direct = (seq_stat >= lower_stat_threshold) & (seq_stat <= upper_stat_threshold)
             elif option_name.endswith("k2"):
                 seq_stat = _sequence_mean(token_k2)
                 seq_keep_bool_direct = seq_stat <= upper_value
@@ -371,8 +375,8 @@ def compute_rollout_rejection_mask(
         else:
             raise ValueError(f"Unsupported rollout_rs option: {option_name}.")
 
-        metrics_upper_threshold = upper_log if is_k1_option else upper_value
-        metrics_lower_threshold = lower_log if (is_k1_option and lower_log is not None) else 0.0
+        metrics_upper_threshold = upper_stat_threshold if is_k1_option else upper_value
+        metrics_lower_threshold = lower_stat_threshold if is_k1_option and lower_stat_threshold is not None else 0.0
 
         token_keep_mask = token_keep_bool.to(dtype=log_ratio.dtype)
         combined_mask = combined_mask * token_keep_mask


### PR DESCRIPTION
## What This Fixes

This fixes a quiet rollout correction bug in veRL's K1 rejection sampling modes.

Here "K1 rollout" means rollout rejection sampling with a K1 off-policy
statistic. The rollout path has already produced tokens and logprobs. During
training, veRL compares the training policy probability against the rollout
policy probability:

```text
ratio = pi_old / pi_rollout
K1 statistic = -log(ratio)
```

`rollout_rs_threshold="lower_upper"` is a ratio interval. For example:

```text
algorithm.rollout_correction.rollout_rs=token_k1
algorithm.rollout_correction.rollout_rs_threshold=0.6_1.4
```

means tokens should remain trainable only when their ratio is inside
`[0.6, 1.4]`.

Before this patch, veRL compared the K1 statistic against `[log(lower),
log(upper)]`. That silently accepts the wrong ratio interval for
non-reciprocal bounds. In the minimal reproducer below, `ratio=1.5` is above the
configured upper bound `1.4`, but the unpatched implementation keeps it.

```text
configured ratio bounds = [0.6, 1.4]
ratio = pi_old / pi_rollout = 1.5
unpatched token_k1 modified_response_mask = [[1.0]]
expected token_k1 modified_response_mask = [[0.0]]
```

Training does not crash. The failure is that rollout correction silently keeps
or rejects the wrong off-policy tokens/sequences.

## Root Cause

K1 uses `-log(ratio)` as the statistic, but `rollout_rs_threshold` is specified
as a ratio interval. A ratio interval must be converted before comparing against
`-log(ratio)`:

```text
ratio bounds:      [lower, upper]
K1 stat bounds:    [-log(upper), -log(lower)]
```

The old implementation used:

```text
[log(lower), log(upper)]
```

That happens to work for reciprocal intervals such as `[0.5, 2.0]`, because the
incorrect and correct statistic bounds are identical:

```text
correct: [-log(2.0), -log(0.5)] = [-0.693, 0.693]
old:     [ log(0.5),  log(2.0)] = [-0.693, 0.693]
```

For non-reciprocal intervals such as `[0.6, 1.4]`, the accepted region becomes
wrong:

```text
correct K1 stat bounds: [-log(1.4), -log(0.6)] ~= [-0.336, 0.511]
old K1 stat bounds:     [ log(0.6),  log(1.4)] ~= [-0.511, 0.336]
```

The old bounds therefore keep high ratios such as `1.5` and reject valid lower
ratios such as `0.65`.

## Fix

This patch adds a helper that converts K1 ratio bounds into K1 statistic bounds:

```python
def _k1_stat_bounds_from_ratio_bounds(lower_ratio: float, upper_ratio: float) -> tuple[float, float]:
    return -math.log(upper_ratio), -math.log(lower_ratio)
```

The converted bounds are then used by:

- `token_k1`
- `seq_sum_k1`
- `seq_mean_k1`

The regression tests cover token-level K1 and sequence-mean K1 with
non-reciprocal ratio bounds.

## Duplicate Check

I checked upstream before preparing this PR and did not find an existing matching
fix or report:

- PR search: [`rollout_rs token_k1 threshold lower upper`](https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout_rs+token_k1+threshold+lower+upper)
- PR search: [`rollout correction k1 threshold ratio bounds`](https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout+correction+k1+threshold+ratio+bounds)
- PR search: [`compute_rollout_rejection_mask token_k1 log ratio`](https://github.com/verl-project/verl/pulls?q=is%3Apr+compute_rollout_rejection_mask+token_k1+log+ratio)
- Issue search: [`rollout_rs token_k1 threshold lower upper`](https://github.com/verl-project/verl/issues?q=is%3Aissue+rollout_rs+token_k1+threshold+lower+upper)

No matching upstream PR or issue was found as of 2026-05-17.

## Validation Recipe

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "schema_version": 1,
  "bug_id": "BUG-9A07260C3301",
  "title": "K1 rollout rejection misinterprets non-reciprocal ratio bounds",
  "target": "verl",
  "validation_mode": "real_target_boundary_hook",
  "target_boundaries": [
    "verl.trainer.ppo.rollout_corr_helper.compute_rollout_rejection_mask"
  ],
  "requires_model_download": false,
  "requires_dataset_download": false,
  "environment": {
    "VERL_REPO": "path to the veRL checkout under test",
    "OUTPUT_DIR": "directory where validation JSON should be written",
    "EXPECTATION": "confirmed for unpatched, not_triggered for fixed",
    "PYTHON": "python3"
  },
  "constructed_scenario": {
    "rollout_rs": "token_k1 and seq_mean_k1",
    "rollout_rs_threshold": "0.6_1.4",
    "ratio_definition": "ratio = pi_old / pi_rollout",
    "token_ratios": [[0.55, 0.65, 1.0, 1.35, 1.5]],
    "sequence_ratios": [[1.5, 1.5], [0.65, 0.65]]
  },
  "expected_unpatched": {
    "status": "confirmed",
    "token_modified_response_mask": [[0.0, 0.0, 1.0, 1.0, 1.0]],
    "seq_mean_modified_response_mask": [[1.0, 1.0], [0.0, 0.0]],
    "finding": "ratio bounds were compared as [log(lower), log(upper)] against -log(ratio)"
  },
  "expected_fixed": {
    "status": "not_triggered",
    "token_modified_response_mask": [[0.0, 1.0, 1.0, 1.0, 0.0]],
    "seq_mean_modified_response_mask": [[0.0, 0.0], [1.0, 1.0]],
    "finding": "ratio bounds were converted to [-log(upper), -log(lower)] before comparing K1 statistics"
  },
  "outputs": {
    "validation": "training_signal_validation.json"
  }
}
```

## Validation Runner

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${VERL_REPO:?Set VERL_REPO to the veRL checkout under test}"
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/output}"
PYTHON="${PYTHON:-python3}"
EXPECTATION="${EXPECTATION:-any}"

mkdir -p "${OUTPUT_DIR}"

export VERL_REPO OUTPUT_DIR EXPECTATION
export PYTHONPATH="${VERL_REPO}${PYTHONPATH:+:${PYTHONPATH}}"

"${PYTHON}" "${SCRIPT_DIR}/k1_rollout_rs_bounds_hook.py"
```

Example commands:

```bash
VERL_REPO=/path/to/unpatched/verl \
OUTPUT_DIR=/tmp/BUG-9A07260C3301/unpatched \
EXPECTATION=confirmed \
artifacts/manual-repro/BUG-9A07260C3301/run_validation.sh

VERL_REPO=/path/to/fixed/verl \
OUTPUT_DIR=/tmp/BUG-9A07260C3301/fixed \
EXPECTATION=not_triggered \
artifacts/manual-repro/BUG-9A07260C3301/run_validation.sh
```

## Boundary Hook

```python
from __future__ import annotations

import json
import os
import subprocess
import sys
from pathlib import Path

import torch


BUG_ID = "BUG-9A07260C3301"
TITLE = "K1 rollout rejection misinterprets non-reciprocal ratio bounds"


def _git_commit(repo: Path) -> str | None:
    try:
        return subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
    except Exception:
        return None


def _tolist(tensor: torch.Tensor) -> list:
    return tensor.detach().cpu().tolist()


def _write_json(path: Path, payload: dict) -> None:
    path.parent.mkdir(parents=True, exist_ok=True)
    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")


def _run_case(compute_rollout_rejection_mask, ratios: torch.Tensor, rollout_rs: str) -> tuple[torch.Tensor, dict]:
    response_mask = torch.ones_like(ratios)
    log_ratio = torch.log(ratios)
    return compute_rollout_rejection_mask(
        log_ratio=log_ratio,
        response_mask=response_mask,
        rollout_rs=rollout_rs,
        rollout_rs_threshold="0.6_1.4",
    )


def main() -> None:
    repo = Path(os.environ["VERL_REPO"]).resolve()
    output_dir = Path(os.environ["OUTPUT_DIR"]).resolve()
    expectation = os.environ.get("EXPECTATION", "any")

    if str(repo) not in sys.path:
        sys.path.insert(0, str(repo))

    from verl.trainer.ppo.rollout_corr_helper import compute_rollout_rejection_mask

    token_ratios = torch.tensor([[0.55, 0.65, 1.0, 1.35, 1.5]], dtype=torch.float32)
    seq_ratios = torch.tensor([[1.5, 1.5], [0.65, 0.65]], dtype=torch.float32)

    token_mask, token_metrics = _run_case(compute_rollout_rejection_mask, token_ratios, "token_k1")
    seq_mask, seq_metrics = _run_case(compute_rollout_rejection_mask, seq_ratios, "seq_mean_k1")

    unpatched_token_mask = [[0.0, 0.0, 1.0, 1.0, 1.0]]
    unpatched_seq_mask = [[1.0, 1.0], [0.0, 0.0]]
    fixed_token_mask = [[0.0, 1.0, 1.0, 1.0, 0.0]]
    fixed_seq_mask = [[0.0, 0.0], [1.0, 1.0]]

    observed_token_mask = _tolist(token_mask)
    observed_seq_mask = _tolist(seq_mask)

    if observed_token_mask == unpatched_token_mask and observed_seq_mask == unpatched_seq_mask:
        status = "confirmed"
        finding = "K1 compared -log(ratio) against [log(lower), log(upper)], keeping ratio 1.5 and rejecting ratio 0.65."
    elif observed_token_mask == fixed_token_mask and observed_seq_mask == fixed_seq_mask:
        status = "not_triggered"
        finding = "K1 converted ratio bounds to [-log(upper), -log(lower)], rejecting ratio 1.5 and keeping ratio 0.65."
    else:
        status = "unexpected"
        finding = "K1 rollout rejection produced an unrecognized mask pattern."

    payload = {
        "kind": "rl_sentinel_training_signal_validation",
        "bug_id": BUG_ID,
        "title": TITLE,
        "status": status,
        "finding": finding,
        "repo": str(repo),
        "commit": _git_commit(repo),
        "target_boundary": "verl.trainer.ppo.rollout_corr_helper.compute_rollout_rejection_mask",
        "scenario": {
            "rollout_rs_threshold": "0.6_1.4",
            "ratio_definition": "ratio = pi_old / pi_rollout",
            "token_case": {
                "rollout_rs": "token_k1",
                "ratios": [[0.55, 0.65, 1.0, 1.35, 1.5]],
            },
            "sequence_case": {
                "rollout_rs": "seq_mean_k1",
                "ratios": [[1.5, 1.5], [0.65, 0.65]],
            },
        },
        "observed": {
            "token_modified_response_mask": observed_token_mask,
            "seq_mean_modified_response_mask": observed_seq_mask,
            "token_metrics": token_metrics,
            "seq_mean_metrics": seq_metrics,
        },
        "expected": {
            "unpatched": {
                "status": "confirmed",
                "token_modified_response_mask": unpatched_token_mask,
                "seq_mean_modified_response_mask": unpatched_seq_mask,
            },
            "fixed": {
                "status": "not_triggered",
                "token_modified_response_mask": fixed_token_mask,
                "seq_mean_modified_response_mask": fixed_seq_mask,
            },
        },
    }

    output_path = output_dir / "training_signal_validation.json"
    _write_json(output_path, payload)
    print(json.dumps(payload, indent=2))

    if expectation != "any" and status != expectation:
        raise SystemExit(f"expected status {expectation!r}, got {status!r}")


if __name__ == "__main__":
    main()
```

## Validation Output

Unpatched veRL:

```json
{
  "bug_id": "BUG-9A07260C3301",
  "status": "confirmed",
  "commit": "5b8986bb94237163c603ed9be08d2f73c3e5d0ba",
  "observed": {
    "token_modified_response_mask": [[0.0, 0.0, 1.0, 1.0, 1.0]],
    "seq_mean_modified_response_mask": [[1.0, 1.0], [0.0, 0.0]]
  }
}
```

Fixed branch:

```json
{
  "bug_id": "BUG-9A07260C3301",
  "status": "not_triggered",
  "commit": "3508a36bbb5aab09782d784af307188186142c67",
  "observed": {
    "token_modified_response_mask": [[0.0, 1.0, 1.0, 1.0, 0.0]],
    "seq_mean_modified_response_mask": [[0.0, 0.0], [1.0, 1.0]]
  }
}
```

## Tests

```bash
python3 -m pytest -q \
  tests/trainer/ppo/test_rollout_corr.py::test_token_k1_respects_non_reciprocal_ratio_bounds \
  tests/trainer/ppo/test_rollout_corr.py::test_seq_mean_k1_respects_non_reciprocal_geometric_ratio_bounds
python3 -m pytest -q tests/trainer/ppo/test_rollout_corr.py
python3 -m ruff check verl/trainer/ppo/rollout_corr_helper.py tests/trainer/ppo/test_rollout_corr.py
python3 -m ruff format --check verl/trainer/ppo/rollout_corr_helper.py tests/trainer/ppo/test_rollout_corr.py
```

Results:

- `2 passed, 1 warning in 8.08s`
- `20 passed, 2 warnings in 8.25s`
- `All checks passed!`
- `2 files already formatted`

## API Impact

No public API change. This only corrects how K1 ratio thresholds are converted
inside rollout rejection sampling.

AI assistance: this local draft and patch were prepared with Codex assistance
and reviewed in the local workspace.
