### PR TITLE
fix: restore rollout state after checkpoint update failures

### DIFF
--- a/tests/checkpoint_engine/test_manager_cleanup_on_cpu.py
+++ b/tests/checkpoint_engine/test_manager_cleanup_on_cpu.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from verl.checkpoint_engine import base as checkpoint_base
+from verl.checkpoint_engine.base import CheckpointEngineManager
+
+
+class _FakeReplica:
+    def __init__(self, events: list[str]):
+        self.events = events
+        self.workers = ["worker"]
+
+    async def abort_all_requests(self):
+        self.events.append("abort")
+
+    async def release_kv_cache(self):
+        self.events.append("release_kv_cache")
+
+    async def resume_kv_cache(self):
+        self.events.append("resume_kv_cache")
+
+    async def resume_generation(self):
+        self.events.append("resume_generation")
+
+
+class _FakeWorkerGroup:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        name: str,
+        fail_update: bool = False,
+        fail_finalize: bool = False,
+    ):
+        self.events = events
+        self.name = name
+        self.world_size = 1
+        self.workers = ["worker"]
+        self.fail_update = fail_update
+        self.fail_finalize = fail_finalize
+
+    def update_weights(self, **kwargs):
+        self.events.append(f"{self.name}.update_weights")
+        if self.fail_update:
+            return [RuntimeError(f"{self.name} update failed")]
+        return [f"{self.name}.update_weights.done"]
+
+    def execute_checkpoint_engine(self, methods):
+        assert methods == ["finalize"]
+        self.events.append(f"{self.name}.finalize")
+        if self.fail_finalize:
+            return [RuntimeError(f"{self.name} finalize failed")]
+        return [f"{self.name}.finalize.done"]
+
+
+def _manager(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+    *,
+    fail_build: bool = False,
+    fail_update: bool = False,
+    fail_finalize: bool = False,
+) -> CheckpointEngineManager:
+    trainer = _FakeWorkerGroup(
+        events,
+        name="trainer",
+        fail_update=fail_update,
+        fail_finalize=fail_finalize,
+    )
+    rollout = _FakeWorkerGroup(events, name="rollout")
+
+    def fake_ray_get(refs):
+        for ref in refs:
+            if isinstance(ref, Exception):
+                raise ref
+        return refs
+
+    def fake_ray_worker_group(*, worker_handles, ray_cls_with_init):
+        assert worker_handles == ["worker"]
+        return rollout
+
+    monkeypatch.setattr(checkpoint_base.ray, "get", fake_ray_get)
+    monkeypatch.setattr(checkpoint_base, "RayWorkerGroup", fake_ray_worker_group)
+
+    manager = CheckpointEngineManager.__new__(CheckpointEngineManager)
+    manager.backend = "nccl"
+    manager.trainer = trainer
+    manager.replicas = [_FakeReplica(events)]
+
+    def build_process_group(rollout_group):
+        assert rollout_group is rollout
+        events.append("build_process_group")
+        if fail_build:
+            raise RuntimeError("build process group failed")
+
+    manager.build_process_group = build_process_group
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_update_weights_restores_rollout_state_when_process_group_build_fails(monkeypatch):
+    events = []
+    manager = _manager(monkeypatch, events, fail_build=True)
+
+    with pytest.raises(RuntimeError, match="build process group failed"):
+        await manager.update_weights(global_steps=7)
+
+    assert events == [
+        "abort",
+        "release_kv_cache",
+        "build_process_group",
+        "trainer.finalize",
+        "rollout.finalize",
+        "resume_kv_cache",
+        "resume_generation",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_weights_restores_rollout_state_when_transfer_fails(monkeypatch):
+    events = []
+    manager = _manager(monkeypatch, events, fail_update=True)
+
+    with pytest.raises(RuntimeError, match="trainer update failed"):
+        await manager.update_weights(global_steps=7)
+
+    assert events == [
+        "abort",
+        "release_kv_cache",
+        "build_process_group",
+        "trainer.update_weights",
+        "rollout.update_weights",
+        "trainer.finalize",
+        "rollout.finalize",
+        "resume_kv_cache",
+        "resume_generation",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_weights_raises_cleanup_error_after_success(monkeypatch):
+    events = []
+    manager = _manager(monkeypatch, events, fail_finalize=True)
+
+    with pytest.raises(RuntimeError, match="trainer finalize failed"):
+        await manager.update_weights(global_steps=7)
+
+    assert events == [
+        "abort",
+        "release_kv_cache",
+        "build_process_group",
+        "trainer.update_weights",
+        "rollout.update_weights",
+        "trainer.finalize",
+        "rollout.finalize",
+        "resume_kv_cache",
+        "resume_generation",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_weights_preserves_primary_error_when_cleanup_fails(monkeypatch):
+    events = []
+    manager = _manager(monkeypatch, events, fail_update=True, fail_finalize=True)
+
+    with pytest.raises(RuntimeError, match="trainer update failed"):
+        await manager.update_weights(global_steps=7)
+
+    assert "trainer.finalize" in events
+    assert "resume_kv_cache" in events
+    assert "resume_generation" in events

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Generator
@@ -28,6 +29,8 @@ from verl.utils.ray_utils import auto_await
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig, RolloutConfig
 from verl.workers.rollout import BaseRollout, RolloutReplica, get_rollout_class
 from verl.workers.rollout.utils import ensure_async_iterator
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -389,6 +392,14 @@ class CheckpointEngineManager:
             trainer.execute_checkpoint_engine(**trainer_kwargs) + rollout.execute_checkpoint_engine(**rollout_kwargs)
         )
 
+    def finalize_process_group(self, rollout: RayWorkerGroup):
+        """Finalize checkpoint engines on trainer and rollout workers."""
+        trainer = self.trainer
+        ray.get(
+            trainer.execute_checkpoint_engine(["finalize"] * trainer.world_size)
+            + rollout.execute_checkpoint_engine(["finalize"] * rollout.world_size)
+        )
+
     def add_replicas(self, replicas: list[RolloutReplica]):
         """Add rollout replicas to the manager for elastic scale up, will rebuild process group.
 
@@ -457,39 +468,91 @@ class CheckpointEngineManager:
             ray.get(self.trainer.update_weights(global_steps=global_steps, mode=self.backend))
             return
 
-        # 1. abort and save all unfinished requests for partial rollout
-        await self.abort_replicas()
+        rollout: RayWorkerGroup | None = None
+        resume_generation = False
+        resume_kv_cache = False
+        finalize_checkpoint_engines = False
+        primary_error: BaseException | None = None
+        try:
+            # 1. abort and save all unfinished requests for partial rollout
+            resume_generation = True
+            await self.abort_replicas()
 
-        # 2. create a temporay worker group for all replicas
-        workers = []
-        for replica in self.replicas:
-            workers.extend(replica.workers)
-        rollout = RayWorkerGroup(worker_handles=workers, ray_cls_with_init=RayClassWithInitArgs(cls=_worker_cls))
-        trainer = self.trainer
+            # 2. create a temporary worker group for all replicas
+            workers = []
+            for replica in self.replicas:
+                workers.extend(replica.workers)
+            rollout = RayWorkerGroup(worker_handles=workers, ray_cls_with_init=RayClassWithInitArgs(cls=_worker_cls))
+            trainer = self.trainer
 
-        # 3. release kv_cache before weight sync (weights stay in place)
-        await self.release_kv_cache_replicas()
+            # 3. release kv_cache before weight sync (weights stay in place)
+            resume_kv_cache = True
+            await self.release_kv_cache_replicas()
 
-        # 4. build process group
-        self.build_process_group(rollout)
+            # 4. build process group
+            finalize_checkpoint_engines = True
+            self.build_process_group(rollout)
 
-        # 5. update weights of all workers
-        ray.get(
-            trainer.update_weights(global_steps=global_steps, mode=self.backend)
-            + rollout.update_weights(global_steps=global_steps)
+            # 5. update weights of all workers
+            ray.get(
+                trainer.update_weights(global_steps=global_steps, mode=self.backend)
+                + rollout.update_weights(global_steps=global_steps)
+            )
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            cleanup_error = await self._cleanup_weight_update(
+                rollout,
+                finalize_checkpoint_engines=finalize_checkpoint_engines,
+                resume_kv_cache=resume_kv_cache,
+                resume_generation=resume_generation,
+                primary_error=primary_error,
+            )
+            if cleanup_error is not None and primary_error is None:
+                raise cleanup_error
+
+    async def _cleanup_weight_update(
+        self,
+        rollout: RayWorkerGroup | None,
+        *,
+        finalize_checkpoint_engines: bool,
+        resume_kv_cache: bool,
+        resume_generation: bool,
+        primary_error: BaseException | None,
+    ) -> Exception | None:
+        cleanup_errors: list[tuple[str, Exception]] = []
+
+        if finalize_checkpoint_engines and rollout is not None:
+            try:
+                self.finalize_process_group(rollout)
+            except Exception as exc:
+                self._record_cleanup_error(cleanup_errors, "finalize checkpoint engines", exc)
+
+        if resume_kv_cache:
+            try:
+                await self.resume_kv_cache_replicas()
+            except Exception as exc:
+                self._record_cleanup_error(cleanup_errors, "resume kv cache", exc)
+
+        if resume_generation:
+            try:
+                await self.resume_generation_replicas()
+            except Exception as exc:
+                self._record_cleanup_error(cleanup_errors, "resume generation", exc)
+
+        if not cleanup_errors or primary_error is not None:
+            return None
+        return cleanup_errors[0][1]
+
+    @staticmethod
+    def _record_cleanup_error(cleanup_errors: list[tuple[str, Exception]], label: str, exc: Exception) -> None:
+        cleanup_errors.append((label, exc))
+        logger.warning(
+            "CheckpointEngineManager failed to %s during update_weights cleanup",
+            label,
+            exc_info=(type(exc), exc, exc.__traceback__),
         )
-
-        # 6. finalize all workers
-        ray.get(
-            trainer.execute_checkpoint_engine(["finalize"] * trainer.world_size)
-            + rollout.execute_checkpoint_engine(["finalize"] * rollout.world_size)
-        )
-
-        # 7. restore kv_cache after weight sync
-        await self.resume_kv_cache_replicas()
-
-        # 8. resume all unfinished requests for partial rollout
-        await self.resume_generation_replicas()
 
 
 async def split_weight_chunks(


### PR DESCRIPTION
## Summary
- finalize checkpoint engines from CheckpointEngineManager cleanup even when process-group build or weight transfer fails
- always attempt to restore KV cache and resume generation after non-naive checkpoint update interruptions
- add a CPU unit test covering build failure, transfer failure, cleanup failure, and primary-error preservation

## Tests
- python3 -m py_compile verl/checkpoint_engine/base.py tests/checkpoint_engine/test_manager_cleanup_on_cpu.py
- PYTHONPATH=/home/ubuntu/verl /home/ubuntu/checkpoint-engine/.venv/bin/python -m pytest tests/checkpoint_engine/test_manager_cleanup_on_cpu.py -q
- uv run --python /usr/bin/python3.10 --no-project --with ruff ruff check verl/checkpoint_engine/base.py tests/checkpoint_engine/test_manager_cleanup_on_cpu.py
- git diff --check