### PR TITLE
[BREAKING][worker, ckpt] refactor: rename ActorRolloutRefWorker.update_weights to actor_weights_to_rollout

### DIFF
--- a/tests/checkpoint_engine/test_utils.py
+++ b/tests/checkpoint_engine/test_utils.py
@@ -40,7 +40,7 @@ class TrainingWorkerTest(TrainingWorker):
         self.checkpoint_engine = CheckpointEngineRegistry.new(backend, bucket_size=bucket_size, **engine_kwargs)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
-    async def update_weights(self, global_steps: int = None, mode: str = "auto"):
+    async def actor_weights_to_rollout(self, global_steps: int = None, mode: str = "auto"):
         per_tensor_param, _ = self.engine.get_per_tensor_param()
         await self.checkpoint_engine.send_weights(per_tensor_param)
 

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -454,7 +454,7 @@ class CheckpointEngineManager:
 
         # 0. update weights for sync training with colocated trainer and rollout
         if self.backend == "naive":
-            ray.get(self.trainer.update_weights(global_steps=global_steps, mode=self.backend))
+            ray.get(self.trainer.actor_weights_to_rollout(global_steps=global_steps, mode=self.backend))
             return
 
         # 1. abort and save all unfinished requests for partial rollout
@@ -475,7 +475,7 @@ class CheckpointEngineManager:
 
         # 5. update weights of all workers
         ray.get(
-            trainer.update_weights(global_steps=global_steps, mode=self.backend)
+            trainer.actor_weights_to_rollout(global_steps=global_steps, mode=self.backend)
             + rollout.update_weights(global_steps=global_steps)
         )
 

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -656,12 +656,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self.actor.save_checkpoint(local_path, hdfs_path, global_step, max_ckpt_to_keep)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
-    async def update_weights(self, global_steps: int = None, mode: str = "auto"):
+    async def actor_weights_to_rollout(self, global_steps: int = None, mode: str = "auto"):
         """Update weights from trainer to rollout.
 
         1. For sync training with colocated trainer and rollout, update rollout directly from model engine.
-           - before update_weights: rollout should be in sleep mode.
-           - after update_weights: rollout should be in wake_up mode.
+           - before actor_weights_to_rollout: rollout should be in sleep mode.
+           - after actor_weights_to_rollout: rollout should be in wake_up mode.
         2. For async training with disaggregated trainer and rollout, send_weights only by checkpoint engine.
 
         LoRA handling: when model.lora.merge=True (peft_merge), LoRA is merged into
@@ -722,7 +722,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             per_tensor_param, peft_config=peft_config, base_sync_done=True, global_steps=global_steps
         )
 
-        log_gpu_memory_usage("After update_weights", logger=logger)
+        log_gpu_memory_usage("After actor_weights_to_rollout", logger=logger)
 
         # 3. offload model to cpu
         if self.actor.engine.is_param_offload_enabled:

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -184,7 +184,7 @@ class ServerAdapter(BaseRollout):
         # sleep_level controls what gets released during sleep/release:
         #   2 (default) = release weights + kv_cache (full sleep, merge path)
         #   1 = release kv_cache only (keep base weights, adapter path)
-        # Set by engine_workers.update_weights() when lora.merge=False.
+        # Set by engine_workers.actor_weights_to_rollout() when lora.merge=False.
         self.sleep_level = 2
 
     async def _init_server_adapter(self):


### PR DESCRIPTION
### What does this PR do?

Rename `ActorRolloutRefWorker.update_weights` to `actor_weights_to_rollout` to remove the
name collision with the rollout-side `update_weights` (e.g. `SGLangRollout.update_weights`,
`VLLMRollout.update_weights`, `TRTLLMRollout.update_weights`) and with the higher-level
`CheckpointManager.update_weights` wrapper.

Before this PR there were three same-named methods sitting on adjacent layers, only
distinguishable by argument signature (`mode=...` on the trainer side, `weights=...` on
the rollout side). That made stack traces, grep-driven navigation, and code review
needlessly ambiguous — especially in `checkpoint_engine/base.py:478-479` where
`trainer.update_weights(...)` and `rollout.update_weights(...)` are called on the same
line. The new name makes the direction of the weight flow explicit (actor → rollout).

No behavior change: pure rename + callers + docstrings/comments.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+update_weights+rename
  (no open PR proposes the same rename; this PR does not duplicate other in-flight work)
- [x] Format the PR title as `[{modules}] {type}: {description}`
- [x] `[BREAKING]` prefix added — the renamed method is decorated with
      `@register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)` and is therefore part
      of the trainer-side RPC surface; downstream checkpoint-engine integrations that
      call `trainer.update_weights(global_steps=..., mode=...)` must be updated.

### Test

CI-only refactor; no algorithmic change to verify. Validated by:

1. Static check that all in-tree call sites of the trainer-side method are migrated:
