### PR TITLE
[sglang, one_step_off] fix: add free_cache_engine guard to resume_kv_cache

### DIFF
--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -487,7 +487,7 @@ class SGLangHttpServer:
 
     async def resume_kv_cache(self):
         """Restore kv_cache GPU memory after a weight sync. Counterpart to release_kv_cache()."""
-        if self.node_rank != 0:
+        if self.node_rank != 0 or not self.config.free_cache_engine:
             return
         obj = ResumeMemoryOccupationReqInput(tags=["kv_cache"])
         await self.tokenizer_manager.resume_memory_occupation(obj, None)


### PR DESCRIPTION

### What does this PR do?

Fix `KeyError: 'kv_cache'` crash during NCCL weight sync when using one-step off-policy or fully-async trainers with SGLang rollout and `free_cache_engine=False`.

`resume_kv_cache()` was missing the `free_cache_engine` guard that its counterpart `release_kv_cache()` already has. When `free_cache_engine=False`, `release_kv_cache()` is a no-op so `'kv_cache'` is never added to SGLang's `offload_tags` set. However `resume_kv_cache()` still tried to call `resume_memory_occupation(tags=["kv_cache"])`, which triggers `self.offload_tags.remove('kv_cache')` in SGLang's `scheduler_update_weights_mixin` → `KeyError`.

This one-line fix aligns `resume_kv_cache()` with `release_kv_cache()` by adding the same `or not self.config.free_cache_engine` guard condition.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+resume_kv_cache+free_cache_engine
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Reproduced with one-step off-policy training (`python3 -m verl.experimental.one_step_off_policy.main_ppo`) using SGLang rollout with `free_cache_engine=False` and NCCL checkpoint engine. Before the fix, the training crashes at the first `_fit_update_weights()` call with:

```
KeyError: 'kv_cache'
  File "scheduler_update_weights_mixin.py", line 153, in resume_memory_occupation
    self.offload_tags.remove(tag)
```

After the fix, the weight sync step completes successfully without the `KeyError`.

Not feasible to add CI test: this requires a multi-GPU setup with separated actor/rollout GPUs and NCCL checkpoint engine, which is beyond the scope of existing CI infrastructure.

### API and Usage Example

No API changes. The fix is transparent — `resume_kv_cache()` now correctly skips the resume operation when `free_cache_engine=False`, matching the behavior of `release_kv_cache()`.

### Design & Code Changes

- `verl/workers/rollout/sglang_rollout/async_sglang_server.py`: Add `or not self.config.free_cache_engine` to the early-return guard in `resume_kv_cache()` (line 490), making it consistent with `release_kv_cache()` (line 483).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). N/A — one-line bug fix, no documentation changes needed.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Requires multi-GPU separated actor/rollout setup with NCCL checkpoint engine, not available in CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. N/A.
