### PR TITLE
[fsdp] fix: add sp and use_remove_padding validation for SFT and RL in fsdp engine

### DIFF
--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -324,12 +324,6 @@ class FSDPActorConfig(ActorConfig):
         """Validate FSDP actor configuration with runtime parameters."""
         super().validate(n_gpus, train_batch_size, model_config)
 
-        if self.strategy in {"fsdp", "fsdp2"} and self.ulysses_sequence_parallel_size > 1:
-            if model_config and not model_config.get("use_remove_padding", False):
-                raise ValueError(
-                    "When using sequence parallelism for actor/ref policy, you must enable `use_remove_padding`."
-                )
-
 
 @dataclass
 class VeOmniActorConfig(ActorConfig):

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -216,13 +216,6 @@ class FSDPCriticConfig(CriticConfig):
         # falls back to FSDP1 even when critic.strategy="fsdp2".
         object.__setattr__(self.engine, "strategy", self.strategy)
 
-        if self.strategy in {"fsdp", "fsdp2"}:
-            if self.ulysses_sequence_parallel_size > 1:
-                if not self.model.get("use_remove_padding", False):
-                    raise ValueError(
-                        "When using sequence parallelism for critic, you must enable `use_remove_padding`."
-                    )
-
     def validate(self, n_gpus: int, train_batch_size: int):
         """Validate FSDP critic configuration with runtime parameters."""
         super().validate(n_gpus, train_batch_size)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -124,6 +124,12 @@ class FSDPEngine(BaseEngine):
 
         self.use_remove_padding = self.model_config.use_remove_padding
 
+        if self.engine_config.ulysses_sequence_parallel_size > 1 and not self.use_remove_padding:
+            raise ValueError(
+                "When using sequence parallelism (ulysses_sequence_parallel_size > 1), "
+                "you must enable `use_remove_padding`."
+            )
+
         self._init_device_mesh()
 
         if self.engine_config.full_determinism:


### PR DESCRIPTION
### What does this PR do?

Move the use_remove_padding + sequence parallelism validation from upper-level config classes into FSDPEngine.__init__(), ensuring both SFT and RL training paths are uniformly covered.

When using Ulysses sequence parallelism (ulysses_sequence_parallel_size > 1), use_remove_padding must be enabled – this is an FSDP engine-level requirement. However, the validation for this constraint was only present in FSDPActorConfig.validate() and FSDPCriticConfig.__post_init__(), which are RL-specific config wrappers. The SFT trainer uses FSDPEngineConfig directly and bypasses these wrappers entirely, so SFT had no validation at all – a misconfigured SFT run with SP enabled but use_remove_padding disabled would fail silently or with obscure runtime errors.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
