### PR TITLE
[fully_async] feat: fully async profiling

### DIFF
--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
@@ -135,6 +135,12 @@ When Rollout runs in `Agent Loop <../advance/agent_loop.rst>`_ mode, performance
    - vLLM Engine: Automatically collects AsyncLLM scheduling stacks and inference process performance data. Does not support setting analysis (defaults to no analysis, requires offline analysis) and profiler_level (defaults to level1).
    - SGLang Engine: Automatically collects inference process performance data. Does not support the memory option in contents. Does not support setting analysis (defaults to enabled) and profiler_level (defaults to level0).
 
+**Fully Async Policy Mode Description**:
+
+1. In `Fully Async Policy <https://verl.readthedocs.io/en/latest/advance/fully_async.html>`_ mode, ``global_profiler.steps`` refers to the step **after each** ``update_weights`` round. This is consistent with synchronous mode, not a per mini-batch step within a single training round.
+
+2. Because it reuses Agent Loop collection capabilities, the notes for `Fully Async Policy <https://verl.readthedocs.io/en/latest/advance/fully_async.html>`_ mode are the same as for Agent Loop.
+
 
 Visualization
 -------------

--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
@@ -127,6 +127,12 @@ Last updated: 12/20/2025.
    - vLLM 引擎：自动采集 AsyncLLM 调度栈及推理进程性能数据。不支持设置 analysis（默认不解析，需离线解析）和 profiler_level（默认 level1）。
    - SGLang 引擎：自动采集推理进程性能数据。不支持 contents 中的 memory 配置项。不支持设置 analysis（默认解析）和 profiler_level（默认 level0）。
 
+**Fully Async Policy 模式说明**：
+
+1. 在 `Fully Async Policy <https://verl.readthedocs.io/en/latest/advance/fully_async.html>`_ 模式下，`global_profiler.steps` 代表每一轮`update_weights`后的`step`, 这点和同步模式下保持同步，而非单轮的`mini-batch step`.
+
+2. 因为复用AgentLoop采集能力，因此在 `Fully Async Policy <https://verl.readthedocs.io/en/latest/advance/fully_async.html>`_ 模式下的注意事项和AgentLoop相同。
+
 可视化
 ------
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -594,6 +594,14 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
         return timing_raw
 
+    async def _start_profiling(self):
+        """Start rollout profiling on all replicas via LLMServerManager after weight sync."""
+        await self.llm_server_manager.start_profile()
+
+    async def _stop_profiling(self):
+        """Stop rollout profiling on all replicas before the next weight sync."""
+        await self.llm_server_manager.stop_profile()
+
     def do_validate(self):
         """Run validation and return metrics"""
         timing_raw = {}

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -519,7 +519,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         profiler_step = last_profiler_step + 1
        
-       if steps is not None and profiler_step in steps:
+        if steps is not None and profiler_step in steps:
             await asyncio.wrap_future(
                 self.rollouter._start_profiling.remote().future()
             )

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -429,7 +429,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         self.reward_extra_infos_dict = {}
 
         steps = self.config.global_profiler.steps
-        should_profile = steps is not None and (self.current_param_version - 1) in steps
+        should_profile = steps is not None and (self.current_param_version + 1) in steps
         self._fit_start_profile(should_profiler=should_profile)
 
         with marked_timer("step", self.timing_raw):
@@ -503,7 +503,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             return
 
         steps = self.config.global_profiler.steps
-        last_profiler_step = self.current_param_version - 1
+        last_profiler_step = self.current_param_version
         if steps is not None and last_profiler_step in steps:
             await asyncio.wrap_future(
                 self.rollouter._stop_profiling.remote().future()
@@ -518,7 +518,8 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         )
 
         profiler_step = last_profiler_step + 1
-        if steps is not None and profiler_step in steps:
+       
+       if steps is not None and profiler_step in steps:
             await asyncio.wrap_future(
                 self.rollouter._start_profiling.remote().future()
             )

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -391,11 +391,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         self.global_steps += 1
 
         self.prev_step_profile = False
-        self.curr_step_profile = (
-            self.global_steps in self.config.global_profiler.steps
-            if self.config.global_profiler.steps is not None
-            else False
-        )
+        self.curr_step_profile = False
         self.next_step_profile = False
 
         # Use queue mode, no need for traditional dataloader iterator
@@ -432,7 +428,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         self.reward_tensor = None
         self.reward_extra_infos_dict = {}
 
-        self._fit_start_profile()
+        steps = self.config.global_profiler.steps
+        should_profile = steps is not None and (self.current_param_version - 1) in steps
+        self._fit_start_profile(should_profiler=should_profile)
 
         with marked_timer("step", self.timing_raw):
             batch = await self._fit_generate(None)
@@ -449,7 +447,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         await self._fit_validate()
         self._fit_save_checkpoint()
-        self._fit_stop_profile()
+        self._fit_stop_profile(should_profiler=should_profile)
         self._fit_collect_metrics(batch)
         self._fit_postprocess_step()
 
@@ -504,6 +502,13 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         if self.local_trigger_step != 1:
             return
 
+        steps = self.config.global_profiler.steps
+        last_profiler_step = self.current_param_version - 1
+        if steps is not None and last_profiler_step in steps:
+            await asyncio.wrap_future(
+                self.rollouter._stop_profiling.remote().future()
+            )
+
         with marked_timer("timing_s/param_sync", self.timing_raw):
             await self.checkpoint_manager.update_weights(global_steps=self.current_param_version)
         print(
@@ -511,6 +516,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             f"timing_s/param_sync: {self.timing_raw['timing_s/param_sync']:.4f} seconds "
             f"self.current_param_version: {self.current_param_version}"
         )
+
+        profiler_step = last_profiler_step + 1
+        if steps is not None and profiler_step in steps:
+            await asyncio.wrap_future(
+                self.rollouter._start_profiling.remote().future()
+            )
 
         # Reset staleness in rollouter
         timing_raw = await asyncio.wrap_future(self.rollouter.reset_staleness.remote().future())

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -505,9 +505,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         steps = self.config.global_profiler.steps
         last_profiler_step = self.current_param_version
         if steps is not None and last_profiler_step in steps:
-            await asyncio.wrap_future(
-                self.rollouter._stop_profiling.remote().future()
-            )
+            await asyncio.wrap_future(self.rollouter._stop_profiling.remote().future())
 
         with marked_timer("timing_s/param_sync", self.timing_raw):
             await self.checkpoint_manager.update_weights(global_steps=self.current_param_version)
@@ -518,11 +516,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         )
 
         profiler_step = last_profiler_step + 1
-       
+
         if steps is not None and profiler_step in steps:
-            await asyncio.wrap_future(
-                self.rollouter._start_profiling.remote().future()
-            )
+            await asyncio.wrap_future(self.rollouter._start_profiling.remote().future())
 
         # Reset staleness in rollouter
         timing_raw = await asyncio.wrap_future(self.rollouter.reset_staleness.remote().future())

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -381,14 +381,20 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
             self.actor_rollout_wg.async_calls_finalize_fn_exec(blocking=False)
         self.is_last_step = self.global_steps >= self.total_training_steps
 
-    def _fit_start_profile(self):
+    def _fit_start_profile(self, should_profiler=None):
         timing_raw = self.timing_raw
+        if should_profiler is not None:
+            self.curr_step_profile = should_profiler
         with marked_timer("start_profile", timing_raw):
-            self._start_profiling(
-                not self.prev_step_profile and self.curr_step_profile
-                if self.config.global_profiler.profile_continuous_steps
-                else self.curr_step_profile
-            )
+            if should_profiler is None:
+                do_profile = (
+                    not self.prev_step_profile and self.curr_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else self.curr_step_profile
+                )
+            else:
+                do_profile = should_profiler
+            self._start_profiling(do_profile)
 
     def _fit_get_batch(self, batch_dict: dict) -> DataProto:
         batch = DataProto.from_single_dict(batch_dict)
@@ -690,21 +696,26 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                 # TODO: Check separation is needed.
                 # self.checkpoint_manager.update_weights()
 
-    def _fit_stop_profile(self):
+    def _fit_stop_profile(self, should_profiler=None):
         timing_raw = self.timing_raw
         with marked_timer("stop_profile", timing_raw):
-            self.next_step_profile = (
-                self.global_steps + 1 in self.config.global_profiler.steps
-                if self.config.global_profiler.steps is not None
-                else False
-            )
-            self._stop_profiling(
-                self.curr_step_profile and not self.next_step_profile
-                if self.config.global_profiler.profile_continuous_steps
-                else self.curr_step_profile
-            )
+            if should_profiler is None:
+                self.next_step_profile = (
+                    self.global_steps + 1 in self.config.global_profiler.steps
+                    if self.config.global_profiler.steps is not None
+                    else False
+                )
+                do_profile = (
+                    self.curr_step_profile and not self.next_step_profile
+                    if self.config.global_profiler.profile_continuous_steps
+                    else self.curr_step_profile
+                )
+            else:
+                do_profile = should_profiler
+            self._stop_profiling(do_profile)
             self.prev_step_profile = self.curr_step_profile
-            self.curr_step_profile = self.next_step_profile
+            if should_profiler is None:
+                self.curr_step_profile = self.next_step_profile
 
     def _fit_collect_metrics(self, batch):
         metrics = self.metrics


### PR DESCRIPTION
### What does this PR do?

#### Select the appropriate definition of step
The concept of step is ambiguous in fully async mode. In rollout, rollout_step refers to the generation of each prompt. In the trainer, train_step means executing one mini-batch step whenever the data queue accumulates `train_prompt_mini_bsz` pairs of prompts and responses.
Due to queue and concurrency mechanisms, prompts corresponding to rollout_steps cannot run in the expected order. Meanwhile, the definition of train_step here is inconsistent with that in sync mode.
Therefore, we follow the step definition of sync mode, and regard the completion of one update_weights as the end of one training step.

#### Adaptation for fullyAsyncTrainer
The profiling of `PPOTrainer` is basically adapted. However, `global_steps` in fullyasync only represents the number of minibatch steps, while the other parameter `current_param_version` indicates the number of parameter updates, which is the step we need.

#### Adaptation for fullyAsyncRollout
Reused the profiling capability of `llm_server_manager` in `AgentLoop`. The profiling switch is controlled before and after `update_weights` in the `fullyAsyncTrainer`.

#### Appendix: Introduction to step-related parameters in fully async mode
`rollout.total_rollout_step`: Number of rollout prompts
`actor_rollout_ref.actor.ppo_mini_batch_size` : Number of samples required for one mini-batch training
`async_training.trigger_parameter_sync_step` : Number of mini-batches required to trigger one weight update
`trainer.total_epochs`: Participate in the calculation of total_rollout_steps. The steps must not exceed `len(data) * epoch`.

total_train_steps = total_rollout_step / (ppo_mini_batch_size × trigger_parameter_sync_step)

</byte-sheet-html-origin><!--EndFragment--><!--EndFragment-->
</body>
</html>

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
Base on https://github.com/verl-project/verl/blob/main/tests/special_e2e/run_fully_async_policy.sh, add necessary profiling enable configs shown in `API and Usage Example`

To quickly display collected data, we use the [RL Timeline visualization](https://github.com/verl-project/rl-insight/blob/main/docs/overview/RL_Timeline_quickstart.md) tool in [rl-insight](https://github.com/verl-project/rl-insight).

Test steps are as follows:
1. modify script parameters, model_path, datasets, profiling configs
2. cd verl & bash ./tests/special_e2e/run_fully_async_policy.sh
3. add profiling path in rl-insight/examples/mstx_exec.sh
4. cd rl-insight & bash ./examples/mstx_exec.sh

#### Case 1

```
train_prompt_mini_bsz=16
total_rollout_steps=$(((192)))
trigger_parameter_sync_step=4
PROFILE_STEPS="[1,2]"
```
<img width="209" height="216" alt="image" src="https://github.com/user-attachments/assets/6199336e-28d1-4e24-8dda-d552a5c8040a" />
<img width="1478" height="700" alt="image" src="https://github.com/user-attachments/assets/6026ede5-eddc-49c5-9946-a2d690fb3c2f" />

#### Case 2

```
train_prompt_mini_bsz=16
total_rollout_steps=$(((192)))
trigger_parameter_sync_step=4
PROFILE_STEPS="[1,3]"
```
<img width="200" height="204" alt="image" src="https://github.com/user-attachments/assets/fd77d570-f565-407e-8e20-4ef5da6e76fa" />
<img width="2257" height="775" alt="image" src="https://github.com/user-attachments/assets/268d0523-a761-4eec-b9d1-75d3da222945" />


### API and Usage Example
The usage is exactly the same as sync mode.

```bash
SAVE_PATH="/path/to/profile"
LEVEL="level1"
CONTENTS=['npu','cpu']
ANALYSIS=False
PROFILE_STEPS="[1,2]"
PROFILE_RANKS_ALL=True
DISCRETE=True
PROFILER_ENABLE=True

python3 -m verl.experimental.fully_async_policy.fully_async_main \
        ...
        actor_rollout_ref.actor.profiler.enable=${PROFILER_ENABLE} \
        actor_rollout_ref.actor.profiler.tool=npu \
        actor_rollout_ref.actor.profiler.all_ranks=${PROFILE_RANKS_ALL} \
        actor_rollout_ref.actor.profiler.tool_config.npu.discrete=${DISCRETE} \
        actor_rollout_ref.actor.profiler.tool_config.npu.contents=${CONTENTS} \
        actor_rollout_ref.actor.profiler.tool_config.npu.level=${LEVEL} \
        actor_rollout_ref.actor.profiler.tool_config.npu.analysis=${ANALYSIS} \
        global_profiler.tool=npu \
        global_profiler.steps=${PROFILE_STEPS} \
        global_profiler.save_path=${SAVE_PATH}
```


### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
