### PR TITLE
[rollout,vllm,cfg] feat: expose vLLM tool-calling config

### DIFF
--- a/tests/workers/config/test_rollout_config_on_cpu.py
+++ b/tests/workers/config/test_rollout_config_on_cpu.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.workers.config.rollout import RolloutConfig
+
+
+def test_rollout_yaml_exposes_vllm_tool_calling_defaults():
+    """Smoke test documented vLLM tool-calling defaults in rollout config."""
+    cfg = OmegaConf.load("verl/trainer/config/rollout/rollout.yaml")
+
+    assert cfg.engine_kwargs.vllm.enable_auto_tool_choice is False
+    assert cfg.engine_kwargs.vllm.tool_call_parser is None
+    assert cfg.engine_kwargs.vllm.tool_parser_plugin is None
+
+
+def test_vllm_auto_tool_choice_requires_tool_call_parser():
+    with pytest.raises(ValueError, match="tool_call_parser"):
+        RolloutConfig(
+            name="vllm",
+            engine_kwargs={"vllm": {"enable_auto_tool_choice": True}},
+        )
+
+
+def test_vllm_auto_tool_choice_accepts_tool_call_parser():
+    cfg = RolloutConfig(
+        name="vllm",
+        engine_kwargs={"vllm": {"enable_auto_tool_choice": True, "tool_call_parser": "hermes"}},
+    )
+
+    assert cfg.engine_kwargs["vllm"]["tool_call_parser"] == "hermes"

--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -15,6 +15,7 @@
 import json
 
 import pytest
+from omegaconf import OmegaConf
 
 from verl.workers.rollout.vllm_cli_args import build_cli_args_from_config
 
@@ -83,6 +84,20 @@ class TestBuildCliArgsFromConfig:
         assert result[0] == "--extra-config"
         # JSON output may have different key ordering, so parse and compare
         assert json.loads(result[1]) == {"key": "value", "nested": True}
+
+    def test_omegaconf_container_values(self):
+        """OmegaConf list/dict values are handled like plain Python containers."""
+        config = OmegaConf.create(
+            {
+                "cuda-graph-sizes": [1, 2, 4],
+                "extra-config": {"key": "value", "nested": True},
+            }
+        )
+        result = build_cli_args_from_config(config)
+
+        assert result[:4] == ["--cuda-graph-sizes", "1", "2", "4"]
+        assert result[4] == "--extra-config"
+        assert json.loads(result[5]) == {"key": "value", "nested": True}
 
     def test_mixed_config(self):
         """Test a realistic mixed configuration."""

--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from verl.workers.rollout.vllm_rollout.utils import build_cli_args_from_config
+from verl.workers.rollout.vllm_cli_args import build_cli_args_from_config
 
 
 class TestBuildCliArgsFromConfig:
@@ -109,6 +109,23 @@ class TestBuildCliArgsFromConfig:
         # Check skipped values are not present
         assert "--disable-log-requests" not in result
         assert "--lora-path" not in result
+
+    def test_vllm_tool_calling_options(self):
+        """vLLM tool-calling options are serialized for the serve parser."""
+        config = {
+            "enable_auto_tool_choice": True,
+            "tool_call_parser": "hermes",
+            "tool_parser_plugin": "custom.tool_parser",
+        }
+        result = build_cli_args_from_config(config)
+
+        assert result == [
+            "--enable_auto_tool_choice",
+            "--tool_call_parser",
+            "hermes",
+            "--tool_parser_plugin",
+            "custom.tool_parser",
+        ]
 
     def test_preserves_order(self):
         """Arguments should preserve dictionary order (Python 3.7+)."""

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -302,7 +302,10 @@ actor_rollout_ref:
     over_sample_rate: 0
     multi_stage_wake_up: false
     engine_kwargs:
-      vllm: {}
+      vllm:
+        enable_auto_tool_choice: false
+        tool_call_parser: null
+        tool_parser_plugin: null
       sglang: {}
       trtllm: {}
     val_kwargs:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -267,7 +267,10 @@ actor_rollout_ref:
     over_sample_rate: 0
     multi_stage_wake_up: false
     engine_kwargs:
-      vllm: {}
+      vllm:
+        enable_auto_tool_choice: false
+        tool_call_parser: null
+        tool_parser_plugin: null
       sglang: {}
       trtllm: {}
     val_kwargs:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -274,7 +274,10 @@ actor_rollout_ref:
     over_sample_rate: 0
     multi_stage_wake_up: false
     engine_kwargs:
-      vllm: {}
+      vllm:
+        enable_auto_tool_choice: false
+        tool_call_parser: null
+        tool_parser_plugin: null
       sglang: {}
       trtllm: {}
     val_kwargs:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -265,7 +265,10 @@ actor_rollout_ref:
     over_sample_rate: 0
     multi_stage_wake_up: false
     engine_kwargs:
-      vllm: {}
+      vllm:
+        enable_auto_tool_choice: false
+        tool_call_parser: null
+        tool_parser_plugin: null
       sglang: {}
       trtllm: {}
     val_kwargs:

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -131,7 +131,16 @@ multi_stage_wake_up: false
 engine_kwargs:
 
   # vllm engine config
-  vllm: {}
+  vllm:
+
+    # Whether to enable vLLM auto tool choice. Requires a compatible tool_call_parser.
+    enable_auto_tool_choice: False
+
+    # vLLM tool call parser name, e.g. hermes, llama3_json, mistral.
+    tool_call_parser: null
+
+    # Optional Python module path for a custom vLLM tool parser plugin.
+    tool_parser_plugin: null
 
   # sglang engine config
   sglang: {}

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -297,6 +297,14 @@ class RolloutConfig(BaseConfig):
                 stacklevel=2,
             )
 
+        vllm_engine_kwargs = (self.engine_kwargs or {}).get("vllm", {}) or {}
+        if self.name == "vllm" and vllm_engine_kwargs.get("enable_auto_tool_choice", False):
+            if not vllm_engine_kwargs.get("tool_call_parser"):
+                raise ValueError(
+                    "`actor_rollout_ref.rollout.engine_kwargs.vllm.tool_call_parser` must be set when "
+                    "`actor_rollout_ref.rollout.engine_kwargs.vllm.enable_auto_tool_choice=True`."
+                )
+
         if self.name != "trtllm" and self.expert_parallel_size > 1:
             assert self.expert_parallel_size == (self.tensor_model_parallel_size * self.data_parallel_size), (
                 "expert_parallel_size must be equal to tensor_model_parallel_size * data_parallel_size"

--- a/verl/workers/rollout/vllm_cli_args.py
+++ b/verl/workers/rollout/vllm_cli_args.py
@@ -12,10 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+from collections.abc import Mapping
 from typing import Any
 
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
-def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
+
+def _to_plain_container(value: Any) -> Any:
+    if isinstance(value, DictConfig | ListConfig):
+        return OmegaConf.to_container(value, resolve=True)
+    if isinstance(value, Mapping):
+        return {k: _to_plain_container(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_to_plain_container(v) for v in value]
+    return value
+
+
+def build_cli_args_from_config(config: Mapping[str, Any] | DictConfig) -> list[str]:
     """
     Convert a config dictionary to CLI arguments for vLLM server.
 
@@ -34,6 +47,10 @@ def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
     Returns:
         List of CLI argument strings
     """
+    config = _to_plain_container(config)
+    if not isinstance(config, Mapping):
+        raise TypeError(f"config must be a mapping, got {type(config).__name__}")
+
     cli_args = []
     for k, v in config.items():
         if v is None:

--- a/verl/workers/rollout/vllm_cli_args.py
+++ b/verl/workers/rollout/vllm_cli_args.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from typing import Any
+
+
+def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
+    """
+    Convert a config dictionary to CLI arguments for vLLM server.
+
+    Handles different value types appropriately:
+    - None: skipped
+    - bool True: adds '--key'
+    - bool False: skipped
+    - list: expands to '--key item1 item2 ...'
+    - empty list: skipped (vLLM uses nargs="+" which requires at least one value)
+    - dict: JSON serialized
+    - other: string converted
+
+    Args:
+        config: Dictionary of configuration key-value pairs
+
+    Returns:
+        List of CLI argument strings
+    """
+    cli_args = []
+    for k, v in config.items():
+        if v is None:
+            continue
+        if isinstance(v, bool):
+            if v:
+                cli_args.append(f"--{k}")
+        elif isinstance(v, list):
+            if not v:
+                # Skip empty lists - vLLM uses nargs="+" which requires at least one value
+                continue
+            # Lists need to be expanded as multiple separate arguments
+            # e.g., --cuda-graph-sizes 1 2 4 8 becomes ['--cuda-graph-sizes', '1', '2', '4', '8']
+            cli_args.append(f"--{k}")
+            cli_args.extend([str(item) for item in v])
+        else:
+            cli_args.append(f"--{k}")
+            # Use json.dumps for dict to ensure valid JSON format
+            cli_args.append(json.dumps(v) if isinstance(v, dict) else str(v))
+    return cli_args

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
-import json
 import logging
 import os
 import platform
 import signal
 import threading
 from types import MethodType
-from typing import Any, Literal, Optional, get_args
+from typing import Literal, Optional, get_args
 
 import torch
 from vllm.outputs import RequestOutput
@@ -316,47 +315,6 @@ class SuppressSignalInThread:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         signal.signal = self.original_signal
-
-
-def build_cli_args_from_config(config: dict[str, Any]) -> list[str]:
-    """
-    Convert a config dictionary to CLI arguments for vLLM server.
-
-    Handles different value types appropriately:
-    - None: skipped
-    - bool True: adds '--key'
-    - bool False: skipped
-    - list: expands to '--key item1 item2 ...'
-    - empty list: skipped (vLLM uses nargs="+" which requires at least one value)
-    - dict: JSON serialized
-    - other: string converted
-
-    Args:
-        config: Dictionary of configuration key-value pairs
-
-    Returns:
-        List of CLI argument strings
-    """
-    cli_args = []
-    for k, v in config.items():
-        if v is None:
-            continue
-        if isinstance(v, bool):
-            if v:
-                cli_args.append(f"--{k}")
-        elif isinstance(v, list):
-            if not v:
-                # Skip empty lists - vLLM uses nargs="+" which requires at least one value
-                continue
-            # Lists need to be expanded as multiple separate arguments
-            # e.g., --cuda-graph-sizes 1 2 4 8 becomes ['--cuda-graph-sizes', '1', '2', '4', '8']
-            cli_args.append(f"--{k}")
-            cli_args.extend([str(item) for item in v])
-        else:
-            cli_args.append(f"--{k}")
-            # Use json.dumps for dict to ensure valid JSON format
-            cli_args.append(json.dumps(v) if isinstance(v, dict) else str(v))
-    return cli_args
 
 
 def extract_prompt_logprobs(output: RequestOutput, num_prompt_logprobs: Optional[int], result_dict: dict[str, list]):

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -43,12 +43,12 @@ from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
+from verl.workers.rollout.vllm_cli_args import build_cli_args_from_config
 from verl.workers.rollout.vllm_rollout.utils import (
     VLLM_LORA_INT_ID,
     VLLM_LORA_NAME,
     VLLM_LORA_PATH,
     SuppressSignalInThread,
-    build_cli_args_from_config,
     extract_prompt_logprobs,
     get_vllm_max_lora_rank,
 )


### PR DESCRIPTION
### What does this PR do?

This PR adds minimal vLLM tool-calling config plumbing for rollout:

- exposes vLLM engine kwargs for `enable_auto_tool_choice`, `tool_call_parser`, and `tool_parser_plugin` in rollout config
- validates that `tool_call_parser` is set when `enable_auto_tool_choice=True` for vLLM rollouts
- moves vLLM CLI arg serialization into a lightweight helper that can be tested without importing vLLM
- adds CPU tests for the rollout config defaults, validation, and CLI arg serialization

This is intentionally scoped to config plumbing and validation. It does not implement full native vLLM tool execution, parser result handling, or multi-turn tool state.

Refs #3911, #344

### Duplicate-work check

- No open PR references #3911 or #344.
- No open PR found for `enable_auto_tool_choice`, `tool_call_parser`, or `tool_parser_plugin`.
- Related tool parser PRs such as #6406 and #6480 are model/parser-specific and do not duplicate this vLLM rollout config plumbing.

### Tests

```bash
python -m pytest tests/workers/config/test_rollout_config_on_cpu.py tests/workers/rollout/test_vllm_cli_args_on_cpu.py tests/special_sanity/test_config_docs.py -q
```

Result:

```text
19 passed, 1 warning
```

Also ran targeted formatting/lint checks and whitespace check:

```bash
pre-commit run ruff-format --files tests/workers/config/test_rollout_config_on_cpu.py tests/workers/rollout/test_vllm_cli_args_on_cpu.py verl/workers/config/rollout.py verl/workers/rollout/vllm_cli_args.py verl/workers/rollout/vllm_rollout/utils.py verl/workers/rollout/vllm_rollout/vllm_async_server.py
pre-commit run ruff --files tests/workers/config/test_rollout_config_on_cpu.py tests/workers/rollout/test_vllm_cli_args_on_cpu.py verl/workers/config/rollout.py verl/workers/rollout/vllm_cli_args.py verl/workers/rollout/vllm_rollout/utils.py verl/workers/rollout/vllm_rollout/vllm_async_server.py
git diff --check
```

### AI Assistance

AI assistance was used for code navigation, patch drafting, and test suggestions. I reviewed every changed line and validated the final changes with the tests above.