### PR TITLE
[veomni] feat: reduce extra memory from O(E) to O(E/ep_size) during weight refit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@
 /verl/workers/engine @eric-haibin-lin @vermouth1992 @ZihengJiang @ArronHZG
 /verl/workers/roles @eric-haibin-lin @vermouth1992 @ZihengJiang
 /verl/workers/engine/fsdp @eric-haibin-lin @vermouth1992 @ZihengJiang
+/verl/workers/engine/veomni @wuxibin89 @Luosuu @FoolPlayer
 /verl/workers/rollout/vllm_rollout @wuxibin89 @PeterSH6 @chenhaiq @ArronHZG
 /verl/workers/rollout/sglang_rollout @zhaochenyang20 @SwordFaith @chenhaiq @ArronHZG
 /verl/workers/engine/megatron @ISEEKYAN @vermouth1992

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -139,6 +139,9 @@ jobs:
         run: |
           ray stop --force
           MODEL_ID=Qwen/Qwen3-VL-2B-Instruct TRAIN_FILES=${HOME}/data/geo3k/train.parquet VAL_FILES=${HOME}/data/gsm8k/test.parquet FSDP_SIZE=8 SP_SIZE=1 bash tests/special_e2e/run_ppo_trainer_veomni.sh
+      - name: Test export unfused experts
+        run: |
+          torchrun --nproc_per_node=8 -m pytest tests/utils/veomni/test_special_export_unfused_experts.py
 
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_veomni_vllm.yml
@@ -141,7 +141,7 @@ jobs:
           MODEL_ID=Qwen/Qwen3-VL-2B-Instruct TRAIN_FILES=${HOME}/data/geo3k/train.parquet VAL_FILES=${HOME}/data/gsm8k/test.parquet FSDP_SIZE=8 SP_SIZE=1 bash tests/special_e2e/run_ppo_trainer_veomni.sh
       - name: Test export unfused experts
         run: |
-          torchrun --nproc_per_node=8 -m pytest tests/utils/veomni/test_special_export_unfused_experts.py
+          torchrun --nproc_per_node=8 tests/utils/veomni/test_special_export_unfused_experts.py
 
   cleanup:
     runs-on: ubuntu-latest

--- a/tests/utils/veomni/test_special_export_unfused_experts.py
+++ b/tests/utils/veomni/test_special_export_unfused_experts.py
@@ -1,0 +1,135 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import fully_shard
+from torch.distributed.tensor import DTensor, Shard, distribute_tensor
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import Qwen3_5MoeTextConfig
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeDecoderLayer
+
+from verl.workers.engine.veomni.utils import MOE_PARAM_HANDERS
+
+
+def get_by_path(obj, path: str):
+    for part in path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def set_by_path(obj, path: str, value):
+    parts = path.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    setattr(obj, parts[-1], value)
+
+
+def get_per_tensor_param(model, device_mesh):
+    ep_rank, ep_size, ep_group = (
+        device_mesh["ep"].get_local_rank(),
+        device_mesh["ep"].size(),
+        device_mesh["ep"].get_group(),
+    )
+    process_func = MOE_PARAM_HANDERS["qwen3_5_moe"]
+
+    for name, param in model.named_parameters():
+        if not isinstance(param, DTensor):
+            continue
+        unsharded_tensor = param.full_tensor()
+        buffer = torch.empty_like(unsharded_tensor)  # [num_experts/ep_size, H, I]
+        for src_ep_rank in range(ep_size):
+            tensor = unsharded_tensor if src_ep_rank == ep_rank else buffer
+            torch.distributed.broadcast(tensor, group_src=src_ep_rank, group=ep_group)
+            yield from process_func(name, tensor, ep_rank=src_ep_rank)
+
+
+def test_veomni_export_unfused_experts():
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+
+    master_addr = os.environ["MASTER_ADDR"]
+    master_port = os.environ["MASTER_PORT"]
+    world_size = int(os.environ["WORLD_SIZE"])
+    rank = int(os.environ["RANK"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+
+    # init process group
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(
+        backend="nccl", init_method=f"tcp://{master_addr}:{master_port}", world_size=world_size, rank=rank
+    )
+
+    ep_device_mesh = dist.device_mesh.init_device_mesh("cuda", mesh_shape=(2, 4), mesh_dim_names=["efsdp", "ep"])
+
+    config = Qwen3_5MoeTextConfig()
+    layer = Qwen3_5MoeDecoderLayer(config, layer_idx=0)
+    expert_param_names = [
+        "mlp.experts.gate_up_proj",
+        "mlp.experts.down_proj",
+    ]
+
+    # 0. random init experts
+    for param_name in expert_param_names:
+        param = get_by_path(layer, param_name)
+        param.data.normal_(mean=0.0, std=0.01)
+    state_dict = {k: v.clone() for k, v in layer.state_dict().items()}
+
+    # 1. split experts by ep_size in dim=0
+    for param_name in expert_param_names:
+        param = get_by_path(layer, param_name)
+        dtensor = distribute_tensor(
+            param, device_mesh=ep_device_mesh["ep"], placements=(Shard(dim=0),), src_data_rank=None
+        )
+        local_tensor = dtensor.to_local()
+        local_param = torch.nn.Parameter(local_tensor, requires_grad=param.requires_grad)
+        set_by_path(layer, param_name, local_param)
+
+    # 2. fully shard local experts by ep_fsdp_mesh in dim=1
+    ep_mesh_dim_names = ep_device_mesh.mesh_dim_names
+    ep_fsdp_mesh = ep_device_mesh[ep_mesh_dim_names[:-1]]
+    shard_placement_fn = lambda x: Shard(dim=1)
+    fully_shard(layer.mlp.experts, mesh=ep_fsdp_mesh, shard_placement_fn=shard_placement_fn, reshard_after_forward=True)
+
+    exported_params = {}
+    for name, param in get_per_tensor_param(layer, ep_device_mesh):
+        if dist.get_rank() == 0:
+            print(f"rank: {dist.get_rank()}, name: {name}, param: {param.shape}")
+        exported_params[name] = param.clone()
+
+    gate, up, down = [], [], []
+    for name, param in exported_params.items():
+        # mlp.experts.{idx}.down_proj.weight
+        idx = int(name.split(".")[-3])
+        if "gate_proj" in name:
+            gate.append((idx, param))
+        elif "up_proj" in name:
+            up.append((idx, param))
+        elif "down_proj" in name:
+            down.append((idx, param))
+    gate = sorted(gate, key=lambda x: x[0])
+    up = sorted(up, key=lambda x: x[0])
+    down = sorted(down, key=lambda x: x[0])
+    gate = torch.stack([param for _, param in gate], dim=0)
+    up = torch.stack([param for _, param in up], dim=0)
+    down_proj = torch.stack([param for _, param in down], dim=0)
+    gate_up_proj = torch.cat((gate, up), dim=1)
+
+    assert torch.equal(gate_up_proj, state_dict["mlp.experts.gate_up_proj"].to("cuda")), "gate_up_proj is not equal"
+    assert torch.equal(down_proj, state_dict["mlp.experts.down_proj"].to("cuda")), "down_proj is not equal"
+
+
+if __name__ == "__main__":
+    test_veomni_export_unfused_experts()

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -95,7 +95,7 @@ def _detect_platform_name() -> str:
         return env_platform
 
     names = PlatformRegistry.registered_names()
-    logger.info("Registered platforms: %s", names)
+    logger.debug("Registered platforms: %s", names)
 
     for name in names:
         platform_cls = PlatformRegistry.get(name)
@@ -104,7 +104,7 @@ def _detect_platform_name() -> str:
         try:
             instance = platform_cls()
             if instance.is_platform_available(use_smi_check=True):
-                logger.info("Auto-detected platform: %s", name)
+                logger.debug("Auto-detected platform: %s", name)
                 return name
         except Exception as e:
             logger.debug("Platform '%s' detection failed: %s", name, e)
@@ -143,7 +143,7 @@ def get_platform() -> PlatformBase:
     if _current_platform is None:
         name = _detect_platform_name()
         _current_platform = _create_platform(name)
-        logger.info("verl platform initialised: %s", _current_platform.device_name)
+        logger.debug("verl platform initialised: %s", _current_platform.device_name)
     return _current_platform
 
 

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -652,10 +652,9 @@ class VeOmniEngine(FSDPEngine):
         if self._is_offload_param:
             offload_veomni_model_to_cpu(self.module)
 
-        device = get_device_id()
         ps = parallel_state.get_parallel_state()
         model_type = getattr(self.module.config, "model_type", "default")
-        process_func = MOE_PARAM_HANDERS.get(model_type, lambda n, t: iter([(n, t)]))
+        process_func = MOE_PARAM_HANDERS.get(model_type, lambda n, t, ep_rank: iter([(n, t)]))
 
         def param_generator():
             for name, param in params.items():
@@ -665,18 +664,16 @@ class VeOmniEngine(FSDPEngine):
                 is_proj = any(p in name for p in ["down_proj", "gate_proj", "up_proj", "gate_up_proj"])
 
                 if is_expert_layer and is_proj and ps.ep_enabled:
-                    output_shape = list(unsharded_tensor.shape)
-                    output_shape[0] *= ps.extra_parallel_sizes["ep"]
-                    stacked_tensor = torch.empty(output_shape, dtype=unsharded_tensor.dtype, device=device)
+                    ep_rank, ep_size = ps.ep_rank, ps.ep_size
+                    buffer = torch.empty_like(unsharded_tensor)  # [num_experts/ep_size, H, I]
+                    for src_ep_rank in range(ep_size):
+                        tensor = unsharded_tensor if src_ep_rank == ep_rank else buffer
+                        torch.distributed.broadcast(tensor, group_src=src_ep_rank, group=ps.ep_group)
+                        yield from process_func(name, tensor, ep_rank=src_ep_rank)
 
-                    # all gather expert tensors [32, H, I] -> [128, H, I]
-                    torch.distributed.all_gather_into_tensor(stacked_tensor, unsharded_tensor, group=ps.ep_group)
-                    yield from process_func(name, stacked_tensor)
-
-                    del stacked_tensor
                 else:
                     if is_expert_layer:
-                        yield from process_func(name, unsharded_tensor)
+                        yield from process_func(name, unsharded_tensor, ep_rank=0)
                     else:
                         yield name, unsharded_tensor
 

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -108,13 +108,30 @@ def load_veomni_optimizer(optimizer, device_id):
                         state[key] = value.to(device_id, non_blocking=True)
 
 
-def _map_moe_params_qwen3_moe(name, tensor):
-    for i in range(tensor.size(0)):
-        new_key = name.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight"
+def _map_moe_params_common(name, tensor, ep_rank):
+    num_experts_per_rank = tensor.size(0)
+    for i in range(num_experts_per_rank):
+        idx = ep_rank * num_experts_per_rank + i
+        new_key = name.replace("mlp.experts.", f"mlp.experts.{idx}.") + ".weight"
         yield new_key, tensor[i].to(get_device_id(), non_blocking=True)
 
 
+def _map_moe_params_qwen3_moe(name, tensor, ep_rank):
+    if "gate_up_proj" in name:
+        gate, up = tensor.chunk(2, dim=1)
+        params = {
+            name.replace("gate_up_proj", "gate_proj"): gate,
+            name.replace("gate_up_proj", "up_proj"): up,
+        }
+    else:
+        params = {name: tensor}
+
+    for key, value in params.items():
+        yield from _map_moe_params_common(key, value, ep_rank)
+
+
 MOE_PARAM_HANDERS = {
-    "qwen3_moe": _map_moe_params_qwen3_moe,
-    "deepseek_v3": _map_moe_params_qwen3_moe,
+    "qwen3_moe": _map_moe_params_common,
+    "deepseek_v3": _map_moe_params_common,
+    "qwen3_5_moe": _map_moe_params_qwen3_moe,
 }


### PR DESCRIPTION
### What does this PR do?

Before this PR, during weight refit, veomni materialize MoE experts by `all_gather`, requiring extra peak memory `O(E)`.

This PR replace `all_gather` by `broadcast`, each rank broadcast its local sharded experts to other ranks within ep groups sequentially, reducing extra peak memory  from `O(E)` to `O(E/ep_size`).

Convergence verify: Qwen/Qwen3.5-35B-A3B ep_size=4 on gsm8k.
