### PR TITLE
[ckpt] fix: use asyncio to run the _run method

### DIFF
--- a/verl/checkpoint_engine/hccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/hccl_checkpoint_engine.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import logging
 import os
 import time
@@ -70,7 +71,8 @@ class BroadcastOperation:
         self.socket = socket
         self.topic = topic
 
-        self._run()
+        loop = asyncio.get_running_loop()
+        self._task = loop.run_in_executor(None, self._run)
 
     def _run(self):
         # broadcast tensor meta via zeromq PUB/SUB
@@ -90,6 +92,7 @@ class BroadcastOperation:
         Returns:
             dict[str, TensorMeta]: The bucket meta after broadcast.
         """
+        await self._task
         return self.metadata
 
 


### PR DESCRIPTION
Refactor _run method to use asyncio for execution.

#### What does this PR do?

Refactor `HCCLCheckpointEngine.BroadcastOperation._run` to run in an asyncio executor, matching the NCCL implementation.  
This keeps the `BroadcastOperation` interface consistent across backends and allows the async training pipeline to overlap communication with computation more effectively.

### Test

Verified with end-to-end async training runs on HCCL/NCCL backends.

### API and Usage Example

No API changes.

```python
broadcast_op = BroadcastOperation(...)
metadata = await broadcast_op.wait_for_complete()
```
