### PR TITLE
[ci] add PIP_INDEX_URL and UV_INDEX_URL to fix pip install uv timeout on Ascend

### DIFF
--- a/.github/workflows/e2e_ascend.yml
+++ b/.github/workflows/e2e_ascend.yml
@@ -82,6 +82,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -147,6 +150,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -213,6 +219,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/e2e_fully_async_policy_ascend.yml
+++ b/.github/workflows/e2e_fully_async_policy_ascend.yml
@@ -100,6 +100,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -152,6 +155,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/e2e_one_step_off_policy_ascend.yml
+++ b/.github/workflows/e2e_one_step_off_policy_ascend.yml
@@ -100,6 +100,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -152,6 +155,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/e2e_ppo_trainer_megatron_sglang_2_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_sglang_2_ascend.yml
@@ -107,6 +107,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/e2e_ppo_trainer_megatron_sglang_ascend.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_sglang_ascend.yml
@@ -108,6 +108,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/nightly_ascend.yml
+++ b/.github/workflows/nightly_ascend.yml
@@ -150,6 +150,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -265,6 +268,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |
@@ -310,6 +316,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/reward_model_sglang_ascend.yml
+++ b/.github/workflows/reward_model_sglang_ascend.yml
@@ -80,6 +80,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |

--- a/.github/workflows/sgl_ascend.yml
+++ b/.github/workflows/sgl_ascend.yml
@@ -96,6 +96,9 @@ jobs:
       UV_HTTP_TIMEOUT: 120
       UV_NO_CACHE: "1"
       UV_SYSTEM_PYTHON: "1"
+      UV_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_INDEX_URL: "http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple"
+      PIP_TRUSTED_HOST: "cache-service.nginx-pypi-cache.svc.cluster.local"
     steps:
       - name: Check npu and CANN info
         run: |


### PR DESCRIPTION
## Problem

`pip install uv` in Ascend CI workflows was timing out because pip used default PyPI (`files.pythonhosted.org`) with no index configuration. The `UV_*` environment variables don't apply to pip.

## Changes

Added to all 14 ascend workflow jobs across 8 files:

- `UV_INDEX_URL`: internal PyPI cache (was also missing — uv was going to public PyPI too)
- `PIP_INDEX_URL`: internal PyPI cache (fixes `pip install uv` timeout)  
- `PIP_TRUSTED_HOST`: allow HTTP access to cache service

## Affected workflows

- `e2e_ascend.yml` (3 jobs)
- `e2e_fully_async_policy_ascend.yml` (2 jobs)
- `e2e_one_step_off_policy_ascend.yml` (2 jobs)
- `e2e_ppo_trainer_megatron_sglang_2_ascend.yml` (1 job)
- `e2e_ppo_trainer_megatron_sglang_ascend.yml` (1 job)
- `nightly_ascend.yml` (3 jobs)
- `reward_model_sglang_ascend.yml` (1 job)
- `sgl_ascend.yml` (1 job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)