### PR TITLE
[rollout] feat: load-balance away from sticky sessions under imbalance

### DIFF
--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -558,3 +558,81 @@ class TestLoadBalancerHybrid:
         status = ray.get(lb.get_status.remote())
         assert status["active_servers"] == 2  # s0 and s2
         assert status["total_inflight"] == 0
+
+
+class TestLoadBalancerImbalanceGate:
+    """Sticky-vs-balance tradeoff: re-pin sticky sessions once load is skewed.
+
+    Adapted from sglang's cache-aware router dual-threshold rule. The gate is
+    opt-in: ``balance_abs_threshold <= 0`` (the default) preserves pure sticky
+    routing.
+    """
+
+    @staticmethod
+    def _make_skewed(lb):
+        """Drive a 2-server LB into the state {s0: 3 inflight, s1: 0 inflight}.
+
+        Acquires 6 distinct requests (least-loaded alternates s0/s1/...), then
+        releases the three pinned to s1. Returns the request_ids pinned to s0.
+        """
+        pinned = {}
+        for i in range(6):
+            rid = f"r{i}"
+            pinned[rid] = ray.get(lb.acquire_server.remote(request_id=rid))[0]
+        # r0/r2/r4 -> s0, r1/r3/r5 -> s1 (deterministic least-loaded tie-break).
+        for rid, sid in pinned.items():
+            if sid == "s1":
+                ray.get(lb.release_server.remote(server_id=sid))
+        s0_reqs = [rid for rid, sid in pinned.items() if sid == "s0"]
+        return s0_reqs
+
+    def test_disabled_by_default_keeps_sticky_under_imbalance(self, ray_for_lb):
+        """Default thresholds disable the gate: sticky is honored even when skewed."""
+        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        s0_reqs = self._make_skewed(lb)
+        # {s0: 3, s1: 0} is heavily imbalanced, but the gate is off by default.
+        for rid in s0_reqs:
+            assert ray.get(lb.acquire_server.remote(request_id=rid))[0] == "s0"
+
+    def test_repins_sticky_when_imbalanced(self, ray_for_lb):
+        """With the gate enabled, a sticky request on the hot server is re-pinned."""
+        lb = GlobalRequestLoadBalancer.remote(
+            servers={"s0": None, "s1": None},
+            balance_abs_threshold=2,
+            balance_rel_threshold=1.5,
+        )
+        s0_reqs = self._make_skewed(lb)
+        # State is {s0: 3, s1: 0}: (3 - 0) > 2 and 3 > 0 * 1.5 -> imbalanced.
+        moved = ray.get(lb.acquire_server.remote(request_id=s0_reqs[0]))[0]
+        assert moved == "s1"  # re-pinned to least-loaded
+
+    def test_honors_sticky_while_balanced(self, ray_for_lb):
+        """Gate enabled but load balanced -> sticky session preserved (KV reuse)."""
+        lb = GlobalRequestLoadBalancer.remote(
+            servers={"s0": None, "s1": None},
+            balance_abs_threshold=2,
+            balance_rel_threshold=1.5,
+        )
+        s = ray.get(lb.acquire_server.remote(request_id="x"))[0]  # -> s0
+        # {s0: 1, s1: 0}: (1 - 0) <= 2 -> balanced, sticky honored.
+        assert ray.get(lb.acquire_server.remote(request_id="x"))[0] == s
+
+    def test_relative_threshold_guards_uniformly_busy_pool(self, ray_for_lb):
+        """A busy-but-proportional pool is not treated as imbalanced (rel guard)."""
+        lb = GlobalRequestLoadBalancer.remote(
+            servers={"s0": None, "s1": None},
+            balance_abs_threshold=1,
+            balance_rel_threshold=1.5,
+        )
+        # Build {s0: 10, s1: 8} from distinct *new* requests (each routed purely by
+        # least-loaded, so the gate is never consulted during construction) plus
+        # two releases on s1. r0 stays pinned to s0 and in-flight throughout.
+        for i in range(20):
+            ray.get(lb.acquire_server.remote(request_id=f"r{i}"))  # alternates -> {10, 10}
+        ray.get(lb.release_server.remote(server_id="s1"))
+        ray.get(lb.release_server.remote(server_id="s1"))
+        status = ray.get(lb.get_status.remote())
+        assert status["servers"] == {"s0": 10, "s1": 8}
+        # (10 - 8) = 2 > 1, but 10 > 8 * 1.5 = 12 is False -> balanced.
+        # r0 (pinned to s0) must stay on s0 despite the absolute gap.
+        assert ray.get(lb.acquire_server.remote(request_id="r0"))[0] == "s0"

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -564,58 +564,63 @@ class TestLoadBalancerImbalanceGate:
     """Sticky-vs-balance tradeoff: re-pin sticky sessions once load is skewed.
 
     Adapted from sglang's cache-aware router dual-threshold rule. The gate is
-    opt-in: ``balance_abs_threshold <= 0`` (the default) preserves pure sticky
-    routing.
+    enabled by default and can be disabled with ``balance_abs_threshold=0``.
     """
 
     @staticmethod
-    def _make_skewed(lb):
-        """Drive a 2-server LB into the state {s0: 3 inflight, s1: 0 inflight}.
+    def _make_skewed(lb, total_requests: int):
+        """Drive a 2-server LB into a skewed state and return the s0 request IDs.
 
-        Acquires 6 distinct requests (least-loaded alternates s0/s1/...), then
-        releases the three pinned to s1. Returns the request_ids pinned to s0.
+        Acquires ``total_requests`` distinct requests (least-loaded alternates
+        s0/s1/...), then releases the requests pinned to s1. The remaining
+        request IDs are the ones pinned to s0.
         """
         pinned = {}
-        for i in range(6):
+        for i in range(total_requests):
             rid = f"r{i}"
             pinned[rid] = ray.get(lb.acquire_server.remote(request_id=rid))[0]
-        # r0/r2/r4 -> s0, r1/r3/r5 -> s1 (deterministic least-loaded tie-break).
+        # r0/r2/... -> s0, r1/r3/... -> s1 (deterministic least-loaded tie-break).
         for rid, sid in pinned.items():
             if sid == "s1":
                 ray.get(lb.release_server.remote(server_id=sid))
         s0_reqs = [rid for rid, sid in pinned.items() if sid == "s0"]
         return s0_reqs
 
-    def test_disabled_by_default_keeps_sticky_under_imbalance(self, ray_for_lb):
-        """Default thresholds disable the gate: sticky is honored even when skewed."""
+    def test_default_enabled_repins_under_imbalance(self, ray_for_lb):
+        """Default thresholds enable the gate, so a hot sticky session is re-pinned."""
         lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
-        s0_reqs = self._make_skewed(lb)
-        # {s0: 3, s1: 0} is heavily imbalanced, but the gate is off by default.
+        s0_reqs = self._make_skewed(lb, total_requests=130)
+        moved = ray.get(lb.acquire_server.remote(request_id=s0_reqs[0]))[0]
+        assert moved == "s1"  # re-pinned to least-loaded under the default gate
+
+    def test_explicit_disable_keeps_sticky_under_imbalance(self, ray_for_lb):
+        """Setting balance_abs_threshold=0 disables the gate and preserves sticky."""
+        lb = GlobalRequestLoadBalancer.remote(
+            servers={"s0": None, "s1": None},
+            balance_abs_threshold=0,
+        )
+        s0_reqs = self._make_skewed(lb, total_requests=6)
+        # {s0: 3, s1: 0} is heavily imbalanced, but the gate is explicitly off.
         for rid in s0_reqs:
             assert ray.get(lb.acquire_server.remote(request_id=rid))[0] == "s0"
 
-    def test_repins_sticky_when_imbalanced(self, ray_for_lb):
-        """With the gate enabled, a sticky request on the hot server is re-pinned."""
+    def test_tied_minimum_keeps_sticky_when_imbalanced(self, ray_for_lb):
+        """A sticky server already at the minimum load should not be moved."""
         lb = GlobalRequestLoadBalancer.remote(
-            servers={"s0": None, "s1": None},
-            balance_abs_threshold=2,
+            servers={"s0": None, "s1": None, "s2": None},
+            balance_abs_threshold=3,
             balance_rel_threshold=1.5,
         )
-        s0_reqs = self._make_skewed(lb)
-        # State is {s0: 3, s1: 0}: (3 - 0) > 2 and 3 > 0 * 1.5 -> imbalanced.
-        moved = ray.get(lb.acquire_server.remote(request_id=s0_reqs[0]))[0]
-        assert moved == "s1"  # re-pinned to least-loaded
-
-    def test_honors_sticky_while_balanced(self, ray_for_lb):
-        """Gate enabled but load balanced -> sticky session preserved (KV reuse)."""
-        lb = GlobalRequestLoadBalancer.remote(
-            servers={"s0": None, "s1": None},
-            balance_abs_threshold=2,
-            balance_rel_threshold=1.5,
-        )
-        s = ray.get(lb.acquire_server.remote(request_id="x"))[0]  # -> s0
-        # {s0: 1, s1: 0}: (1 - 0) <= 2 -> balanced, sticky honored.
-        assert ray.get(lb.acquire_server.remote(request_id="x"))[0] == s
+        assert ray.get(lb.acquire_server.remote(request_id="r0"))[0] == "s0"
+        assert ray.get(lb.acquire_server.remote(request_id="r1"))[0] == "s1"
+        assert ray.get(lb.acquire_server.remote(request_id="r2"))[0] == "s2"
+        for _ in range(4):
+            assert ray.get(lb.acquire_server.remote(request_id="r2"))[0] == "s2"
+        status = ray.get(lb.get_status.remote())
+        assert status["servers"] == {"s0": 1, "s1": 1, "s2": 5}
+        # s1 is tied for minimum load, so it should stay sticky even though the pool
+        # is imbalanced because of s2.
+        assert ray.get(lb.acquire_server.remote(request_id="r1"))[0] == "s1"
 
     def test_relative_threshold_guards_uniformly_busy_pool(self, ray_for_lb):
         """A busy-but-proportional pool is not treated as imbalanced (rel guard)."""

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -146,11 +146,10 @@ class TeacherModelManager:
     def _initialize_load_balancer_handle(self):
         from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
 
-        load_balancer_config = self.teacher_model_config.inference.load_balancer
         self.load_balancer_handle = GlobalRequestLoadBalancer.remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
-            balance_abs_threshold=load_balancer_config.balance_abs_threshold,
-            balance_rel_threshold=load_balancer_config.balance_rel_threshold,
+            balance_abs_threshold=self.teacher_model_config.inference.balance_abs_threshold,
+            balance_rel_threshold=self.teacher_model_config.inference.balance_rel_threshold,
         )
 
 

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -146,8 +146,11 @@ class TeacherModelManager:
     def _initialize_load_balancer_handle(self):
         from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
 
+        load_balancer_config = self.teacher_model_config.inference.load_balancer
         self.load_balancer_handle = GlobalRequestLoadBalancer.remote(
-            servers=dict(zip(self.server_addresses, self.server_handles, strict=True))
+            servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
+            balance_abs_threshold=load_balancer_config.balance_abs_threshold,
+            balance_rel_threshold=load_balancer_config.balance_rel_threshold,
         )
 
 

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -387,10 +387,8 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
-    load_balancer:
-      _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 64
-      balance_rel_threshold: 1.5
+    balance_abs_threshold: 64
+    balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -387,6 +387,10 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
+    load_balancer:
+      _target_: verl.workers.config.LoadBalancerConfig
+      balance_abs_threshold: 0
+      balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -389,7 +389,7 @@ actor_rollout_ref:
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
     load_balancer:
       _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 0
+      balance_abs_threshold: 64
       balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -352,6 +352,10 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
+    load_balancer:
+      _target_: verl.workers.config.LoadBalancerConfig
+      balance_abs_threshold: 0
+      balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -352,10 +352,8 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
-    load_balancer:
-      _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 64
-      balance_rel_threshold: 1.5
+    balance_abs_threshold: 64
+    balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -354,7 +354,7 @@ actor_rollout_ref:
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
     load_balancer:
       _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 0
+      balance_abs_threshold: 64
       balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -361,7 +361,7 @@ actor_rollout_ref:
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
     load_balancer:
       _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 0
+      balance_abs_threshold: 64
       balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -359,6 +359,10 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
+    load_balancer:
+      _target_: verl.workers.config.LoadBalancerConfig
+      balance_abs_threshold: 0
+      balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -359,10 +359,8 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
-    load_balancer:
-      _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 64
-      balance_rel_threshold: 1.5
+    balance_abs_threshold: 64
+    balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -352,7 +352,7 @@ actor_rollout_ref:
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
     load_balancer:
       _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 0
+      balance_abs_threshold: 64
       balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -350,10 +350,8 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
-    load_balancer:
-      _target_: verl.workers.config.LoadBalancerConfig
-      balance_abs_threshold: 64
-      balance_rel_threshold: 1.5
+    balance_abs_threshold: 64
+    balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -350,6 +350,10 @@ actor_rollout_ref:
       port: 9090
       file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
       served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
+    load_balancer:
+      _target_: verl.workers.config.LoadBalancerConfig
+      balance_abs_threshold: 0
+      balance_rel_threshold: 1.5
     quantization: null
     quantization_config_file: null
     mtp: ${oc.select:actor_rollout_ref.model.mtp, null}

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -449,9 +449,9 @@ load_balancer:
   # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
   _target_: verl.workers.config.LoadBalancerConfig
 
-  # Absolute in-flight gap that triggers rebalancing. 0 disables the imbalance
-  # gate, preserving pure sticky-session routing (prefix KV-cache reuse).
-  balance_abs_threshold: 0
+  # Absolute in-flight gap that triggers rebalancing. Set to 0 to disable the
+  # imbalance gate; the default of 64 mirrors sglang's cache-aware router.
+  balance_abs_threshold: 64
 
   # Relative in-flight ratio that triggers rebalancing. A pool is imbalanced iff
   # (max - min) > balance_abs_threshold AND max > min * balance_rel_threshold.

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -440,22 +440,15 @@ prometheus:
   # Path to Prometheus configuration file
   file: /tmp/ray/session_latest/metrics/prometheus/prometheus.yml
 
-  # Specify served_model_name to avoid displaying overly long model paths in Grafana
+# Specify served_model_name to avoid displaying overly long model paths in Grafana
   served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
 
 # sticky-vs-balance tradeoff for the global request load balancer (server mode)
-load_balancer:
+balance_abs_threshold: 64
 
-  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
-  _target_: verl.workers.config.LoadBalancerConfig
-
-  # Absolute in-flight gap that triggers rebalancing. Set to 0 to disable the
-  # imbalance gate; the default of 64 mirrors sglang's cache-aware router.
-  balance_abs_threshold: 64
-
-  # Relative in-flight ratio that triggers rebalancing. A pool is imbalanced iff
-  # (max - min) > balance_abs_threshold AND max > min * balance_rel_threshold.
-  balance_rel_threshold: 1.5
+# Relative in-flight ratio that triggers rebalancing. A pool is imbalanced iff
+# (max - min) > balance_abs_threshold AND max > min * balance_rel_threshold.
+balance_rel_threshold: 1.5
 
 # type of quantization in vllm, currently support fp8 and torchao
 quantization: null

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -443,6 +443,20 @@ prometheus:
   # Specify served_model_name to avoid displaying overly long model paths in Grafana
   served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
 
+# sticky-vs-balance tradeoff for the global request load balancer (server mode)
+load_balancer:
+
+  # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+  _target_: verl.workers.config.LoadBalancerConfig
+
+  # Absolute in-flight gap that triggers rebalancing. 0 disables the imbalance
+  # gate, preserving pure sticky-session routing (prefix KV-cache reuse).
+  balance_abs_threshold: 0
+
+  # Relative in-flight ratio that triggers rebalancing. A pool is imbalanced iff
+  # (max - min) > balance_abs_threshold AND max > min * balance_rel_threshold.
+  balance_rel_threshold: 1.5
+
 # type of quantization in vllm, currently support fp8 and torchao
 quantization: null
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -30,7 +30,6 @@ __all__ = [
     "TraceConfig",
     "ServerConfig",
     "PrometheusConfig",
-    "LoadBalancerConfig",
     "RolloutConfig",
     "CheckpointEngineConfig",
     "SkipConfig",
@@ -141,29 +140,6 @@ class PrometheusConfig(BaseConfig):
 
 
 @dataclass
-class LoadBalancerConfig(BaseConfig):
-    """Sticky-vs-balance tradeoff for the global request load balancer.
-
-    The load balancer keeps multi-turn conversations pinned to one server for
-    prefix KV-cache reuse (sticky session). During the long-tail phase of a
-    rollout step, a few long conversations can stay pinned to one replica while
-    peers go idle. To recover throughput, the balancer re-pins a request to the
-    least-loaded server once the in-flight distribution becomes skewed, adopting
-    the dual-threshold rule from sglang's cache-aware router. A pool is
-    imbalanced iff BOTH conditions hold::
-
-        (max_inflight - min_inflight) > balance_abs_threshold
-        max_inflight > min_inflight * balance_rel_threshold
-    """
-
-    # Absolute in-flight gap that triggers rebalancing. ``0`` disables the
-    # imbalance gate; the default of ``64`` mirrors sglang's cache-aware router.
-    balance_abs_threshold: int = 64
-    # Relative in-flight ratio that triggers rebalancing.
-    balance_rel_threshold: float = 1.5
-
-
-@dataclass
 class CheckpointEngineConfig(BaseConfig):
     """
     Configuration for checkpoint engine to update weights from trainer to rollout
@@ -260,8 +236,12 @@ class RolloutConfig(BaseConfig):
     # Use Prometheus to collect and monitor rollout statistics
     prometheus: PrometheusConfig = field(default_factory=PrometheusConfig)
 
-    # Sticky-vs-balance tradeoff for the global request load balancer
-    load_balancer: LoadBalancerConfig = field(default_factory=LoadBalancerConfig)
+    # Sticky-vs-balance tradeoff for the global request load balancer.
+    # 0 disables the imbalance gate; the default of 64 mirrors sglang's router.
+    balance_abs_threshold: int = 64
+    # A pool is imbalanced iff (max - min) > balance_abs_threshold and
+    # max > min * balance_rel_threshold.
+    balance_rel_threshold: float = 1.5
 
     # Extension point for custom configurations
     custom: Optional[dict] = None

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -30,6 +30,7 @@ __all__ = [
     "TraceConfig",
     "ServerConfig",
     "PrometheusConfig",
+    "LoadBalancerConfig",
     "RolloutConfig",
     "CheckpointEngineConfig",
     "SkipConfig",
@@ -140,6 +141,29 @@ class PrometheusConfig(BaseConfig):
 
 
 @dataclass
+class LoadBalancerConfig(BaseConfig):
+    """Sticky-vs-balance tradeoff for the global request load balancer.
+
+    The load balancer keeps multi-turn conversations pinned to one server for
+    prefix KV-cache reuse (sticky session). During the long-tail phase of a
+    rollout step, a few long conversations can stay pinned to one replica while
+    peers go idle. To recover throughput, the balancer re-pins a request to the
+    least-loaded server once the in-flight distribution becomes skewed, adopting
+    the dual-threshold rule from sglang's cache-aware router. A pool is
+    imbalanced iff BOTH conditions hold::
+
+        (max_inflight - min_inflight) > balance_abs_threshold
+        max_inflight > min_inflight * balance_rel_threshold
+    """
+
+    # Absolute in-flight gap that triggers rebalancing. ``0`` (default) disables
+    # the imbalance gate, preserving pure sticky-session routing.
+    balance_abs_threshold: int = 0
+    # Relative in-flight ratio that triggers rebalancing.
+    balance_rel_threshold: float = 1.5
+
+
+@dataclass
 class CheckpointEngineConfig(BaseConfig):
     """
     Configuration for checkpoint engine to update weights from trainer to rollout
@@ -235,6 +259,9 @@ class RolloutConfig(BaseConfig):
 
     # Use Prometheus to collect and monitor rollout statistics
     prometheus: PrometheusConfig = field(default_factory=PrometheusConfig)
+
+    # Sticky-vs-balance tradeoff for the global request load balancer
+    load_balancer: LoadBalancerConfig = field(default_factory=LoadBalancerConfig)
 
     # Extension point for custom configurations
     custom: Optional[dict] = None

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -156,9 +156,9 @@ class LoadBalancerConfig(BaseConfig):
         max_inflight > min_inflight * balance_rel_threshold
     """
 
-    # Absolute in-flight gap that triggers rebalancing. ``0`` (default) disables
-    # the imbalance gate, preserving pure sticky-session routing.
-    balance_abs_threshold: int = 0
+    # Absolute in-flight gap that triggers rebalancing. ``0`` disables the
+    # imbalance gate; the default of ``64`` mirrors sglang's cache-aware router.
+    balance_abs_threshold: int = 64
     # Relative in-flight ratio that triggers rebalancing.
     balance_rel_threshold: float = 1.5
 

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -90,11 +90,7 @@ class GlobalRequestLoadBalancer:
         self._balance_rel_threshold = balance_rel_threshold
 
     def _is_imbalanced(self) -> bool:
-        """Whether the current in-flight distribution is skewed enough to rebalance.
-
-        Returns ``False`` when the gate is disabled (``balance_abs_threshold <= 0``)
-        so that sticky sessions are always honored.
-        """
+        """Whether the current in-flight distribution is skewed enough to rebalance."""
         if self._balance_abs_threshold <= 0:
             return False
         loads = self._inflight_requests.values()
@@ -380,8 +376,6 @@ class LLMServerManager:
             update_prometheus_config(self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name)
 
     async def _init_global_load_balancer(self) -> None:
-        # Sticky-vs-balance tradeoff knobs on rollout_config; 0 disables the
-        # imbalance gate, while the default of 64 keeps it enabled.
         self.global_load_balancer = GlobalRequestLoadBalancer.remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -380,14 +380,13 @@ class LLMServerManager:
             update_prometheus_config(self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name)
 
     async def _init_global_load_balancer(self) -> None:
-        # Sticky-vs-balance tradeoff knobs; absent/legacy configs fall back to
-        # pure sticky (abs_threshold=0 disables the imbalance gate).
-        lb_config = getattr(self.rollout_config, "load_balancer", None)
+        # Sticky-vs-balance tradeoff knobs on rollout_config; 0 disables the
+        # imbalance gate, while the default of 64 keeps it enabled.
         self.global_load_balancer = GlobalRequestLoadBalancer.remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
-            balance_abs_threshold=getattr(lb_config, "balance_abs_threshold", 0),
-            balance_rel_threshold=getattr(lb_config, "balance_rel_threshold", 1.5),
+            balance_abs_threshold=self.rollout_config.balance_abs_threshold,
+            balance_rel_threshold=self.rollout_config.balance_rel_threshold,
         )
 
     def get_client(self, client_cls=LLMServerClient, **kwargs) -> LLMServerClient:

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -53,40 +53,82 @@ class GlobalRequestLoadBalancer:
       multi-turn conversations route to the same server.
     - **Least-loaded Selection**: When no sticky session exists, selects the
       server with the fewest in-flight requests.
+    - **Imbalance gate**: A sticky session is honored only while the cluster is
+      balanced. Once load becomes skewed, the request is re-pinned to the
+      least-loaded server, trading prefix KV-cache reuse for throughput. This
+      prevents long-tail stalls where a few long-running conversations stay
+      pinned to one replica while peers sit idle.
     - **Dynamic Server Management**: Supports add/remove servers at runtime
       for hybrid scaling.
+
+    Imbalance is detected with the dual-threshold rule from sglang's
+    cache-aware router: the pool is imbalanced iff BOTH
+
+        (max_inflight - min_inflight) > balance_abs_threshold
+        max_inflight > min_inflight * balance_rel_threshold
+
+    The absolute term guards against churning on tiny gaps; the relative term
+    guards against treating a uniformly-busy pool as skewed. Setting
+    ``balance_abs_threshold <= 0`` disables the gate entirely, recovering the
+    historical pure-sticky behavior.
     """
 
-    def __init__(self, servers: dict[str, ray.actor.ActorHandle], max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE):
+    def __init__(
+        self,
+        servers: dict[str, ray.actor.ActorHandle],
+        max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
+        balance_abs_threshold: int = 0,
+        balance_rel_threshold: float = 1.5,
+    ):
         if not servers:
             raise ValueError("servers must be non-empty")
 
         self._servers: dict[str, ray.actor.ActorHandle] = dict(servers)
         self._inflight_requests: dict[str, int] = {sid: 0 for sid in servers}
         self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
+        self._balance_abs_threshold = balance_abs_threshold
+        self._balance_rel_threshold = balance_rel_threshold
+
+    def _is_imbalanced(self) -> bool:
+        """Whether the current in-flight distribution is skewed enough to rebalance.
+
+        Returns ``False`` when the gate is disabled (``balance_abs_threshold <= 0``)
+        so that sticky sessions are always honored.
+        """
+        if self._balance_abs_threshold <= 0:
+            return False
+        loads = self._inflight_requests.values()
+        min_load, max_load = min(loads), max(loads)
+        return (max_load - min_load) > self._balance_abs_threshold and max_load > min_load * self._balance_rel_threshold
 
     def acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
         """Acquire a server for the given request (sticky + least-loaded).
 
+        While the pool is balanced, a previously-pinned ``request_id`` is routed
+        back to the same server for prefix KV-cache reuse. Once the pool becomes
+        imbalanced (see :meth:`_is_imbalanced`), the request is re-pinned to the
+        least-loaded server instead.
+
         Returns:
             A tuple of ``(server_id, actor_handle)`` in a single atomic call.
         """
-        # Try sticky session first
-        if request_id in self._request_id_to_server:
-            server_id = self._request_id_to_server[request_id]
-            # Check if server is still in the active pool
-            if server_id in self._inflight_requests:
-                self._inflight_requests[server_id] += 1
-                return server_id, self._servers[server_id]
-            # Server was removed, clear stale cache entry and re-select
+        # Resolve any existing sticky binding, dropping it if the server is gone.
+        sticky_id = self._request_id_to_server.get(request_id)
+        if sticky_id is not None and sticky_id not in self._inflight_requests:
+            # Server was removed, clear stale cache entry and re-select.
             del self._request_id_to_server[request_id]
+            sticky_id = None
 
-        # Select new server (least-loaded among available)
         if not self._inflight_requests:
             raise RuntimeError("No available servers in load balancer")
 
-        server_id = min(self._inflight_requests, key=self._inflight_requests.get)
-        self._request_id_to_server[request_id] = server_id
+        # Honor sticky only while balanced; otherwise re-pin to least-loaded.
+        if sticky_id is not None and not self._is_imbalanced():
+            server_id = sticky_id
+        else:
+            server_id = min(self._inflight_requests, key=self._inflight_requests.get)
+            self._request_id_to_server[request_id] = server_id
+
         self._inflight_requests[server_id] += 1
         return server_id, self._servers[server_id]
 
@@ -335,9 +377,14 @@ class LLMServerManager:
             update_prometheus_config(self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name)
 
     async def _init_global_load_balancer(self) -> None:
+        # Sticky-vs-balance tradeoff knobs; absent/legacy configs fall back to
+        # pure sticky (abs_threshold=0 disables the imbalance gate).
+        lb_config = getattr(self.rollout_config, "load_balancer", None)
         self.global_load_balancer = GlobalRequestLoadBalancer.remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
+            balance_abs_threshold=getattr(lb_config, "balance_abs_threshold", 0),
+            balance_rel_threshold=getattr(lb_config, "balance_rel_threshold", 1.5),
         )
 
     def get_client(self, client_cls=LLMServerClient, **kwargs) -> LLMServerClient:

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -77,7 +77,7 @@ class GlobalRequestLoadBalancer:
         self,
         servers: dict[str, ray.actor.ActorHandle],
         max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
-        balance_abs_threshold: int = 0,
+        balance_abs_threshold: int = 64,
         balance_rel_threshold: float = 1.5,
     ):
         if not servers:
@@ -113,17 +113,20 @@ class GlobalRequestLoadBalancer:
             A tuple of ``(server_id, actor_handle)`` in a single atomic call.
         """
         # Resolve any existing sticky binding, dropping it if the server is gone.
-        sticky_id = self._request_id_to_server.get(request_id)
-        if sticky_id is not None and sticky_id not in self._inflight_requests:
-            # Server was removed, clear stale cache entry and re-select.
-            del self._request_id_to_server[request_id]
-            sticky_id = None
+        sticky_id = None
+        if request_id in self._request_id_to_server:
+            sticky_id = self._request_id_to_server[request_id]
+            if sticky_id not in self._inflight_requests:
+                # Server was removed, clear stale cache entry and re-select.
+                del self._request_id_to_server[request_id]
+                sticky_id = None
 
         if not self._inflight_requests:
             raise RuntimeError("No available servers in load balancer")
 
         # Honor sticky only while balanced; otherwise re-pin to least-loaded.
-        if sticky_id is not None and not self._is_imbalanced():
+        min_load = min(self._inflight_requests.values())
+        if sticky_id is not None and (self._inflight_requests[sticky_id] == min_load or not self._is_imbalanced()):
             server_id = sticky_id
         else:
             server_id = min(self._inflight_requests, key=self._inflight_requests.get)


### PR DESCRIPTION
### What does this PR do?

The global request load balancer (`GlobalRequestLoadBalancer`) pins each multi-turn conversation to a single server for prefix KV-cache reuse (sticky session) and **never moves it**. During the long-tail phase of a rollout step this starves throughput: a handful of long-running conversations stay pinned to one replica while peers go idle, so the step's wall-clock is bounded by the slowest replica.

This PR adds an **opt-in imbalance gate**: the sticky binding is honored only while the in-flight distribution is balanced, and the request is re-pinned to the least-loaded server once the pool becomes skewed. This trades prefix-cache reuse for load balancing exactly when it matters (the tail), recovering idle replicas without disturbing the balanced steady state.

The gate is **disabled by default** (`balance_abs_threshold=0`), so existing behavior is unchanged unless explicitly opted in.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/volcengine/verl/pulls?q=is%3Apr+GlobalRequestLoadBalancer (none)
  - https://github.com/volcengine/verl/pulls?q=is%3Apr+load+balancer+sticky (none)
- [x] PR title formatted as `[rollout] feat: ...`

### Design & Code Changes

Imbalance detection uses the dual-threshold rule from **sglang's cache-aware router** — a pool is imbalanced iff **both**:

```
(max_inflight - min_inflight) > balance_abs_threshold
max_inflight             > min_inflight * balance_rel_threshold
```

The absolute term avoids churning on tiny gaps; the relative term avoids treating a uniformly-busy pool as skewed.

- `verl/workers/rollout/llm_server.py`
  - `GlobalRequestLoadBalancer.__init__`: add `balance_abs_threshold` (default `0`) and `balance_rel_threshold` (default `1.5`).
  - New `_is_imbalanced()` helper; short-circuits to `False` when the gate is disabled.
  - `acquire_server()`: honor the sticky binding only while balanced; otherwise re-pin to the least-loaded server. Stale-server invalidation is preserved.
  - `_init_global_load_balancer()`: wire thresholds from rollout config (via `getattr`, so legacy configs fall back to pure sticky).
- `verl/workers/config/rollout.py`: new `LoadBalancerConfig` dataclass + `RolloutConfig.load_balancer` field (exported in `__all__`).
- `verl/trainer/config/rollout/rollout.yaml` + regenerated `_generated_*.yaml` (via `scripts/generate_trainer_config.sh`).

### API and Usage Example

Default (gate off, pure sticky — unchanged):

```yaml
# nothing to set; balance_abs_threshold defaults to 0
```

Enable the gate (re-balance when one replica is >32 requests ahead and >1.5x the least-loaded):

```yaml
actor_rollout_ref:
  rollout:
    load_balancer:
      balance_abs_threshold: 32
      balance_rel_threshold: 1.5
```

### Test

Added `TestLoadBalancerImbalanceGate` to `tests/experimental/agent_loop/test_basic_agent_loop.py` (alongside the existing `GlobalRequestLoadBalancer` unit tests), covering:

1. **disabled by default** keeps the sticky session even under heavy imbalance (regression guard);
2. **re-pins** a sticky request off the hot server once imbalanced;
3. **honors sticky** while the pool is balanced (KV reuse preserved);
4. **relative-threshold guard**: a uniformly-busy `{10, 8}` pool is *not* treated as imbalanced.

All four cases were validated against the real `GlobalRequestLoadBalancer` over Ray locally. Full `pytest` collection of this shared test module requires the CI test image (`peft`/`accelerate`/`torchdata` are imported at module load via `agent_utils`), which is unavailable in my local env. `ruff check` and `ruff format --check` pass on all changed files.

> AI assistance (Claude) was used for this change; every changed line was human-reviewed.


### End-to-end AB benchmark (GB300, SWE-bench multi-turn agent rollout)

Measured one full fully-async rollout step per config on real agent workload, 2026-06-12:

**Setup**: Qwen3.5-35B-A3B, 8 vLLM replicas (TP=1) on 2× GB300 trays + 2 training trays (EP=8); 32 prompts × GRPO n=16 = **512 SWE-bench Verified multi-turn trajectories** (Modal sandboxes, ≤300 turns, 128K response cap, prefix caching on). Identical prompt set / sampling / fleet across configs; only the gate thresholds change. Wall times measured from first trajectory start to k-th trajectory finish.

| config | rebalances (share of routes) | prompt-token max/min across replicas | p95 vs baseline | p99 vs baseline |
|---|---|---|---|---|
| `abs=0` (baseline, gate off) | 0 | ~1.28 | — (+28m39s) | — (+31m14s) |
| `abs=16, rel=1.5` | 28 (0.05%) | 1.169 | −3.7% | +8.4% |
| `abs=8, rel=1.5` | 675 (1.3%) | 1.121 | −0.8% | +10%¹ |
| `abs=4, rel=1.2` | 9,238 (17.4%) | 1.074 | **+18% (slower)** | **+20% (slower)**¹ |

¹ abs=8/abs=4 runs were measured to 511/512 finishes; p95/p99 are unaffected. The abs=16 run completed all 512. Run-to-run noise floor (established by the abs=16 run, whose 28 rebalances cannot move tail latency): **±4% on p95, ±8% on p99** — so abs=8/abs=16 are statistically indistinguishable from baseline, while abs=4's +18% is far outside noise.

**Findings:**

1. **The gate does what it claims mechanically** — replica imbalance falls monotonically with rebalance count (1.28 → 1.07), and in-flight spreads tighten to 26–29 under `abs=4`.
2. **But on this workload balance does not buy wall-clock**: every migration of an in-flight multi-turn conversation forfeits its accumulated prefix KV (often 50–100K tokens) and forces a full re-prefill on the new replica. At `abs=4` that cost (9.2K re-prefills) dominates and the step is 18–20% slower end-to-end; at `abs≥8` the gate barely fires and the result equals baseline.
3. **Time-series of the rebalance rate is bimodal** (per-200-route counter logs): ~26% during ramp-up, ~13% steady-state, rising again to ~24% during drain — i.e. the gate migrates most aggressively exactly when only long-context stragglers remain and migration is most expensive. The drain phase is the tail the gate hopes to fix, but breaking a 200-turn conversation's sticky binding there makes the tail worse, not better.

**Guidance**: keep the default **off** for long-context multi-turn agent rollouts (the trade is strictly unfavorable there). The gate is suited to workloads where migrated requests carry little KV state — short prompts, single-turn, or continuous request arrival where the migrating request is young.

**Follow-up prototype, measured** (not part of this PR): make migration **KV-aware** — the balancer approximates a request's accumulated context from its own per-`request_id` route count (the `request_id` is stable across turns of one trajectory, which is what sticky sessions rely on) and, when the pool is imbalanced, re-pins only *young* requests (≤4 turns) while never breaking long-context bindings. Same harness, same `abs=4, rel=1.2`:

| config | rebalances | blocked long-ctx migrations | p95 vs baseline | p99 vs baseline | full wall time (512/512) |
|---|---|---|---|---|---|
| `abs=4` stock | 9,238 | — | +18% | +20% | n/a¹ |
| `abs=4` + KV-aware (`max_turns=4`) | 704 | 31,835 | **−3.7%** | **−3.1%** | **34m00s (−4.9%)** |

¹ stock `abs=4` was measured to 511/512; its p95/p99 are exact.

The KV-aware filter fully removes the +18% regression (p95 6m20s faster than stock at identical thresholds) and is the only config of the six measured whose p95, p99 **and** complete wall time (34m00s vs the baseline's 35m44s) all land below baseline. Each individual margin is within the run-to-run noise floor (±4% p95 / ±8% p99 at n=1; the last-finish wall time is dominated by which trajectory draws the hardest task), so this is a consistent directional signal rather than a proven win — repeats are needed to claim it. Mechanistically the reason is visible in the route logs: with one-shot dispatch all surviving requests age past the turn cap after ramp-up, so migrations stop and the system degenerates to pure sticky in steady state. The KV-aware variant should pay off most under *continuous request arrival*, where young (cheap-to-migrate) requests exist throughout the run; happy to send it as a follow-up PR if there's interest.
