### PR TITLE
[rollout, fully_async] feat: add Harbor agentic RL agent loop

### DIFF
--- a/tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py
+++ b/tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py
@@ -1,0 +1,195 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for HarborAgentLoop's pure flatten/merge helpers.
+
+These cover the prefix-aware trajectory merge that converts Harbor's per-turn
+rollout_details into the linear (prompt_ids, response_ids, response_mask)
+format VeRL's training pipeline expects.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from verl.experimental.agentic_rl_harbor.harbor_agent_loop import (
+    _build_step_wise,
+    _is_prefix,
+    _merge_stepwise,
+)
+
+
+def _rd(prompts, completions, logprobs):
+    """Build a single Harbor-style rollout_details segment."""
+    return [
+        {
+            "prompt_token_ids": prompts,
+            "completion_token_ids": completions,
+            "logprobs": logprobs,
+        }
+    ]
+
+
+def test_is_prefix_basic():
+    assert _is_prefix([], [1, 2, 3])
+    assert _is_prefix([1, 2], [1, 2, 3])
+    assert _is_prefix([1, 2, 3], [1, 2, 3])
+    assert not _is_prefix([1, 2, 3], [1, 2])
+    assert not _is_prefix([1, 4], [1, 2, 3])
+
+
+def test_build_step_wise_single_turn():
+    rd = _rd([[1, 2]], [[10, 11]], [[-0.1, -0.2]])
+    turns = _build_step_wise(rd)
+    assert len(turns) == 1
+    assert turns[0] == {
+        "prompt_ids": [1, 2],
+        "comp_ids": [10, 11],
+        "logprobs": [-0.1, -0.2],
+    }
+
+
+def test_build_step_wise_multi_turn():
+    rd = _rd(
+        prompts=[[1, 2], [1, 2, 10, 11, 3], [1, 2, 10, 11, 3, 20, 4]],
+        completions=[[10, 11], [20], [30, 31]],
+        logprobs=[[-0.1, -0.2], [-0.3], [-0.4, -0.5]],
+    )
+    turns = _build_step_wise(rd)
+    assert len(turns) == 3
+    assert turns[1]["prompt_ids"] == [1, 2, 10, 11, 3]
+    assert turns[2]["comp_ids"] == [30, 31]
+
+
+def test_build_step_wise_rejects_multiple_segments():
+    bad = [
+        {"prompt_token_ids": [[1]], "completion_token_ids": [[2]], "logprobs": [[-0.1]]},
+        {"prompt_token_ids": [[3]], "completion_token_ids": [[4]], "logprobs": [[-0.2]]},
+    ]
+    with pytest.raises(AssertionError):
+        _build_step_wise(bad)
+
+
+def test_build_step_wise_rejects_mismatched_lengths():
+    bad = _rd([[1, 2]], [[10, 11]], [[-0.1, -0.2, -0.3]])  # logprobs longer than completion
+    with pytest.raises(AssertionError):
+        _build_step_wise(bad)
+
+
+def test_merge_stepwise_single_turn_one_group():
+    turns = [{"prompt_ids": [1, 2], "comp_ids": [10, 11], "logprobs": [-0.1, -0.2]}]
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["prompt_ids"] == [1, 2]
+    assert g["response_ids"] == [10, 11]
+    assert g["response_mask"] == [1, 1]
+    assert g["response_logprobs"] == [-0.1, -0.2]
+
+
+def test_merge_stepwise_clean_prefix_collapses_to_one_group():
+    # Harbor re-rendered prompts each strictly extend prompt[t-1] + comp[t-1]
+    # by appending observation tokens (3 between turns 1->2; 4 between 2->3).
+    turns = [
+        {"prompt_ids": [1, 2], "comp_ids": [10, 11], "logprobs": [-0.1, -0.2]},
+        {"prompt_ids": [1, 2, 10, 11, 3], "comp_ids": [20], "logprobs": [-0.3]},
+        {"prompt_ids": [1, 2, 10, 11, 3, 20, 4], "comp_ids": [30, 31], "logprobs": [-0.4, -0.5]},
+    ]
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["prompt_ids"] == [1, 2]
+    # comp[0] | obs(3) | comp[1] | obs(4) | comp[2]
+    assert g["response_ids"] == [10, 11, 3, 20, 4, 30, 31]
+    assert g["response_mask"] == [1, 1, 0, 1, 0, 1, 1]
+    # Observation tokens get logprob 0.0 (masked out anyway).
+    assert g["response_logprobs"] == [-0.1, -0.2, 0.0, -0.3, 0.0, -0.4, -0.5]
+    # Mask sum equals total completion tokens across all turns.
+    assert sum(g["response_mask"]) == 5
+
+
+def test_merge_stepwise_prefix_divergence_flushes_new_group():
+    # turn 2's prompt does NOT extend turn 1's prompt+comp (the chat template
+    # re-rendered history non-trivially), so a new merge group is started.
+    turns = [
+        {"prompt_ids": [1, 2], "comp_ids": [10, 11], "logprobs": [-0.1, -0.2]},
+        # Diverges at index 2 (5 vs 10).
+        {"prompt_ids": [1, 2, 5, 6], "comp_ids": [20, 21], "logprobs": [-0.3, -0.4]},
+    ]
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 2
+
+    g0, g1 = groups
+    assert g0["prompt_ids"] == [1, 2]
+    assert g0["response_ids"] == [10, 11]
+    assert g0["response_mask"] == [1, 1]
+
+    assert g1["prompt_ids"] == [1, 2, 5, 6]
+    assert g1["response_ids"] == [20, 21]
+    assert g1["response_mask"] == [1, 1]
+
+
+def test_merge_stepwise_partial_divergence_after_clean_extension():
+    # turns 0->1 extend cleanly; turn 2 diverges -> two groups.
+    turns = [
+        {"prompt_ids": [1, 2], "comp_ids": [10], "logprobs": [-0.1]},
+        {"prompt_ids": [1, 2, 10, 3], "comp_ids": [20], "logprobs": [-0.2]},
+        # Diverges from g0's cursor [1,2,10,3,20].
+        {"prompt_ids": [1, 2, 99], "comp_ids": [30], "logprobs": [-0.3]},
+    ]
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 2
+    g0, g1 = groups
+    assert g0["prompt_ids"] == [1, 2]
+    assert g0["response_ids"] == [10, 3, 20]
+    assert g0["response_mask"] == [1, 0, 1]
+    assert g1["prompt_ids"] == [1, 2, 99]
+    assert g1["response_ids"] == [30]
+
+
+def test_merge_stepwise_divergence_when_next_prompt_is_shorter_than_cursor():
+    # If Harbor returns a re-rendered prompt that is *shorter* than the running
+    # cursor (rare, but possible if the template summarised history), the
+    # length check alone rejects the prefix and we flush a new group.
+    turns = [
+        {"prompt_ids": [1, 2, 3, 4], "comp_ids": [10, 11], "logprobs": [-0.1, -0.2]},
+        {"prompt_ids": [1, 2], "comp_ids": [20], "logprobs": [-0.3]},
+    ]
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 2
+    assert groups[0]["prompt_ids"] == [1, 2, 3, 4]
+    assert groups[1]["prompt_ids"] == [1, 2]
+
+
+def test_merge_stepwise_empty_raises():
+    with pytest.raises(AssertionError):
+        _merge_stepwise([])
+
+
+def test_build_then_merge_end_to_end_clean():
+    # _build_step_wise + _merge_stepwise on a fully prefix-clean trajectory
+    # should be equivalent to gluing all completions into one big group.
+    rd = _rd(
+        prompts=[[1, 2], [1, 2, 10, 11], [1, 2, 10, 11, 20]],
+        completions=[[10, 11], [20], [30]],
+        logprobs=[[-0.1, -0.1], [-0.2], [-0.3]],
+    )
+    turns = _build_step_wise(rd)
+    groups = _merge_stepwise(turns)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["prompt_ids"] == [1, 2]
+    assert g["response_ids"] == [10, 11, 20, 30]
+    # No observation tokens between turns (next prompt extends by exactly comp).
+    assert g["response_mask"] == [1, 1, 1, 1]
+    assert sum(g["response_mask"]) == sum(len(c) for c in [[10, 11], [20], [30]])

--- a/tests/special_sanity/check_license.py
+++ b/tests/special_sanity/check_license.py
@@ -31,6 +31,7 @@ license_head_meituan = "Copyright 2025 Meituan Ltd. and/or its affiliates"
 license_head_huawei = "Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_huawei_26 = "Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved."
 license_head_nvidia = "Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved."
+license_head_alibaba_26 = "Copyright 2026 Alibaba Group"
 license_headers = [
     license_head_bytedance,
     license_head_bytedance_25,
@@ -46,6 +47,7 @@ license_headers = [
     license_head_huawei,
     license_head_huawei_26,
     license_head_nvidia,
+    license_head_alibaba_26,
 ]
 
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -361,7 +361,12 @@ def register(agent_name: str):
 
     def decorator(subclass: type[AgentLoopBase]) -> type[AgentLoopBase]:
         fqdn = f"{subclass.__module__}.{subclass.__qualname__}"
-        _agent_loop_registry[agent_name] = {"_target_": fqdn}
+        # setdefault, not assignment: AgentLoopWorker.__init__ may have already
+        # populated this entry from `agent_loop_config_path` with extra fields
+        # (kwargs to be forwarded by hydra.utils.instantiate). When that loaded
+        # config later triggers a module import, the decorator must not clobber
+        # the rich entry back down to a bare `{"_target_": ...}`.
+        _agent_loop_registry.setdefault(agent_name, {"_target_": fqdn})
         return subclass
 
     return decorator

--- a/verl/experimental/agentic_rl_harbor/README.md
+++ b/verl/experimental/agentic_rl_harbor/README.md
@@ -1,0 +1,165 @@
+# Recipe: Agentic RL with Harbor
+
+**Author:** `https://github.com/myjlyjly`
+
+Last updated: 05/21/2026.
+
+This recipe wires VeRL's `AgentLoopBase` to [Laude Institute's Harbor](https://github.com/laude-institute/b-harbor) framework so each training sample is a full Harbor `Trial` running a multi-turn agent against a remote sandbox (Daytona / Modal).
+Harbor's per-turn rollout details are flattened back into the linear `(prompt_ids, response_ids, response_mask)` format VeRL's PPO/GRPO trainers expect, and the loop plugs straight into [`fully_async_policy`](../fully_async_policy/README.md) for async training.
+
+## Layout
+
+```
+verl/experimental/agentic_rl_harbor/
+├── harbor_agent_loop.py                     # @register("harbor_agent") -- one Trial per sample
+├── harbor_dataset.py                        # HarborTaskDataset: enumerates task directories
+├── prepare_harbor_dataset.py                # Pull a Harbor dataset from HF Hub and unpack it
+├── cleanup_daytona.py                       # List / delete leaked Daytona sandboxes (preflight)
+├── config/harbor_agent.yaml                 # agent_loop registry entry + TrialConfig template
+├── templates/
+│   └── qwen3_acc_thinking.jinja2            # Qwen3 chat template w/ accumulate-thinking
+└── shell/
+    └── run_qwen3_8b_harbor_fully_async.sh   # full demo (fully_async + GRPO + Harbor)
+```
+
+## Prereqs
+
+```bash
+# Python deps (versions this recipe has been tested with)
+pip install 'harbor[daytona]==0.6.1' 'litellm==1.82.6'
+
+# Sandbox credentials -- Harbor runs each trial in a remote sandbox. Pick one:
+#   Daytona (default https://app.daytona.io/api):
+export DAYTONA_API_KEY=...
+export DAYTONA_API_URL=...
+#   Modal:
+export MODAL_TOKEN_ID=...
+export MODAL_TOKEN_SECRET=...
+```
+
+## Prepare data
+
+Harbor expects each sample to be a directory containing `instruction.md` (plus
+optional verifier and starter files).
+`prepare_harbor_dataset.py` pulls a HF dataset whose parquet files have `path`
+and `task_binary` columns and unpacks each `task_binary` tarball under `~/data/harbor/<repo>/`:
+
+```bash
+# Default (Qwen3-8B can get non-zero reward signal here):
+python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
+    --dataset DCAgent/exp_rpt_curriculum-easy
+python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
+    --dataset laion/exp_rpt_exercism-python-v2
+```
+
+## Quick start
+
+```bash
+# Optional preflight -- delete any Daytona sandboxes leaked by a previous crash
+# (ray stop --force / OOM / SIGKILL skip Harbor's _stop_sandbox teardown, leaving
+# sandboxes alive on the Daytona side and consuming your CPU quota until the
+# 30 min auto_stop_interval elapses). See "Sandbox concurrency cap" below.
+python verl/experimental/agentic_rl_harbor/cleanup_daytona.py            # list only
+python verl/experimental/agentic_rl_harbor/cleanup_daytona.py --delete   # delete all
+
+# Full demo: GRPO + fully_async + Harbor on Qwen3-8B (8 GPUs, 4 rollout + 4 train).
+# All knobs are env-var overridable.
+ray stop --force && bash verl/experimental/agentic_rl_harbor/shell/run_qwen3_8b_harbor_fully_async.sh
+```
+
+## How it fits together
+
+* `data.custom_cls` points at `HarborTaskDataset`, which emits one row per task
+  directory. Each row carries `task_path` and `agent_name="harbor_agent"`.
+* `actor_rollout_ref.rollout.agent.agent_loop_config_path` points at
+  `config/harbor_agent.yaml`, which registers `HarborAgentLoop` and supplies the
+  `harbor_trial_config` template (Harbor `TrialConfig`: trials_dir, agent.name,
+  max_turns, environment.type, etc.).
+* `HarborAgentLoop.run()` picks a VeRL rollout server, builds a per-trial
+  `TrialConfig` (sets `task.path` / `agent.kwargs.api_base` /
+  `agent.kwargs.session_id`), runs the trial via Harbor, and converts
+  `rollout_details` to the VeRL agent-loop output via
+  `_build_step_wise` + `_merge_stepwise`.
+
+## Key configuration notes
+
+* **`served_model_name`.** vLLM advertises the model under
+  `actor_rollout_ref.rollout.prometheus.served_model_name` (basename'd if it
+  contains a path separator). HarborAgentLoop reuses that value to build the
+  LiteLLM target `hosted_vllm/<served_model_name>`. Set
+  `prometheus.enable=True` and `prometheus.served_model_name=<basename>` (the
+  shell scripts do this for you) to keep both sides in sync.
+* **Chat template.** The default Qwen3 chat template strips `<think>...</think>`
+  blocks from non-last assistant messages on every re-render, breaking the
+  prefix invariant `_merge_stepwise` relies on. Pass
+  `templates/qwen3_acc_thinking.jinja2` to vLLM via
+  `+actor_rollout_ref.rollout.engine_kwargs.vllm.chat_template=...` (the shell
+  scripts do this for you). The merge logic now tolerates prefix divergence
+  (it flushes a new merge group and randomly picks one for the policy gradient
+  update), but every divergence costs you a smaller training group from that
+  trajectory — keeping the prefix invariant gives one big group per trajectory.
+* **`harbor_trial_config` is read straight from the YAML** — its sub-fields
+  (`trials_dir`, `agent.name`, `agent.kwargs.max_turns`, `environment.type`,
+  ...) are not exposed through hydra's main config tree, so they cannot be
+  overridden on the CLI. To change them, edit `config/harbor_agent.yaml` or
+  copy it and set `actor_rollout_ref.rollout.agent.agent_loop_config_path` to
+  the copy.
+* **`partial_rollout` is not supported.** Harbor trials run in a remote sandbox
+  (daytona/modal) whose container/shell-session state cannot be checkpointed,
+  so `async_training.partial_rollout=False` is mandatory. This caps the loop
+  at fully_async Mode 3 (async stream pipeline w/ stale samples); see
+  [`fully_async_policy/README.md`](../fully_async_policy/README.md) for the
+  Mode 1/2/3/4 taxonomy.
+* **Sandbox concurrency cap (Daytona).** Every trial allocates one Daytona
+  sandbox sized by `override_cpus` in `config/harbor_agent.yaml` (default 1).
+  Daytona's free tier caps total in-flight CPU at 10 — exceeding it surfaces as:
+  ```
+  Failed to create sandbox: Total CPU limit exceeded. Maximum allowed: 10.
+  ```
+  Concurrent trials follow `fully_async_rollouter.py:set_max_required_samples`:
+  ```
+  max_required_samples   = ppo_mini_batch_size * require_batches
+                           * (staleness_threshold + 1) * trigger_parameter_sync_step
+  max_concurrent_samples = min(replicas * 16, max_required_samples)
+  concurrent_trials      ~= max_concurrent_samples * N_RESP_PER_PROMPT
+  ```
+  The shipped defaults (`ppo_mini=2, require=1, trigger=2, n=2, staleness=0.1`)
+  evaluate to `2*1*1.1*2 = 4` samples → 8 concurrent trials (2 CPU of headroom
+  under the 10-cap). Raising `STALENESS_THRESHOLD` back to `1.0` to fully
+  exercise Mode 3 requires upgrading the Daytona tier
+  (<https://app.daytona.io/dashboard/limits>) or switching to a local sandbox.
+  The shell script has a detailed trade-off table in its `Async knobs` block.
+* **Leaked sandboxes after a crash.** `ray stop --force`, OOM kills, or any
+  abrupt termination skips `DaytonaEnvironment._stop_sandbox`, leaving live
+  sandboxes behind that continue to consume the account's CPU quota until
+  `auto_stop_interval_mins` elapses (30 min in the shipped yaml). Run
+  `cleanup_daytona.py --delete` as a preflight before re-launching.
+* **`min/max_global_steps` is stamped 0.** Standard agent loops get the rollout
+  server's weight version through `extra_fields["global_steps"]`; Harbor goes
+  through LiteLLM/HTTP and bypasses that path, so we stamp 0 instead. This
+  makes fully_async's `param_version_diversity` log metric always read 1, but
+  staleness control / partial-rollout stats are unaffected (they stay correct
+  because we never enable partial_rollout).
+
+## Tests
+
+CPU-only unit tests for the prefix-aware merge live at
+[`tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py`](../../../tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py).
+They cover: clean-prefix collapse to a single group, prefix-divergence flush
+into multiple groups, malformed `rollout_details` rejection, and the
+short-prompt edge case.
+
+## Acknowledgements
+
+* Harbor framework: <https://github.com/laude-institute/b-harbor>
+* SkyRL (Apache 2.0): <https://github.com/NovaSky-AI/SkyRL> — the following
+  pieces are adapted from SkyRL's Harbor integration (file headers carry the
+  per-file provenance URLs):
+  * `_build_step_wise` / `_merge_stepwise` follow `harbor_generator.py`'s
+    two-stage layout.
+  * `prepare_harbor_dataset.py` is near-verbatim from
+    `examples/train_integrations/harbor/prepare_harbor_dataset.py`.
+  * The `harbor_trial_config` block in `config/harbor_agent.yaml` is
+    verbatim from `examples/train_integrations/harbor/harbor_trial_config/default.yaml`.
+  * `templates/qwen3_acc_thinking.jinja2` is verbatim from
+    `skyrl/train/utils/templates/qwen3_acc_thinking.jinja2`.

--- a/verl/experimental/agentic_rl_harbor/__init__.py
+++ b/verl/experimental/agentic_rl_harbor/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/verl/experimental/agentic_rl_harbor/cleanup_daytona.py
+++ b/verl/experimental/agentic_rl_harbor/cleanup_daytona.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+List and delete Daytona sandboxes held by the current API key.
+
+A crashed Harbor run (e.g. ``ray stop --force`` mid-training, OOM, SIGKILL)
+skips ``DaytonaEnvironment._stop_sandbox`` and leaves sandboxes alive on the
+Daytona side. They keep consuming the account's CPU quota until
+``auto_stop_interval_mins`` elapses (default 30 min in
+``config/harbor_agent.yaml``), which can starve the next run and produce:
+
+    Failed to create sandbox: Total CPU limit exceeded. Maximum allowed: N.
+
+Recommended as a preflight before re-launching Harbor jobs:
+
+    python verl/experimental/agentic_rl_harbor/cleanup_daytona.py             # list only
+    python verl/experimental/agentic_rl_harbor/cleanup_daytona.py --delete    # delete all
+    python verl/experimental/agentic_rl_harbor/cleanup_daytona.py --delete --state stopped
+
+Authentication: reads ``DAYTONA_API_KEY`` (and optional ``DAYTONA_API_URL``,
+``DAYTONA_TARGET``) from the environment, same as Harbor itself.
+"""
+
+import argparse
+import os
+import sys
+
+
+def _iter_sandboxes(client, labels):
+    """Yield every sandbox across all pages (Daytona paginates ``list()``)."""
+    page = 1
+    while True:
+        result = client.list(labels=labels, page=page)
+        items = getattr(result, "items", None) or []
+        for sandbox in items:
+            yield sandbox
+        total_pages = getattr(result, "total_pages", 1) or 1
+        if page >= total_pages or not items:
+            return
+        page += 1
+
+
+def _parse_labels(label_args):
+    if not label_args:
+        return None
+    out = {}
+    for kv in label_args:
+        if "=" not in kv:
+            raise SystemExit(f"--label expects key=value, got: {kv!r}")
+        k, v = kv.split("=", 1)
+        out[k.strip()] = v.strip()
+    return out
+
+
+def _summarize(sandbox):
+    return (
+        f"id={sandbox.id}  "
+        f"state={getattr(sandbox, 'state', '?')}  "
+        f"cpu={getattr(sandbox, 'cpu', '?')}  "
+        f"created={getattr(sandbox, 'created_at', '?')}"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="List / delete Daytona sandboxes for the current API key.")
+    parser.add_argument("--delete", action="store_true", help="Delete matched sandboxes (default: list only).")
+    parser.add_argument(
+        "--state",
+        action="append",
+        default=None,
+        help="Only act on sandboxes in this state (e.g. started, stopped, error). Repeatable.",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=None,
+        help="Filter by label, format key=value. Repeatable. Forwarded to Daytona list().",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Per-sandbox delete timeout in seconds (default 60).",
+    )
+    args = parser.parse_args()
+
+    if not os.environ.get("DAYTONA_API_KEY"):
+        print("error: DAYTONA_API_KEY is not set in the environment.", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from daytona import Daytona
+    except ImportError as e:
+        print(f"error: failed to import daytona SDK: {e}", file=sys.stderr)
+        print("hint: pip install 'harbor[daytona]'", file=sys.stderr)
+        sys.exit(2)
+
+    client = Daytona()
+    label_filter = _parse_labels(args.label)
+    state_filter = set(args.state) if args.state else None
+
+    sandboxes = []
+    for sandbox in _iter_sandboxes(client, label_filter):
+        if state_filter and getattr(sandbox, "state", None) not in state_filter:
+            continue
+        sandboxes.append(sandbox)
+
+    print(f"Found {len(sandboxes)} sandbox(es) matching filters.")
+    for sandbox in sandboxes:
+        print(f"  {_summarize(sandbox)}")
+
+    if not args.delete:
+        print("\n(list-only; pass --delete to remove them)")
+        return
+
+    if not sandboxes:
+        return
+
+    print(f"\nDeleting {len(sandboxes)} sandbox(es)...")
+    failures = 0
+    for sandbox in sandboxes:
+        print(f"  delete {sandbox.id} ...", end=" ", flush=True)
+        try:
+            client.delete(sandbox, timeout=args.timeout)
+            print("ok")
+        except Exception as e:
+            failures += 1
+            print(f"failed: {e}")
+    print(f"Done. {len(sandboxes) - failures} deleted, {failures} failed.")
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/verl/experimental/agentic_rl_harbor/config/harbor_agent.yaml
+++ b/verl/experimental/agentic_rl_harbor/config/harbor_agent.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The `harbor_trial_config` block below is adapted from SkyRL (Apache 2.0):
+#   https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train_integrations/harbor/harbor_trial_config/default.yaml
+
+- name: harbor_agent
+  _target_: verl.experimental.agentic_rl_harbor.harbor_agent_loop.HarborAgentLoop
+
+  # Set this to the value vLLM advertises (basename of the model path by default).
+  # Override on the command line:
+  #   actor_rollout_ref.rollout.agent.agent_loop_kwargs.served_model_name=Qwen3-8B
+  served_model_name: null
+
+  harbor_trial_config:
+    trials_dir: trials
+    timeout_multiplier: 1.0
+
+    agent:
+      name: terminus-2
+      override_timeout_sec: 1200
+      kwargs:
+        max_turns: 32
+        suppress_max_turns_warning: true
+        enable_summarize: false
+        collect_rollout_details: true
+        temperature: 1.0
+        model_info:
+          max_input_tokens: 32768
+          max_output_tokens: 32768
+          input_cost_per_token: 0.0
+          output_cost_per_token: 0.0
+        llm_kwargs:
+          timeout: 900
+          max_retries: 0
+          top_p: 1.0
+          top_k: -1
+          min_p: 0.0
+
+    environment:
+      type: daytona
+      override_cpus: 1
+      override_memory_mb: 1024
+      override_storage_mb: 1024
+      suppress_override_warnings: true
+      kwargs:
+        auto_stop_interval_mins: 30
+
+    verifier:
+      disable: false

--- a/verl/experimental/agentic_rl_harbor/harbor_agent_loop.py
+++ b/verl/experimental/agentic_rl_harbor/harbor_agent_loop.py
@@ -1,0 +1,347 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# `_build_step_wise` and `_merge_stepwise` are adapted from SkyRL (Apache 2.0):
+#   https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train_integrations/harbor/harbor_generator.py
+"""
+Harbor agent loop for VeRL.
+
+Bridges VeRL's :class:`AgentLoopBase` to Laude Institute's Harbor framework.
+For each sample we spin up a Harbor :class:`Trial`, point it at a VeRL rollout
+HTTP endpoint, and convert the multi-turn rollout details Harbor returns into
+the linear (prompt_ids + response_ids + response_mask) format VeRL expects.
+
+The conversion uses a two-stage layout: (1) ``_build_step_wise`` flattens
+rollout_details into one entry per LLM turn, (2) ``_merge_stepwise`` greedily
+merges turns into prefix-coherent groups (re-emitting obs deltas with
+response_mask=0 in between), flushing a new group whenever Harbor's
+re-rendered prompt diverges from ``prompt[t-1] + completion[t-1]``. A divergent
+re-render is treated as a benign group boundary instead of a fatal error so the
+loop tolerates chat templates that don't perfectly preserve prior-turn tokens.
+"""
+
+import logging
+import os
+import random
+from copy import deepcopy
+from typing import Any, Optional
+from uuid import uuid4
+
+from omegaconf import DictConfig, OmegaConf
+
+from verl.experimental.agent_loop.agent_loop import (
+    AgentLoopBase,
+    AgentLoopMetrics,
+    AgentLoopOutput,
+    register,
+)
+from verl.utils.profiler import simple_timer
+from verl.utils.rollout_trace import rollout_trace_op
+
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Suppress noisy LiteLLM logging (Harbor uses LiteLLM internally).
+try:
+    import logging as _logging
+
+    import litellm
+
+    litellm.suppress_debug_info = True
+    litellm.set_verbose = False
+    _logging.getLogger("LiteLLM").setLevel(_logging.WARNING)
+except ImportError:  # litellm only required at runtime
+    pass
+
+# How many times to retry a single trial on transient errors before giving up.
+MAX_NUM_RETRIES_PER_TRIAL = 2
+
+
+def _build_step_wise(rollout_details: list) -> list[dict]:
+    """Flatten Harbor rollout_details into one entry per LLM turn.
+
+    Returns ``[{"prompt_ids", "comp_ids", "logprobs"}, ...]`` with one entry per turn.
+    """
+    assert len(rollout_details) == 1, f"Expected exactly one rollout segment, got {len(rollout_details)}."
+    rd = rollout_details[0]
+    prompts = rd["prompt_token_ids"]
+    completions = rd["completion_token_ids"]
+    logprobs = rd["logprobs"]
+    n = len(completions)
+    assert len(prompts) == n and len(logprobs) == n, (
+        f"Malformed rollout_details (prompts={len(prompts)}, completions={n}, logprobs={len(logprobs)})"
+    )
+    turns = []
+    for t in range(n):
+        assert len(logprobs[t]) == len(completions[t]), "logprobs and completion lengths must match"
+        turns.append({"prompt_ids": list(prompts[t]), "comp_ids": list(completions[t]), "logprobs": list(logprobs[t])})
+    return turns
+
+
+def _is_prefix(maybe_prefix: list[int], candidate: list[int]) -> bool:
+    return len(maybe_prefix) <= len(candidate) and maybe_prefix == candidate[: len(maybe_prefix)]
+
+
+def _merge_stepwise(turns: list[dict]) -> list[dict]:
+    """Greedy prefix-aware merge of step-wise turns into trajectory groups.
+
+    Each output group is a self-contained
+    ``{prompt_ids, response_ids, response_mask, response_logprobs}``: inside a
+    group the response stream is ``comp[t]`` interleaved with obs deltas (the
+    prefix-extension between consecutive prompts), with obs tokens masked to 0.
+    Whenever ``prompt[t-1] + comp[t-1]`` is *not* a prefix of ``prompt[t]``
+    (Harbor re-rendered the history non-trivially), we flush the current group
+    and start a fresh one rooted at turn t. Returns one group when prefix holds
+    throughout.
+    """
+    assert turns, "expected at least one turn"
+
+    def _new_group(turn):
+        return {
+            "prompt_ids": list(turn["prompt_ids"]),
+            "response_ids": list(turn["comp_ids"]),
+            "response_mask": [1] * len(turn["comp_ids"]),
+            "response_logprobs": list(turn["logprobs"]),
+        }
+
+    groups: list[dict] = []
+    g = _new_group(turns[0])
+    for t in turns[1:]:
+        cursor_len = len(g["prompt_ids"]) + len(g["response_ids"])
+        next_prompt = t["prompt_ids"]
+        # cursor == g["prompt_ids"] + g["response_ids"]; build it lazily for the prefix check.
+        if len(next_prompt) >= cursor_len and _is_prefix(g["prompt_ids"] + g["response_ids"], next_prompt):
+            obs = next_prompt[cursor_len:]
+            g["response_ids"].extend(obs)
+            g["response_mask"].extend([0] * len(obs))
+            g["response_logprobs"].extend([0.0] * len(obs))
+            g["response_ids"].extend(t["comp_ids"])
+            g["response_mask"].extend([1] * len(t["comp_ids"]))
+            g["response_logprobs"].extend(t["logprobs"])
+        else:
+            groups.append(g)
+            g = _new_group(t)
+    groups.append(g)
+    return groups
+
+
+@register("harbor_agent")
+class HarborAgentLoop(AgentLoopBase):
+    """Run one Harbor trial per sample.
+
+    Per-task config is taken from ``harbor_trial_config`` in the agent_loop YAML.
+    The model name and api_base are injected at runtime from VeRL's rollout
+    server addresses; ``session_id`` is generated per trial.
+    """
+
+    def __init__(
+        self,
+        trainer_config,
+        server_manager,
+        tokenizer,
+        processor,
+        dataset_cls,
+        data_config,
+        harbor_trial_config: Optional[Any] = None,
+        served_model_name: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            trainer_config=trainer_config,
+            server_manager=server_manager,
+            tokenizer=tokenizer,
+            processor=processor,
+            dataset_cls=dataset_cls,
+            data_config=data_config,
+            **kwargs,
+        )
+
+        if harbor_trial_config is None:
+            raise ValueError("HarborAgentLoop requires `harbor_trial_config`; declare it in your agent_loop YAML.")
+        if isinstance(harbor_trial_config, DictConfig):
+            harbor_trial_config = OmegaConf.to_container(harbor_trial_config, resolve=True)
+        self._harbor_template: dict = deepcopy(harbor_trial_config)
+
+        # ``served_model_name`` must match what vLLM advertises. vLLM's async server
+        # (vllm_async_server.py) takes ``rollout.prometheus.served_model_name`` and
+        # strips it down to the basename when the value contains a path separator,
+        # so we apply the same basename rule here to stay in sync. Default for
+        # ``prometheus.served_model_name`` is the full model path, which would
+        # otherwise yield a malformed ``hosted_vllm//root/...`` LiteLLM target.
+        if served_model_name is None:
+            prom_name = getattr(self.rollout_config.prometheus, "served_model_name", None)
+            served_model_name = prom_name or str(self.config.actor_rollout_ref.model.path)
+        served_model_name = os.path.basename(str(served_model_name).rstrip("/"))
+        if not served_model_name:
+            raise ValueError(
+                "Could not resolve served_model_name; pass it explicitly via "
+                "agent_loop_kwargs.served_model_name=<name>."
+            )
+        if not getattr(self.rollout_config.prometheus, "enable", False):
+            logger.warning(
+                "rollout.prometheus.enable=False; vLLM may advertise the full model path "
+                "instead of '%s'. Set prometheus.enable=True (and prometheus.served_model_name) "
+                "to keep both sides in sync.",
+                served_model_name,
+            )
+        self._served_model_name = served_model_name
+
+        self._harbor_template.setdefault("agent", {})
+        self._harbor_template["agent"]["model_name"] = f"hosted_vllm/{self._served_model_name}"
+        agent_kwargs = self._harbor_template["agent"].setdefault("kwargs", {})
+        agent_kwargs.setdefault("collect_rollout_details", True)
+        if not agent_kwargs.get("collect_rollout_details", False):
+            raise ValueError("HarborAgentLoop requires agent.kwargs.collect_rollout_details=true.")
+        if agent_kwargs.get("enable_summarize", False):
+            raise ValueError("HarborAgentLoop does not support agent.kwargs.enable_summarize=true.")
+
+        self._prompt_length = self.rollout_config.prompt_length
+        self._response_length = self.rollout_config.response_length
+
+    async def _resolve_api_base(self) -> str:
+        """Pick a VeRL rollout server address and turn it into an OpenAI base URL."""
+        servers = await self.server_manager._load_balancer.get_all_servers.remote()
+        if not servers:
+            raise RuntimeError("No rollout servers registered with the load balancer.")
+        return f"http://{random.choice(servers)}/v1"
+
+    async def _run_trial(self, task_path: str, request_id: str):
+        """Run a Harbor trial with retries."""
+        from harbor.models.trial.config import TrialConfig
+        from harbor.trial.trial import Trial
+
+        api_base = await self._resolve_api_base()
+        last_results = None
+        is_context_length_error = False
+        is_agent_timeout_error = False
+
+        for attempt in range(MAX_NUM_RETRIES_PER_TRIAL):
+            prefix = f"Trajectory {request_id} attempt {attempt + 1}/{MAX_NUM_RETRIES_PER_TRIAL}"
+            try:
+                cfg = deepcopy(self._harbor_template)
+                cfg["task"] = {"path": task_path}
+                cfg["agent"]["kwargs"]["api_base"] = api_base
+                cfg["agent"]["kwargs"]["session_id"] = uuid4().hex
+
+                trial = await Trial.create(TrialConfig.model_validate(cfg))
+                last_results = await trial.run()
+
+                exc_type = last_results.exception_info.exception_type if last_results.exception_info else None
+                is_context_length_error = exc_type == "ContextLengthExceededError"
+                is_agent_timeout_error = exc_type == "AgentTimeoutError"
+
+                if is_agent_timeout_error:
+                    logger.debug("%s hit AgentTimeoutError (no retry)", prefix)
+                    return None, "agent_timeout", 0.0, 0
+                if is_context_length_error:
+                    reward = 0.0
+                elif not last_results.verifier_result:
+                    logger.warning("%s missing verifier_result, retrying. info=%s", prefix, last_results.exception_info)
+                    continue
+                else:
+                    reward = float(last_results.verifier_result.rewards["reward"])
+
+                rollout_details = last_results.agent_result.rollout_details
+                num_turns = last_results.agent_result.metadata["n_episodes"]
+                if (
+                    rollout_details
+                    and len(rollout_details) >= 1
+                    and len(rollout_details[0].get("completion_token_ids", [])) > 0
+                ):
+                    return (
+                        rollout_details,
+                        "context_length" if is_context_length_error else "complete",
+                        reward,
+                        num_turns,
+                    )
+                logger.warning("%s empty rollout_details, retrying", prefix)
+            except Exception as e:
+                logger.warning("%s failed: %s", prefix, e)
+                continue
+
+        return None, "error", 0.0, 0
+
+    @rollout_trace_op
+    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        # ``task_path`` is provided by HarborTaskDataset; fall back to extra_info for convenience.
+        task_path = kwargs.get("task_path")
+        if not task_path:
+            extra_info = kwargs.get("extra_info") or {}
+            task_path = extra_info.get("task_path")
+        if not task_path:
+            raise ValueError("HarborAgentLoop requires a `task_path` field on each sample.")
+
+        request_id = uuid4().hex
+        metrics: dict[str, float] = {}
+        with simple_timer("generate_sequences", metrics):
+            rollout_details, stop_reason, reward, num_turns = await self._run_trial(task_path, request_id)
+
+        # fully_async expects per-sample ``min/max_global_steps`` to drive its
+        # staleness / partial_rollout stats; standard agent loops get this via
+        # ``super().generate()`` returning ``extra_fields["global_steps"]`` from the
+        # vLLM server. Harbor goes through LiteLLM/HTTP and bypasses that path,
+        # and the server class doesn't expose a public getter we can call from here.
+        # We stamp 0 instead: with ``STALENESS_THRESHOLD=0`` + ``partial_rollout=False``
+        # (the only mode this loop is exercised in) all samples come from one weight
+        # version anyway, so ``abs(end - start) == 0`` is the correct answer; the
+        # only loss is the ``param_version_diversity`` log metric (always 1).
+        version_fields = {"min_global_steps": 0, "max_global_steps": 0}
+
+        if rollout_details is None:
+            # Failed trajectory: emit a single masked token so downstream padding works.
+            return AgentLoopOutput(
+                prompt_ids=[0],
+                response_ids=[0],
+                response_mask=[0],
+                response_logprobs=[0.0],
+                reward_score=0.0,
+                num_turns=0,
+                metrics=AgentLoopMetrics(**metrics),
+                extra_fields={"stop_reason": stop_reason, "harbor_failed": True, **version_fields},
+            )
+
+        # Step-wise + prefix-aware merge. With multiple groups, pick one uniformly
+        # at random for the policy gradient update; the trajectory reward is attached
+        # to whichever group is picked. See README for selection-strategy notes.
+        turns = _build_step_wise(rollout_details)
+        groups = _merge_stepwise(turns)
+        if len(groups) > 1:
+            logger.warning(
+                "Harbor trajectory %s split into %d merge groups (prefix divergence); "
+                "randomly sampling one for policy gradient.",
+                request_id,
+                len(groups),
+            )
+        group = random.choice(groups)
+
+        prompt_ids = group["prompt_ids"][: self._prompt_length]
+        response_ids = group["response_ids"][: self._response_length]
+        response_mask = group["response_mask"][: self._response_length]
+        response_logprobs = group["response_logprobs"][: self._response_length]
+
+        return AgentLoopOutput(
+            prompt_ids=prompt_ids,
+            response_ids=response_ids,
+            response_mask=response_mask,
+            response_logprobs=response_logprobs,
+            reward_score=reward,
+            num_turns=num_turns,
+            metrics=AgentLoopMetrics(**metrics),
+            extra_fields={
+                "stop_reason": stop_reason,
+                "harbor_failed": False,
+                "harbor_num_merge_groups": len(groups),
+                **version_fields,
+            },
+        )

--- a/verl/experimental/agentic_rl_harbor/harbor_dataset.py
+++ b/verl/experimental/agentic_rl_harbor/harbor_dataset.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Dataset that yields Harbor task directory paths.
+
+Each item is one Harbor task (a directory containing ``instruction.md``).
+The actual task instruction is loaded lazily by Harbor inside the agent loop;
+we only carry the path here.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import torch
+from omegaconf import DictConfig
+from torch.utils.data import Dataset
+
+logger = logging.getLogger(__name__)
+
+
+class HarborTaskDataset(Dataset):
+    """List Harbor task directories under ``data_files``.
+
+    A task directory is any subdirectory containing an ``instruction.md`` file.
+    """
+
+    def __init__(
+        self,
+        data_files: str | list[str],
+        tokenizer=None,
+        processor=None,
+        config: Optional[DictConfig] = None,
+        max_samples: int = -1,
+    ):
+        self.tokenizer = tokenizer
+        self.processor = processor
+        self.config = config
+
+        if isinstance(data_files, str):
+            data_files = [data_files]
+
+        task_paths: list[Path] = []
+        for source in data_files:
+            root = Path(source)
+            if not root.exists():
+                logger.warning("Harbor data path does not exist: %s", source)
+                continue
+            if root.is_dir():
+                if self._is_task_dir(root):
+                    task_paths.append(root)
+                    continue
+                task_paths.extend(sorted(d for d in root.iterdir() if self._is_task_dir(d)))
+            else:
+                logger.warning("Harbor data path is not a directory: %s", source)
+
+        if max_samples > 0:
+            task_paths = task_paths[:max_samples]
+
+        if not task_paths:
+            raise ValueError(f"No Harbor tasks found under {data_files}")
+
+        self.task_paths = task_paths
+        logger.info("HarborTaskDataset initialized with %d tasks", len(self.task_paths))
+
+    @staticmethod
+    def _is_task_dir(path: Path) -> bool:
+        return path.is_dir() and (path / "instruction.md").is_file()
+
+    def __len__(self) -> int:
+        return len(self.task_paths)
+
+    def __getitem__(self, idx: int) -> dict:
+        task_path = str(self.task_paths[idx])
+        return {
+            # raw_prompt is unused by HarborAgentLoop (Harbor reads the task itself),
+            # but VeRL's pipeline expects it to be present.
+            "raw_prompt": [{"role": "user", "content": task_path}],
+            "task_path": task_path,
+            "agent_name": "harbor_agent",
+            "data_source": "harbor",
+            "reward_model": {"ground_truth": ""},
+            "extra_info": {"index": idx, "task_path": task_path},
+            "index": idx,
+            "tools_kwargs": {},
+            "interaction_kwargs": {},
+            # DataProto.batch must be non-empty.
+            "dummy_tensor": torch.tensor([0], dtype=torch.uint8),
+        }

--- a/verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py
+++ b/verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Alibaba Group
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Adapted from SkyRL (Apache 2.0):
+#   https://github.com/NovaSky-AI/SkyRL/blob/main/examples/train_integrations/harbor/prepare_harbor_dataset.py
+"""
+Prepare Harbor task datasets from HuggingFace Hub.
+
+Downloads a dataset and extracts Harbor tasks from parquet files containing
+tar-archived task directories (columns: path, task_binary).
+
+Output directory defaults to ~/data/harbor/<repo-name>.
+
+Usage:
+
+    python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
+        --dataset DCAgent/exp_rpt_curriculum-easy
+"""
+
+import argparse
+import io
+import os
+import shutil
+import tarfile
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path, PurePosixPath
+
+import pyarrow.parquet as pq
+
+
+def _is_within(base: Path, target: Path) -> bool:
+    try:
+        return os.path.commonpath([str(base.resolve()), str(target.resolve())]) == str(base.resolve())
+    except Exception:
+        return False
+
+
+def _sanitize_tar_member_name(name: str) -> str:
+    p = PurePosixPath(name)
+    parts = [part for part in p.parts if part not in ("..", ".", "")]
+    while parts and parts[0] == "/":
+        parts.pop(0)
+    return str(PurePosixPath(*parts)) if parts else ""
+
+
+def _safe_extract_tar(archive_bytes: bytes, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    buf = io.BytesIO(archive_bytes)
+    with tarfile.open(fileobj=buf, mode="r:*") as tf:
+        for member in tf.getmembers():
+            member_name = _sanitize_tar_member_name(member.name)
+            if not member_name or member_name.endswith("/"):
+                (dest_dir / member_name).mkdir(parents=True, exist_ok=True)
+                continue
+            if ".snapshot" in PurePosixPath(member_name).parts:
+                continue
+            target = (dest_dir / member_name).resolve()
+            if not _is_within(dest_dir, target):
+                raise RuntimeError(f"Unsafe path in archive: {member.name}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if member.isfile():
+                with tf.extractfile(member) as src:
+                    if src is None:
+                        continue
+                    with open(target, "wb") as dst:
+                        dst.write(src.read())
+            elif member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+
+
+def _extract_one(args: tuple) -> bool:
+    rel_path, data, output_dir_str = args
+    if not isinstance(rel_path, str) or not isinstance(data, bytes | bytearray | memoryview):
+        return False
+    output_dir = Path(output_dir_str)
+
+    safe_rel = PurePosixPath(rel_path)
+    parts = [p for p in safe_rel.parts if p not in ("..", "")]
+    rel_norm = Path(*parts) if parts else Path("task_unknown")
+    target_dir = (output_dir / rel_norm).resolve()
+
+    if not _is_within(output_dir, target_dir):
+        return False
+
+    if target_dir.exists() and (target_dir / "instruction.md").exists():
+        return True
+
+    try:
+        _safe_extract_tar(bytes(data), target_dir)
+        return True
+    except Exception as e:
+        print(f"  Warning: Failed to extract {rel_path}: {e}")
+        return False
+
+
+def extract_parquet(parquet_path: Path, output_dir: Path) -> int:
+    table = pq.read_table(parquet_path)
+    path_col = table.column("path").to_pylist()
+    data_col = table.column("task_binary").to_pylist()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    args = [(p, d, str(output_dir)) for p, d in zip(path_col, data_col, strict=False)]
+
+    with ProcessPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(_extract_one, args, chunksize=64))
+
+    return sum(results)
+
+
+def prepare(dataset_name: str, output_dir: str | None = None) -> str:
+    from huggingface_hub import snapshot_download
+
+    repo_name = dataset_name.split("/")[-1] if "/" in dataset_name else dataset_name
+    if output_dir is None:
+        output_dir = os.path.join("~/data/harbor", repo_name)
+    output_path = Path(os.path.expanduser(output_dir)).resolve()
+
+    print(f"Downloading {dataset_name}...")
+    snapshot_dir = Path(snapshot_download(repo_id=dataset_name, repo_type="dataset"))
+    print(f"Downloaded to {snapshot_dir}")
+
+    parquets = []
+    for f in snapshot_dir.glob("**/*.parquet"):
+        try:
+            schema = pq.read_schema(f)
+            if "path" in schema.names and "task_binary" in schema.names:
+                parquets.append(f)
+        except Exception as e:
+            print(f"  Warning: Could not read schema from {f}: {e}")
+            continue
+
+    if not parquets:
+        print("No parquet files found, symlinking snapshot directly...")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if output_path.is_symlink():
+            output_path.unlink()
+        elif output_path.exists():
+            shutil.rmtree(output_path)
+        output_path.symlink_to(snapshot_dir)
+        print(f"Done! Symlinked {output_path} -> {snapshot_dir}")
+        return str(output_path)
+
+    total = 0
+    for pq_file in parquets:
+        print(f"Extracting {pq_file.name}...")
+        total += extract_parquet(pq_file, output_path)
+
+    print(f"Done! {total} tasks extracted to {output_path}")
+    return str(output_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Prepare Harbor task dataset from HuggingFace Hub")
+    parser.add_argument("--dataset", required=True, help="HuggingFace dataset (e.g. DCAgent/exp_rpt_curriculum-easy)")
+    parser.add_argument("--output_dir", default=None, help="Output directory (default: ~/data/harbor/<repo-name>)")
+    args = parser.parse_args()
+    prepare(args.dataset, args.output_dir)

--- a/verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py
+++ b/verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py
@@ -73,8 +73,12 @@ def _safe_extract_tar(archive_bytes: bytes, dest_dir: Path) -> None:
                 with tf.extractfile(member) as src:
                     if src is None:
                         continue
+            if member.isfile():
+                with tf.extractfile(member) as src:
+                    if src is None:
+                        continue
                     with open(target, "wb") as dst:
-                        dst.write(src.read())
+                        shutil.copyfileobj(src, dst)
             elif member.isdir():
                 target.mkdir(parents=True, exist_ok=True)
 
@@ -112,7 +116,7 @@ def extract_parquet(parquet_path: Path, output_dir: Path) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     args = [(p, d, str(output_dir)) for p, d in zip(path_col, data_col, strict=False)]
 
-    with ProcessPoolExecutor(max_workers=8) as pool:
+    with ProcessPoolExecutor(max_workers=None) as pool:
         results = list(pool.map(_extract_one, args, chunksize=64))
 
     return sum(results)

--- a/verl/experimental/agentic_rl_harbor/shell/run_qwen3_8b_harbor_fully_async.sh
+++ b/verl/experimental/agentic_rl_harbor/shell/run_qwen3_8b_harbor_fully_async.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Train Qwen3-8B with Harbor + VeRL fully_async_policy on Harbor task datasets.
+#
+# Defaults to TaskTrove v2 "easy" buckets (curriculum-easy / exercism-python-v2)
+# because Qwen3-8B's pass@1 on competition-grade datasets like CodeContests is
+# essentially zero, which collapses GRPO advantages to zero (no gradient signal)
+# and still pays the full sandbox cost. Override HARBOR_TRAIN/HARBOR_VAL to point
+# at a harder split when you have a stronger model.
+#
+# Prereqs (versions this recipe has been tested with):
+#   pip install 'harbor[daytona]==0.6.1' 'litellm==1.82.6'
+#   python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
+#       --dataset DCAgent/exp_rpt_curriculum-easy
+#   python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
+#       --dataset laion/exp_rpt_exercism-python-v2
+#
+# Sandbox credentials (Harbor runs trials on a remote sandbox; pick one):
+#   export DAYTONA_API_KEY=...    # default https://app.daytona.io/api
+#   export DAYTONA_API_URL=...    # get an API key from https://app.daytona.io/dashboard/keys
+
+set -xeuo pipefail
+export VLLM_USE_V1=1
+
+#----------------------- Paths -----------------------
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+HARBOR_PKG=${HARBOR_PKG:-$(cd "$SCRIPT_DIR/.." && pwd)}
+
+MODEL_PATH=${MODEL_PATH:-/root/Qwen3-8B}
+SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-$(basename "$MODEL_PATH")}
+
+DATA_DIR=${DATA_DIR:-$HOME/data/harbor}
+HARBOR_TRAIN=${HARBOR_TRAIN:-$DATA_DIR/exp_rpt_curriculum-easy}
+HARBOR_VAL=${HARBOR_VAL:-$DATA_DIR/exp_rpt_exercism-python-v2}
+TRAIN_FILES="['$HARBOR_TRAIN']"
+VAL_FILES="['$HARBOR_VAL']"
+
+HARBOR_DATASET_PY=${HARBOR_DATASET_PY:-$HARBOR_PKG/harbor_dataset.py}
+HARBOR_AGENT_LOOP_YAML=${HARBOR_AGENT_LOOP_YAML:-$HARBOR_PKG/config/harbor_agent.yaml}
+# Default Qwen3 chat template strips <think> blocks from non-last assistant turns,
+# breaking the prefix invariant HarborAgentLoop's _merge_stepwise relies on. The
+# accumulate-thinking variant keeps assistant content as-is across turns so a
+# trajectory merges into a single training group instead of being split.
+CHAT_TEMPLATE_PATH=${CHAT_TEMPLATE_PATH:-$HARBOR_PKG/templates/qwen3_acc_thinking.jinja2}
+
+RUN_NAME=${RUN_NAME:-qwen3_8b_harbor_fully_async}
+LOG_ROOT=${LOG_ROOT:-/root/logs/$RUN_NAME}
+CKPT_DIR=${CKPT_DIR:-$LOG_ROOT/ckpts}
+
+#----------------------- Algorithm -----------------------
+ADV_ESTIMATOR=${ADV_ESTIMATOR:-grpo}
+N_RESP_PER_PROMPT=${N_RESP_PER_PROMPT:-2}
+N_RESP_PER_PROMPT_VAL=${N_RESP_PER_PROMPT_VAL:-1}
+
+PPO_MINI_BATCH_SIZE=${PPO_MINI_BATCH_SIZE:-2}
+GEN_BATCH_SIZE=${GEN_BATCH_SIZE:-1}
+TOTAL_ROLLOUT_STEPS=${TOTAL_ROLLOUT_STEPS:-32}
+TRAIN_MAX_SAMPLES=${TRAIN_MAX_SAMPLES:-32}
+TOTAL_EPOCHS=${TOTAL_EPOCHS:-1}
+LOG_VAL_GENERATIONS=${LOG_VAL_GENERATIONS:-10}
+
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-4096}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-$((32768 - MAX_PROMPT_LENGTH))}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-32768}
+
+ACTOR_LR=${ACTOR_LR:-1e-6}
+ROLLOUT_GPU_MEM_UTIL=${ROLLOUT_GPU_MEM_UTIL:-0.85}
+OFFLOAD=${OFFLOAD:-True}
+
+#----------------------- Async knobs (cf. fully_async_policy README) -----------------------
+# Harbor trials run in a remote sandbox whose state is not serializable, so
+# partial_rollout (Mode 4 in fully_async_policy/README.md) is not supported.
+#
+# Sandbox concurrency cap (IMPORTANT -- Daytona free tier defaults to 10 CPUs):
+#   Each trial launches a Daytona sandbox that takes override_cpus=1 (see
+#   config/harbor_agent.yaml). Exceeding the tier's total CPU quota is rejected
+#   server-side with:
+#     "Failed to create sandbox: Total CPU limit exceeded. Maximum allowed: 10."
+#   The number of concurrent trials follows FullyAsyncRollouter (see
+#   fully_async_rollouter.py:529-541):
+#     max_required_samples   = ppo_mini_batch_size * require_batches
+#                              * (staleness_threshold + 1) * trigger_parameter_sync_step
+#     max_concurrent_samples = min(replicas * 16, max_required_samples)
+#     concurrent_trials      ~= max_concurrent_samples * N_RESP_PER_PROMPT
+#
+#   Hard constraints we can't relax further:
+#     N_RESP_PER_PROMPT=2          -- GRPO minimum (n=1 -> advantage is always 0)
+#     PPO_MINI_BATCH_SIZE=2        -- must be divisible by train DP = N_GPUS_TRAIN/TRAIN_SP = 2
+#     REQUIRE_BATCHES=1            -- streaming granularity, Mode 3 demo
+#     TRIGGER_PARAM_SYNC_STEP=2    -- Mode 3 definition requires > 1
+#   That leaves STALENESS_THRESHOLD as the only knob to keep concurrent_trials <= 10
+#   while preserving Mode 3 (which requires staleness > 0).
+#
+#   Trade-off table at the current other defaults (ppo_mini=2, require=1, trigger=2, n=2):
+#     staleness=1.0 -> max_req=8  -> 16 trials (tripped Daytona quota; was the old default)
+#     staleness=0.5 -> max_req=6  -> 12 trials (still over the 10-CPU cap)
+#     staleness=0.25-> max_req=5  -> 10 trials (exactly at cap, no headroom -> teardown race risk)
+#     staleness=0.1 -> max_req=4  ->  8 trials (2 CPU headroom; Mode 3 preserved)  <-- current default
+#     staleness=0.0 -> max_req=4  ->  8 trials (would degrade to Mode 2)
+#
+#   After upgrading the Daytona tier (https://app.daytona.io/dashboard/limits) or
+#   switching to a local sandbox, raise STALENESS_THRESHOLD back to 1.0 to fully
+#   exercise Mode 3 -- the "truly async" tier where trainer consumes samples from
+#   the previous weight version while rollouter is already producing for the next.
+STALENESS_THRESHOLD=${STALENESS_THRESHOLD:-0.1}
+TRIGGER_PARAM_SYNC_STEP=${TRIGGER_PARAM_SYNC_STEP:-2}
+REQUIRE_BATCHES=${REQUIRE_BATCHES:-1}
+PARTIAL_ROLLOUT=${PARTIAL_ROLLOUT:-False}
+TEST_FREQ=${TEST_FREQ:--1}
+
+#----------------------- Resources -----------------------
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+N_GPUS_ROLLOUT=${N_GPUS_ROLLOUT:-4}
+N_GPUS_TRAIN=${N_GPUS_TRAIN:-$((NGPUS_PER_NODE - N_GPUS_ROLLOUT))}
+INFER_TP=${INFER_TP:-2}
+TRAIN_SP=${TRAIN_SP:-2}
+FSDP_SIZE=${FSDP_SIZE:-$N_GPUS_TRAIN}
+
+ACTOR_MAX_TOKEN_LEN_PER_GPU=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+LOG_PROB_MAX_TOKEN_LEN_PER_GPU=$((ACTOR_MAX_TOKEN_LEN_PER_GPU * 4))
+
+python3 -m verl.experimental.fully_async_policy.fully_async_main \
+    algorithm.adv_estimator=$ADV_ESTIMATOR \
+    algorithm.use_kl_in_reward=False \
+    algorithm.kl_ctrl.kl_coef=0.0 \
+    data.train_files="$TRAIN_FILES" \
+    data.val_files="$VAL_FILES" \
+    data.return_raw_chat=True \
+    data.train_batch_size=0 \
+    data.gen_batch_size=$GEN_BATCH_SIZE \
+    data.train_max_samples=$TRAIN_MAX_SAMPLES \
+    data.max_prompt_length=$MAX_PROMPT_LENGTH \
+    data.max_response_length=$MAX_RESPONSE_LENGTH \
+    data.custom_cls.path=$HARBOR_DATASET_PY \
+    data.custom_cls.name=HarborTaskDataset \
+    actor_rollout_ref.hybrid_engine=False \
+    actor_rollout_ref.model.path=$MODEL_PATH \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.0 \
+    actor_rollout_ref.actor.clip_ratio_low=0.2 \
+    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.optim.lr=$ACTOR_LR \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.ppo_mini_batch_size=$PPO_MINI_BATCH_SIZE \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=$ACTOR_MAX_TOKEN_LEN_PER_GPU \
+    actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \
+    actor_rollout_ref.actor.fsdp_config.fsdp_size=$FSDP_SIZE \
+    actor_rollout_ref.actor.fsdp_config.param_offload=$OFFLOAD \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=$OFFLOAD \
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=$TRAIN_SP \
+    actor_rollout_ref.actor.use_rollout_log_probs=True \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=$LOG_PROB_MAX_TOKEN_LEN_PER_GPU \
+    critic.strategy=fsdp2 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=$INFER_TP \
+    actor_rollout_ref.rollout.gpu_memory_utilization=$ROLLOUT_GPU_MEM_UTIL \
+    actor_rollout_ref.rollout.n=$N_RESP_PER_PROMPT \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.disable_log_stats=False \
+    actor_rollout_ref.rollout.prometheus.enable=True \
+    actor_rollout_ref.rollout.prometheus.served_model_name=$SERVED_MODEL_NAME \
+    actor_rollout_ref.rollout.max_model_len=$MAX_MODEL_LEN \
+    actor_rollout_ref.rollout.multi_turn.enable=True \
+    actor_rollout_ref.rollout.val_kwargs.top_p=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0 \
+    actor_rollout_ref.rollout.val_kwargs.n=$N_RESP_PER_PROMPT_VAL \
+    actor_rollout_ref.rollout.agent.agent_loop_config_path=$HARBOR_AGENT_LOOP_YAML \
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.chat_template=$CHAT_TEMPLATE_PATH \
+    trainer.logger=['console'] \
+    trainer.project_name=harbor \
+    trainer.experiment_name=$RUN_NAME \
+    trainer.val_before_train=False \
+    trainer.test_freq=$TEST_FREQ \
+    trainer.save_freq=-1 \
+    trainer.default_local_dir=$CKPT_DIR \
+    trainer.log_val_generations=$LOG_VAL_GENERATIONS \
+    trainer.nnodes=$NNODES \
+    trainer.n_gpus_per_node=$N_GPUS_TRAIN \
+    rollout.nnodes=$NNODES \
+    rollout.n_gpus_per_node=$N_GPUS_ROLLOUT \
+    rollout.total_rollout_steps=$TOTAL_ROLLOUT_STEPS \
+    trainer.total_epochs=$TOTAL_EPOCHS \
+    async_training.staleness_threshold=$STALENESS_THRESHOLD \
+    async_training.trigger_parameter_sync_step=$TRIGGER_PARAM_SYNC_STEP \
+    async_training.require_batches=$REQUIRE_BATCHES \
+    async_training.partial_rollout=$PARTIAL_ROLLOUT \
+    "$@"

--- a/verl/experimental/agentic_rl_harbor/templates/qwen3_acc_thinking.jinja2
+++ b/verl/experimental/agentic_rl_harbor/templates/qwen3_acc_thinking.jinja2
@@ -1,0 +1,96 @@
+{#
+  qwen3_acc_thinking.jinja2 — accumulate-thinking variant of the official Qwen3 chat template.
+
+  Copied verbatim from SkyRL:
+    https://github.com/NovaSky-AI/SkyRL  (Apache 2.0)
+    SkyRL/skyrl/train/utils/templates/qwen3_acc_thinking.jinja2
+
+  Why we need it:
+    The default Qwen3 chat template strips <think>...</think> blocks from non-last
+    assistant messages on every re-render. In multi-turn rollouts that breaks the
+    prefix invariant HarborAgentLoop relies on (turn t+1's prompt should extend
+    turn t's prompt + completion). HarborAgentLoop's _merge_stepwise is now tolerant
+    of prefix breaks (it just flushes a new merge group), but every break costs us a
+    smaller training group from that trajectory — this template keeps assistant
+    content as-is across turns, so prefixes stay strictly appending and we get one
+    big group per trajectory.
+
+    See SkyRL/skyrl/train/utils/templates/README.md for the rationale and the
+    upstream Qwen3 template diff.
+
+  How to use it:
+    Pass to vLLM's OpenAI server via verl's rollout config, e.g.
+        actor_rollout_ref.rollout.engine_kwargs.vllm.chat_template=<path-to-this-file>
+#}
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}


### PR DESCRIPTION
### What does this PR do?

Adds a new experimental recipe under `verl/experimental/agentic_rl_harbor/` that bridges VeRL's `AgentLoopBase` to [Laude Institute's Harbor](https://github.com/laude-institute/b-harbor) framework, so each training sample is a full Harbor `Trial` running a multi-turn agent against a remote sandbox (Daytona / Modal). Harbor's per-turn `rollout_details` are flattened back into the linear `(prompt_ids, response_ids, response_mask)` format VeRL's PPO/GRPO trainers expect, and the loop plugs straight into [`fully_async_policy`](../fully_async_policy/README.md) for async training.

This complements existing single-turn / tool-style agent loops by adding first-class support for *fully sandboxed* multi-turn agentic RL, which is the same integration target SkyRL ships ([reference](https://github.com/NovaSky-AI/SkyRL/tree/main/examples/train_integrations/harbor)).

### Checklist Before Starting

- [x] Search for similar PRs: no existing Harbor integration PR found in this repo.
- [x] PR title follows `[{modules}] {type}: {description}` and uses `rollout, fully_async` as modules.

### Test

**CPU unit tests** (added in this PR, pure helper logic, no GPU / sandbox required):

```bash
pytest tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py
# 12 passed in 7.96s
```

The tests cover `_build_step_wise` + `_merge_stepwise`: clean-prefix collapse to a single training group, prefix-divergence flush into multiple groups, malformed `rollout_details` rejection, and the short-prompt edge case.

**End-to-end smoke run** on 8 × A100 (4 rollout + 4 train) with Qwen3-8B + GRPO + fully_async + Daytona free-tier sandbox:

```bash
python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
    --dataset DCAgent/exp_rpt_curriculum-easy
python verl/experimental/agentic_rl_harbor/prepare_harbor_dataset.py \
    --dataset laion/exp_rpt_exercism-python-v2
ray stop --force && \
    bash verl/experimental/agentic_rl_harbor/shell/run_qwen3_8b_harbor_fully_async.sh
```

Trains end-to-end, produces non-zero reward signal, no leaked sandboxes after `cleanup_daytona.py --delete` preflight.

### API and Usage Example

No public API change. Activation is via existing rollout-config knobs — no new entrypoint:

```bash
python3 -m verl.experimental.fully_async_policy.fully_async_main \
    data.custom_cls.path=verl/experimental/agentic_rl_harbor/harbor_dataset.py \
    data.custom_cls.name=HarborTaskDataset \
    actor_rollout_ref.rollout.agent.agent_loop_config_path=\
verl/experimental/agentic_rl_harbor/config/harbor_agent.yaml \
    actor_rollout_ref.rollout.prometheus.enable=True \
    actor_rollout_ref.rollout.prometheus.served_model_name=Qwen3-8B \
    +actor_rollout_ref.rollout.engine_kwargs.vllm.chat_template=\
verl/experimental/agentic_rl_harbor/templates/qwen3_acc_thinking.jinja2 \
    ...  # rest of GRPO + fully_async knobs, see shell/run_qwen3_8b_harbor_fully_async.sh
```

The shipped shell script is the canonical, env-var-overridable demo.

### Design & Code Changes

**New files**:

- `verl/experimental/agentic_rl_harbor/`
  - `harbor_agent_loop.py` — `@register("harbor_agent")`, one Harbor `Trial` per sample. Two-stage `_build_step_wise` + prefix-aware `_merge_stepwise` rebuild the linear training format.
  - `harbor_dataset.py` — `HarborTaskDataset`, lists task directories (each containing `instruction.md`); follows the `dummy_tensor` pattern already used in `verl/utils/dataset/rl_dataset.py`.
  - `prepare_harbor_dataset.py` — pulls a Harbor HF dataset and unpacks the per-task tar archives.
  - `cleanup_daytona.py` — list / delete leaked Daytona sandboxes, recommended preflight (a crashed run skips Harbor's `_stop_sandbox` and otherwise burns the account's CPU quota until `auto_stop_interval_mins` elapses).
  - `config/harbor_agent.yaml` — registers `HarborAgentLoop` and supplies the `harbor_trial_config` template.
  - `templates/qwen3_acc_thinking.jinja2` — accumulate-thinking Qwen3 chat template, required to keep `_merge_stepwise`'s prefix invariant across turns.
  - `shell/run_qwen3_8b_harbor_fully_async.sh` — full demo, all knobs env-var overridable.
  - `README.md` — recipe overview, prereqs, async-knobs trade-off table, sandbox concurrency cap notes.
- `tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py` — 12 CPU unit tests for the flatten / merge helpers.

**Touched existing files** — both small, generalizable changes that this recipe surfaced but are not Harbor-specific:

1. `verl/experimental/agent_loop/agent_loop.py` — change `_agent_loop_registry[name] = {"_target_": fqdn}` to `setdefault` inside the `@register` decorator. **Bug:** when `agent_loop_config_path` populates the registry from YAML *before* the implementation module is imported, the entry already carries kwargs (e.g. `harbor_trial_config: ...`) intended for `hydra.utils.instantiate`. The subsequent module import would trigger `@register(...)`, which assigned the bare `{"_target_": fqdn}` and clobbered those kwargs. `setdefault` lets the YAML-loaded rich entry win. No behavior change for agent loops that don't load extra kwargs from YAML (the existing first-write path is preserved).
2. `tests/special_sanity/check_license.py` — register `Copyright 2026 Alibaba Group` so the sanity check passes on the new files. `python tests/special_sanity/check_license.py -d verl/experimental/agentic_rl_harbor tests/experimental/agentic_rl_harbor` succeeds.

**Intentional design choices**:

- **`_resolve_api_base` reads `self.server_manager._load_balancer.get_all_servers.remote()`.** `LLMServerClient` only exposes `_acquire_server / _release_server` for the regular request path; Harbor sends requests through LiteLLM/HTTP and needs the raw server URL for `api_base`. Happy to refactor into a small public `LLMServerClient.get_all_servers()` wrapper in a follow-up if preferred — kept it local to the recipe here to avoid touching shared rollout code in this PR.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
   > Recipe ships its own `README.md` under `verl/experimental/agentic_rl_harbor/`, consistent with `fully_async_policy/` and `one_step_off_policy/` — no top-level `docs/` index entry needed.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: 
      - CPU unit test added at `tests/experimental/agentic_rl_harbor/test_harbor_merge_on_cpu.py`,
        auto-picked up by `cpu_unit_tests.yml` via the `*_on_cpu.py` glob.
        Tests cover the prefix-aware merge logic and don't require Harbor / Daytona
        (the `harbor` import is function-local; `litellm` is wrapped in try/except).
      - End-to-end Harbor training is exercised by `shell/run_qwen3_8b_harbor_fully_async.sh`
        but is not in CI: it requires Daytona/Modal sandbox credentials + GPUs,
        which the public CI doesn't provision. Manually verified on 8 × H100.
- [x] CI request sent in Feishu group on 2026-05-22.
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
