### PR TITLE
[rollout, vllm] fix: fix collective_rpc in HYBRID mode for multi-node DP

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -193,10 +193,12 @@ class vLLMHttpServer:
         kwargs: dict[str, Any] | None = None,
     ):
         if not hasattr(self, "engine"):
-            # Non-master nodes (node_rank != 0) in HYBRID mode run headless via
-            # run_headless() and never set self.engine. All DP worker communication
-            # is handled by the master node through the DP coordinator.
-            return
+            if self.node_rank != 0:
+                # Non-master nodes (node_rank != 0) in HYBRID mode run headless via
+                # run_headless() and never set self.engine. All DP worker communication
+                # is handled by the master node through the DP coordinator.
+                return
+            raise AttributeError("vLLMHttpServer has no attribute 'engine'")
         if self.rollout_mode == RolloutMode.HYBRID:
             if method == "wake_up":
                 # Use engine.wake_up() instead of engine.collective_rpc("wake_up") to

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -192,6 +192,25 @@ class vLLMHttpServer:
         args: tuple = (),
         kwargs: dict[str, Any] | None = None,
     ):
+        if not hasattr(self, "engine"):
+            # Non-master nodes (node_rank != 0) in HYBRID mode run headless via
+            # run_headless() and never set self.engine. All DP worker communication
+            # is handled by the master node through the DP coordinator.
+            return
+        if self.rollout_mode == RolloutMode.HYBRID:
+            if method == "wake_up":
+                # Use engine.wake_up() instead of engine.collective_rpc("wake_up") to
+                # ensure wake_up propagates to ALL data-parallel workers, not just TP
+                # workers within a single DP shard (same reasoning as _sleep_hybrid).
+                await self.engine.wake_up(**(kwargs or {}))
+                await self.engine.reset_prefix_cache()
+                return
+            elif method == "sleep":
+                # Redirect to _sleep_hybrid() which uses engine.sleep() to propagate
+                # sleep to all DP workers (instead of collective_rpc which only reaches
+                # TP workers within a single DP shard).
+                await self._sleep_hybrid()
+                return
         await self.engine.collective_rpc(
             method=method,
             timeout=timeout,


### PR DESCRIPTION
Fixes three related bugs in `vLLMHttpServer.collective_rpc()` that cause crashes or incorrect behavior in HYBRID mode with `data_parallel_size > 1` (multi-node).

**Bug 1 — AttributeError on non-master nodes (`node_rank != 0`)**

In HYBRID mode, `run_headless()` is called on non-master nodes and never sets `self.engine`. But `collective_rpc()` accesses `self.engine` unconditionally, crashing immediately at training start:
```
trainer.fit() → checkpoint_manager.update_weights()
  → rollout.resume(tags=["weights"]) → _execute_method("wake_up")
  → server_handle.collective_rpc.remote("wake_up")
  → self.engine.collective_rpc(...)
AttributeError: 'vLLMHttpServer' object has no attribute 'engine'
```

**Bug 2 — wake_up only reaches one DP shard**

`engine.collective_rpc("wake_up")` only dispatches to TP workers within DP shard 0, leaving other DP shards asleep after weight sync. Same root cause as the sleep fix in ba5c803b.

**Bug 3 — sleep via `collective_rpc` path bypasses `_sleep_hybrid()`**

`release() → _execute_method("sleep") → collective_rpc("sleep")` calls `engine.collective_rpc("sleep")`, scoped to DP shard 0 only. The fix in ba5c803b only covered the `sleep()` method path, not the `collective_rpc()` dispatch path.

**Fix:** In `vLLMHttpServer.collective_rpc()`:
1. Return early if `self.engine` is not set (non-master nodes)
2. For HYBRID + `wake_up`: use `engine.wake_up(**kwargs)` to broadcast to all DP shards via the DP coordinator
3. For HYBRID + `sleep`: redirect to `_sleep_hybrid()` which already uses `engine.sleep()`

These bugs are pre-existing in upstream (since `03b06d71`), not introduced by ba5c803b. They were masked because single-node testing has no `node_rank != 0` servers.

Similar PR search: https://github.com/verl-project/verl/pulls?q=hybrid+sleep+wake_up+collective_rpc (no duplicates found)

### Test

- **Multi-node (2-node) HYBRID training**: previously crashed immediately at `checkpoint_manager.update_weights()` with `AttributeError: 'vLLMHttpServer' object has no attribute 'engine'`; now proceeds past that point.
- **Single-node HYBRID mode**: no regression observed.
- **COLOCATED / STANDALONE modes**: unaffected — all changes are guarded by `self.rollout_mode == RolloutMode.HYBRID`.

### Design & Code Changes

Only `verl/workers/rollout/vllm_rollout/vllm_async_server.py` is modified (+19 lines in `collective_rpc()`):

```python
async def collective_rpc(self, method, timeout=None, args=(), kwargs=None):
    if not hasattr(self, "engine"):
        # Non-master nodes (node_rank != 0) in HYBRID mode run headless and
        # never set self.engine. DP lifecycle is managed by the master's DP coordinator.
        return
    if self.rollout_mode == RolloutMode.HYBRID:
        if method == "wake_up":
            # engine.wake_up() broadcasts to ALL DP shards via DP coordinator
            await self.engine.wake_up(**(kwargs or {}))
            await self.engine.reset_prefix_cache()
            return
        elif method == "sleep":
            # _sleep_hybrid() uses engine.sleep() which also reaches all DP shards
            await self._sleep_hybrid()
            return
    await self.engine.collective_rpc(method=method, timeout=timeout, args=args, kwargs=kwargs)
```

**Note:** For `update_weights_from_ipc`, non-master node servers now return early instead of crashing. Full multi-node DP weight-update support for non-master shards is a separate pre-existing limitation.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (N/A — internal behavior fix, no API change)
- [ ] Add unit or end-to-end test(s): multi-node HYBRID CI test requires `data_parallel_size > 1` GPU setup, not feasible in current CI.
