### PR TITLE
[cfg] fix: align dataclass defaults with yaml

### DIFF
--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -175,7 +175,7 @@ class ActorConfig(BaseConfig):
     kl_loss_type: str = "low_var_kl"
     ppo_epochs: int = 1
     shuffle: bool = False
-    data_loader_seed: int = 1
+    data_loader_seed: int = 42
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
     optim: OptimizerConfig = field(default_factory=OptimizerConfig)
     use_fused_kernels: bool = False

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -88,7 +88,7 @@ class CriticConfig(BaseConfig):
     ppo_infer_micro_batch_size_per_gpu: Optional[int] = None
     ppo_infer_max_token_len_per_gpu: int = 32768
     ppo_epochs: int = 1
-    data_loader_seed: int = 1
+    data_loader_seed: int = 42
     shuffle: bool = True
     cliprange_value: float = 0.5
     loss_agg_mode: str = "token-mean"

--- a/verl/workers/config/reward.py
+++ b/verl/workers/config/reward.py
@@ -84,7 +84,7 @@ class RewardModelConfig(BaseConfig):
 
     enable: bool = False
     enable_resource_pool: bool = False
-    n_gpus_per_node: int = 0
+    n_gpus_per_node: int = 8
     nnodes: int = 0
     model_path: Optional[str] = None
     rollout: RolloutConfig = field(default_factory=RolloutConfig)

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -191,7 +191,7 @@ class RolloutConfig(BaseConfig):
     dtype: str = "bfloat16"
     gpu_memory_utilization: float = 0.5
     ignore_eos: bool = False
-    enforce_eager: bool = True
+    enforce_eager: bool = False
     cudagraph_capture_sizes: Optional[list] = None
     free_cache_engine: bool = True
     data_parallel_size: int = 1
@@ -265,7 +265,7 @@ class RolloutConfig(BaseConfig):
 
     limit_images: Optional[int] = None
 
-    skip_tokenizer_init: bool = False
+    skip_tokenizer_init: bool = True
 
     quantization: Optional[str] = None
 


### PR DESCRIPTION
Match Python dataclass defaults to the Hydra YAML defaults for rollout, actor, critic, and reward model configs.

This keeps direct config instantiation consistent with the normal training entrypoint and avoids zero-sized reward model resource pools.


Fixes #6479


### What does this PR do?
 This PR aligns Python dataclass defaults with the existing Hydra YAML defaults for config fields that can otherwise behave differently when configs are instantiated directly in tests or custom integrations.

  The normal Hydra/YAML training entrypoint behavior is unchanged. This only makes direct dataclass construction consistent with those YAML defaults.


### Checklist Before Starting
 - [x] Search for similar PRs. Paste at least one query link here:
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6479+in%3Abody
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+config+default+mismatch+enforce_eager+data_loader_seed+n_gpus_per_node
  - [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)


### Test

```bash
  /private/tmp/verl-6479-test-venv/bin/python -m pytest tests/workers/config/test_config_defaults_on_cpu.py -q
  # 3 passed

  /private/tmp/verl-6479-test-venv/bin/python -m pytest tests/workers/config/test_actor_config_on_cpu.py tests/workers/config/test_critic_config_on_cpu.py tests/workers/config/test_config_defaults_on_cpu.py -q
  # 13 passed, 10 skipped

  /private/tmp/verl-6479-test-venv/bin/ruff check verl/workers/config/rollout.py verl/workers/config/actor.py verl/workers/config/critic.py verl/workers/config/reward.py tests/workers/config/test_config_defaults_on_cpu.py
  # All checks passed

  /private/tmp/verl-6479-test-venv/bin/ruff format --check verl/workers/config/rollout.py verl/workers/config/actor.py verl/workers/config/critic.py verl/workers/config/reward.py tests/workers/config/test_config_defaults_on_cpu.py
  # 5 files already formatted

  PATH=/private/tmp/verl-6479-test-venv/bin:$PATH /private/tmp/verl-6479-test-venv/bin/pre-commit run --files verl/workers/config/rollout.py verl/workers/config/actor.py verl/workers/config/critic.py verl/workers/config/reward.py tests/workers/config/
  test_config_defaults_on_cpu.py --show-diff-on-failure --color=always
  # Passed


### API and Usage Example
  No public API is changed.

  Direct dataclass instantiation now matches the existing YAML defaults:

  from verl.workers.config import ActorConfig, CriticConfig, RewardModelConfig, RolloutConfig

  assert RolloutConfig(name="vllm").enforce_eager is False
  assert RolloutConfig(name="vllm").skip_tokenizer_init is True
  assert ActorConfig(strategy="fsdp", rollout_n=1, ppo_micro_batch_size_per_gpu=1).data_loader_seed == 42
  assert CriticConfig(strategy="fsdp", ppo_micro_batch_size_per_gpu=1).data_loader_seed == 42
  assert RewardModelConfig().n_gpus_per_node == 8

### Design & Code Changes
  - Align RolloutConfig.enforce_eager with verl/trainer/config/rollout/rollout.yaml.
  - Align RolloutConfig.skip_tokenizer_init with verl/trainer/config/rollout/rollout.yaml.
  - Align ActorConfig.data_loader_seed with verl/trainer/config/actor/actor.yaml.
  - Align CriticConfig.data_loader_seed with verl/trainer/config/critic/critic.yaml.
  - Align RewardModelConfig.n_gpus_per_node with verl/trainer/config/reward/reward.yaml.
  - Add CPU regression coverage in tests/workers/config/test_config_defaults_on_cpu.py.

### Checklist Before Submitting
  - [x] Read the Contribute Guide (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
  - [ ] Apply pre-commit checks (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always
      - Changed-file pre-commit was run and passed.
  - [ ] Add / Update the documentation (https://github.com/verl-project/verl/tree/main/docs).
      - Not needed; this fixes internal config defaults and adds unit coverage.
  - [x] Add unit or end-to-end test(s) to the CI workflow (https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
      - Added tests/workers/config/test_config_defaults_on_cpu.py.
  - [ ] Once your PR is ready for CI, send a message in the ci-request channel (https://verl-project.slack.com/archives/C091TCESWB1) in the verl Slack workspace (https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not
    accessible, please try the Feishu group (飞书群) (https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
  - [ ] If your PR is related to the recipe submodule, please also update the reference to the submodule commit via git submodule update --remote or cd recipe && git pull origin main.

  ### AI Assistance

The hunman inspects the issue, makes the focused code/test changes, and AI runs verification commands. AI prepares this PR report. The human submitter  reviewed the final diff and PR text before submission.
