### PR TITLE
[rollout, tool, cfg] feat: add per-assistant-turn cap for multi-turn agent loop

### DIFF
--- a/tests/experimental/agent_loop/test_call_tool_on_cpu.py
+++ b/tests/experimental/agent_loop/test_call_tool_on_cpu.py
@@ -234,6 +234,34 @@ class TestAssistantResponseLengthLimit(unittest.TestCase):
 
         assert loop._get_turn_sampling_params(agent_data, sampling_params) is None
 
+    def test_exhausted_budget_terminates_even_without_per_turn_cap(self):
+        """Budget check fires regardless of max_assistant_response_length setting."""
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=None)
+        sampling_params = {"temperature": 0}
+        agent_data = FakeAgentData(response_mask=[1] * 100)
+
+        assert loop._get_turn_sampling_params(agent_data, sampling_params) is None
+
+    def test_respects_existing_max_tokens_in_sampling_params(self):
+        """Should take the min of all constraints including caller-provided max_tokens."""
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=64)
+        sampling_params = {"temperature": 0, "max_tokens": 16}
+        agent_data = FakeAgentData(response_mask=[1] * 20)
+
+        turn_sampling_params = loop._get_turn_sampling_params(agent_data, sampling_params)
+
+        assert turn_sampling_params["max_tokens"] == 16
+
+    def test_no_copy_when_existing_max_tokens_is_already_most_restrictive(self):
+        """Avoid unnecessary dict copy when existing max_tokens is already the tightest."""
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=64)
+        sampling_params = {"temperature": 0, "max_tokens": 10}
+        agent_data = FakeAgentData(response_mask=[1] * 20)
+
+        turn_sampling_params = loop._get_turn_sampling_params(agent_data, sampling_params)
+
+        assert turn_sampling_params is sampling_params
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/experimental/agent_loop/test_call_tool_on_cpu.py
+++ b/tests/experimental/agent_loop/test_call_tool_on_cpu.py
@@ -39,6 +39,7 @@ class FakeAgentData:
     """Minimal AgentData for testing."""
 
     tools_kwargs: dict = field(default_factory=dict)
+    response_mask: list[int] = field(default_factory=list)
 
 
 class FakeTool:
@@ -79,6 +80,8 @@ def _make_tool_agent_loop(
     tools: dict[str, Any],
     max_tool_response_length: int = 10000,
     tool_response_truncate_side: str = "left",
+    response_length: int = 100,
+    max_assistant_response_length: int | None = None,
 ):
     """Create a minimal ToolAgentLoop instance with only the fields _call_tool needs."""
     from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
@@ -87,8 +90,11 @@ def _make_tool_agent_loop(
     mock.tools = tools
     mock.max_tool_response_length = max_tool_response_length
     mock.tool_response_truncate_side = tool_response_truncate_side
+    mock.response_length = response_length
+    mock.max_assistant_response_length = max_assistant_response_length
     # Bind the real _call_tool method to our mock
     mock._call_tool = ToolAgentLoop._call_tool.__get__(mock, ToolAgentLoop)
+    mock._get_turn_sampling_params = ToolAgentLoop._get_turn_sampling_params.__get__(mock, ToolAgentLoop)
     return mock
 
 
@@ -186,6 +192,47 @@ class TestCallToolErrorHandling(unittest.IsolatedAsyncioTestCase):
         assert response.text.startswith("Search results")
         assert response.text.endswith("...(truncated)")
         assert "Final answer: Paris" not in response.text
+
+
+class TestAssistantResponseLengthLimit(unittest.TestCase):
+    """Test per-assistant-turn generation limits without launching a rollout server."""
+
+    def test_no_config_keeps_sampling_params_unchanged(self):
+        loop = _make_tool_agent_loop({}, max_assistant_response_length=None)
+        sampling_params = {"temperature": 0}
+        agent_data = FakeAgentData(response_mask=[1] * 90)
+
+        turn_sampling_params = loop._get_turn_sampling_params(agent_data, sampling_params)
+
+        assert turn_sampling_params is sampling_params
+        assert "max_tokens" not in turn_sampling_params
+
+    def test_per_turn_limit_is_clamped_by_remaining_response_budget(self):
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=32)
+        sampling_params = {"temperature": 0}
+        agent_data = FakeAgentData(response_mask=[1] * 90)
+
+        turn_sampling_params = loop._get_turn_sampling_params(agent_data, sampling_params)
+
+        assert turn_sampling_params is not sampling_params
+        assert turn_sampling_params["max_tokens"] == 10
+        assert "max_tokens" not in sampling_params
+
+    def test_per_turn_limit_is_used_when_budget_is_larger(self):
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=32)
+        sampling_params = {"temperature": 0}
+        agent_data = FakeAgentData(response_mask=[1] * 20)
+
+        turn_sampling_params = loop._get_turn_sampling_params(agent_data, sampling_params)
+
+        assert turn_sampling_params["max_tokens"] == 32
+
+    def test_exhausted_response_budget_stops_before_generation(self):
+        loop = _make_tool_agent_loop({}, response_length=100, max_assistant_response_length=32)
+        sampling_params = {"temperature": 0}
+        agent_data = FakeAgentData(response_mask=[1] * 100)
+
+        assert loop._get_turn_sampling_params(agent_data, sampling_params) is None
 
 
 if __name__ == "__main__":

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -283,16 +283,25 @@ class ToolAgentLoop(AgentLoopBase):
     def _get_turn_sampling_params(
         self, agent_data: AgentData, sampling_params: dict[str, Any]
     ) -> Optional[dict[str, Any]]:
-        max_assistant_response_length = self.max_assistant_response_length
-        if max_assistant_response_length is None:
-            return sampling_params
-
-        remaining_response_length = self.response_length - len(agent_data.response_mask)
-        if remaining_response_length <= 0:
+        remaining = self.response_length - len(agent_data.response_mask)
+        if remaining <= 0:
             return None
 
+        max_turn = self.max_assistant_response_length
+        if max_turn is None and "max_tokens" not in sampling_params:
+            return sampling_params
+
+        effective = remaining
+        if max_turn is not None:
+            effective = min(effective, max_turn)
+        if "max_tokens" in sampling_params:
+            effective = min(effective, sampling_params["max_tokens"])
+
+        if sampling_params.get("max_tokens") == effective:
+            return sampling_params
+
         turn_sampling_params = dict(sampling_params)
-        turn_sampling_params["max_tokens"] = min(max_assistant_response_length, remaining_response_length)
+        turn_sampling_params["max_tokens"] = effective
         return turn_sampling_params
 
     async def _handle_processing_tools_state(self, agent_data: AgentData) -> AgentState:

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -102,6 +102,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         self.max_user_turns = self.rollout_config.multi_turn.max_user_turns
         self.max_assistant_turns = self.rollout_config.multi_turn.max_assistant_turns
+        self.max_assistant_response_length = self.rollout_config.multi_turn.max_assistant_response_length
         self.max_parallel_calls = self.rollout_config.multi_turn.max_parallel_calls
         self.max_tool_response_length = self.rollout_config.multi_turn.max_tool_response_length
         self.tool_response_truncate_side = self.rollout_config.multi_turn.tool_response_truncate_side
@@ -222,11 +223,15 @@ class ToolAgentLoop(AgentLoopBase):
             stop_token_ids = list(set((sampling_params.get("stop_token_ids") or []) + self.tool_parser.stop_token_ids))
             sampling_params = {**sampling_params, "stop_token_ids": stop_token_ids}
 
+        turn_sampling_params = self._get_turn_sampling_params(agent_data, sampling_params)
+        if turn_sampling_params is None:
+            return AgentState.TERMINATED
+
         with simple_timer("generate_sequences", agent_data.metrics):
             output: TokenOutput = await self.server_manager.generate(
                 request_id=agent_data.request_id,
                 prompt_ids=agent_data.prompt_ids,
-                sampling_params=sampling_params,
+                sampling_params=turn_sampling_params,
                 image_data=agent_data.image_data,
                 video_data=agent_data.video_data,
                 audio_data=agent_data.audio_data,
@@ -274,6 +279,21 @@ class ToolAgentLoop(AgentLoopBase):
             return AgentState.PROCESSING_TOOLS
         else:
             return AgentState.TERMINATED
+
+    def _get_turn_sampling_params(
+        self, agent_data: AgentData, sampling_params: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
+        max_assistant_response_length = self.max_assistant_response_length
+        if max_assistant_response_length is None:
+            return sampling_params
+
+        remaining_response_length = self.response_length - len(agent_data.response_mask)
+        if remaining_response_length <= 0:
+            return None
+
+        turn_sampling_params = dict(sampling_params)
+        turn_sampling_params["max_tokens"] = min(max_assistant_response_length, remaining_response_length)
+        return turn_sampling_params
 
     async def _handle_processing_tools_state(self, agent_data: AgentData) -> AgentState:
         """Handle the processing tools state: execute tool calls and prepare tool responses."""

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -316,6 +316,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
       max_assistant_turns: null
+      max_assistant_response_length: null
       tool_config_path: null
       function_tool_path: null
       max_user_turns: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -281,6 +281,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
       max_assistant_turns: null
+      max_assistant_response_length: null
       tool_config_path: null
       function_tool_path: null
       max_user_turns: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -288,6 +288,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
       max_assistant_turns: null
+      max_assistant_response_length: null
       tool_config_path: null
       function_tool_path: null
       max_user_turns: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -270,6 +270,7 @@ actor_rollout_ref:
       _target_: verl.workers.config.MultiTurnConfig
       enable: false
       max_assistant_turns: null
+      max_assistant_response_length: null
       tool_config_path: null
       function_tool_path: null
       max_user_turns: null

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -173,6 +173,10 @@ multi_turn:
   # null for no limit (default max_length // 3)
   max_assistant_turns: null
 
+  # null for no per-assistant-turn limit; otherwise caps each assistant generation
+  # while preserving response_length as the full trajectory budget.
+  max_assistant_response_length: null
+
   # YAML config for stateful tools that subclass ``BaseTool``.
   # Use this when a tool needs per-trajectory state, async ``create``/``release``
   # lifecycle hooks, or custom rewards.

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -68,6 +68,7 @@ class MultiTurnConfig(BaseConfig):
 
     enable: bool = False
     max_assistant_turns: Optional[int] = None
+    max_assistant_response_length: Optional[int] = None
     tool_config_path: Optional[str] = None
     function_tool_path: Optional[str] = None
     max_user_turns: Optional[int] = None
@@ -78,6 +79,10 @@ class MultiTurnConfig(BaseConfig):
     tokenization_sanity_check_mode: str = "strict"
     format: str = "hermes"
     num_repeat_rollouts: Optional[int] = None
+
+    def __post_init__(self):
+        if self.max_assistant_response_length is not None and self.max_assistant_response_length <= 0:
+            raise ValueError("`max_assistant_response_length` must be a positive integer or null.")
 
 
 @dataclass


### PR DESCRIPTION
### What does this PR do?

Adds `max_assistant_response_length` config to cap each assistant generation turn in multi-turn agent loops. This solves two problems:

1. **Single-turn budget exhaustion**: Without a per-turn limit, the rollout engine defaults `max_tokens` to the full `response_length` for the first turn. If the model doesn't emit EOS (e.g., repetitive output, malformed tool-call syntax), it generates up to the entire trajectory budget in one turn, leaving nothing for subsequent tool-call rounds.

2. **Long single-turn latency**: Even when the model eventually stops, consuming thousands of tokens in one turn causes unnecessarily long inference latency for that turn, delaying the entire agent loop.

The existing `response_length` check (line 261 in `tool_agent_loop.py`) only detects budget exhaustion **after** generation completes — it cannot prevent the engine from spending all tokens in a single request. `max_assistant_response_length` applies the cap **before** each generation call, giving the agent loop finer-grained control.

Effective `max_tokens` per turn = `min(max_assistant_response_length, remaining_budget, existing_max_tokens)`. When remaining budget ≤ 0, generation terminates immediately without issuing a request — this check fires regardless of whether `max_assistant_response_length` is configured.

### Checklist Before Starting

- [x] Search for similar PRs:
  - `gh pr list --repo verl-project/verl --state open --search "max_assistant_response_length"` → 0 results
  - `gh pr list --repo verl-project/verl --state open --search "per-turn token"` → 0 results
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
python -m pytest tests/experimental/agent_loop/test_call_tool_on_cpu.py -v
# 15 passed (7 new tests for this feature)
```

New test class `TestAssistantResponseLengthLimit` covers:
- `test_no_config_keeps_sampling_params_unchanged` — `null` config + no existing `max_tokens` = no-op
- `test_per_turn_limit_is_clamped_by_remaining_response_budget` — uses remaining budget when smaller than cap
- `test_per_turn_limit_is_used_when_budget_is_larger` — uses per-turn cap when budget allows
- `test_exhausted_response_budget_stops_before_generation` — returns `None` to terminate when budget = 0
- `test_exhausted_budget_terminates_even_without_per_turn_cap` — budget check fires regardless of config
- `test_respects_existing_max_tokens_in_sampling_params` — takes min of all constraints
- `test_no_copy_when_existing_max_tokens_is_already_most_restrictive` — avoids unnecessary dict copy

### API and Usage Example

```yaml
actor_rollout_ref:
  rollout:
    multi_turn:
      max_assistant_response_length: 256  # cap each assistant turn to 256 tokens
      # response_length remains the full trajectory budget (e.g. 2048)
```

| Value | Behavior |
|-------|----------|
| `null` (default) | No per-turn limit, backward compatible (budget check still applies) |
| Positive integer | Each generation request uses `min(cap, remaining_budget, existing_max_tokens)` |
| Budget exhausted | Terminates immediately without issuing a generation request |

### Design & Code Changes

1. **Config** (`verl/workers/config/rollout.py`):
   - Added `max_assistant_response_length: Optional[int]` to `MultiTurnConfig`
   - Added `__post_init__` validation: must be positive integer or `null`

2. **YAML** (`verl/trainer/config/rollout/rollout.yaml` + 4 generated configs):
   - Added `max_assistant_response_length: null` with documentation comment

3. **Core logic** (`verl/experimental/agent_loop/tool_agent_loop.py`):
   - New method `_get_turn_sampling_params()`:
     - Always checks remaining budget first (terminates if ≤ 0)
     - Computes `effective = min(remaining, per_turn_cap, existing_max_tokens)`
     - Returns original dict unchanged when no modification needed
   - Called at the top of `_handle_generating_state`; returns `None` → terminate

4. **Tests** (`tests/experimental/agent_loop/test_call_tool_on_cpu.py`):
   - Extended `FakeAgentData` with `response_mask` field
   - Extended `_make_tool_agent_loop` helper with new params
   - 7 new unit tests covering all branches

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks: all passed (`check-naming-conventions` skipped — false positive from `.venv/ray` package, not reproducible in CI).
- [ ] Add / Update the documentation.
- [x] Add unit tests to cover all the code.
- [ ] Once PR is ready for CI, send a message in the `ci-request` channel.

---

> AI assistance (Claude) was used for code review and PR description drafting. All changes reviewed and tested by the submitter.