### PR TITLE
[tool] feat: add Gemma4 tool parser with stop token and response formatting

### DIFF
--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -204,6 +204,11 @@ class ToolAgentLoop(AgentLoopBase):
         self, agent_data: AgentData, sampling_params: dict[str, Any], ignore_termination: bool = False
     ) -> AgentState:
         """Handle the generating state: generate model response and check for tool calls."""
+        # Inject tool parser stop tokens so generation halts after each tool call
+        if self.tool_parser.stop_token_ids:
+            stop_token_ids = list(set((sampling_params.get("stop_token_ids") or []) + self.tool_parser.stop_token_ids))
+            sampling_params = {**sampling_params, "stop_token_ids": stop_token_ids}
+
         with simple_timer("generate_sequences", agent_data.metrics):
             output: TokenOutput = await self.server_manager.generate(
                 request_id=agent_data.request_id,
@@ -324,6 +329,22 @@ class ToolAgentLoop(AgentLoopBase):
         if self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")
             tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
+            response_ids = await self.loop.run_in_executor(
+                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
+            )
+        elif self.tool_parser_name == "gemma4":
+            # Gemma4's chat template drops tool responses when passed without the preceding
+            # assistant tool_call message. Manually format the response tokens.
+            # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
+            parts = []
+            for msg, name in zip(add_messages, tool_call_names, strict=True):
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
+                if isinstance(content, list):
+                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
+                parts.append(f'<|tool_response>response:{name}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+            tool_response_text = "".join(parts)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -47,6 +47,18 @@ class ToolParser(ABC):
     def __init__(self, tokenizer) -> None:
         self.tokenizer = tokenizer
 
+    @property
+    def stop_token_ids(self) -> list[int]:
+        """Token IDs that should stop generation so the parser can run.
+
+        Models like Qwen3 naturally emit EOS after a tool call, so no extra stop
+        tokens are needed. Models like Gemma4 emit <tool_call|> but continue
+        generating without EOS — they need the closing token as an explicit stop.
+
+        Returns empty list by default (rely on model's EOS behavior).
+        """
+        return []
+
     @abstractmethod
     async def extract_tool_calls(
         self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
@@ -339,3 +351,80 @@ class Qwen3XMLToolParser(ToolParser):
         except Exception as e:
             logger.exception(f"Error in extracting tool call from response: {e}")
             return text, []
+
+
+@ToolParser.register("gemma4")
+class Gemma4ToolParser(ToolParser):
+    """Tool parser for Google Gemma 4 models.
+
+    Format: <|tool_call>call:func_name{key:<|"|>str_val<|"|>,key2:num_val}<tool_call|>
+
+    Reference: https://ai.google.dev/gemma/docs/capabilities/text/function-calling-gemma4
+    """
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<|tool_call>"
+        self.tool_call_end_token = "<tool_call|>"
+        self._stop_token_id = tokenizer.convert_tokens_to_ids("<tool_call|>")
+        self.tool_call_regex = regex.compile(r"<\|tool_call>call:(\w+)\{(.*?)\}<tool_call\|>", regex.DOTALL)
+        self.arg_regex = regex.compile(r'(\w+):(?:<\|"\|>(.*?)<\|"\|>|([^,}]*))')
+
+    @property
+    def stop_token_ids(self) -> list[int]:
+        """Gemma4 doesn't emit EOS after <tool_call|> — it continues generating.
+        Stop on <tool_call|> so the agent loop can execute the tool between calls."""
+        return [self._stop_token_id]
+
+    def _parse_arguments(self, args_str: str) -> dict:
+        result = {}
+        for match in self.arg_regex.finditer(args_str):
+            key = match.group(1)
+            str_val, bare_val = match.group(2), match.group(3)
+            if str_val is not None:
+                result[key] = str_val
+            elif bare_val is not None:
+                bare_val = bare_val.strip()
+                if bare_val.lower() == "true":
+                    result[key] = True
+                elif bare_val.lower() == "false":
+                    result[key] = False
+                elif bare_val.lower() == "null":
+                    result[key] = None
+                else:
+                    try:
+                        result[key] = int(bare_val)
+                    except ValueError:
+                        try:
+                            result[key] = float(bare_val)
+                        except ValueError:
+                            result[key] = bare_val
+        return result
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        loop = get_event_loop()
+        text = await loop.run_in_executor(None, lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False))
+        if self.tokenizer.pad_token:
+            text = text.replace(self.tokenizer.pad_token, "")
+
+        if self.tool_call_start_token not in text:
+            return text, []
+
+        matches = self.tool_call_regex.findall(text)
+        if not matches:
+            return text, []
+
+        function_calls = []
+        for name, args_str in matches:
+            try:
+                arguments = self._parse_arguments(args_str)
+                function_calls.append(FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False)))
+            except Exception as e:
+                logger.error(f"Failed to parse Gemma4 tool call: {e}")
+
+        content_idx = text.find(self.tool_call_start_token)
+        content = text[:content_idx] if content_idx >= 0 else text
+        return content, function_calls


### PR DESCRIPTION
### What does this PR do?


  Adds Gemma4 support to the multi-turn agent loop for tool calling. Gemma4 has two differences from existing models (Qwen, GPT-OSS) that prevent tool calling from working:

  1. **No EOS after tool calls** — Gemma4 generates `<|tool_call>call:func{args}<tool_call|>` then immediately continues generating. Without an explicit stop token, vLLM never stops and the model generates all tool
  calls in one turn, hallucinating responses.

  2. **Tool response format requires function name** — Gemma4's chat template needs `<|tool_response>response:FUNC_NAME{value:"content"}<tool_response|>`. The standard `apply_chat_template({"role": "tool"})` path
  silently drops the content because it lacks the function name context.

  ## Changes

  ### `verl/experimental/agent_loop/tool_parser.py`
  - Add `stop_token_ids` property to `ToolParser` base class (returns `[]` by default)
  - Add `Gemma4ToolParser` class with `stop_token_ids=[49]` (`<tool_call|>` token)
  - Parse Gemma4's tool call format: `<|tool_call>call:func{args}<tool_call|>`

  ### `verl/experimental/agent_loop/tool_agent_loop.py`
  - Inject `stop_token_ids` from tool parser into `sampling_params` before generation
  - Add Gemma4 special case for tool response formatting (same pattern as existing `gpt-oss` case)

  ## Config

  ```yaml
  actor_rollout_ref:
    rollout:
      multi_turn:
        format: gemma4  # Selects Gemma4ToolParser

```

 Tested with Gemma4-26B-A4B on multi-turn tool dataset


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+gemma4+tool+parser
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

No stop token, no response fix - 0%
Stop token only - 13.6%
Stop token + response formatting - 59.2%


### Design & Code Changes

  Follows the same pattern as the existing `gpt-oss` tool parser implementation:
  - `Gemma4ToolParser` in `tool_parser.py` — parses Gemma4's special-token tool call format
  - Response injection in `tool_agent_loop.py` — manual formatting when `apply_chat_template` can't handle the model's response format

  One addition to the base class: `stop_token_ids` property on `ToolParser` (returns `[]` by default). This is needed because Gemma4 doesn't emit EOS after tool calls — unlike Qwen/GPT-OSS which do. The agent loop
  injects these into `sampling_params` before generation.


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Not feasible to add CI test — requires Gemma4 model weights and multi-turn environment. Tested end-to-end on 8×H200 with full training pipeline (FSDP2 + vLLM async rollout).
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
