### PR TITLE
[hardware, recipe] feat: add sft training script for Ascend A3 platform

### DIFF
--- a/examples/sft/gsm8k/run_qwen3_8b_ascend_a3_fsdp.sh
+++ b/examples/sft/gsm8k/run_qwen3_8b_ascend_a3_fsdp.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# SFT | GSM8K | FSDP engine | Ascend A3 NPU (16 NPUs per node)
+
+# Examples:
+#   # plain SFT on Ascend A3
+#   bash run_qwen3_8b_ascend_a3_fsdp.sh /tmp/sft-ckpt
+
+set -x
+
+save_path=$1
+shift 1
+
+# ---- Ascend A3 fixed config ----
+export PYTHONPATH=./verl:$PYTHONPATH
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+nproc_per_node=16
+master_port=12345
+# ---- end Ascend A3 fixed config ----
+
+
+# ---- user-adjustable ----
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-8B}
+SP_SIZE=${SP_SIZE:-1}
+TRAIN_BATCH_SIZE=${TRAIN_BATCH_SIZE:-16}
+MICRO_BATCH_SIZE_PER_GPU=${MICRO_BATCH_SIZE_PER_GPU:-1}
+LR=${LR:-3e-5}
+TOTAL_EPOCHS=${TOTAL_EPOCHS:-2}
+MAX_LENGTH=${MAX_LENGTH:-4096}
+PROJECT_NAME=${PROJECT_NAME:-gsm8k-sft}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-gsm8k-sft-qwen3-8b-instruct-a3}
+# ---- end user-adjustable ----
+
+
+torchrun --nnodes=1 --nproc_per_node=${nproc_per_node} --master_port=${master_port} \
+  -m verl.trainer.sft_trainer \
+  data.train_files=$HOME/data/gsm8k/train.parquet \
+  data.val_files=$HOME/data/gsm8k/test.parquet \
+  data.train_batch_size=${TRAIN_BATCH_SIZE} \
+  data.truncation=right \
+  data.max_length=${MAX_LENGTH} \
+  data.micro_batch_size_per_gpu=${MICRO_BATCH_SIZE_PER_GPU} \
+  data.ignore_input_ids_mismatch=True \
+  optim.lr=${LR} \
+  model.path="${MODEL_PATH}" \
+  model.trust_remote_code=True \
+  model.use_remove_padding=True \
+  trainer.project_name="${PROJECT_NAME}" \
+  trainer.experiment_name="${EXPERIMENT_NAME}" \
+  trainer.total_epochs=${TOTAL_EPOCHS} \
+  trainer.default_local_dir="${save_path}" \
+  trainer.logger='["console"]' \
+  data.use_dynamic_bsz=False \
+  engine.ulysses_sequence_parallel_size=${SP_SIZE}
+


### PR DESCRIPTION
### What does this PR do?

This PR adds a new SFT (Supervised Fine-Tuning) training script to support large language model training on Ascend A3 hardware (single node with 16 NPUs). The script is optimized for the Ascend A3 architecture, ensuring full compatibility with the platform's unique hardware features and improving training stability & efficiency for LLMs.
No related GitHub issues or PRs exist prior to this submission, as this is the first support for Ascend A3 in SFT training scripts.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

pre-commit run --files examples/sft/gsm8k/run_qwen3_8b_ascend_a3_fsdp.sh

Passed.

This script is validated on Ascend A3 single-node 16 NPUs with real LLM training experiments:

Successfully runs SFT training with 16 NPUs in distributed mode
Stable training loss convergence
No hardware compatibility errors / NPU OOM issues
Optimized batch size & distributed config for 16-card A3 platform
Test Environment

Hardware: Ascend A3 Single Node 16 NPUs
Docker Image: quay.io/ascend/verl:verl-8.5.0-a3-ubuntu22.04-py3.11-v0.7.1
CANN Version: 8.5.0
Python: 3.11

### API and Usage Example

```python
bash examples/sft/run_qwen3_8b_ascend_a3_fsdp.sh ./verl_output
```

### Design & Code Changes

- Add example script: examples/sft/gsm8k/run_qwen3_8b_ascend_a3_fsdp\.sh

- Adapt Ascend A3 16-NPU distributed config, taking Qwen3-8B as an example.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
