### PR TITLE
[fsdp] fix: emit distillation outputs in use_remove_padding=False path

### DIFF
--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression guard for verl#6293.
+
+The use_remove_padding=False branch of
+FSDPEngineWithLMHead.prepare_model_outputs previously lacked the
+distillation_use_topk handling that the use_remove_padding=True branch had,
+so distillation outputs were silently dropped from model_output and the
+downstream loss raised KeyError. This test invokes prepare_model_outputs on
+a stub engine for both branches with distillation_use_topk=True and asserts
+the distillation keys produced by logits_processor_func are propagated into
+model_output as nested tensors in both cases.
+
+``logprobs_from_logits`` is patched out: in CI environments where flash-attn
+is installed, it dispatches to a Triton CrossEntropyLoss kernel that cannot
+operate on CPU tensors. The substitute returns a dummy ``log_probs`` tensor
+of the right shape, which is sufficient for this test — the contract under
+test is the propagation of distillation keys, not the numerical correctness
+of log-prob computation.
+"""
+
+import os
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from unittest.mock import patch
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.utils import tensordict_utils as tu
+from verl.utils.dataset.dataset_utils import DatasetPadMode
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
+
+_VOCAB_SIZE = 8
+_DISTILLATION_KEYS = ("distillation_losses", "student_mass")
+
+
+def _make_engine_stub():
+    """Bypass FSDPEngineWithLMHead.__init__; set only attributes that
+    prepare_model_outputs touches in this test path (no SP, no fused kernels,
+    no entropy)."""
+    eng = object.__new__(FSDPEngineWithLMHead)
+    eng.use_ulysses_sp = False
+
+    class _EngineCfg:
+        entropy_checkpointing = False
+
+    eng.engine_config = _EngineCfg()
+    return eng
+
+
+def _make_logits_processor(keys):
+    """Fake top-k distillation processor: returns one (1, total_nnz) tensor per key.
+
+    The real processor (verl/trainer/distillation/losses.py) returns
+    student_logits.shape[:2]; we mimic that contract.
+    """
+
+    def _proc(student_logits, data):
+        n = student_logits.shape[1]
+        return {k: torch.full((1, n), float(i + 1)) for i, k in enumerate(keys)}
+
+    return _proc
+
+
+@pytest.mark.parametrize("use_remove_padding", [True, False])
+def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
+    """distillation_use_topk=True must populate distillation outputs into
+    model_output regardless of use_remove_padding. See verl#6293."""
+    bsz = 2
+    seq_lengths_list = [3, 2]
+    seq_lengths = torch.tensor(seq_lengths_list, dtype=torch.int64)
+    total_nnz = int(seq_lengths.sum())
+
+    cu_seqlens = torch.cat([torch.tensor([0]), seq_lengths.cumsum(0)]).to(torch.int64)
+
+    flat_input_ids = torch.randint(0, _VOCAB_SIZE, (total_nnz,))
+    input_ids_nested = torch.nested.nested_tensor_from_jagged(flat_input_ids, offsets=cu_seqlens)
+
+    input_ids_rmpad_rolled = torch.randint(0, _VOCAB_SIZE, (total_nnz,))
+
+    class _Output:
+        pass
+
+    output = _Output()
+
+    if use_remove_padding:
+        # True branch: output.logits shape (1, total_nnz, V), squeeze(0) -> (total_nnz, V).
+        output.logits = torch.randn(1, total_nnz, _VOCAB_SIZE)
+        output_args = {
+            "input_ids_rmpad_rolled": input_ids_rmpad_rolled,
+            "temperature_rmpad": torch.ones(total_nnz),
+        }
+    else:
+        # False branch: output.logits shape (bsz, max_seqlen, V).
+        max_seqlen = max(seq_lengths_list)
+        output.logits = torch.randn(bsz, max_seqlen, _VOCAB_SIZE)
+        output_args = {
+            "input_ids_rmpad_rolled": input_ids_rmpad_rolled,
+            "temperature": torch.ones(bsz),
+        }
+
+    micro_batch = TensorDict({"input_ids": input_ids_nested}, batch_size=[])
+    tu.assign_non_tensor(
+        micro_batch,
+        use_remove_padding=use_remove_padding,
+        pad_mode=DatasetPadMode.NO_PADDING,
+        use_fused_kernels=False,
+        calculate_entropy=False,
+        calculate_sum_pi_squared=False,
+        distillation_use_topk=True,
+        max_response_length=max(seq_lengths_list),
+    )
+
+    eng = _make_engine_stub()
+
+    # Patch logprobs_from_logits because flash-attn's Triton CrossEntropyLoss
+    # cannot operate on CPU tensors. The shape is what downstream code asserts
+    # against (v.shape == log_probs.shape), and prepare_model_outputs reduces
+    # both branches to a (total_nnz,) log_probs over the rmpad'ed logits.
+    with patch(
+        "verl.workers.engine.fsdp.transformer_impl.logprobs_from_logits",
+        return_value=torch.zeros(total_nnz),
+    ):
+        model_output = FSDPEngineWithLMHead.prepare_model_outputs(
+            eng,
+            output=output,
+            output_args=output_args,
+            micro_batch=micro_batch,
+            logits_processor_func=_make_logits_processor(_DISTILLATION_KEYS),
+        )
+
+    assert "log_probs" in model_output, (
+        f"log_probs missing (use_remove_padding={use_remove_padding}); keys: {list(model_output.keys())}"
+    )
+
+    for k in _DISTILLATION_KEYS:
+        assert k in model_output, (
+            f"Distillation key '{k}' missing from model_output "
+            f"(use_remove_padding={use_remove_padding}); "
+            f"keys: {list(model_output.keys())}"
+        )
+        assert model_output[k].is_nested, (
+            f"Expected '{k}' to be a nested tensor (use_remove_padding={use_remove_padding}); "
+            f"got {type(model_output[k])}"
+        )

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1184,6 +1184,21 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     logits_rmpad = torch.cat([t for t in logits.unbind()])
                     input_ids_rmpad_rolled = output_args["input_ids_rmpad_rolled"]
                     log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
+
+                    # Mirror the use_remove_padding=True branch (see verl#6293).
+                    # No Ulysses SP gather here: this branch is the no-SP path
+                    # (log_probs is also not gathered) and pad_size is only
+                    # populated in output_args along the use_remove_padding=True
+                    # path of prepare_model_inputs.
+                    if distillation_use_topk:
+                        outputs = logits_processor_func(student_logits=logits_rmpad.unsqueeze(0), data=micro_batch)
+                        for k, v in outputs.items():
+                            v = v.squeeze(0)
+                            assert v.shape == log_probs.shape, (
+                                f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
+                            )
+                            model_output[k] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
+
                     # (bsz, j1), for each sample, length of each sample: [real_prompt_length + real_response_length]
                     log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
                     if calculate_entropy:


### PR DESCRIPTION
## Background

#6350 (closed by #6360 revert) regressed the cpu_unit_tests CI job:

```
FAILED tests/workers/test_distillation_topk_symmetry_on_cpu.py::test_distillation_outputs_emitted_in_both_padding_modes[True]
ValueError: Pointer argument (at 0) cannot be accessed from Triton (cpu tensor?)
```

The original fix for #6293 was correct; the test's interaction with `logprobs_from_logits` was not.

Per @wuxibin89's request on #6350, this PR re-applies the production fix and patches the test so it actually runs on CPU.

## Production fix (`verl/workers/engine/fsdp/transformer_impl.py`)

Re-applies the 15-line addition from #6350: the `use_remove_padding=False` branch of `prepare_model_outputs` now mirrors the `True` branch's `distillation_use_topk` handling. Without this, downstream distillation losses raise `KeyError` on the no-rmpad path (#6293 root cause).

No SP gather here — this branch is the no-SP path (`log_probs` is also not gathered), and `pad_size` is only populated in `output_args` along the `use_remove_padding=True` path of `prepare_model_inputs`.

## CPU test fix (`tests/workers/test_distillation_topk_symmetry_on_cpu.py`)

Root cause: `prepare_model_outputs` calls `logprobs_from_logits(logits=logits_rmpad, labels=...)`. When flash-attn is installed in CI, that dispatches to flash-attn's Triton `CrossEntropyLoss`, which only operates on CUDA tensors. The test runs on CPU.

Fix: patch `logprobs_from_logits` for the duration of the call with a substitute that returns `torch.zeros(total_nnz)` of the right shape. The contract under test is the propagation of distillation keys, not the numerical correctness of log-probs. The downstream assertion `v.shape == log_probs.shape` continues to hold because `logits_processor_func` returns tensors of shape `(1, student_logits.shape[1])` and `logits_rmpad` is contiguous along the `total_nnz` dim in both branches.

## Local verification

```
KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest \
    tests/workers/test_distillation_topk_symmetry_on_cpu.py -v
```

Output:

```
collecting ... collected 2 items

tests/workers/test_distillation_topk_symmetry_on_cpu.py::test_distillation_outputs_emitted_in_both_padding_modes[True]  PASSED [ 50%]
tests/workers/test_distillation_topk_symmetry_on_cpu.py::test_distillation_outputs_emitted_in_both_padding_modes[False] PASSED [100%]

============================== 2 passed, 3 warnings in 7.57s ==============================
```

Both parametrizations pass; the previous CI failure mode (`ValueError: Pointer argument (at 0) cannot be accessed from Triton`) is gone because the Triton kernel is no longer reached on the CPU path.

## Refs

- #6293 (issue)
- #6350 (original fix, reverted by #6360)
- #6360 (revert)