### PR TITLE
[fsdp, megatron, trainer] feat: add top-k distillation overlap metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Welcome to register your awesome project build with `verl` for other developers'
 - [RuleReasoner](https://github.com/bigai-nlco/RuleReasoner): **RuleReasoner:** Reinforced Rule-based Reasoning via **Domain-aware Dynamic Sampling** (ICLR 2026) ![GitHub Repo stars](https://img.shields.io/github/stars/bigai-nlco/RuleReasoner)
 - [MetaphorStar](https://metaphorstar.github.io/): **Image Metaphor** Understanding and Reasoning with End-to-End **Visual Reinforcement Learning** ![GitHub Repo stars](https://img.shields.io/github/stars/MING-ZCH/MetaphorStar)
 - [DART-GUI](https://github.com/Computer-use-agents/dart-gui): a decoupled agentic RL framework for Computer Use Agents, achieving ~2× training speedup and ~5× environment utilization! ![GitHub Repo stars](https://img.shields.io/github/stars/Computer-use-agents/dart-gui)
+- [Rethinking OPD](https://github.com/thunlp/OPD): Rethinking On-Policy Distillation of Large Language Models: Phenomenology, Mechanism, and Recipe ![GitHub Repo stars](https://img.shields.io/github/stars/thunlp/OPD)
 
 ## Contribution Guide
 

--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -2,7 +2,7 @@
 
 **Author:** [Jacob Helwig](https://jacobhelwig.github.io/)
 
-Last updated: 05/14/2026.
+Last updated: 05/26/2026.
 
 ## Background
 
@@ -152,6 +152,8 @@ MOPD consolidates multiple specialized policies into a single student model whil
 [7] Yang, Zhuolin, et al. "Nemotron-Cascade 2: Post-Training LLMs with Cascade RL and Multi-Domain On-Policy Distillation." arXiv preprint arXiv:2603.19220, 2026.
 
 [8] DeepSeek-AI. "DeepSeek-V4: Towards Highly Efficient Million-Token Context Intelligence." 2026.
+
+[9] Li, Yaxuan, et al. "Rethinking On-Policy Distillation of Large Language Models: Phenomenology, Mechanism, and Recipe." arXiv preprint arXiv:2604.13016, 2026.
 
 ## Configuration Parameters
 
@@ -587,9 +589,26 @@ These metrics are logged for top-$k$ loss modes such as `forward_kl_topk`.
 - `actor/distillation/teacher_mass_min` / `actor/distillation/teacher_mass_max`  
   Minimum and maximum teacher mass on the teacher top-$k$ tokens within the batch.
 
+- `actor/distillation/overlap_ratio`
+  Average fraction of teacher top-$k$ tokens that also appear in the student's
+  top-$k$ tokens, computed as
+  $|\operatorname{TopK}_{\nu}(s_t) \cap \operatorname{TopK}_{\pi_\theta}(s_t)| / k$
+  over response tokens. A value near `1.0` means the teacher and student top-$k$
+  token sets largely match at student-visited states.
+
+- `actor/distillation/overlap_token_advantage`
+  Average negative teacher-token KL contribution on teacher top-$k$ tokens that
+  also appear in the student's top-$k$ tokens. The per-token value is averaged
+  only over positions with at least one overlapping token; if no response
+  position has overlap, the metric is reported as `0.0`.
+
 `teacher_mass` indicates how much of the teacher distribution is covered by the selected top-$k$. Low `teacher_mass` means the top-$k$ approximation is truncating substantial teacher probability mass. This can happen either by selecting too small $k$, or due to unstable optimization leading to the student generating low probability sequences.
 
 `student_mass` indicates how much probability the student assigns to the teacher-preferred tokens. 
+
+The overlap metrics follow the token-level top-$k$ overlap analysis in [9].
+They are logging-only diagnostics and do not change the distillation loss or
+gradient.
 
 ## Debugging
 
@@ -685,9 +704,10 @@ Using the `DataProto` produced by the Agent Loop (rollouts + teacher logprobs in
    the `student_logits is not None` branch of `distillation_ppo_loss`. The
    logits-processor branch dispatches to `compute_forward_kl_topk`, which has a
    separate implementation per training engine (FSDP and Megatron). Per-token
-   `distillation_losses`, `student_mass`, and `teacher_mass` tensors are
-   written back into `model_output` so the full logits can be freed before the
-   final loss step.
+   `distillation_losses`, `student_mass`, `teacher_mass`, `overlap_count`, and
+   `overlap_token_advantage` tensors are written back into `model_output` so the
+   full logits can be freed before the final loss step. The overlap tensors are
+   used only for logging.
 
 3. **Final loss.** After the forward, the engine calls the loss function with
    `model_output` (full logits already freed); this is the
@@ -746,6 +766,6 @@ The returned scalar loss is what `engine.train_batch` backpropagates.
 
 ### **Tests**
 
-- `tests/workers/test_distillation_topk_symmetry_on_cpu.py` — top-k loss symmetry checks
-- `tests/utils/test_special_megatron_kl_loss_tp.py` — Megatron KL loss under tensor parallelism
+- `tests/workers/test_distillation_topk_symmetry_on_cpu.py` — top-k loss symmetry and overlap metric checks
+- `tests/utils/test_special_megatron_kl_loss_tp.py` — Megatron KL loss and overlap metrics under tensor parallelism
 - `tests/special_e2e/run_fully_async_policy_opd.sh` — end-to-end OPD with the fully-async rollouter

--- a/tests/utils/test_special_megatron_kl_loss_tp.py
+++ b/tests/utils/test_special_megatron_kl_loss_tp.py
@@ -168,8 +168,15 @@ class TestVocabParallelKLDivergence:
             ref_loss.sum().backward()
             grad_ref_shard = full_ref.grad[..., shard_start:shard_end].detach().clone()
 
-            # Compare losses
+            # Compare losses and overlap logging metrics
             torch.testing.assert_close(vp_loss, ref_loss, atol=1e-4, rtol=1e-4)
+            torch.testing.assert_close(
+                loss_out["overlap_token_advantage"],
+                fsdp_loss_out["overlap_token_advantage"],
+                atol=1e-4,
+                rtol=1e-4,
+            )
+            torch.testing.assert_close(loss_out["overlap_count"], fsdp_loss_out["overlap_count"])
 
             # Compare gradients
             torch.testing.assert_close(grad_vp, grad_ref_shard, atol=1e-4, rtol=1e-4)

--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -34,18 +34,21 @@ import os
 
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import torch
 from tensordict import TensorDict
 
+from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk as compute_fsdp_forward_kl_topk
+from verl.trainer.distillation.losses import compute_forward_kl_topk as collect_forward_kl_topk_metrics
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
 
 _VOCAB_SIZE = 8
-_DISTILLATION_KEYS = ("distillation_losses", "student_mass")
+_DISTILLATION_KEYS = ("distillation_losses", "student_mass", "overlap_count", "overlap_token_advantage")
 
 
 def _make_engine_stub():
@@ -157,3 +160,79 @@ def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
             f"Expected '{k}' to be a nested tensor (use_remove_padding={use_remove_padding}); "
             f"got {type(model_output[k])}"
         )
+
+
+def _nested_from_rows(rows):
+    values = torch.tensor(rows)
+    offsets = torch.tensor([0, len(rows)], dtype=torch.int64)
+    return torch.nested.nested_tensor_from_jagged(values, offsets=offsets)
+
+
+def test_forward_kl_topk_emits_overlap_metrics():
+    logits = torch.tensor(
+        [
+            [0.0, 9.0, 8.0, 1.0, 0.0, 0.0],
+            [8.0, 7.0, 0.0, 0.0, 9.0, 0.0],
+            [9.0, 8.0, 7.0, 0.0, 0.0, 0.0],
+        ],
+        dtype=torch.float32,
+    ).unsqueeze(0)
+    teacher_ids = _nested_from_rows([[1, 2], [4, 5], [3, 4]]).to(torch.int64)
+    teacher_logprobs = _nested_from_rows(
+        [
+            [torch.log(torch.tensor(0.7)), torch.log(torch.tensor(0.2))],
+            [torch.log(torch.tensor(0.6)), torch.log(torch.tensor(0.3))],
+            [torch.log(torch.tensor(0.5)), torch.log(torch.tensor(0.4))],
+        ]
+    ).to(torch.float32)
+    config = SimpleNamespace(distillation_loss=SimpleNamespace(log_prob_min_clamp=None))
+
+    output = compute_fsdp_forward_kl_topk(
+        student_logits=logits,
+        teacher_topk_log_probs=teacher_logprobs,
+        teacher_topk_ids=teacher_ids,
+        config=config,
+        data_format="thd",
+    )
+
+    torch.testing.assert_close(output["overlap_count"], torch.tensor([[2, 1, 0]]))
+
+    student_log_probs = torch.log_softmax(logits, dim=-1)
+    gathered_student = torch.gather(student_log_probs, dim=-1, index=teacher_ids.values().unsqueeze(0))
+    teacher_log_probs = teacher_logprobs.values().unsqueeze(0)
+    token_adv = -(teacher_log_probs.exp() * (teacher_log_probs - gathered_student))
+    expected_ota = torch.tensor(
+        [[token_adv[0, 0].mean(), token_adv[0, 1, 0], 0.0]],
+        dtype=output["overlap_token_advantage"].dtype,
+    )
+    torch.testing.assert_close(output["overlap_token_advantage"], expected_ota)
+
+
+def test_forward_kl_topk_metric_aggregation_for_overlap_outputs():
+    data = TensorDict(
+        {
+            "prompts": torch.tensor([[101]]),
+            "responses": torch.tensor([[11, 12, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+            "response_mask": torch.tensor([[1, 1, 0]], dtype=torch.bool),
+        },
+        batch_size=[1],
+    )
+    model_output = {
+        "distillation_losses": torch.tensor([0.1, 0.2, 0.3]),
+        "student_mass": torch.tensor([0.9, 0.8, 0.7]),
+        "teacher_mass": torch.tensor([0.95, 0.85, 0.75]),
+        "overlap_count": torch.tensor([2, 1, 0]),
+        "overlap_token_advantage": torch.tensor([-0.2, -0.4, 0.0]),
+    }
+    distillation_config = SimpleNamespace(distillation_loss=SimpleNamespace(topk=2))
+
+    _, metrics = collect_forward_kl_topk_metrics(
+        config=SimpleNamespace(),
+        distillation_config=distillation_config,
+        model_output=model_output,
+        data=data,
+    )
+
+    assert metrics["distillation/overlap_ratio"] == pytest.approx(0.75)
+    assert metrics["distillation/overlap_token_advantage"] == pytest.approx(-0.3)

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -64,6 +64,7 @@ def compute_forward_kl_topk(
 
     # 2. compute token-wise KL divergence across sp groups
     student_log_probs = F.log_softmax(student_logits, dim=-1)
+    student_topk_ids = torch.topk(student_log_probs, k=teacher_topk_ids.shape[-1], dim=-1).indices
     student_topk_log_probs = torch.gather(student_log_probs, dim=-1, index=teacher_topk_ids)
     student_mass = student_topk_log_probs.exp().sum(dim=-1)
     teacher_mass = teacher_topk_log_probs.exp().sum(dim=-1)
@@ -73,4 +74,21 @@ def compute_forward_kl_topk(
         teacher_topk_log_probs = teacher_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
     distillation_losses = kl_divergence(log_q=student_topk_log_probs, log_p=teacher_topk_log_probs)
 
-    return {"distillation_losses": distillation_losses, "student_mass": student_mass, "teacher_mass": teacher_mass}
+    # Diagnostics for tracking teacher/student top-k overlap in OPD, following
+    # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016).
+    overlap_mask = (teacher_topk_ids.unsqueeze(-1) == student_topk_ids.unsqueeze(-2)).any(dim=-1)
+    overlap_count = overlap_mask.sum(dim=-1)
+    token_kl = teacher_topk_log_probs.exp() * (teacher_topk_log_probs - student_topk_log_probs)
+    overlap_token_advantage_sum = (-token_kl * overlap_mask).sum(dim=-1)
+    overlap_token_advantage = overlap_token_advantage_sum / overlap_count.clamp_min(1)
+    overlap_token_advantage = torch.where(
+        overlap_count > 0, overlap_token_advantage, torch.zeros_like(overlap_token_advantage)
+    )
+
+    return {
+        "distillation_losses": distillation_losses,
+        "student_mass": student_mass,
+        "teacher_mass": teacher_mass,
+        "overlap_count": overlap_count,
+        "overlap_token_advantage": overlap_token_advantage,
+    }

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -308,11 +308,34 @@ def compute_forward_kl_topk(
     distillation_losses = no_padding_2_padding(model_output["distillation_losses"], data)
     student_mass = no_padding_2_padding(model_output["student_mass"], data)
     teacher_mass = no_padding_2_padding(model_output["teacher_mass"], data)
+    overlap_count = model_output.get("overlap_count")
+    overlap_token_advantage = model_output.get("overlap_token_advantage")
+    if overlap_count is not None and overlap_token_advantage is not None:
+        overlap_count = no_padding_2_padding(overlap_count, data)
+        overlap_token_advantage = no_padding_2_padding(overlap_token_advantage, data)
     if data["response_mask"].is_nested:
         response_mask_bool = data["response_mask"].bool().to_padded_tensor(False)
     else:
         response_mask_bool = data["response_mask"].bool()
     assert distillation_losses.shape == student_mass.shape == teacher_mass.shape == response_mask_bool.shape
+
+    overlap_metrics = {}
+    if overlap_count is not None and overlap_token_advantage is not None:
+        assert overlap_count.shape == overlap_token_advantage.shape == response_mask_bool.shape
+        valid_overlap_count = overlap_count[response_mask_bool]
+        k = distillation_config.distillation_loss.topk
+        assert k is not None
+        # Diagnostics for tracking teacher/student top-k overlap in OPD, following
+        # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016):
+        # overlap ratio and average teacher-token KL contribution on overlapped tokens.
+        overlap_metrics["distillation/overlap_ratio"] = (valid_overlap_count.float().mean() / k).item()
+        overlap_position_mask = response_mask_bool & (overlap_count > 0)
+        if overlap_position_mask.any():
+            overlap_metrics["distillation/overlap_token_advantage"] = (
+                overlap_token_advantage[overlap_position_mask].mean().item()
+            )
+        else:
+            overlap_metrics["distillation/overlap_token_advantage"] = 0.0
 
     # Log amount of mass in the top-k log probabilities for both student and teacher.
     student_mass = student_mass[response_mask_bool]
@@ -324,6 +347,7 @@ def compute_forward_kl_topk(
         "distillation/teacher_mass": teacher_mass.mean().item(),
         "distillation/teacher_mass_min": Metric(AggregationType.MIN, teacher_mass.min()),
         "distillation/teacher_mass_max": Metric(AggregationType.MAX, teacher_mass.max()),
+        **overlap_metrics,
     }
 
     # Due to use of top-k, student and teacher distributions don't sum to 1 -> divergences can be negative.

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -94,6 +94,8 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
             partition_vocab_size, rank, world_size
         )
 
+        target_topk_indices_global = target_topk_indices.clone()
+
         # Which target top-k indices fall into this partition's vocab range?
         topk_indices_in_vocab_mask = (target_topk_indices >= vocab_start_index) & (
             target_topk_indices < vocab_end_index
@@ -170,9 +172,48 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
             op=torch.distributed.ReduceOp.SUM,
             group=get_tensor_model_parallel_group(),
         )
-        ctx.mark_non_differentiable(per_token_topk_mass, target_topk_mass)
 
-        return per_token_kl_loss, per_token_topk_mass.detach(), target_topk_mass.detach()
+        # Compute the student's global top-k ids from per-rank vocab-shard candidates.
+        local_topk = min(topk, partition_vocab_size)
+        local_student_topk_logps, local_student_topk_ids = torch.topk(vp_source_logps, k=local_topk, dim=-1)
+        local_student_topk_ids = local_student_topk_ids + vocab_start_index
+        gathered_student_topk_logps = [torch.empty_like(local_student_topk_logps) for _ in range(world_size)]
+        gathered_student_topk_ids = [torch.empty_like(local_student_topk_ids) for _ in range(world_size)]
+        torch.distributed.all_gather(
+            gathered_student_topk_logps, local_student_topk_logps, group=get_tensor_model_parallel_group()
+        )
+        torch.distributed.all_gather(
+            gathered_student_topk_ids, local_student_topk_ids, group=get_tensor_model_parallel_group()
+        )
+        student_topk_logps = torch.cat(gathered_student_topk_logps, dim=-1)
+        student_topk_ids = torch.cat(gathered_student_topk_ids, dim=-1)
+        _, student_topk_positions = torch.topk(student_topk_logps, k=topk, dim=-1)
+        student_topk_ids = torch.gather(student_topk_ids, dim=-1, index=student_topk_positions)
+
+        per_target_token_kl = target_topk_probs * (target_topk_logps - vp_source_topk_logps)
+        torch.distributed.all_reduce(
+            per_target_token_kl,
+            op=torch.distributed.ReduceOp.SUM,
+            group=get_tensor_model_parallel_group(),
+        )
+
+        # Diagnostics for tracking teacher/student top-k overlap in OPD, following
+        # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016).
+        overlap_mask = (target_topk_indices_global.unsqueeze(-1) == student_topk_ids.unsqueeze(-2)).any(dim=-1)
+        overlap_count = overlap_mask.sum(dim=-1)
+        overlap_token_advantage_sum = (-per_target_token_kl * overlap_mask).sum(dim=-1)
+        overlap_token_advantage = overlap_token_advantage_sum / overlap_count.clamp_min(1)
+        overlap_token_advantage = torch.where(
+            overlap_count > 0, overlap_token_advantage, torch.zeros_like(overlap_token_advantage)
+        )
+
+        per_token_topk_mass = per_token_topk_mass.detach()
+        target_topk_mass = target_topk_mass.detach()
+        overlap_count = overlap_count.detach()
+        overlap_token_advantage = overlap_token_advantage.detach()
+        ctx.mark_non_differentiable(per_token_topk_mass, target_topk_mass, overlap_count, overlap_token_advantage)
+
+        return per_token_kl_loss, per_token_topk_mass, target_topk_mass, overlap_count, overlap_token_advantage
 
     @staticmethod
     def backward(
@@ -180,6 +221,8 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
         grad_loss: torch.Tensor,
         grad_source_mass: torch.Tensor,
         grad_target_mass: torch.Tensor,
+        grad_overlap_count: torch.Tensor,
+        grad_overlap_token_advantage: torch.Tensor,
     ):
         """
         Backprop for the per-token loss:
@@ -251,15 +294,19 @@ def compute_forward_kl_topk(
 
     # 2. compute token-wise KL divergence across tp groups
     distillation_loss_config: DistillationLossConfig = config.distillation_loss
-    distillation_losses, student_mass, teacher_mass = _VocabParallelKLDivergence.apply(
-        student_logits,
-        teacher_topk_log_probs_cp_split,
-        teacher_topk_ids_cp_split,
-        distillation_loss_config.log_prob_min_clamp,
+    distillation_losses, student_mass, teacher_mass, overlap_count, overlap_token_advantage = (
+        _VocabParallelKLDivergence.apply(
+            student_logits,
+            teacher_topk_log_probs_cp_split,
+            teacher_topk_ids_cp_split,
+            distillation_loss_config.log_prob_min_clamp,
+        )
     )
 
     return {
         "distillation_losses": distillation_losses,
         "student_mass": student_mass,
         "teacher_mass": teacher_mass,
+        "overlap_count": overlap_count,
+        "overlap_token_advantage": overlap_token_advantage,
     }


### PR DESCRIPTION
### What does this PR do?

This PR adds diagnostic metrics for top-k on-policy distillation, following the token-level top-k overlap analysis in [Rethinking On-Policy Distillation of Large Language Models](https://arxiv.org/abs/2604.13016).

For each response token, the top-k distillation path now tracks how much the student's top-k token set overlaps with the teacher's top-k token set, and logs the average token-level contribution on the overlapping teacher tokens. These metrics help inspect whether OPD is aligning the student with the teacher on high-probability tokens at student-visited states.

Related PRs:

- #4897
- #5499

Duplicate-work check:

- Checked open PRs for [distillation top-k](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+distillation+top-k), [top-k overlap distillation](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+top-k+overlap+distillation), and [overlap_ratio](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+overlap_ratio).
- The closest related open PR is #6194, which adds Nitrobrew as a new OPD loss mode with hidden-state teacher communication and constant-memory KL. This PR is narrower: it keeps the existing `forward_kl_topk` behavior and API unchanged, and only adds top-k overlap diagnostics for the existing top-k distillation path. It does not add a new loss mode, config option, teacher worker path, or communication scheme, so it is not duplicating #6194.

### Checklist Before Starting

- [x] Search for similar PRs. See the duplicate-work check above.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
python3 -m pytest tests/workers/test_distillation_topk_symmetry_on_cpu.py -q
```

Result: 4 passed, 2 warnings.

```bash
torchrun --standalone --nproc_per_node=2 tests/utils/test_special_megatron_kl_loss_tp.py
```

Result: passed all 4 Megatron TP correctness cases.

```bash
pre-commit install
pre-commit run --all-files --show-diff-on-failure --color=always
```

Result: all hooks passed.

Additional validation run after adding the metrics:

- Teacher: `JustRL-DeepSeek-1.5B`
- Student: `DeepSeek-R1-Distill-Qwen-1.5B`
- Dataset: DAPO
- `distillation_loss.topk=16`
- Re-ran the FSDP and Megatron top-k distillation paths with the new diagnostics enabled.

Observed diagnostic metrics:

- `actor/distillation/overlap_ratio` increases from about `0.82` at the beginning of training to about `0.96`, showing that the student's top-k token set increasingly overlaps with the teacher's top-k token set.
- `actor/distillation/overlap_token_advantage` moves from about `-0.007` toward `0`, consistent with the overlapping teacher tokens becoming less penalized by the top-k KL term over training.

Evaluation trends from the same run:

- AIME24 improves from `0.280` to a peak of `0.542`; teacher score is `0.526`.
- AIME25 improves from `0.225` to a peak of `0.398`; teacher score is `0.388`.
- AMC23 improves from `0.630` to a peak of `0.897`; teacher score is `0.910`.

Validation plots:

**FSDP**

<p>
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/fsdp/overlap_ratio.png" alt="FSDP overlap ratio" width="45%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/fsdp/overlap_token_adv.png" alt="FSDP overlap token advantage" width="45%">
</p>

<p>
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/fsdp/AIME24.png" alt="FSDP AIME24" width="30%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/fsdp/AIME25.png" alt="FSDP AIME25" width="30%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/fsdp/AMC23.png" alt="FSDP AMC23" width="30%">
</p>

**Megatron**

<p>
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/megatron/overlap_ratio.png" alt="Megatron overlap ratio" width="45%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/megatron/overlap_token_adv.png" alt="Megatron overlap token advantage" width="45%">
</p>

<p>
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/megatron/aime24.png" alt="Megatron AIME24" width="30%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/megatron/aime25.png" alt="Megatron AIME25" width="30%">
  <img src="https://raw.githubusercontent.com/Turingzero0/verl/929f63cb4892aa250e0b0cf0331e70fb232ab901/megatron/amc23.png" alt="Megatron AMC23" width="30%">
</p>

AI assistance was used to help prepare this PR. All changes were reviewed and validated by the human submitter.

### API and Usage Example

No API or config change is required. Existing top-k distillation runs will automatically emit:

- `distillation/overlap_ratio`
- `distillation/overlap_token_advantage`

when `distillation_loss.topk` is enabled.

### Design & Code Changes

This follows the existing `forward_kl_topk` OPD path and does not introduce a new loss mode, config field, or API surface.

**Metric semantics**

- For each response token, compute the student's top-k token ids using the same `k` as the teacher top-k tensors.
- `overlap_count` is the token-level intersection size between teacher top-k ids and student top-k ids.
- `distillation/overlap_ratio` is the response-masked mean of `overlap_count / k`.
- `overlap_token_advantage` is the average negative teacher-token KL contribution over teacher tokens that are also in the student's top-k set. Tokens with no overlap report `0.0` for this diagnostic.
- These are logging-only diagnostics for the token-level top-k overlap analysis in the OPD paper; they do not change the distillation loss value or gradient.

**FSDP path**

- `verl/trainer/distillation/fsdp/losses.py` computes `student_topk_ids` from `student_log_probs`, builds the teacher/student top-k overlap mask, and returns `overlap_count` plus `overlap_token_advantage` alongside the existing `distillation_losses`, `student_mass`, and `teacher_mass`.
- The existing top-k KL computation is unchanged: teacher top-k ids are still used for the loss, and student/teacher mass metrics keep their previous behavior.

**Shared metric aggregation**

- `verl/trainer/distillation/losses.py` treats the overlap tensors as optional model outputs, pads them back to response shape with the same no-padding helper used by the existing distillation metrics, and logs the final response-masked aggregates.
- Keeping the outputs optional preserves compatibility with any backend that has not been updated to emit the new diagnostics.

**Megatron path**

- `verl/trainer/distillation/megatron/losses.py` computes the student's global top-k set in the vocab-parallel case by taking per-rank local top-k candidates, all-gathering candidates across TP ranks, and selecting the global top-k from the gathered candidates.
- The per-teacher-token KL contribution is all-reduced across TP ranks before computing overlap diagnostics, so Megatron reports the same metric semantics as the FSDP reference path.
- The overlap outputs are detached and marked non-differentiable in the custom autograd function, keeping the backward path limited to the original KL loss.

**Tests**

- `tests/workers/test_distillation_topk_symmetry_on_cpu.py` covers FSDP metric emission and response-masked aggregation.
- `tests/utils/test_special_megatron_kl_loss_tp.py` verifies Megatron TP overlap diagnostics match the FSDP reference in the existing TP correctness cases.

**Documentation**

- `docs/algo/opd.md` documents the new top-k overlap metrics and notes that the overlap tensors are logging-only outputs from the top-k loss path.
- `README.md` adds the OPD paper to the "Awesome Projects Built with verl" list.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Updated `docs/algo/opd.md` with the new top-k overlap metrics and logging-only architecture note, and added the OPD paper to the README project list.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Existing CPU and GPU/special test workflows already cover the updated tests.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable: this PR does not modify the `recipe` submodule.
