### PR TITLE
[algo] fix: stabilize PPO policy-loss ratio computation

### DIFF
--- a/tests/trainer/ppo/test_core_algos_on_cpu.py
+++ b/tests/trainer/ppo/test_core_algos_on_cpu.py
@@ -24,12 +24,16 @@ from verl.trainer.ppo.core_algos import (
     compute_gae_advantage_return,
     compute_grpo_outcome_advantage,
     compute_grpo_vectorized_outcome_advantage,
+    compute_policy_loss_clip_cov,
+    compute_policy_loss_geo_mean,
+    compute_policy_loss_kl_cov,
     compute_rloo_outcome_advantage,
     compute_rloo_vectorized_outcome_advantage,
     get_adv_estimator_fn,
     kl_penalty,
     register_adv_est,
 )
+from verl.workers.config.actor import ActorConfig
 
 
 def mock_test_fn():
@@ -379,6 +383,41 @@ def test_kl_penalty_k3_plus_uses_k2_gradient():
     (grad_k2,) = torch.autograd.grad(out_k2, logprob_k2)
 
     assert torch.allclose(grad_plus, grad_k2)
+
+
+@pytest.mark.parametrize(
+    ("loss_fn", "expected_ppo_kl"),
+    [
+        (compute_policy_loss_clip_cov, -20.0),
+        (compute_policy_loss_kl_cov, 20.0),
+        (compute_policy_loss_geo_mean, -20.0),
+    ],
+)
+def test_policy_loss_variants_clamp_negative_approx_kl_for_stability(loss_fn, expected_ppo_kl):
+    config = ActorConfig(
+        strategy="fsdp",
+        rollout_n=1,
+        ppo_micro_batch_size_per_gpu=1,
+        clip_ratio=1000.0,
+        clip_ratio_low=1000.0,
+        clip_ratio_high=1000.0,
+    )
+    old_log_prob = torch.zeros((2, 2))
+    log_prob = torch.full((2, 2), 1000.0)
+    advantages = -torch.ones((2, 2))
+    response_mask = torch.ones((2, 2))
+
+    pg_loss, metrics = loss_fn(
+        old_log_prob=old_log_prob,
+        log_prob=log_prob,
+        advantages=advantages,
+        response_mask=response_mask,
+        loss_agg_mode="token-mean",
+        config=config,
+    )
+
+    assert torch.isfinite(pg_loss)
+    assert metrics["actor/ppo_kl"] == pytest.approx(expected_ppo_kl)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1787,6 +1787,8 @@ def compute_policy_loss_clip_cov(
     assert clip_cov_ratio > 0, "clip_ratio should be larger than 0."
 
     negative_approx_kl = log_prob - old_log_prob
+    # Clamp negative_approx_kl for stability
+    negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
     ratio = torch.exp(negative_approx_kl)
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
 
@@ -1879,6 +1881,8 @@ def compute_policy_loss_kl_cov(
     assert kl_cov_ratio > 0, "kl_cov_ratio should be larger than 0."
 
     negative_approx_kl = log_prob - old_log_prob
+    # Clamp negative_approx_kl for stability
+    negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
     abs_kl = negative_approx_kl.abs()
     ratio = torch.exp(negative_approx_kl)
     ppo_kl_abs = verl_F.masked_mean(negative_approx_kl.abs(), response_mask)
@@ -1961,8 +1965,8 @@ def compute_policy_loss_geo_mean(
         cliprange_high = cliprange
 
     negative_approx_kl = log_prob - old_log_prob
-    # Clamp negative_approx_kl for stability (uncomment it if you like)
-    # negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
+    # Clamp negative_approx_kl for stability
+    negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
 
     # Clipping at token-level & Clipping wider


### PR DESCRIPTION
Clamp negative_approx_kl in all affected PPO policy-loss variants to prevent extreme-ratio instability and keep losses finite.

Regression test added for extreme log-probability differences with finite loss + bounded KL behavior checks.

### What does this PR do?

This PR partially addresses #6478, specifically issue A around unstable PPO policy-loss behavior when `negative_approx_kl = log_prob - old_log_prob` becomes extremely large.

Several PPO policy-loss variants depend on `exp(negative_approx_kl)`. Without bounding this value, extreme log-probability differences can produce `inf` ratios and unstable or non-finite losses.

This PR clamps `negative_approx_kl` to `[-20, 20]` in the affected policy-loss variants:

- `compute_policy_loss_clip_cov`
- `compute_policy_loss_kl_cov`
- `compute_policy_loss_geo_mean`

It also adds a focused CPU regression test that verifies these loss variants keep finite losses and bounded KL metrics under extreme log-probability differences.

This is not duplicating an existing PR. I checked the current open PRs for #6478 and related PPO loss / `negative_approx_kl` keywords, and found no open PR addressing this same fix.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6478+in%3Abody
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+negative_approx_kl+ppo+kl+clamp+policy+loss
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+clip_cov+kl_cov+geo_mean+ppo+loss
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Passed:

```bash
.venv/bin/python -m pytest tests/trainer/ppo/test_core_algos_on_cpu.py::test_policy_loss_variants_clamp_negative_approx_kl_for_stability -q
.venv/bin/python -m pytest tests/trainer/ppo/test_core_algos_on_cpu.py -q
.venv/bin/ruff check verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py
.venv/bin/ruff format --check verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py
.venv/bin/pre-commit run --files verl/trainer/ppo/core_algos.py tests/trainer/ppo/test_core_algos_on_cpu.py --show-diff-on-failure --color=always
```

### API and Usage Example

No API or config changes.

### Design & Code Changes

The fix is intentionally narrow:

- Clamp `negative_approx_kl` before calling `torch.exp(...)` in the affected PPO policy-loss variants.
- Keep the clamp range consistent with existing PPO loss stability handling in this file.
- Add a regression test covering extreme `log_prob - old_log_prob` values to ensure:
  - the policy loss remains finite
  - the reported KL metric is bounded as expected

Changed files:

- `verl/trainer/ppo/core_algos.py`
- `tests/trainer/ppo/test_core_algos_on_cpu.py`

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Changed-file pre-commit was run and passed.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not applicable: this is an internal numerical-stability fix with no user-facing API/config/docs change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
  - Added a focused CPU unit regression test in `tests/trainer/ppo/test_core_algos_on_cpu.py`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable: this PR does not touch the `recipe` submodule.
