### PR TITLE
[fsdp, model] feat: support qwen3_5 ulysses sp

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -489,11 +489,13 @@ def apply_monkey_patch(
         from transformers.models.qwen3_5.modeling_qwen3_5 import (
             Qwen3_5ForConditionalGeneration,
             Qwen3_5Model,
+            Qwen3_5TextModel,
             Qwen3_5VisionModel,
         )
         from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
             Qwen3_5MoeForConditionalGeneration,
             Qwen3_5MoeModel,
+            Qwen3_5MoeTextModel,
             Qwen3_5MoeVisionModel,
         )
 
@@ -512,6 +514,9 @@ def apply_monkey_patch(
         # Step 2: patch vision model to fix fsdp2 cpu_offload bug.
         Qwen3_5VisionModel.fast_pos_embed_interpolate = fast_pos_embed_interpolate
         Qwen3_5MoeVisionModel.fast_pos_embed_interpolate = fast_pos_embed_interpolate
+        if ulysses_sp_size > 1:
+            patch_vlm_for_ulysses_input_slicing(Qwen3_5TextModel)
+            patch_vlm_for_ulysses_input_slicing(Qwen3_5MoeTextModel)
 
     if use_remove_padding or ulysses_sp_size > 1:
         if hasattr(module, "_flash_attention_forward"):  # transformers <= 4.47.1 or legacy models

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -18,9 +18,15 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from torch.distributed.tensor import DTensor
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5CausalLMOutputWithPast,
     Qwen3_5ForConditionalGeneration,
+)
+
+from verl.utils.ulysses import (
+    get_ulysses_sequence_parallel_world_size,
+    ulysses_pad_and_slice_inputs,
 )
 
 logger = logging.getLogger(__file__)
@@ -215,9 +221,19 @@ def forward_with_torch_backend(
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
     fused_linear_for_ppo = FusedLinearForPPO()
+    vocab_weights = self.lm_head.weight
+    if isinstance(vocab_weights, DTensor):
+        vocab_weights = vocab_weights.full_tensor()
+
+    ulysses_sequence_parallel_size = get_ulysses_sequence_parallel_world_size()
+    if ulysses_sequence_parallel_size > 1:
+        rolled_labels, _, _ = ulysses_pad_and_slice_inputs(
+            rolled_labels, position_ids_rmpad=None, sp_size=ulysses_sequence_parallel_size
+        )
+    hidden_states = hidden_states.to(vocab_weights.dtype)  # bf16 to float
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
-        vocab_weights=self.lm_head.weight,
+        vocab_weights=vocab_weights,
         input_ids=rolled_labels,
         temperature=temperature,
     )
@@ -247,10 +263,20 @@ def forward_with_triton_backend(
         rolled_labels = torch.roll(input_ids, shifts=-1, dims=-1)
     else:
         raise RuntimeError("To use forward_with_triton_backend, either labels or input_ids must be provided.")
+    ulysses_sequence_parallel_size = get_ulysses_sequence_parallel_world_size()
+    if ulysses_sequence_parallel_size > 1:
+        rolled_labels, _, _ = ulysses_pad_and_slice_inputs(
+            rolled_labels, position_ids_rmpad=None, sp_size=ulysses_sequence_parallel_size
+        )
+
+    vocab_weights = self.lm_head.weight
+    hidden_states = hidden_states.to(vocab_weights.dtype)
+    if isinstance(vocab_weights, DTensor):
+        vocab_weights = vocab_weights.full_tensor()
 
     log_probs, entropy = linear_cross_entropy(
         hidden_states,
-        self.lm_head.weight,
+        vocab_weights,
         rolled_labels,
         temperature,
         "none",


### PR DESCRIPTION
### What does this PR do?

support qwen3_5 ulysses sp with fsdp backend. fix https://github.com/verl-project/verl/issues/5762

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:  https://github.com/verl-project/verl/pull/5682
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

the test results are as follows:
<img width="3116" height="1510" alt="image" src="https://github.com/user-attachments/assets/a29d7c6c-6b99-4e9f-aae9-5be2020fc36d" />


### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
