### PR TITLE
[veomni] feat: wire MoE load-balance monitor into VeOmni engine

### DIFF
--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -50,6 +50,7 @@ actor_rollout_ref:
       load_balancing_loss_implementation: eager
       force_use_huggingface: false
       activation_gpu_limit: 0.0
+      moe_load_balance_monitor_interval: 0
     _target_: verl.workers.config.VeOmniActorConfig
     rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
     strategy: veomni
@@ -215,6 +216,7 @@ actor_rollout_ref:
       load_balancing_loss_implementation: ${oc.select:actor_rollout_ref.actor.veomni.load_balancing_loss_implementation,eager}
       force_use_huggingface: false
       activation_gpu_limit: 0.0
+      moe_load_balance_monitor_interval: 0
     _target_: verl.workers.config.VeOmniActorConfig
   rollout:
     _target_: verl.workers.config.RolloutConfig
@@ -498,6 +500,7 @@ critic:
     load_balancing_loss_implementation: eager
     force_use_huggingface: false
     activation_gpu_limit: 0.0
+    moe_load_balance_monitor_interval: 0
   _target_: verl.workers.config.VeOmniCriticConfig
   rollout_n: ${oc.select:actor_rollout_ref.rollout.n,1}
   strategy: veomni

--- a/verl/trainer/config/engine/veomni.yaml
+++ b/verl/trainer/config/engine/veomni.yaml
@@ -65,3 +65,7 @@ load_balancing_loss_implementation: eager
 force_use_huggingface: false
 
 activation_gpu_limit: 0.0
+
+# MoE expert-load monitor interval. When > 0, attach VeOmni's MoERouterMonitor.
+# Scalar metrics flow through Tracking; heatmap images go to wandb on rank 0.
+moe_load_balance_monitor_interval: 0

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -370,6 +370,12 @@ class VeOmniEngineConfig(EngineConfig):
     force_use_huggingface: bool = False
     activation_gpu_limit: float = 0.0
     basic_modules: Optional[list[str]] = field(default_factory=list)
+    # MoE expert-load monitor: when > 0, attach VeOmni's MoERouterMonitor.
+    # Scalar violation metrics flow through the engine's metrics dict (all
+    # Tracking backends); heatmap images are logged directly to wandb on
+    # rank 0. Rollout/log-prob forwards are excluded. Counts are all-reduced
+    # across DP/SP groups. Disabled (0) by default; no-op on non-MoE models.
+    moe_load_balance_monitor_interval: int = 0
 
     def __post_init__(self):
         super().__post_init__()

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -300,11 +300,13 @@ class VeOmniEngine(FSDPEngine):
                 heatmap_key = k
             else:
                 scalars[k] = v
-        if scalars and isinstance(outputs, dict) and "metrics" in outputs:
+        if scalars and hasattr(outputs, "__contains__") and "metrics" in outputs:
             outputs["metrics"].update(scalars)
         if self.rank == 0 and heatmap_key is not None:
-            import wandb
-
+            try:
+                import wandb
+            except ImportError:
+                return
             if wandb.run is not None:
                 start, end = self._moe_monitor._last_step_range
                 img = wandb.Image(moe_metrics[heatmap_key], caption=f"Steps {start}-{end}")

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -144,7 +144,11 @@ class VeOmniEngine(FSDPEngine):
         Applies device, dtype, and precision configurations, including mixed precision.
         Sets up checkpoint manager and FLOPs counter.
         """
+        self._moe_monitor = None
+        self._moe_monitor_step = 0
+
         self._build_model_optimizer()
+        self._init_moe_monitor()
 
         self.checkpoint_manager = FSDPCheckpointManager(
             model=self.module,
@@ -255,6 +259,56 @@ class VeOmniEngine(FSDPEngine):
             self.engine_config.activation_gpu_limit,
         )
 
+    # ------------------------------------------------------------------ #
+    # MoE expert-load monitor                                            #
+    # ------------------------------------------------------------------ #
+
+    def _init_moe_monitor(self) -> None:
+        """Construct, attach hooks, and activate the MoE load-balance monitor."""
+        interval = self.engine_config.moe_load_balance_monitor_interval
+        if interval <= 0:
+            return
+        num_experts = getattr(self.module.config, "num_experts", None)
+        if num_experts is None:
+            logger.warning("moe_load_balance_monitor_interval > 0 but model has no num_experts; skipping.")
+            return
+
+        from veomni.utils.moe_monitor import MoERouterMonitor, attach_moe_router_monitor, set_active_monitor
+
+        ps = parallel_state.get_parallel_state()
+        self._moe_monitor = MoERouterMonitor(num_experts=num_experts, dp_group=ps.fsdp_group)
+        set_active_monitor(self._moe_monitor)
+        attached = attach_moe_router_monitor(self.module, self._moe_monitor)
+        if attached == 0:
+            logger.warning("MoE monitor: no recognized routers found; disabling.")
+            self._moe_monitor.disable()
+            set_active_monitor(None)
+            self._moe_monitor = None
+        else:
+            logger.info(f"MoE monitor: attached to {attached} router(s), interval={interval}.")
+
+    def _log_moe_metrics(self, outputs: Any) -> None:
+        """All-reduce counts, put scalars into outputs, log heatmap image to wandb."""
+        moe_metrics = self._moe_monitor.compute_metrics(current_step=self._moe_monitor_step)
+        if not moe_metrics:
+            return
+        from PIL import Image as PILImage
+
+        scalars = {k: v for k, v in moe_metrics.items() if not isinstance(v, PILImage)}
+        if scalars and isinstance(outputs, dict) and "metrics" in outputs:
+            outputs["metrics"].update(scalars)
+        if self.rank == 0:
+            import wandb
+
+            if wandb.run is not None:
+                images = {}
+                for k, v in moe_metrics.items():
+                    if isinstance(v, PILImage):
+                        start, end = self._moe_monitor._last_step_range
+                        images[k] = wandb.Image(v, caption=f"Steps {start}-{end}")
+                if images:
+                    wandb.log(images, step=self._moe_monitor_step)
+
     def optimizer_step(self):
         """
         Perform an optimization step using the optimizer.
@@ -287,6 +341,12 @@ class VeOmniEngine(FSDPEngine):
         Returns:
             Any: The output of the forward pass, which can be used for loss computation or other purposes.
         """
+        if self._moe_monitor is not None:
+            if forward_only:
+                self._moe_monitor.pause()
+            else:
+                self._moe_monitor.resume()
+
         tu.assign_non_tensor(data, sp_size=parallel_state.get_parallel_state().ulysses_size)
 
         # compute num_tokens in global batch for loss normalization
@@ -312,7 +372,15 @@ class VeOmniEngine(FSDPEngine):
 
             output_lst.append(meta_info)
 
-        return postprocess_batch_func(output_lst=output_lst, indices=indices, data=data)
+        result = postprocess_batch_func(output_lst=output_lst, indices=indices, data=data)
+
+        if not forward_only and self._moe_monitor is not None:
+            self._moe_monitor_step += 1
+            interval = self.engine_config.moe_load_balance_monitor_interval
+            if interval > 0 and self._moe_monitor_step % interval == 0:
+                self._log_moe_metrics(result)
+
+        return result
 
     def get_data_parallel_rank(self):
         return parallel_state.get_parallel_state().device_mesh.get_local_rank("dp")

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -288,29 +288,34 @@ class VeOmniEngine(FSDPEngine):
             logger.info(f"MoE monitor: attached to {attached} router(s), interval={interval}.")
 
     def _log_moe_metrics(self, outputs: Any) -> None:
-        """All-reduce counts, put scalars into outputs, log heatmap image to wandb."""
+        """All-reduce counts and log MoE metrics.
+
+        Scalars and heatmap are logged directly via ``wandb.log`` on rank 0
+        to avoid verl's ``allgather_dict_into_dict`` wrapping them in lists
+        (which breaks wandb chart rendering).
+        """
         moe_metrics = self._moe_monitor.compute_metrics(current_step=self._moe_monitor_step)
         if not moe_metrics:
             return
 
-        heatmap_key = None
-        scalars = {}
+        if self.rank != 0:
+            return
+
+        try:
+            import wandb
+        except ImportError:
+            return
+        if wandb.run is None:
+            return
+
+        log_dict = {}
         for k, v in moe_metrics.items():
             if k.endswith("expert_load_heatmap"):
-                heatmap_key = k
-            else:
-                scalars[k] = v
-        if scalars and hasattr(outputs, "__contains__") and "metrics" in outputs:
-            outputs["metrics"].update(scalars)
-        if self.rank == 0 and heatmap_key is not None:
-            try:
-                import wandb
-            except ImportError:
-                return
-            if wandb.run is not None:
                 start, end = self._moe_monitor._last_step_range
-                img = wandb.Image(moe_metrics[heatmap_key], caption=f"Steps {start}-{end}")
-                wandb.log({heatmap_key: img}, step=self._moe_monitor_step)
+                log_dict[k] = wandb.Image(v, caption=f"Steps {start}-{end}")
+            else:
+                log_dict[k] = v
+        wandb.log(log_dict, step=self._moe_monitor_step)
 
     def optimizer_step(self):
         """

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -292,22 +292,23 @@ class VeOmniEngine(FSDPEngine):
         moe_metrics = self._moe_monitor.compute_metrics(current_step=self._moe_monitor_step)
         if not moe_metrics:
             return
-        from PIL import Image as PILImage
 
-        scalars = {k: v for k, v in moe_metrics.items() if not isinstance(v, PILImage)}
+        heatmap_key = None
+        scalars = {}
+        for k, v in moe_metrics.items():
+            if k.endswith("expert_load_heatmap"):
+                heatmap_key = k
+            else:
+                scalars[k] = v
         if scalars and isinstance(outputs, dict) and "metrics" in outputs:
             outputs["metrics"].update(scalars)
-        if self.rank == 0:
+        if self.rank == 0 and heatmap_key is not None:
             import wandb
 
             if wandb.run is not None:
-                images = {}
-                for k, v in moe_metrics.items():
-                    if isinstance(v, PILImage):
-                        start, end = self._moe_monitor._last_step_range
-                        images[k] = wandb.Image(v, caption=f"Steps {start}-{end}")
-                if images:
-                    wandb.log(images, step=self._moe_monitor_step)
+                start, end = self._moe_monitor._last_step_range
+                img = wandb.Image(moe_metrics[heatmap_key], caption=f"Steps {start}-{end}")
+                wandb.log({heatmap_key: img}, step=self._moe_monitor_step)
 
     def optimizer_step(self):
         """


### PR DESCRIPTION
## Summary

Wire VeOmni's `MoERouterMonitor` (from [VeOmni PR #787](https://github.com/ByteDance-Seed/VeOmni/pull/787)) into the VeOmni training engine so MoE expert load distribution is tracked during RL/SFT training.

- Construct, attach, and activate the monitor in `initialize()` after FSDP parallelization
- Pause during rollout forwards (`forward_only=True`), resume during update forwards
- Scalar violation metrics (`moe/{max,min,avg}_vio/...`) flow through `outputs["metrics"]` for all Tracking backends; heatmap image is logged directly to wandb on rank 0
- Counts are all-reduced across DP/SP groups via the monitor's built-in collective; EP excluded (replicated gate)

### Config

Add `moe_load_balance_monitor_interval` to `VeOmniEngineConfig` (default `0` = disabled; no-op on non-MoE models).

```yaml
# In veomni engine config or via CLI override:
actor_rollout_ref.actor.veomni.moe_load_balance_monitor_interval=10
```

### Code Changes

| File | Change |
|------|--------|
| `verl/workers/engine/veomni/transformer_impl.py` | `_init_moe_monitor()`, `_log_moe_metrics()`, pause/resume + step counter in `forward_backward_batch()` |
| `verl/workers/config/engine.py` | `moe_load_balance_monitor_interval: int = 0` field |
| `verl/trainer/config/engine/veomni.yaml` | Hydra YAML default for the new field |

### Test

Smoke-tested on 8xB200 worker with `qwen3-moe-fake-layers` (4-layer Qwen3-MoE, 128 experts):

- VeOmni SFT trainer, 2 GPUs, `moe_load_balance_monitor_interval=1`, 4 training steps
- Monitor attached to 4 routers on both ranks: `MoE monitor: attached to 4 router(s), interval=1.`
- Training completed with decreasing loss (12.25 -> 11.72)
- `interval=0` (default) is a no-op: no monitor created
- Non-MoE models skip gracefully (`num_experts is None` -> warning + skip)

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to the CI workflow. Not feasible: requires a MoE model on GPU; tested manually on mlx worker.
- [ ] CI request sent.