### PR TITLE
[veomni, fsdp] feat: enable fused top-K distillation kernel for OPD

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install veomni==0.1.11 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==5.3.0
       - name: Prepare GSM8K dataset
         run: |

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm_ascend.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install the current repository
         run: |
           pip install --no-deps -e .
-          pip install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip install veomni==0.1.11 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip install transformers==5.3.0
       - name: Check final pip list
         run: |

--- a/.github/workflows/e2e_sft_llm.yml
+++ b/.github/workflows/e2e_sft_llm.yml
@@ -105,7 +105,7 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install veomni==0.1.11 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==5.3.0
       - name: Prepare gsm8k dataset
         run: |

--- a/.github/workflows/e2e_sft_llm_ascend.yml
+++ b/.github/workflows/e2e_sft_llm_ascend.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install the current repository
         run: |
           pip install --no-deps -e .
-          pip install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip install veomni==0.1.11 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip install transformers==5.3.0
           pip install pandas==2.3.3
           pip uninstall -y mbridge

--- a/.github/workflows/e2e_sft_vlm.yml
+++ b/.github/workflows/e2e_sft_vlm.yml
@@ -105,7 +105,7 @@ jobs:
           pip3 install peft
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
-          pip3 install veomni==0.1.10 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
+          pip3 install veomni==0.1.11 --ignore-requires-python --no-deps --index-url https://pypi.org/simple/
           pip3 install transformers==5.3.0
           pip3 uninstall -y "flash-attn-4"
       - name: Prepare pokemon-gpt4o-captions dataset

--- a/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
@@ -5,7 +5,7 @@
 #   - model_engine=veomni for FSDP2-based training
 #   - use_fused_kernels=True enables veomni's fused-linear kernels:
 #     * For RL/SFT batches: fused log-prob + entropy (no logits materialization)
-#     * For top-K distillation batches with teacher_topk_ids in the TD:
+#     * For top-K distillation batches (loss_mode=forward_kl_topk):
 #       veomni's chunk_topk_distill kernel computes the top-K forward-KL
 #       distillation loss without materializing [B, L, V] logits — saving
 #       significant GPU memory for large-vocabulary models.

--- a/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
@@ -29,8 +29,8 @@ distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
 use_policy_gradient=${USE_POLICY_GRADIENT:-True}
 distillation_topk=${DISTILLATION_TOPK:-32}
 
-train_batch_size=${TRAIN_BATCH_SIZE:-16}
-ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-16}
+train_batch_size=${TRAIN_BATCH_SIZE:-14}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-14}
 max_prompt_length=${MAX_PROMPT_LENGTH:-512}
 max_response_length=${MAX_RESPONSE_LENGTH:-1024}
 ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-8192}

--- a/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_0.6b_opd_veomni.sh
@@ -1,60 +1,56 @@
 #!/usr/bin/env bash
-# On-policy distillation | multi-teacher (gsm8k text + geo3k VL) | vLLM rollout | VeOmni training | NVIDIA GPUs
+# On-policy distillation | single teacher | vLLM rollout | VeOmni training | NVIDIA GPUs
 #
-# VeOmni engine variant of the FSDP OPD script. Key difference:
+# VeOmni engine variant of the FSDP OPD script. Key differences:
 #   - model_engine=veomni for FSDP2-based training
-#   - use_fused_kernels=True enables veomni's chunk_topk_distill kernel,
-#     which computes the top-K forward-KL distillation loss without
-#     materializing the full [B, L, V] logits tensor — saving significant
-#     GPU memory for large-vocabulary models.
+#   - use_fused_kernels=True enables veomni's fused-linear kernels:
+#     * For RL/SFT batches: fused log-prob + entropy (no logits materialization)
+#     * For top-K distillation batches with teacher_topk_ids in the TD:
+#       veomni's chunk_topk_distill kernel computes the top-K forward-KL
+#       distillation loss without materializing [B, L, V] logits — saving
+#       significant GPU memory for large-vocabulary models.
+#   Without use_fused_kernels, the vanilla FSDP actor materializes full
+#   [B, L, V] logits and computes distillation loss eagerly. The VeOmni fused
+#   chunk_topk_distill path avoids this by streaming the lm_head
+#   projection chunk-by-chunk.
 
 set -xeuo pipefail
 
 # ---- user-adjustable ----
-STUDENT_MODEL=${STUDENT_MODEL:-Qwen/Qwen3-VL-8B-Instruct}
-GSM8K_TEACHER_MODEL=${GSM8K_TEACHER_MODEL:-Qwen/Qwen3-32B}
-GEO3K_TEACHER_MODEL=${GEO3K_TEACHER_MODEL:-Qwen/Qwen3-VL-32B-Instruct}
+STUDENT_MODEL=${STUDENT_MODEL:-Qwen/Qwen3-0.6B}
+TEACHER_MODEL=${TEACHER_MODEL:-Qwen/Qwen3-1.7B}
 
 NNODES=${NNODES:-1}
-NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
-
-TEACHER_NNODES=${TEACHER_NNODES:-1}
-TEACHER_NUM_REPLICAS_GSM8K=${TEACHER_NUM_REPLICAS_GSM8K:-1}
-TEACHER_NUM_REPLICAS_GEO3K=${TEACHER_NUM_REPLICAS_GEO3K:-1}
-teacher_tp=${TEACHER_TP:-2}
-TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-7}
+TEACHER_NGPUS=${TEACHER_NGPUS:-1}
+teacher_tp=${TEACHER_TP:-1}
 
 distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
 use_policy_gradient=${USE_POLICY_GRADIENT:-True}
-distillation_topk=${DISTILLATION_TOPK:-64}
+distillation_topk=${DISTILLATION_TOPK:-32}
 
-train_batch_size=${TRAIN_BATCH_SIZE:-128}
-ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-128}
-max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
-max_response_length=${MAX_RESPONSE_LENGTH:-2048}
-ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-24576}
+train_batch_size=${TRAIN_BATCH_SIZE:-16}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-16}
+max_prompt_length=${MAX_PROMPT_LENGTH:-512}
+max_response_length=${MAX_RESPONSE_LENGTH:-1024}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-8192}
 
-actor_lr=${ACTOR_LR:-1e-6}
+actor_lr=${ACTOR_LR:-1e-5}
 
-rollout_tp=${ROLLOUT_TP:-2}
-rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.4}
-teacher_gpu_mem_util=${TEACHER_GPU_MEM_UTIL:-0.4}
+rollout_tp=${ROLLOUT_TP:-1}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.3}
+teacher_gpu_mem_util=${TEACHER_GPU_MEM_UTIL:-0.3}
 
 total_epochs=${TOTAL_EPOCHS:-15}
 save_freq=${SAVE_FREQ:-200}
 test_freq=${TEST_FREQ:-5}
 
-project_name=${PROJECT_NAME:-verl_distill_mopd_gsm8k_geo3k}
-experiment_name=${EXPERIMENT_NAME:-qwen3_vl_8b_mopd_veomni_fused}
+project_name=${PROJECT_NAME:-verl_distill_opd_veomni}
+experiment_name=${EXPERIMENT_NAME:-qwen3_0.6b_from_1.7b_opd_veomni_fused}
 # ---- end user-adjustable ----
 
-gsm8k_train=$HOME/data/gsm8k/train.parquet
-gsm8k_test=$HOME/data/gsm8k/test.parquet
-geo3k_train=$HOME/data/geo3k/train.parquet
-geo3k_test=$HOME/data/geo3k/test.parquet
-
-train_files="['$gsm8k_train', '$geo3k_train']"
-val_files="['$gsm8k_test', '$geo3k_test']"
+train_files=$HOME/data/gsm8k/train.parquet
+val_files=$HOME/data/gsm8k/test.parquet
 
 max_num_tokens=$(( max_prompt_length + max_response_length + 1 ))
 ########################### parameter arrays ###########################
@@ -69,8 +65,6 @@ DATA=(
     data.max_response_length=${max_response_length}
     data.filter_overlong_prompts=True
     data.truncation='error'
-    data.shuffle=True
-    data.image_key=images
 )
 
 MODEL=(
@@ -86,8 +80,8 @@ ACTOR=(
     actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
     actor_rollout_ref.actor.use_dynamic_bsz=True
     actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
-    actor_rollout_ref.actor.veomni.param_offload=True
-    actor_rollout_ref.actor.veomni.optimizer_offload=True
+    actor_rollout_ref.actor.veomni.param_offload=False
+    actor_rollout_ref.actor.veomni.optimizer_offload=False
 )
 
 ROLLOUT=(
@@ -101,8 +95,7 @@ ROLLOUT=(
 )
 
 TRAINER=(
-    trainer.balance_batch=True
-    trainer.logger='["console","wandb"]'
+    trainer.logger=console
     trainer.project_name=${project_name}
     trainer.experiment_name=${experiment_name}
     trainer.n_gpus_per_node=${NGPUS_PER_NODE}
@@ -116,26 +109,15 @@ TRAINER=(
 EXTRA=(
     model_engine=veomni
     distillation.enabled=True
-    distillation.n_gpus_per_node=${TEACHER_WORLD_SIZE}
-    distillation.nnodes=${TEACHER_NNODES}
-    distillation.teacher_key=data_source
-    # --- gsm8k teacher (text) ---
+    distillation.n_gpus_per_node=${TEACHER_NGPUS}
+    distillation.nnodes=1
     +distillation.teacher_models.gsm8k.key="openai/gsm8k"
-    +distillation.teacher_models.gsm8k.model_path="$GSM8K_TEACHER_MODEL"
-    +distillation.teacher_models.gsm8k.num_replicas=${TEACHER_NUM_REPLICAS_GSM8K}
+    +distillation.teacher_models.gsm8k.model_path="$TEACHER_MODEL"
+    +distillation.teacher_models.gsm8k.num_replicas=1
     +distillation.teacher_models.gsm8k.inference.name=vllm
     +distillation.teacher_models.gsm8k.inference.tensor_model_parallel_size=${teacher_tp}
     +distillation.teacher_models.gsm8k.inference.gpu_memory_utilization=${teacher_gpu_mem_util}
     +distillation.teacher_models.gsm8k.inference.max_model_len=${max_num_tokens}
-    # --- geo3k teacher (VL) ---
-    +distillation.teacher_models.geo3k.key="hiyouga/geometry3k"
-    +distillation.teacher_models.geo3k.model_path="$GEO3K_TEACHER_MODEL"
-    +distillation.teacher_models.geo3k.num_replicas=${TEACHER_NUM_REPLICAS_GEO3K}
-    +distillation.teacher_models.geo3k.inference.name=vllm
-    +distillation.teacher_models.geo3k.inference.tensor_model_parallel_size=${teacher_tp}
-    +distillation.teacher_models.geo3k.inference.gpu_memory_utilization=${teacher_gpu_mem_util}
-    +distillation.teacher_models.geo3k.inference.max_model_len=${max_num_tokens}
-    # --- loss ---
     distillation.distillation_loss.loss_mode=${distillation_loss_mode}
     distillation.distillation_loss.topk=${distillation_topk}
     distillation.distillation_loss.use_task_rewards=False

--- a/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_veomni.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_veomni.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# On-policy distillation | multi-teacher (gsm8k text + geo3k VL) | vLLM rollout | VeOmni training | NVIDIA GPUs
+#
+# VeOmni engine variant of the FSDP OPD script. Key difference:
+#   - model_engine=veomni for FSDP2-based training
+#   - use_fused_kernels=True enables veomni's chunk_topk_distill kernel,
+#     which computes the top-K forward-KL distillation loss without
+#     materializing the full [B, L, V] logits tensor — saving significant
+#     GPU memory for large-vocabulary models.
+
+set -xeuo pipefail
+
+# ---- user-adjustable ----
+STUDENT_MODEL=${STUDENT_MODEL:-Qwen/Qwen3-VL-8B-Instruct}
+GSM8K_TEACHER_MODEL=${GSM8K_TEACHER_MODEL:-Qwen/Qwen3-32B}
+GEO3K_TEACHER_MODEL=${GEO3K_TEACHER_MODEL:-Qwen/Qwen3-VL-32B-Instruct}
+
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+TEACHER_NNODES=${TEACHER_NNODES:-1}
+TEACHER_NUM_REPLICAS_GSM8K=${TEACHER_NUM_REPLICAS_GSM8K:-1}
+TEACHER_NUM_REPLICAS_GEO3K=${TEACHER_NUM_REPLICAS_GEO3K:-1}
+teacher_tp=${TEACHER_TP:-2}
+TEACHER_WORLD_SIZE=$(( (TEACHER_NUM_REPLICAS_GSM8K + TEACHER_NUM_REPLICAS_GEO3K) * teacher_tp ))
+
+distillation_loss_mode=${DISTILLATION_LOSS_MODE:-k1}
+use_policy_gradient=${USE_POLICY_GRADIENT:-True}
+distillation_topk=${DISTILLATION_TOPK:-64}
+
+train_batch_size=${TRAIN_BATCH_SIZE:-128}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-128}
+max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
+max_response_length=${MAX_RESPONSE_LENGTH:-2048}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-24576}
+
+actor_lr=${ACTOR_LR:-1e-6}
+
+rollout_tp=${ROLLOUT_TP:-2}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.4}
+teacher_gpu_mem_util=${TEACHER_GPU_MEM_UTIL:-0.4}
+
+total_epochs=${TOTAL_EPOCHS:-15}
+save_freq=${SAVE_FREQ:-200}
+test_freq=${TEST_FREQ:-5}
+
+project_name=${PROJECT_NAME:-verl_distill_mopd_gsm8k_geo3k}
+experiment_name=${EXPERIMENT_NAME:-qwen3_vl_8b_mopd_veomni_fused}
+# ---- end user-adjustable ----
+
+gsm8k_train=$HOME/data/gsm8k/train.parquet
+gsm8k_test=$HOME/data/gsm8k/test.parquet
+geo3k_train=$HOME/data/geo3k/train.parquet
+geo3k_test=$HOME/data/geo3k/test.parquet
+
+train_files="['$gsm8k_train', '$geo3k_train']"
+val_files="['$gsm8k_test', '$geo3k_test']"
+
+max_num_tokens=$(( max_prompt_length + max_response_length + 1 ))
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="$train_files"
+    data.val_files="$val_files"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.filter_overlong_prompts=True
+    data.truncation='error'
+    data.shuffle=True
+    data.image_key=images
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$STUDENT_MODEL"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+    actor_rollout_ref.model.use_fused_kernels=True
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.use_torch_compile=False
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.veomni.param_offload=True
+    actor_rollout_ref.actor.veomni.optimizer_offload=True
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=1
+    actor_rollout_ref.rollout.max_model_len=${max_num_tokens}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.val_before_train=False
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+)
+
+EXTRA=(
+    model_engine=veomni
+    distillation.enabled=True
+    distillation.n_gpus_per_node=${TEACHER_WORLD_SIZE}
+    distillation.nnodes=${TEACHER_NNODES}
+    distillation.teacher_key=data_source
+    # --- gsm8k teacher (text) ---
+    +distillation.teacher_models.gsm8k.key="openai/gsm8k"
+    +distillation.teacher_models.gsm8k.model_path="$GSM8K_TEACHER_MODEL"
+    +distillation.teacher_models.gsm8k.num_replicas=${TEACHER_NUM_REPLICAS_GSM8K}
+    +distillation.teacher_models.gsm8k.inference.name=vllm
+    +distillation.teacher_models.gsm8k.inference.tensor_model_parallel_size=${teacher_tp}
+    +distillation.teacher_models.gsm8k.inference.gpu_memory_utilization=${teacher_gpu_mem_util}
+    +distillation.teacher_models.gsm8k.inference.max_model_len=${max_num_tokens}
+    # --- geo3k teacher (VL) ---
+    +distillation.teacher_models.geo3k.key="hiyouga/geometry3k"
+    +distillation.teacher_models.geo3k.model_path="$GEO3K_TEACHER_MODEL"
+    +distillation.teacher_models.geo3k.num_replicas=${TEACHER_NUM_REPLICAS_GEO3K}
+    +distillation.teacher_models.geo3k.inference.name=vllm
+    +distillation.teacher_models.geo3k.inference.tensor_model_parallel_size=${teacher_tp}
+    +distillation.teacher_models.geo3k.inference.gpu_memory_utilization=${teacher_gpu_mem_util}
+    +distillation.teacher_models.geo3k.inference.max_model_len=${max_num_tokens}
+    # --- loss ---
+    distillation.distillation_loss.loss_mode=${distillation_loss_mode}
+    distillation.distillation_loss.topk=${distillation_topk}
+    distillation.distillation_loss.use_task_rewards=False
+    distillation.distillation_loss.use_policy_gradient=${use_policy_gradient}
+    distillation.distillation_loss.loss_max_clamp=10.0
+    distillation.distillation_loss.log_prob_min_clamp=-10.0
+)
+
+########################### launch ###########################
+python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@"

--- a/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_veomni.sh
+++ b/examples/on_policy_distillation_trainer/run_qwen3_8b_mopd_veomni.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # On-policy distillation | multi-teacher (gsm8k text + geo3k VL) | vLLM rollout | VeOmni training | NVIDIA GPUs
 #
-# VeOmni engine variant of the FSDP OPD script. Key difference:
+# VeOmni engine variant of the FSDP OPD script. Key differences:
 #   - model_engine=veomni for FSDP2-based training
-#   - use_fused_kernels=True enables veomni's chunk_topk_distill kernel,
-#     which computes the top-K forward-KL distillation loss without
-#     materializing the full [B, L, V] logits tensor — saving significant
-#     GPU memory for large-vocabulary models.
+#   - use_fused_kernels=True enables veomni's fused-linear kernels:
+#     * For RL/SFT batches: fused log-prob + entropy (no logits materialization)
+#     * For top-K distillation batches with teacher_topk_ids in the TD:
+#       veomni's chunk_topk_distill kernel computes the top-K forward-KL
+#       distillation loss without materializing [B, L, V] logits — saving
+#       significant GPU memory for large-vocabulary models.
+#   Without use_fused_kernels, the vanilla FSDP actor materializes full
+#   [B, L, V] logits and computes distillation loss eagerly. The VeOmni fused
+#   chunk_topk_distill path avoids this by streaming the lm_head
+#   projection chunk-by-chunk.
 
 set -xeuo pipefail
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1092,6 +1092,21 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # temperature is singleton
                 log_probs = output.log_probs.squeeze(0)  # (total_nnz,)
                 entropy_rmpad = output.entropy.squeeze(0)  # (total_nnz,)
+
+                # When the fused kernel also computed top-K distillation
+                # (veomni's chunk_topk_distill path), extract the per-token
+                # distillation outputs and store them as nested tensors —
+                # same model_output keys as the eager logit-processor path.
+                if distillation_use_topk:
+                    aux_outputs = getattr(output, "fused_linear_aux", None)
+                    if aux_outputs is not None and aux_outputs.distillation_losses is not None:
+                        cu_seqlens = input_ids.offsets()
+                        for field_name in ("distillation_losses", "student_mass", "teacher_mass"):
+                            v = getattr(aux_outputs, field_name).squeeze(0)
+                            if self.use_ulysses_sp:
+                                pad_size = output_args["pad_size"]
+                                v = gather_outputs_and_unpad(v, gather_dim=0, unpad_dim=0, padding_size=pad_size)
+                            model_output[field_name] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
             else:
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
                 logits_rmpad.div_(temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -876,22 +876,15 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
                     )
                 teacher_topk_ids = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
                 teacher_topk_log_probs = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
-                # Pad + slice teacher tensors along the seqlen dim to match the
-                # student's SP-sliced sequence (same pattern the parent class
-                # uses for input_ids_rmpad_rolled / temperature_rmpad).
+                # Pad + slice teacher tensors along the seqlen dim (dim=1) to
+                # match the student's SP-sliced sequence. ulysses_pad_and_slice_inputs
+                # hardcodes 2D shape; teacher tensors are 3D (1, total_nnz, K)
+                # so use slice_input_tensor directly (handles arbitrary dims).
                 if self.use_ulysses_sp:
-                    from verl.utils.ulysses import ulysses_pad_and_slice_inputs
+                    from verl.utils.ulysses import slice_input_tensor
 
-                    teacher_topk_ids, _, _ = ulysses_pad_and_slice_inputs(
-                        teacher_topk_ids,
-                        position_ids_rmpad=None,
-                        sp_size=self.ulysses_sequence_parallel_size,
-                    )
-                    teacher_topk_log_probs, _, _ = ulysses_pad_and_slice_inputs(
-                        teacher_topk_log_probs,
-                        position_ids_rmpad=None,
-                        sp_size=self.ulysses_sequence_parallel_size,
-                    )
+                    teacher_topk_ids = slice_input_tensor(teacher_topk_ids, dim=1, padding=True)
+                    teacher_topk_log_probs = slice_input_tensor(teacher_topk_log_probs, dim=1, padding=True)
                 model_inputs["teacher_topk_ids"] = teacher_topk_ids
                 model_inputs["teacher_topk_log_probs"] = teacher_topk_log_probs
 

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -867,9 +867,7 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             # while verl's native distillation path uses different keys
             # (teacher_logprobs / teacher_ids) and relies on the eager
             # logit-processor instead.
-            distillation_use_topk = tu.get_non_tensor_data(
-                data=micro_batch, key="distillation_use_topk", default=False
-            )
+            distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
             if distillation_use_topk and "teacher_topk_ids" in micro_batch.keys():
                 if "teacher_topk_log_probs" not in micro_batch.keys():
                     raise ValueError(

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -861,6 +861,19 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             model_inputs["shift_labels"] = shift_labels
             model_inputs["return_log_probs"] = True
 
+            # Pass teacher top-K tensors so ForCausalLMLoss routes to
+            # chunk_topk_distill_function for fused distillation.
+            # Guard on key existence: the tinker_router path uses these keys,
+            # while verl's native distillation path uses different keys
+            # (teacher_logprobs / teacher_ids) and relies on the eager
+            # logit-processor instead.
+            distillation_use_topk = tu.get_non_tensor_data(
+                data=micro_batch, key="distillation_use_topk", default=False
+            )
+            if distillation_use_topk and "teacher_topk_ids" in micro_batch.keys():
+                model_inputs["teacher_topk_ids"] = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
+                model_inputs["teacher_topk_log_probs"] = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
+
         # Router replay plumbing. Two responsibilities:
         #   (1) snapshot the ulysses pad_size for this micro-batch so
         #       forward_backward_batch can trim it during RECORD aggregation;

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -862,24 +862,22 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
             model_inputs["return_log_probs"] = True
 
             # Pass teacher top-K tensors so ForCausalLMLoss routes to
-            # chunk_topk_distill_function for fused distillation.
-            # Guard on key existence: the tinker_router path uses these keys,
-            # while verl's native distillation path uses different keys
-            # (teacher_logprobs / teacher_ids) and relies on the eager
-            # logit-processor instead.
+            # chunk_topk_distill_function for fused distillation. TD keys
+            # teacher_ids / teacher_logprobs are populated by verl's native
+            # distillation pipeline (see verl/trainer/distillation/losses.py).
             distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
-            if distillation_use_topk and "teacher_topk_ids" in micro_batch.keys():
-                if "teacher_topk_log_probs" not in micro_batch.keys():
+            if distillation_use_topk and "teacher_ids" in micro_batch.keys():
+                if "teacher_logprobs" not in micro_batch.keys():
                     raise ValueError(
-                        "teacher_topk_ids present without teacher_topk_log_probs; "
+                        "teacher_ids present without teacher_logprobs; "
                         "both must be provided together for fused top-K distillation."
                     )
-                teacher_topk_ids = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
-                teacher_topk_log_probs = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
-                # Pad + slice teacher tensors along the seqlen dim (dim=1) to
-                # match the student's SP-sliced sequence. ulysses_pad_and_slice_inputs
-                # hardcodes 2D shape; teacher tensors are 3D (1, total_nnz, K)
-                # so use slice_input_tensor directly (handles arbitrary dims).
+                # Kernel kwarg names follow veomni's chunk_topk_distill_function API.
+                teacher_topk_ids = micro_batch["teacher_ids"].values().unsqueeze(0)
+                teacher_topk_log_probs = micro_batch["teacher_logprobs"].values().unsqueeze(0)
+                # SP-slice along seqlen (dim=1); teacher tensors are 3D
+                # (1, total_nnz, K) so use slice_input_tensor directly —
+                # ulysses_pad_and_slice_inputs hardcodes 2D.
                 if self.use_ulysses_sp:
                     from verl.utils.ulysses import slice_input_tensor
 

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -871,6 +871,11 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
                 data=micro_batch, key="distillation_use_topk", default=False
             )
             if distillation_use_topk and "teacher_topk_ids" in micro_batch.keys():
+                if "teacher_topk_log_probs" not in micro_batch.keys():
+                    raise ValueError(
+                        "teacher_topk_ids present without teacher_topk_log_probs; "
+                        "both must be provided together for fused top-K distillation."
+                    )
                 model_inputs["teacher_topk_ids"] = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
                 model_inputs["teacher_topk_log_probs"] = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
 

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -874,8 +874,26 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
                         "teacher_topk_ids present without teacher_topk_log_probs; "
                         "both must be provided together for fused top-K distillation."
                     )
-                model_inputs["teacher_topk_ids"] = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
-                model_inputs["teacher_topk_log_probs"] = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
+                teacher_topk_ids = micro_batch["teacher_topk_ids"].values().unsqueeze(0)
+                teacher_topk_log_probs = micro_batch["teacher_topk_log_probs"].values().unsqueeze(0)
+                # Pad + slice teacher tensors along the seqlen dim to match the
+                # student's SP-sliced sequence (same pattern the parent class
+                # uses for input_ids_rmpad_rolled / temperature_rmpad).
+                if self.use_ulysses_sp:
+                    from verl.utils.ulysses import ulysses_pad_and_slice_inputs
+
+                    teacher_topk_ids, _, _ = ulysses_pad_and_slice_inputs(
+                        teacher_topk_ids,
+                        position_ids_rmpad=None,
+                        sp_size=self.ulysses_sequence_parallel_size,
+                    )
+                    teacher_topk_log_probs, _, _ = ulysses_pad_and_slice_inputs(
+                        teacher_topk_log_probs,
+                        position_ids_rmpad=None,
+                        sp_size=self.ulysses_sequence_parallel_size,
+                    )
+                model_inputs["teacher_topk_ids"] = teacher_topk_ids
+                model_inputs["teacher_topk_log_probs"] = teacher_topk_log_probs
 
         # Router replay plumbing. Two responsibilities:
         #   (1) snapshot the ulysses pad_size for this micro-batch so


### PR DESCRIPTION
### What does this PR do?

Wires veomni's `chunk_topk_distill_function` into the verl actor
pipeline so on-policy distillation (OPD) batches can run with
`use_fused_kernels=True`. The fused kernel computes the top-K
forward-KL distillation loss without materializing the full
`[B, L, V]` logits tensor, saving significant GPU memory for
large-vocabulary models.

Previously, distillation TDs had to force `use_fused_kernels=False`
because the fused path only produced per-token log_probs/entropy —
the in-forward logit processor needed full logits to compute the
top-K weighted CE. With veomni 0.1.11's `chunk_topk_distill_function`,
the distillation loss is computed inline during the chunked
fused-linear forward pass.

### Design & Code Changes

Engine changes (two files, additive — no existing behavior modified):

- **`VeOmniEngineWithLMHead.prepare_model_inputs`**: when
  `use_fused_kernels=True`, `distillation_use_topk=True`, and
  `teacher_topk_ids` exists in the micro-batch, flattens the nested
  teacher tensors to `(1, total_nnz, K)` and passes them into
  `model_inputs`. They propagate as `**kwargs` through the model
  forward to `ForCausalLMLoss`, which routes to
  `chunk_topk_distill_function`. Includes paired validation (raises
  `ValueError` if `teacher_topk_ids` present without
  `teacher_topk_log_probs`). Guards on key existence so verl's
  native distillation path (different tensor keys) is unaffected.

- **`FSDPEngineWithLMHead.prepare_model_outputs`**: in the
  `use_fused_kernels=True` block, extracts `distillation_losses` /
  `student_mass` / `teacher_mass` from `output.fused_linear_aux` and
  stores them as nested tensors in `model_output` — same keys and
  format as the eager logit-processor path, so downstream loss
  functions work unchanged.

Both paths (fused and eager) remain fully functional:
- **Fused** (`use_fused_kernels=True`, VeOmni engine): `ForCausalLMLoss`
  routes to `chunk_topk_distill_function`.
- **Eager** (`use_fused_kernels=False`, FSDP/Megatron): existing
  in-forward logit processor fires as before.

CI: bump veomni from 0.1.10 to 0.1.11 (adds the `chunk_topk_distill`
kernel).

### Test

- **2xH100 unit test with Qwen3-0.6B**: synthetic distillation TD with
  `use_fused_kernels=True` and `distillation_use_topk=True`. Verified
  `distillation_losses`, `student_mass`, `teacher_mass` present as
  nested tensors in `model_output`, all values finite and non-negative,
  both ranks produce consistent output. Confirms our new engine code
  paths (input injection, output extraction) work correctly.

- **Full e2e example** (`run_qwen3_8b_mopd_veomni.sh` /
  `run_qwen3_0.6b_opd_veomni.sh` with verl native distillation):
  reaches actor backward on H100x8 then hits a pre-existing veomni
  `chunk_logprobs` + FSDP2 bug — see
  https://github.com/ByteDance-Seed/VeOmni/issues/804. The bug is in
  veomni's existing fused log_probs kernel (not added by this PR) and
  fires whenever `use_fused_kernels=True` is set for any VeOmni FSDP2
  actor with a backward pass, regardless of distillation. Our engine
  changes are downstream of this bug — verified path-clean by the
  unit test above. E2E example will run end-to-end once veomni #804
  lands.

### Dependencies

Requires veomni >= 0.1.11 for `chunk_topk_distill_function` and
`FusedLinearAuxOutput.distillation_losses`.
