### PR TITLE
[training_utils,megatron] fix: keep rmpad logprob labels within sequence

### DIFF
--- a/tests/utils/test_rmpad_logprob_labels_on_cpu.py
+++ b/tests/utils/test_rmpad_logprob_labels_on_cpu.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import types
+
+import torch
+
+from verl.utils import torch_functional
+
+
+def _pad_input(hidden_states, indices, batch, seqlen):
+    output = torch.zeros(
+        batch * seqlen,
+        *hidden_states.shape[1:],
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    output[indices] = hidden_states
+    return output.view(batch, seqlen, *hidden_states.shape[1:])
+
+
+def _unpad_input(hidden_states, attention_mask):
+    indices = torch.nonzero(attention_mask.reshape(-1), as_tuple=False).squeeze(-1)
+    hidden_states = hidden_states.reshape(attention_mask.numel(), *hidden_states.shape[2:])
+    return hidden_states[indices], indices, None, None, None
+
+
+def _install_fake_flash_attn_padding(monkeypatch):
+    flash_attn = types.ModuleType("flash_attn")
+    bert_padding = types.ModuleType("flash_attn.bert_padding")
+    bert_padding.pad_input = _pad_input
+    bert_padding.unpad_input = _unpad_input
+    flash_attn.bert_padding = bert_padding
+    monkeypatch.setitem(sys.modules, "flash_attn", flash_attn)
+    monkeypatch.setitem(sys.modules, "flash_attn.bert_padding", bert_padding)
+
+
+def _return_labels_as_log_probs(monkeypatch):
+    def fake_logprobs_from_logits(logits, labels, inplace_backward=True):
+        return labels.to(dtype=torch.float32)
+
+    monkeypatch.setattr(torch_functional, "logprobs_from_logits", fake_logprobs_from_logits)
+
+
+def test_shifted_labels_do_not_wrap_within_or_across_sequences():
+    input_ids = torch.tensor(
+        [
+            [10, 11, 12],
+            [20, 21, 22],
+        ]
+    )
+    indices = torch.arange(input_ids.numel())
+
+    labels = torch_functional.get_unpad_sequence_shifted_labels(input_ids, indices)
+
+    expected = torch.tensor([11, 12, 12, 21, 22, 22])
+    torch.testing.assert_close(labels, expected)
+
+
+def test_response_rmpad_labels_do_not_cross_sequence_boundaries(monkeypatch):
+    _install_fake_flash_attn_padding(monkeypatch)
+    _return_labels_as_log_probs(monkeypatch)
+
+    input_ids = torch.tensor(
+        [
+            [10, 11, 12, 0, 0],
+            [20, 21, 0, 0, 0],
+        ]
+    )
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 0, 0],
+            [1, 1, 0, 0, 0],
+        ],
+        dtype=torch.bool,
+    )
+    logits_rmpad = torch.zeros((5, 30))
+
+    output = torch_functional.log_probs_from_logits_response_rmpad(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        logits_rmpad=logits_rmpad,
+        response_length=4,
+    )
+
+    expected = torch.tensor(
+        [
+            [11, 12, 0, 0],
+            [21, 0, 0, 0],
+        ],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(output, expected)
+
+
+def test_all_rmpad_labels_do_not_cross_sequence_boundaries(monkeypatch):
+    _install_fake_flash_attn_padding(monkeypatch)
+    _return_labels_as_log_probs(monkeypatch)
+    monkeypatch.setattr(torch_functional, "get_device_name", lambda: "cuda")
+
+    input_ids_rmpad = torch.tensor([[10, 11, 12, 20, 21]])
+    indices = torch.tensor([0, 1, 2, 5, 6])
+    logits_rmpad = torch.zeros((5, 30))
+
+    output = torch_functional.log_probs_from_logits_all_rmpad(
+        input_ids_rmpad=input_ids_rmpad,
+        logits_rmpad=logits_rmpad,
+        indices=indices,
+        batch_size=2,
+        seqlen=5,
+        response_length=4,
+    )
+
+    expected = torch.tensor(
+        [
+            [11, 12, 0, 0],
+            [21, 0, 0, 0],
+        ],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(output, expected)

--- a/verl/utils/megatron/tensor_parallel.py
+++ b/verl/utils/megatron/tensor_parallel.py
@@ -23,6 +23,8 @@ import torch.distributed as dist
 from megatron.core import parallel_state as mpu
 from torch.nn import init
 
+from verl.utils.torch_functional import get_unpad_sequence_shifted_labels
+
 if TYPE_CHECKING:
     from megatron.core import ModelParallelConfig
 
@@ -201,11 +203,10 @@ def vocab_parallel_log_probs_from_logits_response_rmpad(input_ids, attention_mas
     from flash_attn.bert_padding import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
-    input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
-    input_ids_rmpad = input_ids_rmpad.squeeze(-1)
-    input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
+    _, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
+    labels_rmpad = get_unpad_sequence_shifted_labels(input_ids, indices)
     full_log_probs_rmpad = vocab_parallel_log_probs_from_logits(
-        logits=logits_rmpad, labels=input_ids_rmpad_rolled
+        logits=logits_rmpad, labels=labels_rmpad
     )  # (total_nnz,)
     full_output = pad_input(
         hidden_states=full_log_probs_rmpad.unsqueeze(-1), indices=indices, batch=batch_size, seqlen=seqlen

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -611,6 +611,19 @@ def log_probs_from_logits_response(input_ids, logits, response_length):
     return response_log_prob
 
 
+def get_unpad_sequence_shifted_labels(input_ids: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+    """Build next-token labels for unpadded inputs without crossing sequence boundaries.
+
+    ``indices`` maps valid tokens from the padded ``[batch, seqlen]`` input into
+    the rmpad/packed layout. Shifting in the padded layout first keeps labels
+    inside each sequence; shifting the packed tensor directly would leak the
+    first token of sequence i+1 into the last token of sequence i.
+    """
+    labels = input_ids.clone()
+    labels[:, :-1] = input_ids[:, 1:]
+    return labels.reshape(-1)[indices]
+
+
 def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad, response_length):
     """Compute the log_probs from logits with rmpad logits and pad input. Note that
     logits_rmpad = model(input_ids_rmpad). For each sentences, there is a shift between
@@ -627,10 +640,9 @@ def log_probs_from_logits_response_rmpad(input_ids, attention_mask, logits_rmpad
     from flash_attn.bert_padding import pad_input, unpad_input
 
     batch_size, seqlen = input_ids.shape
-    input_ids_rmpad, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
-    input_ids_rmpad = input_ids_rmpad.squeeze(-1)
-    input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
-    full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)  # (total_nnz,)
+    _, indices, *_ = unpad_input(input_ids.unsqueeze(-1), attention_mask=attention_mask)
+    labels_rmpad = get_unpad_sequence_shifted_labels(input_ids, indices)
+    full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=labels_rmpad)  # (total_nnz,)
     full_output = pad_input(
         hidden_states=full_log_probs_rmpad.unsqueeze(-1), indices=indices, batch=batch_size, seqlen=seqlen
     )
@@ -660,8 +672,11 @@ def log_probs_from_logits_all_rmpad(input_ids_rmpad, logits_rmpad, indices, batc
 
     input_ids_rmpad = input_ids_rmpad.transpose(0, 1)  # transpose back to [total_nnz, 1]
     input_ids_rmpad = input_ids_rmpad.squeeze(-1)
-    input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=0)
-    full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)  # (total_nnz,)
+    input_ids = pad_input(
+        hidden_states=input_ids_rmpad.unsqueeze(-1), indices=indices, batch=batch_size, seqlen=seqlen
+    ).squeeze(-1)
+    labels_rmpad = get_unpad_sequence_shifted_labels(input_ids, indices)
+    full_log_probs_rmpad = logprobs_from_logits(logits=logits_rmpad, labels=labels_rmpad)  # (total_nnz,)
     full_output = pad_input(
         hidden_states=full_log_probs_rmpad.unsqueeze(-1), indices=indices, batch=batch_size, seqlen=seqlen
     )


### PR DESCRIPTION
﻿### What does this PR do?

Fixes rmpad log-prob label construction so packed sequences do not leak labels across sample boundaries.

Previously, the rmpad paths built next-token labels with `torch.roll(input_ids_rmpad, shifts=-1, dims=0)`. Since `input_ids_rmpad` is a flat packed tensor, that made the last token of one sequence use the first token of the next sequence as its label.

This PR:

- builds next-token labels in padded `[batch, seqlen]` layout first
- gathers labels back to rmpad order using the existing `indices`
- applies the same fix to the Megatron vocab-parallel rmpad log-prob path
- adds CPU regression tests that reproduce the packed-boundary leakage without requiring FlashAttention

Closes #6475

### Duplicate-work check

- `gh issue view 6475 --repo verl-project/verl --comments`
- `gh pr list --repo verl-project/verl --state open --search "6475 in:body"`
- `gh pr list --repo verl-project/verl --state open --search "torch.roll log_probs_from_logits_response_rmpad"`
- `gh pr list --repo verl-project/verl --state open --search "cross-sequence log_prob"`
- `gh pr list --repo verl-project/verl --state open --search "log_probs_from_logits_all_rmpad"`

No open PRs were found for this issue or these related keywords.

### Tests

```bash
python -m pytest tests/utils/test_rmpad_logprob_labels_on_cpu.py -q
# 3 passed
```

```bash
pre-commit run ruff-format --files verl/utils/torch_functional.py verl/utils/megatron/tensor_parallel.py tests/utils/test_rmpad_logprob_labels_on_cpu.py
# Passed

pre-commit run ruff --files verl/utils/torch_functional.py verl/utils/megatron/tensor_parallel.py tests/utils/test_rmpad_logprob_labels_on_cpu.py
# Passed

git diff --check
# Passed
```

Additional attempted check:

```bash
python -m pytest tests/models/test_transformer.py -q
```

Result: failed in this local environment because FlashAttention2 is not installed; the failure happens during model construction before exercising this patch.

### AI Assistance

AI assistance was used for code navigation, patch drafting, and test suggestions. I reviewed every changed line and validated the final changes with the tests above.
