### PR TITLE
[megatron] fix: tolerate extra kwargs in MTP postprocess patch

### DIFF
--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -87,6 +87,8 @@ def _megatron_gptmodel_postprocess(
     extra_block_kwargs=None,
     inference_context=None,
     is_spec_decode=None,
+    padding_mask=None,
+    **kwargs,
 ):
     """Postprocesses decoder hidden states to generate logits or compute loss.
 


### PR DESCRIPTION
### Summary

`patch_postprocess` (MTP support) replaces `GPTModel._postprocess` with `_megatron_gptmodel_postprocess`. In current Megatron-Core, `GPTModel.forward` calls `self._postprocess(...)` with extra keyword arguments — notably `padding_mask` (the MoE-routing mask). The patched function has a fixed signature with no `**kwargs`, so enabling MTP raises:

```
TypeError: _megatron_gptmodel_postprocess() got an unexpected keyword argument 'padding_mask'
```

This accepts `padding_mask` and adds `**kwargs` so the monkeypatch tolerates keyword arguments threaded into `GPTModel.forward` across Megatron-Core versions. These arguments are consumed in the decoder (e.g. MoE routing), not in logits/loss postprocessing, so ignoring them here preserves behavior.

### Not a duplicate

Checked open PRs/issues: #4539 (draft that adds the MTP patch; does not touch the signature for `padding_mask`/`**kwargs`) and #5332 (a different `labels=None` fused-forward crash). No open PR/issue addresses this.

### Test

Ran verl SFT with `engine=megatron`, `model.mtp.enable=True` against a Megatron-Core whose `GPTModel.forward` passes `padding_mask` to `_postprocess`:
- before: `TypeError ... unexpected keyword argument 'padding_mask'` at the first step
- after: training and validation loss decrease over steps, no crash

### AI assistance

Prepared with AI assistance (Claude) and reviewed by the submitter.
