### PR TITLE
[rollout, vllm] fix: avoid SIGSEGV on ROCm TP=1 by conditionally omitting distributed_executor_backend

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -273,17 +273,19 @@ class vLLMHttpServer:
             **engine_kwargs,
         }
 
-        # On ROCm with TP=1, omit distributed_executor_backend so vLLM defaults
-        # to UniProcExecutor, avoiding a nested WorkerProc spawn that causes
-        # SIGSEGV (HIP runtime issue with two-level multiprocessing spawn
-        # after CUDA/HIP init in a Ray actor).  For TP>1, "mp" is still required.
-        if not self._should_omit_distributed_executor_backend():
-            args["distributed_executor_backend"] = "mp"
-        else:
-            logger.info(
-                "ROCm + TP=1 detected: omitting distributed_executor_backend "
-                "so vLLM uses UniProcExecutor and avoids nested WorkerProc spawn."
-            )
+        # Set distributed_executor_backend default if not already specified
+        # by the user via engine_kwargs.  On ROCm with TP=1, omit it entirely
+        # so vLLM defaults to UniProcExecutor, avoiding a nested WorkerProc
+        # spawn that causes SIGSEGV (HIP runtime issue with two-level
+        # multiprocessing spawn after CUDA/HIP init in a Ray actor).
+        if "distributed_executor_backend" not in args:
+            if not self._should_omit_distributed_executor_backend():
+                args["distributed_executor_backend"] = "mp"
+            else:
+                logger.info(
+                    "ROCm + TP=1 detected: omitting distributed_executor_backend "
+                    "so vLLM uses UniProcExecutor and avoids nested WorkerProc spawn."
+                )
 
         # update profiler args
         profiler_args = build_vllm_profiler_args(

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -251,7 +251,6 @@ class vLLMHttpServer:
             "dtype": self.config.dtype,
             "load_format": self.config.load_format,
             "skip_tokenizer_init": False,
-            "distributed_executor_backend": "mp",
             "worker_extension_cls": self._get_worker_extension_cls(),
             "trust_remote_code": self.model_config.trust_remote_code,
             "max_model_len": self.config.max_model_len,
@@ -273,6 +272,18 @@ class vLLMHttpServer:
             "compilation_config": compilation_config,
             **engine_kwargs,
         }
+
+        # On ROCm with TP=1, omit distributed_executor_backend so vLLM defaults
+        # to UniProcExecutor, avoiding a nested WorkerProc spawn that causes
+        # SIGSEGV (HIP runtime issue with two-level multiprocessing spawn
+        # after CUDA/HIP init in a Ray actor).  For TP>1, "mp" is still required.
+        if not self._should_omit_distributed_executor_backend():
+            args["distributed_executor_backend"] = "mp"
+        else:
+            logger.info(
+                "ROCm + TP=1 detected: omitting distributed_executor_backend "
+                "so vLLM uses UniProcExecutor and avoids nested WorkerProc spawn."
+            )
 
         # update profiler args
         profiler_args = build_vllm_profiler_args(
@@ -885,6 +896,20 @@ class vLLMHttpServer:
             hf_overrides["quantization_config_file"] = self.config.quantization_config_file
 
         return quantization, hf_overrides
+
+    def _should_omit_distributed_executor_backend(self) -> bool:
+        """On ROCm with TP=1, let vLLM default to UniProcExecutor."""
+        try:
+            from vllm.platforms import current_platform
+
+            return current_platform.is_rocm() and int(self.config.tensor_model_parallel_size) == 1
+        except Exception as e:
+            logger.warning(
+                "Failed to check ROCm executor backend condition: %s. "
+                "Falling back to distributed_executor_backend='mp'.",
+                e,
+            )
+            return False
 
     def _get_worker_extension_cls(self) -> str:
         """Return the fully-qualified colocate worker extension class name."""


### PR DESCRIPTION
## Summary

On ROCm (AMD GPU) with `tensor_parallel_size=1`, verl's hardcoded `distributed_executor_backend="mp"` forces vLLM to use `MultiprocExecutor`, creating a **two-level multiprocessing spawn** chain inside a Ray actor:

```
Ray actor (CUDA/HIP already initialized)
  └→ AsyncLLM
       └→ EngineCore_DP0 (1st spawn)
            └→ MultiprocExecutor
                 └→ WorkerProc (2nd spawn) → SIGSEGV (exitcode=-11)
```

The inner `WorkerProc` consistently dies with SIGSEGV before entering `worker_main`. This appears to be a ROCm/HIP runtime issue triggered by nested multiprocessing spawn after HIP initialization.

**Fix**: Conditionally omit `distributed_executor_backend` on ROCm + TP=1, letting vLLM auto-select `UniProcExecutor` (which keeps the worker in-process, no nested spawn). For TP>1, `"mp"` is still set as `MultiprocExecutor` is required.

- CUDA/NVIDIA behavior: **unchanged** (condition is `current_platform.is_rocm()`)
- TP>1 behavior: **unchanged** (condition requires `tensor_model_parallel_size == 1`)

## Investigation

Systematically eliminated all other hypotheses (import order, Ray worker pool, vLLM extensions, ZMQ IPC, etc.) across 10+ test scripts and 50+ runs, then isolated the crash to `AsyncLLM` + `backend="mp"` specifically:

| Variant | `distributed_executor_backend` | Result |
|---------|-------------------------------|--------|
| Bare `LLM()` | N/A | **PASS** |
| `AsyncLLM` + `"mp"` | forced `"mp"` | **CRASH** (SIGSEGV) |
| `AsyncLLM` + default | not set (→ `UniProcExecutor`) | **PASS** |

Verified that `UniProcExecutor` supports the full verl worker extension path (`vLLMColocateWorkerExtension`, `collective_rpc`, `reset_mm_cache`).

## Environment

| Component | Version |
|-----------|---------|
| GPU | AMD MI308X |
| ROCm | 7.0.2 |
| PyTorch | 2.8.0+rocm7.0.2 |
| vLLM | 0.11.0rc2 (V1 engine) |
| verl | main branch |
| Ray | 2.44.1 |

## Scope and Limitations

- **TP>1 on ROCm**: Not tested. The nested spawn issue likely persists for TP>1 since `MultiprocExecutor` is still needed — may require a vLLM upstream fix.
- **Related**: PR #6062 addresses ROCm async training on a different stack (ROCm 7.2 + vLLM 0.18.1rc1).

## Test plan

- [x] Verified fix with AsyncLLM + UniProcExecutor in Ray actor (4 test variants, all PASS)
- [x] Verified `vLLMColocateWorkerExtension` injection works with UniProcExecutor
- [x] Verified `collective_rpc` calls (`reset_mm_cache`, `monkey_patch_model`) succeed
- [x] Full TAGPO training script reaches wandb init successfully (no more SIGSEGV)
- [ ] CUDA/NVIDIA regression test (change is gated by `is_rocm()`, no behavioral change expected)

AI assistance was used (Claude) for drafting this PR description. All code changes were written, reviewed, and tested by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
