### PR TITLE
[data] fix: guard split_keys=None in unfold_column_chunks non_tensor_batch path (fixes #6411)

### DIFF
--- a/tests/test_protocol_on_cpu.py
+++ b/tests/test_protocol_on_cpu.py
@@ -1232,3 +1232,54 @@ def test_serialize_dataproto_with_empty_tensordict():
     deserialized_data = pickle.loads(serialized_data)
     assert len(deserialized_data.batch.keys()) == 0
     assert deserialized_data.batch.batch_size == torch.Size([10])
+
+
+def test_unfold_column_chunks_split_keys_none_does_not_crash_on_non_tensor_batch():
+    """Regression for https://github.com/verl-project/verl/issues/6411.
+
+    ``split_keys=None`` should repeat every non-tensor key (matching the
+    documented behavior) instead of raising ``TypeError`` from
+    ``key in None``.
+    """
+    n_split = 2
+    obs = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])  # (2, 4) → repeat path → (4, 4)
+    labels = ["a", "b"]
+    data = DataProto.from_dict(tensors={"obs": obs}, non_tensors={"labels": labels})
+
+    unfolded = data.unfold_column_chunks(n_split=n_split, split_keys=None)
+
+    # Tensor branch: repeat path (key not in split_keys) → (4, 4)
+    assert unfolded.batch["obs"].shape == (4, 4)
+    expected_obs = torch.repeat_interleave(obs, n_split, dim=0)
+    assert torch.equal(unfolded.batch["obs"], expected_obs)
+
+    # Non-tensor branch: repeat path → np.repeat(labels, 2, axis=0)
+    assert np.array_equal(unfolded.non_tensor_batch["labels"], np.array(["a", "a", "b", "b"]))
+
+
+def test_unfold_column_chunks_split_keys_subset_keeps_split_path():
+    """Happy-path regression: when ``split_keys`` is provided and a tensor
+    key is in it, the membership check still routes that key through the
+    reshape branch (not the repeat branch).
+    """
+    n_split = 2
+    obs = torch.tensor([[1, 2, 3, 4], [5, 6, 7, 8]])  # (2, 4) → reshape (4, 2)
+    extra = torch.tensor([[10, 20], [30, 40]])  # (2, 2) → repeat (4, 2)
+    labels = ["a", "b"]
+    data = DataProto.from_dict(
+        tensors={"obs": obs, "extra": extra},
+        non_tensors={"labels": labels},
+    )
+
+    unfolded = data.unfold_column_chunks(n_split=n_split, split_keys=["obs"])
+
+    # ``obs`` is in split_keys → reshape branch: (2, 4) → (4, 2)
+    assert unfolded.batch["obs"].shape == (4, 2)
+    assert torch.equal(unfolded.batch["obs"], obs.reshape(4, 2))
+
+    # ``extra`` not in split_keys → repeat branch: (2, 2) → (4, 2)
+    assert unfolded.batch["extra"].shape == (4, 2)
+    assert torch.equal(unfolded.batch["extra"], torch.repeat_interleave(extra, n_split, dim=0))
+
+    # Non-tensor key not in split_keys → repeat branch
+    assert np.array_equal(unfolded.non_tensor_batch["labels"], np.array(["a", "a", "b", "b"]))

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -1037,7 +1037,7 @@ class DataProto:
 
         repeated_non_tensor_batch = {}
         for key, val in self.non_tensor_batch.items():
-            if key in split_keys:
+            if split_keys is not None and key in split_keys:
                 shape = list(val.shape)
                 shape[0] = val.shape[0] * n_split
                 shape[1] = val.shape[1] // n_split


### PR DESCRIPTION
## Summary

Re-submitting the fix for #6411 after the formatting issue that caused #6413 to be closed.

`DataProto.unfold_column_chunks` documents `split_keys=None` as a legal input — the docstring says *"if the `split_keys` is not provided, it will repeat all the keys in the second dim"* (line 1019). The `self.batch` branch already guards its membership check (line 1024):

```python
if key in split_keys if split_keys is not None else False:
```

but the `self.non_tensor_batch` branch was missing the same guard (line 1040):

```python
if key in split_keys:
```

so any DataProto carrying a non-tensor key crashes with `TypeError: argument of type 'NoneType' is not iterable` whenever `split_keys=None` — exactly the documented configuration.

This PR adds the missing guard via short-circuit:

```python
if split_keys is not None and key in split_keys:
```

I went with the standard `and` short-circuit rather than mirroring line 1024's conditional-expression form. Both are equivalent; happy to align the two if reviewers prefer one form throughout.

## Why a new PR vs. reopening #6413

#6413 was closed by @wuxibin89 because `pre-commit (3.12)` failed — `ruff format` reformatted two `np.array_equal(...)` calls in the new tests (multi-line → single-line). I had not run `pre-commit run --all-files` locally before pushing, in violation of [`CONTRIBUTING.md`](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting). My mistake.

This PR ships the same logic + the formatting fix, with `pre-commit run --files <changed>` clean locally before push. Apologies for the noise.

## Fixes

- #6411

## Test plan

Two new CPU regression tests in `tests/test_protocol_on_cpu.py`:

- `test_unfold_column_chunks_split_keys_none_does_not_crash_on_non_tensor_batch` — pins the documented contract: with `split_keys=None` + a non-empty `non_tensor_batch`, the call repeats every key (tensor + non-tensor) instead of crashing. Existing `test_dataproto_unfold_column_chunks` covers the `split_keys=["obs1", ...]` cases but never the `None` corner this issue is about.
- `test_unfold_column_chunks_split_keys_subset_keeps_split_path` — happy-path guard: when `split_keys` is provided, keys in it still route through the reshape branch (`(2, 4) → (4, 2)`) and keys not in it (tensor or non-tensor) still route through the repeat branch (`(2, 2) → (4, 2)`).

Local verification on macOS / Python 3.13:

```
$ python3 -m pre_commit run --files verl/protocol.py tests/test_protocol_on_cpu.py
ruff (legacy alias)................................. Passed
ruff format......................................... Passed
mypy................................................ Passed
Generate and verify verl/trainer/config/_generated_*.yaml........ Passed
Check docs Last updated info........................ Passed
Check doc string coverage........................... Passed
Check license....................................... Passed
Check device API usage.............................. Passed
Check DataProto usage............................... Passed
Validate test structure............................. Passed
Check naming conventions............................ Passed
Check example script naming convention.............. Passed
Compile all python files............................ Passed

$ KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest \
    tests/test_protocol_on_cpu.py::test_unfold_column_chunks_split_keys_none... \
    tests/test_protocol_on_cpu.py::test_unfold_column_chunks_split_keys_subset... -v
========================== 2 passed in 4.43s ==========================
```

To confirm the regression test really exercises the bug, I temporarily reverted just the `protocol.py` change and reran the first test:

```
>           if key in split_keys:
            ^^^^^^^^^^^^^^^^^^
E           TypeError: argument of type 'NoneType' is not iterable
verl/protocol.py:1040: TypeError
============================ 1 failed in 4.42s =============================
```

Reapplying the fix restores the green state.

## Notes

I'm the same contributor as #6386 (`distillation_use_topk` symmetry fix in `transformer_impl.py`, merged 5/18). This is another path-symmetry style of bug in the data layer.
