### PR TITLE
[megatron,rollout] fix: align MTP loss and rollout metrics

### DIFF
--- a/examples/mtp_trainer/README.md
+++ b/examples/mtp_trainer/README.md
@@ -7,6 +7,7 @@ MTP uses an auxiliary token-prediction head (speculative / draft head) during tr
 | Script                                                                    | Infer  | Train    | Mode                              | Platform |
 |---------------------------------------------------------------------------|--------|----------|-----------------------------------|----------|
 | `run_mimo_7b_mtp_megatron.sh`                                             | SGLang | Megatron | Sync hybrid-engine                | NVIDIA   |
+| `run_mimo_7b_mtp_rl_vllm_sgl_megatron.sh`                                 | SGLang / vLLM | Megatron | Sync hybrid-engine, slime-aligned RL/EAGLE setup | NVIDIA |
 | `run_mimo_7b_mtp_fully_async_megatron_multinode.sh`                       | SGLang | Megatron | Fully-async split-placement (DAPO)| NVIDIA   |
 
 IMPORTANT: after downloading MiMo-7B-RL, set `max_position_embeddings: 32768` in its `config.json`.

--- a/examples/mtp_trainer/run_mimo_7b_mtp_rl_vllm_sgl_megatron.sh
+++ b/examples/mtp_trainer/run_mimo_7b_mtp_rl_vllm_sgl_megatron.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Reference: https://github.com/THUDM/slime/blob/main/scripts/run-mimo-7B-rl-eagle.sh
+set -xeuo pipefail
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+MODEL_PATH=${MODEL_PATH:-XiaomiMiMo/MiMo-7B-RL}
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+rollout_batch_size=${ROLLOUT_BATCH_SIZE:-32}
+n_samples_per_prompt=${N_SAMPLES_PER_PROMPT:-8}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-32}
+max_prompt_length=${MAX_PROMPT_LENGTH:-2048}
+max_response_length=${MAX_RESPONSE_LENGTH:-8192}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-10240}
+
+actor_lr=${ACTOR_LR:-1e-6}
+entropy_coeff=${ENTROPY_COEFF:-0.0}
+
+clip_ratio_low=${CLIP_RATIO_LOW:-0.2}
+clip_ratio_high=${CLIP_RATIO_HIGH:-0.28}
+
+mtp_loss_scaling_factor=${MTP_LOSS_SCALING_FACTOR:-0.2}
+
+actor_tp=${ACTOR_TP:-2}
+actor_pp=${ACTOR_PP:-1}
+actor_cp=${ACTOR_CP:-1}
+
+rollout_tp=${ROLLOUT_TP:-2}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.7}
+
+# Rollout backend: "sglang" (default) or "vllm".
+rollout_backend=${ROLLOUT_BACKEND:-sglang}
+
+# Set MTP_ROLLOUT_SPEC=0 to disable rollout-time speculative decoding entirely.
+mtp_rollout_spec=${MTP_ROLLOUT_SPEC:-1}
+
+# vLLM-only: number of speculative tokens (vLLM's MTP method draws this many
+# tokens per verify step). Mirrors slime's effective draft budget.
+num_speculative_tokens=${NUM_SPECULATIVE_TOKENS:-3}
+
+# sglang+EAGLE-only: matches slime/scripts/run-mimo-7B-rl-eagle.sh defaults.
+spec_algorithm=${SPEC_ALGORITHM:-EAGLE}
+spec_num_steps=${SPEC_NUM_STEPS:-3}
+spec_eagle_topk=${SPEC_EAGLE_TOPK:-1}
+spec_num_draft_tokens=${SPEC_NUM_DRAFT_TOKENS:-4}
+
+total_epochs=${TOTAL_EPOCHS:-10}
+total_training_steps=${TOTAL_TRAINING_STEPS:-3000}
+save_freq=${SAVE_FREQ:-2000}
+test_freq=${TEST_FREQ:-20}
+
+project_name=${PROJECT_NAME:-mtp}
+experiment_name=${EXPERIMENT_NAME:-mimo_7b_mtp_${rollout_backend}_megatron}
+# ---- end user-adjustable ----
+
+train_file=${TRAIN_FILE:-$HOME/data/dapo-math-17k/train.parquet}
+val_file=${VAL_FILE:-$HOME/data/aime-2024/test.parquet}
+
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="['$train_file']"
+    data.val_files="['$val_file']"
+    data.train_batch_size=${rollout_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.truncation='left'
+    data.trust_remote_code=True
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.trust_remote_code=True
+    actor_rollout_ref.model.mtp.enable=True
+    actor_rollout_ref.model.mtp.enable_train=True
+    actor_rollout_ref.model.mtp.detach_encoder=True
+    actor_rollout_ref.model.mtp.mtp_loss_scaling_factor=${mtp_loss_scaling_factor}
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.optim.lr_warmup_steps=0
+    actor_rollout_ref.actor.optim.lr_decay_style=constant
+    actor_rollout_ref.actor.optim.weight_decay=0.1
+    actor_rollout_ref.actor.optim.clip_grad=1.0
+    actor_rollout_ref.actor.optim.betas=[0.9,0.98]
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=0.0
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
+    actor_rollout_ref.actor.loss_agg_mode=token-mean
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low}
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high}
+    actor_rollout_ref.actor.clip_ratio_c=10.0
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${actor_tp}
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${actor_pp}
+    actor_rollout_ref.actor.megatron.context_parallel_size=${actor_cp}
+    actor_rollout_ref.actor.megatron.sequence_parallel=True
+    actor_rollout_ref.actor.megatron.param_offload=True
+    actor_rollout_ref.actor.megatron.grad_offload=True
+    actor_rollout_ref.actor.megatron.optimizer_offload=True
+    actor_rollout_ref.actor.megatron.use_mbridge=True
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform
+    actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=${rollout_backend}
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=${n_samples_per_prompt}
+    actor_rollout_ref.rollout.temperature=1.0
+    actor_rollout_ref.rollout.top_p=1.0
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+)
+
+if [ "${mtp_rollout_spec}" = "1" ]; then
+    ROLLOUT+=(actor_rollout_ref.model.mtp.enable_rollout=True)
+    if [ "${rollout_backend}" = "vllm" ]; then
+        ROLLOUT+=(
+            actor_rollout_ref.model.mtp.method=mtp
+            actor_rollout_ref.model.mtp.num_speculative_tokens=${num_speculative_tokens}
+        )
+    elif [ "${rollout_backend}" = "sglang" ]; then
+        ROLLOUT+=(
+            actor_rollout_ref.model.mtp.speculative_algorithm=${spec_algorithm}
+            actor_rollout_ref.model.mtp.speculative_num_steps=${spec_num_steps}
+            actor_rollout_ref.model.mtp.speculative_eagle_topk=${spec_eagle_topk}
+            actor_rollout_ref.model.mtp.speculative_num_draft_tokens=${spec_num_draft_tokens}
+        )
+    else
+        echo "Unknown ROLLOUT_BACKEND=${rollout_backend}; expected 'vllm' or 'sglang'" >&2
+        exit 1
+    fi
+fi
+
+REF=(
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${actor_tp}
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${actor_pp}
+    actor_rollout_ref.ref.megatron.context_parallel_size=${actor_cp}
+    actor_rollout_ref.ref.megatron.param_offload=True
+)
+
+REWARD=(
+    reward.reward_manager.name=dapo
+    +reward.reward_kwargs.overlong_buffer_cfg.enable=True
+    +reward.reward_kwargs.overlong_buffer_cfg.len=4096
+    +reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=1.0
+    +reward.reward_kwargs.overlong_buffer_cfg.log=False
+    +reward.reward_kwargs.max_resp_len=${max_response_length}
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.critic_warmup=0
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.val_before_train=False
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+    trainer.total_training_steps=${total_training_steps}
+)
+
+EXTRA=(
+    model_engine=megatron
+)
+
+########################### launch ###########################
+python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${REF[@]}" \
+    "${REWARD[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@"

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -245,20 +245,16 @@ class ToolAgentLoop(AgentLoopBase):
         else:
             agent_data.metrics["num_preempted"] += output.num_preempted if output.num_preempted is not None else 0
 
-        spec_decode_extra_fields = {
-            key: output.extra_fields[key] for key in SPEC_DECODE_EXTRA_KEYS if key in output.extra_fields
-        }
         if not agent_data.extra_fields:
-            agent_data.extra_fields.update(
-                {key: value for key, value in output.extra_fields.items() if key not in SPEC_DECODE_EXTRA_KEYS}
-            )
+            agent_data.extra_fields.update(output.extra_fields)
         else:
-            # Multi-round calls keep first-round extra fields, then update selected counters.
+            # Multi-round calls, only update the maximum max_global_steps.
             max_global_steps = output.extra_fields.get("max_global_steps", None)
             if max_global_steps:
                 agent_data.extra_fields["max_global_steps"] = max_global_steps
-        for key, value in spec_decode_extra_fields.items():
-            agent_data.extra_fields[key] = int(agent_data.extra_fields.get(key, 0)) + int(value)
+            for key in SPEC_DECODE_EXTRA_KEYS:
+                if key in output.extra_fields and key in agent_data.extra_fields:
+                    agent_data.extra_fields[key] = int(agent_data.extra_fields[key]) + int(output.extra_fields[key])
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -39,6 +39,12 @@ from verl.workers.rollout.replica import TokenOutput
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+SPEC_DECODE_EXTRA_KEYS = (
+    "spec_num_draft_tokens",
+    "spec_num_accepted_tokens",
+    "spec_num_verify_steps",
+)
+
 
 class AgentState(Enum):
     PENDING = "pending"
@@ -239,13 +245,20 @@ class ToolAgentLoop(AgentLoopBase):
         else:
             agent_data.metrics["num_preempted"] += output.num_preempted if output.num_preempted is not None else 0
 
+        spec_decode_extra_fields = {
+            key: output.extra_fields[key] for key in SPEC_DECODE_EXTRA_KEYS if key in output.extra_fields
+        }
         if not agent_data.extra_fields:
-            agent_data.extra_fields.update(output.extra_fields)
+            agent_data.extra_fields.update(
+                {key: value for key, value in output.extra_fields.items() if key not in SPEC_DECODE_EXTRA_KEYS}
+            )
         else:
-            # Multi-round calls, only update the maximum max_global_steps.
+            # Multi-round calls keep first-round extra fields, then update selected counters.
             max_global_steps = output.extra_fields.get("max_global_steps", None)
             if max_global_steps:
                 agent_data.extra_fields["max_global_steps"] = max_global_steps
+        for key, value in spec_decode_extra_fields.items():
+            agent_data.extra_fields[key] = int(agent_data.extra_fields.get(key, 0)) + int(value)
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -232,8 +232,6 @@ def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_atten
         )
         batch_size = response_mask.shape[0]
         response_lengths = response_attention_mask.to(torch.int32).sum(dim=-1).tolist()
-        response_offsets = None
-        response_values = None
 
     assert len(input_ids_lengths) == batch_size, (
         f"len(input_ids_lengths)={len(input_ids_lengths)} != batch_size={batch_size}"

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -210,6 +210,59 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
     return v
 
 
+def _build_mtp_loss_mask_nested(response_mask, input_ids_lengths, response_attention_mask):
+    """Build a nested loss_mask aligned to ``input_ids = [prompt; response]`` for MTP.
+
+    ``response_mask`` is response-only data. This expands it to full packed
+    input length as prompt zeros followed by valid response positions.
+    """
+    if isinstance(response_mask, NestedTensor):
+        response_offsets = response_mask.offsets().tolist()
+        response_lengths = [response_offsets[i + 1] - response_offsets[i] for i in range(len(response_offsets) - 1)]
+        batch_size = len(response_lengths)
+        response_values = response_mask.values()
+    else:
+        assert response_attention_mask is not None, "response_attention_mask is required to align padded MTP loss_mask"
+        assert not isinstance(response_attention_mask, NestedTensor), (
+            "response_attention_mask must be a padded (bs, max_response_len) tensor, got NestedTensor"
+        )
+        assert response_attention_mask.shape == response_mask.shape, (
+            f"response_attention_mask shape {response_attention_mask.shape} "
+            f"!= response_mask shape {response_mask.shape}"
+        )
+        batch_size = response_mask.shape[0]
+        response_lengths = response_attention_mask.to(torch.int32).sum(dim=-1).tolist()
+        response_offsets = None
+        response_values = None
+
+    assert len(input_ids_lengths) == batch_size, (
+        f"len(input_ids_lengths)={len(input_ids_lengths)} != batch_size={batch_size}"
+    )
+
+    pieces = []
+    for i in range(batch_size):
+        actual_total = int(input_ids_lengths[i])
+        actual_response = int(response_lengths[i])
+        actual_prompt = actual_total - actual_response
+        assert actual_prompt >= 0, (
+            f"sample {i}: actual_response={actual_response} > actual_total={actual_total}; "
+            "loss_mask cannot be longer than input_ids"
+        )
+        prompt_pad = torch.zeros(actual_prompt, dtype=response_mask.dtype, device=response_mask.device)
+        # Keep the whole valid response span; response_mask may contain internal zeros for tool outputs.
+        if isinstance(response_mask, NestedTensor):
+            response_piece = response_values[response_offsets[i] : response_offsets[i + 1]]
+        else:
+            response_piece = response_mask[i, :actual_response]
+        full = torch.cat([prompt_pad, response_piece], dim=0)
+        assert full.shape[0] == actual_total, (
+            f"sample {i}: built loss_mask length {full.shape[0]} != input_ids length {actual_total}"
+        )
+        pieces.append(full)
+
+    return torch.nested.nested_tensor(pieces, layout=torch.jagged)
+
+
 def gptmodel_forward_model_engine(
     model,
     input_ids,
@@ -257,10 +310,14 @@ def gptmodel_forward_model_engine(
             # Use input_ids sequence length to ensure label and loss_mask alignment
             input_ids_offsets = input_ids.offsets()
             input_ids_lengths = input_ids_offsets.diff().tolist()
+            response_attention_mask = logits_processor_args.get("response_attention_mask", None)
 
             for k in ["label", "loss_mask"]:
                 v = logits_processor_args[k]
-                v = _convert_to_nested_tensor(v, input_ids_lengths)
+                if k == "loss_mask":
+                    v = _build_mtp_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
+                else:
+                    v = _convert_to_nested_tensor(v, input_ids_lengths)
                 logits_processor_args[k] = v
                 args[k] = preprocess_thd_engine(
                     v,
@@ -275,6 +332,8 @@ def gptmodel_forward_model_engine(
 
         if logits_processor_args and "loss_mask" in logits_processor_args:
             logits_processor_args.pop("loss_mask")
+        if logits_processor_args and "response_attention_mask" in logits_processor_args:
+            logits_processor_args.pop("response_attention_mask")
 
         # For VLM model, need to pass bshd format `input_ids` and `attention_mask`.
         attention_mask = None
@@ -335,10 +394,14 @@ def gptmodel_forward_model_engine(
             # Use input_ids sequence length to ensure label and loss_mask alignment
             input_ids_offsets = input_ids.offsets()
             input_ids_lengths = input_ids_offsets.diff().tolist()
+            response_attention_mask = logits_processor_args.get("response_attention_mask", None)
 
             for k in ["label", "loss_mask"]:
                 v = logits_processor_args[k]
-                v = _convert_to_nested_tensor(v, input_ids_lengths)
+                if k == "loss_mask":
+                    v = _build_mtp_loss_mask_nested(v, input_ids_lengths, response_attention_mask)
+                else:
+                    v = _convert_to_nested_tensor(v, input_ids_lengths)
                 logits_processor_args[k] = v
                 args[k] = preprocess_bshd_engine(v, pre_process=True, need_roll=True, use_fp8_padding=use_fp8_padding)[
                     0
@@ -348,6 +411,8 @@ def gptmodel_forward_model_engine(
 
         if logits_processor_args and "loss_mask" in logits_processor_args:
             logits_processor_args.pop("loss_mask")
+        if logits_processor_args and "response_attention_mask" in logits_processor_args:
+            logits_processor_args.pop("response_attention_mask")
 
         # For VLM model, need to pass bshd format `input_ids` and `attention_mask`.
         if vision_model:

--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -222,12 +222,43 @@ def patch_mtp_layer_get_embeddings(model: torch.nn.Module):
         for layer in target_layers:
             layer._get_embeddings_backup = layer._get_embeddings
             layer._get_embeddings = _patched_get_embeddings_for_detach.__get__(layer, layer.__class__)
-            layer._checkpointed_forward_backup = layer._checkpointed_forward
-            layer._checkpointed_forward = _patched_checkpointed_forward.__get__(layer, layer.__class__)
         print(f"Found and patched {len(target_layers)} MTP layer(s) in any of the actor modules")
         return True
     else:
         print("No MTP layers found to patch in any of the actor modules")
+        return False
+
+
+def patch_mtp_layer_checkpointed_forward(model: torch.nn.Module):
+    """Patch the _checkpointed_forward method of MultiTokenPredictionLayer"""
+    from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+
+    # Unwrap each model in the actor_module to get the actual GPTModel
+    model = _get_patching_model(model)
+    # Collect all MultiTokenPredictionLayer instances
+    target_layers = []
+
+    if isinstance(model, GPTModel):
+        # Check if GPTModel has MTP and find the layers
+        if hasattr(model, "mtp") and hasattr(model.mtp, "layers"):
+            for layer in model.mtp.layers:
+                if isinstance(layer, MultiTokenPredictionLayer):
+                    target_layers.append(layer)
+    elif hasattr(model, "layers"):
+        # Check if any layer in the model is MultiTokenPredictionLayer
+        for layer in model.layers:
+            if isinstance(layer, MultiTokenPredictionLayer):
+                target_layers.append(layer)
+
+    if target_layers:
+        for layer in target_layers:
+            layer._checkpointed_forward_backup = layer._checkpointed_forward
+            layer._checkpointed_forward = _patched_checkpointed_forward.__get__(layer, layer.__class__)
+        print(f"Found and patched checkpointed forward for {len(target_layers)} MTP layer(s)")
+        return True
+    else:
+        print("No MTP layers found to patch checkpointed forward")
         return False
 
 
@@ -260,12 +291,45 @@ def unpatch_mtp_layer_get_embeddings(model: torch.nn.Module):
             layer._get_embeddings = layer._get_embeddings_backup
             delattr(layer, "_get_embeddings_backup")
             unpatched_count += 1
-        if hasattr(layer, "_checkpointed_forward_backup"):
-            layer._checkpointed_forward = layer._checkpointed_forward_backup
-            delattr(layer, "_checkpointed_forward_backup")
 
     if unpatched_count > 0:
         print(f"Unpatched {unpatched_count} MTP layer(s)")
+        return True
+    return False
+
+
+def unpatch_mtp_layer_checkpointed_forward(model: torch.nn.Module):
+    """Unpatch the _checkpointed_forward method of MultiTokenPredictionLayer"""
+    from megatron.core.models.gpt.gpt_model import GPTModel
+    from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionLayer
+
+    # Unwrap each model in the actor_module to get the actual GPTModel
+    model = _get_patching_model(model)
+
+    # Collect all MultiTokenPredictionLayer instances
+    target_layers = []
+
+    if isinstance(model, GPTModel):
+        # Check if GPTModel has MTP and find the layers
+        if hasattr(model, "mtp") and hasattr(model.mtp, "layers"):
+            for layer in model.mtp.layers:
+                if isinstance(layer, MultiTokenPredictionLayer):
+                    target_layers.append(layer)
+    elif hasattr(model, "layers"):
+        # Check if any layer in the model is MultiTokenPredictionLayer
+        for layer in model.layers:
+            if isinstance(layer, MultiTokenPredictionLayer):
+                target_layers.append(layer)
+
+    unpatched_count = 0
+    for layer in target_layers:
+        if hasattr(layer, "_checkpointed_forward_backup"):
+            layer._checkpointed_forward = layer._checkpointed_forward_backup
+            delattr(layer, "_checkpointed_forward_backup")
+            unpatched_count += 1
+
+    if unpatched_count > 0:
+        print(f"Unpatched checkpointed forward for {unpatched_count} MTP layer(s)")
         return True
     return False
 

--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -15,10 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Callable
 
 import torch
-from megatron.core import parallel_state
+from megatron.core import parallel_state, tensor_parallel
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.transformer.multi_token_prediction import (
     MTPLossAutoScaler,
@@ -141,7 +142,7 @@ def _megatron_gptmodel_postprocess(
                 scale_logits_fn=scale_logits_fn,
             )
         else:
-            # Legacy Megatron API: manual rolling + compute_output_layer_and_language_model_loss.
+            # Legacy Megatron API: manual rolling + detached output-layer functional_call.
             mtp_labels = labels.clone()
             hidden_states_list = torch.chunk(hidden_states, 1 + self.config.mtp_num_layers, dim=0)
             hidden_states = hidden_states_list[0]
@@ -163,17 +164,19 @@ def _megatron_gptmodel_postprocess(
                     cp_group=cp_group,
                     packed_seq_params=packed_seq_params,
                 )
-                mtp_loss = self.compute_output_layer_and_language_model_loss(
-                    hidden_states_list[mtp_layer_number + 1],
-                    labels=mtp_labels,
-                    weight=self.shared_embedding_or_output_weight(),
-                    sequence_parallel_enabled=self.output_layer.sequence_parallel,
-                    column_parallel_linear=self.output_layer,
-                    col_linear_kwargs={
-                        "weight": output_weight,
+                # Detach output-layer params so MTP loss does not update lm_head.
+                output_layer_params = {k: v.detach() for k, v in self.output_layer.named_parameters()}
+                output_layer_buffers = dict(self.output_layer.named_buffers())
+                mtp_logits, _ = torch.func.functional_call(
+                    self.output_layer,
+                    {**output_layer_params, **output_layer_buffers},
+                    args=(hidden_states_list[mtp_layer_number + 1],),
+                    kwargs={
+                        "weight": output_weight.detach() if output_weight is not None else None,
                         "runtime_gather_output": runtime_gather_output,
                     },
                 )
+                mtp_loss = self.compute_language_model_loss(mtp_labels, mtp_logits)
                 mtp_loss = loss_mask * mtp_loss
                 if self.training:
                     MTPLossLoggingHelper.save_loss_to_tracker(
@@ -219,6 +222,8 @@ def patch_mtp_layer_get_embeddings(model: torch.nn.Module):
         for layer in target_layers:
             layer._get_embeddings_backup = layer._get_embeddings
             layer._get_embeddings = _patched_get_embeddings_for_detach.__get__(layer, layer.__class__)
+            layer._checkpointed_forward_backup = layer._checkpointed_forward
+            layer._checkpointed_forward = _patched_checkpointed_forward.__get__(layer, layer.__class__)
         print(f"Found and patched {len(target_layers)} MTP layer(s) in any of the actor modules")
         return True
     else:
@@ -255,6 +260,9 @@ def unpatch_mtp_layer_get_embeddings(model: torch.nn.Module):
             layer._get_embeddings = layer._get_embeddings_backup
             delattr(layer, "_get_embeddings_backup")
             unpatched_count += 1
+        if hasattr(layer, "_checkpointed_forward_backup"):
+            layer._checkpointed_forward = layer._checkpointed_forward_backup
+            delattr(layer, "_checkpointed_forward_backup")
 
     if unpatched_count > 0:
         print(f"Unpatched {unpatched_count} MTP layer(s)")
@@ -310,10 +318,71 @@ def _patched_get_embeddings_for_detach(
     # Apply custom transformations if needed
     # For example: decoder_input = some_custom_function(decoder_input)
 
-    hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
-
-    # detach decoder_input and hidden_states
+    # Detach token embeddings and main-decoder hidden states for detach_encoder.
     decoder_input = decoder_input.detach()
-    hidden_states = hidden_states.detach()
+    hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=False)
 
     return input_ids, position_ids, decoder_input, hidden_states
+
+
+def _patched_checkpointed_forward(self, forward_func, *args, **kwargs):
+    """Checkpoint MTP forward while keeping non-tensor args out of saved tensors."""
+    # Reference: THUDM/slime Megatron MTP recompute patch.
+    # https://github.com/THUDM/slime/blob/6961f5970e9dbb4716a10ba4a54a28fa3876d274/docker/patch/latest/megatron.patch#L723
+    positional_specs: list = []
+    kw_specs: list = []
+    tensor_args: list[torch.Tensor] = []
+
+    for arg in args:
+        if torch.is_tensor(arg):
+            positional_specs.append(("tensor", len(tensor_args)))
+            tensor_args.append(arg)
+        else:
+            positional_specs.append(("const", arg))
+
+    for key, value in kwargs.items():
+        if torch.is_tensor(value):
+            kw_specs.append((key, ("tensor", len(tensor_args))))
+            tensor_args.append(value)
+        else:
+            kw_specs.append((key, ("const", value)))
+
+    def run(*flat_tensor_args):
+        rebuilt_args = []
+        for spec_type, payload in positional_specs:
+            if spec_type == "tensor":
+                rebuilt_args.append(flat_tensor_args[payload])
+            else:
+                rebuilt_args.append(payload)
+
+        rebuilt_kwargs = {}
+        for key, (spec_type, payload) in kw_specs:
+            if spec_type == "tensor":
+                rebuilt_kwargs[key] = flat_tensor_args[payload]
+            else:
+                rebuilt_kwargs[key] = payload
+
+        return forward_func(*rebuilt_args, **rebuilt_kwargs)
+
+    tensor_args_tuple = tuple(tensor_args)
+
+    def checkpoint_handler():
+        if self.config.fp8:
+            from megatron.core.extensions.transformer_engine import te_checkpoint
+
+            return te_checkpoint(
+                run,
+                self.config.distribute_saved_activations,
+                tensor_parallel.random.get_cuda_rng_tracker,
+                parallel_state.get_tensor_model_parallel_group(),
+                *tensor_args_tuple,
+            )
+        return tensor_parallel.checkpoint(run, self.config.distribute_saved_activations, *tensor_args_tuple)
+
+    if self.config.recompute_method == "uniform":
+        assert self.config.recompute_num_layers == 1, "recompute_num_layers must be 1 for MTP recompute"
+        return checkpoint_handler()
+    if self.config.recompute_method == "block":
+        warnings.warn("recompute_method == 'block' is not supported for MTP yet. Skipping recompute.", stacklevel=2)
+        return forward_func(*args, **kwargs)
+    raise ValueError(f"Invalid activation recompute method: {self.config.recompute_method}")

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -1528,20 +1528,19 @@ class PPOTrainer:
         response_length = data["responses"].offsets().diff()
         global_token_num = (prompt_length + response_length).tolist()
 
-        # Per-request speculative decoding stats. Only fetch when the user has
-        # explicitly enabled spec rollout; otherwise the fields are not in the
-        # transfer queue and a kv_batch_get would error. slime's equivalent
-        # stats live in ``Sample.SpecInfo`` (see ``slime/utils/types.py``).
+        # Only fetch speculative decoding stats when rollout writes them.
         spec_drafts = spec_accepts = spec_verifies = None
-        if self.config.actor_rollout_ref.model.mtp.enable_rollout:
+        mtp_config = getattr(self.config.actor_rollout_ref.model, "mtp", None)
+        if mtp_config is not None and mtp_config.enable and mtp_config.enable_rollout:
             spec_data = tq.kv_batch_get(
                 keys=batch.keys,
                 partition_id=batch.partition_id,
-                select_fields=["spec_num_draft_tokens", "spec_num_accepted_tokens", "spec_num_verify_steps"],
+                select_fields=["extra_fields"],
             )
-            spec_drafts = spec_data["spec_num_draft_tokens"]
-            spec_accepts = spec_data["spec_num_accepted_tokens"]
-            spec_verifies = spec_data["spec_num_verify_steps"]
+            extra_fields = spec_data["extra_fields"].tolist()
+            spec_drafts = [extra_field["spec_num_draft_tokens"] for extra_field in extra_fields]
+            spec_accepts = [extra_field["spec_num_accepted_tokens"] for extra_field in extra_fields]
+            spec_verifies = [extra_field["spec_num_verify_steps"] for extra_field in extra_fields]
 
         data = data.to_padded_tensor()
         data["token_level_scores"] = data["rm_scores"]

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -80,7 +80,7 @@ from verl.trainer.ppo.metric_utils import (
     process_validation_metrics,
 )
 from verl.trainer.ppo.padding_utils import upsample_batch_to_divisible_size
-from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage
+from verl.trainer.ppo.ray_trainer import apply_kl_penalty, compute_advantage, compute_spec_decode_metrics
 from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_add_to_batch
 from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference_policy, need_teacher_policy
 from verl.utils import hf_processor, hf_tokenizer
@@ -1527,6 +1527,22 @@ class PPOTrainer:
         prompt_length = data["prompts"].offsets().diff()
         response_length = data["responses"].offsets().diff()
         global_token_num = (prompt_length + response_length).tolist()
+
+        # Per-request speculative decoding stats. Only fetch when the user has
+        # explicitly enabled spec rollout; otherwise the fields are not in the
+        # transfer queue and a kv_batch_get would error. slime's equivalent
+        # stats live in ``Sample.SpecInfo`` (see ``slime/utils/types.py``).
+        spec_drafts = spec_accepts = spec_verifies = None
+        if self.config.actor_rollout_ref.model.mtp.enable_rollout:
+            spec_data = tq.kv_batch_get(
+                keys=batch.keys,
+                partition_id=batch.partition_id,
+                select_fields=["spec_num_draft_tokens", "spec_num_accepted_tokens", "spec_num_verify_steps"],
+            )
+            spec_drafts = spec_data["spec_num_draft_tokens"]
+            spec_accepts = spec_data["spec_num_accepted_tokens"]
+            spec_verifies = spec_data["spec_num_verify_steps"]
+
         data = data.to_padded_tensor()
         data["token_level_scores"] = data["rm_scores"]
         if "token_level_rewards" not in data:
@@ -1555,6 +1571,10 @@ class PPOTrainer:
                 "training/num_turns/min": num_turns.min(),
             }
         )
+
+        # 4. per-request speculative-decoding aggregation (same metrics async PPO logs;
+        # see compute_spec_decode_metrics in verl/trainer/ppo/ray_trainer.py).
+        metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
 
     def fit(self):
         if self._dump_executor._shutdown:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -139,24 +139,13 @@ def compute_spec_decode_metrics(
     spec_verifies,
     non_padding_mask=None,
 ) -> dict:
-    """Aggregate per-request speculative decoding stats into the two headline
-    metrics slime exposes (``spec_accept_rate`` / ``spec_accept_length``).
+    """Aggregate per-request speculative decoding stats.
 
-    Aggregation matches slime/slime/ray/rollout.py::_compute_spec_metrics —
-    *macro* averaging over requests (compute the per-sample ratio first, then
-    take the mean), not micro averaging over tokens. Macro and micro can
-    differ noticeably when sequences have very different lengths, so keeping
-    them aligned is required for direct slime ↔ verl comparison.
+    Ratios are computed per request and then averaged, so long and short
+    responses have equal metric weight.
 
-    Per slime/slime/utils/types.py::SpecInfo:
-      * spec_accept_rate    = spec_accept_token_num / spec_draft_token_num
-      * spec_accept_length  = completion_token_num / spec_verify_ct
-                            = 1 + spec_accept_token_num / spec_verify_ct
-        (one originally-decoded token per verify step, plus the accepted
-         draft tokens; equivalent to slime's completion / verify_ct).
-
-    The three inputs come from the rollout engine (vLLM ``spec_num_*`` attrs or
-    sglang ``meta_info["spec_*"]`` keys). Either all three are ``None``
+    The three inputs come from the rollout engine (vLLM request spec-decode
+    stats or sglang ``meta_info["spec_*"]`` keys). Either all three are ``None``
     (caller didn't fetch them, e.g. spec rollout disabled) and the function
     is a no-op, or all three are populated; mixed state is a programmer error.
 
@@ -182,8 +171,7 @@ def compute_spec_decode_metrics(
     if len(drafts) == 0:
         return {}
 
-    # slime's per-sample property returns 0.0 when the denominator is 0; we
-    # mirror that exactly so empty/short samples still contribute to the mean.
+    # Treat zero-denominator samples as 0.0 and keep them in the mean.
     per_sample_accept_rate = [(a / d) if d > 0 else 0.0 for a, d in zip(accepts, drafts, strict=True)]
     per_sample_accept_length = [(1.0 + a / v) if v > 0 else 0.0 for a, v in zip(accepts, verifies, strict=True)]
 
@@ -1748,7 +1736,7 @@ class RayPPOTrainer:
                 metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
                 # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
 
-                # Per-request spec decode metrics — token-weighted aggregation (MTP).
+                # Per-request spec decode metrics.
                 metrics.update(
                     compute_spec_decode_metrics(
                         batch.non_tensor_batch.get("spec_num_draft_tokens", None),

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -133,6 +133,67 @@ def compute_response_mask(data: DataProto):
     return attention_mask[:, -response_length:]
 
 
+def compute_spec_decode_metrics(
+    spec_drafts,
+    spec_accepts,
+    spec_verifies,
+    non_padding_mask=None,
+) -> dict:
+    """Aggregate per-request speculative decoding stats into the two headline
+    metrics slime exposes (``spec_accept_rate`` / ``spec_accept_length``).
+
+    Aggregation matches slime/slime/ray/rollout.py::_compute_spec_metrics —
+    *macro* averaging over requests (compute the per-sample ratio first, then
+    take the mean), not micro averaging over tokens. Macro and micro can
+    differ noticeably when sequences have very different lengths, so keeping
+    them aligned is required for direct slime ↔ verl comparison.
+
+    Per slime/slime/utils/types.py::SpecInfo:
+      * spec_accept_rate    = spec_accept_token_num / spec_draft_token_num
+      * spec_accept_length  = completion_token_num / spec_verify_ct
+                            = 1 + spec_accept_token_num / spec_verify_ct
+        (one originally-decoded token per verify step, plus the accepted
+         draft tokens; equivalent to slime's completion / verify_ct).
+
+    The three inputs come from the rollout engine (vLLM ``spec_num_*`` attrs or
+    sglang ``meta_info["spec_*"]`` keys). Either all three are ``None``
+    (caller didn't fetch them, e.g. spec rollout disabled) and the function
+    is a no-op, or all three are populated; mixed state is a programmer error.
+
+    ``non_padding_mask`` is a numpy bool array used by sync PPO to drop padded
+    placeholder samples; pass ``None`` for async PPO.
+    """
+    if spec_drafts is None and spec_accepts is None and spec_verifies is None:
+        return {}
+    assert spec_drafts is not None and spec_accepts is not None and spec_verifies is not None, (
+        "spec_decode metrics require all three of spec_num_draft_tokens / "
+        "spec_num_accepted_tokens / spec_num_verify_steps; got partial inputs"
+    )
+
+    drafts = spec_drafts.tolist() if hasattr(spec_drafts, "tolist") else list(spec_drafts)
+    accepts = spec_accepts.tolist() if hasattr(spec_accepts, "tolist") else list(spec_accepts)
+    verifies = spec_verifies.tolist() if hasattr(spec_verifies, "tolist") else list(spec_verifies)
+
+    if non_padding_mask is not None:
+        drafts = [d for d, keep in zip(drafts, non_padding_mask, strict=True) if keep]
+        accepts = [a for a, keep in zip(accepts, non_padding_mask, strict=True) if keep]
+        verifies = [v for v, keep in zip(verifies, non_padding_mask, strict=True) if keep]
+
+    if len(drafts) == 0:
+        return {}
+
+    # slime's per-sample property returns 0.0 when the denominator is 0; we
+    # mirror that exactly so empty/short samples still contribute to the mean.
+    per_sample_accept_rate = [(a / d) if d > 0 else 0.0 for a, d in zip(accepts, drafts, strict=True)]
+    per_sample_accept_length = [(1.0 + a / v) if v > 0 else 0.0 for a, v in zip(accepts, verifies, strict=True)]
+
+    n = len(drafts)
+    return {
+        "rollout/spec_accept_rate": float(sum(per_sample_accept_rate) / n),
+        "rollout/spec_accept_length": float(sum(per_sample_accept_length) / n),
+    }
+
+
 def compute_advantage(
     data: DataProto,
     adv_estimator: AdvantageEstimator,
@@ -1687,18 +1748,14 @@ class RayPPOTrainer:
                 metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
                 # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
 
-                # Per-request spec decode metrics — token-weighted aggregation (MTP)
-                spec_drafts = batch.non_tensor_batch.get("spec_num_draft_tokens", None)
-                spec_accepts = batch.non_tensor_batch.get("spec_num_accepted_tokens", None)
-                spec_verifies = batch.non_tensor_batch.get("spec_num_verify_steps", None)
-                if spec_drafts is not None:
-                    draft_total = sum(d for d in spec_drafts if d is not None)
-                    accept_total = sum(a for a in spec_accepts if a is not None)
-                    verify_total = sum(v for v in spec_verifies if v is not None)
-                    if draft_total > 0:
-                        metrics["rollout/spec_accept_rate"] = float(accept_total / draft_total)
-                    if verify_total > 0:
-                        metrics["rollout/spec_accept_length"] = float(1.0 + accept_total / verify_total)
+                # Per-request spec decode metrics — token-weighted aggregation (MTP).
+                metrics.update(
+                    compute_spec_decode_metrics(
+                        batch.non_tensor_batch.get("spec_num_draft_tokens", None),
+                        batch.non_tensor_batch.get("spec_num_accepted_tokens", None),
+                        batch.non_tensor_batch.get("spec_num_verify_steps", None),
+                    )
+                )
 
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1687,6 +1687,19 @@ class RayPPOTrainer:
                 metrics.update(compute_variance_proxy_metrics(batch=batch, gradient_norm=gradient_norm))
                 # Note: mismatch metrics (KL, PPL, etc.) are collected at line 1179 after advantage computation
 
+                # Per-request spec decode metrics — token-weighted aggregation (MTP)
+                spec_drafts = batch.non_tensor_batch.get("spec_num_draft_tokens", None)
+                spec_accepts = batch.non_tensor_batch.get("spec_num_accepted_tokens", None)
+                spec_verifies = batch.non_tensor_batch.get("spec_num_verify_steps", None)
+                if spec_drafts is not None:
+                    draft_total = sum(d for d in spec_drafts if d is not None)
+                    accept_total = sum(a for a in spec_accepts if a is not None)
+                    verify_total = sum(v for v in spec_verifies if v is not None)
+                    if draft_total > 0:
+                        metrics["rollout/spec_accept_rate"] = float(accept_total / draft_total)
+                    if verify_total > 0:
+                        metrics["rollout/spec_accept_length"] = float(1.0 + accept_total / verify_total)
+
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)
 

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -1550,6 +1550,7 @@ def check_mtp_config(model_config: HFModelConfig, engine_config: McoreEngineConf
         return
     elif not enable_mtp and has_mtp:
         _set_mtp_num_layers(hf_config, 0)
+        engine_config.override_transformer_config["mtp_num_layers"] = 0
     elif enable_mtp and not has_mtp:
         raise ValueError("enable mtp while model has no mtp layer, please use a model with mtp layer")
     elif enable_mtp and has_mtp:

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -1570,13 +1570,18 @@ def patch_engine_mtp(module, model_config):
         model_config: The model configuration containing MTP settings.
     """
     logger.warning("Applying mtp patch...")
-    from verl.models.mcore.mtp_patch import patch_mtp_layer_get_embeddings, patch_postprocess
+    from verl.models.mcore.mtp_patch import (
+        patch_mtp_layer_checkpointed_forward,
+        patch_mtp_layer_get_embeddings,
+        patch_postprocess,
+    )
 
     print(module)
 
     modules = module if isinstance(module, list) else [module]
     for m in modules:
         patch_postprocess(m)
+        patch_mtp_layer_checkpointed_forward(m)
         if model_config.mtp.detach_encoder:
             patch_mtp_layer_get_embeddings(m)
 

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -168,6 +168,9 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
         Tuples of (name, tensor) for each weight and its scale
     """
 
+    fp8_state.seen_params.clear()
+    fp8_state.fp8_param_names.clear()
+    fp8_state.vllm_patches.clear()
     is_mxfp8_npu = is_mxfp8_vllm_ascend(quant_config)
     if is_mxfp8_npu:
         import torch_npu
@@ -212,8 +215,16 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
         del v, param_lp, param_scale
 
 
-def load_quanted_weights(weights, model_runner):
-    model = model_runner.model
+def load_quanted_weights(weights, model_runner, is_drafter=False):
+    if is_drafter:
+        drafter = getattr(model_runner, "drafter", None)
+        model = drafter.model if drafter is not None and hasattr(drafter, "model") else None
+        assert model is not None, (
+            "load_quanted_weights(is_drafter=True) requires model_runner.drafter.model "
+            "to be present and non-None for FP8 weight loading."
+        )
+    else:
+        model = model_runner.model
     quant_config = model_runner.vllm_config.quant_config
     vllm_dtype = model_runner.vllm_config.model_config.dtype
 

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -170,7 +170,6 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
 
     fp8_state.seen_params.clear()
     fp8_state.fp8_param_names.clear()
-    fp8_state.vllm_patches.clear()
     is_mxfp8_npu = is_mxfp8_vllm_ascend(quant_config)
     if is_mxfp8_npu:
         import torch_npu

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -175,7 +175,6 @@ class MegatronEngine(BaseEngine):
             # but it does not affect the functionality of dynamic CP, so we can use it to avoid the coupling.
             override_transformer_config["dynamic_context_parallel"] = False
             override_transformer_config["context_parallel_size"] = mpu.get_data_parallel_world_size()
-
         self.provider = None
         self.vanilla_bridge = self.engine_config.vanilla_mbridge
 
@@ -373,6 +372,14 @@ class MegatronEngine(BaseEngine):
 
         if self.model_config.mtp.enable:
             patch_engine_mtp(self.module, self.model_config)
+        elif (
+            self.engine_config.forward_only
+            and self.engine_config.override_transformer_config.get("mtp_num_layers") == 0
+        ):
+            from verl.models.mcore.mtp_patch import patch_postprocess
+
+            for model in self.module:
+                patch_postprocess(model)
 
         # For forward_only, we don't need optimizer, lr_scheduler, checkpoint_mananager
         if self.engine_config.forward_only:
@@ -789,6 +796,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
 
         return {
             "input_ids": input_ids,
+            "attention_mask": batch.get("attention_mask", None),
             "loss_mask": loss_mask,
             "multi_modal_inputs": multi_modal_inputs,
             "routed_experts": routed_experts,
@@ -828,6 +836,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
         temperature = batch["temperature"]
         model_inputs = self.prepare_model_inputs(batch)
         input_ids = model_inputs["input_ids"]
+        attention_mask = model_inputs["attention_mask"]
         multi_modal_inputs = model_inputs["multi_modal_inputs"]
         local_cp_size = tu.get_non_tensor_data(data=batch, key="local_cp_size", default=None)
         loss_mask = model_inputs["loss_mask"]
@@ -925,7 +934,15 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 ret["log_probs"] = log_probs
                 return ret
 
-            logits_processor_args = {"label": label, "temperature": temperature, "loss_mask": loss_mask}
+            response_attention_mask = None
+            if attention_mask is not None and not loss_mask.is_nested:
+                response_attention_mask = attention_mask[:, -loss_mask.shape[-1] :]
+            logits_processor_args = {
+                "label": label,
+                "temperature": temperature,
+                "loss_mask": loss_mask,
+                "response_attention_mask": response_attention_mask,
+            }
 
             output = forward_fn(
                 model,

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -354,7 +354,7 @@ class SGLangHttpServer:
             args.update({"enable_return_routed_experts": True})
 
         # mtp
-        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
+        if self.config.mtp.enable and self.config.mtp.enable_rollout:
             # Enable weights CPU backup for sglang >= 0.5.6
             if sglang.__version__ < "0.5.6":
                 raise ValueError(f"sglang version {sglang.__version__} is not supported for MTP rollout")
@@ -651,6 +651,19 @@ class SGLangHttpServer:
                 sequence_length=len(prompt_ids),
                 result_dict=extra_fields,
             )
+
+        # Per-request speculative decoding stats. sglang exposes these on
+        # ``meta_info`` when (a) the build includes the slime sglang patch
+        # (slime/docker/patch/v0.5.9/sglang.patch) and (b) the user has enabled
+        # spec rollout via ``mtp.enable_rollout=True`` (which configures sglang
+        # to do speculative decoding above). Re-key to verl's vLLM-compatible
+        # names so ray_trainer's aggregation works for both backends. Fails
+        # loudly with KeyError if mtp.enable_rollout is set but the slime patch
+        # is missing.
+        if self.config.mtp.enable and self.config.mtp.enable_rollout:
+            extra_fields["spec_num_draft_tokens"] = int(meta_info["spec_draft_token_num"])
+            extra_fields["spec_num_accepted_tokens"] = int(meta_info["spec_accept_token_num"])
+            extra_fields["spec_num_verify_steps"] = int(meta_info["spec_verify_ct"])
 
         return TokenOutput(
             token_ids=token_ids,

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -354,9 +354,9 @@ class SGLangHttpServer:
             args.update({"enable_return_routed_experts": True})
 
         # mtp
-        if self.config.mtp.enable and self.config.mtp.enable_rollout:
+        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
             # Enable weights CPU backup for sglang >= 0.5.6
-            if sglang.__version__ < "0.5.6":
+            if version.parse(sglang.__version__) < version.parse("0.5.6"):
                 raise ValueError(f"sglang version {sglang.__version__} is not supported for MTP rollout")
 
             args["speculative_algorithm"] = self.config.mtp.speculative_algorithm
@@ -652,15 +652,8 @@ class SGLangHttpServer:
                 result_dict=extra_fields,
             )
 
-        # Per-request speculative decoding stats. sglang exposes these on
-        # ``meta_info`` when (a) the build includes the slime sglang patch
-        # (slime/docker/patch/v0.5.9/sglang.patch) and (b) the user has enabled
-        # spec rollout via ``mtp.enable_rollout=True`` (which configures sglang
-        # to do speculative decoding above). Re-key to verl's vLLM-compatible
-        # names so ray_trainer's aggregation works for both backends. Fails
-        # loudly with KeyError if mtp.enable_rollout is set but the slime patch
-        # is missing.
-        if self.config.mtp.enable and self.config.mtp.enable_rollout:
+        # Re-key backend spec-decoding stats to the rollout-common names.
+        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
             extra_fields["spec_num_draft_tokens"] = int(meta_info["spec_draft_token_num"])
             extra_fields["spec_num_accepted_tokens"] = int(meta_info["spec_accept_token_num"])
             extra_fields["spec_num_verify_steps"] = int(meta_info["spec_verify_ct"])

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -164,20 +164,28 @@ class vLLMColocateWorkerExtension:
         spec = self.model_runner.vllm_config.speculative_config
         return spec.draft_model_config if spec is not None and spec.draft_model_config is not None else None
 
+    def _use_mtp_drafter_weight_sync(self):
+        """Return whether the vLLM MTP drafter should receive actor weights."""
+        spec = self.model_runner.vllm_config.speculative_config
+        return spec is not None and spec.method == "mtp" and self._get_drafter_model() is not None
+
     def _iter_all_models(self):
-        """Yield all model objects that need weight updates (main + optional drafter)."""
+        """Yield models that need weight updates.
+
+        Only vLLM MTP drafter sync is supported for now. Independent non-MTP
+        draft models are not compatible with actor weight loading through this path.
+        """
         yield self.model_runner.model
-        drafter_model = self._get_drafter_model()
-        if drafter_model is not None:
-            yield drafter_model
+        if self._use_mtp_drafter_weight_sync():
+            yield self._get_drafter_model()
 
     def _iter_all_models_with_config(self):
-        """Yield (model, model_config) for all models that need post-processing."""
+        """Yield (model, model_config) for models that need post-processing."""
         yield self.model_runner.model, self.model_runner.vllm_config.model_config
-        drafter_model = self._get_drafter_model()
-        draft_cfg = self._get_draft_model_config()
-        if drafter_model is not None and draft_cfg is not None:
-            yield drafter_model, draft_cfg
+        if self._use_mtp_drafter_weight_sync():
+            draft_cfg = self._get_draft_model_config()
+            if draft_cfg is not None:
+                yield self._get_drafter_model(), draft_cfg
 
     def monkey_patch_model(self, vocab_size: int):
         for model in self._iter_all_models():
@@ -272,7 +280,7 @@ class vLLMColocateWorkerExtension:
                 loaded_params = load_quanted_weights(weights, self.model_runner)
                 logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
                 # Keep the draft model in sync when present.
-                if self._get_drafter_model() is not None:
+                if self._use_mtp_drafter_weight_sync():
                     load_quanted_weights(weights, self.model_runner, is_drafter=True)
             else:
                 logger.info("Loading standard weights (non-FP8, async)")

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -154,11 +154,37 @@ class vLLMColocateWorkerExtension:
         instance._is_modelopt_qat = _is_modelopt_qat
         return instance
 
+    def _get_drafter_model(self):
+        """Return the drafter's model object, or None if unavailable."""
+        drafter = getattr(self.model_runner, "drafter", None)
+        return drafter.model if drafter is not None and hasattr(drafter, "model") else None
+
+    def _get_draft_model_config(self):
+        """Return the draft model config from speculative_config, or None."""
+        spec = self.model_runner.vllm_config.speculative_config
+        return spec.draft_model_config if spec is not None and spec.draft_model_config is not None else None
+
+    def _iter_all_models(self):
+        """Yield all model objects that need weight updates (main + optional drafter)."""
+        yield self.model_runner.model
+        drafter_model = self._get_drafter_model()
+        if drafter_model is not None:
+            yield drafter_model
+
+    def _iter_all_models_with_config(self):
+        """Yield (model, model_config) for all models that need post-processing."""
+        yield self.model_runner.model, self.model_runner.vllm_config.model_config
+        drafter_model = self._get_drafter_model()
+        draft_cfg = self._get_draft_model_config()
+        if drafter_model is not None and draft_cfg is not None:
+            yield drafter_model, draft_cfg
+
     def monkey_patch_model(self, vocab_size: int):
-        # patch compute_logits to avoid sampling OOV token
-        monkey_patch_compute_logits(self.model_runner.model, vocab_size)
-        # patch weight loader to support MoE model
-        patch_vllm_moe_model_weight_loader(self.model_runner.model)
+        for model in self._iter_all_models():
+            # patch compute_logits to avoid sampling OOV token
+            monkey_patch_compute_logits(model, vocab_size)
+            # patch weight loader to support MoE model
+            patch_vllm_moe_model_weight_loader(model)
 
     def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
         """Update the weights of the rollout model."""
@@ -181,7 +207,8 @@ class vLLMColocateWorkerExtension:
             # QAT (compressed-tensors): Prepare for weight loading BEFORE receiving any buckets
             from verl.utils.qat import prepare_qat_for_load_weights
 
-            prepare_qat_for_load_weights(self.model_runner.model, device=self.device)
+            for model in self._iter_all_models():
+                prepare_qat_for_load_weights(model, device=self.device)
             logger.info("QAT: prepare_qat_for_load_weights completed")
         elif self._is_modelopt_qat:
             from verl.utils.modelopt.vllm_modelopt_patch import prepare_modelopt_for_weight_reload
@@ -190,7 +217,8 @@ class vLLMColocateWorkerExtension:
             logger.info("ModelOpt: prepare_modelopt_for_weight_reload completed")
         elif use_standard_weight_load:
             # Re-apply here because async IPC weight sync can happen long after init and lose MoE weight_loader attrs.
-            patch_vllm_moe_model_weight_loader(self.model_runner.model)
+            for model in self._iter_all_models():
+                patch_vllm_moe_model_weight_loader(model)
 
         assert self.device is not None
         receiver = BucketedWeightReceiver(
@@ -208,7 +236,8 @@ class vLLMColocateWorkerExtension:
             # QAT (compressed-tensors): call process_weights_after_loading AFTER all buckets are received
             from verl.utils.qat import manual_process_weights_after_loading
 
-            manual_process_weights_after_loading(self.model_runner.model)
+            for model in self._iter_all_models():
+                manual_process_weights_after_loading(model)
             logger.info("QAT: process_weights_after_loading completed")
         elif self._is_modelopt_qat:
             from verl.utils.modelopt.vllm_modelopt_patch import modelopt_process_weights_after_loading
@@ -219,9 +248,8 @@ class vLLMColocateWorkerExtension:
             # Some post-load transforms are non-idempotent; run once after all buckets.
             from vllm.model_executor.model_loader.utils import process_weights_after_loading
 
-            model = self.model_runner.model
-            model_config = self.model_runner.vllm_config.model_config
-            process_weights_after_loading(model, model_config, self.device)
+            for model, model_config in self._iter_all_models_with_config():
+                process_weights_after_loading(model, model_config, self.device)
 
     def _update_weights(self, weights: list[tuple[str, torch.Tensor]], peft_config: dict, base_sync_done: bool):
         if peft_config and base_sync_done:
@@ -243,9 +271,13 @@ class vLLMColocateWorkerExtension:
                 # Convert bf16 weights to fp8 format before loading
                 loaded_params = load_quanted_weights(weights, self.model_runner)
                 logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
+                # Also load into drafter (MTP) model if present
+                if self._get_drafter_model() is not None:
+                    load_quanted_weights(weights, self.model_runner, is_drafter=True)
             else:
                 logger.info("Loading standard weights (non-FP8, async)")
-                self.model_runner.model.load_weights(weights)
+                for model in self._iter_all_models():
+                    model.load_weights(weights)
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication.

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -271,7 +271,7 @@ class vLLMColocateWorkerExtension:
                 # Convert bf16 weights to fp8 format before loading
                 loaded_params = load_quanted_weights(weights, self.model_runner)
                 logger.info(f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}")
-                # Also load into drafter (MTP) model if present
+                # Keep the draft model in sync when present.
                 if self._get_drafter_model() is not None:
                     load_quanted_weights(weights, self.model_runner, is_drafter=True)
             else:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -295,7 +295,7 @@ class vLLMHttpServer:
                     served_model_name = served_model_name.split("/")[-1]
                 args["served_model_name"] = served_model_name
 
-        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
+        if self.config.mtp.enable and self.config.mtp.enable_rollout:
             speculative_config = {
                 "method": self.config.mtp.method,
                 "num_speculative_tokens": self.config.mtp.num_speculative_tokens,
@@ -575,20 +575,15 @@ class vLLMHttpServer:
         if hasattr(final_res.outputs[0], "num_preempted"):
             num_preempted = final_res.outputs[0].num_preempted
 
-        # Extract per-request spec decode stats (if available)
-        spec_decode_info = {}
-        draft_tokens = getattr(final_res, "spec_num_draft_tokens", 0)
-        if draft_tokens > 0:
-            draft = final_res.spec_num_draft_tokens
-            accept = final_res.spec_num_accepted_tokens
-            verify = final_res.spec_num_verify_steps
-            spec_decode_info = {
-                "spec_num_draft_tokens": draft,
-                "spec_num_accepted_tokens": accept,
-                "spec_num_verify_steps": verify,
-            }
-
-        extra_fields.update(spec_decode_info)
+        # Per-request spec decode stats. vLLM populates these attributes on
+        # RequestOutput when speculative decoding is enabled (see verl's MTP
+        # rollout config block above). Mirrors the sglang path in
+        # ``async_sglang_server.py``: gated by config, fail-fast if any of the
+        # three attrs is missing.
+        if self.config.mtp.enable and self.config.mtp.enable_rollout:
+            extra_fields["spec_num_draft_tokens"] = final_res.spec_num_draft_tokens
+            extra_fields["spec_num_accepted_tokens"] = final_res.spec_num_accepted_tokens
+            extra_fields["spec_num_verify_steps"] = final_res.spec_num_verify_steps
         return TokenOutput(
             token_ids=token_ids,
             log_probs=log_probs,

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -573,7 +573,9 @@ class vLLMHttpServer:
 
         # Re-key backend spec-decoding stats to the rollout-common names.
         if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
-            spec_decode_stats = final_res.request_spec_decode_stats
+            if final_res.metrics is None or final_res.metrics.request_spec_decode_stats is None:
+                raise RuntimeError("vLLM MTP rollout requires request_spec_decode_stats; set disable_log_stats=False.")
+            spec_decode_stats = final_res.metrics.request_spec_decode_stats
             extra_fields["spec_num_draft_tokens"] = spec_decode_stats.num_draft_tokens
             extra_fields["spec_num_accepted_tokens"] = spec_decode_stats.num_accepted_tokens
             extra_fields["spec_num_verify_steps"] = spec_decode_stats.num_verify_steps

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -282,6 +282,10 @@ class vLLMHttpServer:
             # vLLM >= 0.13.0 supports profiler config via CLI args; env vars still work but will be deprecated
             args.update(profiler_args)
 
+        # allow deprecated quantization for vLLM >= 0.18.0
+        if _VLLM_VERSION >= version.parse("0.18.0"):
+            args["allow_deprecated_quantization"] = True
+
         if self.config.prometheus.enable:
             if self.config.prometheus.served_model_name:
                 # Extract model name from path if it's a full path
@@ -571,6 +575,20 @@ class vLLMHttpServer:
         if hasattr(final_res.outputs[0], "num_preempted"):
             num_preempted = final_res.outputs[0].num_preempted
 
+        # Extract per-request spec decode stats (if available)
+        spec_decode_info = {}
+        draft_tokens = getattr(final_res, "spec_num_draft_tokens", 0)
+        if draft_tokens > 0:
+            draft = final_res.spec_num_draft_tokens
+            accept = final_res.spec_num_accepted_tokens
+            verify = final_res.spec_num_verify_steps
+            spec_decode_info = {
+                "spec_num_draft_tokens": draft,
+                "spec_num_accepted_tokens": accept,
+                "spec_num_verify_steps": verify,
+            }
+
+        extra_fields.update(spec_decode_info)
         return TokenOutput(
             token_ids=token_ids,
             log_probs=log_probs,

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -282,10 +282,6 @@ class vLLMHttpServer:
             # vLLM >= 0.13.0 supports profiler config via CLI args; env vars still work but will be deprecated
             args.update(profiler_args)
 
-        # allow deprecated quantization for vLLM >= 0.18.0
-        if _VLLM_VERSION >= version.parse("0.18.0"):
-            args["allow_deprecated_quantization"] = True
-
         if self.config.prometheus.enable:
             if self.config.prometheus.served_model_name:
                 # Extract model name from path if it's a full path
@@ -295,7 +291,7 @@ class vLLMHttpServer:
                     served_model_name = served_model_name.split("/")[-1]
                 args["served_model_name"] = served_model_name
 
-        if self.config.mtp.enable and self.config.mtp.enable_rollout:
+        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
             speculative_config = {
                 "method": self.config.mtp.method,
                 "num_speculative_tokens": self.config.mtp.num_speculative_tokens,
@@ -575,15 +571,12 @@ class vLLMHttpServer:
         if hasattr(final_res.outputs[0], "num_preempted"):
             num_preempted = final_res.outputs[0].num_preempted
 
-        # Per-request spec decode stats. vLLM populates these attributes on
-        # RequestOutput when speculative decoding is enabled (see verl's MTP
-        # rollout config block above). Mirrors the sglang path in
-        # ``async_sglang_server.py``: gated by config, fail-fast if any of the
-        # three attrs is missing.
-        if self.config.mtp.enable and self.config.mtp.enable_rollout:
-            extra_fields["spec_num_draft_tokens"] = final_res.spec_num_draft_tokens
-            extra_fields["spec_num_accepted_tokens"] = final_res.spec_num_accepted_tokens
-            extra_fields["spec_num_verify_steps"] = final_res.spec_num_verify_steps
+        # Re-key backend spec-decoding stats to the rollout-common names.
+        if self.config.mtp is not None and self.config.mtp.enable and self.config.mtp.enable_rollout:
+            spec_decode_stats = final_res.request_spec_decode_stats
+            extra_fields["spec_num_draft_tokens"] = spec_decode_stats.num_draft_tokens
+            extra_fields["spec_num_accepted_tokens"] = spec_decode_stats.num_accepted_tokens
+            extra_fields["spec_num_verify_steps"] = spec_decode_stats.num_verify_steps
         return TokenOutput(
             token_ids=token_ids,
             log_probs=log_probs,


### PR DESCRIPTION
## Bug Background

This PR fixes several MTP training and rollout issues in the Megatron path.

The legacy MTP loss path computed auxiliary logits through the model output layer without fully isolating the LM head from the MTP objective. For models with an untied output head, `ColumnParallelLinear` can fall back to its own module parameters when no explicit shared output weight is provided, allowing MTP gradients to update `lm_head` together with the main policy loss. This can shift the verifier/base LM distribution and make the auxiliary MTP objective interfere with the main training objective.

The MTP loss mask was also built from a response-only mask through generic nested-tensor conversion. Since `input_ids` contains both prompt and response tokens while the response mask only covers the response span, this could misalign labels and masks, marking prompt positions as valid MTP-loss tokens or dropping valid response positions after rolling.

Activation recompute for MTP had another edge case: checkpoint wrappers only preserve tensor inputs, but the MTP forward path can receive non-tensor packed-sequence metadata such as `PackedSeqParams`. Passing these objects directly through checkpointing can fail or replay the recompute forward with incomplete arguments.

The reference model does not use MTP for log-prob/KL computation, but MTP-enabled HF configs can still cause Megatron to build MTP blocks on the ref path. That wastes GPU memory and can also make the ref log-prob postprocess enter the MTP loss path. Since ref log-prob does not pass labels, that path can attempt `labels.clone()` on `None` and fail with a `NoneType` error.

Rollout-time MTP/speculative decoding also needed consistent backend wiring and per-request acceptance metrics across vLLM and sglang.

## Fix

- Compute legacy Megatron MTP logits with a detached output-layer `functional_call`, so the auxiliary MTP loss does not update `lm_head`, including untied-output-head models.
- Make `detach_encoder` detach both next-token embeddings and main-decoder hidden states, keeping MTP gradients scoped to the MTP branch instead of adding an auxiliary backward path into the base decoder.
- Rebuild MTP recompute inputs so checkpoint wrappers receive only tensors, while non-tensor args/kwargs are restored inside the recompute closure. The recompute handling references THUDM/slime's Megatron MTP patch linked above.
- Build the MTP loss mask against each packed `input_ids` sequence as `[prompt zeros; response mask]`, then roll labels and masks together for each MTP step.
- Disable HF-configured MTP layers for ref-model Megatron engines when MTP is not enabled for that engine. This avoids loading unused ref MTP blocks, reduces memory usage, and prevents ref log-prob from entering the MTP loss path where `labels` is `None`.
- Add rollout MTP/speculative decoding wiring for vLLM and sglang, including per-request speculative decoding metric aggregation and None-safe handling for non-MTP rollout configs.

## Experiment

<img width="1106" height="1136" alt="image" src="https://github.com/user-attachments/assets/37a989ea-ae74-4593-adf6-243ad6074fdc" />

yellow line: verl original implementation

green line: this PR fix

## Reproduction

Environment used for the comparison:

- Megatron-LM: `NVIDIA/Megatron-LM@23e092f41ec8bc659020e401ddac9576c1cfed7e`
- mbridge: `ArronHZG/mbridge@6bf2d45a15dc4fb52d2f0c38ff546bee33447d10`
- sglang: `v0.5.9`

Script: `examples/mtp_trainer/run_mimo_7b_mtp_rl_vllm_sgl_megatron.sh`
