### PR TITLE
[rollout] fix: use strict zip in build_gpt_oss_tool_response_text

### DIFF
--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -101,8 +101,10 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
 def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]], tool_call_names: list[str]) -> str:
     """Build gpt-oss tool response text (manual formatting + generation prompt)."""
     tool_response_texts: list[str] = []
-    for i, tool_msg in enumerate(messages):
-        actual_tool_name = tool_call_names[i]
+    # Use strict zip so a messages/tool_call_names length mismatch fails loudly
+    # instead of raising an opaque IndexError or silently dropping trailing names
+    # (matches the gemma4 path in tool_agent_loop.py).
+    for tool_msg, actual_tool_name in zip(messages, tool_call_names, strict=True):
         formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], actual_tool_name)
         tool_response_texts.append(formatted)
     return add_generation_prompt_for_gpt_oss("".join(tool_response_texts))


### PR DESCRIPTION
### What

`build_gpt_oss_tool_response_text` iterated `messages` by index into `tool_call_names` without checking equal length: a longer `messages` raises an opaque `IndexError`, a longer `tool_call_names` silently drops trailing names. The sibling gemma4 path already uses `zip(..., strict=True)`.

Switch to `zip(messages, tool_call_names, strict=True)` so any mismatch fails loudly and consistently.

### Scope / honesty

The current sole caller always passes equal-length lists, so this is **defensive hardening** consistent with the gemma4 path rather than a currently-reachable bug. Flagging explicitly per the contribution guidelines — happy to close if maintainers consider it too minor to carry on its own.

### Tests run (CPU)

Mismatched inputs now raise `ValueError` (strict zip) instead of `IndexError` / silent drop; equal-length inputs behave unchanged.

### AI assistance

AI assistance (Claude) was used to locate the issue and draft the fix. Reviewed line-by-line by me.