### PR TITLE
[fully_async, ray] fix: auto-size helper actor CPU reservations

### DIFF
--- a/tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py
@@ -1,0 +1,100 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.experimental.fully_async_policy.ray_actor_resources import (
+    AUTO_CPU_RESERVATION,
+    auto_size_num_cpus,
+    estimate_rollout_worker_group_num_cpus,
+    estimate_trainer_worker_group_num_cpus,
+    get_actor_num_cpus_config,
+    get_actor_num_cpus_config_or_default,
+    resolve_actor_num_cpus,
+)
+
+
+def test_auto_cpu_reservation_keeps_default_when_enough_cpus_available():
+    assert auto_size_num_cpus(default_num_cpus=10, remaining_num_cpus=[10, 2], available_cpus=32) == 10
+
+
+def test_auto_cpu_reservation_scales_with_remaining_actor_defaults():
+    num_cpus = auto_size_num_cpus(default_num_cpus=10, remaining_num_cpus=[10, 2], available_cpus=17)
+
+    assert num_cpus == pytest.approx(7.7273)
+
+
+def test_auto_cpu_reservation_leaves_reserved_worker_group_cpus():
+    num_cpus = auto_size_num_cpus(
+        default_num_cpus=10,
+        remaining_num_cpus=[10, 2],
+        reserved_num_cpus=5,
+        available_cpus=17,
+    )
+
+    assert num_cpus == pytest.approx(5.4545)
+
+
+def test_resolve_actor_num_cpus_uses_explicit_config():
+    config = OmegaConf.create({"async_training": {"rollouter_num_cpus": 4}})
+
+    num_cpus = resolve_actor_num_cpus(
+        config=config,
+        key="rollouter_num_cpus",
+        default_num_cpus=10,
+        remaining_num_cpus=[2],
+        available_cpus=1,
+    )
+
+    assert num_cpus == 4
+
+
+def test_resolve_actor_num_cpus_scales_auto_config():
+    config = OmegaConf.create({"async_training": {"rollouter_num_cpus": AUTO_CPU_RESERVATION}})
+
+    num_cpus = resolve_actor_num_cpus(
+        config=config,
+        key="rollouter_num_cpus",
+        default_num_cpus=10,
+        remaining_num_cpus=[2],
+        available_cpus=4,
+    )
+
+    assert num_cpus == pytest.approx(3.3333)
+
+
+def test_auto_config_is_desired_default_for_pending_actor_reservations():
+    config = OmegaConf.create({"async_training": {"message_queue_num_cpus": AUTO_CPU_RESERVATION}})
+
+    assert get_actor_num_cpus_config_or_default(config, "message_queue_num_cpus", 2) == 2
+
+
+def test_worker_group_cpu_reserve_estimates_default_placement_group_bundles():
+    config = OmegaConf.create(
+        {
+            "trainer": {"nnodes": 1, "n_gpus_per_node": 2},
+            "rollout": {"nnodes": 2, "n_gpus_per_node": 4},
+        }
+    )
+
+    assert estimate_trainer_worker_group_num_cpus(config) == 6
+    assert estimate_rollout_worker_group_num_cpus(config) == 16
+
+
+def test_invalid_actor_num_cpus_config_raises():
+    config = OmegaConf.create({"async_training": {"trainer_num_cpus": "many"}})
+
+    with pytest.raises(ValueError, match="trainer_num_cpus"):
+        get_actor_num_cpus_config(config, "trainer_num_cpus")

--- a/verl/experimental/fully_async_policy/README.md
+++ b/verl/experimental/fully_async_policy/README.md
@@ -106,6 +106,9 @@ https://github.com/ArronHZG/verl-community/blob/main/docs/fully_async_policy_rev
 | `async_training.staleness_threshold`                             | Freshness control                                                                              |
 | `async_training.partial_rollout`                                 | Whether to perform partial_rollout                                                             |
 | `async_training.use_trainer_do_validate`                         | Whether use trainer node to do validate process, default `False`                               |
+| `async_training.trainer_num_cpus`                                | Ray CPU reservation for the FullyAsyncTrainer actor, default `auto`                            |
+| `async_training.rollouter_num_cpus`                              | Ray CPU reservation for the FullyAsyncRollouter actor, default `auto`                          |
+| `async_training.message_queue_num_cpus`                          | Ray CPU reservation for the MessageQueue actor, default `auto`                                 |
 
 **Further Explanation:**
 

--- a/verl/experimental/fully_async_policy/README_zh.md
+++ b/verl/experimental/fully_async_policy/README_zh.md
@@ -83,6 +83,9 @@ https://github.com/ArronHZG/verl-community/blob/main/docs/fully_async_policy_rev
 | `async_training.staleness_threshold`                             | 新鲜度控制                                                           |
 | `async_training.partial_rollout`                                 | 是否进行partial_rollout                                             |
 | `async_training.use_trainer_do_validate`                         | 是否使用Trainer的do_validate方法进行validation，默认值False                  |
+| `async_training.trainer_num_cpus`                                | FullyAsyncTrainer actor 的 Ray CPU 资源预留，默认值 `auto`             |
+| `async_training.rollouter_num_cpus`                              | FullyAsyncRollouter actor 的 Ray CPU 资源预留，默认值 `auto`           |
+| `async_training.message_queue_num_cpus`                          | MessageQueue actor 的 Ray CPU 资源预留，默认值 `auto`                 |
 
 **进一步的解释：**
 

--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml
@@ -25,6 +25,12 @@ async_training:
   # whether to use trainer do_validate
   use_trainer_do_validate: False
 
+  # Ray CPU reservations for fully async helper actors. Use "auto" to scale
+  # reservations down when the cluster has fewer CPUs than the historical defaults.
+  trainer_num_cpus: auto
+  rollouter_num_cpus: auto
+  message_queue_num_cpus: auto
+
 # Rollout config
 rollout:
 

--- a/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
+++ b/verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml
@@ -25,6 +25,12 @@ async_training:
   # whether to use trainer do_validate
   use_trainer_do_validate: False
 
+  # Ray CPU reservations for fully async helper actors. Use "auto" to scale
+  # reservations down when the cluster has fewer CPUs than the historical defaults.
+  trainer_num_cpus: auto
+  rollouter_num_cpus: auto
+  message_queue_num_cpus: auto
+
 # Rollout config
 rollout:
 

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -107,7 +107,12 @@ class FullyAsyncTaskRunner:
             config=config,
             key="message_queue_num_cpus",
             default_num_cpus=DEFAULT_MESSAGE_QUEUE_NUM_CPUS,
-            remaining_keys=(),
+            remaining_keys=(
+                ("trainer_num_cpus", DEFAULT_TRAINER_NUM_CPUS),
+                ("rollouter_num_cpus", DEFAULT_ROLLOUTER_NUM_CPUS),
+            ),
+            reserved_num_cpus=estimate_trainer_worker_group_num_cpus(config)
+            + estimate_rollout_worker_group_num_cpus(config),
         )
         message_queue = MessageQueue.options(num_cpus=message_queue_num_cpus).remote(config, max_queue_size)
         message_queue_client = MessageQueueClient(message_queue)

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -140,8 +140,12 @@ class FullyAsyncTaskRunner:
             config=config,
             key="rollouter_num_cpus",
             default_num_cpus=DEFAULT_ROLLOUTER_NUM_CPUS,
-            remaining_keys=(("message_queue_num_cpus", DEFAULT_MESSAGE_QUEUE_NUM_CPUS),),
-            reserved_num_cpus=estimate_rollout_worker_group_num_cpus(config),
+            remaining_keys=(
+                ("trainer_num_cpus", DEFAULT_TRAINER_NUM_CPUS),
+                ("message_queue_num_cpus", DEFAULT_MESSAGE_QUEUE_NUM_CPUS),
+            ),
+            reserved_num_cpus=estimate_trainer_worker_group_num_cpus(config)
+            + estimate_rollout_worker_group_num_cpus(config),
         )
         rollouter = FullyAsyncRollouter.options(num_cpus=rollouter_num_cpus).remote(
             config=config,

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -25,6 +25,15 @@ from omegaconf import OmegaConf
 from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
 from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
 from verl.experimental.fully_async_policy.message_queue import MessageQueue, MessageQueueClient
+from verl.experimental.fully_async_policy.ray_actor_resources import (
+    DEFAULT_MESSAGE_QUEUE_NUM_CPUS,
+    DEFAULT_ROLLOUTER_NUM_CPUS,
+    DEFAULT_TRAINER_NUM_CPUS,
+    estimate_rollout_worker_group_num_cpus,
+    estimate_trainer_worker_group_num_cpus,
+    get_actor_num_cpus_config_or_default,
+    resolve_actor_num_cpus,
+)
 from verl.experimental.reward_loop import migrate_legacy_reward_impl
 from verl.experimental.separation.utils import create_resource_pool_manager, create_role_worker_mapping
 from verl.trainer.ppo.utils import Role
@@ -94,7 +103,13 @@ class FullyAsyncTaskRunner:
         # max_queue_size
         max_queue_size = ray.get(self.components["rollouter"].get_max_queue_size.remote())
         print(f"[ASYNC MAIN] Creating MessageQueue... max_queue_size {max_queue_size}")
-        message_queue = MessageQueue.remote(config, max_queue_size)
+        message_queue_num_cpus = self._resolve_actor_num_cpus(
+            config=config,
+            key="message_queue_num_cpus",
+            default_num_cpus=DEFAULT_MESSAGE_QUEUE_NUM_CPUS,
+            remaining_keys=(),
+        )
+        message_queue = MessageQueue.options(num_cpus=message_queue_num_cpus).remote(config, max_queue_size)
         message_queue_client = MessageQueueClient(message_queue)
         self.components["message_queue"] = message_queue
         self.components["message_queue_client"] = message_queue_client
@@ -116,7 +131,14 @@ class FullyAsyncTaskRunner:
 
     def _create_rollouter(self, config) -> None:
         print("[ASYNC MAIN] Starting create rollouter...")
-        rollouter = FullyAsyncRollouter.remote(
+        rollouter_num_cpus = self._resolve_actor_num_cpus(
+            config=config,
+            key="rollouter_num_cpus",
+            default_num_cpus=DEFAULT_ROLLOUTER_NUM_CPUS,
+            remaining_keys=(("message_queue_num_cpus", DEFAULT_MESSAGE_QUEUE_NUM_CPUS),),
+            reserved_num_cpus=estimate_rollout_worker_group_num_cpus(config),
+        )
+        rollouter = FullyAsyncRollouter.options(num_cpus=rollouter_num_cpus).remote(
             config=config,
             tokenizer=self.components["tokenizer"],
             processor=self.components["processor"],
@@ -143,7 +165,18 @@ class FullyAsyncTaskRunner:
             if role != Role.Rollout
         }
 
-        trainer = FullyAsyncTrainer.remote(
+        trainer_num_cpus = self._resolve_actor_num_cpus(
+            config=config,
+            key="trainer_num_cpus",
+            default_num_cpus=DEFAULT_TRAINER_NUM_CPUS,
+            remaining_keys=(
+                ("rollouter_num_cpus", DEFAULT_ROLLOUTER_NUM_CPUS),
+                ("message_queue_num_cpus", DEFAULT_MESSAGE_QUEUE_NUM_CPUS),
+            ),
+            reserved_num_cpus=estimate_trainer_worker_group_num_cpus(config)
+            + estimate_rollout_worker_group_num_cpus(config),
+        )
+        trainer = FullyAsyncTrainer.options(num_cpus=trainer_num_cpus).remote(
             config=config,
             tokenizer=self.components["tokenizer"],
             role_worker_mapping=trainer_role_mapping,
@@ -155,6 +188,32 @@ class FullyAsyncTaskRunner:
         ray.get(trainer.init_workers.remote())
         self.components["trainer"] = trainer
         print("[ASYNC MAIN] FullyAsyncTrainer created and initialized successfully")
+
+    def _resolve_actor_num_cpus(
+        self,
+        config,
+        key: str,
+        default_num_cpus: float,
+        remaining_keys,
+        reserved_num_cpus: float = 0.0,
+    ) -> float:
+        remaining_num_cpus = [
+            get_actor_num_cpus_config_or_default(config, remaining_key, remaining_default_num_cpus)
+            for remaining_key, remaining_default_num_cpus in remaining_keys
+        ]
+        num_cpus = resolve_actor_num_cpus(
+            config=config,
+            key=key,
+            default_num_cpus=default_num_cpus,
+            remaining_num_cpus=remaining_num_cpus,
+            reserved_num_cpus=reserved_num_cpus,
+        )
+        print(
+            f"[ASYNC MAIN] Ray CPU reservation for {key}: {num_cpus} "
+            f"(available={ray.available_resources().get('CPU', 'unknown')}, "
+            f"default={default_num_cpus}, remaining={remaining_num_cpus}, reserved={reserved_num_cpus})"
+        )
+        return num_cpus
 
     def _setup_hybrid_worker_group(self, config) -> None:
         """

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -389,7 +389,7 @@ class FullyAsyncAgentLoopManager(AgentLoopManager):
         return worker
 
 
-@ray.remote(num_cpus=10, max_concurrency=100)
+@ray.remote(max_concurrency=100)
 class FullyAsyncRollouter(SeparateRayPPOTrainer):
     """
     Asynchronous sample generator, responsible for continuously generating training samples

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -49,7 +49,7 @@ class TrainingStopException(Exception):
     pass
 
 
-@ray.remote(num_cpus=10)
+@ray.remote
 class FullyAsyncTrainer(SeparateRayPPOTrainer):
     """
     A fully asynchronous PPO trainer that obtains samples from a MessageQueue for training.

--- a/verl/experimental/fully_async_policy/message_queue.py
+++ b/verl/experimental/fully_async_policy/message_queue.py
@@ -23,7 +23,7 @@ from omegaconf import DictConfig
 logger = logging.getLogger(__name__)
 
 
-@ray.remote(num_cpus=2, max_concurrency=20)
+@ray.remote(max_concurrency=20)
 class MessageQueue:
     """
     Simplified Ray-based asynchronous message queue for communication between Rollouter and Trainer

--- a/verl/experimental/fully_async_policy/ray_actor_resources.py
+++ b/verl/experimental/fully_async_policy/ray_actor_resources.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from numbers import Real
+from typing import Any, Iterable
+
+import ray
+
+AUTO_CPU_RESERVATION = "auto"
+
+DEFAULT_TRAINER_NUM_CPUS = 10.0
+DEFAULT_ROLLOUTER_NUM_CPUS = 10.0
+DEFAULT_MESSAGE_QUEUE_NUM_CPUS = 2.0
+DEFAULT_TRAINER_WORKER_GROUP_NUM_CPUS_PER_GPU = 3.0
+DEFAULT_ROLLOUT_WORKER_GROUP_NUM_CPUS_PER_GPU = 2.0
+
+
+def get_actor_num_cpus_config(config: Any, key: str, default: str | float = AUTO_CPU_RESERVATION) -> str | float:
+    async_training_config = getattr(config, "async_training", None)
+    if async_training_config is None:
+        return default
+
+    value = async_training_config.get(key, default)
+    if isinstance(value, str) and value.lower() == AUTO_CPU_RESERVATION:
+        return AUTO_CPU_RESERVATION
+    return _validate_num_cpus(value, key)
+
+
+def get_actor_num_cpus_config_or_default(config: Any, key: str, default_num_cpus: float) -> float:
+    value = get_actor_num_cpus_config(config, key)
+    if value == AUTO_CPU_RESERVATION:
+        return default_num_cpus
+    return value
+
+
+def resolve_actor_num_cpus(
+    config: Any,
+    key: str,
+    default_num_cpus: float,
+    remaining_num_cpus: Iterable[float] = (),
+    reserved_num_cpus: float = 0.0,
+    available_cpus: float | None = None,
+) -> float:
+    configured_num_cpus = get_actor_num_cpus_config(config, key)
+    if configured_num_cpus != AUTO_CPU_RESERVATION:
+        return configured_num_cpus
+
+    if available_cpus is None:
+        available_cpus = _get_available_cpus()
+    if available_cpus is None:
+        return float(default_num_cpus)
+
+    return auto_size_num_cpus(
+        default_num_cpus=default_num_cpus,
+        remaining_num_cpus=remaining_num_cpus,
+        reserved_num_cpus=reserved_num_cpus,
+        available_cpus=available_cpus,
+    )
+
+
+def auto_size_num_cpus(
+    default_num_cpus: float,
+    remaining_num_cpus: Iterable[float] = (),
+    reserved_num_cpus: float = 0.0,
+    available_cpus: float = 0.0,
+) -> float:
+    available_cpus = max(float(available_cpus), 0.0)
+    actor_available_cpus = max(available_cpus - max(float(reserved_num_cpus), 0.0), 0.0)
+    remaining_num_cpus = [max(float(num_cpus), 0.0) for num_cpus in remaining_num_cpus]
+    desired_num_cpus = max(float(default_num_cpus), 0.0)
+    desired_total = desired_num_cpus + sum(remaining_num_cpus)
+
+    if desired_total <= 0:
+        return 0.0
+    if actor_available_cpus >= desired_total:
+        return _round_num_cpus(desired_num_cpus)
+
+    return _round_num_cpus(actor_available_cpus * desired_num_cpus / desired_total)
+
+
+def estimate_trainer_worker_group_num_cpus(config: Any) -> float:
+    return _estimate_worker_group_num_cpus(
+        config=config,
+        config_key="trainer",
+        num_cpus_per_gpu=DEFAULT_TRAINER_WORKER_GROUP_NUM_CPUS_PER_GPU,
+    )
+
+
+def estimate_rollout_worker_group_num_cpus(config: Any) -> float:
+    return _estimate_worker_group_num_cpus(
+        config=config,
+        config_key="rollout",
+        num_cpus_per_gpu=DEFAULT_ROLLOUT_WORKER_GROUP_NUM_CPUS_PER_GPU,
+    )
+
+
+def _get_available_cpus() -> float | None:
+    if not ray.is_initialized():
+        cpu_count = os.cpu_count()
+        return float(cpu_count) if cpu_count is not None else None
+
+    available_cpus = ray.available_resources().get("CPU")
+    if available_cpus is not None:
+        return float(available_cpus)
+
+    cluster_cpus = ray.cluster_resources().get("CPU")
+    if cluster_cpus is not None:
+        return float(cluster_cpus)
+    return None
+
+
+def _validate_num_cpus(value: Any, key: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"async_training.{key} must be a non-negative number or 'auto', got {value!r}")
+
+    if isinstance(value, Real):
+        num_cpus = float(value)
+    elif isinstance(value, str):
+        try:
+            num_cpus = float(value)
+        except ValueError as exc:
+            raise ValueError(f"async_training.{key} must be a non-negative number or 'auto', got {value!r}") from exc
+    else:
+        raise ValueError(f"async_training.{key} must be a non-negative number or 'auto', got {value!r}")
+
+    if num_cpus < 0:
+        raise ValueError(f"async_training.{key} must be non-negative, got {value!r}")
+    return _round_num_cpus(num_cpus)
+
+
+def _round_num_cpus(num_cpus: float) -> float:
+    return round(float(num_cpus), 4)
+
+
+def _estimate_worker_group_num_cpus(config: Any, config_key: str, num_cpus_per_gpu: float) -> float:
+    worker_group_config = getattr(config, config_key, None)
+    if worker_group_config is None:
+        return 0.0
+
+    nnodes = float(worker_group_config.get("nnodes", 0))
+    n_gpus_per_node = float(worker_group_config.get("n_gpus_per_node", 0))
+    return _round_num_cpus(max(nnodes, 0.0) * max(n_gpus_per_node, 0.0) * num_cpus_per_gpu)

--- a/verl/experimental/fully_async_policy/ray_actor_resources.py
+++ b/verl/experimental/fully_async_policy/ray_actor_resources.py
@@ -113,10 +113,6 @@ def _get_available_cpus() -> float | None:
         cpu_count = os.cpu_count()
         return float(cpu_count) if cpu_count is not None else None
 
-    available_cpus = ray.available_resources().get("CPU")
-    if available_cpus is not None:
-        return float(available_cpus)
-
     cluster_cpus = ray.cluster_resources().get("CPU")
     if cluster_cpus is not None:
         return float(cluster_cpus)


### PR DESCRIPTION
### What does this PR do?

Makes fully async helper actor CPU reservations configurable instead of hardcoded in the Ray actor decorators.

The default value is `auto`, which keeps the historical reservations when enough CPUs are available (`FullyAsyncTrainer=10`, `FullyAsyncRollouter=10`, `MessageQueue=2`) and scales them down proportionally on CPU-constrained clusters. The auto-sizing also leaves CPU capacity for the trainer and standalone rollout worker placement groups, so the helper actors do not consume all available CPUs before workers are initialized.

This avoids fully async jobs staying pending on smaller clusters only because helper actors require fixed CPU reservations.

### Checklist Before Starting

- [x] Search for similar PRs. Query links:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully_async+num_cpus
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully_async+CPU+reservation
  - https://github.com/verl-project/verl/issues?q=is%3Aissue+is%3Aopen+fully_async+num_cpus
  - https://github.com/verl-project/verl/issues?q=is%3Aissue+is%3Aopen+fully_async+CPU+reservation
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

- `python3 -m pytest tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py -q`
  - Result: `8 passed in 4.47s`
- `python3 -m ruff check verl/experimental/fully_async_policy/ray_actor_resources.py verl/experimental/fully_async_policy/fully_async_main.py verl/experimental/fully_async_policy/fully_async_rollouter.py verl/experimental/fully_async_policy/fully_async_trainer.py verl/experimental/fully_async_policy/message_queue.py tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py`
  - Result: passed
- `python3 -m py_compile verl/experimental/fully_async_policy/ray_actor_resources.py verl/experimental/fully_async_policy/fully_async_main.py verl/experimental/fully_async_policy/fully_async_rollouter.py verl/experimental/fully_async_policy/fully_async_trainer.py verl/experimental/fully_async_policy/message_queue.py tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py`
  - Result: passed
- `pre-commit run --files verl/experimental/fully_async_policy/ray_actor_resources.py verl/experimental/fully_async_policy/fully_async_main.py verl/experimental/fully_async_policy/fully_async_rollouter.py verl/experimental/fully_async_policy/fully_async_trainer.py verl/experimental/fully_async_policy/message_queue.py verl/experimental/fully_async_policy/config/fully_async_ppo_trainer.yaml verl/experimental/fully_async_policy/config/fully_async_ppo_megatron_trainer.yaml verl/experimental/fully_async_policy/README.md verl/experimental/fully_async_policy/README_zh.md tests/experimental/fully_async_policy/test_ray_actor_resources_on_cpu.py --show-diff-on-failure --color=always`
  - Result: passed
- `pre-commit run --all-files --show-diff-on-failure --color=always`
  - Result: passed

### API and Usage Example

The fully async configs now expose helper actor CPU reservations:

```yaml
async_training:
  trainer_num_cpus: auto
  rollouter_num_cpus: auto
  message_queue_num_cpus: auto
```

Users can still set explicit reservations when they want fixed Ray scheduling behavior:

```bash
async_training.trainer_num_cpus=4 \
async_training.rollouter_num_cpus=4 \
async_training.message_queue_num_cpus=1
```

### Design & Code Changes

- Remove fixed `num_cpus` from the `FullyAsyncTrainer`, `FullyAsyncRollouter`, and `MessageQueue` Ray actor decorators.
- Resolve actor CPU reservations in `FullyAsyncTaskRunner` with `.options(num_cpus=...)` when each actor is created.
- Add `ray_actor_resources.py` for config parsing, validation, and auto-sizing logic.
- Add CPU-only unit tests for default preservation, proportional down-scaling, explicit overrides, invalid config handling, and worker placement-group CPU reserves.
- Document the new config keys in the fully async README files and default config files.

AI assistance was used to prepare this PR. The submitting human should review every changed line and validate the behavior before marking the PR ready for review.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Added CPU-only unit tests under `tests/experimental/fully_async_policy/`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
