### PR TITLE
[trainer, rollout, cfg] feat: add extension points for custom worker configs

### DIFF
--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -819,6 +819,7 @@ class RayPPOTrainer:
                 engine_config=engine_config,
                 optimizer_config=orig_critic_cfg.optim,
                 checkpoint_config=orig_critic_cfg.checkpoint,
+                extra_context=getattr(self, "_critic_extra_context", {}),
             )
 
             critic_cls = RayClassWithInitArgs(cls=self.role_worker_mapping[Role.Critic], config=critic_cfg)

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -609,3 +609,4 @@ class TrainingWorkerConfig(BaseConfig):
     # This function takes model config and the device name as parameter.
     # Users can pass in a higher-order function to take more parameters
     auto_select_engine_optim_fn: Callable[["HFModelConfig", str], tuple["EngineConfig", "OptimizerConfig"]] = None
+    extra_context: dict = field(default_factory=dict)

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -153,7 +153,7 @@ class LLMServerClient:
     def __init__(
         self,
         config: DictConfig,
-        load_balancer_handle: ray.actor.ActorHandle,
+        load_balancer_handle: ray.actor.ActorHandle = None,
         **kwargs,
     ):
         """Initialize the LLMServerClient.
@@ -161,7 +161,8 @@ class LLMServerClient:
         Args:
             config (DictConfig): whole config for main entrypoint.
             load_balancer_handle (ray.actor.ActorHandle): shared global load balancer actor
-                that also holds the server-handle registry.
+                that also holds the server-handle registry. Optional; subclasses that
+                manage server routing externally can pass None.
         """
         self.config = config
         self._load_balancer = load_balancer_handle


### PR DESCRIPTION
## Summary

Add extension points that allow `TaskRunner` subclasses to customize worker configs and LLM server management without monkey-patching internal classes.

## Changes

### 1. `TrainingWorkerConfig.extra_context` (`verl/workers/config/engine.py`)

New `dict` field on `TrainingWorkerConfig` that survives pickle serialization across Ray actor boundaries. TaskRunner subclasses can populate it to pass custom state (e.g. service URLs, feature flags) to worker processes.

### 2. `LLMServerClient.__init__(load_balancer_handle=None)` (`verl/workers/rollout/llm_server.py`)

Make `load_balancer_handle` optional (default `None`). Subclasses that manage server routing externally (e.g. via HTTP proxy) can now call `super().__init__()` safely without providing a local Ray actor handle.

### 3. `LLMServerManager.__init__` comment (`verl/workers/rollout/llm_server.py`)

Document that subclasses can set `self.rollout_replica_class` before calling `super().__init__()` to skip the `get_rollout_replica_class()` registry lookup (which imports vLLM/SGLang). The `hasattr` guard already exists — this just documents the intended usage.

### 4. `RayPPOTrainer._critic_extra_context` (`verl/trainer/ppo/ray_trainer.py`)

`_init_workers` now propagates `self._critic_extra_context` (if set by a `TaskRunner` subclass) into the critic worker's `TrainingWorkerConfig.extra_context`. This provides a clean way for custom TaskRunners to inject per-role context.

## Motivation

Downstream recipe repos that implement custom training strategies currently need to monkey-patch `TrainingWorkerConfig.__init__` and skip `LLMServerManager.__init__` entirely. These extension points provide clean alternatives that don't require global mutation or fragile init bypasses.

## Test plan

- [x] Existing PPO training unaffected (extra_context defaults to `{}`, load_balancer_handle default maintains existing behavior)
- [x] Verified with remote critic backend on Arnold (8x H100, Qwen3-1.7B): 4/4 API endpoints pass, 5 training steps with model updates

## AI assistance disclosure

AI assistance was used for implementation. All changes were verified and tested by a human submitter.