### PR TITLE
feat: analytical auto-parallel for Megatron PPO (auto_parallelization + main_ppo)

### DIFF
--- a/.github/workflows/cpu_unit_tests.yml
+++ b/.github/workflows/cpu_unit_tests.yml
@@ -96,7 +96,7 @@ jobs:
           pip3 install -r requirements-test.txt
           pip3 install --no-deps -e .
       - name: Check final pip list
-          pip3 list
+        run: pip3 list
       - name: Download datasets
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k

--- a/.github/workflows/e2e_fully_async_policy.yml
+++ b/.github/workflows/e2e_fully_async_policy.yml
@@ -1,233 +1,169 @@
-#!/usr/bin/env bash
-set -xeuo pipefail
+# # Tests layout
 
-# Test script for fully_async_policy E2E regression testing
-# This script runs fully async PPO training with both FSDP2 and Megatron backends
-# to ensure the asynchronous training mechanism works correctly
+# Each folder under tests/ corresponds to a test category for a sub-namespace in verl. For instance:
+# - `tests/trainer` for testing functionality related to `verl/trainer`
+# - `tests/models` for testing functionality related to `verl/models`
+# - ...
 
-NUM_GPUS=${NUM_GPUS:-8}
-ACTOR_STRATEGY=${ACTOR_STRATEGY:-"fsdp2"}  # fsdp2 or megatron
-ROLLOUT_NAME=${ROLLOUT_NAME:-"vllm"}       # vllm, sglang, or trtllm
+# There are a few folders with `special_` prefix, created for special purposes:
+# - `special_distributed`: unit tests that must run with multiple GPUs
+# - `special_e2e`: end-to-end tests with training/generation scripts
+# - `special_npu`: tests for NPUs
+# - `special_sanity`: a suite of quick sanity tests
+# - `special_standalone`: a set of test that are designed to run in dedicated environments
 
-# Download model if not exists
-MODEL_ID=${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}
-MODEL_PATH=${MODEL_PATH:-${HOME}/models/${MODEL_ID}}
-# hf download "${MODEL_ID}" --local-dir "${MODEL_PATH}"
+# Accelerators for tests
+# - By default tests are run with GPU available, except for the ones under `special_npu`, and any test script whose name ends with `on_cpu.py`.
+# - For test scripts with `on_cpu.py` name suffix would be tested on CPU resources in linux environment.
 
+# # Workflow layout
 
-rollout_mode="async"
-rollout_name="${ROLLOUT_NAME}"
-return_raw_chat="True"
-if [ "$rollout_name" = "vllm" ]; then
-    export VLLM_USE_V1=1
-fi
+# All CI tests are configured by yaml files in `.github/workflows/`. Here's an overview of all test configs:
+# 1. A list of always triggered CPU sanity tests: `check-pr-title.yml`, `secrets_scan.yml`, `check-pr-title,yml`, `pre-commit.yml`, `doc.yml`
+# 2. Some heavy multi-GPU unit tests, such as `model.yml`, `vllm.yml`, `sgl.yml`
+# 3. End-to-end tests: `e2e_*.yml`
+# 4. Unit tests
+#   - `cpu_unit_tests.yml`, run pytest on all scripts with file name pattern `tests/**/test_*_on_cpu.py`
+#   - `gpu_unit_tests.yml`, run pytest on all scripts with file without the `on_cpu.py` suffix.
+#   - Since cpu/gpu unit tests by default runs all tests under `tests`, please make sure tests are manually excluded in them when
+#     - new workflow yaml is added to `.github/workflows`
+#     - new tests are added to workflow mentioned in 2.
 
-# Algorithm parameters
-adv_estimator=grpo
+name: e2e_fully_async_policy
 
-use_kl_in_reward=False
-kl_coef=0.0
-use_kl_loss=False
-kl_loss_coef=0.0
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  # For push, for now only anti-patterns are specified so it is more conservative
+  # and achieves higher coverage.
+  push:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "**/*.py"
+      - "!**/*.md"
+      - "!**/*.sh"
+      # Other entrypoints
+      - "!examples/*trainer*"
+      - "!tests/**"
+      - "!verl/trainer/main_*.py"
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      - "verl/experimental/fully_async_policy"
+  pull_request:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "**/*.py"
+      - "!**/*.md"
+      - "!**/*.sh"
+      # Other entrypoints
+      - "!examples/**"
+      - "!tests/**"
+      - "!verl/trainer/main_*.py"
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      # Home
+      - "verl/experimental/fully_async_policy"
+      # Entrypoints
+      - ".github/workflows/e2e_fully_async_policy.yml"
+      - "examples/data_preprocess/gsm8k.py"
+      - "tests/special_e2e/run_fully_async_policy.sh"
 
-clip_ratio_low=0.2
-clip_ratio_high=0.28
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
-# Response length parameters
-max_prompt_length=1024
-max_response_length=2048
-enable_overlong_buffer=True
-overlong_buffer_len=128
-overlong_penalty_factor=1.0
+# Declare permissions just read content.
+permissions:
+  contents: read
 
-# Training parameters
-loss_agg_mode="token-mean"
+env:
+  IMAGE: "verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm020.dev1"
+  DYNAMIC_RUNNER_ENDPOINT: "https://sd10g3clalm04ug7alq90.apigateway-cn-beijing.volceapi.com/runner"
 
-# Temperature parameters
-temperature=1.0
-top_p=1.0
-top_k=-1
-val_top_p=0.7
+jobs:
+  setup:
+    if: github.repository_owner == 'verl-project'
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.create-runner.outputs.runner-label }}
+      mlp-task-id: ${{ steps.create-runner.outputs.mlp-task-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: create-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "create"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-image: "${{ env.IMAGE }}"
 
-# Fully async specific parameters
-# Split GPUs evenly between rollout and training.
-n_gpus_rollout=${N_GPUS_ROLLOUT:-$((NUM_GPUS / 2))}
-n_gpus_training=${N_GPUS_TRAINING:-$((NUM_GPUS / 2))}
+  # Test FSDP2 strategy
+  e2e_fully_async_policy_fsdp2:
+    needs: setup
+    runs-on: ["${{ needs.setup.outputs.runner-label || 'L20x8' }}"]
+    timeout-minutes: 10 # Increase timeout for async training
+    env:
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+      ACTOR_STRATEGY: "fsdp2"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Install the current repository
+        run: |
+          pip3 install -r requirements-test.txt
+          pip3 install --no-deps -e .
+          pip3 install cupy-cuda13x==13.6.0
+      - name: Prepare GSM8K dataset
+        run: |
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+      - name: Running the E2E test with fully_async_policy algorithm (FSDP2)
+        run: |
+          ray stop --force
+          bash tests/special_e2e/run_fully_async_policy.sh
 
-train_prompt_bsz=0
-gen_prompt_bsz=1
-n_resp_per_prompt=16
-train_prompt_mini_bsz=16
-total_rollout_steps=$(((128)))
-test_freq=-1
-staleness_threshold=0.5
-trigger_parameter_sync_step=4
-partial_rollout=True
-use_trainer_do_validate=False
+  # Test Megatron strategy
+  e2e_fully_async_policy_megatron:
+    needs: setup
+    runs-on: ["${{ needs.setup.outputs.runner-label || 'L20x8' }}"]
+    timeout-minutes: 10 # Increase timeout for async training
+    env:
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+      ACTOR_STRATEGY: "megatron"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Install the current repository
+        run: |
+          pip3 install -r requirements-test.txt
+          pip3 install --no-deps -e .
+          pip3 install cupy-cuda13x==13.6.0
+          pip3 install git+https://github.com/ISEEKYAN/mbridge.git@main --no-deps --no-build-isolation
+      - name: Prepare GSM8K dataset
+        run: |
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+      - name: Running the E2E test with fully_async_policy algorithm (Megatron)
+        run: |
+          ray stop --force
+          bash tests/special_e2e/run_fully_async_policy.sh
 
-exp_name="$(basename "${MODEL_ID,,}")-fully-async-policy-${rollout_name}-${ACTOR_STRATEGY}-minimal"
-
-echo "Running fully_async_policy with ${ACTOR_STRATEGY} strategy"
-echo "Total GPUs: ${NUM_GPUS}, Rollout GPUs: ${n_gpus_rollout}, Training GPUs: ${n_gpus_training}"
-
-# Common parameters for both FSDP2 and Megatron
-common_params=(
-    data.train_files="${HOME}/data/gsm8k/train.parquet"
-    data.val_files="${HOME}/data/gsm8k/test.parquet"
-    data.prompt_key=prompt
-    data.truncation='left'
-    data.max_prompt_length=${max_prompt_length}
-    data.max_response_length=${max_response_length}
-    data.train_batch_size=${train_prompt_bsz}
-    data.gen_batch_size=${gen_prompt_bsz}
-    data.return_raw_chat=${return_raw_chat}
-    actor_rollout_ref.rollout.n=${n_resp_per_prompt}
-    actor_rollout_ref.rollout.calculate_log_probs=True
-    algorithm.adv_estimator=${adv_estimator}
-    algorithm.use_kl_in_reward=${use_kl_in_reward}
-    algorithm.kl_ctrl.kl_coef=${kl_coef}
-    actor_rollout_ref.hybrid_engine=False
-    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss}
-    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef}
-    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low}
-    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high}
-    actor_rollout_ref.actor.clip_ratio_c=10.0
-    actor_rollout_ref.model.path="${MODEL_PATH}"
-    actor_rollout_ref.actor.optim.lr=1e-6
-    actor_rollout_ref.actor.optim.lr_warmup_steps=-1
-    actor_rollout_ref.actor.optim.weight_decay=0.1
-    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz}
-    actor_rollout_ref.actor.entropy_coeff=0
-    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode}
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.80
-    actor_rollout_ref.rollout.temperature=${temperature}
-    actor_rollout_ref.rollout.top_p=${top_p}
-    actor_rollout_ref.rollout.top_k=${top_k}
-    actor_rollout_ref.rollout.val_kwargs.temperature=${temperature}
-    actor_rollout_ref.rollout.val_kwargs.top_p=${val_top_p}
-    actor_rollout_ref.rollout.val_kwargs.top_k=${top_k}
-    actor_rollout_ref.rollout.val_kwargs.do_sample=True
-    actor_rollout_ref.rollout.val_kwargs.n=1
-    actor_rollout_ref.rollout.enable_chunked_prefill=True
-    actor_rollout_ref.rollout.name=${rollout_name}
-    actor_rollout_ref.rollout.mode=${rollout_mode}
-    actor_rollout_ref.rollout.disable_log_stats=False
-    reward.reward_manager.name=dapo
-    +reward.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer}
-    +reward.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len}
-    +reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor}
-    +reward.reward_kwargs.overlong_buffer_cfg.log=False
-    +reward.reward_kwargs.max_resp_len=${max_response_length}
-    trainer.logger=['console']
-    trainer.project_name='verl-test-fully-async'
-    trainer.experiment_name="${exp_name}"
-    trainer.val_before_train=True
-    trainer.save_freq=-1
-    trainer.resume_mode=disable
-    trainer.nnodes=1
-    trainer.n_gpus_per_node=${n_gpus_training}
-    trainer.log_val_generations=10
-    rollout.nnodes=1
-    rollout.n_gpus_per_node=${n_gpus_rollout}
-    rollout.total_rollout_steps=${total_rollout_steps}
-    trainer.total_epochs=2
-    trainer.test_freq=${test_freq}
-    # Fully async specific configurations
-    async_training.staleness_threshold=${staleness_threshold}
-    async_training.partial_rollout="${partial_rollout}"
-    async_training.trigger_parameter_sync_step="${trigger_parameter_sync_step}"
-    async_training.use_trainer_do_validate=${use_trainer_do_validate}
-    actor_rollout_ref.rollout.checkpoint_engine.backend='nccl'
-    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=1024
-)
-
-    # Detect device
-    device_name=$(python3 - <<'EOF'
-from verl.utils.device import get_device_name
-print(get_device_name())
-EOF
-)
-
-if [ "${ACTOR_STRATEGY}" == "fsdp2" ]; then
-    echo "Running fully async training with FSDP2 strategy..."
-    # FSDP2 specific parameters
-    # trtllm: one replica uses all rollout GPUs as a single TP group.
-    # vllm/sglang: TP=1, rely on data parallelism across replicas.
-    if [ "${rollout_name}" = "trtllm" ]; then
-        gen_tp=${GEN_TP:-${n_gpus_rollout}}
-    else
-        gen_tp=2
-    fi
-    sp_size=1
-    fsdp_size=2
-    ref_offload=True
-    actor_offload=False
-
-    if [ -n "$device_name" ] && [ "$device_name" == "npu" ]; then
-        common_params+=(
-            # Todo The checkpoint_engine.backend should be unified to nccl
-            # actor_rollout_ref.rollout.checkpoint_engine.backend='hccl'
-            actor_rollout_ref.rollout.gpu_memory_utilization=0.70
-        )
-        actor_offload=True
-    fi
-    python3 -m verl.experimental.fully_async_policy.fully_async_main \
-        "${common_params[@]}" \
-        actor_rollout_ref.model.enable_gradient_checkpointing=True \
-        actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \
-        critic.strategy=fsdp2 \
-        actor_rollout_ref.actor.grad_clip=1.0 \
-        actor_rollout_ref.model.use_remove_padding=True \
-        actor_rollout_ref.actor.use_dynamic_bsz=True \
-        actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
-        actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True \
-        actor_rollout_ref.actor.fsdp_config.param_offload=${actor_offload} \
-        actor_rollout_ref.actor.fsdp_config.optimizer_offload=${actor_offload} \
-        actor_rollout_ref.actor.ulysses_sequence_parallel_size=${sp_size} \
-        actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
-        actor_rollout_ref.ref.fsdp_config.param_offload=${ref_offload} \
-        actor_rollout_ref.ref.ulysses_sequence_parallel_size=${sp_size} \
-        actor_rollout_ref.actor.fsdp_config.fsdp_size=${fsdp_size} $@
-
-elif [ "${ACTOR_STRATEGY}" == "megatron" ]; then
-    echo "Running fully async training with Megatron strategy..."
-    # Megatron specific parameters
-    if [ "${rollout_name}" = "trtllm" ]; then
-        gen_tp=${GEN_TP:-${n_gpus_rollout}}
-    else
-        gen_tp=2
-    fi
-    train_tp=2
-    train_pp=$((n_gpus_training / train_tp))
-    ref_offload=True
-    actor_offload=True
-    common_params+=(
-        actor_rollout_ref.rollout.gpu_memory_utilization=0.60
-    )
-
-    python3 -m verl.experimental.fully_async_policy.fully_async_main \
-        --config-path=config \
-        --config-name='fully_async_ppo_megatron_trainer.yaml' \
-        "${common_params[@]}" \
-        actor_rollout_ref.actor.strategy=megatron \
-        critic.strategy=megatron \
-        actor_rollout_ref.actor.optim.lr_decay_steps=10000000 \
-        actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
-        actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
-        actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
-        actor_rollout_ref.actor.megatron.param_offload=${actor_offload} \
-        actor_rollout_ref.actor.megatron.optimizer_offload=${actor_offload} \
-        actor_rollout_ref.actor.megatron.grad_offload=${actor_offload} \
-        actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${train_pp} \
-        actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${train_tp} \
-        actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
-        actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${train_pp} \
-        actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${train_tp} \
-        actor_rollout_ref.ref.megatron.param_offload=${ref_offload} $@
-else
-    echo "Error: Unknown strategy ${ACTOR_STRATEGY}. Please use 'fsdp2' or 'megatron'"
-    exit 1
-fi
-
-echo "Fully async policy E2E test completed successfully with ${ACTOR_STRATEGY} strategy"
-
+  cleanup:
+    runs-on: ubuntu-latest
+    needs: [setup, e2e_fully_async_policy_fsdp2]
+    if: always()
+    steps:
+      - id: destroy-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "destroy"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-task-id: "${{ needs.setup.outputs.mlp-task-id }}"

--- a/docs/PR1_PLACEMENT_SCOPE.md
+++ b/docs/PR1_PLACEMENT_SCOPE.md
@@ -1,0 +1,56 @@
+# PR 1 — Placement search + Ray pool wiring + `main_ppo` init
+
+## Goal
+
+Deliver rack-aware **placement search** end-to-end for the trainer resource pool:
+
+- Discover rack → node layout from Ray (`get_cluster_placement_racks`).
+- Optionally pin placement groups with `RACK_*` bundle resources and/or Ray NodeIDs (`_soft_target_node_id`).
+- Build `resource_pool_spec` and optional `selected_nodes` via `init_pool_degrees_and_spec` when `trainer.enable_placement=true`.
+- Optional: copy pins to `reward_pool` when `placement_reward_pool_follows_trainer=true` and shapes match.
+
+**Out of scope for this PR:** analytical auto-parallel (`verl/utils/auto_parallelization.py`), NPU-specific worker/device tweaks, extra launch scripts, and non-placement docs (those are PR 2 / PR 3).
+
+## Files in this PR
+
+| File | Change |
+|------|--------|
+| `verl/utils/placement.py` | **New** — placement search, validators, `init_pool_degrees_and_spec`, `ParallelismDegrees` (for degree validation when Megatron config exists). |
+| `verl/single_controller/ray/base.py` | `RayResourcePool` / `ResourcePoolManager` — rack labels, node ID hints, `validate_rack_pinned_pools_feasible`. |
+| `verl/trainer/main_ppo.py` | `init_resource_pool_mgr` — reads `trainer.enable_placement`, `placement_pin_*`, `placement_rack_bundle_resource_map`, `placement_reward_pool_follows_trainer`. |
+| `verl/trainer/config/ppo_trainer.yaml` | Trainer keys under `trainer:` for placement. |
+| `verl/trainer/config/ppo_megatron_trainer.yaml` | Same keys (Megatron entry config). |
+
+## Config keys (reference)
+
+- `trainer.enable_placement`
+- `trainer.placement_pin_rack_resources`
+- `trainer.placement_pin_node_affinity`
+- `trainer.placement_rack_bundle_resource_map`
+- `trainer.placement_reward_pool_follows_trainer`
+
+## How to build this branch locally
+
+From a clean branch off upstream `main` (or your fork default):
+
+```bash
+git checkout -b pr1/placement-ray-main-ppo
+git add \
+  verl/utils/placement.py \
+  verl/single_controller/ray/base.py \
+  verl/trainer/main_ppo.py \
+  verl/trainer/config/ppo_trainer.yaml \
+  verl/trainer/config/ppo_megatron_trainer.yaml
+git status   # review
+git commit -m "feat(planner): rack-aware placement search and Ray PG wiring"
+```
+
+## Smoke / review checklist
+
+- [ ] `trainer.enable_placement=false` (default) — behavior matches vanilla verl (flat `resource_pool_spec`).
+- [ ] Single-node with `enable_placement=true` and Ray `RACK_*` on head — job starts; logs show placement selection or flat fallback if no racks.
+- [ ] Multi-node (optional): `placement_pin_rack_resources` / `placement_pin_node_affinity` match your Ray cluster layout.
+
+## PR title (suggested)
+
+`feat: rack-aware placement search for Ray resource pools (placement.py + main_ppo + base)`

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ datasets
 dill
 hydra-core
 liger-kernel
+nest-asyncio
 numpy<2.0.0
 pandas
 peft

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -348,7 +348,7 @@ class ResourcePoolManager:
                 self.resource_pool_spec,
                 self.pool_rack_labels,
                 node_available_resources,
-                max_colocate_count=3,
+                max_colocate_count=self.max_colocate_count,
             )
 
 

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -17,7 +17,7 @@ import os
 import socket
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import ray
@@ -119,6 +119,8 @@ class RayResourcePool(ResourcePool):
         max_colocate_count: int = 10,
         detached=False,
         accelerator_type: Optional[str] = None,
+        node_rack_resources: Optional[list[str]] = None,
+        placement_group_target_node_ids: Optional[list[str]] = None,
     ) -> None:
         super().__init__(process_on_nodes, max_colocate_count)
         self.use_gpu = use_gpu
@@ -127,6 +129,11 @@ class RayResourcePool(ResourcePool):
         self.pgs = None
         self.detached = detached
         self.accelerator_type = accelerator_type
+        # One Ray custom-resource key per logical node (same order as process_on_nodes / PG index).
+        # Must match resources declared on `ray start` (e.g. RACK_A). See placement_pin_rack_resources.
+        self.node_rack_resources = node_rack_resources
+        # Ray NodeID per PG (same order as process_on_nodes); uses placement_group(..., _soft_target_node_id=...).
+        self.placement_group_target_node_ids = placement_group_target_node_ids
 
     def get_placement_groups(self, strategy="STRICT_PACK", name=None, device_name="cuda"):
         if self.pgs is not None:
@@ -150,12 +157,79 @@ class RayResourcePool(ResourcePool):
                 bundle[self.accelerator_type] = 1e-4
         pg_scheme = [[bundle.copy() for _ in range(process_count)] for process_count in self._store]
 
+        if self.node_rack_resources is not None:
+            if len(self.node_rack_resources) != len(self._store):
+                logger.warning(
+                    "node_rack_resources length (%d) != process_on_nodes length (%d); ignoring rack pin",
+                    len(self.node_rack_resources),
+                    len(self._store),
+                )
+            else:
+                for pg_idx, bundles in enumerate(pg_scheme):
+                    rack_key = self.node_rack_resources[pg_idx]
+                    if not rack_key:
+                        continue
+                    for b in bundles:
+                        b[rack_key] = 1e-4
+                logger.info(
+                    "Placement groups request rack resources per node slot: %s",
+                    self.node_rack_resources,
+                )
+
         lifetime = "detached" if self.detached else None
 
-        pgs = [
-            placement_group(bundles=bundles, strategy=strategy, name=pg_name_prefix + str(idx), lifetime=lifetime)
-            for idx, bundles in enumerate(pg_scheme)
-        ]
+        pg_target_ids = self.placement_group_target_node_ids
+        if pg_target_ids is not None and len(pg_target_ids) != len(self._store):
+            logger.warning(
+                "placement_group_target_node_ids length (%d) != process_on_nodes length (%d); ignoring node pin",
+                len(pg_target_ids),
+                len(self._store),
+            )
+            pg_target_ids = None
+
+        if pg_target_ids and any(pg_target_ids):
+            logger.info(
+                "Placement groups use Ray _soft_target_node_id (node hint) per slot: %s",
+                pg_target_ids,
+            )
+
+        pgs = []
+        for idx, bundles in enumerate(pg_scheme):
+            pg_name = pg_name_prefix + str(idx)
+            kwargs = {
+                "bundles": bundles,
+                "strategy": strategy,
+                "name": pg_name,
+                "lifetime": lifetime,
+            }
+            target_nid: Optional[str] = None
+            if pg_target_ids is not None:
+                target_nid = pg_target_ids[idx] or None
+            if target_nid:
+                if strategy != "STRICT_PACK":
+                    logger.warning(
+                        "placement_group node target for %s ignored: _soft_target_node_id requires STRICT_PACK, got %s",
+                        pg_name,
+                        strategy,
+                    )
+                else:
+                    kwargs["_soft_target_node_id"] = target_nid
+            try:
+                pgs.append(placement_group(**kwargs))
+            except TypeError as e:
+                if "_soft_target_node_id" not in kwargs:
+                    raise
+                msg = str(e).lower()
+                if "unexpected keyword" not in msg and "got an unexpected keyword" not in msg:
+                    raise
+                kwargs.pop("_soft_target_node_id", None)
+                if target_nid:
+                    logger.warning(
+                        "placement_group rejected _soft_target_node_id (%s); retrying without node pin for %s",
+                        e,
+                        pg_name,
+                    )
+                pgs.append(placement_group(**kwargs))
 
         ray.get([pg.ready() for pg in pgs])
 
@@ -190,6 +264,8 @@ class ResourcePoolManager:
     resource_pool_spec: dict[str, list[int]]
     mapping: dict[int, str]
     max_colocate_count: int = 3
+    pool_rack_labels: Optional[Dict[str, List[str]]] = None
+    pool_placement_group_target_node_ids: Optional[Dict[str, List[str]]] = None
     resource_pool_dict: dict[str, RayResourcePool] = field(default_factory=dict)
 
     def create_resource_pool(self):
@@ -205,11 +281,35 @@ class ResourcePoolManager:
             # For FSDP backend, using max_colocate_count=3: actor_critic_ref, rollout, reward model (optional)
             # For Megatron backend, we recommend using max_colocate_count>1
             # that can utilize different WorkerGroup for differnt models
+            rack_list: Optional[list[str]] = None
+            if self.pool_rack_labels:
+                rack_list = self.pool_rack_labels.get(resource_pool_name)
+                if rack_list is not None and len(rack_list) != len(process_on_nodes):
+                    logger.warning(
+                        "pool_rack_labels[%s] length %d != process_on_nodes length %d; ignoring rack pin for this pool",
+                        resource_pool_name,
+                        len(rack_list),
+                        len(process_on_nodes),
+                    )
+                    rack_list = None
+            target_nodes: Optional[list[str]] = None
+            if self.pool_placement_group_target_node_ids:
+                target_nodes = self.pool_placement_group_target_node_ids.get(resource_pool_name)
+                if target_nodes is not None and len(target_nodes) != len(process_on_nodes):
+                    logger.warning(
+                        "pool_placement_group_target_node_ids[%s] length %d != process_on_nodes length %d; ignoring node pin for this pool",
+                        resource_pool_name,
+                        len(target_nodes),
+                        len(process_on_nodes),
+                    )
+                    target_nodes = None
             resource_pool = RayResourcePool(
                 process_on_nodes=process_on_nodes,
                 use_gpu=True,
                 max_colocate_count=self.max_colocate_count,
                 name_prefix=resource_pool_name,
+                node_rack_resources=rack_list,
+                placement_group_target_node_ids=target_nodes,
             )
             self.resource_pool_dict[resource_pool_name] = resource_pool
 
@@ -239,6 +339,16 @@ class ResourcePoolManager:
         if total_available_gpus < total_required_gpus:
             raise ValueError(
                 f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}"
+            )
+
+        if self.pool_rack_labels:
+            from verl.utils.placement import validate_rack_pinned_pools_feasible
+
+            validate_rack_pinned_pools_feasible(
+                self.resource_pool_spec,
+                self.pool_rack_labels,
+                node_available_resources,
+                max_colocate_count=3,
             )
 
 

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -85,6 +85,11 @@ override_transformer_config:
   # Attention backend to use (flash,fused,unfused,local,auto). Defaults to auto in mcore, flash in verl
   attention_backend: flash
 
+  # MindSpeed (Ascend NPU): attention mask generation requires micro_batch_size OR use_flash_attn=True
+  # on TransformerConfig (mbridge). Set true here so actor/ref/critic Megatron stacks work without core code changes.
+  # Override per-job if needed, e.g. micro_batch_size: ${actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu}
+  use_flash_attn: true
+
 override_mcore_model_config: {}
 
 # oc.select: default val for ref.megatron.use_mbridge

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -145,6 +145,42 @@ trainer:
   # Number of GPUs per node
   n_gpus_per_node: 8
 
+  # Enable placement search (Ray rack-aware node selection).
+  # Requires Ray nodes to expose `RACK_*` custom resources.
+  enable_placement: false
+
+  # When true with enable_placement, add Ray bundle custom resources (e.g. RACK_A) per logical node
+  # so placement groups schedule only on nodes that declare matching resources in `ray start --resources`.
+  placement_pin_rack_resources: false
+
+  # Optional map from placement rack id (selected_nodes[i][0]) to the exact Ray resource string to put on PG
+  # bundles, if you must differ from the key Ray reports (validated against the cluster at startup).
+  # Example: {RACK_A: rack_a} when nodes declare `rack_a` not `RACK_A`.
+  placement_rack_bundle_resource_map: null
+
+  # When true with enable_placement, pass selected_nodes[i][1] (Ray NodeID) into each PG as
+  # placement_group(..., _soft_target_node_id=...) so STRICT_PACK groups prefer that node (Ray >= 2.x).
+  placement_pin_node_affinity: false
+
+  # When reward_model.enable_resource_pool is true, copy rack/node PG pins from the trainer pool for the
+  # first reward_model.nnodes slots (requires reward n_gpus_per_node == trainer n_gpus_per_node).
+  placement_reward_pool_follows_trainer: true
+
+  # Analytical (formula-based) auto-parallelization for degrees (TP/PP/CP/EP/DP).
+  # Disabled by default; can be enabled via CLI override:
+  #   python -m verl.trainer.main_ppo trainer.auto_parallel.enabled=true
+  auto_parallel:
+    enabled: false
+    # analytical-only mode for now
+    memory_check_mode: "analytical"
+    # multiplier for CI_upper (defensive buffer)
+    safety_margin: 1.10
+    # memory budget fraction
+    target_utilization: 0.90
+    objective: "max_mp"
+    respect_config_parallelism: false
+    allow_context_parallel: false
+
   # Save frequency (by iteration) for model checkpoints
   save_freq: -1
 
@@ -412,6 +448,10 @@ ray_kwargs:
 
   # configs related to ray initialization
   ray_init:
+
+    # If null/omitted, main_ppo uses address="auto" to join a `ray start` cluster (multinode).
+    # Override with e.g. "192.168.1.1:6379" or ray.client() URL when needed.
+    address: null
 
     # Number of CPUs for Ray. Use a fixed number instead of null when using SLURM.
     num_cpus: null

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -15,6 +15,7 @@
 Note that we don't combine the main with ray_trainer as ray_trainer is used by other mpain.
 """
 
+import logging
 import os
 import socket
 
@@ -30,6 +31,8 @@ from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
 from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import deprecated
+
+logger = logging.getLogger(__name__)
 
 
 @deprecated(
@@ -76,8 +79,11 @@ def run_ppo(config, task_runner_class=None) -> None:
 
         runtime_env = OmegaConf.merge(default_runtime_env, runtime_env_kwargs)
         ray_init_kwargs = OmegaConf.create({**ray_init_kwargs, "runtime_env": runtime_env})
-        print(f"ray init kwargs: {ray_init_kwargs}")
-        ray.init(**OmegaConf.to_container(ray_init_kwargs))
+        ray_init_container = OmegaConf.to_container(ray_init_kwargs, resolve=True)
+        if not ray_init_container.get("address"):
+            ray_init_container["address"] = "auto"
+        print(f"ray init kwargs: {ray_init_container}")
+        ray.init(**ray_init_container)
 
     if task_runner_class is None:
         task_runner_class = ray.remote(num_cpus=1)(TaskRunner)  # please make sure main_task is not scheduled on head
@@ -159,9 +165,84 @@ class TaskRunner:
         """Initialize resource pool manager."""
 
         global_pool_id = "global_pool"
-        resource_pool_spec = {
-            global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
-        }
+        reward_pool_id = "reward_pool"
+        selected_nodes = None
+        pool_rack_labels = None
+        pool_placement_group_target_node_ids = None
+        pin_rack = getattr(config.trainer, "placement_pin_rack_resources", False)
+        pin_node = getattr(config.trainer, "placement_pin_node_affinity", False)
+        enable_placement = getattr(config.trainer, "enable_placement", False)
+
+        if pin_rack and not enable_placement:
+            logger.warning(
+                "placement_pin_rack_resources is True but enable_placement is False; rack labels will not be applied"
+            )
+        if pin_node and not enable_placement:
+            logger.warning(
+                "placement_pin_node_affinity is True but enable_placement is False; node pinning will not be applied"
+            )
+
+        # Placement search init (degrees validation + compute_process_on_nodes) runs whenever enable_placement is set.
+        # Rack custom resources on PG bundles are added only when placement_pin_rack_resources is also true.
+        if enable_placement:
+            from verl.utils.placement import init_pool_degrees_and_spec
+
+            _, resource_pool_spec, selected_nodes = init_pool_degrees_and_spec(
+                config, global_pool_id=global_pool_id
+            )
+            if pin_rack:
+                if selected_nodes and len(selected_nodes) == config.trainer.nnodes:
+                    from verl.utils.placement import (
+                        apply_rack_bundle_resource_map,
+                        validate_rack_bundle_resource_labels,
+                    )
+
+                    raw_rack_ids = [str(t[0]) for t in selected_nodes]
+                    rack_map = getattr(config.trainer, "placement_rack_bundle_resource_map", None)
+                    if rack_map is not None:
+                        rack_map = OmegaConf.to_container(rack_map, resolve=True)
+                    if not isinstance(rack_map, dict):
+                        rack_map = None
+                    bundle_rack_names = apply_rack_bundle_resource_map(raw_rack_ids, rack_map)
+                    validate_rack_bundle_resource_labels(bundle_rack_names)
+                    pool_rack_labels = {global_pool_id: bundle_rack_names}
+                    logger.info(
+                        "Ray placement groups will request rack resources per node: %s",
+                        pool_rack_labels[global_pool_id],
+                    )
+                else:
+                    logger.warning(
+                        "placement_pin_rack_resources: missing or mismatched placement selection "
+                        "(len(selected_nodes)=%s, nnodes=%s); skipping rack pin",
+                        len(selected_nodes) if selected_nodes else None,
+                        config.trainer.nnodes,
+                    )
+            if pin_node:
+                if selected_nodes and len(selected_nodes) == config.trainer.nnodes:
+                    from verl.utils.placement import (
+                        validate_placement_targets_distinct_ray_nodes,
+                        validate_ray_node_ids_exist,
+                    )
+
+                    ray_node_ids = [str(t[1]) for t in selected_nodes]
+                    validate_ray_node_ids_exist(ray_node_ids)
+                    validate_placement_targets_distinct_ray_nodes(ray_node_ids)
+                    pool_placement_group_target_node_ids = {global_pool_id: ray_node_ids}
+                    logger.info(
+                        "Placement groups target Ray nodes (NodeID) per slot: %s",
+                        pool_placement_group_target_node_ids[global_pool_id],
+                    )
+                else:
+                    logger.warning(
+                        "placement_pin_node_affinity: missing or mismatched placement selection "
+                        "(len(selected_nodes)=%s, nnodes=%s); skipping node pin",
+                        len(selected_nodes) if selected_nodes else None,
+                        config.trainer.nnodes,
+                    )
+        else:
+            resource_pool_spec = {
+                global_pool_id: [config.trainer.n_gpus_per_node] * config.trainer.nnodes,
+            }
 
         if config.reward.reward_model.enable_resource_pool:
             if config.reward.reward_model.n_gpus_per_node <= 0:
@@ -185,9 +266,67 @@ class TaskRunner:
             teacher_pool = [distillation_config.n_gpus_per_node] * distillation_config.nnodes
             resource_pool_spec["teacher_pool"] = teacher_pool
 
+        # Copy trainer rack/node PG pins onto reward_pool when shapes align (subset or full).
+        follow_reward = getattr(config.trainer, "placement_reward_pool_follows_trainer", True)
+        if (
+            follow_reward
+            and config.reward.reward_model.enable_resource_pool
+            and selected_nodes
+            and len(selected_nodes) == config.trainer.nnodes
+        ):
+            rn = config.reward.reward_model.nnodes
+            rg = config.reward.reward_model.n_gpus_per_node
+            tg = config.trainer.n_gpus_per_node
+            if rg != tg:
+                logger.warning(
+                    "placement_reward_pool_follows_trainer: reward n_gpus_per_node (%s) != trainer (%s); "
+                    "not pinning reward_pool",
+                    rg,
+                    tg,
+                )
+            elif rn > len(selected_nodes):
+                logger.warning(
+                    "placement_reward_pool_follows_trainer: reward nnodes (%s) > placement slots (%s); skip",
+                    rn,
+                    len(selected_nodes),
+                )
+            elif rn <= len(selected_nodes):
+                if pool_rack_labels and global_pool_id in pool_rack_labels:
+                    src_rack = pool_rack_labels[global_pool_id]
+                    pool_rack_labels = dict(pool_rack_labels)
+                    pool_rack_labels[reward_pool_id] = src_rack[:rn]
+                    logger.info(
+                        "placement_reward_pool_follows_trainer: rack labels for %s: %s",
+                        reward_pool_id,
+                        pool_rack_labels[reward_pool_id],
+                    )
+                if pool_placement_group_target_node_ids and global_pool_id in pool_placement_group_target_node_ids:
+                    from verl.utils.placement import (
+                        validate_placement_targets_distinct_ray_nodes,
+                        validate_ray_node_ids_exist,
+                    )
+
+                    src_nodes = pool_placement_group_target_node_ids[global_pool_id]
+                    sliced_nodes = src_nodes[:rn]
+                    validate_ray_node_ids_exist(sliced_nodes)
+                    if len([x for x in sliced_nodes if x]) > 1:
+                        validate_placement_targets_distinct_ray_nodes(sliced_nodes)
+                    pool_placement_group_target_node_ids = dict(pool_placement_group_target_node_ids)
+                    pool_placement_group_target_node_ids[reward_pool_id] = sliced_nodes
+                    logger.info(
+                        "placement_reward_pool_follows_trainer: Ray NodeIDs for %s: %s",
+                        reward_pool_id,
+                        sliced_nodes,
+                    )
+
         from verl.trainer.ppo.ray_trainer import ResourcePoolManager
 
-        resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
+        resource_pool_manager = ResourcePoolManager(
+            resource_pool_spec=resource_pool_spec,
+            mapping=self.mapping,
+            pool_rack_labels=pool_rack_labels,
+            pool_placement_group_target_node_ids=pool_placement_group_target_node_ids,
+        )
         return resource_pool_manager
 
     def add_reward_model_resource_pool(self, config):

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -169,9 +169,9 @@ class TaskRunner:
         selected_nodes = None
         pool_rack_labels = None
         pool_placement_group_target_node_ids = None
-        pin_rack = getattr(config.trainer, "placement_pin_rack_resources", False)
-        pin_node = getattr(config.trainer, "placement_pin_node_affinity", False)
-        enable_placement = getattr(config.trainer, "enable_placement", False)
+        pin_rack = OmegaConf.select(config, "trainer.placement_pin_rack_resources", default=False)
+        pin_node = OmegaConf.select(config, "trainer.placement_pin_node_affinity", default=False)
+        enable_placement = OmegaConf.select(config, "trainer.enable_placement", default=False)
 
         if pin_rack and not enable_placement:
             logger.warning(
@@ -198,7 +198,7 @@ class TaskRunner:
                     )
 
                     raw_rack_ids = [str(t[0]) for t in selected_nodes]
-                    rack_map = getattr(config.trainer, "placement_rack_bundle_resource_map", None)
+                    rack_map = OmegaConf.select(config, "trainer.placement_rack_bundle_resource_map", default=None)
                     if rack_map is not None:
                         rack_map = OmegaConf.to_container(rack_map, resolve=True)
                     if not isinstance(rack_map, dict):
@@ -267,7 +267,7 @@ class TaskRunner:
             resource_pool_spec["teacher_pool"] = teacher_pool
 
         # Copy trainer rack/node PG pins onto reward_pool when shapes align (subset or full).
-        follow_reward = getattr(config.trainer, "placement_reward_pool_follows_trainer", True)
+        follow_reward = OmegaConf.select(config, "trainer.placement_reward_pool_follows_trainer", default=True)
         if (
             follow_reward
             and config.reward.reward_model.enable_resource_pool

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -390,6 +390,10 @@ class TaskRunner:
         # Add a reference policy worker if KL loss or KL reward is used.
         self.add_ref_policy_worker(config, actor_rollout_cls)
 
+        from verl.utils.auto_parallelization import apply_analytical_auto_parallel_degrees
+
+        apply_analytical_auto_parallel_degrees(config)
+
         # validate config
         validate_config(
             config=config,

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -71,6 +71,7 @@ from verl.utils.tracking import ValidationGenerationsLogger
 from verl.workers.config import DistillationConfig, EngineConfig
 from verl.workers.rollout.llm_server import LLMServerManager
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
+from verl.utils.model import compute_position_id_with_mask
 
 
 def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, kl_penalty="kl"):
@@ -417,7 +418,7 @@ class RayPPOTrainer:
         val_batch_size = self.config.data.val_batch_size  # Prefer config value if set
         if val_batch_size is None:
             val_batch_size = len(self.val_dataset)
-
+        val_batch_size = max(1, val_batch_size or 1)  # ensure positive for BatchSampler
         self.val_dataloader = StatefulDataLoader(
             dataset=self.val_dataset,
             batch_size=val_batch_size,
@@ -588,6 +589,59 @@ class RayPPOTrainer:
 
         return gen_batch
 
+    def _tokenize_batch_for_hf_rollout(self, batch: DataProto) -> None:
+        """Tokenize raw_prompt into input_ids, attention_mask, position_ids for HF rollout."""
+        raw_prompts = batch.non_tensor_batch.get("raw_prompt")
+        if raw_prompts is None:
+            return
+        tokenizer = self.tokenizer
+        max_prompt_length = self.config.data.get("max_prompt_length", 512)
+        apply_kwargs = self.config.data.get("apply_chat_template_kwargs", {})
+        orig_padding_side = tokenizer.padding_side
+        tokenizer.padding_side = "left"
+        pad_token_id = tokenizer.pad_token_id or tokenizer.eos_token_id
+        try:
+            formatted = [
+                tokenizer.apply_chat_template(
+                    list(messages),
+                    add_generation_prompt=True,
+                    tokenize=False,
+                    **apply_kwargs,
+                )
+                for messages in raw_prompts
+            ]
+            encoded = tokenizer(
+                formatted,
+                return_tensors="pt",
+                padding="max_length",
+                max_length=max_prompt_length,
+                truncation=True,
+                return_attention_mask=True,
+            )
+            input_ids = encoded["input_ids"]
+            attention_mask = encoded["attention_mask"]
+            position_ids = compute_position_id_with_mask(attention_mask)
+            batch.batch["input_ids"] = input_ids
+            batch.batch["attention_mask"] = attention_mask
+            batch.batch["position_ids"] = position_ids
+        finally:
+            tokenizer.padding_side = orig_padding_side
+
+    def _get_gen_batch_for_hf(self, batch: DataProto) -> DataProto:
+        """Build gen_batch for HF rollout: batch with input_ids, attention_mask, position_ids + reward keys."""
+        reward_keys = {"data_source", "reward_model", "extra_info", "uid"}
+        non_tensor_batch = {k: v for k, v in batch.non_tensor_batch.items() if k in reward_keys}
+        gen_batch = DataProto.from_dict(
+            tensors={
+                "input_ids": batch.batch["input_ids"],
+                "attention_mask": batch.batch["attention_mask"],
+                "position_ids": batch.batch["position_ids"],
+            },
+            meta_info=dict(batch.meta_info),
+        )
+        gen_batch.non_tensor_batch = non_tensor_batch
+        return gen_batch
+
     def _compute_reward_colocate(self, batch: DataProto) -> tuple[torch.Tensor, dict[str, Any]] | torch.Tensor:
         """
         compute reward use colocate reward model
@@ -595,6 +649,39 @@ class RayPPOTrainer:
         assert self.reward_loop_manager is not None, "RewardLoopManager is None"
         batch_reward = self.reward_loop_manager.compute_rm_score(batch)
         return batch_reward
+
+    def _compute_reward_from_ground_truth(self, batch: DataProto) -> None:
+        """Compute rm_scores from ground_truth using default_compute_score (e.g. GSM8K)."""
+        from verl.utils.reward_score import default_compute_score
+
+        reward_models = batch.non_tensor_batch["reward_model"]
+        data_sources = batch.non_tensor_batch.get("data_source", np.array(["openai/gsm8k"] * len(reward_models)))
+        responses = batch.batch["responses"]
+        response_mask = batch.batch["response_mask"]
+        response_length = response_mask.sum(dim=1).long()
+        scores = []
+        for i in range(responses.size(0)):
+            rm = reward_models[i] if isinstance(reward_models[i], dict) else {}
+            ground_truth = rm.get("ground_truth")
+            ds = data_sources[i] if i < len(data_sources) else "openai/gsm8k"
+            data_source = rm.get("data_source", ds)
+            if ground_truth is None:
+                scores.append(0.0)
+                continue
+            response_ids = responses[i]
+            valid_len = int(response_length[i].item())
+            solution_ids = response_ids[:valid_len]
+            solution_str = self.tokenizer.decode(solution_ids, skip_special_tokens=True)
+            try:
+                score = default_compute_score(data_source, solution_str, ground_truth)
+            except Exception:
+                score = 0.0
+            scores.append(float(score))
+        rm_scores = torch.zeros_like(response_mask, dtype=torch.float32)
+        for i, score in enumerate(scores):
+            idx = max(0, int(response_length[i].item()) - 1)
+            rm_scores[i, idx] = score
+        batch.batch["rm_scores"] = rm_scores
 
     def _validate(self, merged: bool = False):
         data_source_lst = []
@@ -626,7 +713,11 @@ class RayPPOTrainer:
             ]
             sample_gts.extend(ground_truths)
 
-            test_gen_batch = self._get_gen_batch(test_batch)
+            if self.config.actor_rollout_ref.rollout.name == "hf":
+                self._tokenize_batch_for_hf_rollout(test_batch)
+                test_gen_batch = self._get_gen_batch_for_hf(test_batch)
+            else:
+                test_gen_batch = self._get_gen_batch(test_batch)
             test_gen_batch.meta_info = {
                 "eos_token_id": self.tokenizer.eos_token_id,
                 "pad_token_id": self.tokenizer.pad_token_id,
@@ -928,11 +1019,18 @@ class RayPPOTrainer:
             self.distillation_config = None
 
         # Support custom AgentLoopManager via config
-        manager_class_fqn = self.config.actor_rollout_ref.rollout.get("agent", {}).get("agent_loop_manager_class")
-        if manager_class_fqn:
-            AgentLoopManager = load_class_from_fqn(manager_class_fqn, "AgentLoopManager")
+        # HF rollout uses colocated generation - bypass async agent loop
+        rollout_name = self.config.actor_rollout_ref.rollout.name
+        if rollout_name == "hf":
+            from verl.trainer.ppo.hf_agent_loop import HFAgentLoopManager
+
+            AgentLoopManager = HFAgentLoopManager
         else:
-            from verl.experimental.agent_loop import AgentLoopManager
+            manager_class_fqn = self.config.actor_rollout_ref.rollout.get("agent", {}).get("agent_loop_manager_class")
+            if manager_class_fqn:
+                AgentLoopManager = load_class_from_fqn(manager_class_fqn, "AgentLoopManager")
+            else:
+                from verl.experimental.agent_loop import AgentLoopManager
 
         # infrastructure overview: https://verl.readthedocs.io/en/latest/advance/reward_loop.html#architecture-design
         # agent_reward_loop: streaming reward computation with actor rollout
@@ -1440,7 +1538,14 @@ class RayPPOTrainer:
                     [str(uuid.uuid4()) for _ in range(len(batch.batch))], dtype=object
                 )
 
-                gen_batch = self._get_gen_batch(batch)
+                if self.config.actor_rollout_ref.rollout.name == "hf":
+                    self._tokenize_batch_for_hf_rollout(batch)
+                    gen_batch = self._get_gen_batch_for_hf(batch)
+                    # Remove tokenized tensors from batch so union with gen_batch_output won't conflict
+                    for key in ("input_ids", "attention_mask", "position_ids"):
+                        batch.batch.pop(key, None)
+                else:
+                    gen_batch = self._get_gen_batch(batch)
 
                 # pass global_steps to trace
                 gen_batch.meta_info["global_steps"] = self.global_steps
@@ -1508,18 +1613,22 @@ class RayPPOTrainer:
 
                     # compute global_valid tokens
                     batch.meta_info["global_token_num"] = torch.sum(batch.batch["attention_mask"], dim=-1).tolist()
-                    # get images_seqlens
+                    # get images_seqlens (text-only data may not have multi_modal_inputs)
                     images_seqlens_all = []
-                    for multi_modal_input in batch.non_tensor_batch["multi_modal_inputs"]:
-                        if "image_grid_thw" not in multi_modal_input.keys():
-                            continue
-                        images_seqlens_all.extend(multi_modal_input["images_seqlens"].tolist())
+                    if "multi_modal_inputs" in batch.non_tensor_batch:
+                        for multi_modal_input in batch.non_tensor_batch["multi_modal_inputs"]:
+                            if "image_grid_thw" not in multi_modal_input.keys():
+                                continue
+                            images_seqlens_all.extend(multi_modal_input["images_seqlens"].tolist())
                     batch.meta_info["images_seqlens"] = images_seqlens_all
                     with marked_timer("reward", timing_raw, color="yellow"):
                         # compute reward model score
                         if self.use_rm and "rm_scores" not in batch.batch.keys():
                             batch_reward = self._compute_reward_colocate(batch)
                             batch = batch.union(batch_reward)
+                        # compute reward from ground_truth when no reward model (e.g. HF rollout + GSM8K)
+                        elif "rm_scores" not in batch.batch.keys() and "reward_model" in batch.non_tensor_batch:
+                            self._compute_reward_from_ground_truth(batch)
 
                         # extract reward_tensor and reward_extra_infos_dict for training
                         reward_tensor, reward_extra_infos_dict = extract_reward(batch)

--- a/verl/utils/auto_parallelization.py
+++ b/verl/utils/auto_parallelization.py
@@ -1,0 +1,902 @@
+"""
+Analytical (formula-based) auto-parallelization utilities for verl.
+
+When `trainer.auto_parallel.enabled=true`, this module may override Megatron and
+rollout parallelism degrees before `validate_config()` runs.
+
+Selection policy (configurable):
+- ``objective=max_mp`` (default): prefer higher TP×PP×CP (more sharding). This matches
+  common Megatron + colocated vLLM scripts (e.g. TP=world_size, DP=1) and avoids the
+  legacy ``max_dp`` behavior that could replace an explicit CLI ``tensor_model_parallel_size=8``
+  with TP=1 whenever the analytical memory estimate passed.
+- ``objective=max_dp``: maximize data parallelism first (documented in ANALYTICAL_AUTO_PARALLEL_DOC).
+
+Safety:
+- If the analytical memory gate rejects every candidate, the fallback search **without**
+  memory uses ``max_mp`` only, never ``max_dp``, so we do not pick TP=1 purely because
+  the estimator was wrong.
+- ``respect_config_parallelism=true``: do not search; validate + optional memory check only,
+  then sync rollout fields — use when you want auto_parallel for validation only.
+- ``allow_context_parallel=false`` (default): only ``context_parallel_size=1`` is considered.
+  Megatron Core ``DotProductAttention`` asserts CP==1 unless ``TEDotProductAttention`` is used
+  (common MindSpeed / mbridge stacks use DotProductAttention → CP>1 from auto-parallel breaks ref/actor init).
+- When HF ``config.json`` is readable, candidates must satisfy ``num_attention_heads % TP == 0``
+  (Megatron Core) and, if ``PP > 1``, ``num_hidden_layers % PP == 0`` — e.g. Qwen2.5-7B has 28 heads,
+  so TP=8 is invalid on that model.
+
+Memory/CI-based acceptance can be extended later; analytical mode uses coarse formulas.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Iterable, Optional
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
+
+def _iter_divisors(n: int) -> Iterable[int]:
+    """Yield positive integer divisors of `n` (unordered)."""
+    if n <= 0:
+        return
+    i = 1
+    while i * i <= n:
+        if n % i == 0:
+            yield i
+            other = n // i
+            if other != i:
+                yield other
+        i += 1
+
+
+def _get_megatron_degrees_from_actor_config(config, n_gpus: int):
+    """
+    Read TP/PP/CP/EP/SP from `actor_rollout_ref.actor.megatron` and derive DP.
+
+    Returns:
+      - degrees_obj: `verl.utils.placement.ParallelismDegrees` instance
+      - etp: expert_tensor_parallel_size (int, default 1)
+    """
+    from verl.utils.placement import extract_degrees_from_config
+
+    degrees_obj = extract_degrees_from_config(config=config, n_gpus=n_gpus)
+    if degrees_obj is None:
+        # For non-megatron actors (e.g. dp/fsdp), we can not safely override degrees.
+        logger.warning(
+            "trainer.auto_parallel.enabled=true but actor engine does not expose `actor_rollout_ref.actor.megatron` "
+            "(skipping auto-parallelization)."
+        )
+        return None
+    return degrees_obj
+
+
+def validate_degrees(degrees, n_gpus: int, n_gpus_per_node: int, nnodes: int) -> None:
+    """
+    Validate candidate degrees for feasibility.
+
+    Raises:
+      ValueError if any hard constraint fails.
+    """
+    messages = degrees.validate(n_gpus=n_gpus, n_gpus_per_node=n_gpus_per_node, nnodes=nnodes)
+    errors = [m for m in messages if m.startswith("ERROR")]
+    warnings = [m for m in messages if m.startswith("WARNING")]
+
+    for w in warnings:
+        logger.warning(w)
+
+    if errors:
+        raise ValueError("\n".join(errors))
+
+
+def _dtype_bytes(dtype: str) -> int:
+    """Best-effort mapping from dtype string to element byte size."""
+    d = (dtype or "").lower()
+    if d in {"bfloat16", "bf16", "float16", "fp16", "half"}:
+        return 2
+    if d in {"float32", "fp32"}:
+        return 4
+    # Conservative default
+    return 2
+
+
+def _get_memory_budget_gb(*, target_utilization: float) -> Optional[float]:
+    """
+    Compute per-device memory budget as: total_device_mem_gb * target_utilization.
+
+    Returns None if device memory can't be queried.
+    """
+    try:
+        import torch
+
+        # 1) Manual override (matches luncher_msrl.py behavior)
+        npu_memory_env = os.environ.get("NPU_MEMORY_GB") or os.environ.get("ASCEND_RT_MEMORY_GB")
+        if npu_memory_env:
+            try:
+                total_gb = float(npu_memory_env)
+                return float(total_gb) * float(target_utilization)
+            except Exception:
+                logger.warning("Invalid NPU_MEMORY_GB/ASCEND_RT_MEMORY_GB=%r. Ignoring.", npu_memory_env)
+
+        # 2) CUDA memory (common on GPU)
+        if hasattr(torch, "cuda") and torch.cuda.is_available():
+            props = torch.cuda.get_device_properties(0)
+            total_gb = props.total_memory / 1024**3
+            return float(total_gb) * float(target_utilization)
+
+        # 3) NPU memory (Ascend)
+        if hasattr(torch, "npu"):
+            # torch_npu exposes either get_device_properties or memory_info
+            try:
+                if hasattr(torch.npu, "get_device_properties"):
+                    props = torch.npu.get_device_properties(0)
+                    # Some versions expose total_memory in bytes
+                    total_mem_bytes = getattr(props, "total_memory", None)
+                    if total_mem_bytes is not None:
+                        total_gb = total_mem_bytes / 1024**3
+                        return float(total_gb) * float(target_utilization)
+            except Exception:
+                pass
+
+            try:
+                if hasattr(torch.npu, "memory_info"):
+                    mem_info = torch.npu.memory_info(0)
+                    # memory_info may return allocated/available; be conservative with "available"
+                    # We'll prefer allocated+reserved isn't stable, so use total if possible.
+                    total_bytes = None
+                    if isinstance(mem_info, dict):
+                        total_bytes = mem_info.get("total") or mem_info.get("total_memory")
+                    if total_bytes is not None:
+                        total_gb = float(total_bytes) / 1024**3
+                        return float(total_gb) * float(target_utilization)
+            except Exception:
+                pass
+
+        # 4) Fallback (keep memory gating active even on NPU environments without torch.npu)
+        logger.warning("Could not auto-detect device total memory. Using default 16.0GB. Set NPU_MEMORY_GB for accuracy.")
+        return 16.0 * float(target_utilization)
+    except Exception as e:
+        logger.warning("Could not query device total memory: %s. Using default 16.0GB.", e)
+        return 16.0 * float(target_utilization)
+
+
+def _try_load_hf_config_json(model_path: str, trust_remote_code: bool) -> Optional[dict[str, Any]]:
+    """
+    Load a model's small HF config (config.json) without downloading weights.
+    """
+    try:
+        from verl.utils.fs import copy_to_local, is_non_local
+
+        src = model_path.rstrip("/")
+        config_json_path = None
+
+        if is_non_local(src):
+            # Copy only config.json to keep this lightweight.
+            config_json_path = copy_to_local(f"{src}/config.json")
+        else:
+            # Local dir or file.
+            if os.path.isdir(src) and os.path.exists(os.path.join(src, "config.json")):
+                config_json_path = os.path.join(src, "config.json")
+            elif os.path.isfile(src) and os.path.basename(src) == "config.json":
+                config_json_path = src
+
+        if config_json_path and os.path.exists(config_json_path):
+            with open(config_json_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+        # Fallback: try HF AutoConfig (downloads only config.json typically).
+        from transformers import AutoConfig
+
+        hf_cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=trust_remote_code)
+        return hf_cfg.to_dict()
+    except Exception as e:
+        logger.warning("Failed to load HF config for analytical memory estimation: %s", e)
+        return None
+
+
+def _try_get_num_attention_heads(config) -> Optional[int]:
+    """Read ``num_attention_heads`` from HF ``config.json`` (Megatron requires TP | heads)."""
+    try:
+        from omegaconf import OmegaConf as _OC
+
+        model_path = _OC.select(config, "actor_rollout_ref.model.path", default=None)
+        if not model_path:
+            return None
+        trust_remote_code = bool(
+            _OC.select(config, "data.trust_remote_code", default=False)
+            or _OC.select(config, "actor_rollout_ref.model.trust_remote_code", default=False)
+        )
+        hf_cfg = _try_load_hf_config_json(str(model_path), trust_remote_code)
+        if not hf_cfg:
+            return None
+        h = hf_cfg.get("num_attention_heads", hf_cfg.get("n_head"))
+        return int(h) if h is not None else None
+    except Exception as e:
+        logger.warning("Could not read num_attention_heads for auto-parallel: %s", e)
+        return None
+
+
+def _try_get_num_hidden_layers(config) -> Optional[int]:
+    """Read layer count for PP divisibility (optional)."""
+    try:
+        from omegaconf import OmegaConf as _OC
+
+        model_path = _OC.select(config, "actor_rollout_ref.model.path", default=None)
+        if not model_path:
+            return None
+        trust_remote_code = bool(
+            _OC.select(config, "data.trust_remote_code", default=False)
+            or _OC.select(config, "actor_rollout_ref.model.trust_remote_code", default=False)
+        )
+        hf_cfg = _try_load_hf_config_json(str(model_path), trust_remote_code)
+        if not hf_cfg:
+            return None
+        n = hf_cfg.get("num_hidden_layers", hf_cfg.get("n_layer"))
+        return int(n) if n is not None else None
+    except Exception as e:
+        logger.warning("Could not read num_hidden_layers for auto-parallel: %s", e)
+        return None
+
+
+def _try_build_memory_estimator_inputs(config) -> Optional[dict[str, Any]]:
+    """
+    Build lightweight analytical memory estimator inputs (no weights).
+    """
+    try:
+        from omegaconf import OmegaConf as _OC
+
+        rollout_cfg = config.actor_rollout_ref.rollout
+        actor_cfg = config.actor_rollout_ref.actor
+        model_cfg = config.actor_rollout_ref.model
+
+        # Dtype + KV cache shapes
+        dtype_bytes = _dtype_bytes(getattr(rollout_cfg, "dtype", "bfloat16"))
+        max_num_seqs = int(getattr(rollout_cfg, "max_num_seqs", 1))
+
+        # For vLLM KV cache, use rollout.max_model_len if set; otherwise fall back
+        # to actor ppo_max_token_len_per_gpu.
+        kv_seq_len = getattr(rollout_cfg, "max_model_len", None)
+        if kv_seq_len is None:
+            kv_seq_len = getattr(actor_cfg, "ppo_max_token_len_per_gpu", None)
+        kv_seq_len = int(kv_seq_len) if kv_seq_len is not None else 16384
+
+        # Training activation memory must not assume the full Megatron PPO token cap when
+        # rollout / dataset use a much shorter context (common in RL). Using 16384 here while
+        # KV uses max_model_len=256 rejects every degree under the analytical memory gate.
+        ppo_max_raw = getattr(actor_cfg, "ppo_max_token_len_per_gpu", None)
+        ppo_max = int(ppo_max_raw) if ppo_max_raw is not None else kv_seq_len
+        data_seq_cap: Optional[int] = None
+        try:
+            pl = _OC.select(config, "data.max_prompt_length", default=None)
+            rl = _OC.select(config, "data.max_response_length", default=None)
+            if pl is not None and rl is not None:
+                data_seq_cap = int(pl) + int(rl)
+        except Exception:
+            data_seq_cap = None
+        train_seq_len = min(ppo_max, kv_seq_len)
+        if data_seq_cap is not None:
+            train_seq_len = min(train_seq_len, max(1, data_seq_cap))
+        train_seq_len = max(1, int(train_seq_len))
+
+        # micro-batch proxy (activation memory is sensitive; be conservative if missing)
+        mbs_per_gpu = getattr(actor_cfg, "ppo_micro_batch_size_per_gpu", None)
+        if mbs_per_gpu is None:
+            mbs_per_gpu = getattr(actor_cfg, "ppo_micro_batch_size", None)
+        if mbs_per_gpu is None:
+            mbs_per_gpu = 1
+        mbs_per_gpu = int(mbs_per_gpu)
+
+        # Load HF config.json (small); trust flag may live on data.* or model.*
+        trust_remote_code = bool(
+            _OC.select(config, "data.trust_remote_code", default=False)
+            or _OC.select(config, "actor_rollout_ref.model.trust_remote_code", default=False)
+        )
+        hf_cfg = _try_load_hf_config_json(model_cfg.path, trust_remote_code)
+        if not hf_cfg:
+            return None
+
+        hidden_size = hf_cfg.get("hidden_size", hf_cfg.get("d_model", None))
+        num_layers = hf_cfg.get("num_hidden_layers", hf_cfg.get("n_layer", None))
+        num_heads = hf_cfg.get("num_attention_heads", hf_cfg.get("n_head", None))
+        intermediate_size = hf_cfg.get("intermediate_size", hf_cfg.get("ffn_dim", None))
+        vocab_size = hf_cfg.get("vocab_size", None)
+
+        if hidden_size is None or num_layers is None or num_heads is None:
+            return None
+
+        # MoE fields (optional)
+        num_experts = hf_cfg.get("num_experts", hf_cfg.get("n_experts", 1))
+        moe_intermediate_size = hf_cfg.get("moe_intermediate_size", intermediate_size)
+        if moe_intermediate_size is None:
+            moe_intermediate_size = intermediate_size if intermediate_size is not None else hidden_size
+
+        return {
+            "hidden_size": int(hidden_size),
+            "num_layers": int(num_layers),
+            "num_heads": int(num_heads),
+            "intermediate_size": int(intermediate_size) if intermediate_size is not None else int(hidden_size),
+            "vocab_size": int(vocab_size) if vocab_size is not None else 0,
+            "num_experts": int(num_experts) if num_experts is not None else 1,
+            "moe_intermediate_size": int(moe_intermediate_size),
+            "dtype_bytes": dtype_bytes,
+            "kv_seq_len": int(kv_seq_len),
+            "train_seq_len": int(train_seq_len),
+            "max_num_seqs": int(max_num_seqs),
+            "micro_batch_per_gpu": int(mbs_per_gpu),
+        }
+    except Exception as e:
+        logger.warning("Failed to build memory estimator inputs: %s", e)
+        return None
+
+
+def _estimate_kv_cache_gb(*, degrees, estimator: dict[str, Any], dtype_bytes: int) -> float:
+    """
+    KV cache estimate (vLLM) per rank.
+
+    Approximations:
+    - PP is forced to 1 for rollout in this module.
+    - KV cache memory is sharded across TP by head dimension partitioning => /TP.
+    """
+    hs = int(estimator["hidden_size"])
+    layers = int(estimator["num_layers"])
+    seq_len = int(estimator["kv_seq_len"])
+    max_num_seqs = int(estimator["max_num_seqs"])
+    tp = int(degrees.tensor_model_parallel_size)
+
+    # k and v: 2 * hidden_size per token, per layer
+    kv_bytes = layers * seq_len * max_num_seqs * 2 * hs * dtype_bytes / max(1, tp)
+    return float(kv_bytes) / 1024**3
+
+
+def _estimate_training_memory_gb(*, degrees, estimator: dict[str, Any]) -> float:
+    """
+    Very rough training memory estimate per rank (weights+optimizer+activations).
+
+    Approximations (conservative defaults):
+    - parameters:
+      * attention params per layer: ~4 * hs^2
+      * MLP params per layer: ~3 * hs * intermediate (gated MLP)
+    - if MoE (num_experts > 1):
+      * expert params per layer: ~num_experts * 3 * hs * moe_intermediate
+      * expert weights are sharded additionally by EP (/EP)
+    - optimizer+grads: 4x weights (params + grads + Adam moments)
+    - activations: scales with (layers * micro_batch * seq_len * hs) and is sharded by (TP*PP*CP)
+    """
+    hs = int(estimator["hidden_size"])
+    layers = int(estimator["num_layers"])
+    intermediate = int(estimator["intermediate_size"])
+    moe_intermediate = int(estimator["moe_intermediate_size"])
+    vocab_size = int(estimator["vocab_size"])
+    num_experts = int(estimator["num_experts"])
+
+    dtype_bytes = int(estimator["dtype_bytes"])
+    train_seq_len = int(estimator["train_seq_len"])
+    micro_batch = int(estimator["micro_batch_per_gpu"])
+
+    tp = int(degrees.tensor_model_parallel_size)
+    pp = int(degrees.pipeline_model_parallel_size)
+    cp = int(degrees.context_parallel_size)
+    ep = int(degrees.expert_model_parallel_size)
+
+    # Embeddings + LM head params (approx); if vocab_size unknown, skip.
+    if vocab_size > 0:
+        embed_params = 2 * vocab_size * hs
+    else:
+        embed_params = 0
+
+    attn_params_per_layer = 4 * hs * hs
+    mlp_params_per_layer = 3 * hs * intermediate
+    dense_params_per_layer = attn_params_per_layer + mlp_params_per_layer
+
+    # Sharding: per-rank weights divide by (TP*PP). MoE expert weights additionally divide by EP.
+    if num_experts > 1:
+        # Expert weights dominate the MLP part.
+        expert_params_per_layer = num_experts * 3 * hs * moe_intermediate
+        dense_params_total = embed_params + layers * attn_params_per_layer
+        expert_params_total = layers * expert_params_per_layer
+
+        weights_dense_gb = (dense_params_total * dtype_bytes) / (1024**3 * max(1, tp * pp))
+        weights_expert_gb = (expert_params_total * dtype_bytes) / (1024**3 * max(1, tp * pp * ep))
+        weights_gb = float(weights_dense_gb + weights_expert_gb)
+    else:
+        total_params = embed_params + layers * dense_params_per_layer
+        weights_gb = (total_params * dtype_bytes) / (1024**3 * max(1, tp * pp))
+
+    # Weights + grads + optimizer moments (roughly 4x params).
+    weights_plus_opt_gb = weights_gb * 4.0
+
+    # Activations estimate: conservative multiplier.
+    activation_multiplier = 2.0
+    # Activations per rank roughly proportional to layers/PP and seq length and sharded by TP/CP.
+    activations_bytes = layers * micro_batch * train_seq_len * hs * dtype_bytes * activation_multiplier
+    activations_gb = activations_bytes / (1024**3 * max(1, tp * pp * cp))
+
+    return float(weights_plus_opt_gb + activations_gb)
+
+
+def _select_degrees_maximize_dp(
+    *,
+    n_gpus_total: int,
+    n_gpus_per_node: int,
+    nnodes: int,
+    base_degrees,
+    seq_len: Optional[int],
+    memory_budget_gb: Optional[float],
+    safety_margin: float,
+    memory_estimator: Optional[dict[str, Any]],
+    gate_kv_cache: bool = True,
+    objective: str = "max_mp",
+    allow_context_parallel: bool = False,
+    num_attention_heads: Optional[int] = None,
+    num_hidden_layers: Optional[int] = None,
+    _memory_fallback: bool = False,
+):
+    """
+    Minimal analytical selector:
+      - Enumerate TP/PP/CP candidates by divisibility.
+      - Derive DP from world size: DP = n_gpus_total / (TP * PP * CP)
+      - Enumerate feasible EP candidates (MoE) and validate EP/DP divisibility.
+      - Choose the candidate by `objective`:
+          * ``max_dp`` (legacy): maximize DP first (throughput-oriented; can override a user TP=8
+            down to TP=1 if the analytical memory gate incorrectly passes).
+          * ``max_mp`` (default): maximize model-parallel product TP×PP×CP first (prefer sharding),
+            which matches typical Megatron + colocated vLLM setups and is safer when the
+            analytical estimate is imperfect.
+
+      Tie-breakers (within objective):
+          1) Prefer tp <= n_gpus_per_node (within-node, when possible)
+          2) Prefer larger CP when seq_len is long (heuristic)
+          3) Prefer smaller EP to reduce expert-parallel all-to-all risk
+    """
+    tp_candidates = sorted(_iter_divisors(n_gpus_total))
+
+    # To limit search, restrict PP and CP to divisors of the remaining factor
+    best = None
+    best_score = None
+    best_kv_gb: Optional[float] = None
+    best_train_gb: Optional[float] = None
+
+    tried = 0
+    feasible = 0
+    mem_pass = 0
+
+    etp = int(base_degrees.expert_tensor_parallel_size or 1)
+    existing_sequence_parallel = bool(base_degrees.sequence_parallel)
+
+    long_seq = seq_len is not None and seq_len > 16000
+    objective = (objective or "max_mp").strip().lower()
+    if objective not in ("max_dp", "max_mp"):
+        logger.warning("Unknown trainer.auto_parallel.objective=%r; using 'max_mp'.", objective)
+        objective = "max_mp"
+
+    if not allow_context_parallel:
+        logger.info(
+            "Auto-parallel: allow_context_parallel=false — search restricted to context_parallel_size=1 "
+            "(Megatron DotProductAttention requires CP==1 unless TEDotProductAttention is enabled)."
+        )
+
+    if num_attention_heads is not None:
+        logger.info(
+            "Auto-parallel: filtering TP/PP by architecture — num_attention_heads=%d "
+            "(Megatron: heads %% TP == 0; PP>1 also requires layers %% PP == 0 when num_hidden_layers known).",
+            int(num_attention_heads),
+        )
+
+    # EP (MoE) policy:
+    # - TP+EP requires sequence parallelism (Megatron Core guidance).
+    # - EP is used for expert-parallel token dispatch (all-to-all style).
+    #   As a practical heuristic (comm/latency risk reduction), we prefer smaller EP.
+    # - We also keep feasibility by enumerating EP as divisors of the user-configured
+    #   base EP. If base EP divides the model's num_experts (true by construction in
+    #   a valid training config), then any divisor of base EP will also divide num_experts.
+    base_ep = int(base_degrees.expert_model_parallel_size)
+    if base_ep > 1:
+        ep_candidates = sorted(set(_iter_divisors(base_ep)))
+        ep_candidates = [e for e in ep_candidates if e > 0]
+    else:
+        ep_candidates = [1]
+
+    for tp in tp_candidates:
+        # Quick EP/DP compatibility check requires dp, which depends on PP and CP.
+        # We still keep the search small by ensuring tp divides n_gpus_total.
+        if n_gpus_total % tp != 0:
+            continue
+        if num_attention_heads is not None and int(num_attention_heads) % int(tp) != 0:
+            continue
+
+        remaining_after_tp = n_gpus_total // tp
+        pp_candidates = sorted(_iter_divisors(remaining_after_tp))
+
+        for pp in pp_candidates:
+            if num_hidden_layers is not None and int(pp) > 1 and int(num_hidden_layers) % int(pp) != 0:
+                continue
+            remaining_after_tp_pp = remaining_after_tp // pp
+            cp_candidates = sorted(_iter_divisors(remaining_after_tp_pp))
+            if not allow_context_parallel:
+                cp_candidates = [c for c in cp_candidates if c == 1]
+
+            for cp in cp_candidates:
+                if n_gpus_total % (tp * pp * cp) != 0:
+                    continue
+
+                dp = n_gpus_total // (tp * pp * cp)
+
+                for ep in ep_candidates:
+                    tried += 1
+                    # EP operates INSIDE DP: enforce dp % ep == 0 for EP>1.
+                    if ep > 1 and dp % ep != 0:
+                        continue
+
+                    # Preserve existing sequence_parallel unless EP+TP requires it.
+                    sp_required = (ep > 1 and tp > 1)
+                    sequence_parallel = existing_sequence_parallel or sp_required
+
+                    candidate = type(base_degrees)(
+                        tensor_model_parallel_size=int(tp),
+                        pipeline_model_parallel_size=int(pp),
+                        context_parallel_size=int(cp),
+                        expert_model_parallel_size=int(ep),
+                        expert_tensor_parallel_size=int(etp),
+                        sequence_parallel=bool(sequence_parallel),
+                        data_parallel_size=int(dp),
+                        model_parallel_size=int(tp * pp * cp),
+                    )
+
+                    # Validate feasibility (may warn/raise depending on constraints)
+                    try:
+                        validate_degrees(candidate, n_gpus_total, n_gpus_per_node, nnodes)
+                    except ValueError:
+                        continue
+                    feasible += 1
+
+                    kv_gb: Optional[float] = None
+                    train_gb: Optional[float] = None
+
+                    # Analytical memory acceptance (simple + conservative so we don't OOM).
+                    if memory_budget_gb is not None and memory_estimator is not None:
+                        train_gb = _estimate_training_memory_gb(degrees=candidate, estimator=memory_estimator)
+                        kv_gb = None
+                        if gate_kv_cache:
+                            kv_gb = _estimate_kv_cache_gb(
+                                degrees=candidate,
+                                estimator=memory_estimator,
+                                dtype_bytes=memory_estimator["dtype_bytes"],
+                            )
+                            # CI_upper surrogate: CI_upper = estimate * safety_margin
+                            if kv_gb * safety_margin > memory_budget_gb:
+                                continue
+                        if train_gb * safety_margin > memory_budget_gb:
+                            continue
+                    mem_pass += 1
+
+                    # Score depends on objective (see docstring).
+                    tp_within_node = int(tp <= n_gpus_per_node)
+                    mp = int(tp * pp * cp)
+                    if objective == "max_dp":
+                        if long_seq:
+                            score = (dp, tp_within_node, cp, -int(ep), -tp, -pp, tp, pp, cp, ep)
+                        else:
+                            score = (dp, tp_within_node, -tp, -int(ep), -pp, pp, cp, ep)
+                    else:
+                        # max_mp: prefer larger TP×PP×CP, then higher TP (typical LLM preference), lower DP.
+                        if long_seq:
+                            score = (mp, tp_within_node, cp, -int(ep), tp, -pp, -dp, pp, cp, ep)
+                        else:
+                            score = (mp, tp_within_node, tp, -int(ep), -pp, -dp, pp, cp, ep)
+
+                    if best is None or score > best_score:
+                        best = candidate
+                        best_score = score
+                        best_kv_gb = kv_gb
+                        best_train_gb = train_gb
+
+    if best is None:
+        if feasible == 0:
+            extra = ""
+            if num_attention_heads is not None:
+                extra = (
+                    f" Check tensor_model_parallel_size divides num_attention_heads={num_attention_heads} "
+                    f"(Megatron Core) and PP divides num_hidden_layers when PP>1."
+                )
+            raise ValueError("No feasible auto-parallel degree configuration found." + extra)
+        if _memory_fallback:
+            raise ValueError(
+                "No feasible auto-parallel degree configuration found after memory fallback "
+                f"(feasible={feasible})."
+            )
+        logger.warning(
+            "Auto-parallel: analytical memory gate rejected all %d feasible candidates "
+            "(budget_gb=%s). Retrying feasibility-only selection without memory gate using "
+            "objective=max_mp (prefer sharding — avoids blindly picking TP=1).",
+            feasible,
+            f"{memory_budget_gb:.2f}" if memory_budget_gb is not None else "n/a",
+        )
+        return _select_degrees_maximize_dp(
+            n_gpus_total=n_gpus_total,
+            n_gpus_per_node=n_gpus_per_node,
+            nnodes=nnodes,
+            base_degrees=base_degrees,
+            seq_len=seq_len,
+            memory_budget_gb=None,
+            safety_margin=safety_margin,
+            memory_estimator=memory_estimator,
+            gate_kv_cache=gate_kv_cache,
+            objective="max_mp",
+            allow_context_parallel=allow_context_parallel,
+            num_attention_heads=num_attention_heads,
+            num_hidden_layers=num_hidden_layers,
+            _memory_fallback=True,
+        )
+
+    logger.info(
+        "Auto-parallel selected degrees (objective=%s): %s",
+        objective,
+        best.get_summary() if hasattr(best, "get_summary") else str(best),
+    )
+    if memory_budget_gb is not None:
+        logger.info(
+            "Auto-parallel memory gate: budget_gb=%.2f, kv_est_gb=%s, train_est_gb=%s, safety_margin=%.4f",
+            float(memory_budget_gb),
+            f"{best_kv_gb:.2f}" if best_kv_gb is not None else "n/a",
+            f"{best_train_gb:.2f}" if best_train_gb is not None else "n/a",
+            float(safety_margin),
+        )
+    logger.info(
+        "Auto-parallel search stats: tried=%d feasible=%d mem_pass=%d",
+        tried,
+        feasible,
+        mem_pass,
+    )
+    return best
+
+
+def _apply_degrees_to_config(config, *, degrees) -> None:
+    """
+    Override config degree fields in-place.
+
+    Training (Megatron-side):
+      - actor_rollout_ref.actor.megatron.*
+      - actor_rollout_ref.ref.megatron.* (if present)
+      - config.critic.megatron.* (if present)
+
+    Rollout (vLLM-side):
+      - actor_rollout_ref.rollout.*
+
+    Note: vLLM/sglang/trtllm rollout currently do not support PP>1; we force PP=1.
+    """
+    # Training-side overrides (actor)
+    config.actor_rollout_ref.actor.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+    config.actor_rollout_ref.actor.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+    config.actor_rollout_ref.actor.megatron.context_parallel_size = degrees.context_parallel_size
+    config.actor_rollout_ref.actor.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+    config.actor_rollout_ref.actor.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+
+    # Training-side overrides (reference policy), only if present in config
+    if "ref" in config.actor_rollout_ref and hasattr(config.actor_rollout_ref.ref, "megatron"):
+        config.actor_rollout_ref.ref.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+        config.actor_rollout_ref.ref.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+        config.actor_rollout_ref.ref.megatron.context_parallel_size = degrees.context_parallel_size
+        config.actor_rollout_ref.ref.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+        config.actor_rollout_ref.ref.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+
+    # Training-side overrides (critic), only if critic uses megatron
+    if hasattr(config, "critic") and getattr(config.critic, "strategy", None) == "megatron" and hasattr(
+        config.critic, "megatron"
+    ):
+        config.critic.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+        config.critic.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+        config.critic.megatron.context_parallel_size = degrees.context_parallel_size
+        config.critic.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+        config.critic.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+
+    # Rollout-side overrides (force PP=1)
+    config.actor_rollout_ref.rollout.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+    config.actor_rollout_ref.rollout.pipeline_model_parallel_size = 1
+    config.actor_rollout_ref.rollout.data_parallel_size = degrees.data_parallel_size
+    # RolloutConfig has an internal constraint:
+    #   if expert_parallel_size > 1:
+    #       expert_parallel_size == tensor_model_parallel_size * data_parallel_size
+    # So map MoE EP from training degrees into the rollout-compatible setting.
+    rollout_ep = int(degrees.expert_model_parallel_size)
+    if rollout_ep > 1:
+        rollout_ep = int(degrees.tensor_model_parallel_size * degrees.data_parallel_size)
+    config.actor_rollout_ref.rollout.expert_parallel_size = rollout_ep
+
+
+def apply_analytical_auto_parallel_degrees(config) -> None:
+    """
+    Apply analytical auto-parallelism degree overrides (in-place).
+
+    This is invoked from `verl/trainer/main_ppo.py` and only mutates config
+    when `trainer.auto_parallel.enabled=true`.
+    """
+    from omegaconf import OmegaConf
+
+    enabled = OmegaConf.select(config, "trainer.auto_parallel.enabled", default=False)
+    if not enabled:
+        return
+
+    n_gpus_per_node = int(config.trainer.n_gpus_per_node)
+    nnodes = int(config.trainer.nnodes)
+    n_gpus_total = n_gpus_per_node * nnodes
+
+    base_degrees = _get_megatron_degrees_from_actor_config(config=config, n_gpus=n_gpus_total)
+    if base_degrees is None:
+        return
+
+    num_attention_heads = _try_get_num_attention_heads(config)
+    num_hidden_layers = _try_get_num_hidden_layers(config)
+
+    # Heuristic long-sequence threshold: try to allocate more degrees to CP.
+    from omegaconf import OmegaConf as _OmegaConf
+
+    actor_seq = _OmegaConf.select(
+        config, "actor_rollout_ref.actor.ppo_max_token_len_per_gpu", default=None
+    )
+    rollout_seq = _OmegaConf.select(config, "actor_rollout_ref.rollout.max_model_len", default=None)
+    seq_len = None
+    for cand in (actor_seq, rollout_seq):
+        try:
+            if cand is not None:
+                cand_i = int(cand)
+                seq_len = cand_i if seq_len is None else max(seq_len, cand_i)
+        except Exception:
+            pass
+
+    # Select candidate degrees (feasibility-first; objective from config).
+    auto_parallel_cfg = _OmegaConf.select(config, "trainer.auto_parallel", default=None)
+    if auto_parallel_cfg is None:
+        return
+
+    target_utilization = float(auto_parallel_cfg.get("target_utilization", 0.9))
+    safety_margin = float(auto_parallel_cfg.get("safety_margin", 1.10))
+    memory_check_mode = str(auto_parallel_cfg.get("memory_check_mode", "analytical"))
+    objective = str(auto_parallel_cfg.get("objective", "max_mp"))
+    respect_config = bool(auto_parallel_cfg.get("respect_config_parallelism", False))
+    allow_context_parallel = bool(auto_parallel_cfg.get("allow_context_parallel", False))
+
+    rollout_name = str(
+        _OmegaConf.select(config, "actor_rollout_ref.rollout.name", default="vllm") or "vllm"
+    ).lower()
+    gate_kv_cache = rollout_name == "vllm"
+
+    # Keep user-provided TP/PP/CP/EP/DP: only validate + optional analytical memory check.
+    if respect_config:
+        if num_attention_heads is not None:
+            tp0 = int(base_degrees.tensor_model_parallel_size)
+            if int(num_attention_heads) % tp0 != 0:
+                raise ValueError(
+                    "respect_config_parallelism: Megatron requires num_attention_heads divisible by "
+                    f"tensor_model_parallel_size, got heads={num_attention_heads}, TP={tp0} "
+                    f"(e.g. Qwen2.5-7B has 28 heads → TP must be in {{1,2,4,7,14,28}}, not 8)."
+                )
+        if num_hidden_layers is not None and int(base_degrees.pipeline_model_parallel_size) > 1:
+            pp0 = int(base_degrees.pipeline_model_parallel_size)
+            if int(num_hidden_layers) % pp0 != 0:
+                raise ValueError(
+                    "respect_config_parallelism: num_hidden_layers must be divisible by "
+                    f"pipeline_model_parallel_size when PP>1, got layers={num_hidden_layers}, PP={pp0}."
+                )
+        if (
+            not allow_context_parallel
+            and int(getattr(base_degrees, "context_parallel_size", 1) or 1) > 1
+        ):
+            logger.warning(
+                "respect_config_parallelism: context_parallel_size=%d with allow_context_parallel=false "
+                "may fail Megatron DotProductAttention (needs TEDotProductAttention for CP>1).",
+                int(base_degrees.context_parallel_size),
+            )
+        validate_degrees(base_degrees, n_gpus_total, n_gpus_per_node, nnodes)
+        if memory_check_mode == "analytical":
+            memory_budget_gb = _get_memory_budget_gb(target_utilization=target_utilization)
+            memory_estimator = _try_build_memory_estimator_inputs(config=config)
+            if memory_budget_gb is not None and memory_estimator is not None:
+                train_gb = _estimate_training_memory_gb(degrees=base_degrees, estimator=memory_estimator)
+                if gate_kv_cache:
+                    kv_gb = _estimate_kv_cache_gb(
+                        degrees=base_degrees,
+                        estimator=memory_estimator,
+                        dtype_bytes=memory_estimator["dtype_bytes"],
+                    )
+                    if kv_gb * safety_margin > memory_budget_gb:
+                        raise ValueError(
+                            "respect_config_parallelism: configured degrees fail KV memory gate "
+                            f"(kv_est_gb={kv_gb:.2f}, budget_gb={memory_budget_gb:.2f}, "
+                            f"safety_margin={safety_margin})."
+                        )
+                if train_gb * safety_margin > memory_budget_gb:
+                    raise ValueError(
+                        "respect_config_parallelism: configured degrees fail training memory gate "
+                        f"(train_est_gb={train_gb:.2f}, budget_gb={memory_budget_gb:.2f}, "
+                        f"safety_margin={safety_margin})."
+                    )
+        _apply_degrees_to_config(config, degrees=base_degrees)
+        logger.info(
+            "Auto-parallel: respect_config_parallelism=true — kept configured degrees (%s).",
+            base_degrees.get_summary() if hasattr(base_degrees, "get_summary") else base_degrees,
+        )
+        return
+
+    memory_budget_gb: Optional[float] = None
+    memory_estimator: Optional[dict[str, Any]] = None
+
+    if memory_check_mode == "analytical":
+        memory_budget_gb = _get_memory_budget_gb(target_utilization=target_utilization)
+        memory_estimator = _try_build_memory_estimator_inputs(config=config)
+
+        logger.info(
+            "Auto-parallel memory inputs: target_utilization=%.3f safety_margin=%.3f budget_gb=%s",
+            target_utilization,
+            safety_margin,
+            f"{memory_budget_gb:.2f}" if memory_budget_gb is not None else "n/a",
+        )
+        if memory_estimator is None:
+            logger.warning(
+                "Auto-parallel memory estimator inputs missing; will skip analytical memory checks."
+            )
+        else:
+            # Log only key estimator values (avoid spamming).
+            logger.info(
+                "Auto-parallel estimator: hidden_size=%d num_layers=%d heads=%d hidden_intermediate=%d dtype_bytes=%d "
+                "kv_seq_len=%d train_seq_len=%d max_num_seqs=%d micro_batch_per_gpu=%d num_experts=%d moe_intermediate=%d",
+                memory_estimator["hidden_size"],
+                memory_estimator["num_layers"],
+                memory_estimator["num_heads"],
+                memory_estimator["intermediate_size"],
+                memory_estimator["dtype_bytes"],
+                memory_estimator["kv_seq_len"],
+                memory_estimator["train_seq_len"],
+                memory_estimator["max_num_seqs"],
+                memory_estimator["micro_batch_per_gpu"],
+                memory_estimator["num_experts"],
+                memory_estimator["moe_intermediate_size"],
+            )
+
+    selected = _select_degrees_maximize_dp(
+        n_gpus_total=n_gpus_total,
+        n_gpus_per_node=n_gpus_per_node,
+        nnodes=nnodes,
+        base_degrees=base_degrees,
+        seq_len=seq_len,
+        memory_budget_gb=memory_budget_gb,
+        safety_margin=safety_margin,
+        memory_estimator=memory_estimator,
+        gate_kv_cache=gate_kv_cache,
+        objective=objective,
+        allow_context_parallel=allow_context_parallel,
+        num_attention_heads=num_attention_heads,
+        num_hidden_layers=num_hidden_layers,
+    )
+
+    # Override config degrees (ignore user-provided degrees on the fields we control).
+    _apply_degrees_to_config(config, degrees=selected)
+
+    # Hard print so you can see the result even if VERL_LOGGING_LEVEL is not INFO.
+    # This is the "ground truth" degrees used for placement-aware scheduling.
+    try:
+        summary = selected.get_summary() if hasattr(selected, "get_summary") else str(selected)
+    except Exception:
+        summary = str(selected)
+    print(
+        f"[AutoParallel] selected degrees={summary} "
+        f"(target_utilization={target_utilization}, safety_margin={safety_margin}, "
+        f"memory_check_mode={memory_check_mode}, objective={objective})",
+        flush=True,
+    )
+    if memory_budget_gb is not None:
+        print(f"[AutoParallel] memory_budget_gb={memory_budget_gb:.4f}GB", flush=True)
+    if memory_estimator is not None:
+        # Print a compact estimator signature (avoid huge dicts / tensors).
+        est_sig = {
+            "hidden_size": memory_estimator.get("hidden_size"),
+            "num_layers": memory_estimator.get("num_layers"),
+            "num_heads": memory_estimator.get("num_heads"),
+            "kv_seq_len": memory_estimator.get("kv_seq_len"),
+            "train_seq_len": memory_estimator.get("train_seq_len"),
+            "micro_batch_per_gpu": memory_estimator.get("micro_batch_per_gpu"),
+            "max_num_seqs": memory_estimator.get("max_num_seqs"),
+        }
+        print(f"[AutoParallel] estimator_signature={est_sig}", flush=True)
+

--- a/verl/utils/auto_parallelization.py
+++ b/verl/utils/auto_parallelization.py
@@ -666,43 +666,48 @@ def _apply_degrees_to_config(config, *, degrees) -> None:
 
     Note: vLLM/sglang/trtllm rollout currently do not support PP>1; we force PP=1.
     """
-    # Training-side overrides (actor)
-    config.actor_rollout_ref.actor.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
-    config.actor_rollout_ref.actor.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
-    config.actor_rollout_ref.actor.megatron.context_parallel_size = degrees.context_parallel_size
-    config.actor_rollout_ref.actor.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
-    config.actor_rollout_ref.actor.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+    from omegaconf import OmegaConf, open_dict
 
-    # Training-side overrides (reference policy), only if present in config
-    if "ref" in config.actor_rollout_ref and hasattr(config.actor_rollout_ref.ref, "megatron"):
-        config.actor_rollout_ref.ref.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
-        config.actor_rollout_ref.ref.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
-        config.actor_rollout_ref.ref.megatron.context_parallel_size = degrees.context_parallel_size
-        config.actor_rollout_ref.ref.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
-        config.actor_rollout_ref.ref.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+    with open_dict(config):
+        # Training-side overrides (actor)
+        config.actor_rollout_ref.actor.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+        config.actor_rollout_ref.actor.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+        config.actor_rollout_ref.actor.megatron.context_parallel_size = degrees.context_parallel_size
+        config.actor_rollout_ref.actor.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+        config.actor_rollout_ref.actor.megatron.sequence_parallel = bool(degrees.sequence_parallel)
 
-    # Training-side overrides (critic), only if critic uses megatron
-    if hasattr(config, "critic") and getattr(config.critic, "strategy", None) == "megatron" and hasattr(
-        config.critic, "megatron"
-    ):
-        config.critic.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
-        config.critic.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
-        config.critic.megatron.context_parallel_size = degrees.context_parallel_size
-        config.critic.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
-        config.critic.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+        # Training-side overrides (reference policy), only if present in config
+        if "ref" in config.actor_rollout_ref and hasattr(config.actor_rollout_ref.ref, "megatron"):
+            config.actor_rollout_ref.ref.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+            config.actor_rollout_ref.ref.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+            config.actor_rollout_ref.ref.megatron.context_parallel_size = degrees.context_parallel_size
+            config.actor_rollout_ref.ref.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+            config.actor_rollout_ref.ref.megatron.sequence_parallel = bool(degrees.sequence_parallel)
 
-    # Rollout-side overrides (force PP=1)
-    config.actor_rollout_ref.rollout.tensor_model_parallel_size = degrees.tensor_model_parallel_size
-    config.actor_rollout_ref.rollout.pipeline_model_parallel_size = 1
-    config.actor_rollout_ref.rollout.data_parallel_size = degrees.data_parallel_size
-    # RolloutConfig has an internal constraint:
-    #   if expert_parallel_size > 1:
-    #       expert_parallel_size == tensor_model_parallel_size * data_parallel_size
-    # So map MoE EP from training degrees into the rollout-compatible setting.
-    rollout_ep = int(degrees.expert_model_parallel_size)
-    if rollout_ep > 1:
-        rollout_ep = int(degrees.tensor_model_parallel_size * degrees.data_parallel_size)
-    config.actor_rollout_ref.rollout.expert_parallel_size = rollout_ep
+        # Training-side overrides (critic), only if critic uses megatron
+        if (
+            OmegaConf.select(config, "critic.strategy", default=None) == "megatron"
+            and hasattr(config, "critic")
+            and hasattr(config.critic, "megatron")
+        ):
+            config.critic.megatron.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+            config.critic.megatron.pipeline_model_parallel_size = degrees.pipeline_model_parallel_size
+            config.critic.megatron.context_parallel_size = degrees.context_parallel_size
+            config.critic.megatron.expert_model_parallel_size = degrees.expert_model_parallel_size
+            config.critic.megatron.sequence_parallel = bool(degrees.sequence_parallel)
+
+        # Rollout-side overrides (force PP=1)
+        config.actor_rollout_ref.rollout.tensor_model_parallel_size = degrees.tensor_model_parallel_size
+        config.actor_rollout_ref.rollout.pipeline_model_parallel_size = 1
+        config.actor_rollout_ref.rollout.data_parallel_size = degrees.data_parallel_size
+        # RolloutConfig has an internal constraint:
+        #   if expert_parallel_size > 1:
+        #       expert_parallel_size == tensor_model_parallel_size * data_parallel_size
+        # So map MoE EP from training degrees into the rollout-compatible setting.
+        rollout_ep = int(degrees.expert_model_parallel_size)
+        if rollout_ep > 1:
+            rollout_ep = int(degrees.tensor_model_parallel_size * degrees.data_parallel_size)
+        config.actor_rollout_ref.rollout.expert_parallel_size = rollout_ep
 
 
 def apply_analytical_auto_parallel_degrees(config) -> None:

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -83,7 +83,7 @@ def validate_config(
         use_reference_policy (bool): is ref policy needed
         use_critic (bool): is critic needed
     """
-    # number of GPUs total
+    # number of GPUs total (0 for CPU mode)
     n_gpus = config.trainer.n_gpus_per_node * config.trainer.nnodes
 
     if not config.actor_rollout_ref.actor.use_dynamic_bsz:
@@ -103,7 +103,8 @@ def validate_config(
             )
             minimal_bsz = megatron_dp * config.actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu
         else:
-            minimal_bsz = n_gpus
+            # CPU mode: n_gpus=0, use minimal_bsz=1 to avoid ZeroDivisionError
+            minimal_bsz = n_gpus if n_gpus > 0 else 1
 
         # 1. Check total batch size for data correctness
         real_train_batch_size = config.data.train_batch_size * config.actor_rollout_ref.rollout.n

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -176,6 +176,14 @@ class RLHFDataset(Dataset):
             dataframes.append(dataframe)
         self.dataframe: datasets.Dataset = datasets.concatenate_datasets(dataframes)
 
+        cols = self.dataframe.column_names
+        if self.prompt_key not in cols:
+            raise ValueError(
+                f"data.prompt_key={self.prompt_key!r} is not a column in the dataset {cols}. "
+                f"Parquet from examples/data_preprocess/gsm8k.py uses chat messages under 'prompt'; "
+                f"set data.prompt_key=prompt (or match your parquet schema)."
+            )
+
         total = len(self.dataframe)
         print(f"dataset len: {len(self.dataframe)}")
 

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -119,6 +119,21 @@ def get_device_id() -> int:
     return get_platform().current_device()
 
 
+def get_distributed_backend() -> str:
+    """Get the distributed process group backend string.
+
+    For CPU: returns 'gloo'.
+    For CUDA/NPU: returns 'cpu:gloo,{device}:{backend}' for multi-device support.
+
+    Returns:
+        str: Backend string for torch.distributed.init_process_group.
+    """
+    device = get_device_name()
+    if device == "cpu":
+        return "gloo"
+    return f"cpu:gloo,{device}:{get_nccl_backend()}"
+
+
 def get_nccl_backend() -> str:
     """Get the distributed communication backend based on device type.
 

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -21,7 +21,14 @@ from datetime import timedelta
 import ray
 import torch.distributed
 
-from verl.utils.device import get_device_name, get_nccl_backend, get_resource_name, get_torch_device, is_npu_available
+from verl.utils.device import (
+    get_device_name,
+    get_distributed_backend,
+    get_nccl_backend,
+    get_resource_name,
+    get_torch_device,
+    is_npu_available,
+)
 from verl.utils.net_utils import is_ipv6
 
 
@@ -83,7 +90,7 @@ def initialize_global_process_group_ray(timeout_second=None, backend=None):
     import torch.distributed
 
     timeout = timedelta(seconds=timeout_second) if timeout_second is not None else None
-    backend = backend or f"cpu:gloo,{get_device_name()}:{get_nccl_backend()}"
+    backend = backend or get_distributed_backend()
     if not torch.distributed.is_initialized():
         rank = int(os.environ.get("RANK", 0))
         world_size = int(os.environ.get("WORLD_SIZE", 1))

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -165,6 +165,8 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
 
 @torch.no_grad()
 def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
+    if get_device_name() == "cpu":
+        return  # no-op: model already on CPU
     if fsdp_version(model) == 2 or fsdp_version(model) == 0:
         offload_fsdp2_model_to_cpu(model, empty_cache)
         return
@@ -199,6 +201,8 @@ def offload_fsdp2_model_to_cpu(model, empty_cache: bool = True):
 
 @torch.no_grad()
 def load_fsdp_model_to_gpu(model: FSDP):
+    if get_device_name() == "cpu":
+        return  # no-op: model already on CPU
     if fsdp_version(model) == 2 or fsdp_version(model) == 0:
         load_fsdp2_model_to_gpu(model)
         return

--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import torch
 
-from verl.utils.device import get_torch_device
+from verl.utils.device import get_device_name, get_torch_device
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
@@ -37,6 +37,9 @@ def aggressive_empty_cache(force_sync: bool = True, max_retries: int = 3) -> Non
         force_sync: Whether to force device synchronization
         max_retries: Maximum number of retries
     """
+    if get_device_name() == "cpu":
+        gc.collect()
+        return
     device = get_torch_device()
     if not device.is_available():
         return
@@ -76,15 +79,16 @@ def aggressive_empty_cache(force_sync: bool = True, max_retries: int = 3) -> Non
 
 def reset_memory_stats() -> None:
     """Reset GPU memory statistics"""
-    if get_torch_device().is_available():
-        device = get_torch_device()
-        device.reset_peak_memory_stats()
-        device.reset_accumulated_memory_stats()
+    if get_device_name() == "cpu" or not get_torch_device().is_available():
+        return
+    device = get_torch_device()
+    device.reset_peak_memory_stats()
+    device.reset_accumulated_memory_stats()
 
 
 def get_memory_info() -> dict:
     """Get detailed GPU memory information"""
-    if not get_torch_device().is_available():
+    if get_device_name() == "cpu" or not get_torch_device().is_available():
         return {}
 
     device = get_torch_device()
@@ -102,7 +106,7 @@ def get_memory_info() -> dict:
 
 def log_memory_usage(stage: str = "current") -> None:
     """Log GPU memory usage"""
-    if not get_torch_device().is_available():
+    if get_device_name() == "cpu" or not get_torch_device().is_available():
         return
 
     info = get_memory_info()

--- a/verl/utils/placement.py
+++ b/verl/utils/placement.py
@@ -1,0 +1,770 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, HUAWEI CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Placement search and parallelism degree utilities for verl.
+
+Enable rack-aware placement search by setting config.trainer.enable_placement = True.
+See docs/msrl_integration/Placement_Explanation.md for detailed documentation.
+"""
+
+import copy
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ParallelismDegrees:
+    """Container for parallelism degrees.
+    
+    Formula: world_size = TP × PP × CP × DP
+    Note: EP operates INSIDE DP, not as a separate dimension.
+    """
+    tensor_model_parallel_size: int = 1
+    pipeline_model_parallel_size: int = 1
+    context_parallel_size: int = 1
+    expert_model_parallel_size: int = 1
+    expert_tensor_parallel_size: int = 1
+    sequence_parallel: bool = False
+    data_parallel_size: int = 1
+    model_parallel_size: int = 1
+    
+    @classmethod
+    def from_megatron_config(cls, megatron_cfg, n_gpus: int) -> "ParallelismDegrees":
+        """Extract parallelism degrees from Megatron config."""
+        tp = int(getattr(megatron_cfg, "tensor_model_parallel_size", 1))
+        pp = int(getattr(megatron_cfg, "pipeline_model_parallel_size", 1))
+        cp = int(getattr(megatron_cfg, "context_parallel_size", 1))
+        ep = int(getattr(megatron_cfg, "expert_model_parallel_size", 1))
+        etp = int(getattr(megatron_cfg, "expert_tensor_parallel_size", 1) or 1)
+        sp = bool(getattr(megatron_cfg, "sequence_parallel", False))
+        
+        model_parallel_size = tp * pp * cp
+        
+        if model_parallel_size > 0 and n_gpus % model_parallel_size == 0:
+            dp = n_gpus // model_parallel_size
+        else:
+            dp = max(1, n_gpus // model_parallel_size) if model_parallel_size > 0 else 1
+        
+        return cls(
+            tensor_model_parallel_size=tp,
+            pipeline_model_parallel_size=pp,
+            context_parallel_size=cp,
+            expert_model_parallel_size=ep,
+            expert_tensor_parallel_size=etp,
+            sequence_parallel=sp,
+            data_parallel_size=dp,
+            model_parallel_size=model_parallel_size,
+        )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for pool_degrees."""
+        return {
+            "tensor_model_parallel_size": self.tensor_model_parallel_size,
+            "pipeline_model_parallel_size": self.pipeline_model_parallel_size,
+            "context_parallel_size": self.context_parallel_size,
+            "expert_model_parallel_size": self.expert_model_parallel_size,
+            "expert_tensor_parallel_size": self.expert_tensor_parallel_size,
+            "sequence_parallel": self.sequence_parallel,
+            "data_parallel_size": self.data_parallel_size,
+            "model_parallel_size": self.model_parallel_size,
+        }
+    
+    def validate(self, n_gpus: int, n_gpus_per_node: int, nnodes: int) -> List[str]:
+        """Validate degrees against cluster configuration. Returns list of messages."""
+        messages = []
+        
+        if n_gpus % self.model_parallel_size != 0:
+            messages.append(
+                f"ERROR: Total GPUs ({n_gpus}) must be divisible by model_parallel_size "
+                f"(TP={self.tensor_model_parallel_size} × PP={self.pipeline_model_parallel_size} "
+                f"× CP={self.context_parallel_size} = {self.model_parallel_size})."
+            )
+        
+        if self.expert_model_parallel_size > 1 and self.data_parallel_size % self.expert_model_parallel_size != 0:
+            messages.append(
+                f"ERROR: EP ({self.expert_model_parallel_size}) must divide DP ({self.data_parallel_size})."
+            )
+        
+        if self.tensor_model_parallel_size > n_gpus_per_node:
+            messages.append(
+                f"WARNING: TP ({self.tensor_model_parallel_size}) > n_gpus_per_node ({n_gpus_per_node}). "
+                f"Cross-node TP may reduce performance."
+            )
+        
+        if self.pipeline_model_parallel_size > 1 and self.pipeline_model_parallel_size > nnodes:
+            messages.append(
+                f"WARNING: PP ({self.pipeline_model_parallel_size}) > nnodes ({nnodes})."
+            )
+        
+        return messages
+    
+    def get_summary(self) -> str:
+        """Return human-readable summary."""
+        return (
+            f"TP={self.tensor_model_parallel_size}, PP={self.pipeline_model_parallel_size}, "
+            f"CP={self.context_parallel_size}, EP={self.expert_model_parallel_size}, "
+            f"DP={self.data_parallel_size}"
+        )
+
+
+def extract_degrees_from_config(config, n_gpus: int) -> Optional[ParallelismDegrees]:
+    """Extract parallelism degrees from verl config."""
+    actor_cfg = getattr(config.actor_rollout_ref, "actor", None)
+    megatron_cfg = getattr(actor_cfg, "megatron", None) if actor_cfg is not None else None
+    
+    if megatron_cfg is None:
+        return None
+    
+    return ParallelismDegrees.from_megatron_config(megatron_cfg, n_gpus)
+
+
+def get_cluster_placement_racks() -> Dict[str, List[str]]:
+    """Discover rack-to-node placement from Ray nodes (looks for RACK_* resources)."""
+    try:
+        import ray
+        nodes = ray.nodes()
+    except Exception as e:
+        logger.warning(f"Failed to query Ray nodes: {e}")
+        return {}
+    
+    rack_map = defaultdict(list)
+    
+    for node in nodes:
+        if not node.get("Alive", False):
+            continue
+
+        resources = node.get("Resources", {})
+        node_id = node.get("NodeID", "")
+
+        # Deterministic pick when a node declares multiple RACK_* resources (same string Ray uses).
+        rack_keys = sorted(
+            (k for k in resources if k.upper().startswith("RACK_")),
+            key=lambda k: k.upper(),
+        )
+        if rack_keys:
+            rack_map[rack_keys[0]].append(node_id)
+
+    return dict(rack_map)
+
+
+def get_ray_declared_rack_resource_keys() -> set[str]:
+    """Exact RACK_* resource name strings on all alive Ray nodes (case-sensitive, as in ``ray start``)."""
+    try:
+        import ray
+    except Exception as e:
+        logger.warning("Failed to import ray for rack resource discovery: %s", e)
+        return set()
+
+    keys: set[str] = set()
+    for node in ray.nodes():
+        if not node.get("Alive", False):
+            continue
+        for key in node.get("Resources", {}):
+            if key.upper().startswith("RACK_"):
+                keys.add(key)
+    return keys
+
+
+def apply_rack_bundle_resource_map(
+    rack_ids: List[str],
+    resource_map: Optional[Dict[str, str]],
+) -> List[str]:
+    """Remap placement rack ids to PG bundle resource names when they must differ from ``selected_nodes[i][0]``."""
+    if not resource_map:
+        return list(rack_ids)
+    return [resource_map.get(rid, rid) for rid in rack_ids]
+
+
+def get_ray_alive_node_ids() -> set[str]:
+    """Ray ``NodeID`` strings for all alive nodes (same as ``selected_nodes[i][1]`` from placement search)."""
+    try:
+        import ray
+    except Exception as e:
+        logger.warning("Failed to import ray for node id validation: %s", e)
+        return set()
+
+    return {n.get("NodeID", "") for n in ray.nodes() if n.get("Alive", False) and n.get("NodeID")}
+
+
+def validate_ray_node_ids_exist(node_ids: List[str]) -> None:
+    """Ensure each id is an alive Ray node's ``NodeID`` (used for placement-group node pinning)."""
+    if not node_ids:
+        return
+    empty_slots = [i for i, nid in enumerate(node_ids) if not nid]
+    if empty_slots:
+        raise ValueError(
+            f"placement_pin_node_affinity: empty Ray NodeID at slot(s) {empty_slots} in selected_nodes"
+        )
+    try:
+        import ray  # noqa: F401
+    except Exception as e:
+        raise RuntimeError(
+            "placement_pin_node_affinity: cannot validate NodeIDs because Ray is not importable"
+        ) from e
+
+    alive = get_ray_alive_node_ids()
+    if not alive:
+        raise ValueError(
+            "placement_pin_node_affinity: ray.nodes() reported no alive NodeIDs; cannot validate placement targets"
+        )
+
+    missing = [nid for nid in node_ids if nid and nid not in alive]
+    if not missing:
+        return
+    raise ValueError(
+        "placement_pin_node_affinity: Ray NodeID(s) "
+        f"{missing} are not among alive nodes. "
+        f"Placement search must use ids from ray.nodes()[*]['NodeID']. "
+        f"Alive NodeIDs (sample): {sorted(x for x in alive if x)[:32]}"
+    )
+
+
+def validate_placement_targets_distinct_ray_nodes(node_ids: List[str]) -> None:
+    """Each PG maps to one machine; duplicate Ray NodeIDs would pack multiple STRICT_PACK groups onto the same node."""
+    nonempty = [nid for nid in node_ids if nid]
+    if len(nonempty) <= 1:
+        return
+    if len(set(nonempty)) != len(nonempty):
+        raise ValueError(
+            "placement_pin_node_affinity: duplicate Ray NodeID among placement targets "
+            f"{node_ids}; each nnodes slot must be a distinct node for multi-node training"
+        )
+
+
+def validate_rack_bundle_resource_labels(rack_labels: List[str]) -> None:
+    """Ensure PG bundle requests use resource names actually declared on the cluster (exact match)."""
+    if not rack_labels:
+        return
+    available = get_ray_declared_rack_resource_keys()
+    missing = [r for r in rack_labels if r and r not in available]
+    if not missing:
+        return
+    raise ValueError(
+        "placement_pin_rack_resources: placement-group bundle rack resource(s) "
+        f"{missing} are not declared on any alive Ray node. Names must match exactly (case-sensitive) "
+        'what `ray start --resources` registers, e.g. \'{"RACK_A": 1}\'. '
+        f"Available RACK_* keys on this cluster: {sorted(available)}"
+    )
+
+
+def _can_place_rack_strict_pack_pg(
+    res: Dict[str, float],
+    n_accel: int,
+    rack_key: str,
+    max_colocate_count: int,
+    rack_fraction: float,
+) -> bool:
+    """One STRICT_PACK PG on a node: n bundles, each with CPU, accelerator, and rack_fraction of RACK_*."""
+    if res.get("CPU", 0) < n_accel * max_colocate_count:
+        return False
+    if rack_key and res.get(rack_key, 0) < n_accel * rack_fraction:
+        return False
+    if res.get("GPU", 0) >= n_accel:
+        return True
+    if res.get("NPU", 0) >= n_accel:
+        return True
+    return False
+
+
+def _consume_rack_strict_pack_pg(
+    res: Dict[str, float],
+    n_accel: int,
+    rack_key: str,
+    max_colocate_count: int,
+    rack_fraction: float,
+) -> None:
+    res["CPU"] = float(res.get("CPU", 0)) - n_accel * max_colocate_count
+    if res.get("GPU", 0) >= n_accel:
+        res["GPU"] = float(res.get("GPU", 0)) - n_accel
+    else:
+        res["NPU"] = float(res.get("NPU", 0)) - n_accel
+    if rack_key:
+        res[rack_key] = float(res.get(rack_key, 0)) - n_accel * rack_fraction
+
+
+def validate_rack_pinned_pools_feasible(
+    resource_pool_spec: Dict[str, List[int]],
+    pool_rack_labels: Optional[Dict[str, List[str]]],
+    node_available_resources: Dict[str, Dict[str, float]],
+    max_colocate_count: int = 3,
+    rack_fraction: float = 1e-4,
+) -> None:
+    """Fail fast before ``pg.ready()`` if RACK-tagged PGs cannot fit per-node (CPU/GPU/NPU + RACK).
+
+    Mirrors ``RayResourcePool.get_placement_groups`` bundle shape: each bundle requests ``rack_fraction``
+    of the rack custom resource (same as accelerator_type). Greedy placement: largest PGs first.
+    """
+    if not pool_rack_labels:
+        return
+
+    slots: List[Tuple[int, str, str]] = []
+    for pool_name, process_on_nodes in resource_pool_spec.items():
+        rack_list = pool_rack_labels.get(pool_name)
+        if not rack_list or len(rack_list) != len(process_on_nodes):
+            continue
+        for idx, n in enumerate(process_on_nodes):
+            rkey = rack_list[idx] if idx < len(rack_list) else ""
+            if not rkey:
+                continue
+            slots.append((n, rkey, f"{pool_name}[{idx}]"))
+
+    if not slots:
+        return
+
+    state: Dict[str, Dict[str, float]] = copy.deepcopy(node_available_resources)
+    for nid in state:
+        state[nid] = {k: float(v) for k, v in state[nid].items()}
+
+    slots.sort(key=lambda x: -x[0])
+
+    for n_accel, rack_key, label in slots:
+        placed = False
+        for node_id, res in state.items():
+            if _can_place_rack_strict_pack_pg(res, n_accel, rack_key, max_colocate_count, rack_fraction):
+                _consume_rack_strict_pack_pg(res, n_accel, rack_key, max_colocate_count, rack_fraction)
+                placed = True
+                break
+        if not placed:
+            sample_nodes = list(state.keys())[:12]
+            raise ValueError(
+                "placement_pin_rack_resources: cannot place a STRICT_PACK placement group on any single node "
+                f"for slot {label} (need {n_accel} GPU or NPU on one node, "
+                f"CPU>={n_accel * max_colocate_count}, and rack {rack_key!r} >= {n_accel * rack_fraction}). "
+                "Total cluster accelerators can be enough while no one node satisfies CPU/GPU/NPU+RACK together. "
+                f"Node ids in this check (sample): {sample_nodes}"
+            )
+
+
+def get_rack_capacities(rack_map: Dict[str, List[str]], npus_per_node: int) -> Dict[str, int]:
+    """Get capacity of each rack in NPUs."""
+    return {rack_id: len(nodes) * npus_per_node for rack_id, nodes in rack_map.items()}
+
+
+def _select_nodes_group_within_rack(
+    total_npus: int,
+    npus_per_node: int,
+    rack_map: Dict[str, List[str]],
+    group_size: int,
+    description: str,
+) -> Optional[List[Tuple[str, str]]]:
+    """Allocate nodes keeping groups of group_size NPUs within the same rack."""
+    if group_size <= 1 or group_size > total_npus:
+        return None
+
+    if total_npus % group_size != 0:
+        logger.debug(f"  ✗ {description}: total NPUs {total_npus} not divisible by group size {group_size}")
+        return None
+
+    num_nodes_needed = (total_npus + npus_per_node - 1) // npus_per_node
+    num_groups = total_npus // group_size
+
+    rack_state: Dict[str, List[Dict[str, Union[str, int]]]] = {
+        rack_id: [{"id": node_id, "remaining": npus_per_node, "used": 0} for node_id in rack_map[rack_id]]
+        for rack_id in rack_map
+    }
+    rack_remaining_capacity = {rack_id: len(nodes) * npus_per_node for rack_id, nodes in rack_map.items()}
+    used_racks = set()
+
+    for group_idx in range(num_groups):
+        candidate_racks = [rid for rid in rack_state if rack_remaining_capacity[rid] >= group_size]
+        if not candidate_racks:
+            logger.debug(f"  ✗ {description}: insufficient rack capacity for group {group_idx}")
+            return None
+
+        candidate_racks.sort(key=lambda rid: (rid not in used_racks, -rack_remaining_capacity[rid], rid))
+        selected_rack = candidate_racks[0]
+        group_remaining = group_size
+
+        for node_state in rack_state[selected_rack]:
+            if group_remaining <= 0:
+                break
+            remaining = int(node_state["remaining"])
+            if remaining <= 0:
+                continue
+            allocation = min(remaining, group_remaining)
+            node_state["remaining"] = remaining - allocation
+            node_state["used"] = int(node_state["used"]) + allocation
+            group_remaining -= allocation
+
+        if group_remaining > 0:
+            logger.debug(f"  ✗ {description}: rack {selected_rack} cannot accommodate group size {group_size}")
+            return None
+
+        rack_remaining_capacity[selected_rack] -= group_size
+        used_racks.add(selected_rack)
+
+    selected_nodes: List[Tuple[str, str]] = []
+    per_rack_usage: Dict[str, Dict[str, int]] = {}
+
+    for rack_id in sorted(rack_state.keys()):
+        rack_usage: Dict[str, int] = {}
+        for node_state in rack_state[rack_id]:
+            used = int(node_state["used"])
+            if used > 0:
+                node_id = str(node_state["id"])
+                selected_nodes.append((rack_id, node_id))
+                rack_usage[node_id] = used
+        if rack_usage:
+            per_rack_usage[rack_id] = rack_usage
+
+    if len(selected_nodes) != num_nodes_needed:
+        logger.debug(f"  ✗ {description}: node count mismatch (expected {num_nodes_needed}, got {len(selected_nodes)})")
+        return None
+
+    logger.info(f"  ✓ Strategy: {description}")
+    for rack_id, usage in per_rack_usage.items():
+        logger.info(f"    {rack_id}: {len(usage)} nodes, {sum(usage.values())} NPUs")
+
+    return selected_nodes
+
+
+def select_balanced_nodes(
+    total_npus: int, 
+    npus_per_node: int, 
+    rack_map: Dict[str, List[str]],
+    degrees: Optional[ParallelismDegrees] = None
+) -> List[Tuple[str, str]]:
+    """Select nodes with rack-aware placement search.
+    
+    Hierarchical approach - try progressively larger groups within rack:
+        1. Single-rack (if all NPUs fit in one rack)
+        2. TP within rack (mandatory, warns if fails)
+        3. TP×CP within rack (if fits, use it; otherwise CP spans racks)
+        4. TP×CP×PP within rack (if fits, use it; otherwise PP spans racks)
+        5. DP replicas within rack (each replica = TP×CP×PP NPUs)
+        6. Sequential fallback (fill largest racks first)
+        7. Symmetric fallback (even distribution)
+    
+    The largest successful grouping is used. Higher communication dimensions
+    (TP, CP) are prioritized to stay within rack for bandwidth.
+    
+    Note: EP is NOT considered for rack placement as it operates within DP dimension.
+    """
+    num_nodes_needed = (total_npus + npus_per_node - 1) // npus_per_node
+    sorted_racks = sorted(rack_map.keys())
+
+    if len(sorted_racks) == 0:
+        raise ValueError("No available rack in placement map")
+
+    rack_capacities = get_rack_capacities(rack_map, npus_per_node)
+
+    logger.info(f"Resource requirements: {total_npus} NPUs ({num_nodes_needed} nodes)")
+    for rack_id in sorted_racks:
+        logger.info(f"  {rack_id}: {rack_capacities[rack_id]} NPUs ({len(rack_map[rack_id])} nodes)")
+
+    # Try single rack first
+    suitable_racks = [(rid, cap) for rid, cap in rack_capacities.items() if cap >= total_npus]
+    if suitable_racks:
+        best_rack = min(suitable_racks, key=lambda x: x[1])
+        rack_id = best_rack[0]
+        logger.info(f"✓ Strategy: single rack allocation ({rack_id})")
+        
+        selected_nodes = []
+        available_nodes = rack_map[rack_id]
+        for i in range(num_nodes_needed):
+            if i < len(available_nodes):
+                selected_nodes.append((rack_id, available_nodes[i]))
+            else:
+                raise ValueError(f"Rack {rack_id} has insufficient nodes")
+        return selected_nodes
+
+    def attempt_group(group_size: int, description: str) -> Optional[List[Tuple[str, str]]]:
+        if group_size <= 1:
+            return None
+        return _select_nodes_group_within_rack(total_npus, npus_per_node, rack_map, group_size, description)
+
+    selection: Optional[List[Tuple[str, str]]] = None
+
+    if degrees:
+        tp_size = degrees.tensor_model_parallel_size
+        cp_size = degrees.context_parallel_size
+        pp_size = degrees.pipeline_model_parallel_size
+        dp_size = degrees.data_parallel_size
+        # Note: EP not used for rack placement as it operates within DP
+
+        logger.info(f"Parallelization: {degrees.get_summary()}")
+
+        # Hierarchical approach: try progressively larger groups within rack
+        # Each level includes all previous levels
+        
+        # Level 1: TP within rack (mandatory - warn if fails)
+        current_group_size = tp_size
+        if tp_size > 1:
+            tp_selection = attempt_group(current_group_size, "TP within rack")
+            if not tp_selection:
+                logger.warning("⚠️ Unable to place TP groups within a single rack.")
+            else:
+                selection = tp_selection
+
+        # Level 2: TP×CP within rack
+        if cp_size > 1:
+            current_group_size = tp_size * cp_size
+            cp_selection = attempt_group(current_group_size, "TP×CP within rack")
+            if cp_selection:
+                selection = cp_selection
+                logger.info(f"  → CP groups fit within rack (group_size={current_group_size})")
+
+        # Level 3: TP×CP×PP within rack
+        if pp_size > 1:
+            current_group_size = tp_size * cp_size * pp_size
+            pp_selection = attempt_group(current_group_size, "TP×CP×PP within rack")
+            if pp_selection:
+                selection = pp_selection
+                logger.info(f"  → PP stages fit within rack (group_size={current_group_size})")
+            else:
+                logger.info(f"  → PP will span racks (TP×CP×PP={current_group_size} > rack capacity)")
+
+        # Level 4: TP×CP×PP×DP within rack (= all NPUs in one rack, already handled above)
+        # If we reach here and DP > 1, DP will span racks
+        if dp_size > 1:
+            # model_parallel_size = TP×CP×PP, this is what stays within each DP replica
+            model_parallel_size = tp_size * cp_size * pp_size
+            full_group_size = model_parallel_size * dp_size  # = total_npus
+            if full_group_size <= total_npus:
+                # Try to fit each DP replica (model_parallel_size) within a rack
+                dp_selection = attempt_group(model_parallel_size, "DP replicas within rack")
+                if dp_selection:
+                    selection = dp_selection
+                    logger.info(f"  → Each DP replica ({model_parallel_size} NPUs) fits within rack")
+                else:
+                    logger.info(f"  → DP will span racks")
+
+    if selection:
+        return selection
+
+    # Sequential fallback (fill rack A, then B, etc.)
+    sequential_selection = _sequential_allocation(total_npus, npus_per_node, num_nodes_needed, rack_map, rack_capacities, sorted_racks)
+    if sequential_selection:
+        return sequential_selection
+
+    # Symmetric fallback (even distribution)
+    return _symmetric_allocation(total_npus, npus_per_node, num_nodes_needed, rack_map, rack_capacities, sorted_racks)
+
+
+def _sequential_allocation(
+    total_npus: int,
+    npus_per_node: int,
+    num_nodes_needed: int,
+    rack_map: Dict[str, List[str]],
+    rack_capacities: Dict[str, int],
+    sorted_racks: List[str],
+) -> Optional[List[Tuple[str, str]]]:
+    """Sequential allocation: fill rack A completely, then B, then C, etc.
+    
+    This minimizes cross-rack communication by keeping most work in fewer racks.
+    """
+    total_capacity = sum(rack_capacities.values())
+    if total_capacity < total_npus:
+        return None
+
+    selected_nodes: List[Tuple[str, str]] = []
+    remaining_nodes = num_nodes_needed
+    per_rack_usage: Dict[str, int] = {}
+
+    # Sort racks by capacity (largest first) for better packing
+    racks_by_capacity = sorted(sorted_racks, key=lambda r: -rack_capacities[r])
+
+    for rack_id in racks_by_capacity:
+        if remaining_nodes <= 0:
+            break
+        
+        available_nodes = rack_map[rack_id]
+        nodes_from_rack = min(len(available_nodes), remaining_nodes)
+        
+        for i in range(nodes_from_rack):
+            selected_nodes.append((rack_id, available_nodes[i]))
+        
+        if nodes_from_rack > 0:
+            per_rack_usage[rack_id] = nodes_from_rack
+        remaining_nodes -= nodes_from_rack
+
+    if remaining_nodes > 0:
+        return None
+
+    logger.info("✓ Strategy: Sequential allocation (fill largest racks first)")
+    for rack_id, count in per_rack_usage.items():
+        logger.info(f"    {rack_id}: {count} nodes, {count * npus_per_node} NPUs")
+
+    return selected_nodes
+
+
+def _symmetric_allocation(
+    total_npus: int,
+    npus_per_node: int,
+    num_nodes_needed: int,
+    rack_map: Dict[str, List[str]],
+    rack_capacities: Dict[str, int],
+    sorted_racks: List[str],
+) -> List[Tuple[str, str]]:
+    """Symmetric fallback allocation across racks."""
+    logger.info("✓ Strategy: Symmetric allocation across racks")
+
+    total_capacity = sum(rack_capacities.values())
+    if total_capacity < total_npus:
+        raise ValueError(f"Insufficient capacity: need {total_npus} NPUs, have {total_capacity}")
+
+    num_racks_available = len(sorted_racks)
+    min_racks_needed = None
+    nodes_per_rack = None
+    remaining_nodes = 0
+
+    # Try perfect symmetry
+    for num_racks_to_use in range(1, num_racks_available + 1):
+        if num_nodes_needed % num_racks_to_use == 0:
+            candidate_nodes_per_rack = num_nodes_needed // num_racks_to_use
+            suitable_count = sum(
+                1 for rack_id in sorted_racks[:num_racks_to_use]
+                if rack_capacities[rack_id] >= candidate_nodes_per_rack * npus_per_node
+                and len(rack_map[rack_id]) >= candidate_nodes_per_rack
+            )
+            if suitable_count == num_racks_to_use:
+                min_racks_needed = num_racks_to_use
+                nodes_per_rack = candidate_nodes_per_rack
+                break
+
+    # Near-symmetric fallback
+    if min_racks_needed is None:
+        for num_racks_to_use in range(1, num_racks_available + 1):
+            base_nodes = num_nodes_needed // num_racks_to_use
+            extra_nodes = num_nodes_needed % num_racks_to_use
+            
+            can_fit = True
+            for i in range(num_racks_to_use):
+                rack_id = sorted_racks[i]
+                nodes_for_this_rack = base_nodes + (1 if i < extra_nodes else 0)
+                if (rack_capacities[rack_id] < nodes_for_this_rack * npus_per_node or
+                    len(rack_map[rack_id]) < nodes_for_this_rack):
+                    can_fit = False
+                    break
+
+            if can_fit:
+                min_racks_needed = num_racks_to_use
+                nodes_per_rack = base_nodes
+                remaining_nodes = extra_nodes
+                break
+
+    if min_racks_needed is None:
+        min_racks_needed = num_racks_available
+        nodes_per_rack = num_nodes_needed // num_racks_available
+        remaining_nodes = num_nodes_needed % num_racks_available
+
+    logger.info(f"  {num_nodes_needed} nodes → {min_racks_needed} racks")
+
+    selected_nodes = []
+    for rack_idx, rack_id in enumerate(sorted_racks[:min_racks_needed]):
+        available_nodes = rack_map[rack_id]
+        nodes_to_take = nodes_per_rack + (1 if rack_idx < remaining_nodes else 0)
+
+        if nodes_to_take > len(available_nodes):
+            raise ValueError(f"Rack {rack_id} has insufficient nodes")
+
+        logger.info(f"  {rack_id}: {nodes_to_take} nodes")
+
+        for node_id in available_nodes[:nodes_to_take]:
+            selected_nodes.append((rack_id, node_id))
+            if len(selected_nodes) >= num_nodes_needed:
+                break
+        if len(selected_nodes) >= num_nodes_needed:
+            break
+
+    return selected_nodes
+
+
+def compute_process_on_nodes(
+    n_gpus_per_node: int,
+    nnodes: int,
+    degrees: Optional[ParallelismDegrees] = None,
+    enable_placement: bool = False,
+) -> Tuple[List[int], Optional[List[Tuple[str, str]]]]:
+    """Compute process_on_nodes with optional placement search."""
+    n_gpus = n_gpus_per_node * nnodes
+    process_on_nodes = [n_gpus_per_node] * nnodes
+    selected_nodes = None
+    
+    if not enable_placement:
+        return process_on_nodes, selected_nodes
+    
+    rack_map = get_cluster_placement_racks()
+    
+    if not rack_map:
+        logger.info("No rack information available, using flat placement")
+        return process_on_nodes, selected_nodes
+    
+    logger.info(f"Placement search enabled. Found {len(rack_map)} racks.")
+    
+    try:
+        selected_nodes = select_balanced_nodes(
+            total_npus=n_gpus,
+            npus_per_node=n_gpus_per_node,
+            rack_map=rack_map,
+            degrees=degrees,
+        )
+        logger.info(f"Placement selection: {len(selected_nodes)} nodes")
+    except Exception as e:
+        logger.warning(f"Placement search failed: {e}. Using flat placement.")
+        selected_nodes = None
+    
+    return process_on_nodes, selected_nodes
+
+
+def init_pool_degrees_and_spec(
+    config,
+    global_pool_id: str = "global_pool",
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, List[int]], Optional[List[Tuple[str, str]]]]:
+    """Initialize pool_degrees and resource_pool_spec from config.
+
+    Set config.trainer.enable_placement = True to enable placement search.
+    With config.trainer.placement_pin_rack_resources, main_ppo passes rack ids from
+    selected_nodes into Ray placement-group bundles as custom resources; names are
+    validated against the live Ray cluster (or remapped via placement_rack_bundle_resource_map).
+    With config.trainer.placement_pin_node_affinity, placement groups use Ray
+    ``_soft_target_node_id`` with ``selected_nodes[i][1]`` (Ray NodeID).
+    """
+    n_gpus_per_node = config.trainer.n_gpus_per_node
+    nnodes = config.trainer.nnodes
+    n_gpus = n_gpus_per_node * nnodes
+    
+    # Default: placement search disabled for backward compatibility
+    enable_placement = getattr(config.trainer, "enable_placement", False)
+    
+    degrees = extract_degrees_from_config(config, n_gpus)
+    
+    pool_degrees: Dict[str, Dict[str, Any]] = {}
+    
+    if degrees is not None:
+        messages = degrees.validate(n_gpus, n_gpus_per_node, nnodes)
+        for msg in messages:
+            if msg.startswith("ERROR"):
+                raise ValueError(msg)
+            else:
+                logger.warning(msg)
+        
+        pool_degrees[global_pool_id] = degrees.to_dict()
+        logger.info(f"Parallelism degrees: {degrees.get_summary()}")
+    
+    process_on_nodes, selected_nodes = compute_process_on_nodes(
+        n_gpus_per_node=n_gpus_per_node,
+        nnodes=nnodes,
+        degrees=degrees,
+        enable_placement=enable_placement,
+    )
+    
+    resource_pool_spec = {global_pool_id: process_on_nodes}
+    
+    return pool_degrees, resource_pool_spec, selected_nodes

--- a/verl/utils/placement.py
+++ b/verl/utils/placement.py
@@ -171,12 +171,13 @@ def get_ray_declared_rack_resource_keys() -> set[str]:
     """Exact RACK_* resource name strings on all alive Ray nodes (case-sensitive, as in ``ray start``)."""
     try:
         import ray
+        nodes = ray.nodes()
     except Exception as e:
-        logger.warning("Failed to import ray for rack resource discovery: %s", e)
+        logger.warning("Failed to query Ray nodes for rack resource discovery: %s", e)
         return set()
 
     keys: set[str] = set()
-    for node in ray.nodes():
+    for node in nodes:
         if not node.get("Alive", False):
             continue
         for key in node.get("Resources", {}):
@@ -199,11 +200,12 @@ def get_ray_alive_node_ids() -> set[str]:
     """Ray ``NodeID`` strings for all alive nodes (same as ``selected_nodes[i][1]`` from placement search)."""
     try:
         import ray
+        nodes = ray.nodes()
     except Exception as e:
-        logger.warning("Failed to import ray for node id validation: %s", e)
+        logger.warning("Failed to query Ray nodes for node id validation: %s", e)
         return set()
 
-    return {n.get("NodeID", "") for n in ray.nodes() if n.get("Alive", False) and n.get("NodeID")}
+    return {n.get("NodeID", "") for n in nodes if n.get("Alive", False) and n.get("NodeID")}
 
 
 def validate_ray_node_ids_exist(node_ids: List[str]) -> None:
@@ -747,7 +749,9 @@ def init_pool_degrees_and_spec(
     n_gpus = n_gpus_per_node * nnodes
     
     # Default: placement search disabled for backward compatibility
-    enable_placement = getattr(config.trainer, "enable_placement", False)
+    from omegaconf import OmegaConf
+
+    enable_placement = OmegaConf.select(config, "trainer.enable_placement", default=False)
     
     degrees = extract_degrees_from_config(config, n_gpus)
     

--- a/verl/utils/placement.py
+++ b/verl/utils/placement.py
@@ -150,6 +150,10 @@ def get_cluster_placement_racks() -> Dict[str, List[str]]:
             continue
 
         resources = node.get("Resources", {})
+        # Skip CPU-only nodes (e.g. head) that may still declare RACK_* resources.
+        if resources.get("GPU", 0) == 0 and resources.get("NPU", 0) == 0:
+            continue
+
         node_id = node.get("NodeID", "")
 
         # Deterministic pick when a node declares multiple RACK_* resources (same string Ray uses).
@@ -614,6 +618,8 @@ def _symmetric_allocation(
 ) -> List[Tuple[str, str]]:
     """Symmetric fallback allocation across racks."""
     logger.info("✓ Strategy: Symmetric allocation across racks")
+    # Prefer racks with more nodes (avoid arbitrary alphabetical ordering).
+    sorted_racks = sorted(sorted_racks, key=lambda r: -len(rack_map[r]))
 
     total_capacity = sum(rack_capacities.values())
     if total_capacity < total_npus:

--- a/verl/utils/profiler/performance.py
+++ b/verl/utils/profiler/performance.py
@@ -212,12 +212,19 @@ def reduce_timing(
     if not dist.is_initialized():
         return timing_raw
 
+    # Gloo backend does not support ReduceOp.AVG; use SUM then divide by world_size
+    use_avg = reduce_op == torch.distributed.ReduceOp.AVG
+    if use_avg:
+        reduce_op = torch.distributed.ReduceOp.SUM
+
     key_list, timing_list = [], []
     for key in sorted(timing_raw.keys()):
         key_list.append(key)
         timing_list.append(timing_raw[key])
     timing_list = torch.tensor(timing_list, dtype=torch.float32, device=get_device_id())
     torch.distributed.all_reduce(timing_list, op=reduce_op)
+    if use_avg:
+        timing_list = timing_list / dist.get_world_size()
     timing_list = [tensor.item() for tensor in timing_list.to("cpu")]
     timing_generate = {key_list[i]: timing_list[i] for i in range(len(key_list))}
     return timing_generate
@@ -229,7 +236,7 @@ def topk_reduce_ratio_min_max(timing: float, k: int = 10) -> tuple[float, float,
         return -1.0, -1.0, -1.0
 
     world_size = dist.get_world_size()
-    timing_tensor = torch.tensor(timing, dtype=torch.float32, device=get_device_id())
+    timing_tensor = torch.tensor([timing], dtype=torch.float32, device=get_device_id())
     tensor_list = [torch.zeros(1, dtype=torch.float32, device=get_device_id()) for _ in range(world_size)]
     torch.distributed.all_gather(tensor_list, timing_tensor)
     tensor_stack = torch.stack(tensor_list)

--- a/verl/workers/rollout/hf_rollout.py
+++ b/verl/workers/rollout/hf_rollout.py
@@ -21,6 +21,7 @@ to perform generation.
 import contextlib
 
 import torch
+from omegaconf import OmegaConf
 import torch.distributed
 from tensordict import TensorDict
 from torch import nn
@@ -37,10 +38,31 @@ __all__ = ["HFRollout"]
 
 
 class HFRollout(BaseRollout):
-    def __init__(self, module: nn.Module, config):
-        super().__init__()
-        self.config = config
+    def __init__(self, module: nn.Module, config, model_config=None, device_mesh=None):
+        from verl.utils.config import omega_conf_to_dataclass
+        from verl.workers.config import HFModelConfig
+
+        _model_config = model_config if model_config is not None else omega_conf_to_dataclass({}, dataclass_type=HFModelConfig)
+        super().__init__(config=config, model_config=_model_config, device_mesh=device_mesh)
+        self.config = config if (hasattr(config, "get") or isinstance(config, dict)) else {}  # keep dict-like for .get()
         self.module = module
+
+    async def resume(self, tags: list[str]):
+        """No-op: HFRollout uses the same module as actor, weights already in memory."""
+        pass
+
+    async def update_weights(
+        self,
+        weights,  # Generator[tuple[str, torch.Tensor], None, None]
+        **kwargs,
+    ):
+        """No-op: HFRollout uses the same module as actor, no weight sync needed."""
+        for _ in weights:
+            pass
+
+    async def release(self):
+        """No-op: HFRollout does not manage separate GPU memory."""
+        pass
 
     def generate_sequences(self, prompts: DataProto) -> DataProto:
         batch_size = prompts.batch.batch_size[0]
@@ -170,8 +192,9 @@ class HFRollout(BaseRollout):
             batch_size=generated_batch_size,
         )
 
-        # empty cache before compute old_log_prob
-        get_torch_device().empty_cache()
+        # empty cache before compute old_log_prob (no-op on CPU)
+        if get_device_name() != "cpu" and hasattr(get_torch_device(), "empty_cache"):
+            get_torch_device().empty_cache()
 
         self.module.train()
         return DataProto(batch=batch)


### PR DESCRIPTION

## Summary

Adds **analytical auto-parallelization** for Megatron-based PPO training (optional, off by default):

- New `verl/utils/auto_parallelization.py`: formula-based TP/PP/CP/EP/DP search with memory gating (`trainer.auto_parallel.*`).
- `main_ppo`: calls `apply_analytical_auto_parallel_degrees()` before `validate_config()` when `trainer.auto_parallel.enabled=true`.
- Supporting changes: device/distributed helpers (`get_distributed_backend`), `validate_config` CPU-mode guard, Megatron engine config, HF rollout tokenization in `ray_trainer` / `hf_rollout`.

**Depends on PR1** (rack-aware placement): uses `verl.utils.placement.extract_degrees_from_config` / `ParallelismDegrees`. Merge PR1 first, or review this stacked on top of PR1.


Duplicate check
Searched open PRs on verl-project/verl for analytical auto-parallel / auto_parallelization; no matching open PR at submit time.

## Stack
- **PR1:** placement search — link your PR1 URL here: `https://github.com/verl-project/verl/pull/XXXX`
- **This PR:** auto-parallel (commits `d2f9a7be`, `84156db2` on `pr2/auto-parallel-config`)

## Config (already in `ppo_trainer.yaml` from PR1; enabled via CLI)



```bash
python -m verl.trainer.main_ppo trainer.auto_parallel.enabled=true

