### PR TITLE
[reward] fix: union reward_extra_info keys across samples in compute_rm_score

### DIFF
--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -339,10 +339,17 @@ class RewardLoopManager:
         batch = TensorDict({"rm_scores": rm_scores}, batch_size=len(data))
 
         reward_extra_infos = [output.get("reward_extra_info", {}) for output in outputs_flat]
-        reward_extra_keys = list(reward_extra_infos[0].keys())
+        # Collect the union of keys across all outputs rather than only the first
+        # one. Different samples may produce different reward_extra_info keys; using
+        # only outputs[0] either raises KeyError (a later sample is missing a key
+        # the first one has) or silently drops keys (present only in later samples).
+        reward_extra_keys = list(dict.fromkeys(key for info in reward_extra_infos for key in info))
         non_tensor_batch = {}
         for key in reward_extra_keys:
-            non_tensor_batch[key] = np.array([info[key] for info in reward_extra_infos])
+            # Preserve the original dtype on the common (consistent-keys) path; only
+            # missing values fall back to None (yielding an object array) instead of
+            # raising KeyError.
+            non_tensor_batch[key] = np.array([info.get(key, None) for info in reward_extra_infos])
 
         if self.reward_model_manager is not None:
             self.reward_model_manager.sleep()


### PR DESCRIPTION
### What

`compute_rm_score` built the extra-info column set from `reward_extra_infos[0]` only. When samples in a batch carry different `reward_extra_info` keys, this either raises `KeyError` (a later sample is missing a key the first one has) or silently drops keys that appear only in later samples.

Fix: collect the order-preserving **union** of keys across all outputs and use `info.get(key, None)` so a missing value falls back to `None` instead of crashing. The common case where every sample shares the same keys is unchanged, including the resulting array dtype.

> Note: missing values fall back to `None` (object array for that column). If maintainers prefer a stricter contract (assert all samples share the same keys) or a typed default, happy to adjust.

### Why this is not a duplicate

No open PR touches `compute_rm_score` / reward_extra_info assembly.

### Tests run (CPU, replicating lines 341-345)

```
consistent keys            -> dtype preserved (float64), values [1.0 0.5]
later sample missing key   -> no KeyError (acc = [1.0 None])
first sample missing key   -> key retained (was silently dropped)
```

### AI assistance

AI assistance (Claude) was used to locate the issue and draft the fix. Reviewed line-by-line by me.