### PR TITLE
[doc] chore: Update Ascend Docker build guidance

### DIFF
--- a/docs/ascend_tutorial/get_start/dockerfile_build_guidance.rst
+++ b/docs/ascend_tutorial/get_start/dockerfile_build_guidance.rst
@@ -1,13 +1,13 @@
 Ascend Dockerfile Build Guidance
 ===================================
 
-Last updated: 05/09/2026.
+Last updated: 05/19/2026.
 
 
 镜像获取 & 公开镜像地址
---------------------
+--------------------------
 
-昇腾在 `quay.io/ascend/verl <https://quay.io/repository/ascend/verl?tab=tags&tag=latest>`_ 中托管每日构建的 A2/A3 镜像，基于上述 Dockerfile 构建。
+昇腾在 `quay.io/ascend/verl <https://quay.io/repository/ascend/verl?tab=tags&tag=latest>`_ 中托管每日构建的 A2/A3 镜像，基于下方“Dockerfile构建镜像脚本清单”中列出的 Dockerfile 构建。
 
 每日构建镜像名格式：verl-{CANN版本}-{NPU设备类型}-{操作系统版本}-{python版本}-latest
 
@@ -26,7 +26,7 @@ Atlas 800T A3
 
 
 镜像内各组件版本信息清单
-----------------
+--------------------------
 
 ================= ============
 组件               版本
@@ -49,23 +49,29 @@ sgl-kernel-npu     2026.02.01
 
 
 
+.. _ascend-dockerfile-list:
+
 Dockerfile构建镜像脚本清单
 ---------------------------
 
-============== ============== ============== ==============================================================
-设备类型         基础镜像版本     推理后端        参考文件
-============== ============== ============== ==============================================================
-A2              8.2.RC1        vLLM            `Dockerfile.ascend_8.2.rc1_a2 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.2.rc1_a2>`_
-A2              8.3.RC1        vLLM            `Dockerfile.ascend_8.3.rc1_a2 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.3.rc1_a2>`_
-A2              8.5.0          vLLM            `Dockerfile.ascend_8.5.0_a2 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a2>`_
-A2              8.3.RC1        SGLang          `Dockerfile.ascend.sglang_8.3.rc1_a2 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.3.rc1_a2>`_
-A2              8.5.0          SGLang          `Dockerfile.ascend.sglang_8.5.0_a2 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.5.0_a2>`_
-A3              8.2.RC1        vLLM            `Dockerfile.ascend_8.2.rc1_a3 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.2.rc1_a3>`_
-A3              8.3.RC1        vLLM            `Dockerfile.ascend_8.3.rc1_a3 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.3.rc1_a3>`_
-A3              8.5.0          vLLM            `Dockerfile.ascend_8.5.0_a3 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a3>`_
-A3              8.3.RC1        SGLang          `Dockerfile.ascend.sglang_8.3.rc1_a3 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.3.rc1_a3>`_
-A3              8.5.0          SGLang          `Dockerfile.ascend.sglang_8.5.0_a3 <https://github.com/volcengine/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.5.0_a3>`_
-============== ============== ============== ==============================================================
+============== ================== ============== ===========================================================================================================
+设备类型         CANN基础镜像版本      推理后端        参考文件
+============== ================== ============== ===========================================================================================================
+A2              8.5.1 + 8.5.2组件  vLLM            `Dockerfile.ascend_8.5.2_a2_qwen3-5 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.2_a2_qwen3-5>`_
+A2              8.5.0              vLLM            `Dockerfile.ascend_8.5.0_a2 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a2>`_
+A2              8.5.0              vLLM            `Dockerfile.ascend_8.5.0_a2_v0.7.1 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a2_v0.7.1>`_
+A2              8.3.RC1            vLLM            `Dockerfile.ascend_8.3.rc1_a2 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.3.rc1_a2>`_
+A2              8.2.RC1            vLLM            `Dockerfile.ascend_8.2.rc1_a2 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.2.rc1_a2>`_
+A2              8.5.0              SGLang          `Dockerfile.ascend.sglang_8.5.0_a2 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.5.0_a2>`_
+A2              8.3.RC1            SGLang          `Dockerfile.ascend.sglang_8.3.rc1_a2 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.3.rc1_a2>`_
+A3              8.5.1 + 8.5.2组件  vLLM            `Dockerfile.ascend_8.5.2_a3_qwen3-5 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.2_a3_qwen3-5>`_
+A3              8.5.0              vLLM            `Dockerfile.ascend_8.5.0_a3 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a3>`_
+A3              8.5.0              vLLM            `Dockerfile.ascend_8.5.0_a3_v0.7.1 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.5.0_a3_v0.7.1>`_
+A3              8.3.RC1            vLLM            `Dockerfile.ascend_8.3.rc1_a3 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.3.rc1_a3>`_
+A3              8.2.RC1            vLLM            `Dockerfile.ascend_8.2.rc1_a3 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend_8.2.rc1_a3>`_
+A3              8.5.0              SGLang          `Dockerfile.ascend.sglang_8.5.0_a3 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.5.0_a3>`_
+A3              8.3.RC1            SGLang          `Dockerfile.ascend.sglang_8.3.rc1_a3 <https://github.com/verl-project/verl/blob/main/docker/ascend/Dockerfile.ascend.sglang_8.3.rc1_a3>`_
+============== ================== ============== ===========================================================================================================
 
 **说明：**
 
@@ -83,23 +89,26 @@ A3              8.5.0          SGLang          `Dockerfile.ascend.sglang_8.5.0_a
 
    # Build the image
    # vLLM
-   docker build -f Dockerfile.ascend_8.3.rc1_a2 -t verl-ascend:8.3.rc1-a2 .
+   docker build -f Dockerfile.ascend_8.5.0_a2 -t verl-ascend:8.5.0-a2 .
    # SGLang
-   docker build -f Dockerfile.ascend.sglang_8.3.rc1_a2 -t verl-ascend-sglang:8.3.rc1-a2 .
+   docker build -f Dockerfile.ascend.sglang_8.5.0_a2 -t verl-ascend-sglang:8.5.0-a2 .
+
+   # Query local images after build
+   docker images
 
 **说明：**
 
-* 以VLLM的镜像为例，``Dockerfile.ascend_8.3.rc1_a2`` 为 Dockerfile 文件名，``verl-ascend:8.3.rc1-a2`` 中， verl-ascend 为自定义的镜像名称，8.3.rc1-a2 为自定义的镜像标签
+* 以 vLLM 的镜像为例，``Dockerfile.ascend_8.5.0_a2`` 为 Dockerfile 文件名，``verl-ascend:8.5.0-a2`` 中， verl-ascend 为自定义的镜像名称，8.5.0-a2 为自定义的镜像标签
 
 容器启动命令模板
---------
+----------------
 
 .. code:: bash
 
    docker run -dit \
        --ipc=host \
        --network host \
-       --name your_docker_name \
+       --name {your_docker_name} \
        --privileged \
        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
        -v /usr/local/Ascend/firmware:/usr/local/Ascend/firmware \
@@ -107,29 +116,29 @@ A3              8.5.0          SGLang          `Dockerfile.ascend.sglang_8.5.0_a
        -v /usr/sbin:/usr/sbin \
        -v /home:/home \
        -v /data:/data \
-       image_name:tag \
+       {image_name}:{tag} \
        /bin/bash
 
 **说明：**
 
 * 如需挂载其他本地路径到容器，请自行添加 ``-v <宿主机路径>:<容器内路径>``
-* 建议将 ``your_docker_name`` 替换为具有实际意义的容器名称
+* 建议将 ``{your_docker_name}`` 替换为具有实际意义的容器名称
 * ``--privileged`` 参数授予容器扩展权限，请根据实际安全需求评估是否必要
-* ``image_name:tag`` 请换成容器构建时对应的镜像名称与标签
+* ``{image_name}:{tag}`` 请换成容器构建时对应的镜像名称与标签
 
 启动容器
 --------
 
 .. code:: bash
 
-   docker start your_docker_name
+   docker start {your_docker_name}
 
 进入正在运行的容器
 ------------------
 
 .. code:: bash
 
-   docker exec -it your_docker_name bash
+   docker exec -it {your_docker_name} bash
 
 
 声明


### PR DESCRIPTION

### What does this PR do?

Closes #6369.
  This PR updates the Ascend Dockerfile build guidance to address the documentation issues reported in #6369:

  - Clarifies that the public daily Ascend images are built from the Dockerfiles listed in the Dockerfile table below.
  - Renames the ambiguous `基础镜像版本` column to `CANN基础镜像版本`.
  - Updates the Dockerfile table to cover all 14 files currently under `docker/ascend`.
  - Reorders A2/A3 Dockerfiles so newer versions are easier to find within each backend group.
  - Refreshes the build examples to use the newer 8.5.0 Dockerfiles.
  - Standardizes `vLLM` capitalization.
  - Adds `{}` markers for user-provided container/image placeholders.
  - Adds `docker images` after the build command so users can inspect locally built images.

  I also verified the two `8.5.2_qwen3-5` Dockerfiles: they start from CANN 8.5.1 base images and install 8.5.2 components, so the table documents them as `8.5.1 + 8.5.2组件` instead of presenting the base image version as pure 8.5.2.


### Checklist Before Starting

  - [x] Search for similar PRs. Paste at least one query link here:
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6369+in%3Abody
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+Ascend+Dockerfile+build+guidance
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+dockerfile_build_guidance
  - [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

 python -m docutils --halt=error --exit-status=warning docs/ascend_tutorial/get_start/dockerfile_build_guidance.rst /tmp/dockerfile_build_guidance.html

  Passed.

  pre-commit run --files docs/ascend_tutorial/get_start/dockerfile_build_guidance.rst

  Passed.

### API and Usage Example

No API changes. This is a documentation-only PR


### Design & Code Changes

This PR only changes docs/ascend_tutorial/get_start/dockerfile_build_guidance.rst.

 The documentation now matches the current docker/ascend file list and makes the build/run examples clearer for users who need to substitute their own image names, tags, and container names.



### Checklist Before Submitting

  - [x] Read the Contribute Guide (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
  - [x] Apply pre-commit checks (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always
      - Changed-file pre-commit was run and passed; full all-files pre-commit was not run.
  - [x] Add / Update the documentation (https://github.com/verl-project/verl/tree/main/docs).
  - [ ] Add unit or end-to-end test(s) to the CI workflow (https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: this is a documentation-only change, so no unit or end-to-end test is added.
  - [ ] Once your PR is ready for CI, send a message in the ci-request channel (https://verl-project.slack.com/archives/C091TCESWB1) in the verl Slack workspace (https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible,
    please try the Feishu group (飞书群) (https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
  - [ ] If your PR is related to the recipe submodule, please also update the reference to the submodule commit via git submodule update --remote or cd recipe && git pull origin main.
      - Not applicable; this PR does not touch the recipe submodule.
