### PR TITLE
[fully_async] fix: initialize _dump_executor in FullyAsyncTrainer and FullyAsyncRollouter

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -439,6 +439,8 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
         self.use_prefix_grouper = self.config.actor_rollout_ref.actor.get("use_prefix_grouper", False)
 
+        self._init_dump_executor()
+
         # ==================== fully async config ====================
 
         print("[FullyAsyncRollouter] Creating datasets...")

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -109,6 +109,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         self.global_steps = 0
         self.epoch = 0
         self._init_dump_executor()
+        self.validation_generations_logger = None
         self.max_steps_duration = 0
         self.progress_bar = None
         self.is_last_step = False

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -108,6 +108,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         # ==================== SeparateRayPPOTrainer config ====================
         self.global_steps = 0
         self.epoch = 0
+        self._init_dump_executor()
         self.max_steps_duration = 0
         self.progress_bar = None
         self.is_last_step = False


### PR DESCRIPTION
  ## Description:

  ### What does this PR do?

  `FullyAsyncTrainer` and `FullyAsyncRollouter` both skip `super().__init__()` from `RayPPOTrainer`, so `_dump_executor` (a `ThreadPoolExecutor` created by `_init_dump_executor()`) is never initialized. This causes
  an `AttributeError` when `_dump_generations()` is called during validation or training rollout logging.

  ### Error

```
  File "verl/experimental/fully_async_policy/fully_async_trainer.py", line 446, in fit_step
      self._fit_dump_data(batch)
  File "verl/experimental/separation/ray_trainer.py", line 652, in _fit_dump_data
      self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
  File "verl/trainer/ppo/ray_trainer.py", line 436, in _dump_generations
      future = self._dump_executor.submit(
               ^^^^^^^^^^^^^^^^^^^
  AttributeError: 'FullyAsyncTrainer' object has no attribute '_dump_executor'. Did you mean: '_init_dump_executor'?
```
  Same error occurs in `FullyAsyncRollouter.do_validate()` → `_validate()` → `_dump_generations()`.

  ### Fix

  Add `self._init_dump_executor()` to both `FullyAsyncTrainer.__init__()` and `FullyAsyncRollouter.__init__()`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Added experiment log above
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
