### PR TITLE
[trainer] Improve one-step dataloader exhaustion error

### DIFF
--- a/tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
+++ b/tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.experimental.one_step_off_policy.ray_trainer import OneStepOffRayTrainer
+
+
+async def _none_batch():
+    return None
+
+
+def test_fit_generate_reports_dataloader_exhaustion_on_cpu():
+    trainer = OneStepOffRayTrainer.__new__(OneStepOffRayTrainer)
+    trainer.metrics = {}
+    trainer.timing_raw = {}
+    trainer.global_steps = 5
+    trainer.total_training_steps = 10
+    trainer.config = OmegaConf.create(
+        {
+            "data": {
+                "train_batch_size": 8,
+                "train_max_samples": 32,
+            },
+            "trainer": {
+                "total_epochs": 1,
+                "total_training_steps": 10,
+            },
+        }
+    )
+
+    async def run():
+        batch_data_future = asyncio.create_task(_none_batch())
+        with pytest.raises(RuntimeError, match="Training dataloader was exhausted"):
+            await trainer._fit_generate(batch_data_future, iter(()))
+
+    asyncio.run(run())

--- a/tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
+++ b/tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
@@ -30,22 +30,17 @@ def test_fit_generate_reports_dataloader_exhaustion_on_cpu():
     trainer.timing_raw = {}
     trainer.global_steps = 5
     trainer.total_training_steps = 10
-    trainer.config = OmegaConf.create(
-        {
-            "data": {
-                "train_batch_size": 8,
-                "train_max_samples": 32,
-            },
-            "trainer": {
-                "total_epochs": 1,
-                "total_training_steps": 10,
-            },
-        }
-    )
+    trainer.config = OmegaConf.create({"data": {"train_batch_size": 8}})
 
     async def run():
         batch_data_future = asyncio.create_task(_none_batch())
-        with pytest.raises(RuntimeError, match="Training dataloader was exhausted"):
+        with pytest.raises(RuntimeError) as exc_info:
             await trainer._fit_generate(batch_data_future, iter(()))
+        message = str(exc_info.value)
+        assert "Training dataloader was exhausted" in message
+        assert "data.train_batch_size=8" in message
+        assert "data.train_max_samples=N/A" in message
+        assert "trainer.total_epochs=N/A" in message
+        assert "trainer.total_training_steps=N/A" in message
 
     asyncio.run(run())

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -399,7 +399,11 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
                 total_epochs = OmegaConf.select(self.config, "trainer.total_epochs", default="N/A")
                 total_training_steps = OmegaConf.select(
                     self.config, "trainer.total_training_steps", default="N/A"
-                )
+            if batch_data is None:
+                train_batch_size = OmegaConf.select(self.config, "data.train_batch_size", default="N/A")
+                train_max_samples = OmegaConf.select(self.config, "data.train_max_samples", default="N/A")
+                total_epochs = OmegaConf.select(self.config, "trainer.total_epochs", default="N/A")
+                total_training_steps = OmegaConf.select(self.config, "trainer.total_training_steps", default="N/A")
                 raise RuntimeError(
                     "Training dataloader was exhausted before one-step-off-policy reached "
                     f"step {self.global_steps}/{self.total_training_steps}. "

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -392,7 +392,19 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
         timing_raw = self.timing_raw
 
         with marked_timer("gen", timing_raw, color="red"):
-            _metrics, _timing_raw, epoch, batch, future_reward = await batch_data_future
+            batch_data = await batch_data_future
+            if batch_data is None:
+                raise RuntimeError(
+                    "Training dataloader was exhausted before one-step-off-policy reached "
+                    f"step {self.global_steps}/{self.total_training_steps}. "
+                    f"Current data.train_batch_size={self.config.data.train_batch_size}, "
+                    f"data.train_max_samples={self.config.data.get('train_max_samples', -1)}, "
+                    f"trainer.total_epochs={self.config.trainer.total_epochs}, "
+                    f"trainer.total_training_steps={self.config.trainer.total_training_steps}. "
+                    "Increase data.train_max_samples or trainer.total_epochs, or reduce "
+                    "trainer.total_training_steps."
+                )
+            _metrics, _timing_raw, epoch, batch, future_reward = batch_data
             batch.meta_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
             timing_raw.update(batch.meta_info["timing"])
             timing_raw.update(_timing_raw)

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -394,13 +394,19 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
         with marked_timer("gen", timing_raw, color="red"):
             batch_data = await batch_data_future
             if batch_data is None:
+                train_batch_size = OmegaConf.select(self.config, "data.train_batch_size", default="N/A")
+                train_max_samples = OmegaConf.select(self.config, "data.train_max_samples", default="N/A")
+                total_epochs = OmegaConf.select(self.config, "trainer.total_epochs", default="N/A")
+                total_training_steps = OmegaConf.select(
+                    self.config, "trainer.total_training_steps", default="N/A"
+                )
                 raise RuntimeError(
                     "Training dataloader was exhausted before one-step-off-policy reached "
                     f"step {self.global_steps}/{self.total_training_steps}. "
-                    f"Current data.train_batch_size={self.config.data.train_batch_size}, "
-                    f"data.train_max_samples={self.config.data.get('train_max_samples', -1)}, "
-                    f"trainer.total_epochs={self.config.trainer.total_epochs}, "
-                    f"trainer.total_training_steps={self.config.trainer.total_training_steps}. "
+                    f"Current data.train_batch_size={train_batch_size}, "
+                    f"data.train_max_samples={train_max_samples}, "
+                    f"trainer.total_epochs={total_epochs}, "
+                    f"trainer.total_training_steps={total_training_steps}. "
                     "Increase data.train_max_samples or trainer.total_epochs, or reduce "
                     "trainer.total_training_steps."
                 )


### PR DESCRIPTION
### What does this PR do?

Improves the error handling in `one_step_off_policy` when the training dataloader is exhausted before the configured number of training steps is reached.

Previously, `_async_gen_next_batch()` returned `None` on `StopIteration`, and `_fit_generate()` immediately unpacked that value, producing a low-level error:

```text
TypeError: cannot unpack non-iterable NoneType object
```

This PR turns that case into a clear `RuntimeError` that reports the current step and relevant data/trainer settings, so users can adjust `data.train_max_samples`, `trainer.total_epochs`, or `trainer.total_training_steps` directly.

### Why this is not duplicating existing work

Duplicate checks run against `verl-project/verl` open PRs/issues:

```bash
gh pr list --repo verl-project/verl --state open --search "one_step_off_policy NoneType" --limit 20
gh pr list --repo verl-project/verl --state open --search "cannot unpack non-iterable NoneType object" --limit 20
gh pr list --repo verl-project/verl --state open --search "dataloader exhausted" --limit 20
gh pr list --repo verl-project/verl --state open --search "one-step-off-policy dataloader" --limit 20
gh issue list --repo verl-project/verl --state open --search "one_step_off_policy NoneType" --limit 20
gh issue list --repo verl-project/verl --state open --search "cannot unpack non-iterable NoneType object" --limit 20
gh issue list --repo verl-project/verl --state open --search "dataloader exhausted" --limit 20
gh issue list --repo verl-project/verl --state open --search "one-step-off-policy dataloader" --limit 20
```

The only nearby open PR found was #3475, which adds dataloader buffering to conserve filtered samples. This PR is materially different: it only improves the `one_step_off_policy` error path when no next batch is available.

### Tests

```bash
PYTHONPATH=$PWD pytest -q tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
ruff check verl/experimental/one_step_off_policy/ray_trainer.py tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
python -m py_compile verl/experimental/one_step_off_policy/ray_trainer.py tests/experimental/one_step_off_policy/test_ray_trainer_on_cpu.py
git diff --check
```

Results: targeted pytest passed (`1 passed`), ruff passed, py_compile passed, and diff check passed.

### AI assistance

AI assistance was used to prepare this draft PR. The human submitter should review every changed line and rerun the relevant tests before marking it ready for review.