### PR TITLE
[data] fix: default image_patch_size to processor's real patch_size in filter_overlong_prompts

### DIFF
--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -110,7 +110,7 @@ class RLHFDataset(Dataset):
         self.audio_key = config.get("audio_key", "audios")
         # Default to the processor's real patch_size to align with the rollout path.
         _default_patch_size = getattr(getattr(self.processor, "image_processor", None), "patch_size", 14)
-        self.image_patch_size = config.get("image_patch_size", _default_patch_size)
+        self.image_patch_size = config.get("image_patch_size") or _default_patch_size
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.return_full_prompt = config.get("return_full_prompt", False)

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -108,7 +108,9 @@ class RLHFDataset(Dataset):
         self.image_key = config.get("image_key", "images")
         self.video_key = config.get("video_key", "videos")
         self.audio_key = config.get("audio_key", "audios")
-        self.image_patch_size = config.get("image_patch_size", 14)
+        # Default to the processor's real patch_size to align with the rollout path.
+        _default_patch_size = getattr(getattr(self.processor, "image_processor", None), "patch_size", 14)
+        self.image_patch_size = config.get("image_patch_size", _default_patch_size)
         self.max_prompt_length = config.get("max_prompt_length", 1024)
         self.return_raw_chat = config.get("return_raw_chat", False)
         self.return_full_prompt = config.get("return_full_prompt", False)


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in `agent_loop._postprocess` caused by `filter_overlong_prompts` under-counting vision tokens when the model's real `image_processor.patch_size` differs from the hardcoded default of 14.

Related issue: #6592

### Checklist Before Starting

- [x] Search for similar PRs. No existing PR found for this issue.
  Query: https://github.com/verl-project/verl/pulls?q=image_patch_size

### Test

Validated on Qwen3-VL (real `patch_size=16`) with `filter_overlong_prompts=True` and `data.image_patch_size` unset:

- **Before**: borderline samples (estimated ≤ `max_prompt_length` with patch_size=14, actual > `max_prompt_length` with patch_size=16) pass the filter and crash at rollout:
  ```
  RuntimeError: Sizes of tensors must match except in dimension 0.
  Expected size 3072 but got size 3084 for tensor number 88 in the list.
  ```
- **After**: filter uses the processor's real patch_size=16, over-length samples are correctly filtered, no crash.

### API and Usage Example

No API change. Explicit `data.image_patch_size` config still overrides the default.

```python
# Before (always defaulted to 14):
self.image_patch_size = config.get("image_patch_size", 14)

# After (defaults to processor's real patch_size, falls back to 14 if unavailable):
_default_patch_size = getattr(getattr(self.processor, "image_processor", None), "patch_size", 14)
self.image_patch_size = config.get("image_patch_size", _default_patch_size)
```

### Design & Code Changes

**Root cause**: `filter_overlong_prompts` in `RLHFDataset` and the rollout path in `AgentLoopWorker` both call `qwen_vl_utils.process_vision_info` with `image_patch_size` to perform `smart_resize` — which aligns image dimensions to a `patch_size × merge_size` grid before counting vision tokens. However, they read `image_patch_size` from different sources:

- **Rollout** (`agent_loop.py:253`): reads from `processor.image_processor.patch_size` (real value)
- **Filter** (`rl_dataset.py:111`): hardcoded default `14`

For Qwen3-VL (`patch_size=16, merge_size=2`), filter aligns to a 28-grid while rollout aligns to a 32-grid, producing different vision token counts. A sample estimated at ≤ `max_prompt_length` by the filter can be longer at rollout, and `tokenizer.pad(padding="max_length")` never truncates, so the over-length sample breaks `torch.cat(dim=0)` in `_postprocess`.

**Fix**: one-line change in `verl/utils/dataset/rl_dataset.py` — default `image_patch_size` to `processor.image_processor.patch_size`, exactly mirroring `agent_loop.py:253`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply pre-commit checks
- [ ] Add / Update the documentation (N/A — no user-facing change)
- [ ] Add unit or end-to-end test(s): the fix is a one-line default value correction; a unit test would require a real VL processor. Will add if requested.
