### PR TITLE
[veomni] feat: add VeOmni-native critic support

### DIFF
--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -21,7 +21,13 @@ from verl.base_config import BaseConfig
 from verl.trainer.config import BaseModelConfig, CheckpointConfig
 from verl.utils.profiler import ProfilerConfig
 
-from .engine import FSDPEngineConfig, McoreEngineConfig, MindSpeedEngineConfig, TorchtitanEngineConfig
+from .engine import (
+    FSDPEngineConfig,
+    McoreEngineConfig,
+    MindSpeedEngineConfig,
+    TorchtitanEngineConfig,
+    VeOmniEngineConfig,
+)
 from .model import HFModelConfig
 from .optimizer import OptimizerConfig
 
@@ -32,6 +38,7 @@ __all__ = [
     "TorchTitanCriticConfig",
     "FSDPCriticModelCfg",
     "MindSpeedCriticConfig",
+    "VeOmniCriticConfig",
 ]
 
 
@@ -298,3 +305,38 @@ class MindSpeedCriticConfig(CriticConfig):
     def validate(self, n_gpus: int, train_batch_size: int):
         """Validate mindspeed critic configuration with runtime parameters."""
         super().validate(n_gpus, train_batch_size)
+
+
+@dataclass
+class VeOmniCriticConfig(CriticConfig):
+    """Configuration for VeOmni-based critic model training.
+
+    Uses VeOmni's FSDP2 + sequence parallelism engine for the value model,
+    mirroring VeOmniActorConfig but for the critic role.
+
+    Args:
+        strategy (str): Training strategy set to 'veomni'.
+        veomni (VeOmniEngineConfig): VeOmni engine configuration.
+    """
+
+    strategy: str = "veomni"
+    veomni: VeOmniEngineConfig = field(default_factory=VeOmniEngineConfig)
+    grad_clip: float = 1.0
+
+    def __post_init__(self):
+        """Set engine to VeOmni config."""
+        super().__post_init__()
+        self.engine = self.veomni
+
+    def validate(self, n_gpus: int, train_batch_size: int):
+        """Validate VeOmni critic configuration with runtime parameters."""
+        super().validate(n_gpus, train_batch_size)
+
+        if not self.use_dynamic_bsz:
+            sp_size = self.veomni.ulysses_parallel_size
+            if self.ppo_micro_batch_size is not None:
+                if self.ppo_micro_batch_size * sp_size < n_gpus:
+                    raise ValueError(
+                        f"critic.ppo_micro_batch_size ({self.ppo_micro_batch_size}) * "
+                        f"veomni.ulysses_parallel_size ({sp_size}) must be >= n_gpus ({n_gpus})"
+                    )

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -966,7 +966,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         input_ids_rmpad,
                         position_ids_rmpad=position_ids_rmpad,
                         sp_size=self.ulysses_sequence_parallel_size,
-                        skip_position_ids_rmpad=True if self.__class__.__name__ == "VeOmniEngineWithLMHead" else False,
+                        skip_position_ids_rmpad=getattr(self, "_veomni_handles_position_ids", False),
                     )
                 input_ids_rmpad_rolled, _, _ = ulysses_pad_and_slice_inputs(
                     input_ids_rmpad_rolled,

--- a/verl/workers/engine/veomni/__init__.py
+++ b/verl/workers/engine/veomni/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .transformer_impl import VeOmniEngine, VeOmniEngineWithLMHead
+from .transformer_impl import VeOmniEngine, VeOmniEngineWithLMHead, VeOmniEngineWithValueHead
 
-__all__ = ["VeOmniEngine", "VeOmniEngineWithLMHead"]
+__all__ = ["VeOmniEngine", "VeOmniEngineWithLMHead", "VeOmniEngineWithValueHead"]

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -44,7 +44,7 @@ from verl.utils.ulysses import (
 from verl.workers.config import HFModelConfig, VeOmniEngineConfig, VeOmniOptimizerConfig
 
 from ..base import BaseEngineCtx, EngineRegistry
-from ..fsdp.transformer_impl import FSDPEngine, FSDPEngineWithLMHead
+from ..fsdp.transformer_impl import FSDPEngine, FSDPEngineWithLMHead, FSDPEngineWithValueHead
 from ..utils import enable_full_determinism, postprocess_batch_func, prepare_micro_batches
 from .utils import (
     MOE_PARAM_HANDERS,
@@ -59,6 +59,32 @@ logger = logging.getLogger(__file__)
 
 
 class VeOmniEngine(FSDPEngine):
+    _veomni_handles_position_ids = True
+
+    def _apply_veomni_input_transforms(self, model_inputs: dict, micro_batch: TensorDict):
+        """Apply VeOmni-specific input transforms shared by LM and value heads.
+
+        Handles vision-language model masks, sequence parallel sharding,
+        and flash attention kwargs from position_ids.
+        """
+        input_ids_rmpad = model_inputs["input_ids"]
+        sp_enabled = parallel_state.get_parallel_state().sp_enabled
+        sp_shard_collator = OmniSequenceShardCollator() if sp_enabled else None
+
+        if self.module.config.model_type in VL_TYPE2INDEX.keys():
+            image_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["IMAGE_INPUT_INDEX"]
+            video_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["VIDEO_INPUT_INDEX"]
+            model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
+
+            if sp_enabled:
+                sp_shard_collator(model_inputs)
+
+        use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
+        if use_remove_padding and model_inputs.get("position_ids", None) is not None:
+            model_inputs.update(_prepare_veomni_flash_attention_kwargs(model_inputs["position_ids"]))
+            if sp_enabled:
+                model_inputs["position_ids"] = sp_shard_collator.sp_slice(model_inputs["position_ids"], dim=-1)
+
     def __init__(
         self,
         model_config: HFModelConfig,
@@ -631,34 +657,34 @@ def _prepare_veomni_flash_attention_kwargs(position_ids: torch.Tensor) -> dict[s
 class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
     def prepare_model_inputs(self, micro_batch: TensorDict):
         model_inputs, output_args = super().prepare_model_inputs(micro_batch)
-        input_ids_rmpad = model_inputs["input_ids"]
-        sp_enabled = parallel_state.get_parallel_state().sp_enabled
-        sp_shard_collator = OmniSequenceShardCollator() if sp_enabled else None
-
-        if self.module.config.model_type in VL_TYPE2INDEX.keys():
-            image_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["IMAGE_INPUT_INDEX"]
-            video_mask = input_ids_rmpad == VL_TYPE2INDEX[self.module.config.model_type]["VIDEO_INPUT_INDEX"]
-            model_inputs.update({"image_mask": image_mask, "video_mask": video_mask})
-
-            if sp_enabled:
-                sp_shard_collator(model_inputs)
-
-        use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
-        if use_remove_padding and model_inputs.get("position_ids", None) is not None:
-            model_inputs.update(_prepare_veomni_flash_attention_kwargs(model_inputs["position_ids"]))
-            if sp_enabled:
-                model_inputs["position_ids"] = sp_shard_collator.sp_slice(model_inputs["position_ids"], dim=-1)
+        self._apply_veomni_input_transforms(model_inputs, micro_batch)
 
         # Activate VeOmni's chunk_logprobs path: ForCausalLMLoss short-circuits
         # to per-token log_probs/entropy on return_log_probs=True. Pass the
         # already-rolled labels as shift_labels so chunk_logprobs skips its
         # internal causal shift and the output seq length matches the input —
         # prepare_model_outputs().squeeze(0) then lands at (total_nnz,).
+        use_remove_padding = tu.get_non_tensor_data(data=micro_batch, key="use_remove_padding", default=True)
         use_fused_kernels = tu.get_non_tensor_data(data=micro_batch, key="use_fused_kernels", default=False)
         if use_fused_kernels and use_remove_padding:
+            input_ids_rmpad = model_inputs["input_ids"]
             shift_labels = output_args["input_ids_rmpad_rolled"].unsqueeze(0)
             model_inputs["labels"] = input_ids_rmpad
             model_inputs["shift_labels"] = shift_labels
             model_inputs["return_log_probs"] = True
 
+        return model_inputs, output_args
+
+
+@EngineRegistry.register(model_type="value_model", backend=["veomni"], device=["cuda", "npu"])
+class VeOmniEngineWithValueHead(VeOmniEngine, FSDPEngineWithValueHead):
+    """Value model engine using VeOmni's FSDP2 + sequence parallelism.
+
+    Combines VeOmniEngine (model init, parallel state, activation offloading)
+    with FSDPEngineWithValueHead (TokenClassification output → per-token values).
+    """
+
+    def prepare_model_inputs(self, micro_batch: TensorDict):
+        model_inputs, output_args = super().prepare_model_inputs(micro_batch)
+        self._apply_veomni_input_transforms(model_inputs, micro_batch)
         return model_inputs, output_args


### PR DESCRIPTION
## Summary

Enable critic/value model training using VeOmni's FSDP2 + sequence parallelism engine. `VeOmniCriticConfig` was referenced in `veomni_critic.yaml` but never implemented — this PR fills that gap.

- Add `VeOmniCriticConfig` dataclass in `verl/workers/config/critic.py`
- Add `VeOmniEngineWithValueHead` in `verl/workers/engine/veomni/`, registered as `model_type="value_model"` `backend=["veomni"]` for cuda and npu
- Fix fragile class-name guard in `FSDPEngineWithLMHead.prepare_model_inputs` that caused double-sliced `position_ids` under sequence parallelism for VeOmni subclasses other than `VeOmniEngineWithLMHead`; replaced with a `_veomni_handles_position_ids` class attribute on `VeOmniEngine`

## Test commands and results

PPO training (GAE + critic) with Qwen3-0.6B on 8x H100, FSDP_SIZE=4, SP_SIZE=2:

```bash
python3 -m verl.trainer.main_ppo \
    model_engine=veomni \
    algorithm.adv_estimator=gae \
    actor_rollout_ref.model.path=Qwen3-0.6B \
    critic.model.path=Qwen3-0.6B \
    ... # (full params in test script)
    trainer.total_training_steps=1
```

Results (1 step):
```
[Timing]      compute_values=2.76s  update_critic=2.51s  update_actor=3.60s
[Actor]       loss=1.36e-02  approx_kl=4.36e-04
[Critic]      loss=1.29e-02  clipfrac=0.00
[Values]      mean=-4.74e-04  std=7.21e-03
[Advantages]  mean=-5.02e-08  std=2.39e-02  (GAE)
```

Import/registry tests also verified:
- `VeOmniCriticConfig` instantiation + Hydra `omega_conf_to_dataclass`
- `EngineRegistry.get("value_model", "veomni", "cuda")` → `VeOmniEngineWithValueHead`
- MRO: `VeOmniEngineWithValueHead → VeOmniEngine → FSDPEngineWithValueHead → FSDPEngineWithLMHead → FSDPEngine → BaseEngine → object`
- `_veomni_handles_position_ids` attribute correctly inherited by all VeOmni subclasses, absent from FSDP classes

## AI assistance disclosure

AI assistance was used for initial implementation and review. All changes were verified and tested by a human submitter.