### PR TITLE
[rollout] feat: add Trackio rollout trace logging

### DIFF
--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -106,25 +106,6 @@ Weave can select multiple trace items and then compare the differences among the
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/weave_trace_compare.png?raw=true
 
-Usage of Trackio
-----------------
-
-1. Basic Configuration
-~~~~~~~~~~~~~~~~~~~~~~
-
-1. Configuration Parameters
-
-   1. ``actor_rollout_ref.rollout.trace.backend=trackio``
-   2. ``trainer.logger=['console', 'trackio']``. This item is optional for rollout traces, but recommended so metrics, validation generations, and traces are available in one Trackio run.
-   3. ``trainer.project_name=$project_name``
-   4. ``trainer.experiment_name=$experiment_name``
-
-2. View Log
-~~~~~~~~~~~
-
-After executing training, open the Trackio dashboard and select the configured project and experiment. Rollout trace operations are logged as Trackio traces with ``step``, ``sample_index``, ``rollout_n``, ``validate``, and ``experiment_name`` metadata. Validation generations are also logged as Trackio traces when ``trackio`` is enabled in ``trainer.logger``.
-
-
 Usage of mlflow
 ---------------
 
@@ -163,3 +144,22 @@ Note:
 
 1. mlflow does not support comparing multiple traces
 2. rollout_trace can not associate the mlflow trace with the run, so the trace content cannot be seen in the mlflow run logs.
+
+
+Usage of Trackio
+----------------
+
+1. Basic Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Configuration Parameters
+
+   1. ``actor_rollout_ref.rollout.trace.backend=trackio``
+   2. ``trainer.logger=['console', 'trackio']``. This item is optional for rollout traces, but recommended so metrics, validation generations, and traces are available in one Trackio run.
+   3. ``trainer.project_name=$project_name``
+   4. ``trainer.experiment_name=$experiment_name``
+
+2. View Log
+~~~~~~~~~~~
+
+After executing training, open the Trackio dashboard and select the configured project and experiment. Rollout trace operations are logged as Trackio traces with ``step``, ``sample_index``, ``rollout_n``, ``validate``, and ``experiment_name`` metadata. Validation generations are also logged as Trackio traces when ``trackio`` is enabled in ``trainer.logger``.

--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -8,13 +8,13 @@ Applicable Scenarios
 
 Agentic RL involves multiple turns of conversations, tool invocations, and user interactions during the rollout process. During the Model Training process, it is necessary to track function calls, inputs, and outputs to understand the flow path of data within the application. The Trace feature helps, in complex multi-round conversations, to view the transformation of data during each interaction and the entire process leading to the final output by recording the inputs, outputs, and corresponding timestamps of functions, which is conducive to understanding the details of how the model processes data and optimizing the training results.
 
-The Trace feature integrates commonly used Agent trace tools, including wandb weave and mlflow, which are already supported. Users can choose the appropriate trace tool according to their own needs and preferences. Here, we introduce the usage of each tool.
+The Trace feature integrates commonly used Agent trace tools, including wandb weave, mlflow, and Trackio, which are already supported. Users can choose the appropriate trace tool according to their own needs and preferences. Here, we introduce the usage of each tool.
 
 
 Trace Parameter Configuration
 -----------------------------
 
-- ``actor_rollout_ref.rollout.trace.backend=mlflow|weave`` # the trace backend type
+- ``actor_rollout_ref.rollout.trace.backend=mlflow|weave|trackio`` # the trace backend type
 - ``actor_rollout_ref.rollout.trace.token2text=True`` # To show decoded text in trace view
 - ``actor_rollout_ref.rollout.trace.max_samples_per_step_per_worker=N`` # Limit traces per worker (optional)
 
@@ -105,6 +105,25 @@ After enabling token2text, prompt_text and response_text will be automatically a
 Weave can select multiple trace items and then compare the differences among them.
 
 .. image:: https://github.com/eric-haibin-lin/verl-community/blob/main/docs/weave_trace_compare.png?raw=true
+
+Usage of Trackio
+----------------
+
+1. Basic Configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+1. Configuration Parameters
+
+   1. ``actor_rollout_ref.rollout.trace.backend=trackio``
+   2. ``trainer.logger=['console', 'trackio']``. This item is optional for rollout traces, but recommended so metrics, validation generations, and traces are available in one Trackio run.
+   3. ``trainer.project_name=$project_name``
+   4. ``trainer.experiment_name=$experiment_name``
+
+2. View Log
+~~~~~~~~~~~
+
+After executing training, open the Trackio dashboard and select the configured project and experiment. Rollout trace operations are logged as Trackio traces with ``step``, ``sample_index``, ``rollout_n``, ``validate``, and ``experiment_name`` metadata. Validation generations are also logged as Trackio traces when ``trackio`` is enabled in ``trainer.logger``.
+
 
 Usage of mlflow
 ---------------

--- a/docs/advance/rollout_trace.rst
+++ b/docs/advance/rollout_trace.rst
@@ -162,4 +162,8 @@ Usage of Trackio
 2. View Log
 ~~~~~~~~~~~
 
-After executing training, open the Trackio dashboard and select the configured project and experiment. Rollout trace operations are logged as Trackio traces with ``step``, ``sample_index``, ``rollout_n``, ``validate``, and ``experiment_name`` metadata. Validation generations are also logged as Trackio traces when ``trackio`` is enabled in ``trainer.logger``.
+After executing training, open the Trackio dashboard and select the configured project and experiment. Rollout trace operations are logged as Trackio traces with ``step``, ``sample_index``, ``rollout_n``, ``validate``, and ``experiment_name`` metadata. Validation generations are also logged as Trackio traces when ``trackio`` is enabled in ``trainer.logger``. Click on any Trace to expand it:
+
+.. image:: https://huggingface.co/buckets/trackio/doc-images/resolve/traces-verl.png
+
+

--- a/tests/utils/test_rollout_trace_on_cpu.py
+++ b/tests/utils/test_rollout_trace_on_cpu.py
@@ -43,6 +43,20 @@ def mock_weave_client():
         yield mock_client
 
 
+@pytest.fixture
+def mock_trackio_client():
+    """Mocks the trackio module, yielding the mock module."""
+    mock_trackio = MagicMock()
+    mock_trackio.Trace.side_effect = lambda messages, metadata=None: {
+        "_type": "trackio.trace",
+        "messages": messages,
+        "metadata": metadata or {},
+    }
+
+    with patch.dict(sys.modules, {"trackio": mock_trackio}):
+        yield mock_trackio
+
+
 class TracedClass:
     @rollout_trace_op
     # @weave.op
@@ -126,6 +140,28 @@ async def test_rollout_trace_with_dummy_backend(mock_weave_client):
     await instance.my_method("test_a")
 
     mock_weave_client.create_call.assert_not_called()
+
+
+async def test_rollout_trace_with_trackio_backend(mock_trackio_client):
+    """Tests that the trackio backend logs a Trackio Trace."""
+    RolloutTraceConfig.init(project_name="my-project", experiment_name="my-experiment", backend="trackio")
+    instance = TracedClass()
+
+    with rollout_trace_attr(step=1, sample_index=2, rollout_n=3):
+        result = await instance.my_method("test_a", b="test_b")
+
+    assert result == "result: test_a, test_b"
+    mock_trackio_client.init.assert_called_once_with(
+        project="my-project", name="my-experiment", config={"framework": "verl"}
+    )
+    mock_trackio_client.Trace.assert_called_once()
+    trace_kwargs = mock_trackio_client.Trace.call_args.kwargs
+    assert trace_kwargs["messages"][0]["content"] == "verl rollout trace operation: TracedClass.my_method"
+    assert trace_kwargs["metadata"]["step"] == 1
+    assert trace_kwargs["metadata"]["sample_index"] == 2
+    mock_trackio_client.log.assert_called_once()
+    log_kwargs = mock_trackio_client.log.call_args.kwargs
+    assert log_kwargs["step"] == 1
 
 
 async def test_trace_disabled_with_trace_false(mock_weave_client):

--- a/tests/utils/test_rollout_trace_on_cpu.py
+++ b/tests/utils/test_rollout_trace_on_cpu.py
@@ -91,6 +91,17 @@ class UntracedClass:
         return x * 2
 
 
+class ChatTraceClass:
+    @rollout_trace_op
+    async def run(self, messages, sampling_params):
+        return {
+            "prompt_ids": [1, 2, 3],
+            "response_ids": [4],
+            "response_text": "4",
+            "reward": 1.0,
+        }
+
+
 async def test_rollout_trace_on_untraced_class():
     """Tests that the decorator works correctly when no backend is configured."""
     instance = UntracedClass()
@@ -165,6 +176,30 @@ async def test_rollout_trace_with_trackio_backend(mock_trackio_client):
     mock_trackio_client.log.assert_called_once()
     log_kwargs = mock_trackio_client.log.call_args.kwargs
     assert log_kwargs["step"] == 1
+
+
+async def test_trackio_backend_uses_chat_messages_when_available(mock_trackio_client):
+    RolloutTraceConfig.init(project_name="my-project", experiment_name="my-experiment", backend="trackio")
+    instance = ChatTraceClass()
+    input_messages = [
+        {"role": "system", "content": "You are a concise math assistant."},
+        {"role": "user", "content": "What is 2 + 2?"},
+    ]
+
+    with rollout_trace_attr(step=1, sample_index=2, rollout_n=3):
+        await instance.run(
+            messages=input_messages,
+            sampling_params={"temperature": 0.0, "max_tokens": 16},
+        )
+
+    trace_kwargs = mock_trackio_client.Trace.call_args.kwargs
+    assert trace_kwargs["messages"] == [
+        *input_messages,
+        {"role": "assistant", "content": "4"},
+    ]
+    assert trace_kwargs["metadata"]["inputs"] == {"sampling_params": {"temperature": 0.0, "max_tokens": 16}}
+    assert trace_kwargs["metadata"]["output"]["prompt_ids"] == [1, 2, 3]
+    assert trace_kwargs["metadata"]["output"]["response_text"] == "4"
 
 
 async def test_trace_disabled_with_trace_false(mock_weave_client):

--- a/tests/utils/test_rollout_trace_on_cpu.py
+++ b/tests/utils/test_rollout_trace_on_cpu.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,6 +48,8 @@ def mock_weave_client():
 def mock_trackio_client():
     """Mocks the trackio module, yielding the mock module."""
     mock_trackio = MagicMock()
+    mock_trackio.context_vars = types.SimpleNamespace(current_run=MagicMock())
+    mock_trackio.context_vars.current_run.get.return_value = None
     mock_trackio.Trace.side_effect = lambda messages, metadata=None: {
         "_type": "trackio.trace",
         "messages": messages,

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import types
 from unittest.mock import MagicMock, patch

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 from verl.utils.tracking import ValidationGenerationsLogger
@@ -6,6 +7,8 @@ from verl.utils.tracking import ValidationGenerationsLogger
 
 def test_validation_generations_logger_logs_trackio_traces():
     mock_trackio = MagicMock()
+    mock_trackio.context_vars = types.SimpleNamespace(current_run=MagicMock())
+    mock_trackio.context_vars.current_run.get.return_value = None
     mock_trackio.Trace.side_effect = lambda messages, metadata=None: {
         "_type": "trackio.trace",
         "messages": messages,

--- a/tests/utils/test_tracking_on_cpu.py
+++ b/tests/utils/test_tracking_on_cpu.py
@@ -1,0 +1,31 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+from verl.utils.tracking import ValidationGenerationsLogger
+
+
+def test_validation_generations_logger_logs_trackio_traces():
+    mock_trackio = MagicMock()
+    mock_trackio.Trace.side_effect = lambda messages, metadata=None: {
+        "_type": "trackio.trace",
+        "messages": messages,
+        "metadata": metadata or {},
+    }
+
+    with patch.dict(sys.modules, {"trackio": mock_trackio}):
+        ValidationGenerationsLogger().log(
+            ["trackio"],
+            samples=[["question", "answer", 0.5]],
+            step=7,
+        )
+
+    mock_trackio.Trace.assert_called_once()
+    trace_kwargs = mock_trackio.Trace.call_args.kwargs
+    assert trace_kwargs["messages"] == [
+        {"role": "user", "content": "question"},
+        {"role": "assistant", "content": "answer"},
+    ]
+    assert trace_kwargs["metadata"]["source"] == "validation_generations"
+    assert trace_kwargs["metadata"]["score"] == 0.5
+    mock_trackio.log.assert_called_once()
+    assert mock_trackio.log.call_args.kwargs["step"] == 7

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -303,7 +303,7 @@ trace:
   # Experiment name for run identification in tracking tools
   experiment_name: ${oc.select:trainer.experiment_name,null}
 
-  # trace backend, support mlflow, weave
+  # trace backend, support mlflow, weave, trackio
   backend: null
 
   # whether translate token id to text in output

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -15,6 +15,7 @@
 import contextlib
 import functools
 import inspect
+import json
 import os
 from contextvars import ContextVar
 from typing import Optional
@@ -24,13 +25,14 @@ from pydantic import BaseModel
 from verl.utils.ray_utils import get_event_loop
 
 _trace_enabled: ContextVar[bool] = ContextVar("_trace_enabled", default=True)
+_trace_attributes: ContextVar[Optional[dict]] = ContextVar("_trace_attributes", default=None)
 
 
 class RolloutTraceConfig:
     """Configuration for rollout tracing with various backends.
 
     Singleton configuration class for managing rollout trace settings across different
-    tracing backends like Weave and MLflow.
+            tracing backends like Weave, MLflow, and Trackio.
 
     Args:
         backend (Optional[str]): Tracing backend to use ('weave', 'mlflow', or None).
@@ -98,6 +100,11 @@ class RolloutTraceConfig:
             mlflow.set_tracking_uri(MLFLOW_TRACKING_URI)
 
             mlflow.set_experiment(project_name)
+        elif backend == "trackio":
+            import trackio
+
+            trackio.init(project=project_name, name=experiment_name, config={"framework": "verl"})
+            config.client = trackio
         else:
             config.client = None
 
@@ -162,21 +169,110 @@ def rollout_trace_attr(
         yield
         return
 
+    token = _trace_attributes.set(attributes)
     if backend == "weave":
         import weave
 
-        with weave.attributes(attributes):
-            yield
+        try:
+            with weave.attributes(attributes):
+                yield
+        finally:
+            _trace_attributes.reset(token)
     elif backend == "mlflow":
         import mlflow
 
-        with mlflow.start_span(name=name) as span:
-            trace_id = span.trace_id
-            for key, value in attributes.items():
-                mlflow.set_trace_tag(trace_id, str(key), str(value))
-            yield
+        try:
+            with mlflow.start_span(name=name) as span:
+                trace_id = span.trace_id
+                for key, value in attributes.items():
+                    mlflow.set_trace_tag(trace_id, str(key), str(value))
+                yield
+        finally:
+            _trace_attributes.reset(token)
     else:
-        yield
+        try:
+            yield
+        finally:
+            _trace_attributes.reset(token)
+
+
+def _json_trace_content(value):
+    if isinstance(value, BaseModel):
+        value = value.model_dump()
+    return json.dumps(value, default=str, ensure_ascii=False)
+
+
+def _json_trace_metadata(value):
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_trace_metadata(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_trace_metadata(v) for v in value]
+    return str(value)
+
+
+def _trackio_trace_key(op_name):
+    return "rollout_trace/" + "".join(char if char.isalnum() or char in "._-" else "_" for char in op_name)
+
+
+def _trackio_trace_step(attributes):
+    step = attributes.get("step")
+    if step is None:
+        return None
+    try:
+        return int(step)
+    except (TypeError, ValueError):
+        return None
+
+
+def _log_trackio_trace(op_name, inputs, output=None, exception=None):
+    trackio = RolloutTraceConfig.get_client()
+    attributes = _current_trace_attributes()
+    metadata = {
+        "op": op_name,
+        "backend": "trackio",
+        "experiment_name": RolloutTraceConfig.get_instance().experiment_name,
+        **{key: _json_trace_metadata(value) for key, value in attributes.items()},
+    }
+    if exception is not None:
+        metadata["status"] = "error"
+        metadata["exception_type"] = type(exception).__name__
+    else:
+        metadata["status"] = "success"
+
+    messages = [
+        {"role": "system", "content": f"verl rollout trace operation: {op_name}"},
+        {"role": "user", "content": _json_trace_content({"inputs": inputs})},
+    ]
+    if exception is not None:
+        messages.append(
+            {
+                "role": "assistant",
+                "content": _json_trace_content(
+                    {
+                        "exception_type": type(exception).__name__,
+                        "exception": str(exception),
+                    }
+                ),
+            }
+        )
+    else:
+        messages.append({"role": "assistant", "content": _json_trace_content({"output": output})})
+
+    trackio.log(
+        {_trackio_trace_key(op_name): trackio.Trace(messages=messages, metadata=metadata)},
+        step=_trackio_trace_step(attributes),
+    )
+
+
+def _current_trace_attributes():
+    backend = RolloutTraceConfig.get_backend()
+    if backend == "weave":
+        from weave.trace.context import call_context
+
+        return {**call_context.call_attributes.get()}
+    return {**(_trace_attributes.get() or {})}
 
 
 def rollout_trace_op(func):
@@ -218,9 +314,8 @@ def rollout_trace_op(func):
 
         if backend == "weave":
             tracer = RolloutTraceConfig.get_client()
-            from weave.trace.context import call_context
 
-            cur_attributes = {**call_context.call_attributes.get()}
+            cur_attributes = _current_trace_attributes()
             call = tracer.create_call(op=func.__qualname__, inputs=inputs, attributes=cur_attributes)
             try:
                 result = await func(self, *args, **kwargs)
@@ -249,6 +344,18 @@ def rollout_trace_op(func):
                     span.set_outputs(result)
 
             return result
+        elif backend == "trackio":
+            try:
+                result = await func(self, *args, **kwargs)
+                if enable_token2text:
+                    _result = await add_token2text(self, result)
+                    _log_trackio_trace(func.__qualname__, inputs, output=_result)
+                else:
+                    _log_trackio_trace(func.__qualname__, inputs, output=result)
+                return result
+            except Exception as e:
+                _log_trackio_trace(func.__qualname__, inputs, exception=e)
+                raise e
 
         else:
             return await func(self, *args, **kwargs)
@@ -270,9 +377,8 @@ def rollout_trace_op(func):
 
         if backend == "weave":
             tracer = RolloutTraceConfig.get_client()
-            from weave.trace.context import call_context
 
-            cur_attributes = {**call_context.call_attributes.get()}
+            cur_attributes = _current_trace_attributes()
             call = tracer.create_call(op=func.__qualname__, inputs=inputs, attributes=cur_attributes)
             try:
                 result = func(self, *args, **kwargs)
@@ -285,6 +391,14 @@ def rollout_trace_op(func):
             import mlflow
 
             return mlflow.trace(func)(self, *args, **kwargs)
+        elif backend == "trackio":
+            try:
+                result = func(self, *args, **kwargs)
+                _log_trackio_trace(func.__qualname__, inputs, output=result)
+                return result
+            except Exception as e:
+                _log_trackio_trace(func.__qualname__, inputs, exception=e)
+                raise e
         else:
             return func(self, *args, **kwargs)
 

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 from verl.utils.ray_utils import get_event_loop
 
 _trace_enabled: ContextVar[bool] = ContextVar("_trace_enabled", default=True)
-_trace_attributes: ContextVar[Optional[dict]] = ContextVar("_trace_attributes", default=None)
+_trace_attributes: ContextVar[dict | None] = ContextVar("_trace_attributes", default=None)
 
 
 class RolloutTraceConfig:
@@ -47,13 +47,13 @@ class RolloutTraceConfig:
     """
 
     _instance: Optional["RolloutTraceConfig"] = None
-    backend: Optional[str] = None
-    client: Optional[object] = None
+    backend: str | None = None
+    client: object | None = None
     token2text: bool = False
     _initialized: bool = False
     project_name: str = None
     experiment_name: str = None
-    max_samples_per_step_per_worker: Optional[int] = None
+    max_samples_per_step_per_worker: int | None = None
 
     def __new__(cls, *args, **kwargs):
         if cls._instance is None:
@@ -74,7 +74,7 @@ class RolloutTraceConfig:
         experiment_name: str,
         backend: str,
         token2text: bool = False,
-        max_samples_per_step_per_worker: Optional[int] = None,
+        max_samples_per_step_per_worker: int | None = None,
     ):
         config = cls.get_instance()
         if config._initialized:
@@ -113,15 +113,15 @@ class RolloutTraceConfig:
         config._initialized = True
 
     @classmethod
-    def get_backend(cls) -> Optional[str]:
+    def get_backend(cls) -> str | None:
         return cls.get_instance().backend
 
     @classmethod
-    def get_client(cls) -> Optional[object]:
+    def get_client(cls) -> object | None:
         return cls.get_instance().client
 
     @classmethod
-    def enable_token2text(cls) -> Optional[bool]:
+    def enable_token2text(cls) -> bool | None:
         return cls.get_instance().token2text
 
     @classmethod

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -102,8 +102,10 @@ class RolloutTraceConfig:
             mlflow.set_experiment(project_name)
         elif backend == "trackio":
             import trackio
+            from trackio import context_vars
 
-            trackio.init(project=project_name, name=experiment_name, config={"framework": "verl"})
+            if context_vars.current_run.get() is None:
+                trackio.init(project=project_name, name=experiment_name, config={"framework": "verl"})
             config.client = trackio
         else:
             config.client = None

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -205,6 +205,8 @@ def _json_trace_content(value):
 
 
 def _json_trace_metadata(value):
+    if isinstance(value, BaseModel):
+        value = value.model_dump()
     if value is None or isinstance(value, str | int | float | bool):
         return value
     if isinstance(value, dict):
@@ -212,6 +214,25 @@ def _json_trace_metadata(value):
     if isinstance(value, list | tuple):
         return [_json_trace_metadata(v) for v in value]
     return str(value)
+
+
+def _trackio_message_dict(message):
+    if not isinstance(message, dict):
+        return None
+    role = message.get("role")
+    if not isinstance(role, str):
+        return None
+    return dict(message)
+
+
+def _trackio_output_dict(output):
+    if isinstance(output, BaseModel):
+        return output.model_dump()
+    if isinstance(output, dict):
+        return output
+    if hasattr(output, "__dict__"):
+        return dict(vars(output))
+    return None
 
 
 def _trackio_trace_key(op_name):
@@ -231,10 +252,13 @@ def _trackio_trace_step(attributes):
 def _log_trackio_trace(op_name, inputs, output=None, exception=None):
     trackio = RolloutTraceConfig.get_client()
     attributes = _current_trace_attributes()
+    metadata_inputs = {key: value for key, value in inputs.items() if key != "messages"}
+    output_dict = _trackio_output_dict(output)
     metadata = {
         "op": op_name,
         "backend": "trackio",
         "experiment_name": RolloutTraceConfig.get_instance().experiment_name,
+        "inputs": _json_trace_metadata(metadata_inputs),
         **{key: _json_trace_metadata(value) for key, value in attributes.items()},
     }
     if exception is not None:
@@ -242,11 +266,21 @@ def _log_trackio_trace(op_name, inputs, output=None, exception=None):
         metadata["exception_type"] = type(exception).__name__
     else:
         metadata["status"] = "success"
+        metadata["output"] = _json_trace_metadata(output_dict if output_dict is not None else output)
 
-    messages = [
-        {"role": "system", "content": f"verl rollout trace operation: {op_name}"},
-        {"role": "user", "content": _json_trace_content({"inputs": inputs})},
-    ]
+    messages = []
+    input_messages = inputs.get("messages") if isinstance(inputs, dict) else None
+    if isinstance(input_messages, list):
+        messages = [
+            message for message in (_trackio_message_dict(message) for message in input_messages) if message is not None
+        ]
+
+    if not messages:
+        messages = [
+            {"role": "system", "content": f"verl rollout trace operation: {op_name}"},
+            {"role": "user", "content": _json_trace_content({"inputs": inputs})},
+        ]
+
     if exception is not None:
         messages.append(
             {
@@ -259,6 +293,10 @@ def _log_trackio_trace(op_name, inputs, output=None, exception=None):
                 ),
             }
         )
+    elif output_dict is not None and output_dict.get("response_text"):
+        messages.append({"role": "assistant", "content": str(output_dict["response_text"])})
+    elif output_dict is not None and output_dict.get("answer"):
+        messages.append({"role": "assistant", "content": str(output_dict["answer"])})
     else:
         messages.append({"role": "assistant", "content": _json_trace_content({"output": output})})
 

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -392,6 +392,8 @@ class ValidationGenerationsLogger:
             self.log_generations_to_swanlab(samples, step)
         if "mlflow" in loggers:
             self.log_generations_to_mlflow(samples, step)
+        if "trackio" in loggers:
+            self.log_generations_to_trackio(samples, step)
 
         if "clearml" in loggers:
             self.log_generations_to_clearml(samples, step)
@@ -475,6 +477,34 @@ class ValidationGenerationsLogger:
                 mlflow.log_artifact(validation_gen_step_file)
         except Exception as e:
             print(f"WARNING: save validation generation file to mlflow failed with error {e}")
+
+    def log_generations_to_trackio(self, samples, step):
+        """Log validation generations to trackio as traces."""
+        import trackio
+
+        traces = []
+        for sample_index, sample in enumerate(samples):
+            if len(sample) >= 3:
+                input_text, output_text, score = sample[0], sample[1], sample[2]
+            else:
+                input_text, output_text, score = sample, "", None
+
+            traces.append(
+                trackio.Trace(
+                    messages=[
+                        {"role": "user", "content": str(input_text)},
+                        {"role": "assistant", "content": str(output_text)},
+                    ],
+                    metadata={
+                        "source": "validation_generations",
+                        "sample_index": sample_index,
+                        "score": score,
+                    },
+                )
+            )
+
+        if traces:
+            trackio.log({"val/generations": traces}, step=step)
 
     def log_generations_to_clearml(self, samples, step):
         """Log validation generation to clearml as table"""

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -82,9 +82,11 @@ class Tracking:
 
         if "trackio" in default_backend:
             import trackio
+            from trackio import context_vars
 
-            trackio.init(project=project_name, name=experiment_name, config=config)
-            self.logger["trackio"] = trackio
+            if context_vars.current_run.get() is None:
+                trackio.init(project=project_name, name=experiment_name, config=config)
+            self.logger["trackio"] = _TrackioLoggingAdapter(trackio)
 
         if "mlflow" in default_backend:
             import os
@@ -250,6 +252,20 @@ class ClearMLLogger:
 
     def finish(self):
         self._task.close()
+
+
+class _TrackioLoggingAdapter:
+    def __init__(self, trackio):
+        self.trackio = trackio
+
+    def log(self, data, step):
+        self.trackio.log(data, step=step)
+
+    def finish(self):
+        from trackio import context_vars
+
+        if context_vars.current_run.get() is not None:
+            self.trackio.finish()
 
 
 class FileLogger:


### PR DESCRIPTION
Hi folks! This PR adds trace logging via [Trackio](https://github.com/gradio-app/trackio), the free, local-first experiment tracking library from Hugging Face 🤗

This PR follows the existing pattern from `mlflow` and `weave`, specifically I

- added `actor_rollout_ref.rollout.trace.backend=trackio` support to the rollout trace backend
- added logging rollout trace operations as `trackio.Trace` records with step/sample metadata
- adding logging validation generations as Trackio traces when `trackio` is enabled in `trainer.logger`
- documented the Trackio trace backend and add tests with mocked Trackio

## Duplicate-work check

I checked open PRs with these searches before opening this PR:

- `trackio Trace`
- `rollout trace trackio`
- `validation generations trackio`

No open PRs matched this work.

## AI assistance

AI assistance was used to prepare this PR. 