### PR TITLE
[algo] fix rollout rejected rows in group advantages

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -22,14 +22,31 @@ import torch
 import verl.trainer.ppo.core_algos
 from verl.trainer.ppo.core_algos import (
     compute_gae_advantage_return,
+    compute_gdpo_outcome_advantage,
+    compute_gpg_outcome_advantage,
     compute_grpo_outcome_advantage,
+    compute_grpo_passk_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
+    compute_opo_outcome_advantage,
+    compute_reinforce_plus_plus_baseline_outcome_advantage,
     compute_rloo_outcome_advantage,
     compute_rloo_vectorized_outcome_advantage,
     get_adv_estimator_fn,
     kl_penalty,
     register_adv_est,
 )
+
+GROUP_OUTCOME_ADVANTAGE_CASES = [
+    (compute_grpo_outcome_advantage, {"norm_adv_by_std_in_grpo": False}),
+    (compute_grpo_vectorized_outcome_advantage, {"norm_adv_by_std_in_grpo": False}),
+    (compute_grpo_passk_outcome_advantage, {"config": {"norm_adv_by_std_in_grpo": False}}),
+    (compute_reinforce_plus_plus_baseline_outcome_advantage, {}),
+    (compute_rloo_outcome_advantage, {}),
+    (compute_opo_outcome_advantage, {}),
+    (compute_gpg_outcome_advantage, {}),
+    (compute_rloo_vectorized_outcome_advantage, {}),
+    (compute_gdpo_outcome_advantage, {"norm_adv_by_std_in_grpo": False}),
+]
 
 
 def mock_test_fn():
@@ -196,6 +213,48 @@ def test_multi_turn_compute_gae_advantage_return():
     assert torch.equal(adv1, adv2), f"{adv1=}, {adv2=}"
     assert torch.equal(ret1, ret2), f"{ret1=}, {ret2=}"
     print(f" [CORRECT] \n\n{adv1=}, \n\n{ret1=}")
+
+
+@pytest.mark.parametrize("adv_fn,kwargs", GROUP_OUTCOME_ADVANTAGE_CASES)
+def test_outcome_estimators_keep_reward_when_only_reward_storage_token_is_masked(adv_fn, kwargs):
+    response_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
+    token_level_rewards = torch.tensor([[0.0, 1.0], [0.0, 0.0]])
+    index = np.array(["prompt", "prompt"], dtype=object)
+
+    advantages, returns = adv_fn(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+        **kwargs,
+    )
+
+    assert torch.count_nonzero(advantages).item() > 0
+    assert torch.count_nonzero(returns).item() > 0
+
+
+@pytest.mark.parametrize("adv_fn,kwargs", GROUP_OUTCOME_ADVANTAGE_CASES)
+def test_outcome_advantage_estimators_ignore_fully_masked_group_members(adv_fn, kwargs):
+    response_mask = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])
+    token_level_rewards = torch.tensor([[0.0, 0.0, 100.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]])
+    index = np.array(["same_prompt", "same_prompt", "same_prompt"], dtype=object)
+
+    full_advantages, full_returns = adv_fn(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+        **kwargs,
+    )
+    valid_only_advantages, valid_only_returns = adv_fn(
+        token_level_rewards=token_level_rewards[1:],
+        response_mask=response_mask[1:],
+        index=np.array(["same_prompt", "same_prompt"], dtype=object),
+        **kwargs,
+    )
+
+    torch.testing.assert_close(full_advantages[0], torch.zeros_like(full_advantages[0]))
+    torch.testing.assert_close(full_returns[0], torch.zeros_like(full_returns[0]))
+    torch.testing.assert_close(full_advantages[1:], valid_only_advantages)
+    torch.testing.assert_close(full_returns[1:], valid_only_returns)
 
 
 def _make_group_index(batch_size: int, num_groups: int) -> np.ndarray:

--- a/tests/trainer/ppo/test_rollout_corr_integration.py
+++ b/tests/trainer/ppo/test_rollout_corr_integration.py
@@ -16,10 +16,13 @@
 import pytest
 import torch
 
+from verl import DataProto
 from verl.trainer.config.algorithm import RolloutCorrectionConfig
-from verl.trainer.ppo.core_algos import compute_policy_loss_vanilla
+from verl.trainer.ppo.core_algos import AdvantageEstimator, compute_policy_loss_vanilla
+from verl.trainer.ppo.ray_trainer import compute_advantage
 from verl.trainer.ppo.rollout_corr_helper import (
     compute_offpolicy_metrics,
+    compute_rollout_correction_and_add_to_batch,
     compute_rollout_correction_and_rejection_mask,
 )
 from verl.workers.config.actor import ActorConfig
@@ -267,6 +270,44 @@ class TestRolloutISIntegration:
         assert metrics["rollout_corr/rollout_is_oob_ratio"] == pytest.approx(1.0 / 3.0, abs=1e-6)
         torch.testing.assert_close(rollout_is_weights, expected_weights, atol=1e-6, rtol=1e-6)
         torch.testing.assert_close(pg_loss, expected_loss, atol=1e-6, rtol=1e-6)
+
+    def test_rejected_sequences_do_not_pollute_group_advantage(self):
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        seq_length = 3
+        old_log_prob = torch.tensor([[-2.0] * seq_length, [-2.0] * seq_length], device=device)
+        rollout_log_prob = torch.tensor(
+            [
+                [-1.0] * seq_length,
+                [-2.5] * seq_length,
+            ],
+            device=device,
+        )
+        response_mask = torch.ones(2, seq_length, device=device)
+        token_level_rewards = torch.tensor([[0.0, 0.0, 100.0], [0.0, 0.0, 1.0]], device=device)
+
+        batch = DataProto.from_dict(
+            tensors={
+                "old_log_probs": old_log_prob,
+                "rollout_log_probs": rollout_log_prob,
+                "response_mask": response_mask,
+                "token_level_scores": token_level_rewards.clone(),
+                "token_level_rewards": token_level_rewards.clone(),
+            },
+            non_tensors={"uid": ["same_prompt", "same_prompt"]},
+        )
+        config = RolloutCorrectionConfig(rollout_rs="token_k1", rollout_rs_threshold="0.5_2.0")
+
+        batch, _ = compute_rollout_correction_and_add_to_batch(batch, config)
+        batch = compute_advantage(
+            batch,
+            adv_estimator=AdvantageEstimator.GRPO,
+            norm_adv_by_std_in_grpo=False,
+        )
+
+        assert torch.all(batch.batch["response_mask"][0] == 0)
+        torch.testing.assert_close(batch.batch["token_level_rewards"][0], token_level_rewards[0])
+        torch.testing.assert_close(batch.batch["advantages"][0], torch.zeros(seq_length, device=device))
+        torch.testing.assert_close(batch.batch["advantages"][1], torch.ones(seq_length, device=device))
 
 
 class TestRolloutCorrectionConfigNormalization:

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -212,6 +212,10 @@ def get_kl_controller(kl_ctrl):
         raise NotImplementedError
 
 
+def _valid_response_rows(response_mask: torch.Tensor) -> torch.Tensor:
+    return response_mask.sum(dim=-1) > 0
+
+
 @register_adv_est(AdvantageEstimator.GAE)  # or simply: @register_adv_est("gae")
 def compute_gae_advantage_return(
     token_level_rewards: torch.Tensor,
@@ -302,6 +306,8 @@ def compute_grpo_outcome_advantage(
             shape is (bs, response_length)
     """
     scores = token_level_rewards.sum(dim=-1)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -310,11 +316,13 @@ def compute_grpo_outcome_advantage(
     with torch.no_grad():
         bsz = scores.shape[0]
         for i in range(bsz):
+            if not valid_response_list[i]:
+                continue
             id2score[index[i]].append(scores[i])
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
-                id2std[idx] = torch.tensor(1.0)
+                id2mean[idx] = scores.new_tensor(0.0)
+                id2std[idx] = scores.new_tensor(1.0)
             elif len(id2score[idx]) > 1:
                 scores_tensor = torch.stack(id2score[idx])
                 id2mean[idx] = torch.mean(scores_tensor)
@@ -322,6 +330,9 @@ def compute_grpo_outcome_advantage(
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
+            if not valid_response_list[i]:
+                scores[i] = 0
+                continue
             if norm_adv_by_std_in_grpo:
                 scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
             else:
@@ -348,12 +359,17 @@ def compute_grpo_vectorized_outcome_advantage(
     """
     with torch.no_grad():
         scores = token_level_rewards.sum(dim=-1)
+        valid_response = _valid_response_rows(response_mask)
         g = as_torch_index(index, device=scores.device)
-        mean_g, std_g, _ = group_mean_std(scores, g, eps=0.0, device=scores.device)
-        if norm_adv_by_std_in_grpo:
-            scalars = (scores - mean_g[g]) / (std_g[g] + epsilon)
-        else:
-            scalars = scores - mean_g[g]
+        scalars = torch.zeros_like(scores)
+        if torch.any(valid_response):
+            mean_g, std_g, _ = group_mean_std(scores[valid_response], g[valid_response], eps=0.0, device=scores.device)
+            if norm_adv_by_std_in_grpo:
+                scalars[valid_response] = (scores[valid_response] - mean_g[g[valid_response]]) / (
+                    std_g[g[valid_response]] + epsilon
+                )
+            else:
+                scalars[valid_response] = scores[valid_response] - mean_g[g[valid_response]]
         advantages = scalars.unsqueeze(-1) * response_mask
         return advantages, advantages
 
@@ -499,8 +515,11 @@ def compute_grpo_passk_outcome_advantage(
     # if True, normalize advantage by std within group
     norm_adv_by_std_in_grpo = config.get("norm_adv_by_std_in_grpo", True)
     scores = token_level_rewards.sum(dim=-1)  # (bs,)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
     advantages = torch.zeros_like(scores)
 
+    id2total_count: defaultdict[Any, int] = defaultdict(int)
     id2scores = defaultdict(list)
     id2indices = defaultdict(list)
 
@@ -508,15 +527,20 @@ def compute_grpo_passk_outcome_advantage(
         bsz = scores.shape[0]
         for i in range(bsz):
             idx = index[i]
+            id2total_count[idx] += 1
+            if not valid_response_list[i]:
+                continue
             id2scores[idx].append(scores[i])
             id2indices[idx].append(i)
 
         for idx in id2scores:
             rewards = torch.stack(id2scores[idx])  # (k,)
             if rewards.numel() < 2:
-                raise ValueError(
-                    f"Pass@k requires at least 2 samples per group. Got {rewards.numel()} for group {idx}."
-                )
+                if id2total_count[idx] < 2:
+                    raise ValueError(
+                        f"Pass@k requires at least 2 samples per group. Got {id2total_count[idx]} for group {idx}."
+                    )
+                continue
             topk, topk_idx = torch.topk(rewards, 2)
             r_max, r_second_max = topk[0], topk[1]
             i_max = id2indices[idx][topk_idx[0].item()]
@@ -560,6 +584,8 @@ def compute_reinforce_plus_plus_baseline_outcome_advantage(
     """
     response_length = token_level_rewards.shape[-1]
     scores = token_level_rewards.sum(dim=-1)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -567,15 +593,20 @@ def compute_reinforce_plus_plus_baseline_outcome_advantage(
     with torch.no_grad():
         bsz = scores.shape[0]
         for i in range(bsz):
+            if not valid_response_list[i]:
+                continue
             id2score[index[i]].append(scores[i])
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
+                id2mean[idx] = scores.new_tensor(0.0)
             elif len(id2score[idx]) > 1:
                 id2mean[idx] = torch.mean(torch.stack(id2score[idx]))
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
+            if not valid_response_list[i]:
+                scores[i] = 0
+                continue
             scores[i] = scores[i] - id2mean[index[i]]
 
         scores = scores.unsqueeze(-1).tile([1, response_length]) * response_mask
@@ -610,6 +641,8 @@ def compute_rloo_outcome_advantage(
             shape: (bs, response_length)
     """
     scores = token_level_rewards.sum(dim=-1)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -617,15 +650,20 @@ def compute_rloo_outcome_advantage(
     with torch.no_grad():
         bsz = scores.shape[0]
         for i in range(bsz):
+            if not valid_response_list[i]:
+                continue
             id2score[index[i]].append(scores[i])
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
+                id2mean[idx] = scores.new_tensor(0.0)
             elif len(id2score[idx]) > 1:
                 id2mean[idx] = torch.mean(torch.stack(id2score[idx]))
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
+            if not valid_response_list[i]:
+                scores[i] = 0
+                continue
             response_num = len(id2score[index[i]])
             if response_num > 1:
                 scores[i] = scores[i] * response_num / (response_num - 1) - id2mean[index[i]] * response_num / (
@@ -663,6 +701,8 @@ def compute_opo_outcome_advantage(
     """
     response_length = response_mask.sum(dim=-1)
     scores = token_level_rewards.sum(dim=-1)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
 
     id2score = defaultdict(list)
     id2len = defaultdict(list)
@@ -671,12 +711,14 @@ def compute_opo_outcome_advantage(
     with torch.no_grad():
         bsz = scores.shape[0]
         for i in range(bsz):
+            if not valid_response_list[i]:
+                continue
             id2score[index[i]].append(scores[i])
             id2len[index[i]].append(response_length[i])
 
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2bsl[idx] = torch.tensor(0.0)
+                id2bsl[idx] = scores.new_tensor(0.0)
             elif len(id2score[idx]) > 1:
                 score_tensor = torch.stack(id2score[idx])
                 len_tensor = torch.stack(id2len[idx])
@@ -684,6 +726,9 @@ def compute_opo_outcome_advantage(
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
+            if not valid_response_list[i]:
+                scores[i] = 0
+                continue
             scores[i] = scores[i] - id2bsl[index[i]]
         scores = scores.unsqueeze(-1) * response_mask
 
@@ -798,6 +843,8 @@ def compute_gpg_outcome_advantage(
             shape: (bs, response_length)
     """
     scores = token_level_rewards.sum(dim=-1)
+    valid_response = _valid_response_rows(response_mask)
+    valid_response_list = valid_response.detach().cpu().tolist()
 
     id2score = defaultdict(list)
     id2mean = {}
@@ -805,16 +852,19 @@ def compute_gpg_outcome_advantage(
 
     with torch.no_grad():
         bsz = scores.shape[0]
-        m = torch.count_nonzero(scores)
-        alpha = bsz / m.clamp(min=1)
+        valid_scores = scores[valid_response]
+        m = torch.count_nonzero(valid_scores)
+        alpha = int(valid_response.sum().item()) / m.clamp(min=1)
 
         for i in range(bsz):
+            if not valid_response_list[i]:
+                continue
             id2score[index[i]].append(scores[i])
 
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
-                id2std[idx] = torch.tensor(1.0)
+                id2mean[idx] = scores.new_tensor(0.0)
+                id2std[idx] = scores.new_tensor(1.0)
             elif len(id2score[idx]) > 1:
                 scores_tensor = torch.stack(id2score[idx])
                 id2mean[idx] = torch.mean(scores_tensor)
@@ -822,6 +872,9 @@ def compute_gpg_outcome_advantage(
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):
+            if not valid_response_list[i]:
+                scores[i] = 0
+                continue
             scores[i] = alpha * (scores[i] - id2mean[index[i]]) / (f_norm)
         scores = scores.unsqueeze(-1) * response_mask
 
@@ -856,10 +909,18 @@ def compute_rloo_vectorized_outcome_advantage(
     scores = token_level_rewards.sum(dim=-1)
 
     with torch.no_grad():
-        inv = torch.from_numpy(np.unique(index, return_inverse=True)[1]).to(scores.device)
+        valid_response = _valid_response_rows(response_mask)
+        adv = torch.zeros_like(scores)
+        if torch.any(valid_response):
+            inv = as_torch_index(index, device=scores.device)
+            valid_inv = inv[valid_response]
+            valid_scores = scores[valid_response]
 
-        c = torch.bincount(inv)[inv].to(scores.dtype)
-        adv = ((c * scores - torch.bincount(inv, weights=scores)[inv]) / (c - 1).clamp_min(1)) * (c > 1)
+            c = torch.bincount(valid_inv)[valid_inv].to(scores.dtype)
+            valid_adv = (
+                (c * valid_scores - torch.bincount(valid_inv, weights=valid_scores)[valid_inv]) / (c - 1).clamp_min(1)
+            ) * (c > 1)
+            adv[valid_response] = valid_adv
 
         adv = adv.unsqueeze(-1) * response_mask
 


### PR DESCRIPTION
### What does this PR do?

This is a reopen of both https://github.com/verl-project/verl/pull/6375. It fixes a quiet GRPO advantage leak when rollout rejection sampling fully rejects one response in a same-prompt group. Different from #6375, this PR uses a more general and understandable patch to fix this bug.

The bug is triggered when all of the following are true:

- `algorithm.adv_estimator=grpo`
- rollout correction rejection sampling is enabled, for example `algorithm.rollout_correction.rollout_rs=seq_sum_k1`
- the rollout batch contains multiple responses with the same `uid`
- one response is fully rejected, so its `response_mask` becomes all zero
- that rejected response still has non-zero `token_level_rewards`

In this case, the rejected response no longer trains itself, but it can still change the GRPO baseline for accepted sibling responses from the same prompt.

### How is this bug introduced?

The implementation of GRPO uses `scores = token_level_rewards.sum(dim=-1)` to aggregate token-level rewards to response-level reward. Then it calculates advantage:
```python
# compute_grpo_outcome_advantage
bsz = scores.shape[0]
for i in range(bsz):
    id2score[index[i]].append(scores[i])
for idx in id2score:
    if len(id2score[idx]) == 1:
        id2mean[idx] = torch.tensor(0.0)
        id2std[idx] = torch.tensor(1.0)
    elif len(id2score[idx]) > 1:
        scores_tensor = torch.stack(id2score[idx])
        id2mean[idx] = torch.mean(scores_tensor)
        id2std[idx] = torch.std(scores_tensor)
    else:
        raise ValueError(f"no score in prompt index: {idx}")
for i in range(bsz):
    if norm_adv_by_std_in_grpo:
        scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
    else:
        scores[i] = scores[i] - id2mean[index[i]]
scores = scores.unsqueeze(-1) * response_mask
```
where the last statement `scores = scores.unsqueeze(-1) * response_mask` masks off tokens.

In `SeparateRayPPOTrainer`'s `fit_step`, the code first calculates the reward (`batch = self._fit_compute_reward(batch)`), then calls `self._fit_compute_advantage(batch)`, where `compute_rollout_correction_and_add_to_batch` may happen before `compute_advantage`, which finally calls `compute_grpo_outcome_advantage`.

`compute_rollout_correction_and_add_to_batch` performs rollout correction by rejecting stale tokens or responses. If it rejects a response, it masks off all tokens from it, resulting a all-zero tensor.

However, there is a gap between all-zero mask and removing it from policy update. 
Suppose a response (or sequence) is totally masked off, `scores = scores.unsqueeze(-1) * response_mask` from `compute_grpo_outcome_advantage` turns its score to all zeros, but it still influences the in-group advantage in the following code:
```python
if norm_adv_by_std_in_grpo:
    scores[i] = (scores[i] - id2mean[index[i]]) / (id2std[index[i]] + epsilon)
else:
    scores[i] = scores[i] - id2mean[index[i]]
```
In other words, its reward still changes other responses' advantages though it has been dropped off by `compute_grpo_outcome_advantage`.

This bug is not excludedly owned by GRPO. Outcome-style group estimators (GRPO,vectorized GRPO,PassK,RF++ baseline,RLOO,OPO,GPG,vectorized RLOO) all have the same bug. This PR is trying to fix them all.
