### PR TITLE
[veomni] fix: VeOmniEngineWithValueHead loads ForTokenClassification

### DIFF
--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -224,6 +224,14 @@ class VeOmniEngine(FSDPEngine):
 
         return lr_scheduler
 
+    def _get_model_config_path(self):
+        """Return the config path (or PretrainedConfig) for build_foundation_model.
+
+        Subclasses can override to modify the HF config before model construction
+        (e.g. VeOmniEngineWithValueHead rewrites architectures to ForTokenClassification).
+        """
+        return self.model_config.local_hf_config_path
+
     def _build_model_optimizer(self):
         # build_foundation_model runs apply_ops_config(ops_implementation)
         # before constructing the model, so per-model device_patch files see
@@ -240,7 +248,7 @@ class VeOmniEngine(FSDPEngine):
 
         # Load base model with specified configuration and dtype
         module = build_foundation_model(
-            config_path=self.model_config.local_hf_config_path,
+            config_path=self._get_model_config_path(),
             weights_path=self.model_config.local_path,
             torch_dtype="float32" if self.engine_config.mixed_precision else "bfloat16",
             attn_implementation=self.engine_config.attn_implementation,
@@ -757,8 +765,30 @@ class VeOmniEngineWithValueHead(VeOmniEngine, FSDPEngineWithValueHead):
     """Value model engine using VeOmni's FSDP2 + sequence parallelism.
 
     Combines VeOmniEngine (model init, parallel state, activation offloading)
-    with FSDPEngineWithValueHead (TokenClassification output → per-token values).
+    with FSDPEngineWithValueHead (TokenClassification output -> per-token values).
     """
+
+    def _get_model_config_path(self):
+        """Return a modified HF config that loads ForTokenClassification(num_labels=1).
+
+        Uses HF's AutoModelForTokenClassification model mapping to resolve the
+        canonical ForTokenClassification class name for this model family, then
+        sets config.architectures so VeOmni's MODELING_REGISTRY dispatches to it.
+        """
+        from transformers import AutoModelForTokenClassification
+        from veomni.models.auto import build_config
+
+        config = build_config(self.model_config.local_hf_config_path)
+        config.num_labels = 1
+        config.classifier_dropout = 0.0
+        config.hidden_dropout = "0"
+        config.summary_dropout_prob = 0.0
+        config.tie_word_embeddings = False
+        token_cls = AutoModelForTokenClassification._model_mapping.get(type(config))
+        if token_cls is None:
+            raise ValueError(f"No ForTokenClassification class in transformers for {type(config).__name__}.")
+        config.architectures = [token_cls.__name__]
+        return config
 
     def prepare_model_inputs(self, micro_batch: TensorDict):
         model_inputs, output_args = super().prepare_model_inputs(micro_batch)


### PR DESCRIPTION
## Summary

Fix `VeOmniEngineWithValueHead` to correctly load `ForTokenClassification(num_labels=1)` instead of `ForCausalLM`, producing per-token scalar values instead of vocabulary logits.

## Problem

`VeOmniEngine._build_model_optimizer` calls `build_foundation_model(config_path=self.model_config.local_hf_config_path)` which always dispatches `ForCausalLM`. The FSDP path (`FSDPEngineWithLMHead._build_module`) has a `model_type == "value_model"` branch that loads `ForTokenClassification` with `num_labels=1`, but VeOmni's override completely bypasses it.

Result: the critic/value model outputs `(B, seq_len, vocab_size)` logits instead of `(B, seq_len)` scalar values, breaking PPO training with VeOmni backend.

## Solution

Add a `_get_model_config_path()` hook to `VeOmniEngine` that returns the config path for `build_foundation_model`. The base implementation returns `self.model_config.local_hf_config_path` (no change in behavior). `VeOmniEngineWithValueHead` overrides it to:

1. Build and modify the HF config: `num_labels=1`, `classifier_dropout=0.0`, `tie_word_embeddings=False`
2. Rewrite `config.architectures` from `*ForCausalLM` to `*ForTokenClassification`
3. Return the modified config object

No code duplication — the parent's `_build_model_optimizer` handles all building, parallelization, and optimizer setup.

**Dependency:** Requires VeOmni to register `ForTokenClassification` in its model registries. See ByteDance-Seed/VeOmni#795.

## Test commands and results

PPO training (GAE + critic) with Qwen3-1.7B on 8x H100, `critic.strategy=veomni`:

```
compute_values:     shape=[8, 32], values=[-6.81, 0.33, 0.35, 1.10, 1.59]
compute_advantages: advantages=[4.61, 1.02, 1.04, ...], returns=[2.15, 1.72, ...]
update_critic (5 steps):
  Step 1: vf_loss=2.3592, vpred=3.1081
  Step 2: vf_loss=1.1023, vpred=2.0843
  Step 3: vf_loss=1.6634, vpred=2.8548
  Step 4: vf_loss=1.6687, vpred=2.8229
  Step 5: vf_loss=1.4617, vpred=2.6175
```

## AI assistance disclosure

AI assistance was used for initial implementation. All changes were verified and tested by a human submitter on Arnold (8x H100).