### PR TITLE
[reward] fix: release worker count when NaiveRouter request fails after retries

### DIFF
--- a/verl/experimental/reward_loop/router/naive_router.py
+++ b/verl/experimental/reward_loop/router/naive_router.py
@@ -147,30 +147,35 @@ class NaiveRouter:
         body = await request.body()
         headers = dict(request.headers)
 
-        for attempt in range(self.max_attempts):
-            # Send request to worker
-            try:
-                async with self.client.request(request.method, target_url, data=body, headers=headers) as response:
-                    response.raise_for_status()
-                    output = await _read_async_response(response)
-                    self._release_worker(worker_url)
-                    return output
-            except asyncio.TimeoutError:
-                logger.warning(f"Async request to {endpoint} timed out (attempt {attempt + 1})")
-            except aiohttp.ClientConnectorError:
-                logger.warning(f"Connection error for {endpoint} (attempt {attempt + 1})")
-            except aiohttp.ClientResponseError as e:
-                logger.error(f"HTTP error for {endpoint}: {e}")
-                raise
-            except Exception as e:
-                logger.error(f"Unexpected error for {endpoint}: {e}")
-                if attempt == self.max_attempts - 1:
+        try:
+            for attempt in range(self.max_attempts):
+                # Send request to worker
+                try:
+                    async with self.client.request(request.method, target_url, data=body, headers=headers) as response:
+                        response.raise_for_status()
+                        output = await _read_async_response(response)
+                        return output
+                except asyncio.TimeoutError:
+                    logger.warning(f"Async request to {endpoint} timed out (attempt {attempt + 1})")
+                except aiohttp.ClientConnectorError:
+                    logger.warning(f"Connection error for {endpoint} (attempt {attempt + 1})")
+                except aiohttp.ClientResponseError as e:
+                    logger.error(f"HTTP error for {endpoint}: {e}")
                     raise
+                except Exception as e:
+                    logger.error(f"Unexpected error for {endpoint}: {e}")
+                    if attempt == self.max_attempts - 1:
+                        raise
 
-            if attempt < self.max_attempts - 1:
-                await asyncio.sleep(self.retry_delay * (2**attempt))
+                if attempt < self.max_attempts - 1:
+                    await asyncio.sleep(self.retry_delay * (2**attempt))
 
-        raise RuntimeError(f"Failed to complete async request to {endpoint} after {self.max_attempts} attempts")
+            raise RuntimeError(f"Failed to complete async request to {endpoint} after {self.max_attempts} attempts")
+        finally:
+            # Always balance the increment from _select_worker(), even when the
+            # request fails or raises after exhausting retries; otherwise the
+            # worker's count leaks upward and skews load balancing permanently.
+            self._release_worker(worker_url)
 
     def _select_worker(self) -> str:
         """Select the least-loaded worker (simple round-robin by request count)."""


### PR DESCRIPTION
### What

`NaiveRouter._select_worker()` increments `request_counts[url]`, but `_release_worker()` was only called on the **success** path. When all `max_attempts` fail and the method raises (the `RuntimeError` after the loop, or a re-raised `ClientResponseError` / final unexpected error), the worker's count is never decremented and leaks upward forever. Since selection is `min(request_counts, ...)`, a repeatedly-failing worker accumulates phantom load and permanently skews load balancing.

Fix: wrap the retry loop in `try/finally` and release the worker in `finally`, so the single increment from `_select_worker()` is always balanced exactly once, success or failure.

### Why this is not a duplicate

No open PR touches `naive_router` / worker accounting.

### Tests run (CPU)

Replicating the method's control flow: after 3 requests whose worker is always down, `request_counts` returns to `{0, 0}` with the fix (previously leaked to non-zero and never recovered).

### AI assistance

AI assistance (Claude) was used to locate the issue and draft the fix. Reviewed line-by-line by me.