### PR TITLE
[trainer, fsdp, rollout, model, data] feat: Qwen3-Omni-30B-A3B Thinker LoRA RL support

### DIFF
--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -330,9 +330,11 @@ def apply_monkey_patch(
     try:
         num_attention_heads, num_key_value_heads = model.config.num_attention_heads, model.config.num_key_value_heads
     except AttributeError:
+        # Some multimodal configs nest text_config differently; fall back to get_text_config().
+        text_config = getattr(model.config, "text_config", None) or model.config.get_text_config()
         num_attention_heads, num_key_value_heads = (
-            model.config.text_config.num_attention_heads,
-            model.config.text_config.num_key_value_heads,
+            text_config.num_attention_heads,
+            text_config.num_key_value_heads,
         )
 
     assert num_attention_heads % ulysses_sp_size == 0, (

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -109,8 +109,11 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
 
     from torch.distributed.fsdp.wrap import _or_policy, lambda_auto_wrap_policy
 
-    # Add lambda policy for LoRA modules if is_lora is True
-    if is_lora:
+    # Add lambda policy for LoRA modules if is_lora is True. Skip when
+    # min_num_params > 0: combining size policy with lambda policy creates
+    # nested FSDP units whose allgather order can diverge across ranks under
+    # variable input lengths (use_remove_padding), causing NCCL deadlocks.
+    if is_lora and min_num_params == 0:
 
         def lambda_policy_fn(module):
             return bool(
@@ -628,49 +631,56 @@ def fsdp2_clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinit
     return total_norm
 
 
-def layered_summon_lora_params(fsdp_module) -> OrderedDict:
+def layered_summon_lora_params(fsdp_module, is_diffusers=False) -> OrderedDict:
+    """Collect LoRA params one FSDP unit at a time to keep peak GPU memory low.
+
+    Iterates every FSDP unit (parent before child via named_modules order) and
+    summons each one individually. Works for any wrap granularity (layer, MLP,
+    expert) — including MoE models where wrap typically lands at
+    ``layers.<i>.mlp`` rather than the transformer-layer level.
+
+    Safe with nested units: ``submodule.state_dict()`` returns gathered tensors
+    for the unit being summoned but only sharded tensors for nested children.
+    Sharded entries collected first get overwritten when the child unit is
+    summoned later, so every LoRA tensor is gathered exactly once.
+    """
     from peft.utils.save_and_load import get_peft_model_state_dict
 
-    def __prefix_submodules(module, prefix):
-        for name, submodule in module.named_modules():
-            if name.startswith(prefix) and "." not in name[len(prefix) :]:
-                yield name, submodule
-
     lora_params = OrderedDict()
-    prefix_list = [
-        # fsdp
-        "_fsdp_wrapped_module.base_model.model.",
-        "_fsdp_wrapped_module.base_model.model.model.",
-        "_fsdp_wrapped_module.base_model.model.model.layers.",
-        "_fsdp_wrapped_module.base_model.model.model.language_model.layers.",
-        # fsdp2
-        "base_model.model.",
-        "base_model.model.model.",
-        "base_model.model.model.layers.",
-        "base_model.model.model.language_model.layers.",
-    ]
     peft_model = getattr(fsdp_module, "_fsdp_wrapped_module", fsdp_module)
-    for prefix in prefix_list:
-        for name, submodule in __prefix_submodules(fsdp_module, prefix):
-            prefix = name.replace("_fsdp_wrapped_module.base_model.model.", "base_model.model.")
-            if name.endswith(".model") or name.endswith(".layers"):
+
+    for name, submodule in fsdp_module.named_modules():
+        if name == "":
+            # Skip root: full summon defeats the purpose.
+            continue
+        if fsdp_version(submodule) == 0:
+            continue
+        # Strip every ``_fsdp_wrapped_module.`` segment to match the names
+        # downstream consumers (vllm LoRA loader, peft state_dict) expect.
+        clean_prefix = name.replace("_fsdp_wrapped_module.", "")
+        if clean_prefix.endswith(".model") or clean_prefix.endswith(".layers"):
+            continue
+
+        with FSDP.summon_full_params(submodule, writeback=False):
+            sub_lora_params = get_peft_model_state_dict(peft_model, state_dict=submodule.state_dict())
+            if not sub_lora_params:
                 continue
-            if fsdp_version(submodule) > 0:
-                with FSDP.summon_full_params(submodule, writeback=False):
-                    sub_lora_params = get_peft_model_state_dict(peft_model, state_dict=submodule.state_dict())
-                    sub_lora_params = {
-                        f"{prefix}.{name}": param.full_tensor().detach().cpu()
-                        if hasattr(param, "full_tensor")
-                        else param.detach().cpu()
-                        for name, param in sub_lora_params.items()
-                    }
-                    lora_params.update(sub_lora_params)
-                    submodule._is_root = False
-                get_torch_device().empty_cache()
+            sub_lora_params = {
+                f"{clean_prefix}.{key}": (
+                    param.full_tensor().detach().cpu() if hasattr(param, "full_tensor") else param.detach().cpu()
+                )
+                for key, param in sub_lora_params.items()
+            }
+            lora_params.update(sub_lora_params)
+            submodule._is_root = False
+        get_torch_device().empty_cache()
+
     return lora_params
 
 
-def collect_lora_params(module: FSDP, layered_summon: bool, base_sync_done: bool) -> OrderedDict:
+def collect_lora_params(
+    module: FSDP, layered_summon: bool, base_sync_done: bool, is_diffusers: bool = False
+) -> OrderedDict:
     """
     collect lora params or full params if base model is not ready in vllm
     work with if isinstance(self.module._fsdp_wrapped_module, PeftModel)
@@ -686,7 +696,20 @@ def collect_lora_params(module: FSDP, layered_summon: bool, base_sync_done: bool
                     "To use layered_summon, you must make sure base-model is preloaded in vllm, e.g. let "
                     "rollout.load_format=safetensors"
                 )
-            lora_params = layered_summon_lora_params(module)
+            lora_params = layered_summon_lora_params(module, is_diffusers=is_diffusers)
+            if not lora_params:
+                import logging
+
+                logging.getLogger(__name__).warning("layered_summon returned empty, falling back to full summon")
+                with FSDP.summon_full_params(module, writeback=False, offload_to_cpu=True):
+                    lora_params = get_peft_model_state_dict(peft_model)
+                    lora_params = {
+                        name: param.full_tensor().detach().cpu()
+                        if hasattr(param, "full_tensor")
+                        else param.detach().cpu()
+                        for name, param in lora_params.items()
+                    }
+                get_torch_device().empty_cache()
         else:
             with FSDP.summon_full_params(module, writeback=False):
                 if base_sync_done:

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -677,10 +677,80 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
 
 _architecture_to_auto_class = {
     "ForCausalLM": AutoModelForCausalLM,
+    "Qwen3OmniMoeForConditionalGeneration": AutoModelForCausalLM,
     "ForVision2Seq": AutoModelForVision2Seq,
     "ForTokenClassification": AutoModelForTokenClassification,
     "ForSequenceClassification": AutoModelForSequenceClassification,
 }
+
+# Register Qwen3-Omni Thinker in AutoModelForCausalLM so verl's FSDP engine can load it.
+# Qwen3OmniMoe uses the "ForConditionalGeneration" suffix but is a decoder-only causal LM.
+try:
+    from transformers.models.qwen3_omni_moe import (
+        Qwen3OmniMoeConfig,
+        Qwen3OmniMoeForConditionalGeneration,
+    )
+
+    def _qwen3_omni_get_input_embeddings(self):
+        return self.thinker.get_input_embeddings()
+
+    def _qwen3_omni_set_input_embeddings(self, value):
+        self.thinker.set_input_embeddings(value)
+
+    def _qwen3_omni_forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        labels=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        **kwargs,
+    ):
+        return self.thinker(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            **kwargs,
+        )
+
+    Qwen3OmniMoeForConditionalGeneration.forward = _qwen3_omni_forward
+    Qwen3OmniMoeForConditionalGeneration.get_input_embeddings = _qwen3_omni_get_input_embeddings
+    Qwen3OmniMoeForConditionalGeneration.set_input_embeddings = _qwen3_omni_set_input_embeddings
+    # _no_split_modules in upstream incorrectly references Qwen3OmniMoeDecoderLayer
+    # (does not exist); the actual Thinker decoder layer is Qwen3OmniMoeThinkerTextDecoderLayer.
+    Qwen3OmniMoeForConditionalGeneration._no_split_modules = ["Qwen3OmniMoeThinkerTextDecoderLayer"]
+    Qwen3OmniMoeForConditionalGeneration._verl_strip_modules = [
+        "talker",
+        "code2wav",
+        "code_predictor",
+    ]
+
+    # tie_word_embeddings=True forces use_meta_tensor=False during FSDP init,
+    # which OOMs on a 30B-A3B base. Use a no-op descriptor to override at the
+    # config class level (so config __init__ assignments are tolerated).
+    class _FalseTieDescriptor:
+        def __get__(self, obj, objtype=None):
+            return False
+
+        def __set__(self, obj, value):
+            pass
+
+    Qwen3OmniMoeConfig.tie_word_embeddings = _FalseTieDescriptor()
+    AutoModelForCausalLM.register(Qwen3OmniMoeConfig, Qwen3OmniMoeForConditionalGeneration)
+except ImportError:
+    pass
 
 
 def get_hf_auto_model_class(hf_config):

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -218,6 +218,17 @@ def hf_processor(name_or_path, **kwargs):
                 from transformers.models.qwen3_vl import Qwen3VLModel
 
                 model_class = Qwen3VLModel
+            case "Qwen3OmniMoeProcessor":
+                from transformers.models.qwen3_omni_moe import Qwen3OmniMoeThinkerForConditionalGeneration
+
+                model_class = Qwen3OmniMoeThinkerForConditionalGeneration
+                # Token IDs / spatial_merge_size live on thinker_config, not the
+                # top-level Qwen3OmniMoeConfig that AutoConfig returned.
+                processor.config = config.thinker_config
+                processor.spatial_merge_size = config.thinker_config.vision_config.spatial_merge_size
+                processor.get_llm_pos_ids_for_vision = types.MethodType(
+                    model_class.get_llm_pos_ids_for_vision, processor
+                )
             case "Glm4vImageProcessor":
                 from transformers.models.glm4v import Glm4vModel
 

--- a/verl/utils/vllm/utils.py
+++ b/verl/utils/vllm/utils.py
@@ -60,7 +60,8 @@ class VLLMHijack:
                 lora_tensors = None
                 from vllm.lora.peft_helper import PEFTHelper
 
-                if isinstance(lora_request, TensorLoRARequest):
+                _has_tensor_lora = hasattr(lora_request, "peft_config") and hasattr(lora_request, "lora_tensors")
+                if isinstance(lora_request, TensorLoRARequest) or _has_tensor_lora:
                     peft_config = lora_request.peft_config
                     lora_tensors = lora_request.lora_tensors
                     peft_helper = PEFTHelper.from_dict(peft_config)
@@ -96,7 +97,7 @@ class VLLMHijack:
                     lora_request_kwargs["target_embedding_padding"] = (
                         self.vocab_size + self.lora_config.lora_extra_vocab_size
                     )
-                if isinstance(lora_request, TensorLoRARequest):
+                if isinstance(lora_request, TensorLoRARequest) or _has_tensor_lora:
                     lora = self._lora_model_cls.from_lora_tensors(
                         tensors=lora_tensors,
                         **lora_request_kwargs,

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -249,6 +249,14 @@ class FSDPEngine(BaseEngine):
                     config=self.model_config.hf_config,
                     trust_remote_code=self.model_config.trust_remote_code,
                 )
+
+                # Strip sub-modules listed in _verl_strip_modules (e.g.
+                # talker / code2wav for Qwen3-Omni Thinker-only training).
+                _strip_list = getattr(module, "_verl_strip_modules", [])
+                for attr in _strip_list:
+                    if hasattr(module, attr):
+                        delattr(module, attr)
+                        logger.info(f"Stripped unused sub-module '{attr}' to reduce memory")
             else:
                 from verl.utils.model import load_valuehead_model
 
@@ -328,6 +336,20 @@ class FSDPEngine(BaseEngine):
                 "bias": "none",
             }
             module = get_peft_model(module, LoraConfig(**lora_config))
+
+            # Mixed bf16 base + fp32 adapter trips FSDP's "all params in a flat
+            # group must share dtype" assertion. Cast adapter params to base
+            # dtype only when they actually differ.
+            base_dtype = next((p.dtype for p in module.parameters() if not p.requires_grad), None)
+            if base_dtype is not None:
+                mismatched = [p for p in module.parameters() if p.requires_grad and p.dtype != base_dtype]
+                if mismatched:
+                    logger.info(
+                        f"Casting {len(mismatched)} LoRA adapter params from "
+                        f"{mismatched[0].dtype} to {base_dtype} to match base."
+                    )
+                    for param in mismatched:
+                        param.data = param.data.to(base_dtype)
 
         return module
 

--- a/verl/workers/rollout/base.py
+++ b/verl/workers/rollout/base.py
@@ -84,6 +84,7 @@ _ROLLOUT_REGISTRY = {
     ("vllm", "async"): "verl.workers.rollout.vllm_rollout.ServerAdapter",
     ("sglang", "async"): "verl.workers.rollout.sglang_rollout.sglang_rollout.ServerAdapter",
     ("trtllm", "async"): "verl.workers.rollout.trtllm_rollout.trtllm_rollout.ServerAdapter",
+    ("vllm_omni", "async"): "verl.workers.rollout.vllm_rollout.ServerAdapter",
 }
 
 

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -374,10 +374,17 @@ def _load_trtllm():
     return TRTLLMReplica
 
 
+def _load_vllm_omni():
+    from verl_omni.workers.rollout.vllm_rollout.vllm_omni_async_server import vLLMOmniReplica
+
+    return vLLMOmniReplica
+
+
 # Register built-in types
 RolloutReplicaRegistry.register("vllm", _load_vllm)
 RolloutReplicaRegistry.register("sglang", _load_sglang)
 RolloutReplicaRegistry.register("trtllm", _load_trtllm)
+RolloutReplicaRegistry.register("vllm_omni", _load_vllm_omni)
 
 
 def get_rollout_replica_class(rollout: str, disaggregation_enabled: bool = False) -> type[RolloutReplica]:


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end support for training the Qwen3-Omni-30B-A3B Thinker stage via LoRA + GSPO using verl's FSDP backend and verl-omni's `vllm_omni` rollout. 

Tested on Qwen3-Omni-30B-A3B-Instruct, 4× H100 80GB. Pipeline runs through rollout, ref-logprob, actor update, ckpt save / resume, and val.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - No existing PR addresses Qwen3-Omni training support or the MoE-wrap `layered_summon` issue.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI). Title: `[trainer, fsdp, rollout, model, data] feat: Qwen3-Omni-30B-A3B RL training support`.
- [x] No `[BREAKING]` — all changes are additive or behavior-compatible (existing models / configs unaffected).

### Test

CI cannot exercise Qwen3-Omni (the model needs ~30 GB on disk and 4× H100 80GB to run end-to-end). Validated by manual smoke test:

```
# After applying this PR + corresponding verl-omni / vllm-omni PRs:
bash examples/gspo_trainer/run_qwen3_omni_thinker_gspo_lora.sh \
    trainer.total_training_steps=2 \
    data.val_max_samples=20
```

### API and Usage Example
No public API changes. New behavior is opt-in via the model class (Qwen3OmniMoeForConditionalGeneration), the rollout name (vllm_omni), and the optional _verl_strip_modules / _FalseTieDescriptor hooks on the model class — all of which only activate for Qwen3-Omni.

### Design & Code Changes
8 files touched. Each change is scoped and targeted:

verl/utils/tokenizer.py (+11)
```
Add a Qwen3OmniMoeProcessor arm to the match block in hf_processor().
Token IDs (image_token_id, vision_start_token_id, audio_token_id, position_id_per_seconds) live on thinker_config, not the top-level Qwen3OmniMoeConfig that AutoConfig returns; override processor.config = config.thinker_config so the bound get_rope_index finds them.
Expose processor.spatial_merge_size (model-level attribute, not on the config) and bind get_llm_pos_ids_for_vision (helper called by get_rope_index) so multimodal RoPE position computation works on the processor object.
```

verl/utils/model.py (+70)
```
Register Qwen3OmniMoeForConditionalGeneration with AutoModelForCausalLM. Despite the suffix, the Thinker is a decoder-only causal LM; downstream code paths (FSDP engine, LoRA target matching) all go through AutoModelForCausalLM.
Patch forward / get_input_embeddings / set_input_embeddings to delegate to self.thinker, so the full Qwen3OmniMoe...ForConditionalGeneration wrapper transparently behaves like the Thinker for training purposes.
_no_split_modules: upstream class incorrectly references Qwen3OmniMoeDecoderLayer (does not exist); set to the real class Qwen3OmniMoeThinkerTextDecoderLayer.
Add _verl_strip_modules = ["talker", "code2wav", "code_predictor"] — consumed by the FSDP engine (next file) to drop unused sub-modules and free GPU memory during Thinker post-training.
Use a _FalseTieDescriptor to override tie_word_embeddings at the config-class level: the upstream config sets it True, which forces use_meta_tensor=False in FSDP init and OOMs on 30B-A3B; the descriptor returns False while tolerating no-op writes from __init__.
All wrapped in try / except ImportError so users without the Qwen3-Omni transformers package are unaffected.
```

verl/utils/fsdp_utils.py (+88, −38)
```
get_fsdp_wrap_policy: skip the LoRA lambda policy when min_num_params > 0. Combining the size policy with the lambda policy creates nested FSDP units (LoRA leaves inside decoder-layer units) whose allgather order can diverge across ranks under variable-length inputs (use_remove_padding), causing NCCL deadlocks.
Rewrite layered_summon_lora_params to iterate FSDP units directly via named_modules() + fsdp_version(), instead of matching a fixed list of layer-level prefixes. The previous implementation assumed wrap landed at the transformer-layer level — on MoE models it typically lands at layers.<i>.mlp (because each MoE MLP exceeds min_num_params while attention does not), so the prefix list matched zero FSDP units and the function returned empty. The rewrite is wrap-granularity-agnostic and works for dense, MoE, and omni-modality models. Adds an is_diffusers parameter (currently unused on this side, threaded through for the matching verl-omni PR).
collect_lora_params: pass is_diffusers through; if layered_summon_lora_params still returns empty (e.g. unusual wrap graph), fall back to a single full summon and warn instead of silently shipping zero LoRA tensors.
```

verl/workers/engine/fsdp/transformer_impl.py (+22)
```
After auto_class.from_pretrained(...), strip any sub-modules listed in module._verl_strip_modules (e.g. talker / code2wav / code_predictor for Qwen3-Omni Thinker-only training). Without this the Talker stack is also loaded onto GPU and OOMs on 30B-A3B.
After get_peft_model(...), cast LoRA adapter params to the base model's dtype if (and only if) they actually mismatch. Mixed bf16 base + fp32 adapter trips FSDP's "all params in a flat group must share dtype" assertion. The cast is logged so users can see when it fires.
```

verl/workers/rollout/base.py (+1) and verl/workers/rollout/replica.py (+7)
```
Register ("vllm_omni", "async") in _ROLLOUT_REGISTRY.
Register vllm_omni in RolloutReplicaRegistry, pointing at the vLLMOmniReplica provided by verl-omni.
```

verl/utils/vllm/utils.py (+5, −2)
```
Detect verl-omni's OmniTensorLoRARequest via duck typing (hasattr(lora_request, "peft_config") and hasattr(lora_request, "lora_tensors")) in addition to isinstance(lora_request, TensorLoRARequest). Pre-existing isinstance flows continue to work; the new check only matters for verl-omni's own subclass.
```

verl/models/transformers/monkey_patch.py (+4, −2)
```
apply_monkey_patch: when the top-level config does not directly expose text_config, fall back to model.config.get_text_config(). Some multimodal configs (Qwen3-Omni's Qwen3OmniMoeConfig) nest text_config under thinker_config and expose it only via the helper.
```

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
