### PR TITLE
[megatron] fix: Fix GPU memory leak in ref model offload by explicitly releasing storage

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -468,6 +468,28 @@ def mcore_model_parallel_config(
     )
 
 
+def _can_safely_resize_storage(tensor: torch.Tensor) -> bool:
+    """Check whether it is safe to call ``storage().resize_(0)`` on *tensor*.
+
+    Resizing the underlying storage to zero immediately frees the GPU memory
+    but also invalidates **every** tensor that shares the same storage
+    (e.g. views, tied weights stored as different Python objects, or slices
+    of a DDP flat buffer).  This function returns True only when the tensor
+    exclusively owns its entire storage, making ``resize_(0)`` safe.
+    """
+    return (
+        # Storage holds exactly the elements of this tensor – no room for
+        # other tensors sharing the same storage.
+        tensor.storage().size() == tensor.numel()
+        # Tensor starts at the beginning of the storage – not a slice/view
+        # offset into a larger buffer.
+        and tensor.storage_offset() == 0
+        # Tensor is contiguous in memory – rules out transposed or
+        # non-contiguous views that only occupy part of the storage layout.
+        and tensor.is_contiguous()
+    )
+
+
 @torch.no_grad()
 def offload_megatron_model_to_cpu(models):
     """
@@ -538,9 +560,16 @@ def offload_megatron_model_to_cpu(models):
         else:
             # we need this for ref module
             for _, param in model_chunk.named_parameters():
-                param.data = param.data.to("cpu", non_blocking=True)
+                old_data = param.data
+                param.data = param.data.to("cpu")
+                if _can_safely_resize_storage(old_data):
+                    old_data.storage().resize_(0)
                 if param.grad is not None:
-                    param.grad = param.grad.to("cpu", non_blocking=True)
+                    old_grad = param.grad
+                    param.grad = param.grad.to("cpu")
+                    if _can_safely_resize_storage(old_grad):
+                        old_grad.storage().resize_(0)
+
     gc.collect()
     get_torch_device().empty_cache()
 


### PR DESCRIPTION
### What does this PR do?

fix: Fix GPU memory leak in ref model offload by explicitly releasing storage

### Checklist Before Starting

In offload_megatron_model_to_cpu, the non-DDP path (used for reference modules) had two issues:

GPU memory not released promptly: The old implementation `param.data = param.data.to("cpu", non_blocking=True) `replaces the parameter's data tensor, but the old GPU tensor remains referenced until Python GC runs. For large models, this delayed release causes a transient GPU memory spike — the new CPU copy and the old GPU storage coexist — which can trigger OOM kills in memory-constrained environments.

Async copy before storage free is unsafe: Using `non_blocking=True` followed by an implicit (delayed) storage release risks data corruption, as the GPU storage could be freed before the asynchronous D2H transfer completes.
Changes:

Save a reference to the old GPU tensor before reassignment, then explicitly call `old_data.storage().resize_(0)` to immediately free the GPU memory after the synchronous copy completes.
Use synchronous copy (non_blocking=False, the default) to guarantee the D2H transfer finishes before the GPU storage is deallocated.

This aligns the non-DDP offload path with the DDP buffer path, which already uses synchronous copy + explicit resize_(0) for the same reasons.



- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

In NPU, I observed ~4GB leaked:
<img width="2470" height="1472" alt="20260522-183924" src="https://github.com/user-attachments/assets/f1379611-5112-45ab-a757-6f59f2b4f75a" />

GPU also found 1~2GB leaked:
<img width="2922" height="1464" alt="20260522-183942" src="https://github.com/user-attachments/assets/a5205d94-dc95-41f5-8f62-2de3a71c0e41" />


> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
