### PR TITLE
[reward] fix: mask tool observations before default reward scoring

### DIFF
--- a/tests/workers/reward_manager/test_response_mask_on_cpu.py
+++ b/tests/workers/reward_manager/test_response_mask_on_cpu.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+
+from verl import DataProto
+from verl.workers.reward_manager.naive import NaiveRewardManager
+
+
+class ToyTokenizer:
+    def __init__(self):
+        self.vocab = {1: "prompt", 10: "assistant", 11: "final", 99: "TOOL_LEAK", 0: "<pad>"}
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        ids = token_ids.tolist() if hasattr(token_ids, "tolist") else list(token_ids)
+        pieces = [self.vocab[int(token_id)] for token_id in ids]
+        if skip_special_tokens:
+            pieces = [piece for piece in pieces if piece != "<pad>"]
+        return " ".join(pieces)
+
+
+def test_naive_reward_manager_uses_response_mask_for_tool_observations():
+    captured = {}
+
+    def compute_score(data_source, solution_str, ground_truth, extra_info):
+        captured["solution_str"] = solution_str
+        captured["full_response_str"] = extra_info["full_response_str"]
+        return 1.0 if "TOOL_LEAK" not in solution_str else -1.0
+
+    data = DataProto.from_dict(
+        tensors={
+            "prompts": torch.tensor([[1]]),
+            "responses": torch.tensor([[10, 11, 99, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 0]]),
+            "response_mask": torch.tensor([[1, 1, 0, 0]]),
+        },
+        non_tensors={
+            "data_source": np.array(["tool_task"], dtype=object),
+            "reward_model": np.array([{"ground_truth": "final"}], dtype=object),
+        },
+    )
+    manager = NaiveRewardManager(tokenizer=ToyTokenizer(), num_examine=0, compute_score=compute_score)
+
+    reward = manager(data)
+
+    assert captured["solution_str"] == "assistant final"
+    assert captured["full_response_str"] == "assistant final TOOL_LEAK"
+    torch.testing.assert_close(reward, torch.tensor([[0.0, 1.0, 0.0, 0.0]]))

--- a/tests/workers/reward_manager/test_response_mask_on_cpu.py
+++ b/tests/workers/reward_manager/test_response_mask_on_cpu.py
@@ -16,7 +16,9 @@ import numpy as np
 import torch
 
 from verl import DataProto
+from verl.workers.reward_manager.batch import BatchRewardManager
 from verl.workers.reward_manager.naive import NaiveRewardManager
+from verl.workers.reward_manager.response_utils import select_response_ids_for_reward
 
 
 class ToyTokenizer:
@@ -57,4 +59,51 @@ def test_naive_reward_manager_uses_response_mask_for_tool_observations():
 
     assert captured["solution_str"] == "assistant final"
     assert captured["full_response_str"] == "assistant final TOOL_LEAK"
+    torch.testing.assert_close(reward, torch.tensor([[0.0, 1.0, 0.0, 0.0]]))
+
+
+def test_select_response_ids_for_reward_returns_empty_for_all_zero_response_mask():
+    response_ids = torch.tensor([99, 98, 0])
+    response_attention_mask = torch.tensor([1, 1, 0])
+    response_mask = torch.tensor([0, 0, 0])
+
+    valid_response_ids, reward_index = select_response_ids_for_reward(
+        response_ids=response_ids,
+        response_attention_mask=response_attention_mask,
+        response_mask=response_mask,
+    )
+
+    assert valid_response_ids.tolist() == []
+    assert reward_index == 0
+
+
+def test_batch_reward_manager_reuses_filtered_response_for_scoring_and_logging(capsys):
+    captured = {}
+
+    def compute_score(data_sources, solution_strs, ground_truths, extra_infos):
+        captured["solution_strs"] = solution_strs
+        captured["full_response_str"] = extra_infos[0]["full_response_str"]
+        return [1.0 if "TOOL_LEAK" not in solution_strs[0] else -1.0]
+
+    data = DataProto.from_dict(
+        tensors={
+            "prompts": torch.tensor([[1]]),
+            "responses": torch.tensor([[10, 11, 99, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 0]]),
+            "response_mask": torch.tensor([[1, 1, 0, 0]]),
+        },
+        non_tensors={
+            "data_source": np.array(["tool_task"], dtype=object),
+            "reward_model": np.array([{"ground_truth": "final"}], dtype=object),
+        },
+    )
+    manager = BatchRewardManager(tokenizer=ToyTokenizer(), num_examine=1, compute_score=compute_score)
+
+    reward = manager(data)
+    printed = capsys.readouterr().out
+
+    assert captured["solution_strs"] == ["assistant final"]
+    assert captured["full_response_str"] == "assistant final TOOL_LEAK"
+    assert "[response] assistant final\n" in printed
+    assert "TOOL_LEAK" not in printed
     torch.testing.assert_close(reward, torch.tensor([[0.0, 1.0, 0.0, 0.0]]))

--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -45,7 +45,7 @@ class BatchRewardManager(AbstractRewardManager):
         self.reward_fn_key = reward_fn_key
         self.reward_kwargs = reward_kwargs
 
-    def verify(self, data):
+    def _prepare_reward_inputs(self, data):
         prompt_ids = data.batch["prompts"]
         response_ids = data.batch["responses"]
         attention_mask = data.batch["attention_mask"]
@@ -54,15 +54,24 @@ class BatchRewardManager(AbstractRewardManager):
         response_mask = data.batch.get("response_mask", None)
 
         responses_str = []
+        reward_indices = []
+        full_responses_str = []
         for i in range(len(data)):
-            valid_response_ids, _ = select_response_ids_for_reward(
+            valid_response_ids, reward_index = select_response_ids_for_reward(
                 response_ids=response_ids[i],
                 response_attention_mask=attention_mask[i, prompt_len:],
                 response_mask=response_mask[i] if response_mask is not None else None,
             )
             response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
             responses_str.append(response_str)
+            reward_indices.append(reward_index)
 
+            full_response_ids = response_ids[i][: int(attention_mask[i, prompt_len:].sum().item())]
+            full_responses_str.append(self.tokenizer.decode(full_response_ids, skip_special_tokens=True))
+
+        return responses_str, reward_indices, full_responses_str
+
+    def _compute_scores(self, data, responses_str, full_responses_str):
         ground_truths = [item.non_tensor_batch["reward_model"].get("ground_truth", None) for item in data]
         data_sources = data.non_tensor_batch[self.reward_fn_key]
         rollout_reward_scores = data.non_tensor_batch.get("reward_scores", [{} for _ in range(len(data))])
@@ -70,8 +79,7 @@ class BatchRewardManager(AbstractRewardManager):
 
         for i in range(len(data)):
             extras[i]["rollout_reward_scores"] = rollout_reward_scores[i]
-            full_response_ids = response_ids[i][: int(attention_mask[i, prompt_len:].sum().item())]
-            extras[i]["full_response_str"] = self.tokenizer.decode(full_response_ids, skip_special_tokens=True)
+            extras[i]["full_response_str"] = full_responses_str[i]
 
         scores = self.compute_score(
             data_sources=data_sources,
@@ -83,6 +91,10 @@ class BatchRewardManager(AbstractRewardManager):
 
         return scores
 
+    def verify(self, data):
+        responses_str, _, full_responses_str = self._prepare_reward_inputs(data)
+        return self._compute_scores(data, responses_str, full_responses_str)
+
     def __call__(self, data: DataProto, return_dict: bool = False) -> torch.Tensor | dict[str, Any]:
         # If there is rm score, we directly return rm score. Otherwise, we compute via rm_score_fn
         reward_from_rm_scores = self._extract_reward_from_rm_scores(data, return_dict)
@@ -92,23 +104,15 @@ class BatchRewardManager(AbstractRewardManager):
         reward_tensor = torch.zeros_like(data.batch["responses"], dtype=torch.float32)
         reward_extra_info = defaultdict(list)
         prompt_ids = data.batch["prompts"]
-        prompt_len = prompt_ids.shape[-1]
-        attention_mask = data.batch["attention_mask"]
-        valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
-        response_mask = data.batch.get("response_mask", None)
         data_sources = data.non_tensor_batch[self.reward_fn_key]
 
-        scores = self.verify(data)
+        responses_str, reward_indices, full_responses_str = self._prepare_reward_inputs(data)
+        scores = self._compute_scores(data, responses_str, full_responses_str)
         rewards = []
         already_printed: dict[str, Any] = {}
 
         for i in range(len(data)):
-            length = valid_response_lengths[i].item()
-            _, reward_index = select_response_ids_for_reward(
-                response_ids=data.batch["responses"][i],
-                response_attention_mask=attention_mask[i, prompt_len:],
-                response_mask=response_mask[i] if response_mask is not None else None,
-            )
+            reward_index = reward_indices[i]
             score = scores[i]
 
             if isinstance(score, dict):
@@ -123,7 +127,7 @@ class BatchRewardManager(AbstractRewardManager):
 
             data_source = data_sources[i]
             if already_printed.get(data_source, 0) < self.num_examine:
-                response_str = self.tokenizer.decode(data.batch["responses"][i][:length], skip_special_tokens=True)
+                response_str = responses_str[i]
                 prompt_str = self.tokenizer.decode(data.batch["prompts"][i], skip_special_tokens=True)
                 ground_truth = data[i].non_tensor_batch["reward_model"].get("ground_truth", None)
                 print("[prompt]", prompt_str)

--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -20,6 +20,7 @@ import torch
 from verl import DataProto
 from verl.workers.reward_manager import register
 from verl.workers.reward_manager.abstract import AbstractRewardManager, RawRewardFn
+from verl.workers.reward_manager.response_utils import select_response_ids_for_reward
 
 
 @register("batch")
@@ -50,12 +51,15 @@ class BatchRewardManager(AbstractRewardManager):
         attention_mask = data.batch["attention_mask"]
 
         prompt_len = prompt_ids.shape[-1]
-        valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
+        response_mask = data.batch.get("response_mask", None)
 
         responses_str = []
         for i in range(len(data)):
-            valid_len = valid_response_lengths[i]
-            valid_response_ids = response_ids[i][:valid_len]
+            valid_response_ids, _ = select_response_ids_for_reward(
+                response_ids=response_ids[i],
+                response_attention_mask=attention_mask[i, prompt_len:],
+                response_mask=response_mask[i] if response_mask is not None else None,
+            )
             response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
             responses_str.append(response_str)
 
@@ -66,6 +70,8 @@ class BatchRewardManager(AbstractRewardManager):
 
         for i in range(len(data)):
             extras[i]["rollout_reward_scores"] = rollout_reward_scores[i]
+            full_response_ids = response_ids[i][: int(attention_mask[i, prompt_len:].sum().item())]
+            extras[i]["full_response_str"] = self.tokenizer.decode(full_response_ids, skip_special_tokens=True)
 
         scores = self.compute_score(
             data_sources=data_sources,
@@ -89,6 +95,7 @@ class BatchRewardManager(AbstractRewardManager):
         prompt_len = prompt_ids.shape[-1]
         attention_mask = data.batch["attention_mask"]
         valid_response_lengths = attention_mask[:, prompt_len:].sum(dim=-1)
+        response_mask = data.batch.get("response_mask", None)
         data_sources = data.non_tensor_batch[self.reward_fn_key]
 
         scores = self.verify(data)
@@ -97,6 +104,11 @@ class BatchRewardManager(AbstractRewardManager):
 
         for i in range(len(data)):
             length = valid_response_lengths[i].item()
+            _, reward_index = select_response_ids_for_reward(
+                response_ids=data.batch["responses"][i],
+                response_attention_mask=attention_mask[i, prompt_len:],
+                response_mask=response_mask[i] if response_mask is not None else None,
+            )
             score = scores[i]
 
             if isinstance(score, dict):
@@ -107,7 +119,7 @@ class BatchRewardManager(AbstractRewardManager):
                 reward = score
 
             rewards.append(reward)
-            reward_tensor[i, length - 1] = reward
+            reward_tensor[i, reward_index] = reward
 
             data_source = data_sources[i]
             if already_printed.get(data_source, 0) < self.num_examine:

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -20,6 +20,7 @@ from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 from verl.workers.reward_manager import register
 from verl.workers.reward_manager.abstract import AbstractRewardManager
+from verl.workers.reward_manager.response_utils import select_response_ids_for_reward
 
 
 @register("dapo")
@@ -79,12 +80,19 @@ class DAPORewardManager(AbstractRewardManager):
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
-            valid_response_ids = response_ids[:valid_response_length]
+            response_attention_mask = data_item.batch["attention_mask"][prompt_length:]
+            response_mask = data_item.batch.get("response_mask", None)
+            valid_response_ids, reward_index = select_response_ids_for_reward(
+                response_ids=response_ids,
+                response_attention_mask=response_attention_mask,
+                response_mask=response_mask,
+            )
 
             # decode
             prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
             response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
+            full_response_ids = response_ids[: int(response_attention_mask.sum().item())]
+            full_response_str = self.tokenizer.decode(full_response_ids, skip_special_tokens=True)
             eos_token = self.tokenizer.eos_token
             if response_str.endswith(eos_token):
                 response_str = response_str[: -len(eos_token)]
@@ -98,6 +106,7 @@ class DAPORewardManager(AbstractRewardManager):
             rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
 
             extra_info["rollout_reward_scores"] = rollout_reward_scores
+            extra_info["full_response_str"] = full_response_str
 
             result = self.compute_score(
                 data_source=data_source,
@@ -121,6 +130,7 @@ class DAPORewardManager(AbstractRewardManager):
             if self.overlong_buffer_cfg.enable:
                 overlong_buffer_len = self.overlong_buffer_cfg.len
                 expected_len = self.max_resp_len - overlong_buffer_len
+                valid_response_length = int(response_attention_mask.sum().item())
                 exceed_len = valid_response_length - expected_len
                 overlong_penalty_factor = self.overlong_buffer_cfg.penalty_factor
                 overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
@@ -129,7 +139,7 @@ class DAPORewardManager(AbstractRewardManager):
                     reward_extra_info["overlong_reward"].append(overlong_reward)
                     reward_extra_info["overlong"].append(overlong_reward < 0)
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            reward_tensor[i, reward_index] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -21,6 +21,7 @@ from verl import DataProto
 from verl.utils.reward_score import default_compute_score
 from verl.workers.reward_manager import register
 from verl.workers.reward_manager.abstract import AbstractRewardManager
+from verl.workers.reward_manager.response_utils import select_response_ids_for_reward
 
 
 @register("naive")
@@ -67,12 +68,19 @@ class NaiveRewardManager(AbstractRewardManager):
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
-            valid_response_ids = response_ids[:valid_response_length]
+            response_attention_mask = data_item.batch["attention_mask"][prompt_length:]
+            response_mask = data_item.batch.get("response_mask", None)
+            valid_response_ids, reward_index = select_response_ids_for_reward(
+                response_ids=response_ids,
+                response_attention_mask=response_attention_mask,
+                response_mask=response_mask,
+            )
 
             # decode
             prompt_str = self.tokenizer.decode(valid_prompt_ids, skip_special_tokens=True)
             response_str = self.tokenizer.decode(valid_response_ids, skip_special_tokens=True)
+            full_response_ids = response_ids[: int(response_attention_mask.sum().item())]
+            full_response_str = self.tokenizer.decode(full_response_ids, skip_special_tokens=True)
 
             ground_truth = data_item.non_tensor_batch["reward_model"]["ground_truth"]
             data_source = data_item.non_tensor_batch[self.reward_fn_key]
@@ -81,6 +89,7 @@ class NaiveRewardManager(AbstractRewardManager):
             rollout_reward_scores = data_item.non_tensor_batch.get("reward_scores", {})
             extra_info["num_turns"] = num_turns
             extra_info["rollout_reward_scores"] = rollout_reward_scores
+            extra_info["full_response_str"] = full_response_str
 
             score = self.compute_score(
                 data_source=data_source,
@@ -97,7 +106,7 @@ class NaiveRewardManager(AbstractRewardManager):
             else:
                 reward = score
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            reward_tensor[i, reward_index] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/response_utils.py
+++ b/verl/workers/reward_manager/response_utils.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def select_response_ids_for_reward(
+    response_ids: torch.Tensor,
+    response_attention_mask: torch.Tensor,
+    response_mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, int]:
+    """Select model-generated response ids and the token index that should receive reward."""
+    valid_response_length = int(response_attention_mask.sum().item())
+    valid_response_ids = response_ids[:valid_response_length]
+    reward_index = max(valid_response_length - 1, 0)
+
+    if response_mask is None:
+        return valid_response_ids, reward_index
+
+    valid_model_mask = response_mask[:valid_response_length].bool()
+    if not torch.any(valid_model_mask):
+        return valid_response_ids, reward_index
+
+    valid_response_ids = valid_response_ids[valid_model_mask]
+    reward_index = int(valid_model_mask.nonzero(as_tuple=False)[-1].item())
+    return valid_response_ids, reward_index

--- a/verl/workers/reward_manager/response_utils.py
+++ b/verl/workers/reward_manager/response_utils.py
@@ -30,7 +30,7 @@ def select_response_ids_for_reward(
 
     valid_model_mask = response_mask[:valid_response_length].bool()
     if not torch.any(valid_model_mask):
-        return valid_response_ids, reward_index
+        return response_ids[:0], 0
 
     valid_response_ids = valid_response_ids[valid_model_mask]
     reward_index = int(valid_model_mask.nonzero(as_tuple=False)[-1].item())


### PR DESCRIPTION
### What does this PR do?

This PR fixes a quiet reward false-positive bug in multi-turn/tool rollout.

Default reward managers such as `naive`, `dapo`, and `batch` decode the response
with `attention_mask`. In agent/tool rollout, `attention_mask` marks both
model-generated tokens and tool observation tokens as present, while
`response_mask` marks only policy-generated tokens. A reward function can
therefore see tool output as if it were assistant output.

Concrete trigger:

```text
prompts:        [prompt]
responses:      [assistant, final, TOOL_LEAK, pad]
attention_mask: [prompt=1, assistant=1, final=1, TOOL_LEAK=1, pad=0]
response_mask:  [assistant=1, final=1, TOOL_LEAK=0, pad=0]
```

Before this fix, default reward scoring can pass this `solution_str` to the
reward function:

```text
assistant final TOOL_LEAK
```

That is wrong for policy reward: `TOOL_LEAK` is a tool observation and is not
optimized by the policy loss. For example, if a verifier/tool observation
contains the final answer, the model can receive positive reward for text it did
not generate.

After this fix, default reward managers pass only model-generated response
tokens to `solution_str`:

```text
assistant final
```

They also place the scalar reward on the last model-generated token instead of
the last attention-valid tool token. The full decoded trajectory remains
available as `extra_info["full_response_str"]` for custom reward functions that
intentionally need tool context.

### Root Cause

Default reward managers used `attention_mask[:, prompt_len:]` to decide which
response tokens to decode and where to place scalar reward.

In single-turn rollout this is fine because attention-valid response tokens are
model tokens. In multi-turn/tool rollout, tool observations are also
attention-valid. The correct mask for policy reward text and reward placement is
`response_mask` when it is present.

### Fix

This PR adds `select_response_ids_for_reward()` and uses it in the default
reward managers.

- If `response_mask` is absent, keep the existing attention-mask behavior.
- If `response_mask` is present, decode `solution_str` from model-generated
  response tokens only.
- Place scalar reward on the last model-generated token.
- Preserve the full attention-valid decoded response in
  `extra_info["full_response_str"]`.

### Duplicate Check

I checked upstream PRs and issues before preparing this patch, following
`AGENTS.md`.

- PR query: `reward manager response_mask tool observations solution_str`
  - Link: https://github.com/verl-project/verl/pulls?q=is%3Apr+reward+manager+response_mask+tool+observations+solution_str
  - Result: no matching upstream PR.
- PR query: `tool observation reward manager response_mask`
  - Link: https://github.com/verl-project/verl/pulls?q=is%3Apr+tool+observation+reward+manager+response_mask
  - Result: returned unrelated feature work such as #4897, but no PR that fixes
    default reward managers decoding `solution_str` from tool observations.
- PR query: `reward manager tool response response_mask`
  - Link: https://github.com/verl-project/verl/pulls?q=is%3Apr+reward+manager+tool+response+response_mask
  - Result: returned broader multi-turn/agent-loop PRs such as #5506, #5951,
    #5503, #4897, #4096, #4176, #2113, and #1037. These are not duplicates:
    none patches `naive`, `dapo`, or `batch` reward managers to use
    `response_mask` for `solution_str` and reward placement.
- Issue query: `tool observations reward manager response_mask`
  - Link: https://github.com/verl-project/verl/issues?q=is%3Aissue+tool+observations+reward+manager+response_mask
  - Result: no exact open issue for default reward managers scoring tool
    observations as assistant output.

Related but not duplicate:

- Issue #4814 asks how custom reward functions can access the full rollout. This
  PR does not remove access to full rollout text; it keeps that text in
  `extra_info["full_response_str"]`. The fix only changes the default
  policy-reward `solution_str` so it no longer treats `response_mask=0` tool
  observations as model output.

### Validation Recipe

```json
{
  "kind": "rl_sentinel_validation_recipe",
  "schema_version": 1,
  "bug_id": "BUG-42F0E8A5C9D1",
  "title": "Default reward managers score tool observations as model output",
  "target": "verl",
  "validation_mode": "real_target_boundary_hook",
  "target_boundaries": [
    "verl.workers.reward_manager.naive.NaiveRewardManager.__call__"
  ],
  "requires_model_download": false,
  "requires_dataset_download": false,
  "environment": {
    "VERL_REPO": "path to the veRL checkout under test",
    "OUTPUT_DIR": "directory where validation JSON should be written",
    "EXPECTATION": "confirmed for unpatched, not_triggered for fixed",
    "PYTHON": "python3"
  },
  "constructed_scenario": {
    "reward_manager": "naive",
    "prompt_ids": [1],
    "response_ids": [10, 11, 99, 0],
    "decoded_response_ids": {
      "10": "assistant",
      "11": "final",
      "99": "TOOL_LEAK",
      "0": "<pad>"
    },
    "attention_mask": [1, 1, 1, 1, 0],
    "response_mask": [1, 1, 0, 0],
    "reward_function": "returns -1.0 if TOOL_LEAK is present in solution_str, else 1.0"
  },
  "expected_unpatched": {
    "status": "confirmed",
    "solution_str": "assistant final TOOL_LEAK",
    "reward_tensor": [[0.0, 0.0, -1.0, 0.0]]
  },
  "expected_fixed": {
    "status": "not_triggered",
    "solution_str": "assistant final",
    "full_response_str": "assistant final TOOL_LEAK",
    "reward_tensor": [[0.0, 1.0, 0.0, 0.0]]
  },
  "outputs": {
    "validation": "training_signal_validation.json"
  }
}
```

### Validation Runner

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${VERL_REPO:?Set VERL_REPO to the veRL checkout under test}"
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
OUTPUT_DIR="${OUTPUT_DIR:-${SCRIPT_DIR}/output}"
PYTHON="${PYTHON:-python3}"
EXPECTATION="${EXPECTATION:-any}"

mkdir -p "${OUTPUT_DIR}"

export VERL_REPO OUTPUT_DIR EXPECTATION
export PYTHONPATH="${VERL_REPO}${PYTHONPATH:+:${PYTHONPATH}}"

"${PYTHON}" "${SCRIPT_DIR}/reward_manager_tool_observation_hook.py"
```

Run against unpatched and fixed checkouts:

```bash
VERL_REPO=/path/to/unpatched-verl \
OUTPUT_DIR=./BUG-42F0E8A5C9D1-unpatched \
EXPECTATION=confirmed \
./run_validation.sh

VERL_REPO=/path/to/fixed-verl \
OUTPUT_DIR=./BUG-42F0E8A5C9D1-fixed \
EXPECTATION=not_triggered \
./run_validation.sh
```

### Boundary Hook

```python
from __future__ import annotations

import json
import os
import subprocess
import sys
from pathlib import Path

import numpy as np
import torch


BUG_ID = "BUG-42F0E8A5C9D1"
TITLE = "Default reward managers score tool observations as model output"


class ToyTokenizer:
    def __init__(self) -> None:
        self.vocab = {
            1: "prompt",
            10: "assistant",
            11: "final",
            99: "TOOL_LEAK",
            0: "<pad>",
        }

    def decode(self, token_ids, skip_special_tokens=True):
        ids = token_ids.tolist() if hasattr(token_ids, "tolist") else list(token_ids)
        pieces = [self.vocab[int(token_id)] for token_id in ids]
        if skip_special_tokens:
            pieces = [piece for piece in pieces if piece != "<pad>"]
        return " ".join(pieces)


def _git_commit(repo: Path) -> str | None:
    try:
        return subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
    except Exception:
        return None


def _tolist(tensor: torch.Tensor) -> list:
    return tensor.detach().cpu().tolist()


def _write_json(path: Path, payload: dict) -> None:
    path.parent.mkdir(parents=True, exist_ok=True)
    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")


def main() -> None:
    repo = Path(os.environ["VERL_REPO"]).resolve()
    output_dir = Path(os.environ["OUTPUT_DIR"]).resolve()
    expectation = os.environ.get("EXPECTATION", "any")

    if str(repo) not in sys.path:
        sys.path.insert(0, str(repo))

    from verl import DataProto
    from verl.workers.reward_manager.naive import NaiveRewardManager

    captured = {}

    def compute_score(data_source, solution_str, ground_truth, extra_info):
        captured["data_source"] = data_source
        captured["solution_str"] = solution_str
        captured["ground_truth"] = ground_truth
        captured["extra_info"] = dict(extra_info)
        return -1.0 if "TOOL_LEAK" in solution_str else 1.0

    data = DataProto.from_dict(
        tensors={
            "prompts": torch.tensor([[1]], dtype=torch.long),
            "responses": torch.tensor([[10, 11, 99, 0]], dtype=torch.long),
            "attention_mask": torch.tensor([[1, 1, 1, 1, 0]], dtype=torch.long),
            "response_mask": torch.tensor([[1, 1, 0, 0]], dtype=torch.long),
        },
        non_tensors={
            "data_source": np.array(["tool_task"], dtype=object),
            "reward_model": np.array([{"ground_truth": "final"}], dtype=object),
            "extra_info": np.array([{}], dtype=object),
        },
    )

    manager = NaiveRewardManager(tokenizer=ToyTokenizer(), num_examine=0, compute_score=compute_score)
    reward_tensor = manager(data)

    solution_str = captured.get("solution_str")
    full_response_str = captured.get("extra_info", {}).get("full_response_str")
    reward = _tolist(reward_tensor)

    if solution_str == "assistant final TOOL_LEAK" and reward == [[0.0, 0.0, -1.0, 0.0]]:
        status = "confirmed"
        finding = "default reward manager scored a response_mask=0 tool observation as model output"
    elif solution_str == "assistant final" and full_response_str == "assistant final TOOL_LEAK" and reward == [
        [0.0, 1.0, 0.0, 0.0]
    ]:
        status = "not_triggered"
        finding = "default reward manager used response_mask for reward text and reward placement"
    else:
        status = "unexpected"
        finding = "reward manager produced an unrecognized response/reward shape"

    payload = {
        "kind": "rl_sentinel_training_signal_validation",
        "bug_id": BUG_ID,
        "title": TITLE,
        "status": status,
        "finding": finding,
        "commit": _git_commit(repo),
        "target_boundaries": [
            "verl.workers.reward_manager.naive.NaiveRewardManager.__call__",
        ],
        "scenario": {
            "prompt_ids": [[1]],
            "response_ids": [[10, 11, 99, 0]],
            "attention_mask": [[1, 1, 1, 1, 0]],
            "response_mask": [[1, 1, 0, 0]],
            "token_text": {
                "1": "prompt",
                "10": "assistant",
                "11": "final",
                "99": "TOOL_LEAK",
                "0": "<pad>",
            },
            "reward_rule": "return -1.0 if TOOL_LEAK appears in solution_str, else 1.0",
        },
        "observed": {
            "solution_str": solution_str,
            "full_response_str": full_response_str,
            "reward_tensor": reward,
            "score_data_source": captured.get("data_source"),
            "score_ground_truth": captured.get("ground_truth"),
        },
    }

    output_path = output_dir / "training_signal_validation.json"
    _write_json(output_path, payload)
    print(json.dumps(payload, indent=2))

    if expectation != "any" and status != expectation:
        raise SystemExit(f"expected status {expectation!r}, got {status!r}")


if __name__ == "__main__":
    main()
```

### Validation Output

Unpatched checkout:

```json
{
  "bug_id": "BUG-42F0E8A5C9D1",
  "status": "confirmed",
  "finding": "default reward manager scored a response_mask=0 tool observation as model output",
  "observed": {
    "solution_str": "assistant final TOOL_LEAK",
    "full_response_str": null,
    "reward_tensor": [[0.0, 0.0, -1.0, 0.0]]
  }
}
```

Fixed branch:

```json
{
  "bug_id": "BUG-42F0E8A5C9D1",
  "status": "not_triggered",
  "finding": "default reward manager used response_mask for reward text and reward placement",
  "observed": {
    "solution_str": "assistant final",
    "full_response_str": "assistant final TOOL_LEAK",
    "reward_tensor": [[0.0, 1.0, 0.0, 0.0]]
  }
}
```

### Test

```bash
python3 -m pytest -q tests/workers/reward_manager/test_response_mask_on_cpu.py tests/workers/reward_manager/test_registry_on_cpu.py
python3 -m ruff check verl/workers/reward_manager/response_utils.py verl/workers/reward_manager/naive.py verl/workers/reward_manager/dapo.py verl/workers/reward_manager/batch.py tests/workers/reward_manager/test_response_mask_on_cpu.py
python3 -m ruff format --check verl/workers/reward_manager/response_utils.py verl/workers/reward_manager/naive.py verl/workers/reward_manager/dapo.py verl/workers/reward_manager/batch.py tests/workers/reward_manager/test_response_mask_on_cpu.py
```

Results:

- `8 passed, 2 warnings in 7.64s`
- `All checks passed!`
- `5 files already formatted`

### API and Usage Example

No public API or config change.

Existing default reward managers now treat `response_mask` as the policy-reward
visibility mask when it is present. Custom reward functions that need the full
tool trajectory can read `extra_info["full_response_str"]`.

### Checklist Before Starting

- [x] Read `CONTRIBUTING.md`.
- [x] Read `AGENTS.md`.
- [x] Searched upstream PRs/issues and documented duplicate-check results above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Checklist Before Submitting

- [x] Added focused CPU regression coverage for masked tool observations.
- [x] Ran focused pytest and ruff checks listed above.
- [ ] Run full `pre-commit run --all-files --show-diff-on-failure --color=always ruff` before requesting review.
- [ ] Request CI after opening the PR.
- [ ] Human submitter should review every changed line and verify the boundary-hook output.

AI assistance: OpenAI Codex was used for local investigation, validation, and patch drafting.
