### PR TITLE
[reward_manager] fix: guard against empty responses and None overlong_buffer_cfg

### DIFF
--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -118,7 +118,7 @@ class DAPORewardManager(AbstractRewardManager):
 
             reward = score
 
-            if self.overlong_buffer_cfg.enable:
+            if self.overlong_buffer_cfg is not None and self.overlong_buffer_cfg.enable:
                 overlong_buffer_len = self.overlong_buffer_cfg.len
                 expected_len = self.max_resp_len - overlong_buffer_len
                 exceed_len = valid_response_length - expected_len
@@ -129,7 +129,8 @@ class DAPORewardManager(AbstractRewardManager):
                     reward_extra_info["overlong_reward"].append(overlong_reward)
                     reward_extra_info["overlong"].append(overlong_reward < 0)
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -129,8 +129,8 @@ class DAPORewardManager(AbstractRewardManager):
                     reward_extra_info["overlong_reward"].append(overlong_reward)
                     reward_extra_info["overlong"].append(overlong_reward < 0)
 
-            if valid_response_length > 0:
-                reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length.item() > 0:
+                reward_tensor[i, valid_response_length.item() - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -97,7 +97,8 @@ class NaiveRewardManager(AbstractRewardManager):
             else:
                 reward = score
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -97,8 +97,8 @@ class NaiveRewardManager(AbstractRewardManager):
             else:
                 reward = score
 
-            if valid_response_length > 0:
-                reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length.item() > 0:
+                reward_tensor[i, valid_response_length.item() - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -174,7 +174,8 @@ class PrimeRewardManager(AbstractRewardManager):
 
         for i in range(len(data)):
             data_source = data_sources[i]
-            reward_tensor[i, valid_response_length[i].item() - 1] = scores[i]
+            if valid_response_length[i].item() > 0:
+                reward_tensor[i, valid_response_length[i].item() - 1] = scores[i]
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0


### PR DESCRIPTION
## Problem

Two silent bugs found via static analysis in `verl/workers/reward_manager/`:

### Bug 1 — `DAPORewardManager`: `AttributeError` when `overlong_buffer_cfg=None`

`__call__` accessed `self.overlong_buffer_cfg.enable` (line 121) without first checking for `None`. Since `overlong_buffer_cfg` defaults to `None`, any call without this argument crashes at runtime:

```
AttributeError: 'NoneType' object has no attribute 'enable'
```

The `__init__` method correctly guards with `if self.overlong_buffer_cfg is not None:`, but `__call__` did not.

### Bug 2 — All three managers: reward written to index `-1` for empty responses

`NaiveRewardManager`, `DAPORewardManager`, and `PrimeRewardManager` all compute:

```python
reward_tensor[i, valid_response_length - 1] = reward
```

When `valid_response_length == 0` (aborted generation, fully-padded response), this becomes `reward_tensor[i, -1]` — Python/PyTorch silently writes the reward to the **last position** of the row, corrupting training signal with no error raised.

> **Related**: PR #5613 fixes the same pattern in `core_algos.py` for GDPO. This PR addresses the same class of bug in the three `reward_manager` classes, which are separate code paths not covered by #5613.

## Fix

1. Add `is not None` guard before `.enable` access in `dapo.py`.
2. Add `if valid_response_length > 0:` guard before reward placement in all three managers.

## Validation

Confirmed with a minimal Python script (no GPU required):

```
[Bug 1] dapo.py: overlong_buffer_cfg=None → AttributeError
  BEFORE: CRASH confirmed → 'NoneType' object has no attribute 'enable'
  AFTER fix: No crash ✓

[Bug 2] reward placement with valid_response_length=0
  BEFORE: row0=[0.0, 0.0, 0.0, 0.0, 1.0]  ← reward silently placed at index -1 (WRONG)
  AFTER:  row0=[0.0, 0.0, 0.0, 0.0, 0.0]  ← empty response skipped (CORRECT)
          row1=[0.0, 0.0, 2.0, 0.0, 0.0]  ← normal response unaffected (CORRECT)

[PASS] Both bugs confirmed and fixes validated ✓
```

## Checklist

- [x] Not duplicating an existing PR (related to #5613 which covers `core_algos.py` only; this PR covers `reward_manager/` files)
- [x] All changed lines reviewed
- [x] Validation script run and passing
- [x] AI assistance used (Claude) for static analysis and fix generation; all changes reviewed and verified by human submitter