### PR TITLE
[ci,veomni] fix: make router-replay install test independent of veomn…

### DIFF
--- a/tests/utils/veomni/test_router_replay_on_cpu.py
+++ b/tests/utils/veomni/test_router_replay_on_cpu.py
@@ -385,12 +385,10 @@ def test_install_without_veomni_raises(ctrl):
     typed RuntimeError pointing the user at the dependency, not a raw
     ImportError."""
     with pytest.MonkeyPatch.context() as mp:
-        # Drop both the package and the submodule from sys.modules to
-        # force a real ImportError inside install().
-        mp.delitem(sys.modules, "veomni.utils.moe_router_replay", raising=False)
-        mp.delitem(sys.modules, "veomni.utils", raising=False)
-        mp.delitem(sys.modules, "veomni", raising=False)
-        # Also poison the import path so a fresh import attempt fails.
-        mp.setattr("sys.path", [p for p in sys.path if "veomni" not in p.lower()])
+        # Setting sys.modules[name] = None makes Python's import machinery
+        # raise ImportError on `from veomni.utils.moe_router_replay import ...`
+        # without needing to manipulate sys.path (which doesn't help when
+        # veomni is installed in site-packages).
+        mp.setitem(sys.modules, "veomni.utils.moe_router_replay", None)
         with pytest.raises(RuntimeError, match="VeOmni build"):
             ctrl.install(nn.Linear(1, 1))


### PR DESCRIPTION
### What does this PR do?

Fix `tests/utils/veomni/test_router_replay_on_cpu.py::test_install_without_veomni_raises` failing in CI

### Checklist Before Starting

- [x] Searched for similar PRs: `gh pr list --repo verl-project/verl --state open --search "router
 replay install test"` — none found.
- [x] PR title format: `[ci,veomni] fix: make router-replay install test independent of veomni
install path`

### Test

Verified on a Linux workspace with `veomni==0.1.10` installed (matching the CI image):

```bash
pytest tests/utils/veomni/test_router_replay_on_cpu.py -v
# 15 passed in 3.24s