### PR TITLE
[agent_loop, tool] fix: support hermes-format tool calls on gpt-oss tokenizer models

### DIFF
--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -361,7 +361,13 @@ class ToolAgentLoop(AgentLoopBase):
 
         if self.tool_parser_name == "gpt-oss" or self._is_gpt_oss_tokenizer:
             logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
+            text_only_messages = []
+            for msg in add_messages:
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
+                text_only_messages.append({**msg, "content": content})
+            tool_response_text = build_gpt_oss_tool_response_text(text_only_messages, tool_call_names)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -118,6 +118,15 @@ class ToolAgentLoop(AgentLoopBase):
         self.tool_parser = ToolParser.get_tool_parser(self.rollout_config.multi_turn.format, self.tokenizer)
         self.tool_parser_name = self.rollout_config.multi_turn.format
 
+        # Detect gpt-oss tokenizer by presence of <|channel|> special token.
+        # When detected, tool responses must be manually formatted (bypassing apply_chat_template)
+        # regardless of the tool parser, since the gpt-oss jinja template does not support
+        # standard role:tool messages.
+        _channel_token_id = self.tokenizer.convert_tokens_to_ids("<|channel|>")
+        self._is_gpt_oss_tokenizer = (
+            _channel_token_id is not None and _channel_token_id != self.tokenizer.unk_token_id
+        )
+
         self.prompt_length = self.rollout_config.prompt_length
         self.response_length = self.rollout_config.response_length
 
@@ -350,7 +359,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.messages.extend(add_messages)
 
-        if self.tool_parser_name == "gpt-oss":
+        if self.tool_parser_name == "gpt-oss" or self._is_gpt_oss_tokenizer:
             logger.info("manually format tool responses for gpt-oss")
             tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
             response_ids = await self.loop.run_in_executor(


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the multi-turn tool agent loop when using a model with a gpt-oss tokenizer that emits hermes-style `<tool_call>` tool calls.

Models based on a gpt-oss tokenizer but SFT-trained to emit hermes-style `<tool_call>` blocks crash during multi-turn rollout with:
```
jinja2.exceptions.TemplateError: Message has tool role, but there was no
previous assistant message with a tool call!
```
Root cause: `format: hermes` correctly parses `<tool_call>` and executes tools, but then calls `apply_chat_template` with a standard `role: tool` message. The gpt-oss jinja template rejects this format since it expects `tool_calls` as a structured attribute on the assistant message, not a separate `role: tool` entry.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=gpt-oss+tool+apply_chat_template
  - https://github.com/verl-project/verl/pulls?q=tool_agent_loop+gpt-oss

### Test

Reproduced the `TemplateError` crash by running multi-turn rollout with a gpt-oss-tokenizer model configured with `format: hermes`. After this fix, tool execution proceeds normally and tool results are encoded as gpt-oss channel tokens.

### API and Usage Example

No API change. Behavior is automatically correct when a gpt-oss tokenizer is detected. Existing configs using `format: hermes` with gpt-oss tokenizer models will work without any change.

### Design & Code Changes

**`verl/experimental/agent_loop/tool_agent_loop.py`**

The `gpt-oss` and `gemma4` parsers already have dedicated manual tool response formatters that bypass `apply_chat_template`. The fix detects whether the loaded tokenizer is gpt-oss-style (presence of `<|channel|>` special token) and routes tool response encoding through `build_gpt_oss_tool_response_text` regardless of which parser is configured:

```python
# __init__: detect gpt-oss tokenizer once
_channel_token_id = self.tokenizer.convert_tokens_to_ids("<|channel|>")
self._is_gpt_oss_tokenizer = (
    _channel_token_id is not None and _channel_token_id != self.tokenizer.unk_token_id
)

# _handle_processing_tools_state: route accordingly
if self.tool_parser_name == "gpt-oss" or self._is_gpt_oss_tokenizer:
    tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
    ...
```

This decouples the tool call **extraction** format (`tool_parser_name`, e.g. `hermes` or `gpt-oss`) from the tool response **encoding** format (gpt-oss channel tokens vs. chat template), allowing models that mix gpt-oss framing with hermes-format tool outputs to work correctly.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: the crash requires a real gpt-oss model checkpoint with hermes-format SFT, which is not feasible in CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
