### PR TITLE
[megatron, trainer] fix: preserve BSHD top-k distillation shape

### DIFF
--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression coverage for verl#6492."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size: int = 4):
+    megatron = types.ModuleType("megatron")
+    core = types.ModuleType("megatron.core")
+    parallel_state = types.ModuleType("megatron.core.parallel_state")
+    packed_seq_params = types.ModuleType("megatron.core.packed_seq_params")
+
+    parallel_state.get_context_parallel_world_size = lambda: 1
+    parallel_state.get_context_parallel_rank = lambda: 0
+    parallel_state.get_tensor_model_parallel_world_size = lambda: tp_size
+    packed_seq_params.PackedSeqParams = type("PackedSeqParams", (), {})
+
+    core.parallel_state = parallel_state
+    megatron.core = core
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.parallel_state", parallel_state)
+    monkeypatch.setitem(sys.modules, "megatron.core.packed_seq_params", packed_seq_params)
+
+    util_path = Path(__file__).parents[2] / "verl" / "models" / "mcore" / "util.py"
+    spec = importlib.util.spec_from_file_location("mcore_util_regression", util_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _nested_tensor(rows: list[torch.Tensor]) -> torch.Tensor:
+    return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+
+def _check_topk_preprocess(monkeypatch, device: torch.device):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch)
+    topk = 64
+
+    logprob_rows = [
+        torch.arange(3 * topk, dtype=torch.float32, device=device).reshape(3, topk),
+        torch.arange(2 * topk, dtype=torch.float32, device=device).reshape(2, topk) + 1000,
+    ]
+    teacher_logprobs = _nested_tensor(logprob_rows)
+
+    logprobs_bshd, attention_mask, position_ids = mcore_util.preprocess_bshd_engine(teacher_logprobs)
+
+    assert logprobs_bshd.shape == (2, 4, topk)
+    assert logprobs_bshd.device.type == device.type
+    assert attention_mask.device.type == device.type
+    assert position_ids.shape == (2, 4)
+    torch.testing.assert_close(logprobs_bshd[0, :3], logprob_rows[0])
+    torch.testing.assert_close(logprobs_bshd[1, :2], logprob_rows[1])
+    torch.testing.assert_close(logprobs_bshd[0, 3], torch.zeros(topk, dtype=torch.float32, device=device))
+    torch.testing.assert_close(logprobs_bshd[1, 2:], torch.zeros(2, topk, dtype=torch.float32, device=device))
+    torch.testing.assert_close(
+        attention_mask,
+        torch.tensor([[True, True, True, False], [True, True, False, False]], device=device),
+    )
+    torch.testing.assert_close(
+        position_ids,
+        torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long, device=device),
+    )
+
+    id_rows = [
+        torch.arange(3 * topk, dtype=torch.long, device=device).reshape(3, topk),
+        torch.arange(2 * topk, dtype=torch.long, device=device).reshape(2, topk) + 2000,
+    ]
+    teacher_ids = _nested_tensor(id_rows)
+    ids_bshd, ids_attention_mask, _ = mcore_util.preprocess_bshd_engine(teacher_ids)
+
+    assert ids_bshd.shape == (2, 4, topk)
+    assert ids_bshd.dtype == torch.long
+    torch.testing.assert_close(ids_bshd[0, :3], id_rows[0])
+    torch.testing.assert_close(ids_bshd[1, :2], id_rows[1])
+    torch.testing.assert_close(ids_attention_mask, attention_mask)
+
+
+def test_preprocess_bshd_engine_preserves_1d_input_shape_on_cpu(monkeypatch):
+    mcore_util = _load_mcore_util_with_stubbed_megatron(monkeypatch)
+    rows = [
+        torch.tensor([11, 12, 13], dtype=torch.long),
+        torch.tensor([21, 22], dtype=torch.long),
+    ]
+    input_ids = _nested_tensor(rows)
+
+    input_ids_bshd, attention_mask, position_ids = mcore_util.preprocess_bshd_engine(input_ids)
+
+    assert input_ids_bshd.shape == (2, 4)
+    torch.testing.assert_close(input_ids_bshd[0], torch.tensor([11, 12, 13, 0], dtype=torch.long))
+    torch.testing.assert_close(input_ids_bshd[1], torch.tensor([21, 22, 0, 0], dtype=torch.long))
+    torch.testing.assert_close(
+        attention_mask,
+        torch.tensor([[True, True, True, False], [True, True, False, False]]),
+    )
+    torch.testing.assert_close(position_ids, torch.tensor([[0, 1, 2, 3], [0, 1, 2, 3]], dtype=torch.long))
+
+
+def test_preprocess_bshd_engine_preserves_topk_dense_dim_on_cpu(monkeypatch):
+    _check_topk_preprocess(monkeypatch, torch.device("cpu"))
+
+
+def test_preprocess_bshd_engine_preserves_topk_dense_dim_on_gpu(monkeypatch):
+    if not torch.cuda.is_available():
+        pytest.skip("Requires CUDA")
+    _check_topk_preprocess(monkeypatch, torch.device("cuda"))

--- a/tests/utils/test_special_megatron_kl_loss_tp.py
+++ b/tests/utils/test_special_megatron_kl_loss_tp.py
@@ -120,6 +120,24 @@ class TestVocabParallelKLDivergence:
     def to_nested(self, tensor: torch.Tensor) -> torch.Tensor:
         return torch.nested.as_nested_tensor([tensor[i] for i in range(tensor.shape[0])], layout=torch.jagged)
 
+    def pad_for_bshd_preprocess(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Mirror preprocess_bshd_engine's CP=1 sequence padding for student logits."""
+        assert mpu.get_context_parallel_world_size() == 1, "This TP KL test does not initialize context parallelism"
+        align_size = mpu.get_tensor_model_parallel_world_size()
+        pad_size = (align_size - tensor.shape[1] % align_size) % align_size
+        if pad_size == 0:
+            return tensor
+
+        padded = torch.zeros(
+            tensor.shape[0],
+            tensor.shape[1] + pad_size,
+            *tensor.shape[2:],
+            dtype=tensor.dtype,
+            device=tensor.device,
+        )
+        padded[:, : tensor.shape[1]] = tensor
+        return padded
+
     def verify_correctness(self, iterations: int = 5):
         self.cleanup()
         self.generate_hyper()
@@ -138,12 +156,13 @@ class TestVocabParallelKLDivergence:
             dist.broadcast(full_student_logits, src=0, group=self.group)
             dist.broadcast(teacher_topk_logps, src=0, group=self.group)
             dist.broadcast(teacher_topk_ids, src=0, group=self.group)
-            full_student_logits = full_student_logits.reshape(1, -1, self.vocab_size)
+            full_student_logits_bshd = full_student_logits
+            full_student_logits_thd = full_student_logits_bshd.reshape(1, -1, self.vocab_size)
             teacher_topk_logps = self.to_nested(teacher_topk_logps)
             teacher_topk_ids = self.to_nested(teacher_topk_ids)
 
             # VP implementation on sharded logits
-            vp_logits = full_student_logits[..., shard_start:shard_end].contiguous().detach().requires_grad_(True)
+            vp_logits = full_student_logits_thd[..., shard_start:shard_end].contiguous().detach().requires_grad_(True)
             loss_out = compute_forward_kl_topk_vp(
                 student_logits=vp_logits,
                 teacher_topk_log_probs=teacher_topk_logps,
@@ -156,7 +175,7 @@ class TestVocabParallelKLDivergence:
             grad_vp = vp_logits.grad.detach().clone()
 
             # Reference implementation on full logits
-            full_ref = full_student_logits.detach().clone().requires_grad_(True)
+            full_ref = full_student_logits_thd.detach().clone().requires_grad_(True)
             fsdp_loss_out = compute_forward_kl_topk_ref(
                 student_logits=full_ref,
                 teacher_topk_log_probs=teacher_topk_logps,
@@ -180,6 +199,39 @@ class TestVocabParallelKLDivergence:
 
             # Compare gradients
             torch.testing.assert_close(grad_vp, grad_ref_shard, atol=1e-4, rtol=1e-4)
+
+            # BSHD path should preserve the top-k dense dimension when preprocessing teacher tensors.
+            full_student_logits_bshd_padded = self.pad_for_bshd_preprocess(full_student_logits_bshd)
+            vp_logits_bshd = (
+                full_student_logits_bshd_padded[..., shard_start:shard_end].contiguous().detach().requires_grad_(True)
+            )
+            loss_out_bshd = compute_forward_kl_topk_vp(
+                student_logits=vp_logits_bshd,
+                teacher_topk_log_probs=teacher_topk_logps,
+                teacher_topk_ids=teacher_topk_ids,
+                config=cfg,
+                data_format="bshd",
+            )
+            vp_loss_bshd = loss_out_bshd["distillation_losses"]
+            vp_loss_bshd[:, : self.seq_len].sum().backward()
+            grad_vp_bshd = vp_logits_bshd.grad.detach().clone()
+
+            torch.testing.assert_close(vp_loss_bshd[:, : self.seq_len].reshape(1, -1), ref_loss, atol=1e-4, rtol=1e-4)
+            torch.testing.assert_close(
+                loss_out_bshd["overlap_token_advantage"][:, : self.seq_len].reshape(1, -1),
+                fsdp_loss_out["overlap_token_advantage"],
+                atol=1e-4,
+                rtol=1e-4,
+            )
+            torch.testing.assert_close(
+                loss_out_bshd["overlap_count"][:, : self.seq_len].reshape(1, -1), fsdp_loss_out["overlap_count"]
+            )
+            torch.testing.assert_close(
+                grad_vp_bshd[:, : self.seq_len].reshape(1, -1, self.shard_size),
+                grad_ref_shard,
+                atol=1e-4,
+                rtol=1e-4,
+            )
 
         if self.local_rank == 0:
             print(f"[PASS] VP KL divergence correctness verified for test case {self.test_case_idx}")

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -567,11 +567,15 @@ def preprocess_bshd_engine(
     """
     Preprocess bshd sequences
     return "input_ids, attention_mask, position_ids"
+
+    The input is a jagged nested tensor with shape [batch, seq, ...]. Any
+    dense dimensions after seq are preserved in the returned padded tensor.
     """
     cp_size = mpu.get_context_parallel_world_size()
     cp_rank = mpu.get_context_parallel_rank()
 
     batch_size = input_ids.shape[0]
+    dense_shape = tuple(input_ids.shape[2:])
     seqlens_in_batch = input_ids.offsets().diff()
     max_seqlen = seqlens_in_batch.max().item()
     tp_size = mpu.get_tensor_model_parallel_world_size()
@@ -598,7 +602,9 @@ def preprocess_bshd_engine(
 
     local_max_seqlen = max_seqlen // cp_size if cp_size > 1 else max_seqlen
     attention_mask = torch.zeros(batch_size, local_max_seqlen, dtype=torch.bool, device=input_ids.device)
-    input_ids_bshd = torch.zeros(batch_size, local_max_seqlen, dtype=input_ids.dtype, device=input_ids.device)
+    input_ids_bshd = torch.zeros(
+        (batch_size, local_max_seqlen, *dense_shape), dtype=input_ids.dtype, device=input_ids.device
+    )
     seqlens_in_batch_cpu: list[int] = seqlens_in_batch.tolist()
     for i in range(batch_size):
         seqlen_i = int(seqlens_in_batch_cpu[i])
@@ -609,7 +615,7 @@ def preprocess_bshd_engine(
 
         seq = input_ids[i]
         if seqlen_i < max_seqlen:
-            seq_padded = torch.zeros(max_seqlen, dtype=seq.dtype, device=seq.device)
+            seq_padded = torch.zeros((max_seqlen, *dense_shape), dtype=seq.dtype, device=seq.device)
             seq_padded[:seqlen_i] = seq
             seq = seq_padded
 
@@ -639,7 +645,7 @@ def preprocess_bshd_engine(
 
     if cp_size <= 1:
         position_ids = torch.arange(local_max_seqlen, dtype=torch.long, device=input_ids.device)
-        position_ids = position_ids.unsqueeze(0).expand_as(input_ids_bshd)
+        position_ids = position_ids.unsqueeze(0).expand_as(attention_mask)
     else:
         chunk_len = max_seqlen // (2 * cp_size)
         first_pos = torch.arange(
@@ -651,7 +657,7 @@ def preprocess_bshd_engine(
             dtype=torch.long,
             device=input_ids.device,
         )
-        position_ids = torch.cat((first_pos, second_pos), dim=0).unsqueeze(0).expand_as(input_ids_bshd)
+        position_ids = torch.cat((first_pos, second_pos), dim=0).unsqueeze(0).expand_as(attention_mask)
     if need_roll and cp_size <= 1:
         input_ids_bshd = torch.roll(input_ids_bshd, shifts=-1, dims=1)
 


### PR DESCRIPTION
### What does this PR do?

Fixes #6492.

  Megatron OPD top-k distillation passes teacher tensors shaped like `[batch, seq_len, topk]` into the BSHD preprocessing path. `preprocess_bshd_engine` previously allocated padded tensors as if inputs were only `[batch, seq_len]`, so teacher top-k logprobs / ids
  could fail when `topk` is present.

  This PR updates `preprocess_bshd_engine` to preserve dense trailing dimensions after the sequence dimension, treating inputs as `[batch, seq_len, ...]`. Attention masks and position ids remain sequence-shaped `[batch, seq_len]`.

  It also adds regression coverage for:
  - regular 1D BSHD inputs;
  - teacher top-k tensors shaped `[batch, seq_len, 64]` on CPU and GPU;
  - Megatron vocab-parallel KL BSHD behavior compared with the THD/reference path, including TP sequence padding.


### Checklist Before Starting
  - [x] Search for similar PRs. Paste at least one query link here:
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6492+in%3Abody
    - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+megatron+distillation+topk+bshd+preprocess
    - `gh pr list --repo verl-project/verl --state open --search "6492 in:body"` returned no results.
    - `gh pr list --repo verl-project/verl --state open --search "megatron distillation topk bshd preprocess"` returned no results.
  - [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)


### Test

  python -m py_compile tests/utils/test_megatron_bshd_preprocess.py tests/utils/test_special_megatron_kl_loss_tp.py verl/models/mcore/util.py

  python -m pytest tests/utils/test_megatron_bshd_preprocess.py -q
   2 passed, 1 skipped

  xyz worker launch --resourcetype workspace --cpu 4 --memory 8 --gpu 1 --type Tesla-V100-SXM2-32GB --workdir /home/tiger/workspace/6492/verl --no-input --logdir /tmp/xyz-6492-preprocess -- python -m pytest tests/utils/test_megatron_bshd_preprocess.py -q
   3 passed in 9.98s
  
### API and Usage Example

  No public API or config changes.
### Design & Code Changes

  - verl/models/mcore/util.py
      - Preserve any dense trailing dimensions in preprocess_bshd_engine.
      - Allocate padded BSHD tensors as (batch, local_seq_len, *dense_shape).
      - Keep attention_mask and position_ids sequence-shaped.
  - tests/utils/test_megatron_bshd_preprocess.py
      - Add CPU coverage for existing [batch, seq_len] behavior.
      - Add CPU/GPU coverage for [batch, seq_len, topk] teacher logprobs / ids.
  - tests/utils/test_special_megatron_kl_loss_tp.py
      - Extend the Megatron vocab-parallel KL test to exercise data_format="bshd".
      - Pad student logits consistently with BSHD preprocessing and compare only valid sequence tokens against the THD/reference path.

### Checklist Before Submitting
  - [x] Read the Contribute Guide (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
  - [ ] Apply pre-commit checks (https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always
  - [ ] Add / Update the documentation (https://github.com/verl-project/verl/tree/main/docs). Not needed: bug fix only, no user-facing API/config change.
  - [x] Add unit or end-to-end test(s) to the CI workflow (https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Existing GPU workflow already runs tests/utils/test_special_megatron_kl_loss_tp.py; this PR extends that test and adds
    focused CPU/GPU regression coverage.
  - [ ] Once your PR is ready for CI, send a message in the ci-request channel.
  - [ ] If your PR is related to the recipe submodule, please also update the reference to the submodule commit via git submodule update --remote or cd recipe && git pull origin main.

