### PR TITLE
[ckpt] feat: pass global steps to checkpoint engines

### DIFF
--- a/tests/checkpoint_engine/test_global_steps_on_cpu.py
+++ b/tests/checkpoint_engine/test_global_steps_on_cpu.py
@@ -1,0 +1,98 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+from verl.checkpoint_engine.base import CheckpointEngineWorker
+from verl.workers.engine_workers import ActorRolloutRefWorker
+
+
+class _FakeTrainerEngine:
+    def __init__(self):
+        self.weights = [("w", object())]
+
+    def get_per_tensor_param(self):
+        return iter(self.weights), None
+
+
+class _FakeCheckpointEngine:
+    def __init__(self):
+        self.sent_global_steps = None
+        self.received_global_steps = None
+        self.sent_weights = None
+
+    async def send_weights(self, weights, global_steps=None):
+        self.sent_global_steps = global_steps
+        self.sent_weights = list(weights)
+
+    def receive_weights(self, global_steps=None):
+        self.received_global_steps = global_steps
+
+        async def _weights():
+            yield "w", object()
+
+        return _weights()
+
+
+class _FakeServerAdapter:
+    def __init__(self):
+        self.global_steps = None
+        self.weights = None
+
+    async def update_weights(self, weights, global_steps=None):
+        self.global_steps = global_steps
+        self.weights = [item async for item in weights]
+
+
+def test_actor_worker_passes_global_steps_to_checkpoint_engine_send():
+    checkpoint_engine = _FakeCheckpointEngine()
+    worker = ActorRolloutRefWorker.__new__(ActorRolloutRefWorker)
+    worker.config = SimpleNamespace(
+        rollout=SimpleNamespace(
+            checkpoint_engine=SimpleNamespace(backend="modelexpress"),
+        ),
+    )
+    worker.actor = SimpleNamespace(engine=_FakeTrainerEngine())
+    worker.checkpoint_engine = checkpoint_engine
+
+    asyncio.run(
+        ActorRolloutRefWorker.update_weights.__wrapped__(
+            worker,
+            global_steps=17,
+            mode="auto",
+        )
+    )
+
+    assert checkpoint_engine.sent_global_steps == 17
+    assert checkpoint_engine.sent_weights == worker.actor.engine.weights
+
+
+def test_checkpoint_worker_passes_global_steps_to_receive_and_rollout_update():
+    checkpoint_engine = _FakeCheckpointEngine()
+    server_adapter = _FakeServerAdapter()
+    worker = CheckpointEngineWorker.__new__(CheckpointEngineWorker)
+    worker.checkpoint_engine = checkpoint_engine
+    worker.server_adapter = server_adapter
+
+    asyncio.run(
+        CheckpointEngineWorker.update_weights.__wrapped__(
+            worker,
+            global_steps=17,
+        )
+    )
+
+    assert checkpoint_engine.received_global_steps == 17
+    assert server_adapter.global_steps == 17
+    assert [name for name, _tensor in server_adapter.weights] == ["w"]

--- a/tests/checkpoint_engine/test_utils.py
+++ b/tests/checkpoint_engine/test_utils.py
@@ -42,7 +42,7 @@ class TrainingWorkerTest(TrainingWorker):
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None, mode: str = "auto"):
         per_tensor_param, _ = self.engine.get_per_tensor_param()
-        await self.checkpoint_engine.send_weights(per_tensor_param)
+        await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE, blocking=False)
     def execute_checkpoint_engine(self, method: str, *args, **kwargs):

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -171,17 +171,28 @@ class CheckpointEngine(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps: Optional trainer step/version associated with this weight update.
         """
         raise NotImplementedError
 
     @abstractmethod
-    async def receive_weights(self) -> Generator[tuple[str, torch.Tensor], None, None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Receive the weights of the model.
+
+        Args:
+            global_steps: Optional trainer step/version associated with this weight update.
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
@@ -235,16 +246,27 @@ class ColocatedCheckpointEngine(CheckpointEngine):
     def build_topology(cls, *args, **kwargs):
         raise NotImplementedError
 
-    def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps: Optional trainer step/version associated with this weight update.
         """
         self.weights = weights
 
-    def receive_weights(self) -> Generator[tuple[str, torch.Tensor], None, None]:
+    def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Receive the weights of the model.
+
+        Args:
+            global_steps: Optional trainer step/version associated with this weight update.
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
@@ -299,7 +321,7 @@ class CheckpointEngineWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None):
-        weights = self.checkpoint_engine.receive_weights()
+        weights = self.checkpoint_engine.receive_weights(global_steps=global_steps)
         await self.server_adapter.update_weights(weights, global_steps=global_steps)
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE, blocking=False)

--- a/verl/checkpoint_engine/hccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/hccl_checkpoint_engine.py
@@ -227,7 +227,11 @@ class HCCLCheckpointEngine(CheckpointEngine):
         logger.info(f"init_process_group rank: {self.rank}, world_size: {self.world_size}")
 
     @torch.no_grad()
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
@@ -300,7 +304,10 @@ class HCCLCheckpointEngine(CheckpointEngine):
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
 
     @torch.no_grad()
-    async def receive_weights(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive the weights of the model.
 
         Yields:

--- a/verl/checkpoint_engine/kimi_checkpoint_engine.py
+++ b/verl/checkpoint_engine/kimi_checkpoint_engine.py
@@ -318,7 +318,11 @@ class KIMICheckpointEngine(CheckpointEngine):
             self.initialized = True
 
     @torch.no_grad()
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
@@ -359,7 +363,10 @@ class KIMICheckpointEngine(CheckpointEngine):
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
 
     @torch.no_grad()
-    async def receive_weights(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive the weights of the model.
 
         Yields:

--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -147,7 +147,11 @@ class MooncakeCheckpointEngine(CheckpointEngine):
             await asyncio.sleep(0)
 
     @torch.no_grad()
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send weights using Mooncake TransferEngine"""
         if self.rank < 0:
             for name, weight in weights:
@@ -219,7 +223,10 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         )
 
     @torch.no_grad()
-    async def receive_weights(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive weights using Mooncake TransferEngine"""
         start_time = time.time()
         total_bytes = 0

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -227,7 +227,11 @@ class NCCLCheckpointEngine(CheckpointEngine):
         logger.info(f"init_process_group rank: {self.rank}, world_size: {self.world_size}")
 
     @torch.no_grad()
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
@@ -295,7 +299,10 @@ class NCCLCheckpointEngine(CheckpointEngine):
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
 
     @torch.no_grad()
-    async def receive_weights(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive the weights of the model.
 
         Yields:

--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -368,7 +368,11 @@ class NIXLCheckpointEngine(CheckpointEngine):
         self.next_agent = None
 
     @torch.no_grad()
-    async def send_weights(self, weights: Generator[tuple[str, torch.Tensor], None, None]):
+    async def send_weights(
+        self,
+        weights: Generator[tuple[str, torch.Tensor], None, None],
+        global_steps: int | None = None,
+    ):
         """Send the weights of the model.
 
         Args:
@@ -433,7 +437,10 @@ class NIXLCheckpointEngine(CheckpointEngine):
         logger.info(f"Rank {self.rank} send weights done, time cost: {time.time() - start_time:.2f}s")
 
     @torch.no_grad()
-    async def receive_weights(self) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    async def receive_weights(
+        self,
+        global_steps: int | None = None,
+    ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
         """Receive the weights of the model.
 
         Yields:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -696,7 +696,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         # 0. send_weights only for async training with disaggregated trainer and rollout
         if effective_mode != "naive":
             per_tensor_param, _ = self.actor.engine.get_per_tensor_param()
-            await self.checkpoint_engine.send_weights(per_tensor_param)
+            await self.checkpoint_engine.send_weights(per_tensor_param, global_steps=global_steps)
             return
 
         set_expandable_segments(False)


### PR DESCRIPTION
## Summary

Passes the trainer `global_steps` value through checkpoint-engine send/receive hooks.

This keeps existing checkpoint backends behavior-compatible because the new argument defaults to `None` and is ignored by the built-in NCCL, NIXL, Mooncake, HCCL, Kimi, and colocated backends.

## Why

Custom checkpoint backends may need the update step as a stable model-version identifier. In particular, external/versioned weight-sync backends need the same version on the trainer publish side and rollout receive side rather than relying on local counters or environment variables.

## Changes

- Adds optional `global_steps: int | None = None` to `CheckpointEngine.send_weights()` and `receive_weights()`.
- Passes `global_steps` from `ActorRolloutRefWorker.update_weights()` into `send_weights()`.
- Passes `global_steps` from `CheckpointEngineWorker.update_weights()` into `receive_weights()`.
- Updates built-in checkpoint engine method signatures to accept and ignore the optional value.
- Updates checkpoint-engine test utility worker to pass the value through.
- Adds CPU tests for trainer-side send propagation and rollout-side receive/update propagation.

## Validation

- `/home/ubuntu/checkpoint-engine/.venv/bin/python -m py_compile verl/checkpoint_engine/base.py verl/checkpoint_engine/nccl_checkpoint_engine.py verl/checkpoint_engine/nixl_checkpoint_engine.py verl/checkpoint_engine/mooncake_checkpoint_engine.py verl/checkpoint_engine/hccl_checkpoint_engine.py verl/checkpoint_engine/kimi_checkpoint_engine.py verl/workers/engine_workers.py tests/checkpoint_engine/test_utils.py tests/checkpoint_engine/test_global_steps_on_cpu.py`
- `/home/ubuntu/checkpoint-engine/.venv/bin/python -m pytest tests/checkpoint_engine/test_global_steps_on_cpu.py -q` (`2 passed`)
- `git diff --check`

I did not run the GPU checkpoint-engine tests in this VM for this PR; the added coverage is CPU-only and focused on version propagation.