### PR TITLE
[rollout, reward] feat: add full determinism support for vLLM rollout and reward model

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -129,6 +129,11 @@ jobs:
       - name: Test vllm server abort functionality
         run: |
           pytest tests/workers/rollout/rollout_vllm/test_vllm_abort.py -v -s
+      - name: Test vllm rollout generation determinism (same-instance + cross-instance + cross-instance AgentLoop)
+        run: |
+          VLLM_DETERMINISM_DENSE_MODEL_PATH=${HOME}/models/Qwen/Qwen2.5-0.5B-Instruct \
+          VLLM_DETERMINISM_N_GPUS=2 \
+          pytest tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py -v -s
 
   vllm_checkpoint_engine:
     needs: setup

--- a/docs/advance/determinism.md
+++ b/docs/advance/determinism.md
@@ -1,0 +1,148 @@
+# Full Determinism for Reproducible RL Training
+
+**Authors**: Haichuan Hu, Yongxiang Huang, Jiawei Zhang, Nguyen Long
+
+Last updated: 06/16/2026.
+
+## Overview
+
+By default, RL training in verl is **not** bitwise reproducible: identical configs run twice can produce different reward curves due to nondeterminism in GPU kernels, request scheduling, hash-based routing, and batch composition. The full determinism feature closes these gaps, enabling two identical runs to produce **bitwise-aligned reward curves**.
+
+Useful for:
+
+- **Debugging**: reproduce a training failure exactly, step-by-step
+- **Regression testing**: verify that a code change has no silent effect on training outcomes
+- **Research**: ensure fair comparison when evaluating algorithmic changes
+
+## Quick Start
+
+```yaml
+actor_rollout_ref:
+  rollout:
+    full_determinism: true
+    seed: 42
+  actor:
+    fsdp_config:
+      full_determinism: true
+  ref:
+    fsdp_config:
+      full_determinism: true
+
+reward:
+  reward_model:
+    enable: true
+    rollout:
+      full_determinism: true
+      seed: 42
+```
+
+Or via Hydra overrides:
+
+```bash
+python -m verl.trainer.main_ppo \
+  actor_rollout_ref.rollout.full_determinism=true \
+  actor_rollout_ref.rollout.seed=42 \
+  actor_rollout_ref.actor.fsdp_config.full_determinism=true \
+  actor_rollout_ref.ref.fsdp_config.full_determinism=true \
+  reward.reward_model.enable=true \
+  reward.reward_model.rollout.full_determinism=true \
+  reward.reward_model.rollout.seed=42 \
+  [other config overrides...]
+```
+
+> **Important:** `PYTHONHASHSEED` must be set **before the Python interpreter starts**. verl handles this automatically — it sets `PYTHONHASHSEED` from `rollout.seed` before `ray.init()` and propagates it to all Ray actors. Do NOT set it manually.
+
+## Configuration Reference
+
+| Parameter | Default | Scope | Description |
+|-----------|---------|-------|-------------|
+| `actor_rollout_ref.rollout.full_determinism` | `false` | Rollout | Enables deterministic rollout generation |
+| `actor_rollout_ref.rollout.seed` | `42` | Rollout | Base seed; each replica uses `replica_rank + seed` |
+| `actor_rollout_ref.actor.fsdp_config.full_determinism` | `false` | Actor | Enables deterministic PyTorch ops for actor |
+| `actor_rollout_ref.ref.fsdp_config.full_determinism` | `false` | Ref model | Enables deterministic PyTorch ops for reference model |
+| `reward.reward_model.rollout.full_determinism` | `false` | Reward model | Enables deterministic RM inference (forces `max_num_seqs=1`) |
+| `reward.reward_model.rollout.seed` | `42` | Reward model | Base seed for RM vLLM server |
+
+## How It Works
+
+Determinism is enforced at five layers. All must be enabled for full E2E reproducibility:
+
+### PyTorch-level
+
+`enable_full_determinism(seed)` sets `PYTHONHASHSEED`, `CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, seeds all RNGs, calls `torch.use_deterministic_algorithms(True, warn_only=True)`, and disables cuDNN benchmarking. Applied in all training engine implementations.
+
+### Environment propagation
+
+`main_ppo.run_ppo()` sets three env vars before `ray.init()`:
+
+- `PYTHONHASHSEED` — freezes Python hash() and dict ordering
+- `VERL_FULL_DETERMINISM` — signals subprocesses to apply determinism
+- `VLLM_BATCH_INVARIANT` — makes vLLM outputs independent of batch composition
+
+These are forwarded to all Ray actors via `PPO_RAY_RUNTIME_ENV`.
+
+### vLLM batch invariance + per-request seed
+
+`VLLM_BATCH_INVARIANT=1` ensures vLLM outputs don't depend on which other requests are batched together. Each `generate()` call injects `SamplingParams.seed = replica_rank + config.seed` to reset RNG per request.
+
+### Priority scheduling + deterministic routing
+
+Without determinism, request order depends on arrival timing and server selection on dict iteration order. When `full_determinism=true`:
+
+- Each sample gets a globally unique priority injected into the batch (`non_tensor_batch["priority"]`), so each rollout request is scheduled with a stable, distinct priority
+- `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` instead of random UUID
+- `GlobalRequestLoadBalancer` tie-breaking uses `hash(request_id) % len(candidates)` — deterministic with frozen `PYTHONHASHSEED`
+
+> **Note:** `priority` is a vLLM-only parameter. `LLMServerClient.generate()` automatically filters it for non-vLLM backends.
+
+### Reward model serialization
+
+vLLM's `/classify` endpoint (used by RM) does not support priority or batch invariance. When `full_determinism=true`, `RewardModelManager` forces `max_num_seqs=1`, serializing RM inference one request at a time.
+
+## Side Effects and Limitations
+
+**Performance**: deterministic PyTorch kernels are slower, cuDNN benchmarking is disabled, and RM `max_num_seqs=1` causes severe throughput loss. Typical E2E throughput drops 10–30% without RM; RM determinism can drop significantly more.
+
+**Recommendation**: Only enable for debugging, regression testing, or research. Leave disabled for production training.
+
+**Nondeterministic fallbacks**: Some GPU ops have no deterministic implementation. `torch.use_deterministic_algorithms(True, warn_only=True)` warns when these are encountered.
+
+**Backend support**:
+
+| Backend | Rollout | Reward model |
+|---------|---------|--------------|
+| vLLM | ✅ | ✅ (serialized) |
+| SGLang | ❌ | ❌ |
+| TensorRT-LLM | ❌ | ❌ |
+
+**PYTHONHASHSEED**: Must be set before process start. verl handles this automatically; manual Ray actor creation must propagate it via `runtime_env`.
+
+**Data parallelism**: Each replica uses `replica_rank + seed`, producing different but internally reproducible outputs. Two runs with the same config produce bitwise-aligned results.
+
+**Multi-turn agent not supported**: Full determinism only works for single-turn rollouts (`single_turn_agent_loop`). Multi-turn rollouts (`tool_agent_loop`) are **not** bitwise reproducible, for two reasons:
+
+- `tool_agent_loop` uses a random UUID per trajectory as `request_id` and does not pass `priority` to `server_manager.generate()`, so the deterministic routing and priority scheduling described above do not apply.
+- Even with those added, each turn is interleaved with external tool calls whose execution time varies across runs, so the order in which requests arrive at vLLM cannot be made deterministic. This is inherent to multi-turn agentic workloads.
+
+For bitwise-reproducible rollouts, use `single_turn_agent_loop`. (The per-request sampling seed is still applied to multi-turn requests inside the vLLM server, but this alone is not sufficient for end-to-end reproducibility.)
+
+## Verifying Determinism
+
+Rollout determinism (bitwise reproducible vLLM generation):
+
+```bash
+VLLM_DETERMINISM_DENSE_MODEL_PATH=${HOME}/models/Qwen/Qwen2.5-0.5B-Instruct \
+VLLM_DETERMINISM_N_GPUS=2 \
+pytest tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py -v -s
+```
+
+E2E training (bitwise-aligned reward curves across two full PPO runs):
+
+```bash
+python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
+  --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \
+  --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
+  --train_files ~/data/gsm8k/train.parquet \
+  --val_files ~/data/gsm8k/test.parquet \
+  --n_gpus 2 --n_steps 5
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ verl is fast with:
    data/transfer_queue.md
    advance/grafana_prometheus.md
    advance/mtp.md
+   advance/determinism.md
 
 .. toctree::
    :maxdepth: 1

--- a/tests/experimental/agent_loop/agent_utils.py
+++ b/tests/experimental/agent_loop/agent_utils.py
@@ -42,15 +42,19 @@ def init_agent_loop_manager(config: DictConfig) -> AgentLoopManager | RayWorkerG
     mapping = {
         Role.ActorRollout: global_pool_id,
     }
-    if config.reward.reward_model.enable_resource_pool:
-        mapping[Role.RewardModel] = "reward_pool"
-        if config.reward.reward_model.n_gpus_per_node <= 0:
-            raise ValueError("config.reward.reward_model.n_gpus_per_node must be greater than 0")
-        if config.reward.reward_model.nnodes <= 0:
-            raise ValueError("config.reward.reward_model.nnodes must be greater than 0")
-
-        reward_pool = [config.reward.reward_model.n_gpus_per_node] * config.reward.reward_model.nnodes
-        resource_pool_spec["reward_pool"] = reward_pool
+    if config.reward.reward_model.enable:
+        if config.reward.reward_model.enable_resource_pool:
+            mapping[Role.RewardModel] = "reward_pool"
+            if config.reward.reward_model.n_gpus_per_node <= 0:
+                raise ValueError("config.reward.reward_model.n_gpus_per_node must be greater than 0")
+            if config.reward.reward_model.nnodes <= 0:
+                raise ValueError("config.reward.reward_model.nnodes must be greater than 0")
+            reward_pool = [config.reward.reward_model.n_gpus_per_node] * config.reward.reward_model.nnodes
+            resource_pool_spec["reward_pool"] = reward_pool
+        else:
+            mapping[Role.RewardModel] = global_pool_id
+            config.reward.reward_model.nnodes = config.trainer.nnodes
+            config.reward.reward_model.n_gpus_per_node = config.trainer.n_gpus_per_node
     resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=mapping)
     resource_pool_manager.create_resource_pool()
     resource_pool_to_cls = {pool: {} for pool in resource_pool_manager.resource_pool_dict.values()}

--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -45,8 +45,9 @@ class _FakeServerManager:
         video_data: Optional[list[Any]] = None,
         audio_data: Optional[list[Any]] = None,
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> TokenOutput:
-        del request_id, sampling_params, image_data, video_data, audio_data, mm_processor_kwargs
+        del request_id, sampling_params, image_data, video_data, audio_data, mm_processor_kwargs, kwargs
         # Return a short, deterministic "generation" for testing.
         return TokenOutput(token_ids=prompt_ids[-1:] + [11, 12, 13], log_probs=[0.0, 0.0, 0.0, 0.0])
 

--- a/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
+++ b/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+E2E determinism verification: run PPO training twice, verify reward curves bitwise aligned.
+
+Uses colocate mode: RM shares the same GPU pool with actor/ref/rollout,
+so RM scoring goes through the ``_compute_reward_colocate`` path with
+sleep/wake GPU memory management.
+
+Usage:
+  python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
+    --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \
+    --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
+    --train_files ~/data/gsm8k/train.parquet \
+    --val_files ~/data/gsm8k/test.parquet \
+    --n_gpus 2 --n_steps 5
+
+Defaults to 2 GPUs: all shared by actor/ref/rollout/RM in colocate mode.
+
+After both runs complete, verifies bitwise alignment of reward curves and
+saves a comparison plot to output_dir/determinism_reward_curves.png.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Seed used for all determinism configs — same across both runs.
+SEED = 42
+
+
+def run_training(
+    policy_model,
+    rm_model,
+    n_gpus,
+    n_steps,
+    run_name,
+    output_dir,
+    rollout_tp=1,
+    rm_tp=1,
+    train_files=None,
+    val_files=None,
+):
+    """Run one PPO training session via main_ppo using Hydra overrides.
+
+    Uses colocate mode (RM shares the same GPU pool with actor/ref/rollout)
+    so that RM scoring goes through the well-tested ``_compute_reward_colocate``
+    path with sleep/wake GPU memory management.
+
+    Args:
+        n_gpus: Total GPUs visible to the trainer.  All are shared by
+            actor/ref/rollout/RM in colocate mode.
+        rollout_tp: Rollout TP per replica.
+        rm_tp: RM TP per replica.  In colocate mode, RM replicas share the
+            same GPUs as rollout; ``n_gpus // rollout_tp`` rollout replicas and
+            ``n_gpus // rm_tp`` RM replicas are created.
+    """
+    env = os.environ.copy()
+    jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
+    env = os.environ.copy()
+    env["VLLM_DISABLE_COMPILE_CACHE"] = "1"
+    env["TOKENIZERS_PARALLELISM"] = "true"
+    env["NCCL_DEBUG"] = "WARN"
+    env["VLLM_LOGGING_LEVEL"] = "WARN"
+    env["VERL_FILE_LOGGER_PATH"] = jsonl_path
+    # PYTHONHASHSEED must be set before Python starts; this ensures deterministic
+    # hash() across all processes spawned by this training run (driver, Ray actors,
+    # NaiveRouter subprocess, etc.).
+    env["PYTHONHASHSEED"] = str(SEED)
+    env["VERL_DETERMINISM_DEBUG"] = "1"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "verl.trainer.main_ppo",
+        # Rollout
+        "actor_rollout_ref.rollout.name=vllm",
+        "actor_rollout_ref.rollout.mode=async",
+        "actor_rollout_ref.rollout.full_determinism=true",
+        f"actor_rollout_ref.rollout.seed={SEED}",
+        "actor_rollout_ref.rollout.scheduling_policy=priority",
+        "actor_rollout_ref.rollout.enforce_eager=true",
+        "actor_rollout_ref.rollout.temperature=0.7",
+        "actor_rollout_ref.rollout.calculate_log_probs=true",
+        "actor_rollout_ref.rollout.n=1",
+        "actor_rollout_ref.rollout.prompt_length=64",
+        "actor_rollout_ref.rollout.response_length=64",
+        "actor_rollout_ref.rollout.max_model_len=128",
+        "actor_rollout_ref.rollout.max_num_seqs=4",
+        f"actor_rollout_ref.rollout.tensor_model_parallel_size={rollout_tp}",
+        "actor_rollout_ref.rollout.agent.num_workers=1",
+        "actor_rollout_ref.rollout.disable_log_stats=true",
+        # Actor
+        "actor_rollout_ref.actor.fsdp_config.full_determinism=true",
+        f"actor_rollout_ref.actor.fsdp_config.seed={SEED}",
+        "actor_rollout_ref.actor.fsdp_config.param_offload=true",
+        "actor_rollout_ref.actor.fsdp_config.optimizer_offload=true",
+        "actor_rollout_ref.actor.fsdp_config.fsdp_size=1",
+        "actor_rollout_ref.actor.use_dynamic_bsz=true",
+        "actor_rollout_ref.actor.ppo_mini_batch_size=4",
+        # Ref
+        "actor_rollout_ref.ref.fsdp_config.full_determinism=true",
+        f"actor_rollout_ref.ref.fsdp_config.seed={SEED}",
+        # Model
+        f"actor_rollout_ref.model.path={policy_model}",
+        "actor_rollout_ref.model.trust_remote_code=true",
+        # RM — colocate mode: shares GPU pool with actor/ref/rollout.
+        # RM scoring goes through _compute_reward_colocate path with
+        # sleep/wake GPU memory management (not agent-loop HTTP path).
+        "reward.reward_model.enable=true",
+        f"reward.reward_model.model_path={rm_model}",
+        "reward.reward_model.rollout.name=vllm",
+        "reward.reward_model.rollout.full_determinism=true",
+        f"reward.reward_model.rollout.seed={SEED}",
+        "reward.reward_model.rollout.enforce_eager=true",
+        "reward.reward_model.rollout.gpu_memory_utilization=0.4",
+        f"reward.reward_model.rollout.tensor_model_parallel_size={rm_tp}",
+        "reward.reward_model.rollout.max_model_len=512",
+        # Serialize RM inference for determinism: max_num_seqs=1 ensures
+        # each RM forward pass processes one request at a time.
+        "reward.reward_model.rollout.max_num_seqs=1",
+        "reward.reward_model.rollout.skip_tokenizer_init=false",
+        "reward.reward_model.rollout.disable_log_stats=true",
+        "reward.reward_manager.name=dapo",
+        # Algorithm
+        "algorithm.adv_estimator=grpo",
+        "critic.enable=false",
+        # Trainer
+        f"trainer.n_gpus_per_node={n_gpus}",
+        "trainer.nnodes=1",
+        f"trainer.total_training_steps={n_steps}",
+        "trainer.total_epochs=1",
+        "data.train_batch_size=8",
+        f"trainer.experiment_name={run_name}",
+        "trainer.logger=[console,file]",
+        # Data
+        "data.shuffle=true",
+        f"data.seed={SEED}",
+        "data.max_prompt_length=64",
+        "data.max_response_length=64",
+        f"+exp_name={run_name}",
+        # Limit data to avoid long iterations
+        "data.train_max_samples=64",
+        "data.val_max_samples=64",
+    ]
+    if train_files:
+        cmd.append(f"data.train_files={train_files}")
+    if val_files:
+        cmd.append(f"data.val_files={val_files}")
+
+    print(f"\n{'=' * 60}")
+    print(f"Starting {run_name}")
+    print(f"{'=' * 60}\n")
+
+    subprocess.run(["ray", "stop"], env=env, capture_output=True)
+    time.sleep(3)
+
+    result = subprocess.run(cmd, env=env)
+    if result.returncode != 0:
+        print(f"ERROR: {run_name} failed (return code {result.returncode})")
+        # Print the JSONL file if it exists — it may contain partial metrics useful for debugging.
+        jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
+        if os.path.exists(jsonl_path):
+            print(f"Partial metrics in {jsonl_path}:")
+            with open(jsonl_path) as f:
+                for line in f:
+                    print(line.rstrip())
+        sys.exit(1)
+
+    print(f"\n{run_name} completed.")
+
+
+def read_metrics_from_jsonl(output_dir, run_name):
+    """Read per-step metrics from FileLogger JSONL output."""
+    filepath = os.path.join(output_dir, f"{run_name}.jsonl")
+    if not os.path.exists(filepath):
+        print(f"ERROR: Metrics file not found at {filepath}")
+        sys.exit(1)
+
+    steps = {}
+    with open(filepath) as f:
+        for line in f:
+            entry = json.loads(line)
+            step = entry["step"]
+            steps[step] = entry["data"]
+    return steps
+
+
+def _pick_reward_key(data: dict) -> str | None:
+    """Pick the best reward key from a single step's data dict.
+
+    Training steps use ``critic/rewards/mean``; validation (step 0) uses
+    ``val-core/.../reward/mean@1``.  Returns None if nothing matches.
+    """
+    # Training-step keys (preferred order)
+    for key in ["critic/rewards/mean", "reward/mean", "train/reward/mean"]:
+        if key in data:
+            return key
+    # Validation-step keys
+    for key in ["val-core/unknown/reward/mean@1", "val-core/reward/mean"]:
+        if key in data:
+            return key
+    # Fallback: any key containing both "reward" and "mean"
+    for key in data:
+        if "reward" in key.lower() and "mean" in key.lower():
+            return key
+    return None
+
+
+def extract_reward_curve(metrics_by_step):
+    """Extract mean reward per step from metrics dict.
+
+    Step 0 (validation) uses a different key namespace than training steps,
+    so we pick the best key for each step independently.
+    """
+    steps = sorted(metrics_by_step.keys())
+    rewards = []
+    for s in steps:
+        key = _pick_reward_key(metrics_by_step[s])
+        if key is None:
+            print(f"ERROR: No reward key found in step {s}")
+            print(f"  Available keys: {list(metrics_by_step[s].keys())}")
+            sys.exit(1)
+        rewards.append(metrics_by_step[s][key])
+
+    train_key = _pick_reward_key(metrics_by_step.get(1, {}))
+    val_key = _pick_reward_key(metrics_by_step.get(0, {}))
+    print(f"Using training reward key: {train_key}, validation reward key: {val_key}")
+
+    return steps, rewards
+
+
+def verify_bitwise_alignment(rewards1, rewards2):
+    """Verify two reward curves are bitwise aligned (float32)."""
+    r1 = np.array(rewards1, dtype=np.float32)
+    r2 = np.array(rewards2, dtype=np.float32)
+
+    assert len(r1) == len(r2), f"Length mismatch: {len(r1)} vs {len(r2)}"
+
+    aligned = np.all(r1 == r2)
+    max_diff = float(np.max(np.abs(r1 - r2))) if not aligned else 0.0
+
+    print(f"\n{'=' * 60}")
+    print("Bitwise alignment check (float32)")
+    print(f"  Steps: {len(r1)}")
+    print(f"  Aligned: {aligned}")
+    print(f"  Max diff: {max_diff}")
+    print(f"  Run 1: {r1.tolist()}")
+    print(f"  Run 2: {r2.tolist()}")
+    if not aligned:
+        for i in range(len(r1)):
+            if r1[i] != r2[i]:
+                print(f"  Step {i + 1} DIFF: {float(r1[i])} vs {float(r2[i])}, diff={abs(float(r1[i]) - float(r2[i]))}")
+    print(f"{'=' * 60}")
+
+    return aligned
+
+
+def plot_reward_curves(steps1, rewards1, rewards2, output_path):
+    """Plot two reward curves overlaid for visual comparison."""
+    r1 = [float(r) for r in rewards1]
+    r2 = [float(r) for r in rewards2]
+    steps = [s for s in steps1]
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    ax.plot(steps, r1, "o-", label="Run 1", linewidth=2.5, markersize=10, color="#2563eb", zorder=3)
+    ax.plot(steps, r2, "s-", label="Run 2", linewidth=2.5, markersize=10, color="#dc2626", zorder=2)
+
+    ax.set_xlabel("Training Step", fontsize=14)
+    ax.set_ylabel("Mean Reward", fontsize=14)
+    ax.set_title("E2E Determinism: Reward Curve Comparison", fontsize=16, fontweight="bold")
+    ax.legend(fontsize=12)
+    ax.grid(True, alpha=0.3)
+
+    aligned = np.all(np.array(r1, dtype=np.float32) == np.array(r2, dtype=np.float32))
+    color = "green" if aligned else "red"
+    status = "✓ BITWISE ALIGNED" if aligned else "✗ NOT ALIGNED"
+    ax.annotate(
+        status,
+        xy=(0.5, 0.95),
+        xycoords="axes fraction",
+        fontsize=16,
+        ha="center",
+        fontweight="bold",
+        color=color,
+        bbox=dict(boxstyle="round,pad=0.3", facecolor="white", edgecolor=color, alpha=0.9),
+    )
+
+    if aligned:
+        ax.annotate(
+            "max_diff = 0 (float32)", xy=(0.5, 0.88), xycoords="axes fraction", fontsize=12, ha="center", color="green"
+        )
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    print(f"\nPlot saved to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E determinism verification: run twice, compare reward curves")
+    parser.add_argument("--policy_model", default="~/models/Qwen/Qwen2.5-0.5B-Instruct")
+    parser.add_argument("--rm_model", default="~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B")
+    # All GPUs shared by actor/ref/rollout/RM in colocate mode.
+    parser.add_argument("--n_gpus", type=int, default=2)
+    parser.add_argument("--rollout_tp", type=int, default=1)
+    parser.add_argument("--rm_tp", type=int, default=1)
+    parser.add_argument("--n_steps", type=int, default=2)
+    parser.add_argument("--train_files", default=None, help="Path to training data parquet")
+    parser.add_argument("--val_files", default=None, help="Path to validation data parquet")
+    parser.add_argument("--output_dir", default="/tmp/determinism_e2e")
+    parser.add_argument("--project_name", default="determinism_e2e")
+    args = parser.parse_args()
+
+    policy_model = os.path.expanduser(args.policy_model)
+    rm_model = os.path.expanduser(args.rm_model)
+    output_dir = os.path.expanduser(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    common_kwargs = dict(
+        policy_model=policy_model,
+        rm_model=rm_model,
+        n_gpus=args.n_gpus,
+        n_steps=args.n_steps,
+        output_dir=output_dir,
+        rollout_tp=args.rollout_tp,
+        rm_tp=args.rm_tp,
+        train_files=args.train_files,
+        val_files=args.val_files,
+    )
+
+    # ── Run 1 ──
+    run_training(run_name="run1", **common_kwargs)
+
+    # ── Run 2 ──
+    run_training(run_name="run2", **common_kwargs)
+
+    # ── Read metrics ──
+    metrics1 = read_metrics_from_jsonl(output_dir, "run1")
+    metrics2 = read_metrics_from_jsonl(output_dir, "run2")
+
+    steps1, rewards1 = extract_reward_curve(metrics1)
+    steps2, rewards2 = extract_reward_curve(metrics2)
+
+    # ── Verify ──
+    aligned = verify_bitwise_alignment(rewards1, rewards2)
+
+    # ── Plot ──
+    plot_path = os.path.join(output_dir, "determinism_reward_curves.png")
+    plot_reward_curves(steps1, rewards1, rewards2, plot_path)
+
+    if aligned:
+        print("\n🎉 SUCCESS: E2E determinism verified — reward curves are bitwise aligned!")
+    else:
+        print("\n❌ FAILURE: Reward curves are NOT bitwise aligned.")
+        print(
+            "Check: actor/critic full_determinism, rollout seed + priority"
+            " + batch_invariant, RM full_determinism, data shuffle seed"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
@@ -1,0 +1,308 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test vLLM rollout generation determinism.
+
+Same-instance determinism is trivial (same RNG state). Cross-instance
+determinism requires PYTHONHASHSEED set before Python starts, because
+hash() and dict ordering are frozen at interpreter startup.
+
+Tests:
+1. Same-instance: rollout twice on one vLLM server (baseline).
+2. Cross-instance vLLM: two separate server instances produce identical logprobs.
+3. Cross-instance AgentLoop: two full AgentLoopManager pipelines produce identical logprobs.
+
+Cross-instance RewardLoop determinism is verified by the separate E2E script:
+  tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
+
+Environment overrides:
+  VLLM_DETERMINISM_DENSE_MODEL_PATH  - policy model (default Qwen2.5-0.5B-Instruct)
+  VLLM_DETERMINISM_N_GPUS            - GPUs for AgentLoop tests (default 1)
+"""
+
+import asyncio
+import math
+import os
+
+import numpy as np
+import ray
+import torch
+from hydra import compose, initialize_config_dir
+from transformers import AutoTokenizer
+
+from tests.experimental.agent_loop.agent_utils import init_agent_loop_manager
+from verl.protocol import DataProto
+from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.replica import get_rollout_replica_class
+
+SEED = 42
+DENSE_MODEL_PATH = os.path.expanduser(
+    os.getenv("VLLM_DETERMINISM_DENSE_MODEL_PATH", "~/models/Qwen/Qwen2.5-0.5B-Instruct")
+)
+
+PROMPTS = [
+    "Write one short sentence about deterministic generation.",
+    "Explain what reproducibility means in one sentence.",
+    "Describe batch invariance in one short phrase.",
+]
+
+RAY_RUNTIME_ENV = {
+    "env_vars": {
+        "TOKENIZERS_PARALLELISM": "true",
+        "NCCL_DEBUG": "WARN",
+        "VLLM_LOGGING_LEVEL": "INFO",
+        "VLLM_USE_V1": "1",
+        "VLLM_DISABLE_COMPILE_CACHE": "1",
+        "PYTHONHASHSEED": str(SEED),
+    }
+}
+
+
+def _get_config_dir():
+    config_dir = os.path.abspath("verl/verl/trainer/config")
+    if not os.path.exists(config_dir):
+        config_dir = os.path.abspath("verl/trainer/config")
+    return config_dir
+
+
+def _pearson_correlation(first, second):
+    f = torch.tensor(first, dtype=torch.float64)
+    s = torch.tensor(second, dtype=torch.float64)
+    return torch.corrcoef(torch.stack([f, s], dim=0))[0, 1].item()
+
+
+def _make_rollout_config(model_path, seed):
+    with initialize_config_dir(config_dir=_get_config_dir(), version_base=None):
+        config = compose(config_name="ppo_trainer")
+    config.trainer.n_gpus_per_node = 1
+    config.trainer.nnodes = 1
+    config.actor_rollout_ref.model.path = model_path
+    config.actor_rollout_ref.model.trust_remote_code = True
+    config.actor_rollout_ref.rollout.name = "vllm"
+    config.actor_rollout_ref.rollout.mode = "async"
+    config.actor_rollout_ref.rollout.tensor_model_parallel_size = 1
+    config.actor_rollout_ref.rollout.prompt_length = 128
+    config.actor_rollout_ref.rollout.response_length = 256
+    config.actor_rollout_ref.rollout.max_model_len = 512
+    config.actor_rollout_ref.rollout.max_num_seqs = 8
+    config.actor_rollout_ref.rollout.gpu_memory_utilization = 0.4
+    config.actor_rollout_ref.rollout.enforce_eager = True
+    config.actor_rollout_ref.rollout.full_determinism = True
+    config.actor_rollout_ref.rollout.seed = seed
+    config.actor_rollout_ref.rollout.scheduling_policy = "priority"
+    return config
+
+
+def _make_e2e_config(model_path, seed, n_gpus=2):
+    """Config for full AgentLoopManager pipeline."""
+    with initialize_config_dir(config_dir=_get_config_dir(), version_base=None):
+        config = compose(
+            config_name="ppo_trainer",
+            overrides=[
+                "actor_rollout_ref.actor.use_dynamic_bsz=true",
+                "actor_rollout_ref.actor.fsdp_config.param_offload=true",
+                "actor_rollout_ref.actor.fsdp_config.optimizer_offload=true",
+                "reward.reward_manager.name=dapo",
+                "+reward.reward_kwargs.overlong_buffer_cfg.enable=False",
+                "+reward.reward_kwargs.overlong_buffer_cfg.len=3072",
+                "+reward.reward_kwargs.max_resp_len=4096",
+            ],
+        )
+    config.trainer.n_gpus_per_node = n_gpus
+    config.trainer.nnodes = 1
+    config.actor_rollout_ref.model.path = model_path
+    config.actor_rollout_ref.model.trust_remote_code = True
+    config.actor_rollout_ref.rollout.name = "vllm"
+    config.actor_rollout_ref.rollout.mode = "async"
+    config.actor_rollout_ref.rollout.tensor_model_parallel_size = 1
+    config.actor_rollout_ref.rollout.prompt_length = 128
+    config.actor_rollout_ref.rollout.response_length = 256
+    config.actor_rollout_ref.rollout.max_model_len = 512
+    config.actor_rollout_ref.rollout.max_num_seqs = 8
+    config.actor_rollout_ref.rollout.gpu_memory_utilization = 0.4
+    config.actor_rollout_ref.rollout.enforce_eager = True
+    config.actor_rollout_ref.rollout.full_determinism = True
+    config.actor_rollout_ref.rollout.seed = seed
+    config.actor_rollout_ref.rollout.scheduling_policy = "priority"
+    config.actor_rollout_ref.rollout.calculate_log_probs = True
+    config.actor_rollout_ref.rollout.temperature = 0.7
+    config.actor_rollout_ref.rollout.top_p = 1.0
+    config.actor_rollout_ref.rollout.n = 1
+    config.actor_rollout_ref.rollout.agent.num_workers = 1
+    config.actor_rollout_ref.rollout.skip_tokenizer_init = False
+    config.actor_rollout_ref.rollout.disable_log_stats = True
+    return config
+
+
+# ──── Helpers for standalone vLLM tests ────
+
+
+def _run_once(server, tokenizer, prompt_texts):
+    refs = []
+    for i, text in enumerate(prompt_texts):
+        prompt_ids = normalize_token_ids(
+            tokenizer.apply_chat_template(
+                [{"role": "user", "content": text}],
+                add_generation_prompt=True,
+                tokenize=True,
+            )
+        )
+        refs.append(
+            server._server_handle.generate.remote(
+                request_id=f"determinism_{i}",
+                prompt_ids=prompt_ids,
+                sampling_params={"temperature": 0.7, "top_p": 1.0, "logprobs": True},
+                priority=i,
+                image_data=None,
+            )
+        )
+    outputs = ray.get(refs, timeout=120.0)
+    return [(o.token_ids, o.log_probs) for o in outputs]
+
+
+def _create_vllm_server(config, replica_rank=0, is_reward_model=False, name_suffix=""):
+    rollout_server_class = get_rollout_replica_class("vllm")
+    server = rollout_server_class(
+        replica_rank=replica_rank,
+        config=config.actor_rollout_ref.rollout,
+        model_config=config.actor_rollout_ref.model,
+        gpus_per_node=1,
+        is_reward_model=is_reward_model,
+        name_suffix=name_suffix,
+    )
+    asyncio.run(server.init_standalone())
+    return server
+
+
+def _compare_logprobs(first, second, label):
+    for i in range(len(first)):
+        ids1, lp1 = first[i]
+        ids2, lp2 = second[i]
+        f1 = torch.tensor(lp1, dtype=torch.float32)
+        f2 = torch.tensor(lp2, dtype=torch.float32)
+        ids_match = ids1 == ids2
+        lp_match = torch.equal(f1, f2)
+        max_diff = torch.max(torch.abs(f1 - f2)).item() if not lp_match else 0.0
+        corr = _pearson_correlation(lp1, lp2)
+        print(
+            f"  {label} prompt-{i}: ids_match={ids_match}, logprobs_match={lp_match}, "
+            f"max_diff={max_diff:.6e}, corr={corr:.12f}"
+        )
+        assert ids_match
+        assert lp_match, f"max_diff={max_diff}"
+        assert math.isclose(corr, 1.0, abs_tol=1e-12), f"corr={corr}"
+
+
+# ──── Helpers for AgentLoop tests ────
+
+
+def _make_agent_loop_batch():
+    return DataProto(
+        non_tensor_batch={
+            "raw_prompt": np.array([[{"role": "user", "content": p}] for p in PROMPTS], dtype=object),
+            "agent_name": np.array(["single_turn_agent"] * len(PROMPTS)),
+            "data_source": np.array(["openai/gsm8k"] * len(PROMPTS)),
+            "reward_model": np.array([{"style": "rule", "ground_truth": "1.0"}] * len(PROMPTS)),
+        },
+    )
+
+
+def _compare_dataproto_logprobs(first, second, label):
+    """Compare rollout_log_probs and responses at valid positions."""
+    lp1 = first.batch["rollout_log_probs"]
+    lp2 = second.batch["rollout_log_probs"]
+    mask1 = first.batch["response_mask"].bool()
+    mask2 = second.batch["response_mask"].bool()
+    assert torch.equal(mask1, mask2), f"{label}: response_mask mismatch"
+    assert torch.equal(first.batch["responses"][mask1], second.batch["responses"][mask2]), (
+        f"{label}: token IDs mismatch"
+    )
+    v1 = lp1[mask1]
+    v2 = lp2[mask2]
+    assert torch.equal(v1, v2), f"{label}: logprob mismatch, max_diff={torch.max(torch.abs(v1 - v2)).item()}"
+    corr = _pearson_correlation(v1.float().tolist(), v2.float().tolist())
+    assert math.isclose(corr, 1.0, abs_tol=1e-12), f"{label}: corr={corr}"
+    print(f"  {label}: logprobs_match=True, corr={corr:.12f}")
+
+
+# ──── Test 1: Same-instance vLLM ────
+
+
+def test_rollout_determinism_same_instance():
+    ray.shutdown()
+    ray.init(runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
+
+    config = _make_rollout_config(DENSE_MODEL_PATH, SEED)
+    tokenizer = AutoTokenizer.from_pretrained(DENSE_MODEL_PATH, trust_remote_code=True)
+    server = _create_vllm_server(config)
+
+    r1 = _run_once(server, tokenizer, PROMPTS)
+    r2 = _run_once(server, tokenizer, PROMPTS)
+    _compare_logprobs(r1, r2, "[same-instance]")
+    print("✓ Same-instance determinism verified")
+    ray.shutdown()
+
+
+# ──── Test 2: Cross-instance vLLM ────
+
+
+def test_rollout_determinism_cross_instance():
+    ray.shutdown()
+    ray.init(runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
+
+    config = _make_rollout_config(DENSE_MODEL_PATH, SEED)
+    tokenizer = AutoTokenizer.from_pretrained(DENSE_MODEL_PATH, trust_remote_code=True)
+
+    s1 = _create_vllm_server(config, replica_rank=0, name_suffix="run1")
+    r1 = _run_once(s1, tokenizer, PROMPTS)
+
+    s2 = _create_vllm_server(config, replica_rank=0, name_suffix="run2")
+    r2 = _run_once(s2, tokenizer, PROMPTS)
+
+    _compare_logprobs(r1, r2, "[cross-instance]")
+    print("✓ Cross-instance determinism verified")
+    ray.shutdown()
+
+
+# ──── Test 3: Cross-instance AgentLoop ────
+
+
+def test_agent_loop_determinism_cross_instance():
+    """Two full AgentLoopManager pipelines produce identical logprobs."""
+    n_gpus = int(os.getenv("VLLM_DETERMINISM_N_GPUS", "1"))
+
+    config = _make_e2e_config(DENSE_MODEL_PATH, SEED, n_gpus=n_gpus)
+    batch = _make_agent_loop_batch()
+
+    # Run 1
+    ray.shutdown()
+    ray.init(runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
+    mgr1 = init_agent_loop_manager(config)
+    r1 = mgr1.generate_sequences(prompts=batch)
+    ray.shutdown()
+
+    # Run 2
+    ray.init(runtime_env=RAY_RUNTIME_ENV, ignore_reinit_error=True)
+    mgr2 = init_agent_loop_manager(config)
+    r2 = mgr2.generate_sequences(prompts=batch)
+    ray.shutdown()
+
+    _compare_dataproto_logprobs(r1, r2, "[agent-loop-cross-instance]")
+    print("✓ AgentLoop cross-instance determinism verified")
+
+
+if __name__ == "__main__":
+    test_rollout_determinism_same_instance()
+    test_rollout_determinism_cross_instance()
+    test_agent_loop_determinism_cross_instance()

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1119,6 +1119,12 @@ class AgentLoopManager:
         Returns:
             DataProto: Output batch.
         """
+        # Attach per-sample priority to the batch (like ``uid``) so each sample gets
+        # a globally-unique priority that flows to vLLM request scheduling. Assigned
+        # before chunking so chunks own disjoint ranges without per-worker offsets.
+        if "priority" not in prompts.non_tensor_batch:
+            prompts.non_tensor_batch["priority"] = np.arange(len(prompts), dtype=np.int64)
+
         chunkes = prompts.chunk(len(self.agent_loop_workers))
         outputs = await asyncio.gather(
             *[

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -35,7 +35,9 @@ class SingleTurnAgentLoop(AgentLoopBase):
         self.response_length = self.rollout_config.response_length
 
     @rollout_trace_op
-    async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+    async def run(self, sampling_params: dict[str, Any], priority: int = 0, **kwargs) -> AgentLoopOutput:
+        # priority may arrive as np.int64 from non_tensor_batch; normalize to Python int.
+        priority = int(priority)
         messages = list(kwargs["raw_prompt"])
 
         # 1. extract multimodal inputs from messages
@@ -57,14 +59,16 @@ class SingleTurnAgentLoop(AgentLoopBase):
         # 3. generate sequences
         metrics = {}
         with simple_timer("generate_sequences", metrics):
+            request_id = f"det-{priority}" if getattr(self.rollout_config, "full_determinism", False) else uuid4().hex
             output: TokenOutput = await self.server_manager.generate(
-                request_id=uuid4().hex,
+                request_id=request_id,
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=images,
-                video_data=videos,
                 audio_data=audios,
+                video_data=videos,
                 mm_processor_kwargs=mm_processor_kwargs,
+                priority=priority,
             )
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1

--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -41,6 +41,21 @@ class RewardModelManager:
         """
         self.config = config
         self.resource_pool = resource_pool
+
+        # Determinism workaround: vLLM /classify (pooling path) does not honor
+        # `priority` and is not covered by VLLM_BATCH_INVARIANT, so co-batched RM
+        # forward passes break bitwise reproducibility. Force max_num_seqs=1 to
+        # serialize RM inference whenever full_determinism is enabled.
+        if self.config.rollout.full_determinism and self.config.rollout.max_num_seqs != 1:
+            logger.warning(
+                "[reward_model] full_determinism=True: forcing rollout.max_num_seqs "
+                "from %d to 1. vLLM pooling/classify does not support priority "
+                "scheduling or batch invariance; serializing RM inference is "
+                "currently the only way to keep RM scores bitwise reproducible.",
+                self.config.rollout.max_num_seqs,
+            )
+            self.config.rollout.max_num_seqs = 1
+
         self._initialize_llm_servers()
         self._initialize_router()
         assert self.config.rollout.skip_tokenizer_init is False, "Reward model should not skip tokenizer init."

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -269,6 +269,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    full_determinism: false
+    seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -764,6 +766,8 @@ reward:
       load_format: auto
       layered_summon: false
       scheduling_policy: fcfs
+      full_determinism: false
+      seed: 42
       multi_stage_wake_up: false
       engine_kwargs: {}
       limit_images: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -235,6 +235,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    full_determinism: false
+    seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -698,6 +700,8 @@ reward:
       load_format: auto
       layered_summon: false
       scheduling_policy: fcfs
+      full_determinism: false
+      seed: 42
       multi_stage_wake_up: false
       engine_kwargs: {}
       limit_images: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -242,6 +242,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    full_determinism: false
+    seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -718,6 +720,8 @@ reward:
       load_format: auto
       layered_summon: false
       scheduling_policy: fcfs
+      full_determinism: false
+      seed: 42
       multi_stage_wake_up: false
       engine_kwargs: {}
       limit_images: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -247,6 +247,8 @@ actor_rollout_ref:
     temperature: 1.0
     top_k: -1
     top_p: 1
+    full_determinism: false
+    seed: 42
     prompt_length: ${oc.select:data.max_prompt_length,512}
     response_length: ${oc.select:data.max_response_length,512}
     dtype: bfloat16
@@ -724,6 +726,8 @@ reward:
       load_format: auto
       layered_summon: false
       scheduling_policy: fcfs
+      full_determinism: false
+      seed: 42
       multi_stage_wake_up: false
       engine_kwargs: {}
       limit_images: null

--- a/verl/trainer/config/reward/reward.yaml
+++ b/verl/trainer/config/reward/reward.yaml
@@ -53,6 +53,8 @@ reward_model:
     load_format: auto
     layered_summon: false
     scheduling_policy: fcfs
+    full_determinism: false
+    seed: 42
     multi_stage_wake_up: false
     engine_kwargs: {}
     limit_images: null

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -22,6 +22,14 @@ top_k: -1
 # Top-p sampling parameter. Default 1.0.
 top_p: 1
 
+# Whether to enable full determinism for reproducibility in rollout.
+# See https://pytorch.org/docs/stable/notes/randomness.html for details.
+full_determinism: false
+
+# Random seed for rollout. Used as the seed for vLLM sampling and
+# enable_full_determinism() when full_determinism is True.
+seed: 42
+
 # typically the same as data max prompt length
 # same as data.max_prompt_length if it exists
 prompt_length: ${oc.select:data.max_prompt_length,512}

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -73,4 +73,7 @@ def get_ppo_ray_runtime_env():
     for key in list(runtime_env["env_vars"].keys()):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)
+    # Always forward these at call-time, not import-time.
+    for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT"):
+        runtime_env["env_vars"][key] = os.environ.get(key, "0")
     return runtime_env

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -39,6 +39,15 @@ def run_ppo(config, task_runner_class) -> None:
                 model paths, and training hyperparameters.
         task_runner_class: For recipe to change TaskRunner.
     """
+    # Propagate determinism env vars from config before ray.init() so
+    # get_ppo_ray_runtime_env() forwards them to all Ray actors.
+    rollout_cfg = config.actor_rollout_ref.rollout
+    rm_rollout_cfg = config.reward.reward_model.rollout
+    if rollout_cfg.full_determinism or (config.reward.reward_model.enable and rm_rollout_cfg.full_determinism):
+        os.environ["VERL_FULL_DETERMINISM"] = "1"
+        os.environ["VLLM_BATCH_INVARIANT"] = "1"
+        os.environ["PYTHONHASHSEED"] = str(rollout_cfg.seed)
+
     # Check if Ray is not initialized
     if not ray.is_initialized():
         # Initialize Ray with a local cluster configuration

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1569,7 +1569,6 @@ class RayPPOTrainer:
                                 metrics.update(calculate_debug_metrics(batch))
 
                     assert "old_log_probs" in batch.batch, f'"old_log_prob" not in {batch.batch.keys()=}'
-
                     if self.use_reference_policy:
                         # compute reference log_prob
                         with marked_timer(str(Role.RefPolicy), timing_raw, color="olive"):
@@ -1628,7 +1627,6 @@ class RayPPOTrainer:
                             norm_adv_by_std_in_grpo=norm_adv_by_std_in_grpo,
                             config=self.config.algorithm,
                         )
-
                     # update critic
                     if self.use_critic:
                         with marked_timer("update_critic", timing_raw, color="pink"):

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -151,6 +151,8 @@ class RolloutConfig(BaseConfig):
         "response_length",
         "expert_parallel_size",
         "moe_tensor_parallel_size",
+        "full_determinism",
+        "max_num_seqs",
     }
 
     name: Optional[str] = MISSING
@@ -164,6 +166,13 @@ class RolloutConfig(BaseConfig):
     do_sample: bool = True
     n: int = 1
     repetition_penalty: float = 1.0
+
+    # Whether to enable full determinism for reproducibility.
+    full_determinism: bool = False
+
+    # Random seed for rollout. Used as the seed for vLLM sampling and
+    # enable_full_determinism() when full_determinism is True.
+    seed: int = 42
 
     # Early termination threshold for multi-turn rollout in sglang.
     # Abort remaining requests when (1 - over_sample_rate) * total_requests are completed.

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -55,17 +55,26 @@ class GlobalRequestLoadBalancer:
       multi-turn conversations route to the same server.
     - **Least-loaded Selection**: When no sticky session exists, selects the
       server with the fewest in-flight requests.
+    - **Deterministic Routing**: When ``full_determinism=True``, tie-breaking
+      among equally-loaded servers uses ``hash(request_id)`` so the same
+      request always routes to the same server across runs.
     - **Dynamic Server Management**: Supports add/remove servers at runtime
       for hybrid scaling.
     """
 
-    def __init__(self, servers: dict[str, ray.actor.ActorHandle], max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE):
+    def __init__(
+        self,
+        servers: dict[str, ray.actor.ActorHandle],
+        max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
+        full_determinism: bool = False,
+    ):
         if not servers:
             raise ValueError("servers must be non-empty")
 
         self._servers: dict[str, ray.actor.ActorHandle] = dict(servers)
         self._inflight_requests: dict[str, int] = {sid: 0 for sid in servers}
         self._request_id_to_server: LRUCache = LRUCache(maxsize=max_cache_size)
+        self._full_determinism = full_determinism
 
     def acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
         """Acquire a server for the given request (sticky + least-loaded).
@@ -87,7 +96,15 @@ class GlobalRequestLoadBalancer:
         if not self._inflight_requests:
             raise RuntimeError("No available servers in load balancer")
 
-        server_id = min(self._inflight_requests, key=self._inflight_requests.get)
+        min_count = min(self._inflight_requests.values())
+        candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
+        if len(candidates) == 1:
+            server_id = candidates[0]
+        elif self._full_determinism:
+            # Deterministic tie-breaking: same request_id → same server across runs
+            server_id = candidates[hash(request_id) % len(candidates)]
+        else:
+            server_id = candidates[0]
         self._request_id_to_server[request_id] = server_id
         self._inflight_requests[server_id] += 1
         return server_id, self._servers[server_id]
@@ -171,7 +188,8 @@ class LLMServerClient:
 
     async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
         # Atomic acquire: returns (server_id, handle) in one Ray RPC.
-        return await self._load_balancer.acquire_server.remote(request_id=request_id)
+        server_id, handle = await self._load_balancer.acquire_server.remote(request_id=request_id)
+        return server_id, handle
 
     def _release_server(self, server_id: str) -> None:
         # Fire-and-forget: release is just a counter decrement, no need to await.
@@ -208,6 +226,11 @@ class LLMServerClient:
                 multimodal_kwargs["audio_data"] = audio_data
             if mm_processor_kwargs:
                 multimodal_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
+            # priority is only supported by vLLM rollout server.
+            priority = kwargs.pop("priority", 0)
+            priority_kwargs = (
+                {"priority": priority} if priority != 0 and self.config.actor_rollout_ref.rollout.name == "vllm" else {}
+            )
             output: TokenOutput = await server.generate.remote(
                 request_id=uuid4().hex,  # use new request_id for each turn
                 prompt_ids=prompt_ids,
@@ -215,6 +238,7 @@ class LLMServerClient:
                 image_data=image_data,
                 video_data=video_data,
                 **multimodal_kwargs,
+                **priority_kwargs,
                 **kwargs,
             )
             global_steps = output.extra_fields.get("global_steps")
@@ -241,6 +265,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
         video_data: Optional[list[Any]] = None,
         audio_data: Optional[list[Any]] = None,
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> TokenOutput:
         """Generate tokens from prompt ids.
 
@@ -282,6 +307,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                 video_data=video_data,
                 audio_data=audio_data,
                 mm_processor_kwargs=mm_processor_kwargs,
+                **kwargs,
             )
 
             # 2. merge output into final_output
@@ -445,6 +471,7 @@ class LLMServerManager:
         self.global_load_balancer = GlobalRequestLoadBalancer.remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
+            full_determinism=getattr(self.rollout_config, "full_determinism", False),
         )
 
     def get_client(self, client_cls=LLMServerClient, **kwargs) -> LLMServerClient:

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -152,6 +152,19 @@ class vLLMColocateWorkerExtension:
     def __new__(cls, **kwargs):
         set_death_signal()
 
+        if os.environ.get("VERL_FULL_DETERMINISM", "0") == "1":
+            from verl.workers.engine.utils import enable_full_determinism
+
+            # VERL_SEED is set by vLLMHttpServer.__init__ only when the
+            # rollout config has full_determinism=true.  Worker sub-processes
+            # inherit their parent's env, so rollout workers will see it but
+            # RM workers (whose parent vLLMHttpServer does not set it) won't.
+            # If VERL_SEED is missing, skip — RM doesn't need the determinism
+            # patch, only rollout does.
+            verl_seed = os.environ.get("VERL_SEED")
+            if verl_seed is not None:
+                enable_full_determinism(seed=int(verl_seed))
+
         # 1. patch for Lora
         VLLMHijack.hijack()
         # 2. patch online fp8 quant

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -127,6 +127,15 @@ class vLLMHttpServer:
         self.model_config = self._init_model_config(model_config)
         self._validate_configs()
 
+        if self.config.full_determinism:
+            from verl.workers.engine.utils import enable_full_determinism
+
+            rollout_seed = replica_rank + self.config.seed
+            enable_full_determinism(seed=rollout_seed)
+            os.environ["VERL_FULL_DETERMINISM"] = "1"
+            os.environ["VERL_SEED"] = str(rollout_seed)
+            os.environ["VLLM_BATCH_INVARIANT"] = "1"
+
         self.rollout_mode = rollout_mode
         self.workers = workers
 
@@ -273,7 +282,7 @@ class vLLMHttpServer:
             "gpu_memory_utilization": self.config.gpu_memory_utilization,
             "disable_log_stats": self.config.disable_log_stats,
             "tensor_parallel_size": self.config.tensor_model_parallel_size,
-            "seed": self.replica_rank + (self.config.get("seed") or 0),
+            "seed": self.replica_rank + self.config.seed,
             "override_generation_config": json.dumps(override_generation_config),
             "quantization": quantization,
             "hf_overrides": hf_overrides,
@@ -507,8 +516,10 @@ class vLLMHttpServer:
         )
         sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
-
         sampling_params.setdefault("ignore_eos", self.config.get("ignore_eos", False))
+        # Inject per-request seed for deterministic sampling when full_determinism is enabled.
+        if self.config.full_determinism:
+            sampling_params.setdefault("seed", self.replica_rank + self.config.seed)
         sampling_params = SamplingParams(max_tokens=max_tokens, **sampling_params)
         prompt_ids = qwen2_5_vl_dedup_image_tokens(prompt_ids, self.model_config.processor)
         multi_modal_data = {}


### PR DESCRIPTION
### What does this PR do?

Adds full determinism support for vLLM rollout + reward model inference, enabling reproducible E2E training where two identical runs produce bitwise-aligned reward curves.

Previously, determinism was only available for training engines via `EngineConfig.full_determinism`. The rollout path had no `full_determinism` or `seed` config, and the reward model path had no deterministic routing. This PR closes those gaps.

### Related Issues
Closes #6570

### Test

**Rollout determinism** (3 tests, verifying bit-wise logprob equality across separate vLLM server instances):

```bash
VLLM_DETERMINISM_DENSE_MODEL_PATH=${HOME}/models/Qwen/Qwen2.5-0.5B-Instruct \
VLLM_DETERMINISM_N_GPUS=8 \
pytest tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py -v -s
```

Tests cover:
1. **Same-instance** — rollout twice on one vLLM server (baseline).
2. **Cross-instance vLLM** — two separate server instances produce identical logprobs.
3. **Cross-instance AgentLoop** — two full AgentLoopManager pipelines produce identical logprobs.

**E2E training determinism** (reward curve bitwise alignment across two complete training runs):

```bash
python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
  --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \
  --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
  --train_files ~/data/gsm8k/train.parquet \
  --val_files ~/data/gsm8k/test.parquet \
  --n_gpus 2 --n_steps 5
```

This runs two full PPO training sessions (rollout → RM → advantage → actor update → weight sync) in colocate mode, then verifies that per-step mean rewards are bitwise identical and generates a comparison plot:

<img width="1484" height="885" alt="CD03E89E-F159-443A-C19F-DBCBC4E243C6" src="https://github.com/user-attachments/assets/e2d0bbe1-95c7-41c9-9339-0685f22556a5" />


### API and Usage

```yaml
actor_rollout_ref:
  rollout:
    full_determinism: true
    seed: 42
    scheduling_policy: priority

reward:
  reward_model:
    rollout:
      full_determinism: true
      seed: 42
```

- `full_determinism: true` — enables PyTorch determinism + vLLM batch invariance + per-request seed injection + PYTHONHASHSEED propagation + RM `max_num_seqs=1` serialization
- `seed: 42` — base seed; vLLM uses `replica_rank + seed` per replica; `PYTHONHASHSEED` is auto-set from this seed before `ray.init()` and forwarded via Ray runtime_env
- `scheduling_policy: priority` — deterministic request ordering via globally unique priorities

Defaults (`full_determinism: false`, `seed: 42`, `scheduling_policy: fcfs`) preserve existing behavior.

### Design

Determinism is applied at five layers:

1. **PyTorch-level** — `enable_full_determinism(seed)` called in `vLLMHttpServer.__init__` when `full_determinism=True`; env vars `VERL_FULL_DETERMINISM` and `VERL_SEED` are exported so worker subprocesses (via `vLLMColocateWorkerExtension.__new__`) also apply it.
2. **Env var propagation** — `VERL_FULL_DETERMINISM`, `VLLM_BATCH_INVARIANT`, and `PYTHONHASHSEED` are auto-set in `main_ppo.run_ppo()` from config before `ray.init()`, then forwarded via `PPO_RAY_RUNTIME_ENV` to all Ray actors (including RM vLLM servers and NaiveRouter subprocess).
3. **vLLM batch invariance** — `VLLM_BATCH_INVARIANT=1` makes outputs independent of batch composition.
4. **Per-request seed injection** — `SamplingParams.seed = replica_rank + config.seed` injected on each `generate()` call to reset RNG state per request.
5. **Priority scheduling + deterministic LB routing + RM serialization** — global priority via `global_priority_offset + sample_index`; deterministic `request_id=f"det-{priority}"` in `SingleTurnAgentLoop`; `GlobalRequestLoadBalancer` uses `hash(request_id) % len(candidates)` for tie-breaking; `RewardModelManager` forces `max_num_seqs=1` because vLLM `/classify` path does not support priority scheduling or batch invariance.

### Code Changes

| File | Change |
|---|---|
| `verl/workers/config/rollout.py` | Add `full_determinism`, `seed` to `RolloutConfig`; add `full_determinism`, `max_num_seqs` to `_mutable_fields` |
| `verl/workers/rollout/vllm_rollout/vllm_async_server.py` | Call `enable_full_determinism(seed)` + export env vars in `__init__`; inject `SamplingParams.seed = replica_rank + config.seed` in `generate()` |
| `verl/workers/rollout/vllm_rollout/utils.py` | Propagate determinism to worker subprocesses via `VERL_FULL_DETERMINISM` / `VERL_SEED` env vars |
| `verl/workers/rollout/llm_server.py` | Add `full_determinism` to `GlobalRequestLoadBalancer`; deterministic tie-breaking via `hash(request_id) % len(candidates)` |
| `verl/experimental/agent_loop/agent_loop.py` | Compute and pass `global_priority_offset` per chunk |
| `verl/experimental/agent_loop/single_turn_agent_loop.py` | Use deterministic `request_id=f"det-{priority}"` when `full_determinism=True` |
| `verl/experimental/reward_loop/reward_model.py` | Force `max_num_seqs=1` when `full_determinism=True` |
| `verl/experimental/reward_loop/reward_loop.py` | Determinism debug logging for RM score assembly |
| `verl/trainer/constants_ppo.py` | Forward `PYTHONHASHSEED`, `VERL_FULL_DETERMINISM`, `VLLM_BATCH_INVARIANT` via `PPO_RAY_RUNTIME_ENV` |
| `verl/trainer/main_ppo.py` | Auto-set env vars from config before `ray.init()` for determinism propagation |
| `verl/trainer/ppo/ray_trainer.py` | `_dbg_checksum` debug helpers; deterministic validation generation logging |
| `verl/trainer/config/reward/reward.yaml` | Add `full_determinism`, `seed` defaults |
| `verl/trainer/config/rollout/rollout.yaml` | Add `full_determinism`, `seed` defaults |
| `_generated_ppo_*_trainer.yaml` | Propagate rollout determinism defaults |
| `tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py` | 3 rollout determinism tests |
| `tests/experimental/reward_loop/run_determinism_e2e_with_rm.py` | E2E training determinism script + visualization; RM `full_determinism=true` |
| `tests/experimental/agent_loop/agent_utils.py` | Shared test utilities |
| `.github/workflows/vllm.yml` | CI step for rollout determinism tests |

### CC Lists
@SamitHuang @zhtmike

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote`.
