### PR TITLE
[trainer] refactor: clear memory after tensordict.union

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -48,6 +48,29 @@ def test_union_tensor_dict():
         union_tensor_dict(data1, data_with_copied_obs)
 
 
+def test_union_tensor_dict_del_source():
+    obs = torch.randn(100, 10)
+
+    data1 = TensorDict({"obs": obs, "act": torch.randn(100, 3)}, batch_size=[100])
+    data2 = TensorDict({"next_obs": torch.randn(100, 10), "rew": torch.randn(100)}, batch_size=[100])
+
+    result = union_tensor_dict(data1, data2)
+
+    next_obs_orig = data2["next_obs"].clone()
+    rew_orig = data2["rew"].clone()
+
+    del data2
+
+    assert "obs" in result.keys()
+    assert "act" in result.keys()
+    assert "next_obs" in result.keys()
+    assert "rew" in result.keys()
+
+    assert torch.equal(result["next_obs"], next_obs_orig)
+    assert torch.equal(result["rew"], rew_orig)
+    assert torch.equal(data1["obs"], obs)
+
+
 def test_union_numpy_dict():
     """
     A comprehensive test suite for union_numpy_dict, covering standard use

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -599,6 +599,7 @@ class RayPPOTrainer:
                 self.checkpoint_manager.sleep_replicas()
                 batch_reward = self._compute_reward_colocate(test_output_gen_batch_padded)
                 test_output_gen_batch_padded = test_output_gen_batch_padded.union(batch_reward)
+                del batch_reward
                 # wake up rollout model
                 # replace with wake_up method once supported
                 self.checkpoint_manager.update_weights(self.global_steps)
@@ -614,6 +615,7 @@ class RayPPOTrainer:
             sample_outputs.extend(output_texts)
 
             test_batch = test_batch.union(test_output_gen_batch)
+            del test_output_gen_batch
             test_batch.meta_info["validate"] = True
 
             # Store original inputs
@@ -1437,6 +1439,7 @@ class RayPPOTrainer:
                         if self.use_rm and "rm_scores" not in gen_baseline_output.batch.keys():
                             baseline_reward = self._compute_reward_colocate(gen_baseline_output)
                             gen_baseline_output = gen_baseline_output.union(baseline_reward)
+                            del baseline_reward
 
                         reward_baseline_tensor = gen_baseline_output.batch["rm_scores"].sum(dim=-1)
                         batch.batch["reward_baselines"] = reward_baseline_tensor
@@ -1446,6 +1449,7 @@ class RayPPOTrainer:
                     # repeat to align with repeated responses in rollout
                     batch = batch.repeat(repeat_times=self.config.actor_rollout_ref.rollout.n, interleave=True)
                     batch = batch.union(gen_batch_output)
+                    del gen_batch_output
 
                     if "response_mask" not in batch.batch.keys():
                         batch.batch["response_mask"] = compute_response_mask(batch)
@@ -1470,6 +1474,7 @@ class RayPPOTrainer:
                         if self.use_rm and "rm_scores" not in batch.batch.keys():
                             batch_reward = self._compute_reward_colocate(batch)
                             batch = batch.union(batch_reward)
+                            del batch_reward
 
                         # extract reward_tensor and reward_extra_infos_dict for training
                         reward_tensor, reward_extra_infos_dict = extract_reward(batch)
@@ -1515,6 +1520,7 @@ class RayPPOTrainer:
                                     "it should not be set when using R2 mode."
                                 )
                             batch = batch.union(old_log_prob)
+                            del old_log_prob
                             if "rollout_log_probs" in batch.batch.keys():
                                 # TODO: we may want to add diff of probs too.
                                 from verl.utils.debug.metrics import calculate_debug_metrics
@@ -1528,12 +1534,15 @@ class RayPPOTrainer:
                         with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
                             ref_log_prob = self._compute_ref_log_prob(batch)
                             batch = batch.union(ref_log_prob)
+                            del ref_log_prob
+
 
                     # compute values
                     if self.use_critic:
                         with marked_timer("values", timing_raw, color="cyan"):
                             values = self._compute_values(batch)
                             batch = batch.union(values)
+                            del values
 
                     with marked_timer("adv", timing_raw, color="brown"):
                         # we combine with rule-based rm


### PR DESCRIPTION
### What does this PR do?

This PR adds explicit del statements for temporary DataProto objects immediately after they are merged into a parent batch via .union() in verl/trainer/ppo/ray_trainer.py.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Added UT

### API and Usage Example

No API or config changes.

### Design & Code Changes

When batch.union(other) is called, the resulting TensorDict references the same underlying tensors as other, but the other DataProto object itself (and its metadata) continues to hold references and occupy memory. So, deleting these temporary objects after they are no longer needed reduces memory pressure.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
