### PR TITLE
[worker, model] fix: respect attn_implementation override in load_valuehead_model

### DIFF
--- a/tests/utils/test_model_on_cpu.py
+++ b/tests/utils/test_model_on_cpu.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from types import SimpleNamespace  # Or use a mock object library
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from verl.utils.model import update_model_config
+from verl.utils.model import load_valuehead_model, update_model_config
 
 
 # Parametrize with different override scenarios
@@ -50,3 +51,107 @@ def test_update_model_config(override_kwargs):
         assert mock_config.nested_params.sub_param_x == "original_x", "Nested sub_param_x should be unchanged"
         assert mock_config.nested_params.sub_param_y == 100, "Nested sub_param_y should be unchanged"
         assert not hasattr(mock_config.nested_params, "sub_param_z"), "Nested sub_param_z should not exist"
+
+
+# ---------------------------------------------------------------------------
+# load_valuehead_model: attn_implementation precedence
+# ---------------------------------------------------------------------------
+# These tests pin down the attention-implementation selection contract so the
+# documented ``critic.model.override_config.attn_implementation`` knob keeps
+# working on hardware that cannot run ``flash_attention_2`` (e.g. Turing T4
+# and other pre-Ampere GPUs).
+#
+# Resolution order inside ``load_valuehead_model``:
+#   1. explicit ``attn_implementation`` kwarg
+#   2. ``getattr(model_config, "_attn_implementation", None)``
+#   3. ``"flash_attention_2"`` (historical default)
+
+
+def _make_model_config(_attn_implementation=None):
+    """Build a minimal stand-in for a ``transformers`` ``PretrainedConfig``.
+
+    Only ``_attn_implementation`` is populated, mimicking what
+    ``AutoConfig.from_pretrained(..., attn_implementation=...)`` (and verl's
+    ``HFModelConfig``) would bake in.
+    """
+    cfg = SimpleNamespace()
+    if _attn_implementation is not None:
+        cfg._attn_implementation = _attn_implementation
+    return cfg
+
+
+@pytest.fixture
+def mock_token_classification_from_pretrained():
+    """Patch ``AutoModelForTokenClassification.from_pretrained`` so the test stays CPU-only."""
+    with patch("transformers.AutoModelForTokenClassification.from_pretrained") as mocked:
+        mocked.return_value = MagicMock(name="fake-valuehead-model")
+        yield mocked
+
+
+def test_load_valuehead_model_explicit_attn_implementation_wins(mock_token_classification_from_pretrained):
+    """An explicit ``attn_implementation`` argument must override the config default."""
+    model_config = _make_model_config(_attn_implementation="flash_attention_2")
+
+    load_valuehead_model(
+        local_path="/tmp/fake",
+        torch_dtype="float32",
+        model_config=model_config,
+        trust_remote_code=False,
+        attn_implementation="sdpa",
+    )
+
+    assert mock_token_classification_from_pretrained.call_count == 1
+    kwargs = mock_token_classification_from_pretrained.call_args.kwargs
+    assert kwargs["attn_implementation"] == "sdpa"
+    assert kwargs["pretrained_model_name_or_path"] == "/tmp/fake"
+    assert kwargs["config"] is model_config
+    assert kwargs["trust_remote_code"] is False
+
+
+@pytest.mark.parametrize("impl", ["sdpa", "eager", "flash_attention_2"])
+def test_load_valuehead_model_falls_back_to_model_config(mock_token_classification_from_pretrained, impl):
+    """When no explicit value is given, honour ``model_config._attn_implementation``.
+
+    Regression guard for the documented
+    ``critic.model.override_config.attn_implementation`` override: previously
+    ``load_valuehead_model`` hard-coded ``"flash_attention_2"`` and silently
+    ignored whatever the caller had baked into ``model_config``.
+    """
+    model_config = _make_model_config(_attn_implementation=impl)
+
+    load_valuehead_model(
+        local_path="/tmp/fake",
+        torch_dtype="float32",
+        model_config=model_config,
+        trust_remote_code=False,
+    )
+
+    assert mock_token_classification_from_pretrained.call_args.kwargs["attn_implementation"] == impl
+
+
+def test_load_valuehead_model_defaults_to_flash_attention_2(mock_token_classification_from_pretrained):
+    """Preserve the historical default for callers that pre-date the knob."""
+    model_config = _make_model_config(_attn_implementation=None)
+
+    load_valuehead_model(
+        local_path="/tmp/fake",
+        torch_dtype="float32",
+        model_config=model_config,
+        trust_remote_code=False,
+    )
+
+    assert mock_token_classification_from_pretrained.call_args.kwargs["attn_implementation"] == "flash_attention_2"
+
+
+def test_load_valuehead_model_explicit_none_attr_falls_back(mock_token_classification_from_pretrained):
+    """``_attn_implementation`` explicitly set to ``None`` must still fall back to FA2."""
+    model_config = SimpleNamespace(_attn_implementation=None)
+
+    load_valuehead_model(
+        local_path="/tmp/fake",
+        torch_dtype="float32",
+        model_config=model_config,
+        trust_remote_code=False,
+    )
+
+    assert mock_token_classification_from_pretrained.call_args.kwargs["attn_implementation"] == "flash_attention_2"

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -634,15 +634,38 @@ def patch_valuehead_model(model) -> None:
     model._no_split_modules = getattr(model.pretrained_model, "_no_split_modules", [])
 
 
-def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code):
+def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code, attn_implementation=None):
+    """Load a value-head model (used by critic / reward).
+
+    Args:
+        local_path: Path to the pretrained model.
+        torch_dtype: Target torch dtype.
+        model_config: A ``transformers`` config whose ``_attn_implementation`` will be used
+            as the default when ``attn_implementation`` is not provided.
+        trust_remote_code: Whether to trust remote code in the hub repo.
+        attn_implementation: Explicit attention implementation override
+            (e.g. ``"flash_attention_2"``, ``"sdpa"``, ``"eager"``). When ``None``, this
+            function falls back to ``getattr(model_config, "_attn_implementation", None)``
+            and finally to ``"flash_attention_2"`` to preserve the historical default.
+
+    Note:
+        Older versions of this function hard-coded ``attn_implementation="flash_attention_2"``
+        and ignored the ``_attn_implementation`` baked into ``model_config``, which broke the
+        documented ``critic.model.override_config.attn_implementation`` override on hardware
+        without FA2 support (e.g. Turing T4, pre-Ampere). See
+        https://verl.readthedocs.io/en/latest/advance/attention_implementation.html.
+    """
     from transformers import AutoModelForCausalLM, AutoModelForTokenClassification
+
+    if attn_implementation is None:
+        attn_implementation = getattr(model_config, "_attn_implementation", None) or "flash_attention_2"
 
     try:
         model = AutoModelForTokenClassification.from_pretrained(
             pretrained_model_name_or_path=local_path,
             torch_dtype=torch_dtype,
             config=model_config,
-            attn_implementation="flash_attention_2",
+            attn_implementation=attn_implementation,
             trust_remote_code=trust_remote_code,
         )
         return model
@@ -664,7 +687,7 @@ def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_cod
         pretrained_model_name_or_path=local_path,
         torch_dtype=torch_dtype,
         config=model_config,
-        attn_implementation="flash_attention_2",
+        attn_implementation=attn_implementation,
         trust_remote_code=trust_remote_code,
     )
     # vlm models


### PR DESCRIPTION
### What does this PR do?

Currently, load_valuehead_model() hard-coded `attn_implementation='flash_attention_2'`. 
This broke the documented `critic.model.override_config.attn_implementation` knob on hardware that cannot run FlashAttention-2 (e.g. Turing T4, V100, and other pre-Ampere GPUs), surfacing as:
```
  RuntimeError: FlashAttention only supports Ampere GPUs or newer.
```

Even though the user had explicitly asked for sdpa/eager.

一句话总结：解决现在 T4 卡上用 sdpa 跑不起来verl 的问题（因为代码里写死了`attn_implementation='flash_attention_2'`）

### How to reproduce?
Environment:

Hardware: NVIDIA T4 

Software: PyTorch 2.5.1 + vLLM.

Requirements:
```
verl==0.7.1
vllm==0.13.0
```

Download Qwen2.5-0.5B and openai/gsm8k

Run verl:
```
python3 -u -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    algorithm.kl_ctrl.kl_coef=0.001 \
    data.train_files=$HOME/data/gsm8k/train.parquet \
    data.val_files=$HOME/data/gsm8k/test.parquet \
    data.train_batch_size=32 \
    data.max_prompt_length=256 \
    data.max_response_length=256 \
    actor_rollout_ref.model.path=$HOME/Qwen/Qwen2.5-0.5B-Instruct \
    actor_rollout_ref.model.enable_gradient_checkpointing=True \
    actor_rollout_ref.model.use_remove_padding=False \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.actor.ppo_mini_batch_size=16 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
    actor_rollout_ref.actor.fsdp_config.param_offload=True \
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \
    actor_rollout_ref.ref.fsdp_config.param_offload=True \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.3 \
    actor_rollout_ref.rollout.enforce_eager=True \
    actor_rollout_ref.rollout.free_cache_engine=True \
    actor_rollout_ref.rollout.n=4 \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
    trainer.logger=console \
    trainer.project_name=verl_grpo_gsm8k_demo \
    trainer.experiment_name=qwen2.5_0.5b_t4 \
    trainer.n_gpus_per_node=1 \
    trainer.nnodes=1 \
    trainer.val_before_train=False \
    trainer.save_freq=-1 \
    trainer.test_freq=5 \
    trainer.total_epochs=1
```

Error：
```
Error executing job with overrides: ['algorithm.adv_estimator=grpo', 'algorithm.kl_ctrl.kl_coef=0.001', 'data.train_files=/home/ray/data/gsm8k/train.parquet', 'data.val_files=/home/ray/data/gsm8k/test.parquet', 'data.train_batch_size=32', 'data.max_prompt_length=256', 'data.max_response_length=256', 'actor_rollout_ref.model.path=/home/ray/Qwen/Qwen2.5-0.5B-Instruct', 'actor_rollout_ref.model.enable_gradient_checkpointing=True', 'actor_rollout_ref.model.use_remove_padding=False', 'actor_rollout_ref.actor.optim.lr=1e-6', 'actor_rollout_ref.actor.ppo_mini_batch_size=16', 'actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1', 'actor_rollout_ref.actor.use_kl_loss=True', 'actor_rollout_ref.actor.kl_loss_coef=0.001', 'actor_rollout_ref.actor.kl_loss_type=low_var_kl', 'actor_rollout_ref.actor.fsdp_config.param_offload=True', 'actor_rollout_ref.actor.fsdp_config.optimizer_offload=True', 'actor_rollout_ref.ref.fsdp_config.param_offload=True', 'actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1', 'actor_rollout_ref.rollout.name=vllm', 'actor_rollout_ref.rollout.tensor_model_parallel_size=1', 'actor_rollout_ref.rollout.gpu_memory_utilization=0.3', 'actor_rollout_ref.rollout.enforce_eager=True', 'actor_rollout_ref.rollout.free_cache_engine=True', 'actor_rollout_ref.rollout.n=4', 'actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1', 'trainer.logger=console', 'trainer.project_name=verl_grpo_gsm8k_demo', 'trainer.experiment_name=qwen2.5_0.5b_t4', 'trainer.n_gpus_per_node=1', 'trainer.nnodes=1', 'trainer.val_before_train=False', 'trainer.save_freq=-1', 'trainer.test_freq=5', 'trainer.total_epochs=1']
Traceback (most recent call last):
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/trainer/main_ppo.py", line 45, in main
    run_ppo(config)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/trainer/main_ppo.py", line 99, in run_ppo
    ray.get(runner.run.remote(config))
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 104, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 2967, in get
    values, debugger_breakpoint = worker.get_objects(
                                  ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/ray/_private/worker.py", line 1015, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(ImportError): ray::TaskRunner.run() (pid=6392, ip=10.206.23.1, actor_id=83779f05fb7f96d12799ee7603000000, repr=<main_ppo.TaskRunner object at 0x7f85bc8c1350>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/trainer/main_ppo.py", line 356, in run
    trainer.init_workers()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/trainer/ppo/ray_trainer.py", line 794, in init_workers
    self.ref_policy_wg.init_model()
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/single_controller/ray/base.py", line 55, in __call__
    output = ray.get(output)
             ^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^
                                  ^^^^^^^^^^^^^^^^^^^
ray.exceptions.RayTaskError(ImportError): ray::WorkerDict.ref_init_model() (pid=6536, ip=10.206.23.1, actor_id=20d015c2d53042334b29473603000000, repr=<verl.single_controller.ray.base.WorkerDict object at 0x7f596fefe190>)
  File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 456, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
           ^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/single_controller/ray/base.py", line 932, in func
    return getattr(self.worker_dict[key], name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/single_controller/base/decorator.py", line 427, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/workers/fsdp_workers.py", line 948, in init_model
    self.ref_module_fsdp = self._build_model_optimizer(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/verl/workers/fsdp_workers.py", line 469, in _build_model_optimizer
    actor_module = actor_module_class.from_pretrained(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 604, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 277, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 4971, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/models/qwen2/modeling_qwen2.py", line 409, in __init__
    super().__init__(config)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 2076, in __init__
    self.config._attn_implementation_internal = self._check_and_adjust_attn_implementation(
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 2686, in _check_and_adjust_attn_implementation
    applicable_attn_implementation = self.get_correct_attn_implementation(
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 2714, in get_correct_attn_implementation
    self._flash_attn_2_can_dispatch(is_init_check)
  File "/home/ray/anaconda3/lib/python3.11/site-packages/transformers/modeling_utils.py", line 2422, in _flash_attn_2_can_dispatch
    raise ImportError(f"{preface} the package flash_attn seems to be not installed. {install_message}")
ImportError: FlashAttention2 has been toggled on, but it cannot be used due to the following error: the package flash_attn seems to be not installed. Please refer to the documentation of https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2 to install Flash Attention 2.
```

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

UT added 

