### PR TITLE
[ckpt] fix: extract_step should use the last global_step_ match

### DIFF
--- a/verl/utils/checkpoint/checkpoint_handler.py
+++ b/verl/utils/checkpoint/checkpoint_handler.py
@@ -31,9 +31,12 @@ from verl.workers.engine import BaseEngine
 
 
 def extract_step(path):
-    match = re.search(r"global_step_(\d+)", path)
-    if match:
-        return int(match.group(1))
+    # A path can contain more than one "global_step_<n>" segment (e.g. resuming
+    # from a checkpoint nested under an older run). The actual checkpoint folder
+    # is the last such segment, so take the last match rather than the first.
+    matches = re.findall(r"global_step_(\d+)", path)
+    if matches:
+        return int(matches[-1])
     return None
 
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -465,9 +465,9 @@ class TorchTitanEngine(BaseEngine):
         self.checkpointer.folder = parent_dir
 
         # Extract step number from path (verl uses global_step_N format)
-        match = re.search(r"global_step_(\d+)", local_path)
-        if match:
-            step = int(match.group(1))
+        matches = re.findall(r"global_step_(\d+)", local_path)
+        if matches:
+            step = int(matches[-1])
             self.checkpointer.load(step=step)
         else:
             # Fallback to latest


### PR DESCRIPTION
### What

`extract_step` used `re.search(r"global_step_(\d+)", path)`, which returns the **first** occurrence. When a path contains more than one `global_step_<n>` segment (e.g. resuming from a checkpoint nested under a directory named after an older run), it returns the wrong (earlier) step instead of the actual checkpoint folder's step. A wrong resume step corrupts training-resume bookkeeping (dataloader position, step counter).

Fix: use `re.findall(...)[-1]` to take the **last** match — the same semantics the rest of the codebase already uses via `.split("global_step_")[-1]` (`ray_trainer.py`, `main_ppo_sync.py`, `fully_async_*`). The identical pattern in the torchtitan engine (`verl/workers/engine/torchtitan/transformer_impl.py`) is fixed the same way.

### Why this is not a duplicate

No open PR addresses `extract_step` / checkpoint step parsing (searched `extract_step`, `global_step`).

### Tests run (CPU)

```
extract_step("/exp/global_step_100/run/global_step_250") -> 250   (was 100)
extract_step("/x/global_step_42")                        -> 42
extract_step("/x/model")                                 -> None
```

### AI assistance

AI assistance (Claude) was used to locate the issue and draft the fix. Reviewed line-by-line by me.