### PR TITLE
[reward] feat: add NP reasoning reward functions

### DIFF
--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -91,6 +91,26 @@ def default_compute_score(
 
         res = geo3k.compute_score(solution_str, ground_truth)
     elif data_source in [
+        "bootcamp/NpGcpD",
+        "bootcamp/NpHamiltonianCycle",
+        "bootcamp/NpMaximumCliqueProblem",
+        "bootcamp/NpMaximumSet",
+        "bootcamp/NpMinimumCut",
+        "bootcamp/NpTsp",
+        "bootcamp/NpKnapsack",
+        "bootcamp/NpSetCover",
+        "bootcamp/NpSubsetSum",
+        "bootcamp/NpMeetingSchedule",
+    ]:
+        from . import np
+
+        res = np.compute_score(
+            data_source=data_source,
+            solution_str=solution_str,
+            ground_truth=ground_truth,
+            extra_info=extra_info,
+        )
+    elif data_source in [
         "searchR1_nq",
         "searchR1_triviaqa",
         "searchR1_popqa",

--- a/verl/utils/reward_score/np.py
+++ b/verl/utils/reward_score/np.py
@@ -1,0 +1,107 @@
+import ast
+import json
+from collections.abc import Mapping
+
+from .np_rules import (
+    GCP_D,
+    TSP,
+    hamiltonian_cycle,
+    knapsack,
+    maximum_clique,
+    maximum_set,
+    meeting_schedule,
+    minimum_cut,
+    set_cover,
+    subset_sum,
+)
+
+NP_DATA_SOURCE_TO_VALIDATOR = {
+    "bootcamp/NpGcpD": GCP_D.validation,
+    "bootcamp/NpHamiltonianCycle": hamiltonian_cycle.validation,
+    "bootcamp/NpMaximumCliqueProblem": maximum_clique.validation,
+    "bootcamp/NpMaximumSet": maximum_set.validation,
+    "bootcamp/NpMinimumCut": minimum_cut.validation,
+    "bootcamp/NpTsp": TSP.validation,
+    "bootcamp/NpKnapsack": knapsack.validation,
+    "bootcamp/NpSetCover": set_cover.validation,
+    "bootcamp/NpSubsetSum": subset_sum.validation,
+    "bootcamp/NpMeetingSchedule": meeting_schedule.validation,
+}
+
+LEGACY_TASK_TO_VALIDATOR = {
+    "GCP-D": GCP_D.validation,
+    "TSP": TSP.validation,
+    "hamiltonian-cycle": hamiltonian_cycle.validation,
+    "knapsack": knapsack.validation,
+    "maximum_clique_problem": maximum_clique.validation,
+    "maximum-set": maximum_set.validation,
+    "meeting-schedule": meeting_schedule.validation,
+    "minimum-cut": minimum_cut.validation,
+    "set-cover": set_cover.validation,
+    "subset-sum": subset_sum.validation,
+}
+
+
+def _parse_structured_value(value):
+    if not isinstance(value, str):
+        return value
+
+    value = value.strip()
+    if not value:
+        return value
+
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        try:
+            return ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            return value
+
+
+def _resolve_payload(ground_truth, extra_info):
+    payload = _parse_structured_value(ground_truth)
+    if isinstance(payload, Mapping):
+        question = payload.get("question")
+        target = payload.get("ground_truth")
+    else:
+        question = extra_info.get("question")
+        target = payload
+
+    question = _parse_structured_value(question)
+    target = _parse_structured_value(target)
+    if question is None:
+        raise ValueError("NP reward requires a question in ground_truth or extra_info.")
+    return question, target
+
+
+def _resolve_validator(data_source, extra_info):
+    if data_source in NP_DATA_SOURCE_TO_VALIDATOR:
+        return NP_DATA_SOURCE_TO_VALIDATOR[data_source]
+
+    task_type = extra_info.get("task_type") or extra_info.get("type") or extra_info.get("split")
+    if task_type in LEGACY_TASK_TO_VALIDATOR:
+        return LEGACY_TASK_TO_VALIDATOR[task_type]
+
+    raise ValueError(f"Unknown NP data source or task type: {data_source!r}")
+
+
+def compute_score(
+    solution_str: str,
+    ground_truth,
+    extra_info: dict | None = None,
+    data_source: str | None = None,
+    format_reward: float = -1.0,
+    answer_reward: float = -1.5,
+):
+    """Compute the rule-based reward for Bootcamp NP tasks."""
+    extra_info = extra_info or {}
+    validator = _resolve_validator(data_source, extra_info)
+    question, target = _resolve_payload(ground_truth, extra_info)
+
+    has_answer_tag = "Answer:" in solution_str
+    is_invalid, score, _message = validator(question, solution_str, target)
+
+    format_score = 1.0 if has_answer_tag else format_reward
+    answer_score = answer_reward if is_invalid else score
+    return float(format_score + answer_score)

--- a/verl/utils/reward_score/np.py
+++ b/verl/utils/reward_score/np.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ast
 import json
 from collections.abc import Mapping

--- a/verl/utils/reward_score/np_rules/GCP_D.py
+++ b/verl/utils/reward_score/np_rules/GCP_D.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import minimization_score, normalize_adjacency, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/GCP_D.py
+++ b/verl/utils/reward_score/np_rules/GCP_D.py
@@ -1,0 +1,33 @@
+from .common import minimization_score, normalize_adjacency, parse_int_list
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a graph coloring solution."""
+    if not isinstance(graph, dict):
+        return True, -1, "graph must be a dictionary"
+
+    try:
+        colors = parse_int_list(answer)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    neighbors = normalize_adjacency(graph)
+    num_vertices = len(neighbors)
+    if len(colors) != num_vertices:
+        return True, -1, f"invalid coloring: expected {num_vertices} colors, got {len(colors)}"
+
+    if any(color <= 0 for color in colors):
+        return True, -1, "colors must be positive integers"
+
+    for node, adjacent in neighbors.items():
+        if node < 0 or node >= len(colors):
+            return True, -1, f"node {node} is outside the coloring range"
+        for neighbor in adjacent:
+            if neighbor < 0 or neighbor >= len(colors):
+                return True, -1, f"node {neighbor} is outside the coloring range"
+            if colors[node] == colors[neighbor]:
+                return True, -1, f"nodes {node} and {neighbor} share color {colors[node]}"
+
+    used_colors = len(set(colors))
+    score = minimization_score(ground_truth, used_colors)
+    return False, score, f"valid coloring with {used_colors} colors, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/TSP.py
+++ b/verl/utils/reward_score/np_rules/TSP.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import minimization_score, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/TSP.py
+++ b/verl/utils/reward_score/np_rules/TSP.py
@@ -1,0 +1,32 @@
+from .common import minimization_score, parse_int_list
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a traveling-salesman tour."""
+    if not isinstance(graph, dict) or not graph:
+        return True, -1, "graph must be a non-empty dictionary"
+
+    try:
+        path = parse_int_list(answer)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if path[0] != path[-1]:
+        return True, -1, f"path is not a cycle: start {path[0]} and end {path[-1]} differ"
+
+    cities = {int(city) for city in graph.keys()}
+    if len(path) != len(cities) + 1:
+        return True, -1, f"path length must be {len(cities) + 1}, got {len(path)}"
+    if set(path[:-1]) != cities or len(set(path[:-1])) != len(cities):
+        return True, -1, "path must visit each city exactly once before returning"
+
+    total_distance = 0.0
+    for index in range(len(path) - 1):
+        current, next_city = path[index], path[index + 1]
+        try:
+            total_distance += float(graph[str(current)][str(next_city)])
+        except KeyError:
+            return True, -1, f"no distance found between cities {current} and {next_city}"
+
+    score = minimization_score(ground_truth, total_distance)
+    return False, score, f"total distance: {total_distance:g}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/__init__.py
+++ b/verl/utils/reward_score/np_rules/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Rule validators for Bootcamp NP reward scoring."""

--- a/verl/utils/reward_score/np_rules/__init__.py
+++ b/verl/utils/reward_score/np_rules/__init__.py
@@ -1,0 +1,1 @@
+"""Rule validators for Bootcamp NP reward scoring."""

--- a/verl/utils/reward_score/np_rules/common.py
+++ b/verl/utils/reward_score/np_rules/common.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ast
 import re
 from collections import defaultdict
@@ -27,7 +41,7 @@ def parse_int_list(answer: str, *, allow_empty: bool = False) -> list[int]:
 
     try:
         parsed = parse_answer_literal(answer)
-        if isinstance(parsed, (list, tuple, set)):
+        if isinstance(parsed, list | tuple | set):
             values = list(parsed)
         else:
             raise ValueError("answer must be a list")
@@ -67,7 +81,7 @@ def normalize_adjacency(graph: dict) -> dict[int, set[int]]:
         vertices.add(u)
         if isinstance(adjacent, dict):
             iterator = adjacent.items()
-        elif isinstance(adjacent, Iterable) and not isinstance(adjacent, (str, bytes)):
+        elif isinstance(adjacent, Iterable) and not isinstance(adjacent, str | bytes):
             iterator = ((raw_v, 1) for raw_v in adjacent)
         else:
             continue
@@ -78,7 +92,7 @@ def normalize_adjacency(graph: dict) -> dict[int, set[int]]:
             except (TypeError, ValueError):
                 continue
             vertices.add(v)
-            if isinstance(weight, (int, float)) and weight == 0:
+            if isinstance(weight, int | float) and weight == 0:
                 continue
             neighbors[u].add(v)
             neighbors[v].add(u)

--- a/verl/utils/reward_score/np_rules/common.py
+++ b/verl/utils/reward_score/np_rules/common.py
@@ -1,0 +1,106 @@
+import ast
+import re
+from collections import defaultdict
+from collections.abc import Iterable
+
+
+def answer_payload(answer: str) -> str:
+    if "Answer:" not in answer:
+        raise ValueError("invalid answer: no 'Answer:' in answer")
+    return answer.rsplit("Answer:", 1)[-1].strip()
+
+
+def parse_answer_literal(answer: str):
+    payload = answer_payload(answer)
+    try:
+        return ast.literal_eval(payload)
+    except (ValueError, SyntaxError):
+        first_bracket = payload.find("[")
+        last_bracket = payload.rfind("]")
+        if first_bracket == -1 or last_bracket == -1 or first_bracket >= last_bracket:
+            raise ValueError("invalid literal format") from None
+        return ast.literal_eval(payload[first_bracket : last_bracket + 1])
+
+
+def parse_int_list(answer: str, *, allow_empty: bool = False) -> list[int]:
+    payload = answer_payload(answer)
+
+    try:
+        parsed = parse_answer_literal(answer)
+        if isinstance(parsed, (list, tuple, set)):
+            values = list(parsed)
+        else:
+            raise ValueError("answer must be a list")
+    except (ValueError, SyntaxError):
+        payload = payload.splitlines()[0].strip().replace("'", "").replace('"', "")
+        if "->" in payload:
+            payload = ",".join(part.strip() for part in payload.split("->"))
+        else:
+            match = re.search(r"[{\[\(]([^)}\]]*)[}\])]", payload)
+            if match:
+                payload = match.group(1)
+            else:
+                payload = payload.strip("[](){}")
+        values = [part.strip() for part in payload.split(",") if part.strip()]
+
+    if not values and not allow_empty:
+        raise ValueError("answer list cannot be empty")
+
+    ints = []
+    for value in values:
+        if isinstance(value, bool):
+            raise ValueError("boolean values are not valid integer IDs")
+        ints.append(int(value))
+    return ints
+
+
+def normalize_adjacency(graph: dict) -> dict[int, set[int]]:
+    neighbors = defaultdict(set)
+    vertices = set()
+
+    for raw_u, adjacent in graph.items():
+        try:
+            u = int(raw_u)
+        except (TypeError, ValueError):
+            continue
+
+        vertices.add(u)
+        if isinstance(adjacent, dict):
+            iterator = adjacent.items()
+        elif isinstance(adjacent, Iterable) and not isinstance(adjacent, (str, bytes)):
+            iterator = ((raw_v, 1) for raw_v in adjacent)
+        else:
+            continue
+
+        for raw_v, weight in iterator:
+            try:
+                v = int(raw_v)
+            except (TypeError, ValueError):
+                continue
+            vertices.add(v)
+            if isinstance(weight, (int, float)) and weight == 0:
+                continue
+            neighbors[u].add(v)
+            neighbors[v].add(u)
+
+    for vertex in vertices:
+        neighbors[vertex] = set(neighbors[vertex])
+    return dict(neighbors)
+
+
+def maximization_score(actual: float, optimal: float | int | None) -> float:
+    if optimal is None:
+        return 0.0
+    optimal = float(optimal)
+    if optimal == 0:
+        return 1.0 if actual == 0 else 0.0
+    return actual / optimal
+
+
+def minimization_score(optimal: float | int | None, actual: float) -> float:
+    if optimal is None:
+        return 0.0
+    optimal = float(optimal)
+    if actual == 0:
+        return 1.0 if optimal == 0 else 0.0
+    return optimal / actual

--- a/verl/utils/reward_score/np_rules/hamiltonian_cycle.py
+++ b/verl/utils/reward_score/np_rules/hamiltonian_cycle.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import maximization_score, normalize_adjacency, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/hamiltonian_cycle.py
+++ b/verl/utils/reward_score/np_rules/hamiltonian_cycle.py
@@ -1,0 +1,34 @@
+from .common import maximization_score, normalize_adjacency, parse_int_list
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a simple cycle for the Hamiltonian-cycle task."""
+    if not isinstance(graph, dict):
+        return True, -1, "graph must be a dictionary"
+
+    try:
+        path = parse_int_list(answer)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if path[0] != path[-1]:
+        return True, -1, f"path is not a cycle: start {path[0]} and end {path[-1]} differ"
+
+    visited = path[:-1]
+    if len(set(visited)) != len(visited):
+        return True, -1, "nodes must not repeat except for the closing node"
+
+    neighbors = normalize_adjacency(graph)
+    graph_nodes = set(neighbors.keys())
+    missing = sorted(set(visited) - graph_nodes)
+    if missing:
+        return True, -1, f"nodes are not in the graph: {missing}"
+
+    for index in range(len(path) - 1):
+        current, next_node = path[index], path[index + 1]
+        if next_node not in neighbors.get(current, set()):
+            return True, -1, f"nodes {current} and {next_node} are not connected"
+
+    visited_count = len(set(visited))
+    score = maximization_score(visited_count, ground_truth)
+    return False, score, f"valid cycle visiting {visited_count} nodes, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/knapsack.py
+++ b/verl/utils/reward_score/np_rules/knapsack.py
@@ -1,0 +1,51 @@
+from .common import maximization_score, parse_int_list
+
+
+def validation(data, answer, ground_truth):
+    """Validate a knapsack solution."""
+    if not isinstance(data, dict):
+        return True, -1, "input must be a dictionary"
+    if "capacity" not in data or "items" not in data:
+        return True, -1, "input must contain capacity and items"
+
+    try:
+        capacity = int(data["capacity"])
+    except (TypeError, ValueError):
+        return True, -1, "capacity must be an integer"
+    if capacity < 0:
+        return True, -1, "capacity must be non-negative"
+
+    items = data["items"]
+    if not isinstance(items, dict):
+        return True, -1, "items must be a dictionary"
+    items = {str(item_id): item for item_id, item in items.items()}
+
+    try:
+        chosen = parse_int_list(answer, allow_empty=True)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if len(chosen) != len(set(chosen)):
+        return True, -1, "duplicate item IDs in answer"
+
+    total_weight = 0
+    total_value = 0
+    for item_id in chosen:
+        item = items.get(str(item_id))
+        if item is None:
+            return True, -1, f"item {item_id} does not exist"
+        try:
+            weight = int(item["weight"])
+            value = int(item["value"])
+        except (KeyError, TypeError, ValueError):
+            return True, -1, f"item {item_id} has invalid weight or value"
+        if weight < 0 or value < 0:
+            return True, -1, f"item {item_id} has negative weight or value"
+        total_weight += weight
+        total_value += value
+
+    if total_weight > capacity:
+        return True, -1, f"total weight {total_weight} exceeds capacity {capacity}"
+
+    score = maximization_score(total_value, ground_truth)
+    return False, score, f"total value: {total_value}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/knapsack.py
+++ b/verl/utils/reward_score/np_rules/knapsack.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import maximization_score, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/maximum_clique.py
+++ b/verl/utils/reward_score/np_rules/maximum_clique.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import maximization_score, normalize_adjacency, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/maximum_clique.py
+++ b/verl/utils/reward_score/np_rules/maximum_clique.py
@@ -1,0 +1,31 @@
+from .common import maximization_score, normalize_adjacency, parse_int_list
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a maximum-clique candidate."""
+    if not isinstance(graph, dict):
+        return True, -1, "graph must be a dictionary"
+
+    try:
+        clique = parse_int_list(answer)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if len(clique) != len(set(clique)):
+        return True, -1, "clique contains duplicate vertices"
+
+    neighbors = normalize_adjacency(graph)
+    graph_nodes = set(neighbors.keys())
+    missing = sorted(set(clique) - graph_nodes)
+    if missing:
+        return True, -1, f"vertices are not in the graph: {missing}"
+
+    clique_set = set(clique)
+    for vertex in clique:
+        disconnected = sorted((clique_set - {vertex}) - neighbors.get(vertex, set()))
+        if disconnected:
+            return True, -1, f"vertex {vertex} is not connected to {disconnected}"
+
+    clique_size = len(clique)
+    score = maximization_score(clique_size, ground_truth)
+    return False, score, f"valid clique of size {clique_size}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/maximum_set.py
+++ b/verl/utils/reward_score/np_rules/maximum_set.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import maximization_score, normalize_adjacency, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/maximum_set.py
+++ b/verl/utils/reward_score/np_rules/maximum_set.py
@@ -1,0 +1,32 @@
+from .common import maximization_score, normalize_adjacency, parse_int_list
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a maximum-independent-set candidate."""
+    if not isinstance(graph, dict):
+        return True, -1, "graph must be a dictionary"
+
+    try:
+        independent_set = parse_int_list(answer, allow_empty=True)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    neighbors = normalize_adjacency(graph)
+    if neighbors and not independent_set:
+        return True, -1, "independent set cannot be empty for a non-empty graph"
+    if len(independent_set) != len(set(independent_set)):
+        return True, -1, "independent set contains duplicate vertices"
+
+    graph_nodes = set(neighbors.keys())
+    missing = sorted(set(independent_set) - graph_nodes)
+    if missing:
+        return True, -1, f"vertices are not in the graph: {missing}"
+
+    for index, node in enumerate(independent_set):
+        for other in independent_set[index + 1 :]:
+            if other in neighbors.get(node, set()):
+                return True, -1, f"vertices {node} and {other} are adjacent"
+
+    actual_size = len(independent_set)
+    score = maximization_score(actual_size, ground_truth)
+    return False, score, f"valid independent set of size {actual_size}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/meeting_schedule.py
+++ b/verl/utils/reward_score/np_rules/meeting_schedule.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+
+from .common import maximization_score, parse_answer_literal
+
+
+def validation(data, answer, ground_truth):
+    """Validate a meeting-schedule solution."""
+    if not isinstance(data, dict):
+        return True, -1, "input must be a dictionary"
+
+    try:
+        schedule = parse_answer_literal(answer)
+    except (ValueError, SyntaxError) as exc:
+        return True, -1, str(exc)
+
+    if not isinstance(schedule, list):
+        return True, -1, "answer must be a list of schedule entries"
+
+    meetings = data.get("meetings", {})
+    availability = data.get("attendee_availability", {})
+    rooms = data.get("rooms", {})
+    if not isinstance(meetings, dict) or not isinstance(availability, dict) or not isinstance(rooms, dict):
+        return True, -1, "input must contain meetings, attendee_availability, and rooms dictionaries"
+
+    room_schedule = defaultdict(list)
+    attendee_schedule = defaultdict(list)
+    seen_meetings = set()
+
+    for entry in schedule:
+        if not (isinstance(entry, (tuple, list)) and len(entry) == 3):
+            return True, -1, f"invalid entry: {entry!r}, expected (meeting_id, room_id, start_time)"
+
+        meeting_id, room_id, start = entry
+        meeting_key = str(meeting_id)
+        room_key = str(room_id)
+
+        if meeting_key not in meetings:
+            return True, -1, f"invalid meeting ID: {meeting_id}"
+        if room_key not in rooms:
+            return True, -1, f"invalid room ID: {room_id}"
+        if meeting_key in seen_meetings:
+            return True, -1, f"meeting {meeting_id} scheduled more than once"
+        seen_meetings.add(meeting_key)
+
+        meeting_info = meetings[meeting_key]
+        duration = meeting_info.get("duration")
+        attendees = meeting_info.get("attendees", [])
+        if not isinstance(duration, int) or duration <= 0:
+            return True, -1, f"invalid duration for meeting {meeting_id}"
+
+        try:
+            start = int(start)
+        except (TypeError, ValueError):
+            return True, -1, f"invalid start time for meeting {meeting_id}"
+        end = start + duration
+
+        room_info = rooms[room_key]
+        capacity = room_info.get("capacity") if isinstance(room_info, dict) else room_info
+        if not isinstance(capacity, int) or len(attendees) > capacity:
+            return True, -1, f"meeting {meeting_id} exceeds capacity of room {room_id}"
+
+        for previous_meeting, prev_start, prev_end in room_schedule[room_key]:
+            if start < prev_end and prev_start < end:
+                return True, -1, f"meeting {meeting_id} overlaps with meeting {previous_meeting} in room {room_id}"
+        room_schedule[room_key].append((meeting_key, start, end))
+
+        for attendee in attendees:
+            attendee_key = str(attendee)
+            if attendee_key not in availability:
+                return True, -1, f"attendee {attendee} availability not found"
+            for previous_meeting, prev_start, prev_end in attendee_schedule[attendee_key]:
+                if start < prev_end and prev_start < end:
+                    return True, -1, (
+                        f"attendee {attendee} is double-booked in meetings {previous_meeting} and {meeting_id}"
+                    )
+            is_available = any(
+                start >= available_start and end <= available_end
+                for available_start, available_end in availability[attendee_key]
+            )
+            if not is_available:
+                return True, -1, f"attendee {attendee} is not available for meeting {meeting_id} at {start}-{end}"
+            attendee_schedule[attendee_key].append((meeting_key, start, end))
+
+    scheduled_meetings = len(schedule)
+    score = maximization_score(scheduled_meetings, ground_truth)
+    return False, score, f"scheduled {scheduled_meetings} meetings, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/meeting_schedule.py
+++ b/verl/utils/reward_score/np_rules/meeting_schedule.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import defaultdict
 
 from .common import maximization_score, parse_answer_literal
@@ -27,7 +41,7 @@ def validation(data, answer, ground_truth):
     seen_meetings = set()
 
     for entry in schedule:
-        if not (isinstance(entry, (tuple, list)) and len(entry) == 3):
+        if not (isinstance(entry, tuple | list) and len(entry) == 3):
             return True, -1, f"invalid entry: {entry!r}, expected (meeting_id, room_id, start_time)"
 
         meeting_id, room_id, start = entry
@@ -70,8 +84,10 @@ def validation(data, answer, ground_truth):
                 return True, -1, f"attendee {attendee} availability not found"
             for previous_meeting, prev_start, prev_end in attendee_schedule[attendee_key]:
                 if start < prev_end and prev_start < end:
-                    return True, -1, (
-                        f"attendee {attendee} is double-booked in meetings {previous_meeting} and {meeting_id}"
+                    return (
+                        True,
+                        -1,
+                        (f"attendee {attendee} is double-booked in meetings {previous_meeting} and {meeting_id}"),
                     )
             is_available = any(
                 start >= available_start and end <= available_end

--- a/verl/utils/reward_score/np_rules/minimum_cut.py
+++ b/verl/utils/reward_score/np_rules/minimum_cut.py
@@ -1,0 +1,52 @@
+from .common import minimization_score, parse_answer_literal
+
+
+def validation(graph, answer, ground_truth):
+    """Validate a balanced minimum-bisection solution."""
+    if not isinstance(graph, dict):
+        return True, -1, "graph must be a dictionary"
+
+    try:
+        subsets = parse_answer_literal(answer)
+    except (ValueError, SyntaxError) as exc:
+        return True, -1, str(exc)
+
+    if not isinstance(subsets, list) or len(subsets) != 2:
+        return True, -1, "answer must contain exactly two subsets"
+    if not all(isinstance(subset, list) for subset in subsets):
+        return True, -1, "each subset must be a list of nodes"
+
+    try:
+        subset1 = [int(node) for node in subsets[0]]
+        subset2 = [int(node) for node in subsets[1]]
+    except (TypeError, ValueError):
+        return True, -1, "subsets must contain integer nodes"
+
+    if len(subset1) != len(set(subset1)) or len(subset2) != len(set(subset2)):
+        return True, -1, "subsets must not contain duplicate nodes"
+
+    set1, set2 = set(subset1), set(subset2)
+    if not set1.isdisjoint(set2):
+        return True, -1, f"subsets are not disjoint: {sorted(set1 & set2)}"
+
+    all_nodes = {int(node) for node in graph.keys()}
+    union = set1 | set2
+    if union != all_nodes:
+        missing = sorted(all_nodes - union)
+        extra = sorted(union - all_nodes)
+        return True, -1, f"partition does not match graph nodes; missing={missing}, extra={extra}"
+
+    size_diff = abs(len(set1) - len(set2))
+    if size_diff not in (0, 1) or (len(all_nodes) % 2 == 0 and size_diff != 0):
+        return True, -1, f"partition is not balanced: sizes {len(set1)} and {len(set2)}"
+
+    cut_weight = 0.0
+    for node in set1:
+        for other in set2:
+            try:
+                cut_weight += float(graph[str(node)].get(str(other), 0))
+            except KeyError:
+                return True, -1, f"node {node} or {other} is not in the graph"
+
+    score = minimization_score(ground_truth, cut_weight)
+    return False, score, f"cut weight: {cut_weight:g}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/minimum_cut.py
+++ b/verl/utils/reward_score/np_rules/minimum_cut.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import minimization_score, parse_answer_literal
 
 

--- a/verl/utils/reward_score/np_rules/set_cover.py
+++ b/verl/utils/reward_score/np_rules/set_cover.py
@@ -1,0 +1,46 @@
+from .common import answer_payload, minimization_score, parse_int_list
+
+
+def validation(data, answer, ground_truth):
+    """Validate a set-cover solution."""
+    if not isinstance(data, dict) or "U" not in data or "S" not in data:
+        return True, -1, "input must contain U and S"
+
+    universe = set(data["U"])
+    subsets = data["S"]
+    if not isinstance(subsets, dict):
+        return True, -1, "S must be a dictionary"
+
+    try:
+        payload = answer_payload(answer)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if payload == "Impossible":
+        covered_by_all = set()
+        for subset in subsets.values():
+            covered_by_all.update(subset)
+        if covered_by_all == universe:
+            return True, -1, "a cover exists, but the answer claims Impossible"
+        return False, 1.0, "correctly identified as impossible"
+
+    try:
+        selected_subsets = parse_int_list(answer, allow_empty=True)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    for subset_id in selected_subsets:
+        if str(subset_id) not in subsets:
+            return True, -1, f"invalid subset ID: {subset_id}"
+
+    covered = set()
+    for subset_id in selected_subsets:
+        covered.update(subsets[str(subset_id)])
+
+    if covered != universe:
+        missing = sorted(universe - covered)
+        return True, -1, f"selected subsets do not cover U; missing={missing}"
+
+    used_count = len(selected_subsets)
+    score = minimization_score(ground_truth, used_count)
+    return False, score, f"valid cover using {used_count} subsets, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/set_cover.py
+++ b/verl/utils/reward_score/np_rules/set_cover.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import answer_payload, minimization_score, parse_int_list
 
 

--- a/verl/utils/reward_score/np_rules/subset_sum.py
+++ b/verl/utils/reward_score/np_rules/subset_sum.py
@@ -1,0 +1,32 @@
+from .common import maximization_score, parse_int_list
+
+
+def validation(problem, answer, ground_truth):
+    """Validate a subset-sum solution."""
+    if not isinstance(problem, dict):
+        return True, -1, "problem must be a dictionary"
+
+    numbers = problem.get("numbers")
+    target = problem.get("target")
+    if target is None or not isinstance(numbers, dict):
+        return True, -1, "problem must contain target and numbers"
+
+    try:
+        indices = parse_int_list(answer, allow_empty=True)
+    except ValueError as exc:
+        return True, -1, str(exc)
+
+    if len(indices) != len(set(indices)):
+        return True, -1, "answer contains duplicate indices"
+
+    for index in indices:
+        if str(index) not in numbers:
+            return True, -1, f"index {index} not found in numbers"
+
+    submitted_sum = sum(numbers[str(index)] for index in indices)
+    if submitted_sum != target:
+        return True, -1, f"subset sum {submitted_sum} does not match target {target}"
+
+    subset_size = len(indices)
+    score = maximization_score(subset_size, ground_truth)
+    return False, score, f"valid subset of size {subset_size}, ground truth: {ground_truth}"

--- a/verl/utils/reward_score/np_rules/subset_sum.py
+++ b/verl/utils/reward_score/np_rules/subset_sum.py
@@ -1,3 +1,17 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .common import maximization_score, parse_int_list
 
 


### PR DESCRIPTION
 ### What does this PR do?

  Adds the official reward implementation for training LLMs on NP reasoning tasks from
  https://arxiv.org/abs/2605.08905.

  This PR wires 10 Bootcamp NP data sources into the default reward dispatcher and adds rule-based
  validators for graph coloring, Hamiltonian cycle, maximum clique, maximum independent set, minimum cut,
  TSP, knapsack, set cover, subset sum, and meeting scheduling.

  ### Checklist Before Starting

  - [ ✅] Search for similar PRs. Paste at least one query link here:
  https://github.com/verl-project/verl/pulls?q=is%3Apr+NP+reward
  - [ ✅] Format the PR title as `[{modules}] {type}: {description}`

  ### Test

  Validated locally with:

  ```bash
  ruff check verl/utils/reward_score/__init__.py verl/utils/reward_score/np.py verl/utils/reward_score/
  np_rules
  python -m compileall -q verl/utils/reward_score/np.py verl/utils/reward_score/np_rules

  Also smoke-tested all 10 bootcamp/Np... data sources through default_compute_score with JSON-string
  reward_model["ground_truth"]; each valid optimal answer returned score 2.0.

  ### API and Usage Example

  No new public API is required. NP rewards are selected automatically by data_source.

  from verl.utils.reward_score import default_compute_score

  score = default_compute_score(
      data_source="bootcamp/NpMaximumSet",
      solution_str="Answer: [3, 4, 9, 10, 14, 16, 17]",
      ground_truth='{"question": {...}, "ground_truth": 7}',
      extra_info={},
  )

  ### Design & Code Changes

  - Add verl/utils/reward_score/np.py as the NP reward entrypoint.
  - Add rule validators under verl/utils/reward_score/np_rules/.
  - Register 10 Bootcamp NP data sources in default_compute_score.
  - Support both dict and JSON-string reward_model["ground_truth"] formats.

  ### Checklist Before Submitting

  - [ ✅] Read the Contribute Guide (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
  - [ ✅] Apply pre-commit checks: pre-commit install && pre-commit run --all-files --show-diff-on-failure
    --color=always
  - [ ✅] Add / Update documentation.
  - [ ✅] Add unit or end-to-end test(s). If not feasible, explain why: covered by local rule-level smoke
    tests for all NP data sources.
  - [ ✅] Request CI in the ci-request channel when ready.
  - [ ✅] If related to recipe, update the submodule reference.