### PR TITLE
[1/n][trainer] feat: DPO dataset and collator

### DIFF
--- a/tests/utils/dataset/test_dpo_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_dpo_dataset_on_cpu.py
@@ -1,0 +1,996 @@
+# Copyright 2026 Amazon.com Inc and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the DPO dataset, collator, and related utilities.
+
+Tests cover:
+- Data loading: single file, multi-file, directory, JSONL, error handling
+- Packed-tensor output format: input_ids, loss_mask, boundary_offset
+- Truncation behavior
+- Invalid sample filtering
+- Collator: NestedTensor batching, boundary_offset preservation
+- YAML config resolution
+- Collator subclass defaults
+- Shuffle determinism (property-based)
+- File loading roundtrip (property-based)
+- Code quality: constants, try-parse, formatting standard
+"""
+
+import importlib.util
+import json
+import os
+import re
+import sys
+import tempfile
+import types
+
+import pandas as pd
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+from omegaconf import OmegaConf
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+# Check torch availability once at module level
+_TORCH_AVAILABLE = False
+try:
+    import torch as _torch_check  # noqa: F401
+    _TORCH_AVAILABLE = True
+except ImportError:
+    pass
+
+
+def _get_dpo_dataset_source() -> str:
+    """Read the raw source of dpo_dataset.py for inspection tests."""
+    path = os.path.join(_REPO_ROOT, "verl/utils/dataset/dpo_dataset.py")
+    with open(path) as f:
+        return f.read()
+
+
+def _ensure_mock_dependencies():
+    """Install minimal mock modules for torch, ray, etc. if not available."""
+    if "torch" not in sys.modules:
+        mock_torch = types.ModuleType("torch")
+        mock_torch.Tensor = type("Tensor", (), {})
+        mock_torch.utils = types.ModuleType("torch.utils")
+        mock_torch.utils.data = types.ModuleType("torch.utils.data")
+        mock_torch.utils.data.Dataset = type("Dataset", (), {})
+        mock_torch.nested = types.ModuleType("torch.nested")
+        mock_torch.jagged = "jagged"
+        sys.modules["torch"] = mock_torch
+        sys.modules["torch.utils"] = mock_torch.utils
+        sys.modules["torch.utils.data"] = mock_torch.utils.data
+        sys.modules["torch.nested"] = mock_torch.nested
+
+    if "tensordict" not in sys.modules:
+        mock_td = types.ModuleType("tensordict")
+        mock_td.tensorclass = types.ModuleType("tensordict.tensorclass")
+        mock_td.tensorclass.NonTensorData = type("NonTensorData", (), {})
+        sys.modules["tensordict"] = mock_td
+        sys.modules["tensordict.tensorclass"] = mock_td.tensorclass
+
+    if "transformers" not in sys.modules:
+        mock_tf = types.ModuleType("transformers")
+        mock_tf.PreTrainedTokenizer = type("PreTrainedTokenizer", (), {})
+        sys.modules["transformers"] = mock_tf
+
+    if "ray" not in sys.modules:
+        sys.modules["ray"] = types.ModuleType("ray")
+
+    if "verl" not in sys.modules:
+        mock_verl = types.ModuleType("verl")
+        sys.modules["verl"] = mock_verl
+    else:
+        mock_verl = sys.modules["verl"]
+
+    if not hasattr(mock_verl, "utils"):
+        mock_verl.utils = types.ModuleType("verl.utils")
+        mock_verl.utils.fs = types.ModuleType("verl.utils.fs")
+        mock_verl.utils.fs.copy_to_local = lambda src, **kwargs: src
+        mock_verl.utils.hf_tokenizer = lambda x: x
+        sys.modules.setdefault("verl.utils", mock_verl.utils)
+        sys.modules.setdefault("verl.utils.fs", mock_verl.utils.fs)
+        sys.modules.setdefault(
+            "verl.utils.hf_tokenizer", types.ModuleType("verl.utils.hf_tokenizer")
+        )
+
+    if "verl.utils.tensordict_utils" not in sys.modules:
+        mock_td_utils = types.ModuleType("verl.utils.tensordict_utils")
+        mock_td_utils.nested_tensor_from_tensor_list = lambda tensors: tensors
+        sys.modules["verl.utils.tensordict_utils"] = mock_td_utils
+
+    if "verl.base_config" not in sys.modules:
+        base_config_path = os.path.join(_REPO_ROOT, "verl", "base_config.py")
+        base_spec = importlib.util.spec_from_file_location("verl.base_config", base_config_path)
+        base_mod = importlib.util.module_from_spec(base_spec)
+        base_spec.loader.exec_module(base_mod)
+        sys.modules["verl.base_config"] = base_mod
+        if "verl" in sys.modules:
+            sys.modules["verl"].base_config = base_mod
+
+
+def _load_dataset_utils():
+    """Load verl/utils/dataset/dataset_utils.py directly (no heavy deps)."""
+    _ensure_mock_dependencies()
+    path = os.path.join(_REPO_ROOT, "verl", "utils", "dataset", "dataset_utils.py")
+    spec = importlib.util.spec_from_file_location("dataset_utils", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_dpo_dataset():
+    """Load verl/utils/dataset/dpo_dataset.py directly (no heavy deps)."""
+    _ensure_mock_dependencies()
+    path = os.path.join(_REPO_ROOT, "verl", "utils", "dataset", "dpo_dataset.py")
+    spec = importlib.util.spec_from_file_location("dpo_dataset", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _get_tokenizer():
+    """Get a small tokenizer for testing (requires torch + transformers)."""
+    from verl.utils import hf_tokenizer
+    return hf_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
+
+
+def _create_parquet(tmp_dir: str, name: str = "dpo_data.parquet", num_samples: int = 5, **col_overrides) -> str:
+    """Create a temporary parquet file with single-turn DPO data."""
+    data = {
+        "prompt": [f"Question {i}: What is {i}+{i}?" for i in range(num_samples)],
+        "chosen": [f"The answer is {i*2}." for i in range(num_samples)],
+        "rejected": [f"I think it's {i*2 + 1}." for i in range(num_samples)],
+    }
+    data.update(col_overrides)
+    df = pd.DataFrame(data)
+    path = os.path.join(tmp_dir, name)
+    df.to_parquet(path)
+    return path
+
+
+def _create_jsonl(tmp_dir: str, name: str = "dpo_data.jsonl", num_samples: int = 5) -> str:
+    """Create a temporary JSONL file with DPO data."""
+    path = os.path.join(tmp_dir, name)
+    with open(path, "w") as f:
+        for i in range(num_samples):
+            f.write(json.dumps({
+                "prompt": f"Question {i}?",
+                "chosen": f"Good answer {i}.",
+                "rejected": f"Bad answer {i}.",
+            }) + "\n")
+    return path
+
+
+def _default_config(**overrides):
+    """Create a default DPODataConfig for testing."""
+    from verl.utils.dataset.dpo_dataset import DPODataConfig
+    defaults = {"max_length": 256, "truncation": "right"}
+    defaults.update(overrides)
+    return DPODataConfig(**defaults)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sys_modules():
+    """Snapshot sys.modules before mock injection and restore after."""
+    snapshot = dict(sys.modules)
+    yield
+    sys.modules.clear()
+    sys.modules.update(snapshot)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 1: Data Loading Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not available")
+class TestDPODatasetLoading:
+    """Tests for data loading, validation, and multi-file support."""
+
+    def test_loads_parquet(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir, num_samples=7)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config())
+            assert len(dataset) == 7
+
+    def test_loads_jsonl(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_jsonl(tmp_dir, num_samples=5)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config())
+            assert len(dataset) == 5
+
+    def test_max_samples(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir, num_samples=10)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config(), max_samples=3)
+            assert len(dataset) == 3
+
+    def test_shuffle_changes_order(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir, num_samples=10)
+            ds_no = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config(shuffle=False))
+            ds_yes = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config(shuffle=True, seed=42))
+            assert ds_no.prompts != ds_yes.prompts
+
+    def test_missing_columns_raises(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            df = pd.DataFrame({"wrong_col": ["data"]})
+            path = os.path.join(tmp_dir, "bad.parquet")
+            df.to_parquet(path)
+            with pytest.raises(ValueError, match="missing required columns"):
+                DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config())
+
+    def test_unsupported_format_raises(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "data.csv")
+            with open(path, "w") as f:
+                f.write("prompt,chosen,rejected\nhi,good,bad\n")
+            with pytest.raises(ValueError, match="Could not parse"):
+                DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config())
+
+    def test_custom_column_names(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            df = pd.DataFrame({"q": ["Hi?"], "good": ["Hello!"], "bad": ["Bye"]})
+            path = os.path.join(tmp_dir, "custom.parquet")
+            df.to_parquet(path)
+            config = _default_config(prompt_key="q", chosen_key="good", rejected_key="bad")
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 1
+
+    def test_multi_file_concatenation(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            p1 = _create_parquet(tmp_dir, "part1.parquet", num_samples=5)
+            p2 = _create_parquet(tmp_dir, "part2.parquet", num_samples=8)
+            dataset = DPODataset(data_files=[p1, p2], tokenizer=tokenizer, config=_default_config())
+            assert len(dataset) == 13
+
+    def test_directory_loading(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_parquet(tmp_dir, "a.parquet", num_samples=3)
+            _create_parquet(tmp_dir, "b.parquet", num_samples=4)
+            dataset = DPODataset(data_files=tmp_dir, tokenizer=tokenizer, config=_default_config())
+            assert len(dataset) == 7
+
+    def test_empty_directory_raises(self):
+        from verl.utils.dataset.dpo_dataset import resolve_data_files
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            empty = os.path.join(tmp_dir, "empty")
+            os.makedirs(empty)
+            with pytest.raises(ValueError, match="No .parquet or .jsonl"):
+                resolve_data_files(empty)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 2: Packed-Tensor Output Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not available")
+class TestDPODatasetPackedOutput:
+    """Tests for the packed-tensor output format."""
+
+    @pytest.fixture
+    def dataset(self, tmp_path):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        path = _create_parquet(str(tmp_path), num_samples=3)
+        return DPODataset(data_files=path, tokenizer=_get_tokenizer(), config=_default_config())
+
+    def test_output_keys(self, dataset):
+        sample = dataset[0]
+        assert set(sample.keys()) == {"input_ids", "loss_mask", "boundary_offset"}
+
+    def test_no_old_format_keys(self, dataset):
+        sample = dataset[0]
+        for old_key in ["chosen_input_ids", "rejected_input_ids", "chosen_labels",
+                        "rejected_labels", "chosen_attention_mask", "rejected_attention_mask"]:
+            assert old_key not in sample
+
+    def test_boundary_offset_is_int(self, dataset):
+        assert isinstance(dataset[0]["boundary_offset"], int)
+
+    def test_boundary_offset_in_range(self, dataset):
+        sample = dataset[0]
+        offset = sample["boundary_offset"]
+        total = sample["input_ids"].shape[0]
+        assert 0 < offset < total
+
+    def test_loss_mask_is_binary(self, dataset):
+        mask = dataset[0]["loss_mask"]
+        assert set(mask.unique().tolist()).issubset({0, 1})
+
+    def test_loss_mask_shape_matches_input_ids(self, dataset):
+        sample = dataset[0]
+        assert sample["loss_mask"].shape == sample["input_ids"].shape
+
+    def test_prompt_masked_in_both_halves(self, dataset):
+        sample = dataset[0]
+        offset = sample["boundary_offset"]
+        assert sample["loss_mask"][0] == 0, "Chosen half: first token should be prompt (mask=0)"
+        assert sample["loss_mask"][offset] == 0, "Rejected half: first token should be prompt (mask=0)"
+
+    def test_response_tokens_have_mask_1(self, dataset):
+        sample = dataset[0]
+        mask = sample["loss_mask"]
+        assert mask.sum() > 0, "Should have some response tokens (mask=1)"
+
+    def test_all_samples_accessible(self, dataset):
+        for i in range(len(dataset)):
+            sample = dataset[i]
+            assert "input_ids" in sample
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 3: Truncation Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not available")
+class TestDPODatasetTruncation:
+    """Tests for truncation behavior."""
+
+    def test_right_truncation(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir)
+            config = _default_config(max_length=10, truncation="right")
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            sample = dataset[0]
+            assert sample["input_ids"].shape[0] <= 20
+
+    def test_left_truncation(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir)
+            config = _default_config(max_length=10, truncation="left")
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            sample = dataset[0]
+            assert sample["input_ids"].shape[0] <= 20
+
+    def test_invalid_truncation_raises(self):
+        with pytest.raises(AssertionError):
+            _default_config(max_length=10, truncation="invalid")
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 4: Invalid Sample Filtering Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not available")
+class TestDPODatasetFiltering:
+    """Tests for inspect_and_filter_invalid_samples behavior."""
+
+    def _create_parquet_with_invalids(self, tmp_dir, num_valid=5):
+        data = {
+            "prompt": (
+                [f"Valid prompt {i}" for i in range(num_valid)]
+                + [None, "", "  ", "Good prompt", "Identical prompt"]
+            ),
+            "chosen": (
+                [f"Good answer {i}" for i in range(num_valid)]
+                + ["Some answer", "Some answer", "Some answer", None, "Same response"]
+            ),
+            "rejected": (
+                [f"Bad answer {i}" for i in range(num_valid)]
+                + ["Some bad", "Some bad", "Some bad", "Some bad", "Same response"]
+            ),
+        }
+        df = pd.DataFrame(data)
+        path = os.path.join(tmp_dir, "mixed.parquet")
+        df.to_parquet(path)
+        return path
+
+    def test_remove_invalid_true_drops_samples(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = self._create_parquet_with_invalids(tmp_dir, num_valid=5)
+            config = _default_config(remove_invalid_samples=True)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 5
+
+    def test_remove_invalid_false_keeps_all_samples(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = self._create_parquet_with_invalids(tmp_dir, num_valid=5)
+            config = _default_config(remove_invalid_samples=False)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 10
+
+    def test_remove_invalid_false_logs_warning(self, caplog):
+        import logging
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = self._create_parquet_with_invalids(tmp_dir, num_valid=5)
+            config = _default_config(remove_invalid_samples=False)
+            with caplog.at_level(logging.WARNING):
+                DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert "invalid samples" in caplog.text
+
+    def test_all_valid_samples_no_warning(self, caplog):
+        import logging
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir, num_samples=5)
+            config = _default_config(remove_invalid_samples=False)
+            with caplog.at_level(logging.WARNING):
+                dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert "invalid samples" not in caplog.text
+            assert len(dataset) == 5
+
+    def test_null_rejected_filtered(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = {"prompt": ["Q1", "Q2", "Q3"], "chosen": ["A1", "A2", "A3"], "rejected": ["R1", None, "R3"]}
+            df = pd.DataFrame(data)
+            path = os.path.join(tmp_dir, "null_rej.parquet")
+            df.to_parquet(path)
+            config = _default_config(remove_invalid_samples=True)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 2
+
+    def test_identical_pair_filtered(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = {"prompt": ["Q1", "Q2"], "chosen": ["Same answer", "Different"], "rejected": ["Same answer", "Also different"]}
+            df = pd.DataFrame(data)
+            path = os.path.join(tmp_dir, "identical.parquet")
+            df.to_parquet(path)
+            config = _default_config(remove_invalid_samples=True)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 1
+
+    def test_default_config_does_not_remove(self):
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = {"prompt": ["Q1", "Q2"], "chosen": ["A1", "A2"], "rejected": [None, "R2"]}
+            df = pd.DataFrame(data)
+            path = os.path.join(tmp_dir, "default.parquet")
+            df.to_parquet(path)
+            config = _default_config()
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            assert len(dataset) == 2
+
+    def test_none_values_with_chat_template_do_not_crash(self):
+        """Samples with None fields should not crash when chat_template_key is set."""
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data = {"prompt": ["Q1", None], "chosen": ["A1", "A2"], "rejected": ["R1", None]}
+            df = pd.DataFrame(data)
+            path = os.path.join(tmp_dir, "nulls.parquet")
+            df.to_parquet(path)
+            config = _default_config(chat_template_key="default", remove_invalid_samples=False)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=config)
+            # Should not raise — None values are guarded before apply_chat_template
+            for i in range(len(dataset)):
+                sample = dataset[i]
+                assert "input_ids" in sample
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 5: Collator Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="torch not available")
+class TestDPOCollator:
+    """Tests for DPOTensorCollator with packed sequences."""
+
+    def test_no_padding_produces_nested_tensors(self):
+        import torch
+        from verl.utils.dataset.dataset_utils import DPOTensorCollator
+        collator = DPOTensorCollator("no_padding")
+        batch = [
+            {"input_ids": torch.arange(10), "loss_mask": torch.zeros(10), "boundary_offset": 5},
+            {"input_ids": torch.arange(15), "loss_mask": torch.zeros(15), "boundary_offset": 8},
+        ]
+        result = collator(batch)
+        assert result["input_ids"].is_nested
+        assert result["loss_mask"].is_nested
+
+    def test_batch_size_correct(self):
+        import torch
+        from verl.utils.dataset.dataset_utils import DPOTensorCollator
+        collator = DPOTensorCollator("no_padding")
+        batch = [
+            {"input_ids": torch.arange(10), "loss_mask": torch.zeros(10), "boundary_offset": 5},
+            {"input_ids": torch.arange(15), "loss_mask": torch.zeros(15), "boundary_offset": 8},
+            {"input_ids": torch.arange(12), "loss_mask": torch.zeros(12), "boundary_offset": 6},
+        ]
+        result = collator(batch)
+        assert len(result["input_ids"].offsets()) - 1 == 3
+
+    def test_variable_lengths_preserved(self):
+        import torch
+        from verl.utils.dataset.dataset_utils import DPOTensorCollator
+        collator = DPOTensorCollator("no_padding")
+        batch = [
+            {"input_ids": torch.ones(20), "loss_mask": torch.zeros(20), "boundary_offset": 10},
+            {"input_ids": torch.ones(50), "loss_mask": torch.zeros(50), "boundary_offset": 25},
+        ]
+        result = collator(batch)
+        seqlens = result["input_ids"].offsets().diff()
+        assert seqlens[0].item() == 20
+        assert seqlens[1].item() == 50
+
+    def test_boundary_offsets_preserved(self):
+        import torch
+        from verl.utils.dataset.dataset_utils import DPOTensorCollator
+        collator = DPOTensorCollator("no_padding")
+        batch = [
+            {"input_ids": torch.arange(10), "loss_mask": torch.zeros(10), "boundary_offset": 5},
+            {"input_ids": torch.arange(15), "loss_mask": torch.zeros(15), "boundary_offset": 8},
+        ]
+        result = collator(batch)
+        offsets = result["boundary_offset"]
+        assert offsets is not None
+
+    def test_dataloader_integration(self):
+        import torch
+        from torch.utils.data import DataLoader
+        from verl.utils.dataset.dataset_utils import DPOTensorCollator
+        from verl.utils.dataset.dpo_dataset import DPODataset
+        tokenizer = _get_tokenizer()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = _create_parquet(tmp_dir, num_samples=6)
+            dataset = DPODataset(data_files=path, tokenizer=tokenizer, config=_default_config())
+            collator = DPOTensorCollator("no_padding")
+            dataloader = DataLoader(dataset, batch_size=3, collate_fn=collator)
+            batch = next(iter(dataloader))
+            assert batch["input_ids"].is_nested
+            assert len(batch["input_ids"].offsets()) - 1 == 3
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 6: YAML Config Resolution Tests
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestYamlResolutionPreservation:
+    """Verify dpo_trainer.yaml resolves to expected configuration values."""
+
+    @pytest.fixture(autouse=True)
+    def load_yaml(self):
+        yaml_path = os.path.join(_REPO_ROOT, "verl", "trainer", "config", "dpo_trainer.yaml")
+        self.cfg = OmegaConf.load(yaml_path)
+
+    def test_data_section_keys_preserved(self):
+        expected_keys = {
+            "train_batch_size", "micro_batch_size_per_gpu", "max_token_len_per_gpu",
+            "use_dynamic_bsz", "dataloader_num_workers", "train_files", "val_files", "train_max_samples",
+            "val_max_samples", "prompt_key", "chosen_key", "rejected_key",
+            "pad_mode", "max_length", "truncation", "shuffle",
+            "seed", "remove_invalid_samples", "custom_cls", "use_shm",
+            "apply_chat_template_kwargs", "chat_template_key",
+        }
+        actual_keys = set(self.cfg.data.keys())
+        assert expected_keys.issubset(actual_keys), (
+            f"Missing data keys after load: {expected_keys - actual_keys}"
+        )
+
+    def test_data_scalar_values_preserved(self):
+        data = self.cfg.data
+        assert data.train_batch_size == 256
+        assert data.micro_batch_size_per_gpu == 4
+        assert data.max_token_len_per_gpu == 8192
+        assert data.use_dynamic_bsz is True
+        assert data.train_files is None
+        assert data.val_files is None
+        assert data.train_max_samples == -1
+        assert data.val_max_samples == -1
+        assert data.prompt_key == "prompt"
+        assert data.chosen_key == "chosen"
+        assert data.rejected_key == "rejected"
+        assert data.pad_mode == "no_padding"
+        assert data.max_length == 1024
+        assert data.truncation == "error"
+        assert data.shuffle is True
+        assert data.seed == 42
+        assert data.remove_invalid_samples is False
+        assert data.use_shm is False
+        assert data.chat_template_key is None
+
+    def test_trainer_section_values_preserved(self):
+        trainer = self.cfg.trainer
+        assert trainer.beta == 0.01
+        assert trainer.loss_type == "sigmoid"
+        assert trainer.label_smoothing == 0.0
+        assert trainer.reference_free is False
+        assert trainer.project_name == "dpo-training"
+        assert trainer.experiment_name == "test_run"
+        assert trainer.total_epochs == 3
+        assert trainer.save_freq == -1
+        assert trainer.test_freq == -1
+        assert trainer.nnodes == 1
+        assert trainer.n_gpus_per_node == 1
+
+    def test_checkpoint_section_values_preserved(self):
+        ckpt = self.cfg.checkpoint
+        assert ckpt.save_only_adapter_if_lora is True
+        assert list(ckpt.save_contents) == ["model", "optimizer", "extra", "hf_model"]
+
+    def test_engine_strategy_preserved(self):
+        assert self.cfg.engine.strategy == "fsdp2"
+
+    @given(st.just(True))
+    @settings(max_examples=1)
+    def test_yaml_reload_produces_identical_values(self, _):
+        yaml_path = os.path.join(_REPO_ROOT, "verl", "trainer", "config", "dpo_trainer.yaml")
+        cfg1 = OmegaConf.load(yaml_path)
+        cfg2 = OmegaConf.load(yaml_path)
+        assert OmegaConf.to_container(cfg1) == OmegaConf.to_container(cfg2)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 7: Collator Subclass Defaults
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestCollatorSubclassDefaults:
+    """Verify DPOTensorCollator and SFTTensorCollator default pad_mode values."""
+
+    @pytest.fixture(autouse=True)
+    def load_module(self):
+        self.mod = _load_dataset_utils()
+
+    def test_dpo_tensor_collator_default_is_no_padding(self):
+        collator = self.mod.DPOTensorCollator()
+        assert collator.pad_mode == self.mod.DatasetPadMode.NO_PADDING
+
+    def test_sft_tensor_collator_default_is_left_right(self):
+        collator = self.mod.SFTTensorCollator()
+        assert collator.pad_mode == self.mod.DatasetPadMode.LEFT_RIGHT
+
+    def test_custom_tensor_collator_requires_pad_mode(self):
+        """CustomTensorCollator has no default — pad_mode is required."""
+        with pytest.raises(TypeError):
+            self.mod.CustomTensorCollator()
+
+    @given(st.just(True))
+    @settings(max_examples=1)
+    def test_collator_defaults_are_stable(self, _):
+        for _ in range(5):
+            assert self.mod.DPOTensorCollator().pad_mode == self.mod.DatasetPadMode.NO_PADDING
+            assert self.mod.SFTTensorCollator().pad_mode == self.mod.DatasetPadMode.LEFT_RIGHT
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 8: Shuffle Determinism (property-based)
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestShuffleDeterminism:
+    """Verify shuffle_and_limit determinism and max_samples behavior."""
+
+    @pytest.fixture(autouse=True)
+    def load_module(self):
+        self.mod = _load_dpo_dataset()
+
+    def _make_dataframe(self, n_rows: int) -> pd.DataFrame:
+        return pd.DataFrame({
+            "prompt": [f"prompt_{i}" for i in range(n_rows)],
+            "chosen": [f"chosen_{i}" for i in range(n_rows)],
+            "rejected": [f"rejected_{i}" for i in range(n_rows)],
+        })
+
+    def test_same_seed_same_output(self):
+        df = self._make_dataframe(20)
+        r1 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=42)
+        r2 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=42)
+        pd.testing.assert_frame_equal(r1.reset_index(drop=True), r2.reset_index(drop=True))
+
+    def test_different_seed_different_output(self):
+        df = self._make_dataframe(20)
+        r1 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=42)
+        r2 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=99)
+        assert not r1.reset_index(drop=True).equals(r2.reset_index(drop=True))
+
+    def test_no_shuffle_preserves_order(self):
+        df = self._make_dataframe(10)
+        result = self.mod.shuffle_and_limit(df.copy(), shuffle=False, seed=42)
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), df.reset_index(drop=True))
+
+    def test_max_samples_limits_rows(self):
+        df = self._make_dataframe(20)
+        result = self.mod.shuffle_and_limit(df.copy(), max_samples=5, shuffle=False)
+        assert len(result) == 5
+
+    @given(
+        n_rows=st.integers(min_value=2, max_value=100),
+        seed=st.integers(min_value=0, max_value=2**31 - 1),
+    )
+    @settings(max_examples=20)
+    def test_shuffle_determinism_property(self, n_rows, seed):
+        df = self._make_dataframe(n_rows)
+        r1 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=seed)
+        r2 = self.mod.shuffle_and_limit(df.copy(), shuffle=True, seed=seed)
+        pd.testing.assert_frame_equal(r1.reset_index(drop=True), r2.reset_index(drop=True))
+
+    @given(
+        n_rows=st.integers(min_value=5, max_value=100),
+        max_samples=st.integers(min_value=1, max_value=4),
+    )
+    @settings(max_examples=10)
+    def test_max_samples_property(self, n_rows, max_samples):
+        assume(max_samples < n_rows)
+        df = self._make_dataframe(n_rows)
+        result = self.mod.shuffle_and_limit(df.copy(), max_samples=max_samples, shuffle=False)
+        assert len(result) == max_samples
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 9: File Loading Roundtrip (property-based)
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestFileLoadingPreservation:
+    """Verify load_data_file correctly roundtrips parquet and jsonl files."""
+
+    @pytest.fixture(autouse=True)
+    def load_module(self):
+        self.mod = _load_dpo_dataset()
+
+    def _sample_dataframe(self) -> pd.DataFrame:
+        return pd.DataFrame({
+            "prompt": ["What is 2+2?", "Tell me a joke"],
+            "chosen": ["4", "Why did the chicken cross the road?"],
+            "rejected": ["5", "I don't know any jokes"],
+        })
+
+    def test_load_parquet_file(self):
+        df = self._sample_dataframe()
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            df.to_parquet(f.name)
+            tmp_path = f.name
+        try:
+            loaded = self.mod.load_data_file(tmp_path)
+            pd.testing.assert_frame_equal(loaded, df)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_load_jsonl_file(self):
+        df = self._sample_dataframe()
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            df.to_json(f.name, orient="records", lines=True)
+            tmp_path = f.name
+        try:
+            loaded = self.mod.load_data_file(tmp_path)
+            pd.testing.assert_frame_equal(loaded, df)
+        finally:
+            os.unlink(tmp_path)
+
+    @given(
+        n_rows=st.integers(min_value=1, max_value=20),
+        n_cols=st.integers(min_value=1, max_value=5),
+    )
+    @settings(max_examples=10)
+    def test_parquet_roundtrip_property(self, n_rows, n_cols):
+        data = {f"col_{i}": [f"val_{i}_{j}" for j in range(n_rows)] for i in range(n_cols)}
+        df = pd.DataFrame(data)
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            df.to_parquet(f.name)
+            tmp_path = f.name
+        try:
+            loaded = self.mod.load_data_file(tmp_path)
+            pd.testing.assert_frame_equal(loaded, df)
+        finally:
+            os.unlink(tmp_path)
+
+    @given(
+        n_rows=st.integers(min_value=1, max_value=20),
+        n_cols=st.integers(min_value=1, max_value=5),
+    )
+    @settings(max_examples=10)
+    def test_jsonl_roundtrip_property(self, n_rows, n_cols):
+        data = {f"col_{i}": [f"val_{i}_{j}" for j in range(n_rows)] for i in range(n_cols)}
+        df = pd.DataFrame(data)
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            df.to_json(f.name, orient="records", lines=True)
+            tmp_path = f.name
+        try:
+            loaded = self.mod.load_data_file(tmp_path)
+            pd.testing.assert_frame_equal(loaded, df)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_file_not_found_raises(self):
+        """load_data_file should raise FileNotFoundError for nonexistent files."""
+        with pytest.raises(FileNotFoundError, match="Data file not found"):
+            self.mod.load_data_file("/nonexistent/path/to/data.parquet")
+
+    def test_unsupported_content_raises_value_error(self):
+        """load_data_file should raise ValueError for files that aren't parquet or jsonl."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w") as f:
+            f.write("this is plain text, not parquet or jsonl")
+            tmp_path = f.name
+        try:
+            with pytest.raises(ValueError, match="Could not parse"):
+                self.mod.load_data_file(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_unsupported_content_chains_parquet_error(self):
+        """ValueError from unsupported content should chain the parquet error and include the JSONL error."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False, mode="w") as f:
+            f.write("this is plain text, not parquet or jsonl")
+            tmp_path = f.name
+        try:
+            with pytest.raises(ValueError) as exc_info:
+                self.mod.load_data_file(tmp_path)
+            # Parquet error chained via __cause__
+            assert exc_info.value.__cause__ is not None, (
+                "ValueError should chain the original parquet error via 'from parquet_err'"
+            )
+            # JSONL error included in the message text
+            assert "JSON Lines error:" in str(exc_info.value), (
+                "ValueError message should include the JSON Lines parse error"
+            )
+        finally:
+            os.unlink(tmp_path)
+
+    def test_empty_file_raises(self):
+        """load_data_file should raise on an empty file (not silently return empty DataFrame)."""
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            tmp_path = f.name
+        try:
+            with pytest.raises(Exception):
+                self.mod.load_data_file(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_parquet_with_non_standard_extension(self):
+        """A valid parquet file with a .dat extension should load via try-parse."""
+        df = self._sample_dataframe()
+        with tempfile.NamedTemporaryFile(suffix=".dat", delete=False) as f:
+            df.to_parquet(f.name)
+            tmp_path = f.name
+        try:
+            loaded = self.mod.load_data_file(tmp_path)
+            pd.testing.assert_frame_equal(loaded, df)
+        finally:
+            os.unlink(tmp_path)
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# SECTION 10: YAML & Code Quality Checks
+# ═════════════════════════════════════════════════════════════════════════
+
+
+class TestDpoYamlFormattingStandard:
+    """Assert dpo_trainer.yaml follows the PPO formatting standard."""
+
+    @pytest.fixture(autouse=True)
+    def load_yaml(self):
+        yaml_path = os.path.join(_REPO_ROOT, "verl", "trainer", "config", "dpo_trainer.yaml")
+        with open(yaml_path) as f:
+            self.yaml_content = f.read()
+        self.yaml_lines = self.yaml_content.splitlines()
+
+    def test_has_format_check_header(self):
+        assert "# Format checks enforced on CI:" in self.yaml_content
+
+    def test_no_inline_comments(self):
+        inline_comment_pattern = re.compile(r"^[^#\n]*:\s*[^#\n]+\s+#")
+        violations = []
+        for i, line in enumerate(self.yaml_lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            if inline_comment_pattern.match(line):
+                violations.append(f"  Line {i}: {line.rstrip()}")
+        assert not violations, (
+            f"dpo_trainer.yaml has inline comments:\n" + "\n".join(violations)
+        )
+
+    def test_blank_lines_between_fields(self):
+        field_lines = []
+        for i, line in enumerate(self.yaml_lines):
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                field_lines.append((i, line))
+        violations = []
+        for idx in range(1, len(field_lines)):
+            prev_lineno = field_lines[idx - 1][0]
+            curr_lineno = field_lines[idx][0]
+            if curr_lineno == prev_lineno + 1:
+                prev_stripped = field_lines[idx - 1][1].strip()
+                curr_stripped = field_lines[idx][1].strip()
+                if prev_stripped.startswith("-") and curr_stripped.startswith("-"):
+                    continue
+                violations.append(
+                    f"  Lines {prev_lineno + 1}-{curr_lineno + 1}: "
+                    f"{field_lines[idx - 1][1].rstrip()} / {field_lines[idx][1].rstrip()}"
+                )
+        assert not violations, (
+            f"dpo_trainer.yaml missing blank lines between fields:\n" + "\n".join(violations[:5])
+        )
+
+
+class TestCodeQualityConstants:
+    """Assert named constants and idiomatic patterns in dpo_dataset.py."""
+
+    @pytest.fixture(autouse=True)
+    def load_source(self):
+        self.source = _get_dpo_dataset_source()
+
+    def test_dpo_supported_truncation_constant_exists(self):
+        assert "DPO_SUPPORTED_TRUNCATION" in self.source
+
+    def test_dpo_supported_file_types_constant_exists(self):
+        assert "DPO_SUPPORTED_FILE_TYPES" in self.source
+
+    def test_dpo_data_config_class_defined(self):
+        assert "class DPODataConfig" in self.source
+
+    def test_dpo_data_config_inherits_base_config(self):
+        assert re.search(r"class DPODataConfig\([^)]*BaseConfig[^)]*\)", self.source)
+
+    def test_shuffle_uses_dataframe_sample(self):
+        match = re.search(
+            r"(def shuffle_and_limit\b.*?)(?=\ndef |\nclass |\Z)", self.source, re.DOTALL
+        )
+        assert match is not None
+        func_source = match.group(1)
+        assert ".sample(" in func_source
+        assert "np.random" not in func_source
+        assert "rng.permutation" not in func_source
+
+    def test_load_data_file_uses_try_parse(self):
+        match = re.search(
+            r"(def load_data_file\b.*?)(?=\ndef |\nclass |\Z)", self.source, re.DOTALL
+        )
+        assert match is not None
+        func_source = match.group(1)
+        assert ".endswith(" not in func_source
+        assert "try:" in func_source and "read_parquet" in func_source
+
+    def test_resolve_data_files_references_constant(self):
+        match = re.search(
+            r"(def resolve_data_files\b.*?)(?=\ndef |\nclass |\Z)", self.source, re.DOTALL
+        )
+        assert match is not None
+        assert "DPO_SUPPORTED_FILE_TYPES" in match.group(1)

--- a/tests/utils/dataset/test_dpo_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_dpo_dataset_on_cpu.py
@@ -146,9 +146,36 @@ def _load_dpo_dataset():
 
 
 def _get_tokenizer():
-    """Get a small tokenizer for testing (requires torch + transformers)."""
-    from verl.utils import hf_tokenizer
-    return hf_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
+    """Create a mock tokenizer for testing (no HuggingFace download needed).
+
+    Supports the minimal interface used by DPODataset:
+    - __call__(text, ...) → {"input_ids": tensor}
+    - apply_chat_template(messages, ...) → str
+    - eos_token_id → int
+    """
+    import torch
+
+    class MockTokenizer:
+        eos_token_id = 0
+
+        def __call__(self, text, return_tensors=None, add_special_tokens=True, **kwargs):
+            # Simple char-level "tokenization" — each char becomes a token ID
+            ids = [ord(c) % 256 for c in (text or "")]
+            if not ids:
+                ids = [self.eos_token_id]
+            result = {"input_ids": torch.tensor([ids], dtype=torch.long)}
+            return result
+
+        def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+            # Simple template: join message contents
+            parts = []
+            for msg in messages:
+                parts.append(f"<|{msg['role']}|>{msg['content']}")
+            if add_generation_prompt:
+                parts.append("<|assistant|>")
+            return "\n".join(parts)
+
+    return MockTokenizer()
 
 
 def _create_parquet(tmp_dir: str, name: str = "dpo_data.parquet", num_samples: int = 5, **col_overrides) -> str:

--- a/verl/trainer/config/dpo_trainer.yaml
+++ b/verl/trainer/config/dpo_trainer.yaml
@@ -1,0 +1,221 @@
+# Format checks enforced on CI:
+# 1. Comments must appear above each field.
+# 2. There must be a blank line between each field.
+# 3. Inline comments (after a field on the same line) are not allowed.
+# 4. Indentation level is respected for nested fields.
+
+# DPO Trainer Configuration
+
+# specify the default per-component configs
+defaults:
+
+  # Model config.
+  - model@model: hf_model
+
+  # Engine config.
+  - engine@engine: fsdp
+
+  # Optimizer config.
+  - optim@optim: fsdp
+
+  # Profiler config.
+  - profiler@profiler: profiler
+
+  # load the reference default config, then apply the fields in the current yaml
+  # self config override anything above
+  - _self_
+
+# Engine configuration
+engine:
+
+  # Engine strategy type
+  strategy: fsdp2
+
+# Optimizer configuration
+optim:
+
+  # Learning rate
+  lr: 1e-4
+
+  # Adam beta parameters
+  betas: [0.9, 0.95]
+
+  # Weight decay coefficient
+  weight_decay: 0.0
+
+  # Ratio of warmup steps to total training steps
+  lr_warmup_steps_ratio: 0.1
+
+  # Gradient clipping value
+  clip_grad: 1.0
+
+  # Learning rate scheduler type
+  lr_scheduler_type: cosine
+
+  # Minimum learning rate ratio for scheduler
+  min_lr_ratio: 0.1
+
+# Data configuration
+data:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl.utils.dataset.dpo_dataset.DPODataConfig
+
+  # Total training batch size across all GPUs
+  train_batch_size: 256
+
+  # Fallback for non-dynamic mode. Each DPO sample = 1 packed sequence.
+  micro_batch_size_per_gpu: 4
+
+  # Max total tokens per micro-batch (for dynamic batching)
+  max_token_len_per_gpu: 8192
+
+  # Safe with packed-sequence packing — pairs are packed into single entries
+  use_dynamic_bsz: True
+
+  # Number of workers for the data loader
+  dataloader_num_workers: 8
+
+  # Path to training data files
+  train_files: null
+
+  # Path to validation data files
+  val_files: null
+
+  # Maximum number of training samples (-1 to use full dataset)
+  train_max_samples: -1
+
+  # Maximum number of validation samples (-1 to use full dataset)
+  val_max_samples: -1
+
+  # Key for prompt field in dataset
+  prompt_key: prompt
+
+  # Key for chosen response field in dataset
+  chosen_key: chosen
+
+  # Key for rejected response field in dataset
+  rejected_key: rejected
+
+  # Padding mode for collator
+  pad_mode: no_padding
+
+  # Maximum sequence length
+  max_length: 1024
+
+  # Truncation strategy: "left", "right", or "error"
+  truncation: error
+
+  # Whether to shuffle the dataset
+  shuffle: true
+
+  # Random seed for reproducibility
+  seed: 42
+
+  # Whether to remove invalid samples from the dataset
+  remove_invalid_samples: false
+
+  # Custom dataset class configuration
+  custom_cls:
+
+    # Path to custom dataset class file
+    path: null
+
+    # Name of the custom dataset class
+    name: null
+
+  # Whether to use shared memory for data loading
+  use_shm: False
+
+  # Additional kwargs for chat template application
+  apply_chat_template_kwargs: {}
+
+  # Key for selecting chat template
+  chat_template_key: null
+
+# Checkpoint configuration
+checkpoint:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl.trainer.config.CheckpointConfig
+
+  # Contents to save in checkpoint
+  save_contents: ["model", "optimizer", "extra", "hf_model"]
+
+  # Contents to load from checkpoint
+  load_contents: ${checkpoint.save_contents}
+
+  # When doing LoRA training, save only the adapter (not full model) for regular checkpoints
+  save_only_adapter_if_lora: true
+
+# Model configuration
+model:
+
+  # Dropout probability applied to lora inputs for regularization
+  lora_dropout: 0.05
+
+# Trainer configuration
+trainer:
+
+  # DPO beta parameter controlling divergence from reference policy
+  beta: 0.01
+
+  # DPO loss type
+  loss_type: sigmoid
+
+  # Label smoothing coefficient for DPO loss
+  label_smoothing: 0.0
+
+  # Whether to use reference-free DPO
+  reference_free: false
+
+  # Default local directory for saving checkpoints
+  default_local_dir: checkpoints/${trainer.project_name}/${trainer.experiment_name}
+
+  # Default path to distributed filesystem for saving checkpoints
+  default_hdfs_dir: null
+
+  # Project name for experiment tracking
+  project_name: dpo-training
+
+  # Experiment name for run identification
+  experiment_name: test_run
+
+  # Number of epochs in training
+  total_epochs: 3
+
+  # Total training steps (can be set explicitly or derived from epochs)
+  total_training_steps: null
+
+  # Logging backends to use
+  logger: ['console', 'tensorboard', 'wandb']
+
+  # Save frequency (by iteration) for model checkpoints
+  save_freq: -1
+
+  # Validation frequency (in training iterations)
+  test_freq: -1
+
+  # Maximum number of checkpoints to keep
+  max_ckpt_to_keep: null
+
+  # Resume mode: "auto", "disable", or "resume_path"
+  resume_mode: auto
+
+  # Path to resume training from
+  resume_from_path: null
+
+  # Device to run training on
+  device: cuda
+
+  # Number of nodes used in the training
+  nnodes: 1
+
+  # Number of GPUs per node
+  n_gpus_per_node: 1
+
+  # Profile interval range
+  profile_interval: [-1, -1]
+
+  # When true, also save a merged LoRA model for the final HF checkpoint
+  merge_lora_on_final_save: true

--- a/verl/trainer/config/dpo_trainer.yaml
+++ b/verl/trainer/config/dpo_trainer.yaml
@@ -148,12 +148,6 @@ checkpoint:
   # When doing LoRA training, save only the adapter (not full model) for regular checkpoints
   save_only_adapter_if_lora: true
 
-# Model configuration
-model:
-
-  # Dropout probability applied to lora inputs for regularization
-  lora_dropout: 0.05
-
 # Trainer configuration
 trainer:
 

--- a/verl/utils/dataset/__init__.py
+++ b/verl/utils/dataset/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .dpo_dataset import DPODataset
 from .rl_dataset import RLHFDataset
 from .rm_dataset import RMDataset
 
-__all__ = ["RLHFDataset", "RMDataset"]
+__all__ = ["DPODataset", "RLHFDataset", "RMDataset"]

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -29,14 +29,18 @@ class DatasetPadMode(str, Enum):
     NO_PADDING = "no_padding"
 
 
-class SFTTensorCollator:
+class CustomTensorCollator:
     """
-    A custom collate_fn that handles batching of sequences.
-    1. for variable-length sequences, convert them into NestedTensors.
-    2. for fixed-length sequences, use default_collate.
+    Base collator that combines individual dataset samples into a single batch.
+
+    Supports two modes based on pad_mode:
+        - Right-padded / left-right: All samples are already the same length.
+          Uses PyTorch's default_collate which simply stacks tensors.
+        - No-padding: Samples have variable lengths. Converts them to PyTorch
+          NestedTensors (jagged layout).
     """
 
-    def __init__(self, pad_mode: DatasetPadMode = DatasetPadMode.LEFT_RIGHT):
+    def __init__(self, pad_mode: DatasetPadMode):
         self.pad_mode = pad_mode
 
     def __call__(self, batch: list[dict[str, any]]) -> dict[str, any]:
@@ -51,7 +55,7 @@ class SFTTensorCollator:
 
     def collate_variable_batch(self, batch: list[dict[str, any]]) -> dict[str, any]:
         """
-        Collates a list of samples into a single batch.
+        Collates a list of samples into a single batch using NestedTensors.
 
         Args:
             batch: A list of dictionary samples from the dataset.
@@ -60,12 +64,9 @@ class SFTTensorCollator:
             A dictionary representing the batched data, with variable-length
             sequences converted to NestedTensors.
         """
-
         final_batch = {}
-
         tensor_keys = set().union(*(d.keys() for d in batch))
 
-        # Handle tensor values by creating a NestedTensor.
         for key in tensor_keys:
             if isinstance(batch[0][key], torch.Tensor):
                 tensors = [item[key] for item in batch]
@@ -78,3 +79,27 @@ class SFTTensorCollator:
                 final_batch[key] = torch.stack(tensors, dim=0)
 
         return final_batch
+
+
+class DPOTensorCollator(CustomTensorCollator):
+    """
+    Collator for DPO datasets.
+
+    Defaults to NO_PADDING as the FSDPEngine used in the trainer does not
+    support padding right now.
+    """
+
+    def __init__(self, pad_mode: DatasetPadMode = DatasetPadMode.NO_PADDING):
+        super().__init__(pad_mode)
+
+
+class SFTTensorCollator(CustomTensorCollator):
+    """
+    Collator for SFT datasets.
+
+    Defaults to LEFT_RIGHT padding mode which is the standard for SFT
+    training in verl.
+    """
+
+    def __init__(self, pad_mode: DatasetPadMode = DatasetPadMode.LEFT_RIGHT):
+        super().__init__(pad_mode)

--- a/verl/utils/dataset/dpo_dataset.py
+++ b/verl/utils/dataset/dpo_dataset.py
@@ -1,0 +1,672 @@
+# Copyright 2026 Amazon.com Inc and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Single-turn DPO dataset processing.
+"""
+
+import logging
+import os
+from dataclasses import dataclass, field
+from itertools import takewhile
+from typing import Any, Optional
+
+import glob
+import pandas as pd
+import torch
+from omegaconf import ListConfig
+from torch.utils.data import Dataset
+from transformers import PreTrainedTokenizer
+
+from verl.base_config import BaseConfig
+from verl.utils import hf_tokenizer
+from verl.utils.fs import copy_to_local
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# ─── Constants ────────────────────────────────────────────────────────────
+
+DPO_SUPPORTED_TRUNCATION = ("left", "right", "error")
+DPO_SUPPORTED_FILE_TYPES = ("*.parquet", "*.jsonl")
+
+
+# ─── DPO Data Configuration ──────────────────────────────────────────────
+
+
+@dataclass
+class DPODataConfig(BaseConfig):
+    """Configuration for the DPO data pipeline.
+
+    Covers the full ``data:`` section of ``dpo_trainer.yaml``.  Inherits from
+    BaseConfig to provide a dict-like interface and frozen-field semantics,
+    following the same pattern as FSDPEngineConfig / CheckpointConfig.
+    """
+
+    # ── Batching / engine knobs (used by trainer, not by DPODataset) ─────
+    train_batch_size: int = 256
+    micro_batch_size_per_gpu: int = 4
+    max_token_len_per_gpu: int = 8192
+    use_dynamic_bsz: bool = True
+    dataloader_num_workers: int = 8
+
+    # ── File paths and sampling ──────────────────────────────────────────
+    train_files: Any = None
+    val_files: Any = None
+    train_max_samples: int = -1
+    val_max_samples: int = -1
+
+    # ── Dataset-level settings (used by DPODataset) ──────────────────────
+    prompt_key: str = "prompt"
+    chosen_key: str = "chosen"
+    rejected_key: str = "rejected"
+    max_length: int = 1024
+    truncation: str = "error"
+    shuffle: bool = True
+    seed: int = 42
+    remove_invalid_samples: bool = False
+    use_shm: bool = False
+    chat_template_key: Optional[str] = None
+    apply_chat_template_kwargs: dict = field(default_factory=dict)
+
+    # ── Collator / padding ───────────────────────────────────────────────
+    pad_mode: str = "no_padding"
+
+    # ── Custom dataset class override ────────────────────────────────────
+    custom_cls: Any = field(default_factory=lambda: {"path": None, "name": None})
+
+    def __post_init__(self):
+        assert self.truncation in DPO_SUPPORTED_TRUNCATION, (
+            f"Expect truncation to be one of {DPO_SUPPORTED_TRUNCATION}. Got '{self.truncation}'"
+        )
+
+
+# ─── Data loading and validation ─────────────────────────────────────────
+
+
+def load_data_file(data_file: str, use_shm: bool = False) -> pd.DataFrame:
+    """
+    Copy to local node memory and read a single data file into a pandas DataFrame.
+
+    Uses a try-parse approach: attempts to read as parquet first, then falls
+    back to JSON Lines. This makes the function robust to misnamed files
+    (e.g., parquet content in a ``.dat`` file).
+
+    Args:
+        data_file: Path to a data file (parquet or JSON Lines). Can be a local
+            path or a remote path (HDFS) that will be downloaded first.
+        use_shm: Whether to copy the file to shared memory (/dev/shm) for
+            faster I/O. Useful when the same file is read multiple times.
+
+    Returns:
+        pd.DataFrame containing the loaded data.
+
+    Raises:
+        FileNotFoundError: If the local file does not exist after copy.
+        ValueError: If the file cannot be parsed as either parquet or JSON Lines.
+            The parquet error is chained via ``from`` and the JSON Lines error
+            is included in the message text.
+    """
+    local_file = copy_to_local(data_file, verbose=True, use_shm=use_shm)
+    if not os.path.isfile(local_file):
+        raise FileNotFoundError(f"Data file not found: '{local_file}'")
+    try:
+        dataframe = pd.read_parquet(local_file)
+    except Exception as parquet_err:
+        try:
+            dataframe = pd.read_json(local_file, lines=True)
+        except Exception as jsonl_err:
+            raise ValueError(
+                f"Could not parse {local_file} as parquet or JSON Lines "
+                f"(supported formats: .parquet, .jsonl).\n"
+                f"  JSON Lines error: {jsonl_err}"
+            ) from parquet_err
+    logger.info(f"Dataset loaded: {len(dataframe)} rows from {local_file}")
+    return dataframe
+
+
+def resolve_data_files(data_files: str | list[str] | ListConfig) -> list[str]:
+    """
+    Resolve data_files into a flat list of file paths.
+
+    Handles three input types:
+      - A single file path (string): returns [path]
+      - A directory path (string): scans for all .parquet and .jsonl files inside
+      - A list of file/directory paths: expands directories and returns all files
+
+    Args:
+        data_files: A file path, directory path, or list of either.
+
+    Returns:
+        List of resolved file paths (each ending in .parquet or .jsonl).
+
+    Raises:
+        ValueError: If no supported files are found.
+    """
+
+    if isinstance(data_files, str):
+        data_files = [data_files]
+    elif isinstance(data_files, ListConfig):
+        data_files = list(data_files)
+
+    resolved = []
+    for path in data_files:
+        if os.path.isdir(path):
+            for ext in DPO_SUPPORTED_FILE_TYPES:
+                resolved.extend(sorted(glob.glob(os.path.join(path, ext))))
+        else:
+            resolved.append(path)
+
+    if not resolved:
+        raise ValueError(
+            f"No .parquet or .jsonl files found in: {data_files}. "
+            f"Provide file paths or a directory containing .parquet/.jsonl files."
+        )
+
+    return resolved
+
+
+def load_and_concatenate_data_files(
+    data_files: str | list[str] | ListConfig,
+    required_columns: dict[str, str],
+    use_shm: bool = False,
+) -> pd.DataFrame:
+    """
+    Load one or more data files, validate columns, and concatenate into a single DataFrame.
+
+    Each file is validated to ensure it contains the required columns. All files
+    must have the same required columns (they may have additional columns that
+    will be ignored). After validation, the DataFrames are concatenated row-wise.
+
+    Args:
+        data_files: A file path, directory path, or list of either. Directories
+            are scanned for .parquet and .jsonl files.
+        required_columns: Dict mapping config key names to expected column names.
+            Example: {"prompt_key": "prompt", "chosen_key": "chosen",
+                      "rejected_key": "rejected"}
+        use_shm: Whether to use shared memory for file loading.
+
+    Returns:
+        A single concatenated pd.DataFrame with all rows from all files.
+
+    Raises:
+        ValueError: If no files are found, or any file is missing required columns.
+    """
+    file_paths = resolve_data_files(data_files)
+    logger.info(f"Loading {len(file_paths)} data file(s): {file_paths}")
+
+    dataframes = []
+    for file_path in file_paths:
+        df = load_data_file(file_path, use_shm=use_shm)
+        validate_columns(df, required_columns)
+        dataframes.append(df)
+
+    if len(dataframes) == 1:
+        combined = dataframes[0]
+    else:
+        combined = pd.concat(dataframes, ignore_index=True)
+        logger.info(f"Combined {len(dataframes)} files → {len(combined)} total rows")
+
+    return combined
+
+
+def validate_columns(dataframe: pd.DataFrame, required: dict[str, str]) -> None:
+    """
+    Verify that all required columns exist in the DataFrame.
+
+    Args:
+        dataframe: The loaded DataFrame to validate.
+        required: A dict mapping config key names to expected column names.
+
+    Raises:
+        ValueError: If one or more required columns are missing.
+    """
+    available = set(dataframe.columns)
+    missing = {k: v for k, v in required.items() if v not in available}
+    if missing:
+        desc = ", ".join(f"'{col}' (set via data.{key})" for key, col in missing.items())
+        raise ValueError(
+            f"Dataset is missing required columns: {desc}. "
+            f"Available columns: {sorted(available)}. "
+            f"To fix: rename your columns or set data.prompt_key / data.chosen_key / data.rejected_key."
+        )
+
+
+def shuffle_and_limit(
+    dataframe: pd.DataFrame,
+    max_samples: int = -1,
+    shuffle: bool = False,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """
+    Optionally shuffle the DataFrame and/or limit to a maximum number of rows.
+
+    Args:
+        dataframe: The DataFrame to process.
+        max_samples: Maximum number of samples to keep. -1 = keep all.
+        shuffle: Whether to randomly shuffle the row order.
+        seed: Random seed for reproducible shuffling.
+
+    Returns:
+        pd.DataFrame with rows optionally shuffled and/or limited.
+    """
+    total = len(dataframe)
+
+    # Determine how many rows we actually want
+    n = max_samples if 0 < max_samples < total else total
+
+    if shuffle:
+        # .sample(n=n) handles both the random selection and the limit
+        # ignore_index=True is usually best for training data to avoid index collisions
+        dataframe = dataframe.sample(n=n, random_state=seed, ignore_index=True)
+    elif n < total:
+        # Just limit without shuffling
+        dataframe = dataframe.iloc[:n]
+
+    if n < total:
+        logger.info(f"Selected {n} samples out of {total}")
+
+    return dataframe
+
+
+# ─── DPO-specific preprocessing functions ────────────────────────────────
+
+
+def extract_columns(
+    dataframe: pd.DataFrame,
+    prompt_key: str,
+    chosen_key: str,
+    rejected_key: str,
+) -> tuple[list[str], list[str], list[str]]:
+    """
+    Extract the prompt, chosen, and rejected columns from a DataFrame as Python lists.
+
+    Args:
+        dataframe: The source DataFrame.
+        prompt_key: Column name containing the user prompt text.
+        chosen_key: Column name containing the preferred (chosen) response.
+        rejected_key: Column name containing the dispreferred (rejected) response.
+
+    Returns:
+        Tuple of (prompts, chosen_responses, rejected_responses), each a list of strings.
+    """
+    return (
+        dataframe[prompt_key].tolist(),
+        dataframe[chosen_key].tolist(),
+        dataframe[rejected_key].tolist(),
+    )
+
+
+def inspect_and_filter_invalid_samples(
+    prompts: list[str],
+    chosen_responses: list[str],
+    rejected_responses: list[str],
+    remove_invalid: bool = True,
+) -> tuple[list[str], list[str], list[str]]:
+    """Inspect DPO preference pairs for invalid samples and optionally remove them.
+
+    Always scans all samples and logs a summary of any issues found:
+      - prompt is None/empty/whitespace
+      - chosen response is None/empty/whitespace
+      - rejected response is None/empty/whitespace
+      - chosen == rejected (no preference signal)
+
+    If remove_invalid=True, the invalid samples are dropped and only valid
+    samples are returned. If remove_invalid=False, the warning is logged
+    but all samples (including invalid ones) are returned unchanged.
+
+    Args:
+        prompts: List of prompt strings.
+        chosen_responses: List of chosen response strings.
+        rejected_responses: List of rejected response strings.
+        remove_invalid: If True, remove invalid samples. If False, only warn.
+
+    Returns:
+        Tuple of (prompts, chosen_responses, rejected_responses) — filtered
+        if remove_invalid=True, otherwise unchanged.
+    """
+    total_count = len(prompts)
+    valid_indices = []
+    null_prompt_count = 0
+    null_chosen_count = 0
+    null_rejected_count = 0
+    identical_count = 0
+
+    for i in range(total_count):
+        p = prompts[i]
+        c = chosen_responses[i]
+        r = rejected_responses[i]
+
+        p_valid = p is not None and isinstance(p, str) and p.strip()
+        c_valid = c is not None and isinstance(c, str) and c.strip()
+        r_valid = r is not None and isinstance(r, str) and r.strip()
+
+        if not p_valid:
+            null_prompt_count += 1
+            continue
+        if not c_valid:
+            null_chosen_count += 1
+            continue
+        if not r_valid:
+            null_rejected_count += 1
+            continue
+        if c.strip() == r.strip():
+            identical_count += 1
+            continue
+
+        valid_indices.append(i)
+
+    invalid_count = total_count - len(valid_indices)
+
+    # Always log a summary
+    if invalid_count > 0:
+        detail_parts = []
+        if null_prompt_count > 0:
+            detail_parts.append(f"{null_prompt_count} null/empty prompts")
+        if null_chosen_count > 0:
+            detail_parts.append(f"{null_chosen_count} null/empty chosen responses")
+        if null_rejected_count > 0:
+            detail_parts.append(f"{null_rejected_count} null/empty rejected responses")
+        if identical_count > 0:
+            detail_parts.append(f"{identical_count} identical chosen/rejected pairs")
+        detail_str = ", ".join(detail_parts)
+
+        if remove_invalid:
+            logger.info(
+                f"DPO dataset validation: found {invalid_count}/{total_count} invalid samples "
+                f"({detail_str}). "
+                f"These samples have been removed (data.remove_invalid_samples=true). "
+                f"Training will proceed with {len(valid_indices)} valid samples."
+            )
+        else:
+            logger.warning(
+                f"DPO dataset validation: found {invalid_count}/{total_count} invalid samples "
+                f"({detail_str}). "
+                f"Samples with empty or null fields may produce meaningless DPO loss values and "
+                f"could negatively affect model quality."
+            )
+    else:
+        logger.info(f"DPO dataset validation: all {total_count} samples are valid")
+
+    # Apply filtering only if requested
+    if remove_invalid and invalid_count > 0:
+        prompts = [prompts[i] for i in valid_indices]
+        chosen_responses = [chosen_responses[i] for i in valid_indices]
+        rejected_responses = [rejected_responses[i] for i in valid_indices]
+
+    return prompts, chosen_responses, rejected_responses
+
+
+def apply_chat_template(
+    tokenizer: PreTrainedTokenizer,
+    prompt: str,
+    response: str,
+    chat_template_kwargs: dict | None = None,
+) -> tuple[str, str]:
+    """
+    Format a prompt+response pair using the tokenizer's chat template.
+
+    Builds a full conversation ([user prompt] + [assistant response]), applies
+    the chat template to get the formatted string, then splits it back into
+    the prompt portion and the response portion using longest common prefix
+    matching. This ensures the prompt/response boundary is correctly identified
+    even when the chat template adds special tokens between turns.
+
+    Args:
+        tokenizer: The tokenizer whose chat template will be applied.
+        prompt: The raw user prompt text.
+        response: The raw assistant response text.
+        chat_template_kwargs: Any additional chat template args
+
+    Returns:
+        Tuple of (formatted_prompt_str, formatted_response_str) where
+        formatted_prompt_str includes all chat template tokens up to the
+        assistant generation point, and formatted_response_str is the
+        remainder including assistant content and closing tokens.
+    """
+    if chat_template_kwargs is None:
+        chat_template_kwargs = {}
+    prompt_chat = [{"role": "user", "content": prompt}]
+    prompt_str = tokenizer.apply_chat_template(
+        prompt_chat, add_generation_prompt=True, tokenize=False, **chat_template_kwargs
+    )
+    response_chat = [{"role": "assistant", "content": response}]
+    response_str = tokenizer.apply_chat_template(
+        prompt_chat + response_chat, tokenize=False, **chat_template_kwargs
+    )
+
+    prompt_str = "".join(x for x, _ in takewhile(lambda x: x[0] == x[1], zip(prompt_str, response_str)))
+    response_str = response_str[len(prompt_str):]
+    return prompt_str, response_str
+
+def tokenize_prompt_response(
+    tokenizer: PreTrainedTokenizer,
+    prompt_str: str,
+    response_str: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Tokenize the formatted prompt and response strings into token ID tensors.
+
+    The prompt and response are tokenized separately so we know exactly where
+    the prompt ends and the response begins. This boundary is needed to create
+    the loss_mask (0 for prompt tokens, 1 for response tokens).
+
+    An EOS token is appended to the response_ids to mark the end of generation.
+
+    Args:
+        tokenizer: The tokenizer to use for encoding.
+        prompt_str: The chat-template-formatted prompt string.
+        response_str: The response string.
+    Returns:
+        Tuple of (prompt_ids, response_ids), both 1D torch.Tensor of token IDs.
+        response_ids includes the appended EOS token.
+    """
+    prompt_ids = tokenizer(prompt_str, return_tensors="pt", add_special_tokens=False)["input_ids"][0]
+    response_ids = tokenizer(response_str, return_tensors="pt", add_special_tokens=False)["input_ids"][0]
+    eos_tensor = torch.tensor([tokenizer.eos_token_id], dtype=response_ids.dtype)
+    response_ids = torch.cat([response_ids, eos_tensor])
+
+    return prompt_ids, response_ids
+
+
+# ─── Dataset class ───────────────────────────────────────────────────────
+
+
+class DPODataset(Dataset):
+    """
+    Single-turn DPO dataset that produces (chosen, rejected) pairs.
+
+    Loads a .parquet or .jsonl file and tokenizes each sample into paired
+    sequences for DPO training. Each sample contains a prompt with two
+    responses: one preferred (chosen) and one dispreferred (rejected).
+
+    The dataset applies a fixed preprocessing pipeline in __init__:
+        load_and_concatenate_data_files → shuffle_and_limit → extract_columns
+        → inspect_and_filter_invalid_samples
+
+    And per-sample processing in __getitem__:
+        apply_chat_template → tokenize_prompt_response → build loss_mask → truncate → pack
+
+    Args:
+        data_files: Path(s) to .parquet or .jsonl file(s), or a directory.
+        tokenizer: A PreTrainedTokenizer instance or a string path to load one.
+        config: A DPODataConfig dataclass with data processing options:
+            max_length (int): Maximum sequence length per side. Default 1024.
+            truncation (str): "left", "right", or "error". Default "error".
+            prompt_key (str): Column name for prompt. Default "prompt".
+            chosen_key (str): Column name for chosen response. Default "chosen".
+            rejected_key (str): Column name for rejected response. Default "rejected".
+            remove_invalid_samples (bool): Whether to remove invalid samples. Default False.
+            shuffle (bool): Whether to shuffle before limiting to max_samples. Default True.
+            seed (int): Random seed for shuffle reproducibility. Default None.
+        max_samples: Maximum number of samples to use. -1 for all.
+
+    Returns per __getitem__:
+        dict with keys:
+            input_ids:       (chosen_len + rejected_len,) — packed sequence
+            loss_mask:       (chosen_len + rejected_len,) — 0=prompt, 1=response for each half
+            boundary_offset: int — index where rejected starts in the packed sequence
+    """
+
+    def __init__(
+        self,
+        data_files: str | list[str] | ListConfig,
+        tokenizer,
+        config: DPODataConfig,
+        max_samples: int = -1,
+    ):
+        config = config or DPODataConfig()
+        self.max_length = config.max_length
+        self.truncation = config.truncation
+
+        self.prompt_key = config.prompt_key
+        self.chosen_key = config.chosen_key
+        self.rejected_key = config.rejected_key
+        self.chat_template_key = config.chat_template_key
+        self.apply_chat_template_flag = self.chat_template_key is not None
+        self.chat_template_kwargs = config.apply_chat_template_kwargs
+        self.remove_invalid_samples = config.remove_invalid_samples
+        use_shm = config.use_shm
+
+        if isinstance(tokenizer, str):
+            tokenizer = hf_tokenizer(tokenizer)
+        self.tokenizer: PreTrainedTokenizer = tokenizer
+
+        # Preprocessing pipeline: load → validate columns → limit → extract → inspect/filter
+        required_columns = {
+            "prompt_key": self.prompt_key,
+            "chosen_key": self.chosen_key,
+            "rejected_key": self.rejected_key,
+        }
+        dataframe = load_and_concatenate_data_files(data_files, required_columns, use_shm=use_shm)
+        dataframe = shuffle_and_limit(
+            dataframe,
+            max_samples=max_samples,
+            shuffle=config.shuffle,
+            seed=config.seed,
+        )
+        self.prompts, self.chosen_responses, self.rejected_responses = extract_columns(
+            dataframe, self.prompt_key, self.chosen_key, self.rejected_key
+        )
+
+        # Inspect for invalid samples (always logs), optionally remove them
+        self.prompts, self.chosen_responses, self.rejected_responses = inspect_and_filter_invalid_samples(
+            self.prompts,
+            self.chosen_responses,
+            self.rejected_responses,
+            remove_invalid=self.remove_invalid_samples,
+        )
+
+    def __len__(self):
+        """Return the number of samples in the dataset."""
+        return len(self.prompts)
+
+    def _process_sequence(self, prompt: str, response: str, prefix: str) -> dict[str, torch.Tensor]:
+        """
+        Run the full per-sample processing pipeline for one prompt+response pair.
+
+        Pipeline: apply_chat_template → tokenize_prompt_response → build loss_mask → truncate
+
+        Args:
+            prompt: The raw user prompt text.
+            response: The raw assistant response text (chosen or rejected).
+            prefix: Key prefix for the returned dict — either "chosen" or "rejected".
+
+        Returns:
+            Dict with keys "{prefix}_input_ids" and "{prefix}_loss_mask",
+            each a 1D tensor of shape ≤ max_length.
+        """
+        # Step 1: Format with chat template (only if chat_template_key is set)
+        # Guard against None values (possible when remove_invalid_samples=False)
+        prompt_str = prompt if isinstance(prompt, str) else ""
+        response_str = response if isinstance(response, str) else ""
+        if self.apply_chat_template_flag:
+            prompt_str, response_str = apply_chat_template(
+                self.tokenizer, prompt_str, response_str, self.chat_template_kwargs
+            )
+
+        # Step 2: Tokenize
+        prompt_ids, response_ids = tokenize_prompt_response(self.tokenizer, prompt_str, response_str)
+
+        # Step 3: Concatenate and create loss_mask
+        input_ids = torch.cat((prompt_ids, response_ids), dim=-1)
+        loss_mask = torch.zeros_like(input_ids)
+        prompt_len = prompt_ids.shape[0]
+        loss_mask[prompt_len:] = 1
+
+        # Step 4: Truncate to max_length (no padding — engine uses NestedTensors)
+        original_len = input_ids.shape[0]
+        if original_len > self.max_length:
+            if self.truncation == "error":
+                raise ValueError(
+                    f"Sequence length {original_len} exceeds max_length {self.max_length} "
+                    f"(truncation='error'). Increase data.max_length or set data.truncation to 'left'/'right'."
+                )
+            elif self.truncation == "right":
+                input_ids = input_ids[:self.max_length]
+                loss_mask = loss_mask[:self.max_length]
+            elif self.truncation == "left":
+                input_ids = input_ids[-self.max_length:]
+                loss_mask = loss_mask[-self.max_length:]
+
+        return {
+            f"{prefix}_input_ids": input_ids,
+            f"{prefix}_loss_mask": loss_mask,
+        }
+
+    def __getitem__(self, item):
+        """
+        Get a single DPO training sample as a packed sequence.
+
+        Each sample packs chosen + rejected into ONE sequence:
+          input_ids = [chosen_tokens..., rejected_tokens...]
+          loss_mask = [chosen_loss_mask..., rejected_loss_mask...]
+
+        Plus a boundary_offset integer marking where chosen ends and rejected begins.
+
+        This ensures the chosen/rejected pair stays together through dynamic
+        micro-batching. The micro_batch_transform_fn splits them back into
+        separate sequences before the model forward pass.
+
+        Args:
+            item: Integer index into the dataset.
+
+        Returns:
+            Dict with:
+              input_ids: (chosen_len + rejected_len,) — packed sequence
+              loss_mask: (chosen_len + rejected_len,) — packed mask
+              boundary_offset: int — index where rejected starts
+        """
+        prompt = self.prompts[item]
+        chosen = self.chosen_responses[item]
+        rejected = self.rejected_responses[item]
+
+        # Process chosen and rejected separately
+        chosen_result = self._process_sequence(prompt, chosen, prefix="chosen")
+        rejected_result = self._process_sequence(prompt, rejected, prefix="rejected")
+
+        chosen_ids = chosen_result["chosen_input_ids"]
+        chosen_mask = chosen_result["chosen_loss_mask"]
+        rejected_ids = rejected_result["rejected_input_ids"]
+        rejected_mask = rejected_result["rejected_loss_mask"]
+
+        # Pack into one packed sequence: [chosen_tokens, rejected_tokens]
+        boundary_offset = chosen_ids.shape[0]
+        packed_input_ids = torch.cat([chosen_ids, rejected_ids], dim=0)
+        packed_loss_mask = torch.cat([chosen_mask, rejected_mask], dim=0)
+
+        return {
+            "input_ids": packed_input_ids,
+            "loss_mask": packed_loss_mask,
+            "boundary_offset": int(boundary_offset),
+        }


### PR DESCRIPTION
### What does this PR do?

Add the DPO (Direct Preference Optimization) dataset pipeline to verl. This is the first PR (1/n) toward full DPO training support.                    

  - Introduces DPODataset class that loads preference data (parquet/JSONL), validates columns, filters invalid samples, applies chat templates, tokenizes, and packs chosen+rejected into a single sequence with a boundary_offset marker.
  - Refactors the existing SFTTensorCollator into a base CustomTensorCollator with task-specific subclasses (DPOTensorCollator, SFTTensorCollator).       
  - Adds dpo_trainer.yaml reference Hydra config.
  - Adds comprehensive CPU-only unit tests.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: (https://github.com/search?q=repo%3Averl-project%2Fverl%20dpo&type=code)
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> python -m pytest tests/utils/dataset/test_dpo_dataset_on_cpu.py -q 

### API and Usage Example

```python
from verl.utils.dataset import DPODataset                                   
from verl.utils.dataset.dpo_dataset import DPODataConfig                    
                                                                              
config = DPODataConfig(max_length=1024, truncation="right")                 
dataset = DPODataset(                                                       
      data_files="path/to/preference_data.parquet",                           
      tokenizer=tokenizer,                                                    
      config=config,                                                          
  )
```

### Design & Code Changes

  - verl/utils/dataset/dpo_dataset.py: Core dataset class. Loads data → validates → filters → chat templates → tokenizes → packs chosen+rejected into one tensor with boundary_offset.                                       
  - verl/utils/dataset/dataset_utils.py: Renamed SFTTensorCollator →CustomTensorCollator (base); added DPOTensorCollator (NO_PADDING default) and SFTTensorCollator (LEFT_RIGHT default). Backward-compatible.
  - verl/trainer/config/dpo_trainer.yaml: Reference config with data, optimizer, checkpoint, model, and trainer sections.                         
  - tests/utils/dataset/test_dpo_dataset_on_cpu.py: ~70 unit tests covering loading, tokenization, packing, collation, shuffle determinism, YAML formatting, and code quality.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
