### PR TITLE
[rollout] fix: avoid arbitrary code execution in Qwen3 tool parser

### DIFF
--- a/tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py
+++ b/tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for ``Qwen3XMLToolParser`` parameter-value conversion.
+
+These exercise ``_parse_xml_function_call`` directly (no tokenizer / network
+needed) and in particular guard against arbitrary code execution when a
+non-primitive parameter (e.g. an ``array``) is parsed from untrusted model
+output.
+"""
+
+import json
+
+from verl.experimental.agent_loop.tool_parser import Qwen3XMLToolParser
+from verl.tools.schemas import (
+    OpenAIFunctionParametersSchema,
+    OpenAIFunctionPropertySchema,
+    OpenAIFunctionSchema,
+    OpenAIFunctionToolSchema,
+)
+
+
+def _make_tool(param_name: str, param_type: str) -> OpenAIFunctionToolSchema:
+    return OpenAIFunctionToolSchema(
+        type="function",
+        function=OpenAIFunctionSchema(
+            name="list_tool",
+            description="a tool used for testing",
+            parameters=OpenAIFunctionParametersSchema(
+                type="object",
+                properties={param_name: OpenAIFunctionPropertySchema(type=param_type)},
+                required=[],
+            ),
+        ),
+    )
+
+
+def _parse_single_param(param_type: str, raw_value: str):
+    parser = Qwen3XMLToolParser(tokenizer=None)
+    tool = _make_tool("items", param_type)
+    # The string fed to _parse_xml_function_call is exactly what _get_function_calls
+    # extracts from "<function=NAME>...<parameter=KEY>VALUE</parameter>...</function>".
+    function_call_str = f"list_tool><parameter=items>{raw_value}</parameter>"
+    result = parser._parse_xml_function_call(function_call_str, [tool])
+    return result
+
+
+def test_array_literal_is_parsed():
+    """A legitimate array literal is still parsed into its Python value."""
+    result = _parse_single_param("array", "[1, 2, 3]")
+    # arguments is a JSON string; the list literal round-trips to a JSON array.
+    assert result.arguments == '{"items": [1, 2, 3]}'
+
+
+def test_array_param_does_not_execute_arbitrary_code(tmp_path):
+    """An ``array`` parameter must never execute code from model output.
+
+    Regression test: the value used to be passed to ``eval()``, allowing
+    arbitrary code execution. It must now be handled by ``ast.literal_eval``,
+    which rejects non-literals and degenerates to the raw string.
+    """
+    marker = tmp_path / "pwned.txt"
+    assert not marker.exists()
+
+    payload = f'__import__("os").system("echo pwned > {marker}")'
+    result = _parse_single_param("array", payload)
+
+    # No code executed: the marker file was never created ...
+    assert not marker.exists(), "ast.literal_eval must not execute arbitrary code"
+    # ... and the unparseable value degenerates to the original string unchanged.
+    assert json.loads(result.arguments)["items"] == payload

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 import json
 import logging
 import os
@@ -280,11 +281,14 @@ class Qwen3XMLToolParser(ToolParser):
                             f"JSON object in tool '{func_name}', will try other methods to parse it."
                         )
                 try:
-                    param_value = eval(param_value)
+                    # Use ast.literal_eval instead of eval: the parameter value comes from
+                    # untrusted model output, and eval() would allow arbitrary code execution.
+                    # literal_eval only parses Python literals (lists, tuples, dicts, numbers, ...).
+                    param_value = ast.literal_eval(param_value)
                 except Exception:
                     logger.warning(
                         f"Parsed value '{param_value}' of parameter '{param_name}' cannot be converted "
-                        f"via Python `eval()` in tool '{func_name}', degenerating to string."
+                        f"via `ast.literal_eval()` in tool '{func_name}', degenerating to string."
                     )
                 return param_value
 


### PR DESCRIPTION
### What

`Qwen3XMLToolParser._parse_xml_function_call` converts a parameter value whose declared type is not `string/int/float/bool/object` (e.g. `array`) by calling `eval(param_value)`. `param_value` is taken verbatim from the **decoded model output**, so a crafted tool call lets the model execute arbitrary Python (RCE):

```
<tool_call><function=foo><parameter=items>__import__("os").system("...")</parameter></function></tool_call>
```
with `items` declared as type `array` runs `os.system` at parse time.

This PR replaces `eval()` with `ast.literal_eval()`, which only parses Python literals. Legitimate literals like `[1, 2, 3]` still parse identically; anything else is rejected and degenerates to the raw string (the existing fallback).

### Why this is not a duplicate

- No open PR touches this code or `ast.literal_eval` (searched `tool_parser`, `literal_eval`, `qwen3 tool parser`).
- Issue **#5331** tracks the same vulnerability class and explicitly recommends `ast.literal_eval()`, but lists only `prime_math/grader.py` and `protocol.py` — it does **not** cover this `tool_parser.py` location.

### Tests run

Added `tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py` (CPU, no GPU/tokenizer):
- `test_array_literal_is_parsed`: `array` value `[1, 2, 3]` still parses to `{"items": [1, 2, 3]}`.
- `test_array_param_does_not_execute_arbitrary_code`: a code-execution payload creates **no** side-effect file and degenerates to a string.

Verified locally by exercising the real `_parse_xml_function_call` (module loaded directly to avoid GPU deps):
- before (eval): payload created the marker file → RCE confirmed;
- after (ast.literal_eval): no marker; legitimate `[1,2,3]`/`{"a":1}`/`(1,2)` parse correctly.

(Full `pytest` for this path needs the `.[test]` env (torch/ray/transformers); the targeted repro above was run on CPU.)

### AI assistance

AI assistance (Claude) was used to locate the issue and draft the fix and test. The change has been reviewed line-by-line by me and I can defend it end-to-end.