### PR TITLE
[docker] fix: align stable vllm ARM version with x86

### DIFF
--- a/docker/Dockerfile.stable.vllm
+++ b/docker/Dockerfile.stable.vllm
@@ -1,4 +1,4 @@
-# vllm: x86_64=0.20.2, aarch64=0.18.0
+# vllm: x86_64=0.20.2, aarch64=0.20.2
 
 ARG CUDA_VERSION=13.0.2
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu24.04


### PR DESCRIPTION
### Summary
Align `docker/Dockerfile.stable.vllm` ARM banner with x86: `aarch64=0.20.2`.

Image: `verlai/verl:vllm020.aarch64.dev1`
Digest: `sha256:9c091ae2ffc7ed08e7aec0d4fcb31066ddba0a5d3d580f6e349ad3b8fccca137`

### Duplicate Check
No linked issue. Checked open PRs for `Dockerfile.stable.vllm aarch64 vllm`, `GB200 ARM vLLM 0.20.2`, and `vllm 0.20.2`; no duplicate found.

### Test
```bash
docker run --rm verl:vllm-arm64-vllm0202-arm python -c "import platform, vllm, torch, transformers; print(platform.machine()); print(vllm.__version__); print(torch.__version__); print(transformers.__version__)"
docker push verlai/verl:vllm020.aarch64.dev1
```

Result: `aarch64`, `vllm=0.20.2`, `torch=2.11.0+cu130`, `transformers=5.3.0`.


