### PR TITLE
[docker] fix: align stable sglang image for GB200

### DIFF
--- a/docker/Dockerfile.stable.sglang
+++ b/docker/Dockerfile.stable.sglang
@@ -61,12 +61,19 @@ RUN pip install torchcodec --index-url=https://download.pytorch.org/whl/cu130
 
 RUN pip install qwen-vl-utils==0.0.14
 
-RUN pip uninstall "flash-attn-4" && pip install "flash-attn-4[cu13]"
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        pip show "flash-attn-4"; \
+    else \
+        pip uninstall -y "flash-attn-4" && \
+        pip install "flash-attn-4[cu13]"; \
+    fi
 
-RUN wget https://github.com/sgl-project/whl/releases/download/v0.4.2.post2/sglang_kernel-0.4.2.post2+cu130-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e7ce619274234d182b20da883fcf1d20e7e55cbea90d62244e2b6a3d6c0fc85 && \
-    pip install sglang_kernel-0.4.2.post2+cu130-cp310-abi3-manylinux2014_x86_64.whl --force-reinstall
-
-RUN pip install transformers==5.3.0
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        pip show "sglang-kernel"; \
+    else \
+        wget https://github.com/sgl-project/whl/releases/download/v0.4.2.post2/sglang_kernel-0.4.2.post2+cu130-cp310-abi3-manylinux2014_x86_64.whl#sha256=4e7ce619274234d182b20da883fcf1d20e7e55cbea90d62244e2b6a3d6c0fc85 && \
+        pip install sglang_kernel-0.4.2.post2+cu130-cp310-abi3-manylinux2014_x86_64.whl --force-reinstall; \
+    fi
 
 RUN pip install -U git+https://github.com/ISEEKYAN/mbridge.git@main
 


### PR DESCRIPTION
Update `Dockerfile.stable.sglang` so the stable SGLang image builds on GB200/aarch64 by keeping the SGLang base image's ARM `flash-attn-4`, `sglang-kernel`, and `transformers` deps instead of reinstalling incompatible pins; x86 likely should be simplified the same way, but I left it mostly unchanged because I did not test x86.

Validated container: `verlai/verl:sgl0512.aarch64.dev1`

Sanity passed on a GB200 node: build succeeded, `sglang-kernel` includes SM100 kernels, CUDA matmul/Apex smoke/SGLang CLI all passed.

More tests are welcome, especially x86 build validation.
