### PR TITLE
[doc] fix: delete sglang_multiturn

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ verl is fast with:
 - Reinforcement learning with [PPO](examples/ppo_trainer/), [GRPO](examples/grpo_trainer/), [GSPO](https://github.com/verl-project/verl-recipe/tree/main/gspo/), [ReMax](examples/remax_trainer/), [REINFORCE++](https://verl.readthedocs.io/en/latest/examples/config.html#algorithm), [RLOO](examples/rloo_trainer/), [PRIME](https://github.com/verl-project/verl-recipe/tree/main/prime/), [DAPO](https://github.com/verl-project/verl-recipe/tree/main/dapo/), [DrGRPO](https://github.com/verl-project/verl-recipe/tree/main/drgrpo), [KL_Cov & Clip_Cov](https://github.com/verl-project/verl-recipe/tree/main/entropy) etc.
   - Support model-based reward and function-based reward (verifiable reward) for math, [coding](https://github.com/verl-project/verl-recipe/tree/main/dapo), etc
   - Support vision-language models (VLMs) and [multi-modal RL](examples/grpo_trainer/run_qwen2_5_vl_7b_fsdp.sh) with Qwen2.5-vl, Kimi-VL
-  - [Multi-turn with tool calling](https://github.com/verl-project/verl/tree/main/examples/sglang_multiturn)
+  - [Multi-turn with tool calling](examples/tutorial/agent_loop_get_started/)
 - LLM alignment recipes such as [Self-play preference optimization (SPPO)](https://github.com/verl-project/verl-recipe/tree/main/sppo)
 - Flash attention 2, sequence packing, sequence parallelism via DeepSpeed Ulysses, [LoRA](examples/tuning/lora/run_qwen3_8b_fsdp.sh), [Liger-kernel](examples/sft/gsm8k/run_qwen2_5_0_5b_fsdp.sh) (`USE_LIGER=1`).
 - Scales up to 671B models and hundreds of GPUs with [expert parallelism](https://github.com/verl-project/verl/pull/1467)

--- a/docs/examples/sandbox_fusion_example.rst
+++ b/docs/examples/sandbox_fusion_example.rst
@@ -1,7 +1,7 @@
 Sandbox Fusion Example
 ============================
 
-Last updated: 06/27/2025.
+Last updated: 05/17/2026.
 
 Introduction
 ------------
@@ -45,10 +45,8 @@ To further reduce code verification time, enable parallel processing with:
 
 - ``reward_model.reward_manager=prime``: The Prime reward manager verifies code across multiple subprocesses concurrently.
 
-**Example Script**
+**Example Notebook**
 
-For a practical implementation, refer to the example script:  
+For a practical implementation, refer to the example notebook:  
 
-``examples/sglang_multiturn/run_qwen3_4b_dapo_multiturn_fsdp.sh``
-
-Once you’ve set your API endpoint in the script, you can start the training job.
+``examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb``

--- a/examples/README.md
+++ b/examples/README.md
@@ -129,7 +129,6 @@ under `recipe/` instead.
 | `profile/`           | NPU profiler / torch-memory profiler runs.                                               |
 | `sft/`               | Supervised fine-tuning examples.                                                         |
 | `generation/`        | Rollout-only inference launches.                                                         |
-| `sglang_multiturn/`  | SGLang multi-turn rollout examples.                                                      |
 | `vllm_omni/`         | vLLM omni backend examples.                                                              |
 | `data_preprocess/`   | Scripts that produce the `$HOME/data/<dataset>/*.parquet` layout the run scripts expect. |
 | `prefix_grouper/`    | Prefix-grouped rollout examples.                                                         |


### PR DESCRIPTION
### What does this PR do?

Remove stale references to the deprecated `examples/sglang_multiturn/` directory from documentation and README files. The `sglang_multiturn/` directory has been removed, but several doc files still referenced it, causing broken links and confusion for users looking for multi-turn tool calling examples.

Related: issue #6371

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

N/A — This is a documentation-only change with no functional code modifications. Verified by checking that the updated links and references resolve correctly.

### API and Usage Example

N/A — No API changes.

### Design & Code Changes

- `README.md`: Updated the "Multi-turn with tool calling" link from `examples/sglang_multiturn` to `examples/tutorial/agent_loop_get_started/`.
- `docs/examples/sandbox_fusion_example.rst`: Updated the referenced example path from `examples/sglang_multiturn/run_qwen3_4b_dapo_multiturn_fsdp.sh` to `examples/tutorial/agent_loop_get_started/agent_loop_tutorial.ipynb`, and updated the "Last updated" date.
- `examples/README.md`: Removed the `sglang_multiturn/` entry from the examples directory listing.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Documentation-only change; no code to test.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. (N/A — not related to `recipe`.)
