### PR TITLE
fix: align VL prompt filtering patch size

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -25,12 +25,62 @@ from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
 
 
+class _ImageProcessor:
+    patch_size = 16
+
+
+class _Processor:
+    image_processor = _ImageProcessor()
+
+
 def get_gsm8k_data():
     # prepare test dataset
     local_folder = os.path.expanduser("~/data/gsm8k/")
     local_path = os.path.join(local_folder, "train.parquet")
     os.makedirs(local_folder, exist_ok=True)
     return local_path
+
+
+def test_rl_dataset_uses_processor_image_patch_size_by_default(monkeypatch):
+    monkeypatch.setattr(RLHFDataset, "_download", lambda self: None)
+    monkeypatch.setattr(RLHFDataset, "_read_files_and_tokenize", lambda self: None)
+
+    dataset = RLHFDataset(
+        data_files="dummy.parquet",
+        tokenizer=object(),
+        config=OmegaConf.create({}),
+        processor=_Processor(),
+    )
+
+    assert dataset.image_patch_size == 16
+
+
+def test_rl_dataset_keeps_explicit_image_patch_size(monkeypatch):
+    monkeypatch.setattr(RLHFDataset, "_download", lambda self: None)
+    monkeypatch.setattr(RLHFDataset, "_read_files_and_tokenize", lambda self: None)
+
+    dataset = RLHFDataset(
+        data_files="dummy.parquet",
+        tokenizer=object(),
+        config=OmegaConf.create({"image_patch_size": 14}),
+        processor=_Processor(),
+    )
+
+    assert dataset.image_patch_size == 14
+
+
+def test_rl_dataset_falls_back_when_image_patch_size_is_null(monkeypatch):
+    monkeypatch.setattr(RLHFDataset, "_download", lambda self: None)
+    monkeypatch.setattr(RLHFDataset, "_read_files_and_tokenize", lambda self: None)
+
+    dataset = RLHFDataset(
+        data_files="dummy.parquet",
+        tokenizer=object(),
+        config=OmegaConf.create({"image_patch_size": None}),
+        processor=_Processor(),
+    )
+
+    assert dataset.image_patch_size == 16
 
 
 def test_rl_dataset():

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -108,7 +108,8 @@ class RLHFDataset(Dataset):
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
         self.audio_key = config.get("audio_key", "audios")
-        self.image_patch_size = config.get("image_patch_size", 14)
+        default_image_patch_size = getattr(getattr(processor, "image_processor", None), "patch_size", 14)
+        self.image_patch_size = config.get("image_patch_size") or default_image_patch_size
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.return_full_prompt = config.get("return_full_prompt", False)


### PR DESCRIPTION
## Summary
- default `RLHFDataset.image_patch_size` from `processor.image_processor.patch_size` when a multimodal processor is available
- keep `data.image_patch_size` as an explicit override
- add CPU tests for both the processor-derived default and the override path

This keeps overlong-prompt filtering aligned with the agent-loop rollout path, which already reads the processor's real patch size.

Fixes #6592.

## To verify
- `python -m pytest tests/utils/dataset/test_rl_dataset_on_cpu.py -q -k "image_patch_size"`
- `python -m py_compile verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py`
- `ruff check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py`
- `ruff format --check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py`
- `git diff --check`
