### PR TITLE
[vllm] fix: reset all caches after weight updates

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -641,6 +641,14 @@ class vLLMHttpServer:
             # is a no-op success, so we can pass it unconditionally.
             await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
 
+    async def clear_all_caches(self):
+        await self.clear_kv_cache()
+        if self.node_rank == 0:
+            if _VLLM_VERSION >= version.parse("0.9.0"):
+                await self.engine.reset_mm_cache()
+            if _VLLM_VERSION >= version.parse("0.16.0"):
+                await self.engine.reset_encoder_cache()
+
     async def release_kv_cache(self):
         """Release only kv_cache GPU memory, keeping model weights intact.
         # TODO: support true release of kv_cache

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -641,9 +641,6 @@ class vLLMHttpServer:
             # is a no-op success, so we can pass it unconditionally.
             await self.engine.reset_prefix_cache(**_RESET_PREFIX_CACHE_KWARGS)
 
-    async def clear_all_caches(self):
-        await self.clear_kv_cache()
-        if self.node_rank == 0:
             if _VLLM_VERSION >= version.parse("0.9.0"):
                 await self.engine.reset_mm_cache()
             if _VLLM_VERSION >= version.parse("0.16.0"):

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -190,9 +190,9 @@ class ServerAdapter(BaseRollout):
         if future is not None:
             await future
 
-        # reset prefix cache after updating weights
+        # reset all caches after updating weights
         if self.rollout_rank == 0:
-            await self.server_handle.clear_kv_cache.remote()
+            await self.server_handle.clear_all_caches.remote()
             if global_steps is not None:
                 await self.server_handle.set_global_steps.remote(global_steps)
 

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -190,9 +190,9 @@ class ServerAdapter(BaseRollout):
         if future is not None:
             await future
 
-        # reset all caches after updating weights
+        # reset caches after updating weights
         if self.rollout_rank == 0:
-            await self.server_handle.clear_all_caches.remote()
+            await self.server_handle.clear_kv_cache.remote()
             if global_steps is not None:
                 await self.server_handle.set_global_steps.remote(global_steps)
 


### PR DESCRIPTION
### What does this PR do?

> This PR resets all available vLLM rollout caches after updating model weights.
>
> Previously, verl only reset the prefix/KV cache after `update_weights`. For multimodal rollouts, vLLM may also cache multimodal inputs and encoder outputs. Reusing those cached values after a weight update can lead to stale features being used during rollout.

This change adds a `clear_all_caches` helper on the vLLM HTTP server and calls it after weight updates.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+vllm+cache
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
