### PR TITLE
 [fully_async] feat: Fully Async Policy with TransferQueue

### DIFF
--- a/verl/experimental/fully_async_policy/README_tq_en.md
+++ b/verl/experimental/fully_async_policy/README_tq_en.md
@@ -1,0 +1,432 @@
+# Fully Async Policy with TransferQueue (TQ)
+
+## Overview
+
+This solution builds upon `fully_async_policy` by migrating the data transport channel from Ray **MessageQueue** to **TransferQueue (TQ)**,
+while the training side reuses `main_ppo_sync.py`'s `PPOTrainer` via **multiple inheritance** to directly leverage TQ's native `KVBatchMeta` training pipeline.
+
+### Core Design Principles
+
+1. **Minimal Changes**: Keep `FullyAsyncAgentLoopManager` intact, preserving existing inference generation logic; only adapt lightly via `FullyAsyncAgentLoopManagerTQ`
+2. **ReplayBuffer Flow Control**: Replace the original `_should_pause_generation` with ReplayBuffer (Ray Actor)'s Dual-Layer Slot mechanism
+3. **TQ Replaces MessageQueue**: Data flows through TQ's zero-copy channel, metadata through ReplayBuffer
+4. **Trainer Multiple Inheritance from PPOTrainer**: Reuse the TQ training pipeline via `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)`
+
+### Core Objectives
+
+1. **Zero-Copy Transport**: Use TQ instead of MessageQueue to avoid `ray.cloudpickle` serialization overhead
+2. **Source-Level Flow Control**: Control production speed at dataloader data fetch (`_feed_samples`) via `acquire_slot()`
+3. **Backpressure**: Dual-Layer Slot mechanism limits in-flight requests, eliminating the need for additional pause/resume logic
+4. **Reuse Mature Code**: Trainer side uses multiple inheritance from PPOTrainer, directly using TQ's native batch training pipeline (`_compute_old_log_prob`, `_compute_advantage`, etc.)
+
+## Architecture Comparison
+
+### Existing Architecture (MessageQueue + SeparateRayPPOTrainer)
+
+```mermaid
+graph TB
+    subgraph Rollouter[Rollouter - SeparateRayPPOTrainer]
+        RM[FullyAsyncRollouter]
+        ALM[FullyAsyncAgentLoopManager]
+    end
+
+    subgraph MQ[MessageQueue - Ray Actor]
+        MQ_Q[deque - pickle serialization]
+    end
+
+    subgraph Trainer[Trainer - SeparateRayPPOTrainer]
+        TM[FullyAsyncTrainer]
+    end
+
+    RM -->|_feed_samples| PQ[pending_queue]
+    PQ -->|_processor_worker| ALM
+    ALM -->|generate_sequences_single| RM
+    RM -->|put_sample<br/>cloudpickle| MQ_Q
+    MQ_Q -->|get_sample<br/>cloudpickle| TM
+    TM -->|fit_step| TM
+    RM -.->|_should_pause_generation<br/>check queue_size| MQ_Q
+    RM -.->|staleness_samples<br/>manual counter| RM
+```
+
+**Problems**:
+
+- Full data `ray.cloudpickle` serialization/deserialization overhead is significant
+- Ray Actor single-point bottleneck (MessageQueue)
+- `_should_pause_generation` pause logic is complex (drain → resume)
+- Trainer (`SeparateRayPPOTrainer`) differs greatly from colocate training pipeline, requiring maintenance of two codebases
+
+### New Architecture (TQ + ReplayBuffer + PPOTrainer Multiple Inheritance)
+
+```mermaid
+graph TB
+    subgraph Rollouter["Rollouter (TQFullyAsyncRollouter)"]
+        RM[TQFullyAsyncRollouter]
+        ALM["FullyAsyncAgentLoopManager<br/>(+TQ adapter, wait=True)"]
+    end
+
+    subgraph RB["ReplayBuffer (Ray Actor)"]
+        RB_SLOT["Layer1: Physical Slot<br/>acquire / release"]
+        RB_VER["Layer2: Version Window<br/>reset_staleness resets to zero"]
+        RB_META["Metadata + wait_and_sample"]
+    end
+
+    subgraph TQ[TransferQueue]
+        TQ_DATA["Zero-Copy Tensor"]
+    end
+
+    subgraph Worker["AgentLoopWorkerTQ (main_ppo_sync.py)"]
+        W_POST["_agent_loop_postprocess → tq.put"]
+    end
+
+    subgraph Trainer["Trainer (TQFullyAsyncTrainer)"]
+        TM["Multi-inherit: PPOTrainer + FullyAsyncTrainer"]
+    end
+
+    RM -->|" 1. acquire_slot 🔒 "| RB_SLOT
+    RM -->|" 2. processor "| ALM
+    ALM -->|generate_sequences| Worker
+    Worker -->|" 3. tq.put (status=success/finished) "| TQ_DATA
+    TQ_DATA -->|kv_list poll| RB_META
+    RM -->|" 4. release_slot ✅ "| RB_SLOT
+    TM -->|" 5. wait_and_sample → KVBatchMeta "| RB_META
+    TM -->|" 6. kv_batch_get → PPO pipeline "| TQ_DATA
+    TM -->|" 7. kv_clear + remove "| TQ_DATA
+    TM -->|" 8. reset_staleness "| RB_VER
+```
+
+**Core Changes**:
+
+| Dimension | Existing Architecture | New Architecture |
+|----------------------|------------------------------------------------|---------------------------------------------|
+| **Data Channel** | MessageQueue (pickle) | TransferQueue (zero-copy) |
+| **Metadata Channel** | None (mixed with data) | ReplayBuffer (Ray Actor) |
+| **Flow Control** | `_should_pause_generation` + staleness_samples | `acquire_slot()` at `_feed_samples` source-level control |
+| **Trainer Base Class** | `SeparateRayPPOTrainer` | `PPOTrainer` × `FullyAsyncTrainer` multiple inheritance |
+| **Data Writer** | Rollouter._process_single_sample_streaming | `AgentLoopWorkerTQ._agent_loop_postprocess` |
+| **AgentLoopManager** | `FullyAsyncAgentLoopManager` | `FullyAsyncAgentLoopManagerTQ` (lightweight subclass) |
+| **Pause/Resume Logic** | paused + drain + resume | **Not needed** (slot blocking = flow control) |
+
+## Core Components
+
+### 1. ReplayBuffer (Ray Actor) — Metadata Channel + Dual-Layer Slot Flow Control
+
+File: [`replay_buffer.py`](replay_buffer.py)
+
+A lightweight Ray Actor that simultaneously handles **metadata storage** and **Dual-Layer Slot flow control**.
+
+```python
+@ray.remote(max_concurrency=100)
+class ReplayBuffer:
+    """Ray Actor: metadata channel + slot-based flow control for TQ fully async training.
+
+    Replaces MessageQueue (data channel) in the original fully_async_policy.
+    Key responsibilities:
+    1. Dual-Layer slot backpressure: acquire_slot() blocks rollouter at dataloader source
+    2. Metadata storage: tracks status of each sample via TQ kv_list polling
+    3. Consumer interface: wait_and_sample() for trainer to get finished samples
+    4. Version tracking: reset_staleness() for parameter sync coordination
+    """
+
+    def __init__(
+            self,
+            max_version_slots: int,  # Layer 2: staleness control
+            max_pending_slots: int = 256,  # Layer 1: physical throttling
+            poll_interval: float = 1.0,
+    ):
+```
+
+#### Dual-Layer Slot Control Mechanism
+
+`acquire_slot()` is the **single gatekeeping interface** between Rollouter and RB, simultaneously handling two responsibilities:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                    acquire_slot() Dual-Condition Check                │
+│                                                                      │
+│  Layer 1: Physical (Physical Throttling / OOM Protection)             │
+│    Condition: _pending_slots < max_pending_slots                      │
+│    Source: max_concurrent_samples (e.g., TP×PP×16)                    │
+│    Purpose: Prevent OOM / GPU overload                                │
+│    Release: release_slot() (called after Rollouter writes to TQ)      │
+│                                                                      │
+│  Layer 2: Version Window (Staleness Control / Stale Sample Protection)│
+│    Condition: _version_slots < max_version_slots                      │
+│    Source: required_samples × trigger_parameter_sync_step             │
+│    Purpose: Prevent samples from having overly stale parameter versions│
+│    Release: reset_staleness() resets to zero (called after Trainer   │
+│             parameter sync)                                           │
+│                                                                      │
+│  ✅ Both conditions met → Grant slot (_pending_slots++, _version_slots++) │
+│  ❌ Either condition fails → Block and wait                           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+State Transition:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: Initialization
+    Idle --> Acquired: acquire_slot() both conditions pass
+    Acquired --> InFlight: Write to pending_queue
+    InFlight --> Done: AgentLoopWorkerTQ writes to TQ status=success/finished
+    Done --> Idle: release_slot()
+    note right of Idle
+        L1: pending_slots < max_pending_slots
+        L2: _version_slots < max_version_slots
+    end note
+    note right of Acquired
+        pending_slots++
+        version_slots++
+        Rollouter can continue processing data
+    end note
+    note right of InFlight
+        Generating in progress
+        Layer1 occupies 1 physical slot
+        Layer2 occupies 1 version slot (cumulative)
+    end note
+    note right of Done
+        Layer1: release_slot() → pending_slots--
+        Layer2: unchanged (only reset_staleness resets to zero)
+    end note
+```
+
+#### Core Interfaces
+
+| Interface | Caller | Description |
+|---------------------------------------------------------|--------------------------------------------|-------------------------------|
+| `acquire_slot(timeout, uid)` | Rollouter._feed_samples | Acquire a write slot (blocking, dual-condition check) |
+| `release_slot()` | Rollouter._process_single_sample_streaming | Release physical slot |
+| `wait_and_sample(partition_id, sample_size, rollout_n)` | Trainer._get_keys_from_rb | Block until enough finished samples are available |
+| `remove(partition_id, keys)` | Trainer._cleanup_batch | Remove metadata for consumed samples |
+| `reset_staleness()` | Trainer._fit_reset_staleness | Reset version window after parameter sync, zero out _version_slots |
+| `signal_finish()` | Rollouter._streaming_generation_main | Signal end of production |
+
+#### Background Tasks
+
+- **`_poll_from_tq()`**: Periodically polls `tq.kv_list()` to get a global TQ snapshot, atomically replacing `self.partitions`. Includes UID integrity check: detects orphan keys (meta.uid doesn't match key prefix) and auto-cleans them.
+- **`_monitor_loop()`**: Prints buffer statistics every 60 seconds.
+
+#### Usage Pattern
+
+```python
+# Rollouter side (inside Ray Actor, async)
+acquired = await asyncio.wrap_future(self.replay_buffer.acquire_slot.remote(timeout=None, uid=sample_id).future())
+
+# Trainer side (inside Ray Actor, async)
+sampled_keys_meta = await self.replay_buffer.sample.remote(
+    partition_id="train", sample_size=N, rollout_n=n
+)
+```
+
+---
+
+### 2. FullyAsyncAgentLoopManagerTQ — AgentLoop Lightweight Adapter
+
+File: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)
+
+**Key Points**:
+
+- Worker class changed from default to `AgentLoopWorkerTQ` (defined in `main_ppo_sync.py`)
+- `generate_sequences_single` adds `wait=True`: ensures Rollouter knows when generation completes, avoiding deadlocks
+- `AgentLoopWorkerTQ._agent_loop_postprocess` directly writes results to TQ (`tq.async_kv_batch_put`), does not return data to Rollouter
+
+**Lifecycle after writing to TQ**:
+
+1. `AgentLoopWorkerTQ` writes `{uid}_{session_id}_{index}` response keys (status=success)
+2. `AgentLoopWorkerTQ` writes `{uid}` uid-level key (status=finished)
+3. ReplayBuffer `_poll_from_tq` discovers new keys via `tq.kv_list()`, updates `self.partitions`
+4. ReplayBuffer `wait_and_sample` detects enough finished uids, returns to Trainer
+5. Trainer reads complete data via `tq.kv_batch_get`, executes PPO training
+6. After Trainer finishes training, `tq.kv_clear` + `rb.remove` cleanup
+
+---
+
+### 3. TQFullyAsyncRollouter — Rollouter Adapter
+
+File: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)
+
+An incremental modification subclass based on `FullyAsyncRollouter`. Core changes are concentrated in three areas: data feeding, sample processing, and validation.
+
+#### 3.1 `_feed_samples` — Source-Level Flow Control
+
+**Key Differences from Base Class**:
+
+- No longer calls `prepare_single_generation_data()` (no repeat(n)), instead injects `__rollout_n__` field so that `AgentLoopWorkerTQ._run_prompt` loops n times internally
+- `batch_size=1` (bsz=1), each prompt processed individually
+- `uid`/`__rollout_n__`/`sample_id`/`global_steps` injected as `np.array` into plain dict, becoming `NonTensorStack` after `tu.get_tensordict()`
+
+#### 3.2 `_process_single_sample_streaming` — Simplified to generate + release
+
+**Core Difference from Base Class**: The base class needs to manually put generation results to MessageQueue; in the TQ path, data writing is handled by `AgentLoopWorkerTQ._agent_loop_postprocess`, so Rollouter only needs to call generate then release_slot.
+
+#### 3.3 Deleted/Disabled Methods
+
+| Method | Handling | Reason |
+|-------------------------------|------------|-----------------------------------|
+| `_should_pause_generation()` | Returns `False` | Replaced by `acquire_slot` |
+| `_async_monitor_loop()` | Empty implementation | Monitoring handled by ReplayBuffer._monitor_loop |
+
+#### 3.4 Validation Flow `_validate`
+
+Overrides base class validation method, using TQ + ReplayBuffer path.
+
+---
+
+### 4. TQFullyAsyncTrainer — Multi-Inheritance Trainer
+
+File: [`fully_async_trainer_tq.py`](fully_async_trainer_tq.py)
+
+**The most core design decision**: Use Python multiple inheritance `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)` to gain capabilities from both sides:
+
+```python
+"""
+MRO: TQFullyAsyncTrainer → PPOTrainer → FullyAsyncTrainer → SeparateRayPPOTrainer → ...
+
+Data flow:
+    TQFullyAsyncRollouter --(tq.kv_batch_put)--> TransferQueue (status=finish)
+        |
+    TQFullyAsyncTrainer <-(RB.wait_and_sample)--+--(KVBatchMeta)--> [PPOTrainer pipeline]
+                                                    |
+                                              update_actor(KVBatchMeta)
+"""
+```
+
+---
+
+## Data Flow Details
+
+### Complete Lifecycle Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant R as Rollouter<br/>(_feed_samples)
+    participant RB as ReplayBuffer<br/>(Ray Actor)
+    participant PQ as pending_queue
+    participant P as processor<br/>(_processor_worker)
+    participant ALM_TQ as ALM_TQ<br/>(DataProto→TensorDict)
+    participant ALW as AgentLoopWorkerTQ<br/>(main_ppo_sync.py)
+    participant TQ as TransferQueue
+    participant T as Trainer<br/>(TQFullyAsyncTrainer)
+    Note over R, T: === Phase 1: Rollouter Production (Source-Level Flow Control) ===
+    loop dataloader iteration
+        R ->> RB: acquire_slot(uid=sample_id) [may block🔒]
+        RB -->> R: slot acquired (L1++, L2++)
+        R ->> R: Inject uid/__rollout_n__/sample_id/global_steps
+        R ->> R: tu.get_tensordict(batch_dict) → bsz=1 TensorDict
+        R ->> PQ: put(RolloutSample{full_batch, sample_id})
+    end
+    R ->> PQ: put(None) [end signal]
+    Note over R, T: === Phase 2: Generation (ALM_TQ Adapter + Worker Writes TQ) ===
+    loop processor worker
+        P ->> PQ: get()
+        P ->> ALM_TQ: generate_sequences_single(batch, wait=True)
+        ALM_TQ ->> ALM_TQ: Select worker (round-robin)
+        ALM_TQ ->> ALW: generate_sequences.remote(batch, wait=True)
+        ALW ->> ALW: _run_prompt loops __rollout_n__ times
+        ALW ->> ALW: _compute_score (reward model)
+        ALW ->> TQ: tq.async_kv_batch_put(response keys, status=success)
+        ALW ->> TQ: tq.async_kv_batch_put(uid key, status=finished)
+        ALW -->> ALM_TQ: return (wait=True ensures completion)
+        ALM_TQ -->> P: return
+        P ->> RB: release_slot() ✅ (L1--)
+        RB -->> R: (wake up waiting acquire_slot)
+    end
+
+    Note over R, T: === Phase 3: Trainer Consumption + PPO Training ===
+    loop fit_step (per step)
+        T ->> RB: wait_and_sample(sample_size=N, rollout_n=n) [block⏳]
+        RB -->> T: [(key1,tag1), ..., (keyN,tagN)] (KVBatchMeta)
+        T ->> TQ: kv_batch_get(keys) [called internally by various _compute_* methods]
+        TQ -->> T: Complete tensor data (prompts, responses, log_probs, ...)
+        T ->> T: _balance_batch → _compute_old_log_prob
+        T ->> TQ: kv_batch_put(old_log_prob, ...) [write back to TQ]
+        T ->> T: _compute_advantage → _update_actor
+        T ->> TQ: kv_batch_put(advantages, returns, ...)
+        T ->> TQ: kv_clear(response keys + uid keys)
+        T ->> RB: remove(keys)
+    end
+
+    Note over R, T: === Phase 4: Parameter Sync (every trigger_parameter_sync_step steps) ===
+    T ->> T: _fit_update_weights(): checkpoint_manager.update_weights()
+    T ->> RB: reset_staleness(): _version_slots reset to zero, unblock L2
+```
+
+### Dual-Layer Slot Control Detailed Semantics
+
+| Original Concept (MessageQueue Path) | New Implementation (TQ Path) |
+|-------------------------------|-------------------------------------|
+| `MessageQueue.queue_size` | `RB._pending_slots` (Layer 1: Physical Throttling) |
+| `max_queue_size` | `max_pending_slots` (Layer 1) |
+| `_should_pause_generation()` | **Removed** — `acquire_slot()` dual-condition = flow control |
+| `staleness_samples` (manual counter) | `RB._version_slots` (Layer 2: Cumulative Counter) |
+| `max_required_samples` | `max_version_slots` (Layer 2) |
+| `paused` + `drain` + `resume` | **Preserved but no longer triggers throttling** — only used for safe drain during parameter sync |
+
+**Before vs After Comparison**:
+
+```
+Before (Dual Throttling, Complex State Machine):
+  1. _should_pause_generation(): queue_size >= max_queue_size → pause
+  2. _should_pause_generation(): staleness_samples >= max_required_samples → pause
+  → Need paused/drain/resume state machine
+
+After (acquire_slot Single Interface, Dual Conditions):
+  1. _feed_samples(): acquire_slot()
+     → Layer 1 not met? block (physically full)
+     → Layer 2 not met? block (version window full, wait for reset_staleness)
+     → Both met? proceed
+  → Clean token-bucket semantics, no extra state machine needed
+```
+
+**Parameter Sync Flow**:
+
+```
+Trainer.fit_step:
+  1. wait_and_sample(batch_size) → get finished samples from RB
+  2. ... PPO training pipeline (_compute_* / _update_*) ...
+  3. update_weights() → NCCL sync weights to Rollouter GPUs
+  4. reset_staleness():
+       a. _version_slots = _pending_slots + train_finished_slots (recalculate)
+       b. Reset timers (step_start_time, idle_start_time)
+       c. Notify _slot_available → unblock acquire_slot's Layer 2
+```
+
+## Usage
+
+### Launch Script Example
+
+Key configuration points:
+
+```bash
+# ====== Required fully_async configuration ======
+fully_async=(
+  data.train_batch_size=0                 # Invalid in TQ mode, defaults to 0
+  data.gen_batch_size=1                   # Streaming item-by-item generation
+  trainer.test_freq=-1                     # Validation handled by rollouter
+  actor_rollout_ref.hybrid_engine=False    # Decoupled architecture
+  actor_rollout_ref.rollout.calculate_log_probs=True  # Use rollout log_prob
+  rollout.total_rollout_steps=$(((512*100)))          # Total generation samples
+  trainer.nnodes=1                         # Number of Trainer nodes
+  trainer.n_gpus_per_node=4                # GPUs per Trainer node
+  rollout.nnodes=1                         # Number of Rollouter nodes
+  rollout.n_gpus_per_node=4                # GPUs per Rollouter node
+  async_training.staleness_threshold=0.5   # Staleness threshold
+  async_training.trigger_parameter_sync_step=4  # Parameter sync frequency
+  async_training.require_batches=1         # Batches per fetch
+  async_training.partial_rollout=True       # Support partial rollout
+)
+
+# ====== TQ-specific configuration ======
+transfer_queue=(
+  transfer_queue.enable=True               # ★ Enable TQ mode
+)
+```
+
+### Dependency Installation
+
+```bash
+pip install TransferQueue==0.1.8
+```
+
+All TQ-related code has fallback behavior: when `import transfer_queue` fails, the mock implementation in `verl.utils.transferqueue_utils` is automatically used.
+

--- a/verl/experimental/fully_async_policy/README_tq_zh.md
+++ b/verl/experimental/fully_async_policy/README_tq_zh.md
@@ -1,0 +1,408 @@
+# Fully Async Policy with TransferQueue (TQ)
+
+## 概述
+
+本方案在 `fully_async_policy` 基础上，将数据传输通道从 Ray **MessageQueue** 迁移到 **TransferQueue (TQ)**，
+同时训练侧通过**多继承**复用 `main_ppo_sync.py` 的 `PPOTrainer` 以直接使用 TQ 原生的 `KVBatchMeta` 训练流程。
+
+### 核心设计原则
+
+1. **最小改动**: `FullyAsyncAgentLoopManager` 整体不动，保持现有推理生成逻辑；仅通过 `FullyAsyncAgentLoopManagerTQ` 轻量适配
+2. **ReplayBuffer 控制流速**: 用 ReplayBuffer (Ray Actor) 的 Dual-Layer Slot 机制替代原 `_should_pause_generation`
+3. **TQ 替换 MessageQueue**: 数据走 TQ 零拷贝通道，元数据走 ReplayBuffer
+4. **Trainer 多继承 PPOTrainer**: 通过 `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)` 复用 TQ 训练流程
+
+### 核心目标
+
+1. **零拷贝传输**: 使用 TQ 替代 MessageQueue，避免 `ray.cloudpickle` 序列化开销
+2. **源头限流**: 在 dataloader 数据获取处 (`_feed_samples`) 通过 `acquire_slot()` 控制生产速度
+3. **背压控制**: Dual-Layer Slot 机制限制 in-flight 请求数，无需额外的暂停/恢复逻辑
+4. **复用成熟代码**: Trainer 侧多继承 PPOTrainer，直接使用 TQ 原生的 batch 训练流程（_compute_old_log_prob, _
+   compute_advantage 等）
+
+## 架构对比
+
+### 现有架构 (MessageQueue + SeparateRayPPOTrainer)
+
+```mermaid
+graph TB
+    subgraph Rollouter[Rollouter - SeparateRayPPOTrainer]
+        RM[FullyAsyncRollouter]
+        ALM[FullyAsyncAgentLoopManager]
+    end
+
+    subgraph MQ[MessageQueue - Ray Actor]
+        MQ_Q[deque - pickle序列化]
+    end
+
+    subgraph Trainer[Trainer - SeparateRayPPOTrainer]
+        TM[FullyAsyncTrainer]
+    end
+
+    RM -->|_feed_samples| PQ[pending_queue]
+    PQ -->|_processor_worker| ALM
+    ALM -->|generate_sequences_single| RM
+    RM -->|put_sample<br/>cloudpickle| MQ_Q
+    MQ_Q -->|get_sample<br/>cloudpickle| TM
+    TM -->|fit_step| TM
+    RM -.->|_should_pause_generation<br/>检查queue_size| MQ_Q
+    RM -.->|staleness_samples<br/>手动计数| RM
+```
+
+**问题**:
+
+- 数据完整 `ray.cloudpickle` 序列化/反序列化开销大
+- Ray Actor 单点瓶颈 (MessageQueue)
+- `_should_pause_generation` 暂停逻辑复杂 (drain → resume)
+- Trainer (`SeparateRayPPOTrainer`) 与 colocate 训练流程差异大，维护两套代码
+
+### 新架构 (TQ + ReplayBuffer + PPOTrainer 多继承)
+
+```mermaid
+graph TB
+    subgraph Rollouter["Rollouter (TQFullyAsyncRollouter)"]
+        RM[TQFullyAsyncRollouter]
+        ALM["FullyAsyncAgentLoopManager<br/>(+TQ 适配, wait=True)"]
+    end
+
+    subgraph RB["ReplayBuffer (Ray Actor)"]
+        RB_SLOT["Layer1: Physical Slot<br/>acquire / release"]
+        RB_VER["Layer2: Version Window<br/>reset_staleness 归零"]
+        RB_META["元数据 + wait_and_sample"]
+    end
+
+    subgraph TQ[TransferQueue]
+        TQ_DATA["Zero-Copy Tensor"]
+    end
+
+    subgraph Worker["AgentLoopWorkerTQ (main_ppo_sync.py)"]
+        W_POST["_agent_loop_postprocess → tq.put"]
+    end
+
+    subgraph Trainer["Trainer (TQFullyAsyncTrainer)"]
+        TM["多继承: PPOTrainer + FullyAsyncTrainer"]
+    end
+
+    RM -->|" 1. acquire_slot 🔒 "| RB_SLOT
+    RM -->|" 2. processor "| ALM
+    ALM -->|generate_sequences| Worker
+    Worker -->|" 3. tq.put (status=success/finished) "| TQ_DATA
+    TQ_DATA -->|kv_list poll| RB_META
+    RM -->|" 4. release_slot ✅ "| RB_SLOT
+    TM -->|" 5. wait_and_sample → KVBatchMeta "| RB_META
+    TM -->|" 6. kv_batch_get → PPO pipeline "| TQ_DATA
+    TM -->|" 7. kv_clear + remove "| TQ_DATA
+    TM -->|" 8. reset_staleness "| RB_VER
+```
+
+**核心变化**:
+
+| 维度                   | 现有架构                                           | 新架构                                         |
+|----------------------|------------------------------------------------|---------------------------------------------|
+| **数据通道**             | MessageQueue (pickle)                          | TransferQueue (zero-copy)                   |
+| **元数据通道**            | 无 (混在数据里)                                      | ReplayBuffer (Ray Actor)                    |
+| **流速控制**             | `_should_pause_generation` + staleness_samples | `acquire_slot()` 在 `_feed_samples` 源头控制     |
+| **Trainer 基类**       | `SeparateRayPPOTrainer`                        | `PPOTrainer` × `FullyAsyncTrainer` 多继承      |
+| **数据写入者**            | Rollouter._process_single_sample_streaming     | `AgentLoopWorkerTQ._agent_loop_postprocess` |
+| **AgentLoopManager** | `FullyAsyncAgentLoopManager`                   | `FullyAsyncAgentLoopManagerTQ` (轻量子类)       |
+| **暂停/恢复逻辑**          | paused + drain + resume                        | **不需要** (slot 阻塞即限流)                        |
+
+## 核心组件
+
+### 1. ReplayBuffer (Ray Actor) — 元数据通道 + Dual-Layer Slot 流控
+
+文件: [`replay_buffer.py`](replay_buffer.py)
+
+轻量级 Ray Actor，同时承担**元数据存储**和 **Dual-Layer Slot 流速控制**两大职责。
+
+#### Dual-Layer Slot 控制机制
+
+`acquire_slot()` 是 Rollouter 和 RB 之间的**唯一卡控接口**，同时承担两个职责：
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                    acquire_slot() 双条件检查                          │
+│                                                                      │
+│  Layer 1: Physical (物理限流 / OOM 防护)                             │
+│    条件: _pending_slots < max_pending_slots                           │
+│    来源: max_concurrent_samples (如 TP×PP×16)                        │
+│    作用: 防 OOM / GPU 过载                                           │
+│    释放: release_slot() (Rollouter 写入 TQ 后调用)                    │
+│                                                                      │
+│  Layer 2: Version Window (陈旧度控制 / stale sample 防护)            │
+│    条件: _version_slots < max_version_slots                           │
+│    来源: required_samples × trigger_parameter_sync_step              │
+│    作用: 防止样本参数版本过旧                                         │
+│    释放: reset_staleness() 归零（Trainer 参数同步后调用）             │
+│                                                                      │
+│  ✅ 两个条件都满足 → 发放 slot (_pending_slots++, _version_slots++)  │
+│  ❌ 任一不满足   → 阻塞等待                                           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+状态流转:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle: 初始化
+    Idle --> Acquired: acquire_slot() 双条件通过
+    Acquired --> InFlight: 写入 pending_queue
+    InFlight --> Done: AgentLoopWorkerTQ 写入 TQ status=success/finished
+    Done --> Idle: release_slot()
+    note right of Idle
+        L1: pending_slots < max_pending_slots
+        L2: _version_slots < max_version_slots
+    end note
+    note right of Acquired
+        pending_slots++
+        version_slots++
+        Rollouter 可以继续处理数据
+    end note
+    note right of InFlight
+        正在生成中
+        Layer1 占用 1 个物理 slot
+        Layer2 占用 1 个版本槽位 (累计)
+    end note
+    note right of Done
+        Layer1: release_slot() → pending_slots--
+        Layer2: 不变 (只有 reset_staleness 归零)
+    end note
+```
+
+#### 核心接口
+
+| 接口                                                      | 调用方                                        | 说明                            |
+|---------------------------------------------------------|--------------------------------------------|-------------------------------|
+| `acquire_slot(timeout, uid)`                            | Rollouter._feed_samples                    | 获取写入 slot（阻塞，双条件检查）           |
+| `release_slot()`                                        | Rollouter._process_single_sample_streaming | 释放物理 slot                     |
+| `wait_and_sample(partition_id, sample_size, rollout_n)` | Trainer._get_keys_from_rb                  | 阻塞等待足够数量的 finish 样本           |
+| `remove(partition_id, keys)`                            | Trainer._cleanup_batch                     | 移除已消费样本的元数据                   |
+| `reset_staleness()`                                     | Trainer._fit_reset_staleness               | 参数同步后重置版本窗口，归零 _version_slots |
+| `signal_finish()`                                       | Rollouter._streaming_generation_main       | 通知生产结束                        |
+
+#### 后台任务
+
+- **`_poll_from_tq()`**: 定期轮询 `tq.kv_list()` 获取 TQ 全局快照，原子替换 `self.partitions`。包含 UID 完整性检查：检测孤儿
+  key（meta.uid 与 key 前缀不匹配）并自动清理。
+- **`_monitor_loop()`**: 每 60 秒打印 buffer 统计信息。
+
+#### 调用方式
+
+```python
+# Rollouter 侧 (在 Ray Actor 内部，async)
+acquired = await asyncio.wrap_future(self.replay_buffer.acquire_slot.remote(timeout=None, uid=sample_id).future())
+
+# Trainer 侧 (在 Ray Actor 内部，async)
+sampled_keys_meta = await self.replay_buffer.sample.remote(
+    partition_id="train", sample_size=N, rollout_n=n
+)
+```
+
+---
+
+### 2. FullyAsyncAgentLoopManagerTQ — AgentLoop 轻量适配层
+
+文件: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)
+
+**关键点**:
+
+- Worker 类从默认改为 `AgentLoopWorkerTQ`（定义在 `main_ppo_sync.py` 中）
+- `generate_sequences_single` 增加 `wait=True`：确保 Rollouter 知道生成何时完成，避免死锁
+- `AgentLoopWorkerTQ._agent_loop_postprocess` 直接将结果写入 TQ（`tq.async_kv_batch_put`），不返回数据给 Rollouter
+
+**数据写入 TQ 后的生命周期**:
+
+1. `AgentLoopWorkerTQ` 写入 `{uid}_{session_id}_{index}` 个 response key (status=success)
+2. `AgentLoopWorkerTQ` 写入 `{uid}` uid-level key (status=finished)
+3. ReplayBuffer `_poll_from_tq` 通过 `tq.kv_list()` 发现新 key，更新 `self.partitions`
+4. ReplayBuffer `wait_and_sample` 检测到足够多的 finished uid，返回给 Trainer
+5. Trainer 通过 `tq.kv_batch_get` 读取完整数据，执行 PPO 训练
+6. Trainer 训练完成后 `tq.kv_clear` + `rb.remove` 清理
+
+---
+
+### 3. TQFullyAsyncRollouter — Rollouter 适配层
+
+文件: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)
+
+基于 `FullyAsyncRollouter` 的增量修改子类。核心变化集中在数据馈送、样本处理和验证三个环节。
+
+#### 3.1 `_feed_samples` — 源头限流
+
+**与基类的关键区别**:
+
+- 不再调用 `prepare_single_generation_data()` (不做 repeat(n))，改为注入 `__rollout_n__` 字段让
+  `AgentLoopWorkerTQ._run_prompt` 内部循环 n 次
+- `batch_size=1` (bsz=1)，每个 prompt 单独处理
+- `uid`/`__rollout_n__`/`sample_id`/`global_steps` 作为 `np.array` 注入到 plain dict 中，在 `tu.get_tensordict()` 后变为
+  `NonTensorStack`
+
+#### 3.2 `_process_single_sample_streaming` — 简化为 generate + release
+
+**与基类的核心区别**: 基类需要手动将生成结果 put 到 MessageQueue；TQ 路径下数据写入由
+`AgentLoopWorkerTQ._agent_loop_postprocess` 完成，Rollouter 只需调用 generate 然后 release_slot。
+
+#### 3.3 删除/禁用的方法
+
+| 方法                           | 处理方式       | 原因                                |
+|------------------------------|------------|-----------------------------------|
+| `_should_pause_generation()` | 返回 `False` | 由 `acquire_slot` 替代               |
+| `_async_monitor_loop()`      | 空实现        | 监控由 ReplayBuffer._monitor_loop 承担 |
+
+#### 3.4 验证流程 `_validate`
+
+覆盖基类的验证方法，使用 TQ + ReplayBuffer 路径。
+
+### 4. TQFullyAsyncTrainer — 多继承 Trainer
+
+**最核心的设计决策**: 通过 Python 多继承 `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)` 同时获得两边能力：
+
+```python
+"""
+MRO: TQFullyAsyncTrainer → PPOTrainer → FullyAsyncTrainer → SeparateRayPPOTrainer → ...
+
+Data flow:
+    TQFullyAsyncRollouter --(tq.kv_batch_put)--> TransferQueue (status=finish)
+        |
+    TQFullyAsyncTrainer <-(RB.wait_and_sample)--+--(KVBatchMeta)--> [PPOTrainer pipeline]
+                                                    |
+                                              update_actor(KVBatchMeta)
+"""
+```
+
+## 数据流详解
+
+### 完整生命周期时序图
+
+```mermaid
+sequenceDiagram
+    participant R as Rollouter<br/>(_feed_samples)
+    participant RB as ReplayBuffer<br/>(Ray Actor)
+    participant PQ as pending_queue
+    participant P as processor<br/>(_processor_worker)
+    participant ALM_TQ as ALM_TQ<br/>(DataProto→TensorDict)
+    participant ALW as AgentLoopWorkerTQ<br/>(main_ppo_sync.py)
+    participant TQ as TransferQueue
+    participant T as Trainer<br/>(TQFullyAsyncTrainer)
+    Note over R, T: === Phase 1: Rollouter 生产 (源头限流) ===
+    loop dataloader iteration
+        R ->> RB: acquire_slot(uid=sample_id) [可能阻塞🔒]
+        RB -->> R: slot acquired (L1++, L2++)
+        R ->> R: 注入 uid/__rollout_n__/sample_id/global_steps
+        R ->> R: tu.get_tensordict(batch_dict) → bsz=1 TensorDict
+        R ->> PQ: put(RolloutSample{full_batch, sample_id})
+    end
+    R ->> PQ: put(None) [结束信号]
+    Note over R, T: === Phase 2: 生成 (ALM_TQ 适配 + Worker 写 TQ) ===
+    loop processor worker
+        P ->> PQ: get()
+        P ->> ALM_TQ: generate_sequences_single(batch, wait=True)
+        ALM_TQ ->> ALM_TQ: 选择 worker (round-robin)
+        ALM_TQ ->> ALW: generate_sequences.remote(batch, wait=True)
+        ALW ->> ALW: _run_prompt 循环 __rollout_n__ 次
+        ALW ->> ALW: _compute_score (reward model)
+        ALW ->> TQ: tq.async_kv_batch_put(response keys, status=success)
+        ALW ->> TQ: tq.async_kv_batch_put(uid key, status=finished)
+        ALW -->> ALM_TQ: 返回 (wait=True 确保完成)
+        ALM_TQ -->> P: 返回
+        P ->> RB: release_slot() ✅ (L1--)
+        RB -->> R: (唤醒等待的 acquire_slot)
+    end
+
+    Note over R, T: === Phase 3: Trainer 消费 + PPO 训练 ===
+    loop fit_step (每步)
+        T ->> RB: wait_and_sample(sample_size=N, rollout_n=n) [阻塞⏳]
+        RB -->> T: [(key1,tag1), ..., (keyN,tagN)] (KVBatchMeta)
+        T ->> TQ: kv_batch_get(keys) [内部各 _compute_* 方法调用]
+        TQ -->> T: 完整张量数据 (prompts, responses, log_probs, ...)
+        T ->> T: _balance_batch → _compute_old_log_prob
+        T ->> TQ: kv_batch_put(old_log_prob, ...) [写回 TQ]
+        T ->> T: _compute_advantage → _update_actor
+        T ->> TQ: kv_batch_put(advantages, returns, ...)
+        T ->> TQ: kv_clear(response keys + uid keys)
+        T ->> RB: remove(keys)
+    end
+
+    Note over R, T: === Phase 4: 参数同步 (每 trigger_parameter_sync_step 步) ===
+    T ->> T: _fit_update_weights(): checkpoint_manager.update_weights()
+    T ->> RB: reset_staleness(): _version_slots 归零, 通知 L2 解除阻塞
+```
+
+### Dual-Layer Slot Control 详细语义
+
+| 原概念 (MessageQueue 路径)         | 新实现 (TQ 路径)                         |
+|-------------------------------|-------------------------------------|
+| `MessageQueue.queue_size`     | `RB._pending_slots` (Layer 1: 物理限流) |
+| `max_queue_size`              | `max_pending_slots` (Layer 1)       |
+| `_should_pause_generation()`  | **删除** — `acquire_slot()` 双条件即限流    |
+| `staleness_samples` (手动计数)    | `RB._version_slots` (Layer 2: 累计计数) |
+| `max_required_samples`        | `max_version_slots` (Layer 2)       |
+| `paused` + `drain` + `resume` | **保留但不再触发卡控** — 仅用于参数同步时的安全 drain   |
+
+**改动前后的对比**:
+
+```
+改动前 (双重限流, 复杂状态机):
+  1. _should_pause_generation(): queue_size >= max_queue_size → pause
+  2. _should_pause_generation(): staleness_samples >= max_required_samples → pause
+  → 需要 paused/drain/resume 状态机
+
+改动后 (acquire_slot 单接口双条件):
+  1. _feed_samples(): acquire_slot()
+     → Layer 1 不满足? 阻塞 (物理满)
+     → Layer 2 不满足? 阻塞 (版本窗口满, 等 reset_staleness)
+     → 都满足? 放行
+  → 简洁的令牌桶语义, 无需额外状态机
+```
+
+**参数同步流程**:
+
+```
+Trainer.fit_step:
+  1. wait_and_sample(batch_size) → 从 RB 获取 finish 样本
+  2. ... PPO 训练流程 (_compute_* / _update_*) ...
+  3. update_weights() → NCCL 同步权重到 Rollouter GPUs
+  4. reset_staleness():
+       a. _version_slots = _pending_slots + train_finished_slots (重新计算)
+       b. 重置计时器 (step_start_time, idle_start_time)
+       c. 通知 _slot_available → 解除 acquire_slot 的 Layer 2 阻塞
+```
+
+## 使用方法
+
+### 启动脚本示例
+
+核心配置要点:
+
+```bash
+# ====== 必要的 fully_async 配置 ======
+fully_async=(
+  data.train_batch_size=0                 # TQ 模式下无效，默认 0
+  data.gen_batch_size=1                   # streaming 逐条生成
+  trainer.test_freq=-1                     # 由 rollouter 负责 validate
+  actor_rollout_ref.hybrid_engine=False    # 分离式架构
+  actor_rollout_ref.rollout.calculate_log_probs=True  # 使用 rollout log_prob
+  rollout.total_rollout_steps=$(((512*100)))          # 总生成样本数
+  trainer.nnodes=1                         # Trainer 节点数
+  trainer.n_gpus_per_node=4                # Trainer 每 GPU 数
+  rollout.nnodes=1                         # Rollouter 节点数
+  rollout.n_gpus_per_node=4                # Rollouter 每 GPU 数
+  async_training.staleness_threshold=0.5   # 陈旧度阈值
+  async_training.trigger_parameter_sync_step=4  # 参数同步频率
+  async_training.require_batches=1         # 每次 fetch 的 batch 数
+  async_training.partial_rollout=True       # 支持 partial rollout
+)
+
+# ====== TQ 特有配置 ======
+transfer_queue=(
+  transfer_queue.enable=True               # ★ 启用 TQ 模式
+)
+```
+
+### 依赖安装
+
+```bash
+pip install TransferQueue==0.1.8
+```
+
+所有 TQ 相关代码都有 fallback：当 `import transfer_queue` 失败时，自动使用 `verl.utils.transferqueue_utils` 中的 mock 实现。

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -291,10 +291,8 @@ class MetricsAggregator:
 
     def get_aggregated_metrics(self) -> dict[str, Any]:
         """aggregated metrics"""
-        t = time.time()
         if self.step_count == 0:
             return {}
-
         aggregated = {}
 
         # Aggregate all metrics
@@ -303,9 +301,6 @@ class MetricsAggregator:
 
         # Aggregate special metrics
         aggregated = self._special_metrics_aggergate(aggregated)
-
-        print(f"aggregated metrics done. cost {time.time() - t:.4f} seconds.")
-
         return aggregated
 
     def _special_metrics_aggergate(self, aggregated: dict[str, Any]) -> dict[str, Any]:

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""FullyAsyncTaskRunner: Unified entry point for fully async PPO training.
+
+Supports two data transfer backends (selected via config.transfer_queue.enable):
+- transfer_queue.enable=False (default): MessageQueue + FullyAsyncRollouter/FullyAsyncTrainer
+- transfer_queue.enable=True:  TransferQueue + ReplayBuffer + TQFullyAsyncRollouter/TQFullyAsyncTrainer
+"""
+
 import asyncio
 import os
 import socket
@@ -22,9 +29,6 @@ import hydra
 import ray
 from omegaconf import OmegaConf
 
-from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
-from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
-from verl.experimental.fully_async_policy.message_queue import MessageQueue, MessageQueueClient
 from verl.experimental.reward_loop import migrate_legacy_reward_impl
 from verl.experimental.separation.utils import create_resource_pool_manager, create_role_worker_mapping
 from verl.trainer.ppo.utils import Role
@@ -42,9 +46,42 @@ class FullyAsyncTaskRunner:
         self.running = False
         self.components = {}
         self.shutdown_event = threading.Event()
+        self._use_tq = False
+        # Class references (resolved in run() based on transfer_queue.enable)
+        self._rollouter_cls = None
+        self._trainer_cls = None
 
     def run(self, config):
-        print("[ASYNC MAIN] Starting fully async PPO training...")
+        # Detect backend mode from config and resolve class references
+        self._use_tq = config.transfer_queue.enable
+        if self._use_tq:
+            from verl.experimental.fully_async_policy.fully_async_rollouter_tq import FullyAsyncRollouterTQ
+            from verl.experimental.fully_async_policy.fully_async_trainer_tq import FullyAsyncTrainerTQ
+
+            self._rollouter_cls = ray.remote(FullyAsyncRollouterTQ).options(num_cpus=10, max_concurrency=100)
+            self._trainer_cls = ray.remote(FullyAsyncTrainerTQ).options(num_cpus=10, max_concurrency=100)
+
+            # Initialize TQ in the main process FIRST with config.transfer_queue
+            # This ensures all subsequent tq.init() calls (in Rollouter, Trainer, RB actors)
+            # connect to the SAME shared TransferQueueController instance.
+            try:
+                import transfer_queue as tq
+
+                tq_config = OmegaConf.to_container(getattr(config, "transfer_queue", {}), resolve=True)
+                print(f"[ASYNC MAIN] Initializing TQ with config: {tq_config}", flush=True)
+                tq.init(tq_config)
+                print("[ASYNC MAIN] TQ initialized in main process", flush=True)
+            except Exception as e:
+                print(f"[ASYNC MAIN] TQ init warning: {e}", flush=True)
+        else:
+            from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
+            from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
+
+            self._rollouter_cls = ray.remote(FullyAsyncRollouter).options(num_cpus=10, max_concurrency=100)
+            self._trainer_cls = ray.remote(FullyAsyncTrainer).options(num_cpus=10, max_concurrency=100)
+
+        mode_label = "TQ" if self._use_tq else "MQ"
+        print(f"[ASYNC MAIN] Starting fully async PPO training (mode={mode_label})...")
         self._initialize_components(config)
         self._run_training_loop()
 
@@ -74,13 +111,13 @@ class FullyAsyncTaskRunner:
         self.components["role_worker_mapping"] = role_worker_mapping
         self.components["ray_worker_group_cls"] = ray_worker_group_cls
 
-        print("[ASYNC MAIN] Creating FullyAsyncTrainer first (needed for hybrid worker group injection)...")
+        print("[ASYNC MAIN] Creating Trainer first (needed for hybrid worker group injection)...")
         self._create_trainer(config)
 
         print("[ASYNC MAIN] Injecting trainer's worker group into rollouter for hybrid replicas...")
         self._setup_hybrid_worker_group(config)
 
-        print("[ASYNC MAIN] Creating FullyAsyncRollouter...")
+        print("[ASYNC MAIN] Creating Rollouter...")
         self._create_rollouter(config)
 
         print("[ASYNC MAIN] Setting up rollouter reference on trainer")
@@ -91,16 +128,8 @@ class FullyAsyncTaskRunner:
         print(f"total_train_steps {total_train_steps}")
         ray.get(self.components["trainer"].set_total_train_steps.remote(total_train_steps))
 
-        # max_queue_size
-        max_queue_size = ray.get(self.components["rollouter"].get_max_queue_size.remote())
-        print(f"[ASYNC MAIN] Creating MessageQueue... max_queue_size {max_queue_size}")
-        message_queue = MessageQueue.remote(config, max_queue_size)
-        message_queue_client = MessageQueueClient(message_queue)
-        self.components["message_queue"] = message_queue
-        self.components["message_queue_client"] = message_queue_client
-
-        ray.get(self.components["rollouter"].set_message_queue_client.remote(self.components["message_queue_client"]))
-        ray.get(self.components["trainer"].set_message_queue_client.remote(self.components["message_queue_client"]))
+        # ======== Create data channel (MQ or RB) ========
+        self._create_data_channel(config)
 
         # param_version resume from ckpt or default 0
         ray.get(self.components["trainer"].load_checkpoint.remote())
@@ -114,9 +143,64 @@ class FullyAsyncTaskRunner:
 
         print("[ASYNC MAIN] All components initialized successfully")
 
+    def _create_data_channel(self, config):
+        """Create the data channel: MessageQueue (default) or ReplayBuffer (TQ mode)."""
+        if self._use_tq:
+            self._create_replay_buffer(config)
+        else:
+            self._create_message_queue(config)
+
+    def _create_message_queue(self, config):
+        """Create MessageQueue + MessageQueueClient (original path)."""
+        from verl.experimental.fully_async_policy.message_queue import MessageQueue, MessageQueueClient
+
+        max_queue_size = ray.get(self.components["rollouter"].get_max_queue_size.remote())
+        print(f"[ASYNC MAIN] Creating MessageQueue... max_queue_size {max_queue_size}")
+        message_queue = MessageQueue.remote(config, max_queue_size)
+        message_queue_client = MessageQueueClient(message_queue)
+        self.components["message_queue"] = message_queue
+        self.components["message_queue_client"] = message_queue_client
+
+        ray.get(self.components["rollouter"].set_message_queue_client.remote(self.components["message_queue_client"]))
+        ray.get(self.components["trainer"].set_message_queue_client.remote(self.components["message_queue_client"]))
+
+    def _create_replay_buffer(self, config):
+        """Create ReplayBuffer Ray Actor (TQ mode) with dual-layer slot config.
+
+        Layer 1 (Physical): max_pending_slots = max_concurrent_samples
+            Limits simultaneous in-flight samples (OOM guard).
+            Maps to Rollouter's max_concurrent_samples (e.g. GPU / (TP * PP) * 16).
+
+        Layer 2 (Version window): max_version_slots = max_required_samples
+            Limits total slots per model version (staleness guard).
+            Maps to Rollouter's max_required_samples
+            (= required_samples * trigger_parameter_sync_step).
+        """
+        from verl.experimental.fully_async_policy.replay_buffer import ReplayBuffer
+
+        # Layer 1: Physical concurrency limit
+        max_concurrent_samples = ray.get(self.components["rollouter"].get_max_concurrent_samples.remote())
+        # Layer 2: Version window (staleness) limit
+        max_required_samples = ray.get(self.components["rollouter"].get_max_required_samples.remote())
+
+        print(
+            f"[ASYNC MAIN] Creating ReplayBuffer... "
+            f"max_pending_slots(physical)={max_concurrent_samples}, "
+            f"max_version_slots(staleness)={max_required_samples}"
+        )
+        replay_buffer = ReplayBuffer.remote(
+            max_version_slots=max_required_samples,
+            max_pending_slots=max_concurrent_samples,
+        )
+        self.components["replay_buffer"] = replay_buffer
+
+        ray.get(self.components["rollouter"].set_replay_buffer.remote(replay_buffer))
+        ray.get(self.components["trainer"].set_replay_buffer.remote(replay_buffer))
+
     def _create_rollouter(self, config) -> None:
-        print("[ASYNC MAIN] Starting create rollouter...")
-        rollouter = FullyAsyncRollouter.remote(
+        """Create rollouter: FullyAsyncRollouter (default) or TQFullyAsyncRollouter (TQ mode)."""
+
+        rollouter = self._rollouter_cls.remote(
             config=config,
             tokenizer=self.components["tokenizer"],
             processor=self.components["processor"],
@@ -136,14 +220,14 @@ class FullyAsyncTaskRunner:
         print("[ASYNC MAIN] Rollouter created and initialized successfully")
 
     def _create_trainer(self, config) -> None:
-        print("[ASYNC MAIN] Starting create trainer...")
+        """Create trainer: FullyAsyncTrainer (default) or TQFullyAsyncTrainer (TQ mode)."""
         trainer_role_mapping = {
             role: worker_cls
             for role, worker_cls in self.components["role_worker_mapping"].items()
             if role != Role.Rollout
         }
 
-        trainer = FullyAsyncTrainer.remote(
+        trainer = self._trainer_cls.remote(
             config=config,
             tokenizer=self.components["tokenizer"],
             role_worker_mapping=trainer_role_mapping,
@@ -154,7 +238,7 @@ class FullyAsyncTaskRunner:
 
         ray.get(trainer.init_workers.remote())
         self.components["trainer"] = trainer
-        print("[ASYNC MAIN] FullyAsyncTrainer created and initialized successfully")
+        print("[ASYNC MAIN] Trainer created and initialized successfully")
 
     def _setup_hybrid_worker_group(self, config) -> None:
         """
@@ -177,8 +261,15 @@ class FullyAsyncTaskRunner:
         self.running = True
 
         print("[ASYNC MAIN] Starting Rollouter and Trainer...")
+        print(f"[ASYNC MAIN] rollouter handle: {self.components['rollouter']}", flush=True)
+        print(f"[ASYNC MAIN] trainer handle: {self.components['trainer']}", flush=True)
         rollouter_future = self.components["rollouter"].fit.remote()
         trainer_future = self.components["trainer"].fit.remote()
+        print(
+            f"[ASYNC MAIN] fit.remote() submitted, rollouter_future={rollouter_future},"
+            f" trainer_future={trainer_future}",
+            flush=True,
+        )
 
         futures = [rollouter_future, trainer_future]
 
@@ -205,7 +296,16 @@ class FullyAsyncTaskRunner:
                 ray.cancel(future)
             raise
         finally:
-            asyncio.run(self.components["message_queue_client"].clear_queue())
+            # Cleanup based on mode
+            if self._use_tq:
+                rb = self.components.get("replay_buffer")
+                if rb is not None:
+                    try:
+                        ray.get(rb.signal_finish.remote())
+                    except Exception:
+                        pass
+            else:
+                asyncio.run(self.components["message_queue_client"].clear_queue())
             print("[ASYNC MAIN] Training completed or interrupted")
 
 

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -19,7 +19,6 @@ Supports two data transfer backends (selected via config.transfer_queue.enable):
 - transfer_queue.enable=True:  TransferQueue + ReplayBuffer + TQFullyAsyncRollouter/TQFullyAsyncTrainer
 """
 
-import asyncio
 import os
 import socket
 import threading

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -296,16 +296,6 @@ class FullyAsyncTaskRunner:
                 ray.cancel(future)
             raise
         finally:
-            # Cleanup based on mode
-            if self._use_tq:
-                rb = self.components.get("replay_buffer")
-                if rb is not None:
-                    try:
-                        ray.get(rb.signal_finish.remote())
-                    except Exception:
-                        pass
-            else:
-                asyncio.run(self.components["message_queue_client"].clear_queue())
             print("[ASYNC MAIN] Training completed or interrupted")
 
 

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -391,7 +391,6 @@ class FullyAsyncAgentLoopManager(AgentLoopManager):
         return worker
 
 
-@ray.remote(num_cpus=10, max_concurrency=100)
 class FullyAsyncRollouter(SeparateRayPPOTrainer):
     """
     Asynchronous sample generator, responsible for continuously generating training samples
@@ -483,6 +482,8 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         # When set, its GPUs back hybrid replicas for trainer-side validation.
         self._hybrid_worker_group = None
 
+        self.agent_loop_manager_class = FullyAsyncAgentLoopManager
+
         # Config
         self.staleness_threshold: float = config.async_training.get("staleness_threshold", 1)
         # required_samples use ppo_mini_batch_size*require_batches as the minimum number of samples.
@@ -557,6 +558,14 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """Get rollout worker group"""
         return self.llm_server_manager.get_replicas()
 
+    def get_max_concurrent_samples(self):
+        """Max simultaneous in-flight samples (physical slot limit for RB Layer 1)."""
+        return self.max_concurrent_samples
+
+    def get_max_required_samples(self):
+        """Max samples per model version (version window limit for RB Layer 2)."""
+        return self.max_required_samples
+
     def get_max_queue_size(self):
         return self.max_queue_size
 
@@ -604,7 +613,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """Stop rollout profiling on all replicas before the next weight sync."""
         await self.llm_server_manager.stop_profile()
 
-    def do_validate(self):
+    async def do_validate(self):
         """Run validation and return metrics"""
         timing_raw = {}
         with marked_timer("rollouter/validate_time", timing_raw, color="green"):
@@ -807,7 +816,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             config=self.config,
             worker_group=self.get_hybrid_worker_group(),
         )
-        self.async_rollout_manager = await FullyAsyncAgentLoopManager.create(
+        self.async_rollout_manager = await self.agent_loop_manager_class.create(
             config=self.config,
             llm_client=self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient),
             reward_loop_worker_handles=reward_loop_worker_handles,
@@ -1023,9 +1032,6 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         """
 
         print("[FullyAsyncRollouter] Starting FullyAsyncRollouter...")
-
-        if self.message_queue_client is None:
-            raise ValueError("MessageQueue client not set. Call set_message_queue_client() first.")
 
         # Set the running status flag
         async with self.lock:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
@@ -1,0 +1,484 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import os
+import uuid
+from collections import defaultdict
+
+import numpy as np
+import ray
+import torch
+
+from verl.experimental.fully_async_policy.detach_utils import (
+    RolloutSample,
+    safe_create_task,
+)
+from verl.experimental.fully_async_policy.fully_async_rollouter import (
+    FullyAsyncAgentLoopManager,
+    FullyAsyncRollouter,
+)
+from verl.trainer.main_ppo_sync import AgentLoopWorkerTQ
+from verl.utils import tensordict_utils as tu
+from verl.utils.profiler import marked_timer
+
+try:
+    import transfer_queue as tq
+except ImportError:
+    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    from verl.utils.transferqueue_utils import tq
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class FullyAsyncAgentLoopManagerTQ(FullyAsyncAgentLoopManager):
+    """Agent loop manager that uses :class:`AgentLoopWorkerTQ` workers.
+
+    Key difference from base :class:`FullyAsyncAgentLoopManager`:
+    - Overrides ``generate_sequences_single`` to convert ``DataProto`` → ``TensorDict``
+      before dispatching to workers, aligning with :class:`AgentLoopWorkerTQ`'s
+      ``generate_sequences`` signature which expects ``TensorDict`` (not ``DataProto``).
+    - Default ``wait=True``: waits for all tasks to complete before returning.
+      This ensures Rollouter knows exactly when generation finishes (avoids deadlock).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.agent_loop_workers_class = ray.remote(AgentLoopWorkerTQ)
+        super().__init__(*args, **kwargs)
+
+    async def generate_sequences_single(self, prompts):
+        """Convert DataProto to TensorDict, then dispatch to agent loop worker.
+
+        Aligns with main_ppo_sync.py PPOTrainer.step() which calls::
+
+            batch = tu.get_tensordict(batch_dict)
+            self.async_rollout_manager.generate_sequences(batch)
+
+        Args:
+            prompts: Input batch (DataProto or TensorDict).
+
+        Returns:
+            None — data is written directly to TransferQueue by the worker.
+        """
+        worker = self._select_best_worker()
+        return await worker.generate_sequences.remote(prompts, wait=True)
+
+    def generate_sequences(self, prompts):
+        """
+        Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
+        into TransferQueue once an agent loop finished.
+
+        Args:
+            prompts (TensorDict): Input batch from train or validation dataset.
+        """
+        # mark prompts as pending in replay buffer
+        chunkes = prompts.chunk(len(self.agent_loop_workers))
+        return ray.get(
+            [
+                worker.generate_sequences.remote(chunk)
+                for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=False)
+            ]
+        )
+
+
+class FullyAsyncRollouterTQ(FullyAsyncRollouter):
+    """
+    FullyAsyncRollouter variant that uses TransferQueue + ReplayBuffer instead of MessageQueue.
+
+    Core design:
+    - ReplayBuffer.acquire_slot() in _feed_samples() provides source-level flow control
+      (replaces _should_pause_generation + MessageQueue.queue_size backpressure)
+    - Generated samples are written to TQ (zero-copy) instead of MessageQueue (pickle)
+    - FullyAsyncAgentLoopManager is unchanged — still used for actual generation
+    """
+
+    def __init__(
+        self,
+        config,
+        tokenizer,
+        processor=None,
+        device_name=None,
+    ):
+        super().__init__(config=config, tokenizer=tokenizer, processor=processor, device_name=device_name)
+
+        # ==================== TQ-specific overrides ====================
+        self.replay_buffer = None  # Ray Actor handle, set via set_replay_buffer()
+        self.agent_loop_manager_class = FullyAsyncAgentLoopManagerTQ
+        print("[TQFullyAsyncRollouter] initialized (TQ mode)")
+
+    async def set_replay_buffer(self, replay_buffer):
+        """Set ReplayBuffer Ray Actor handle."""
+        async with self.lock:
+            self.replay_buffer = replay_buffer
+
+            tq.init()
+            print("[TQFullyAsyncRollouter] TQ initialized in Rollouter actor process", flush=True)
+
+    async def _feed_samples(self):
+        """Feed samples from dataloader to pending_queue, with source-level flow control.
+
+        Key difference from base class: acquire_slot() is called BEFORE putting
+        to pending_queue. This blocks the dataloader when too many samples are
+        in-flight, replacing the need for _should_pause_generation().
+
+        Alignment with main_ppo_sync.py PPOTrainer.step():1740-1758:
+            - Do NOT repeat(n) here — let AgentLoopWorkerTQ._run_prompt loop n times
+              via __rollout_n__ field (avoids double-repeat bug).
+            - Set uid/__rollout_n__/sample_id/global_steps in batch_dict (plain dict)
+              BEFORE calling tu.get_tensordict(), so these np.array values become NonTensorStack
+              (supporting per-index access in AgentLoopWorkerTQ.generate_sequences).
+        """
+        continuous_iterator = self._create_continuous_iterator()
+        rollout_n = self.config.actor_rollout_ref.rollout.n
+
+        for epoch, batch_dict in continuous_iterator:
+            sample_id = f"sample_{epoch}_{self.global_steps}"
+            acquired = await self.replay_buffer.acquire_slot.remote(timeout=None, uid=sample_id)
+            if not acquired:
+                print(
+                    f"[TQFullyAsyncRollouter][Feed] ReplayBuffer finished or closed, "
+                    f"stop feeding after {self.global_steps} samples"
+                )
+                break
+
+            # Inject fields into batch_dict (plain dict) BEFORE tu.get_tensordict().
+            # All np.array values become NonTensorStack via get_tensordict:424,
+            # supporting per-index access in AgentLoopWorkerTQ.generate_sequences().
+            batch_dict["uid"] = np.array([sample_id], dtype=object)
+            batch_dict["__rollout_n__"] = np.full(1, rollout_n, dtype=np.int64)
+            batch_dict["sample_id"] = np.array([sample_id], dtype=object)
+            batch_dict["global_steps"] = np.full(1, self.global_steps, dtype=np.int64)
+
+            # Convert to TensorDict (np.array values → NonTensorStack via get_tensordict:424)
+            full_batch = tu.get_tensordict(batch_dict)
+
+            # Set agent_name for non-multi-turn mode (same as prepare_single_generation_data)
+            if not self.config.actor_rollout_ref.rollout.multi_turn.enable:
+                batch_dict["agent_name"] = np.array(["single_turn_agent"], dtype=object)
+                full_batch = tu.get_tensordict(batch_dict)
+
+            rollout_sample = RolloutSample(
+                full_batch=full_batch,
+                sample_id=sample_id,
+                epoch=epoch,
+                rollout_status={},
+            )
+
+            await self.pending_queue.put(rollout_sample)
+
+            # Check if have reached the last step
+            if self.global_steps >= self.total_rollout_steps:
+                print(
+                    f"[TQFullyAsyncRollouter][Feed] "
+                    f"Maximum count has been reached, stop adding new samples: "
+                    f"{self.global_steps} >= {self.total_rollout_steps}"
+                )
+                break
+
+            self.global_steps += 1
+
+        # End signal
+        await self.pending_queue.put(None)
+        print(f"[TQFullyAsyncRollouter][Feed] Sample addition is complete, {self.global_steps} samples have been added")
+
+    async def _process_single_sample_streaming(self, rollout_sample: RolloutSample):
+        """Process a single sample: generate via ALM worker (which writes to TQ blocking), then release slot.
+
+        Simplified from base class:
+        - Base class: generate → put to MessageQueue
+        - TQ path: generate + TQ write both happen INSIDE AgentLoopWorkerTQ
+          (via overridden _agent_loop_postprocess)
+          → we just call it and release the slot
+
+        Note: full_batch now has bsz=1 (no repeat(n)), and contains __rollout_n__.
+              AgentLoopWorkerTQ._run_prompt will loop n times internally to produce
+              n responses per prompt, each written to TQ with a unique key.
+        """
+        try:
+            await self.async_rollout_manager.generate_sequences_single(rollout_sample.full_batch)
+            self.total_generated_samples += 1
+        except Exception as e:
+            logger.exception(f"[TQFullyAsyncRollouter] Failed to process {rollout_sample.sample_id}: {e}")
+        finally:
+            # Always release the slot regardless of success/failure
+            await self.replay_buffer.release_slot.remote()
+
+        self.processed_sample_count += 1
+
+    async def _streaming_generation_main(self):
+        """Main entry for stream processing."""
+        # Start feed and processor tasks (same as base class)
+        print("[TQFullyAsyncRollouter] Starting feed_task...", flush=True)
+        self.feed_task = safe_create_task(self._feed_samples(), name="feed_task")
+        print("[TQFullyAsyncRollouter] Starting processor_task...", flush=True)
+        self.processor_task = safe_create_task(self._processor_worker(), name="processor_task")
+        try:
+            done, pending = await asyncio.wait(
+                [self.feed_task, self.processor_task], return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in done:
+                if task.exception():
+                    raise task.exception()
+
+            if self.feed_task not in done:
+                raise RuntimeError("Processor task exited prematurely")
+
+            print("[TQFullyAsyncRollouter] Sample feed completed")
+            await self.processor_task
+            print("[TQFullyAsyncRollouter] Streaming process completed")
+            await self.pending_queue.join()
+            print("[TQFullyAsyncRollouter] pending_queue joined")
+
+        except Exception as e:
+            print(f"[TQFullyAsyncRollouter] Streaming process exception: {e}")
+            raise e
+        finally:
+            if self.feed_task and not self.feed_task.done():
+                self.feed_task.cancel()
+                await asyncio.gather(self.feed_task, return_exceptions=True)
+
+            if self.processor_task and not self.processor_task.done():
+                self.processor_task.cancel()
+                await asyncio.gather(self.processor_task, return_exceptions=True)
+
+            self.feed_task = None
+            self.processor_task = None
+
+            await self.replay_buffer.signal_finish.remote()
+
+            async with self.lock:
+                self.running = False
+
+    async def do_validate(self):
+        """Run validation and return metrics.
+
+        Overrides FullyAsyncRollouter.do_validate() to use PPOTrainer's
+        _validate() which operates on TransferQueue + ReplayBuffer (TQ path)
+        instead of SeparateRayPPOTrainer's _validate() which uses MessageQueue.
+        """
+        timing_raw = {}
+        with marked_timer("rollouter/validate_time", timing_raw, color="green"):
+            val_metrics: dict = await self._validate()
+        return timing_raw | val_metrics
+
+    async def _validate(self) -> dict[str, float]:
+        # Lists to collect samples for the table
+        sample_uids = []
+        sample_inputs = []
+        sample_outputs = []
+        sample_gts = []
+        sample_scores = []
+        sample_turns = []
+        data_sources = []
+        reward_extra_infos_dict: dict[str, list] = defaultdict(list)
+        dump_all_inputs: list[str] = []
+        dump_all_outputs: list[str] = []
+        dump_all_keys: list[str] = []
+        session_to_sample_idx: dict[str, int] = {}
+
+        for batch_dict in self.val_dataloader:
+            # 1. put batch to agent loop manager
+            batch_dict["uid"] = np.array(
+                [str(uuid.uuid4()) for _ in range(len(batch_dict["raw_prompt"]))], dtype=object
+            )
+            batch = tu.get_tensordict(batch_dict)
+            tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
+            tu.assign_non_tensor_data(batch, "validate", True)
+            self.async_rollout_manager.generate_sequences(batch)
+
+            # 2. sample batch from replay buffer
+            sampled = await self.replay_buffer.sample.remote(
+                partition_id="val", sample_size=len(batch), rollout_n=self.config.actor_rollout_ref.rollout.val_kwargs.n
+            )
+            # Unpack list[tuple[str, dict]] into KVBatchMeta format
+            from verl.utils.transferqueue_utils import KVBatchMeta
+
+            keys = [k for k, _ in sampled]
+            tags = [meta for _, meta in sampled]
+            batch = KVBatchMeta(partition_id="val", keys=keys, tags=tags)
+
+            # 3. [OPTIONAL] compute reward score with colocated reward model
+            if self.reward_loop_manager.reward_loop_worker_handles is None:
+                self.checkpoint_manager.sleep_replicas()
+                batch = self._compute_reward_colocate(batch)
+                self.checkpoint_manager.update_weights()
+
+            # 4. collect necessary data for logging
+            # For multi-output agent loops, only use the final output per session for metrics.
+            # Keys have format {uid}_{session_id}_{index}; keep only the highest index per session.
+            session_max: dict[str, tuple[int, int]] = {}  # session_key -> (max_index, position)
+            for pos, key in enumerate(batch.keys):
+                parts = key.rsplit("_", 2)
+                if len(parts) == 3:
+                    session_key = f"{parts[0]}_{parts[1]}"
+                    index = int(parts[2])
+                    if session_key not in session_max or index > session_max[session_key][0]:
+                        session_max[session_key] = (index, pos)
+                else:
+                    session_max[key] = (0, pos)
+            sorted_sessions = sorted(session_max.items(), key=lambda x: x[1][1])
+            final_indices = [pos for _, (_, pos) in sorted_sessions]
+            final_keys = [batch.keys[i] for i in final_indices]
+            base_offset = len(sample_scores)
+            session_to_sample_idx.update(
+                {session_key: base_offset + j for j, (session_key, _) in enumerate(sorted_sessions)}
+            )
+
+            text_data = tq.kv_batch_get(
+                keys=batch.keys, partition_id=batch.partition_id, select_fields=["prompts", "responses"]
+            )
+            text_data["prompts"] = text_data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            text_data["responses"] = text_data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+            all_inputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["prompts"]]
+            all_outputs = [self.tokenizer.decode(ids, skip_special_tokens=True) for ids in text_data["responses"]]
+
+            fields = ["uid", "rm_scores", "num_turns", "reward_model", "data_source", "extra_fields"]
+
+            data = tq.kv_batch_get(keys=final_keys, partition_id=batch.partition_id, select_fields=fields)
+
+            from tensordict import NonTensorData, NonTensorStack
+
+            # Extract values handling NonTensorStack/NonTensorData (aligned with main_ppo_sync.py:334-337)
+            def _extract(v):
+                if isinstance(v, torch.Tensor):
+                    return v
+                elif isinstance(v, NonTensorStack):
+                    # NonTensorStack may contain non-unique values; use .tolist()
+                    return v.tolist()
+                elif isinstance(v, NonTensorData):
+                    return v.data
+                return v
+
+            _uid = _extract(data.pop("uid"))
+            _rm_scores = _extract(data["rm_scores"])
+            _num_turns = _extract(data.pop("num_turns"))
+
+            # Ensure plain Python types for lists (aligned with main_ppo_sync.py:932-937)
+            sample_uids.extend(_uid.tolist() if hasattr(_uid, "tolist") else list(_uid))
+            sample_outputs.extend(all_outputs[i] for i in final_indices)
+            sample_inputs.extend(all_inputs[i] for i in final_indices)
+            scores = _rm_scores.sum(dim=1).tolist()
+            sample_scores.extend(scores)
+            # np.concatenate requires array-like elements, not scalars (compatible with ray_trainer.py:660)
+            _turns = _num_turns.tolist() if hasattr(_num_turns, "tolist") else list(_num_turns)
+            sample_turns.extend([np.array([t]) for t in _turns])
+            reward_extra_infos_dict["reward"].extend(scores)
+
+            extra_fields_list = data.pop("extra_fields", None)
+            if extra_fields_list is not None:
+                n_prior = len(reward_extra_infos_dict["reward"]) - len(extra_fields_list.tolist())
+                for extra_field in extra_fields_list.tolist():
+                    reward_extra_info = (
+                        extra_field.get("reward_extra_info", {}) if isinstance(extra_field, dict) else {}
+                    )
+                    for key in reward_extra_infos_dict:
+                        if key != "reward" and key not in reward_extra_info:
+                            reward_extra_infos_dict[key].append(None)
+                    for key, value in reward_extra_info.items():
+                        if key not in reward_extra_infos_dict:
+                            reward_extra_infos_dict[key] = [None] * n_prior
+                        reward_extra_infos_dict[key].append(value)
+                    n_prior += 1
+
+            reward_model = data.pop("reward_model", None)
+            if reward_model is not None:
+                sample_gts.extend([item.get("ground_truth", None) for item in reward_model.tolist()])
+            else:
+                sample_gts.extend([None] * len(final_indices))
+
+            data_source = data.pop("data_source", None)
+            if data_source is not None:
+                data_sources.extend(data_source.tolist())
+            else:
+                data_sources.extend(["unknown"] * len(final_indices))
+
+            dump_all_inputs.extend(all_inputs)
+            dump_all_outputs.extend(all_outputs)
+            dump_all_keys.extend(batch.keys)
+
+            # 5. cleanup transfer queue and replay buffer
+            await self._cleanup_batch(batch)
+
+        # logger to wandb
+        self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
+
+        # dump to local dir
+        val_data_dir = self.config.trainer.get("validation_data_dir", None)
+        if val_data_dir:
+            # Sort according to uid (so that generations in the same rollout are together)
+            sort_keys = []
+            for key in dump_all_keys:
+                parts = key.rsplit("_", 2)
+                sort_keys.append((parts[0], int(parts[1]), int(parts[2])) if len(parts) == 3 else (key, 0, 0))
+            sorted_indices = sorted(range(len(dump_all_keys)), key=lambda i: sort_keys[i])
+            dump_all_inputs = [dump_all_inputs[i] for i in sorted_indices]
+            dump_all_outputs = [dump_all_outputs[i] for i in sorted_indices]
+            dump_all_keys = [dump_all_keys[i] for i in sorted_indices]
+
+            # For ground truths, scores and reward extra infos, find the values in the
+            # lists for the final samples of each session
+            dump_all_sessions = [
+                f"{parts[0]}_{parts[1]}" if len(parts) == 3 else key
+                for key in dump_all_keys
+                for parts in [key.rsplit("_", 2)]
+            ]
+            session_final_indices = [session_to_sample_idx[session] for session in dump_all_sessions]
+            self._dump_generations(
+                inputs=dump_all_inputs,
+                outputs=dump_all_outputs,
+                gts=[sample_gts[i] for i in session_final_indices],
+                scores=[sample_scores[i] for i in session_final_indices],
+                reward_extra_infos_dict={
+                    k: [v[i] for i in session_final_indices] for k, v in reward_extra_infos_dict.items()
+                }
+                | {"uid": dump_all_keys},
+                dump_path=val_data_dir,
+            )
+
+        return self._val_metrics_update(data_sources, sample_uids, reward_extra_infos_dict, sample_turns)
+
+    async def _cleanup_batch(self, batch):
+        """Cleanup consumed batch from TQ and RB.
+
+        Two-phase cleanup:
+        1. Clear uid-level keys (deduplicated by uid from tags): removes uid status entries
+           like {'uid': {'status': 'finished'}} from both TQ and RB partitions.
+        2. Clear all sampled response keys: full cleanup of {uid}_{resp_idx} keys from TQ and RB.
+        """
+        # Phase 1: Deduplicate by uid from tags to get uid-level keys
+        uid_keys: set[str] = set()
+        for key, tag in zip(batch.keys, batch.tags, strict=False):
+            uid = tag.get("uid", "") if isinstance(tag, dict) else ""
+            if uid and uid not in uid_keys:
+                uid_keys.add(uid)
+
+        tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
+        await self.replay_buffer.remove.remote(batch.partition_id, list(uid_keys))
+
+        # Phase 2: Clear all sampled response keys (full cleanup)
+        tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
+        await self.replay_buffer.remove.remote(batch.partition_id, batch.keys)
+
+    async def reset_staleness(self):
+        """Reset version window after parameter update."""
+        rb_timing = await self.replay_buffer.reset_staleness.remote()
+        return rb_timing
+
+    async def _should_pause_generation(self) -> bool:
+        return False
+
+    async def _async_monitor_loop(self):
+        pass

--- a/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
@@ -30,6 +30,7 @@ from verl.experimental.fully_async_policy.fully_async_rollouter import (
     FullyAsyncAgentLoopManager,
     FullyAsyncRollouter,
 )
+from verl.experimental.fully_async_policy.replay_buffer import tq_kv_clear
 from verl.trainer.main_ppo_sync import AgentLoopWorkerTQ
 from verl.utils import tensordict_utils as tu
 from verl.utils.profiler import marked_timer
@@ -300,9 +301,8 @@ class FullyAsyncRollouterTQ(FullyAsyncRollouter):
             self.async_rollout_manager.generate_sequences(batch)
 
             # 2. sample batch from replay buffer
-            sampled = await self.replay_buffer.sample.remote(
-                partition_id="val", sample_size=len(batch), rollout_n=self.config.actor_rollout_ref.rollout.val_kwargs.n
-            )
+            sampled = await self.replay_buffer.sample.remote(partition_id="val", sample_size=len(batch))
+
             # Unpack list[tuple[str, dict]] into KVBatchMeta format
             from verl.utils.transferqueue_utils import KVBatchMeta
 
@@ -410,7 +410,7 @@ class FullyAsyncRollouterTQ(FullyAsyncRollouter):
             dump_all_keys.extend(batch.keys)
 
             # 5. cleanup transfer queue and replay buffer
-            await self._cleanup_batch(batch)
+            tq_kv_clear(batch)
 
         # logger to wandb
         self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
@@ -449,28 +449,6 @@ class FullyAsyncRollouterTQ(FullyAsyncRollouter):
             )
 
         return self._val_metrics_update(data_sources, sample_uids, reward_extra_infos_dict, sample_turns)
-
-    async def _cleanup_batch(self, batch):
-        """Cleanup consumed batch from TQ and RB.
-
-        Two-phase cleanup:
-        1. Clear uid-level keys (deduplicated by uid from tags): removes uid status entries
-           like {'uid': {'status': 'finished'}} from both TQ and RB partitions.
-        2. Clear all sampled response keys: full cleanup of {uid}_{resp_idx} keys from TQ and RB.
-        """
-        # Phase 1: Deduplicate by uid from tags to get uid-level keys
-        uid_keys: set[str] = set()
-        for key, tag in zip(batch.keys, batch.tags, strict=False):
-            uid = tag.get("uid", "") if isinstance(tag, dict) else ""
-            if uid and uid not in uid_keys:
-                uid_keys.add(uid)
-
-        tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
-        await self.replay_buffer.remove.remote(batch.partition_id, list(uid_keys))
-
-        # Phase 2: Clear all sampled response keys (full cleanup)
-        tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
-        await self.replay_buffer.remove.remote(batch.partition_id, batch.keys)
 
     async def reset_staleness(self):
         """Reset version window after parameter update."""

--- a/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
@@ -37,7 +37,7 @@ from verl.utils.profiler import marked_timer
 try:
     import transfer_queue as tq
 except ImportError:
-    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    print("Please install TQ by calling `pip install TransferQueue==0.1.8` and try again.")
     from verl.utils.transferqueue_utils import tq
 
 logger = logging.getLogger(__name__)

--- a/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter_tq.py
@@ -77,19 +77,19 @@ class FullyAsyncAgentLoopManagerTQ(FullyAsyncAgentLoopManager):
         worker = self._select_best_worker()
         return await worker.generate_sequences.remote(prompts, wait=True)
 
-    def generate_sequences(self, prompts):
+    async def generate_sequences(self, prompts):
         """
-        Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
-        into TransferQueue once an agent loop finished.
+        Dispatch input batch to agent loop workers with sync wait. Workers put agent loop outputs
+        into TransferQueue once an agent loop finished, and this method returns only after
+        all workers have completed their work.
 
         Args:
             prompts (TensorDict): Input batch from train or validation dataset.
         """
-        # mark prompts as pending in replay buffer
         chunkes = prompts.chunk(len(self.agent_loop_workers))
-        return ray.get(
-            [
-                worker.generate_sequences.remote(chunk)
+        return await asyncio.gather(
+            *[
+                worker.generate_sequences.remote(chunk, wait=True)
                 for worker, chunk in zip(self.agent_loop_workers, chunkes, strict=False)
             ]
         )
@@ -298,7 +298,7 @@ class FullyAsyncRollouterTQ(FullyAsyncRollouter):
             batch = tu.get_tensordict(batch_dict)
             tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
             tu.assign_non_tensor_data(batch, "validate", True)
-            self.async_rollout_manager.generate_sequences(batch)
+            await self.async_rollout_manager.generate_sequences(batch)
 
             # 2. sample batch from replay buffer
             sampled = await self.replay_buffer.sample.remote(partition_id="val", sample_size=len(batch))

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -49,7 +49,6 @@ class TrainingStopException(Exception):
     pass
 
 
-@ray.remote(num_cpus=10)
 class FullyAsyncTrainer(SeparateRayPPOTrainer):
     """
     A fully asynchronous PPO trainer that obtains samples from a MessageQueue for training.
@@ -521,7 +520,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             await asyncio.wrap_future(self.rollouter._start_profiling.remote().future())
 
         # Reset staleness in rollouter
-        timing_raw = await asyncio.wrap_future(self.rollouter.reset_staleness.remote().future())
+        timing_raw = await self.rollouter.reset_staleness.remote()
         self.logger.log(
             data=timing_raw,
             step=self.current_param_version,

--- a/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
@@ -1,0 +1,431 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TQFullyAsyncTrainer: Multi-inheritance trainer combining PPOTrainer's KVBatchMeta pipeline
+with FullyAsyncTrainer's async infrastructure.
+
+MRO: TQFullyAsyncTrainer → PPOTrainer → FullyAsyncTrainer → SeparateRayPPOTrainer → ...
+
+Data flow:
+    TQFullyAsyncRollouter --(tq.kv_batch_put)--> TransferQueue (status=finish)
+        |
+    TQFullyAsyncTrainer <-(RB.wait_and_sample)--+--(KVBatchMeta)--> [PPOTrainer pipeline]
+                                                    |
+                                              update_actor(KVBatchMeta)
+"""
+
+import logging
+import os
+from typing import Any
+
+import numpy as np
+from omegaconf import OmegaConf
+
+from verl.experimental.fully_async_policy.detach_utils import MetricsAggregator
+from verl.experimental.fully_async_policy.fully_async_trainer import (
+    FullyAsyncTrainer,
+    TrainingStopException,
+)
+from verl.single_controller.ray import RayWorkerGroup
+from verl.trainer.main_ppo_sync import PPOTrainer
+from verl.trainer.ppo.ray_trainer import ResourcePoolManager
+from verl.trainer.ppo.utils import Role, WorkerType
+from verl.utils.debug import marked_timer
+from verl.utils.tracking import Tracking, ValidationGenerationsLogger
+
+try:
+    import transfer_queue as tq
+    from transfer_queue import KVBatchMeta
+except ImportError:
+    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    from verl.utils.transferqueue_utils import KVBatchMeta, tq
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer):
+    """
+    Fully async PPO trainer via multi-inheritance.
+
+    - PPOTrainer: provides KVBatchMeta-native training pipeline (_compute_*, _update_*, etc.)
+    - FullyAsyncTrainer: provides async infrastructure (fit loop, param sync, validate, checkpoint)
+    """
+
+    def __init__(
+        self,
+        config,
+        tokenizer,
+        role_worker_mapping: dict[Role, WorkerType],
+        resource_pool_manager: ResourcePoolManager,
+        ray_worker_group_cls: Any = None,
+        device_name=None,
+    ):
+        # ======== 1. PPOTrainer.__init__: config, dataloader, local replay_buffer, worker groups ========
+        PPOTrainer.__init__(
+            self,
+            config=config,
+            role_worker_mapping=role_worker_mapping,
+            resource_pool_manager=resource_pool_manager,
+        )
+        # PPOTrainer doesn't accept device_name/ray_worker_group_cls, set them manually
+        # These are required by FullyAsyncTrainer(SeparateRayPPOTrainer) init_workers pipeline:
+        #   _init_resource_pools → _create_worker_classes → _init_worker_groups → _init_models
+        self.device_name = device_name
+        self.ray_worker_group_cls = ray_worker_group_cls or RayWorkerGroup
+        self.tokenizer = tokenizer
+
+        # Additional attributes from SeparateRayPPOTrainer/RayPPOTrainer.__init__
+        # that PPOTrainer.__init__ doesn't set but _create_worker_classes / _init_models need:
+        from verl.trainer.ppo.utils import need_reward_model
+
+        self.use_rm = need_reward_model(self.config)
+        lora_rank = config.actor_rollout_ref.model.get("lora", {}).get("rank", 0)
+        if lora_rank <= 0:
+            lora_rank = config.actor_rollout_ref.model.get("lora_rank", 0)
+        self.ref_in_actor = lora_rank > 0 or config.actor_rollout_ref.model.get("lora_adapter_path") is not None
+
+        # ======== 2. FullyAsyncTrainer state fields ========
+        # (mirrors FullyAsyncTrainer.__init__ lines 108-163)
+        self.global_steps = 0
+        self.epoch = 0
+        self.max_steps_duration = 0
+        self.progress_bar = None
+        self.is_last_step = False
+        self.prev_step_profile = False
+        self.curr_step_profile = False
+        self.next_step_profile = False
+        self.last_val_metrics = {}
+        self.metrics = {}
+        self.timing_raw = {}
+
+        self.local_trigger_step = 1
+        self.processed_samples = 0
+        self.stale_trajectory_processed = 0
+        self.current_param_version = 0
+        self.total_train_steps = None
+        self.trigger_parameter_sync_step = config.async_training.trigger_parameter_sync_step
+        self.last_ckpt_version = 0
+        self.train_role = Role.ActorRollout if config.async_training.use_trainer_do_validate else Role.Actor
+
+        self.require_batches = config.async_training.require_batches
+        self.required_samples = config.actor_rollout_ref.actor.ppo_mini_batch_size * self.require_batches
+        total_gpus = (
+            config.trainer.nnodes * config.trainer.n_gpus_per_node
+            + config.rollout.nnodes * config.rollout.n_gpus_per_node
+        )
+        self.metrics_aggregator = MetricsAggregator(total_gpus=total_gpus)
+
+        self.rollouter = None
+        self.checkpoint_manager = None
+        self.hybrid_checkpoint_manager = None
+
+        # ======== 3. TQ-specific: ReplayBuffer Ray Actor handle ========
+        self.replay_buffer = None  # Set via set_replay_buffer()
+
+        # Logger
+        self.logger = Tracking(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+            default_backend=self.config.trainer.logger,
+            config=OmegaConf.to_container(self.config, resolve=True),
+        )
+        self.validation_generations_logger = ValidationGenerationsLogger(
+            project_name=self.config.trainer.project_name,
+            experiment_name=self.config.trainer.experiment_name,
+        )
+        print("[TQFullyAsyncTrainer] initialized (multi-inherit: PPOTrainer + FullyAsyncTrainer)")
+
+    async def set_replay_buffer(self, replay_buffer):
+        """Set ReplayBuffer Ray Actor handle."""
+        self.replay_buffer = replay_buffer
+
+    async def init_workers(self):
+        await FullyAsyncTrainer.init_workers(self)
+        tq.init()
+
+    async def _get_keys_from_rb(self) -> KVBatchMeta | None:
+        """
+        Get a KVBatchMeta from TQ via ReplayBuffer.
+
+        Replaces both:
+        - PPOTrainer's generate_sequences() + replay_buffer.sample()
+        - FullyAsyncTrainer's message_queue_client.get_sample() + assemble
+
+        Returns KVBatchMeta compatible with PPOTrainer's entire step() pipeline.
+        """
+        sampled_keys_meta = await self.replay_buffer.sample.remote(
+            partition_id="train",
+            sample_size=self.required_samples,
+            rollout_n=self.config.actor_rollout_ref.rollout.n,
+        )
+
+        if sampled_keys_meta is None or len(sampled_keys_meta) == 0:
+            print("[TQFullyAsyncTrainer] RB returned None (termination signal)")
+            return None
+
+        keys = [k for k, _ in sampled_keys_meta]
+        tags = [meta for _, meta in sampled_keys_meta]
+
+        return KVBatchMeta(partition_id="train", keys=keys, tags=tags)
+
+    async def fit(self):
+        """Main training loop: async RB consumption + PPOTrainer step() pipeline."""
+        print("[TQFullyAsyncTrainer] Starting fit ...", flush=True)
+        print(
+            f"[TQTrainer] fit(): rb={self.replay_buffer is not None}, rollouter={self.rollouter is not None}",
+            flush=True,
+        )
+        if self.replay_buffer is None:
+            raise ValueError("ReplayBuffer not set. Call set_replay_buffer() first.")
+        if self.rollouter is None:
+            raise ValueError("rollouter not set. Call set_rollouter() first.")
+
+        self.max_steps_duration = 0
+
+        self.global_steps += 1
+
+        self.prev_step_profile = False
+        self.curr_step_profile = (
+            self.global_steps in self.config.global_profiler.steps
+            if self.config.global_profiler.steps is not None
+            else False
+        )
+        self.next_step_profile = False
+
+        while True:
+            try:
+                await self.fit_step()
+            except TrainingStopException:
+                print("[TQFullyAsyncTrainer] Training stopped by termination signal")
+                break
+
+        self.progress_bar.close()
+        if self.current_param_version % self.config.trainer.test_freq != 0 or self.local_trigger_step > 1:
+            await self._fit_update_weights()
+            await self._fit_validate()
+        self._fit_save_checkpoint(force=True)
+
+    async def fit_step(self, batch_dict: dict = None):
+        """Single training step: get KVBatchMeta from RB → run PPOTrainer pipeline."""
+        self.metrics = {"training/global_step": self.global_steps, "training/epoch": self.epoch}
+        self.timing_raw = {}
+
+        self._start_profiling()
+
+        with marked_timer("step", self.timing_raw):
+            # Run PPOTrainer's full KVBatchMeta pipeline (steps 2-10)
+            metrics = self.metrics
+            timing_raw = self.timing_raw
+
+            # ★ CORE: Get KVBatchMeta from RB (replaces generate_sequences + replay_buffer.sample)
+
+            # 2. sample batch from replay buffer
+            with marked_timer("gen", timing_raw, color="red"):
+                batch = await self._get_keys_from_rb()
+                if batch is None:
+                    raise TrainingStopException("Training terminated: RB returned None")
+                batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
+            print(
+                f"[TQFullyAsyncTrainer] Waiting for {self.required_samples} samples, "
+                f"keys={len(batch)}, "
+                f"wait={timing_raw['gen']:.2f}s"
+            )
+
+            # 3. [OPTIONAL] compute reward score with colocated reward model
+            # TODO colocate reward not implemented
+
+            # 4. balance batch across data parallel groups
+            batch = self._balance_batch(batch, metrics=metrics)
+
+            # 5. compute old_log_prob
+            with marked_timer("old_log_prob", timing_raw, color="blue"):
+                batch = self._compute_old_log_prob(batch, metrics=metrics)
+
+            # 6. [OPTIONAL] compute ref_log_prob
+            if self.use_reference_policy:
+                with marked_timer("ref", timing_raw, color="olive"):
+                    batch = self._compute_ref_log_prob(batch, metrics=metrics)
+
+            # 7. [OPTIONAL] compute critic values
+            if self.use_critic:
+                with marked_timer("values", timing_raw, color="cyan"):
+                    batch = self._compute_values(batch, metrics=metrics)
+
+            # 8. compute advantage and return
+            with marked_timer("adv", timing_raw, color="brown"):
+                batch = self._compute_advantage(batch, metrics=metrics)
+
+            # 9. [OPTIONAL] update critic
+            if self.use_critic:
+                with marked_timer("update_critic", timing_raw, color="pink"):
+                    batch = self._update_critic(batch, metrics=metrics)
+
+            # 10. update actor
+            if self.config.trainer.critic_warmup <= self.global_steps:
+                with marked_timer("update_actor", timing_raw, color="red"):
+                    batch = self._update_actor(batch, metrics=metrics)
+
+            self._fit_update_local_step()
+            await self._fit_update_weights()
+
+        await self._fit_collect_metrics(batch)
+        await self._cleanup_batch(batch)
+        await self._fit_reset_staleness()
+
+        await self._fit_validate()
+        self._fit_save_checkpoint()
+        self._stop_profiling()
+        self._fit_postprocess_step()
+
+    async def _cleanup_batch(self, batch):
+        """Cleanup consumed batch from TQ and RB.
+
+        Two-phase cleanup:
+        1. Clear uid-level keys (deduplicated by uid from tags): removes uid status entries
+           like {'uid': {'status': 'finished'}} from both TQ and RB partitions.
+        2. Clear all sampled response keys: full cleanup of {uid}_{resp_idx} keys from TQ and RB.
+        """
+        # Phase 1: Deduplicate by uid from tags to get uid-level keys
+        uid_keys: set[str] = set()
+        for key, tag in zip(batch.keys, batch.tags, strict=False):
+            uid = tag.get("uid", "") if isinstance(tag, dict) else ""
+            if uid and uid not in uid_keys:
+                uid_keys.add(uid)
+
+        tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
+        await self.replay_buffer.remove.remote(batch.partition_id, list(uid_keys))
+
+        # Phase 2: Clear all sampled response keys (full cleanup)
+        tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
+        await self.replay_buffer.remove.remote(batch.partition_id, batch.keys)
+
+    async def _fit_update_weights(self):
+        if self.local_trigger_step != 1:
+            return
+
+        with marked_timer("timing_s/param_sync", self.timing_raw):
+            await self.checkpoint_manager.update_weights(global_steps=self.current_param_version)
+        print(
+            f"[FullyAsyncTrainer] _fit_update_weights, "
+            f"timing_s/param_sync: {self.timing_raw['timing_s/param_sync']:.4f} seconds "
+            f"self.current_param_version: {self.current_param_version}"
+        )
+        # Log aggregated training metrics
+        self.logger.log(
+            data=self.metrics_aggregator.get_aggregated_metrics(),
+            step=self.current_param_version,
+        )
+        self.metrics_aggregator.reset()
+
+    async def _fit_reset_staleness(self):
+        # Reset staleness in rollouter
+        if self.local_trigger_step != 1:
+            return
+        timing_raw = await self.rollouter.reset_staleness.remote()
+        self.logger.log(
+            data=timing_raw,
+            step=self.current_param_version,
+        )
+
+    async def _fit_collect_metrics(self, batch: KVBatchMeta):
+        """Collect metrics using PPOTrainer's _compute_metrics (expects KVBatchMeta).
+
+        Also merges rollouter statistics and TQ timing tags to produce the same set of
+        ``fully_async/*`` and ``timing_s/*`` metrics as the non-TQ path's batch assembly.
+        """
+        # 1. Base PPOTrainer metrics (data, timing, throughput, variance proxy)
+        self._compute_metrics(batch, self.metrics, self.timing_raw, global_steps=self.global_steps, epoch=self.epoch)
+
+        # 2. Collect per-sample timing stats from tags for aggregation
+        processing_times = []
+        tool_calls_list = []
+        compute_score_list = []
+        param_versions = []  # max_global_steps per sample (mirrors trajectory_param_versions in detach_utils)
+        param_version_starts = []  # min_global_steps per sample
+        if batch.tags:
+            for tag in batch.tags:
+                if not isinstance(tag, dict):
+                    continue
+                # Collect raw values for aggregation
+                if "timing_s/gen" in tag:
+                    processing_times.append(tag["timing_s/gen"])
+                if "timing_s/agent_loop/tool_calls" in tag:
+                    tool_calls_list.append(tag["timing_s/agent_loop/tool_calls"])
+                if "timing_s/compute_score" in tag:
+                    compute_score_list.append(tag["timing_s/compute_score"])
+                if "max_global_steps" in tag:
+                    param_versions.append(tag["max_global_steps"])
+                if "min_global_steps" in tag:
+                    param_version_starts.append(tag["min_global_steps"])
+                # Merge all fully_async/* and timing_s/* tags directly
+                for key, value in tag.items():
+                    if key.startswith("fully_async") or key.startswith("timing_s"):
+                        self.metrics[key] = value
+
+        # 3. Compute aggregated processing_time stats (mirrors assemble_batch_from_rollout_samples lines 134-149)
+        if processing_times:
+            processing_time_stats = {
+                "fully_async/processing_time/avg": float(np.mean(processing_times)),
+                "fully_async/processing_time/max": float(np.max(processing_times)),
+                "fully_async/processing_time/min": float(np.min(processing_times)),
+                "fully_async/processing_time/tp50": float(np.percentile(processing_times, 50)),
+                "fully_async/processing_time/tp99": float(np.percentile(processing_times, 99)),
+                "fully_async/processing_time/tp95": float(np.percentile(processing_times, 95)),
+            }
+            self.metrics.update(processing_time_stats)
+
+        # 4. Compute tool_calls stats
+        if tool_calls_list:
+            tool_calls_stats = {
+                "timing_s/agent_loop/tool_calls/max": float(np.max(tool_calls_list)),
+                "timing_s/agent_loop/tool_calls/min": float(np.min(tool_calls_list)),
+                "timing_s/agent_loop/tool_calls/mean": float(np.mean(tool_calls_list)),
+            }
+            self.metrics.update(tool_calls_stats)
+
+        # 4b. Compute compute_score stats
+        if compute_score_list:
+            compute_score_stats = {
+                "timing_s/compute_score/max": float(np.max(compute_score_list)),
+                "timing_s/compute_score/min": float(np.min(compute_score_list)),
+                "timing_s/compute_score/mean": float(np.mean(compute_score_list)),
+            }
+            self.metrics.update(compute_score_stats)
+
+        # 5. Compute partial stats from param versions (mirrors assemble_batch_from_rollout_samples lines 151-159)
+        if param_versions and param_version_starts:
+            param_version_diff = [abs(a - b) for a, b in zip(param_versions, param_version_starts, strict=False)]
+            num_diff0 = param_version_diff.count(0)
+            partial_stats = {
+                "fully_async/partial/total_partial_num": len(param_version_diff) - num_diff0,
+                "fully_async/partial/partial_ratio": (len(param_version_diff) - num_diff0) / len(param_version_diff)
+                if param_version_diff
+                else 0.0,
+                "fully_async/partial/max_partial_span": max(param_version_diff) if param_version_diff else 0,
+            }
+            self.metrics.update(partial_stats)
+
+            # 6. stale_trajectory_processed count
+            # Use max_global_steps as trajectory_param_versions
+            stale_traj_count = sum(1 for v in param_versions if self.current_param_version - v >= 1)
+            self.stale_trajectory_processed += stale_traj_count
+            self.metrics["fully_async/count/stale_trajectory_processed"] = self.stale_trajectory_processed
+            self.metrics["fully_async/count/current_param_version"] = self.current_param_version
+
+        # 7. Merge rollouter monitor/count/static stats
+        rollouter_stats = await self.replay_buffer.get_statistics.remote()
+        for k, v in rollouter_stats.items():
+            if isinstance(v, int | float):
+                self.metrics[f"fully_async/{k}"] = v

--- a/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
@@ -37,6 +37,7 @@ from verl.experimental.fully_async_policy.fully_async_trainer import (
     FullyAsyncTrainer,
     TrainingStopException,
 )
+from verl.experimental.fully_async_policy.replay_buffer import tq_kv_clear
 from verl.single_controller.ray import RayWorkerGroup
 from verl.trainer.main_ppo_sync import PPOTrainer
 from verl.trainer.ppo.ray_trainer import ResourcePoolManager
@@ -168,12 +169,19 @@ class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer):
         sampled_keys_meta = await self.replay_buffer.sample.remote(
             partition_id="train",
             sample_size=self.required_samples,
-            rollout_n=self.config.actor_rollout_ref.rollout.n,
         )
 
         if sampled_keys_meta is None or len(sampled_keys_meta) == 0:
             print("[TQFullyAsyncTrainer] RB returned None (termination signal)")
             return None
+
+        rollout_n = self.config.actor_rollout_ref.rollout.n
+        expected = self.required_samples * rollout_n
+        if len(sampled_keys_meta) != expected:
+            # TODO: when multi-trajectory output support is added, this will need to change
+            raise ValueError(
+                f"[ReplayBuffer][sample] BUG: len(all_response_keys)={len(sampled_keys_meta)} != expected={expected}"
+            )
 
         keys = [k for k, _ in sampled_keys_meta]
         tags = [meta for _, meta in sampled_keys_meta]
@@ -237,11 +245,6 @@ class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer):
                 if batch is None:
                     raise TrainingStopException("Training terminated: RB returned None")
                 batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-            print(
-                f"[TQFullyAsyncTrainer] Waiting for {self.required_samples} samples, "
-                f"keys={len(batch)}, "
-                f"wait={timing_raw['gen']:.2f}s"
-            )
 
             # 3. [OPTIONAL] compute reward score with colocated reward model
             # TODO colocate reward not implemented
@@ -281,35 +284,13 @@ class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer):
             await self._fit_update_weights()
 
         await self._fit_collect_metrics(batch)
-        await self._cleanup_batch(batch)
+        tq_kv_clear(batch)
         await self._fit_reset_staleness()
 
         await self._fit_validate()
         self._fit_save_checkpoint()
         self._stop_profiling()
         self._fit_postprocess_step()
-
-    async def _cleanup_batch(self, batch):
-        """Cleanup consumed batch from TQ and RB.
-
-        Two-phase cleanup:
-        1. Clear uid-level keys (deduplicated by uid from tags): removes uid status entries
-           like {'uid': {'status': 'finished'}} from both TQ and RB partitions.
-        2. Clear all sampled response keys: full cleanup of {uid}_{resp_idx} keys from TQ and RB.
-        """
-        # Phase 1: Deduplicate by uid from tags to get uid-level keys
-        uid_keys: set[str] = set()
-        for key, tag in zip(batch.keys, batch.tags, strict=False):
-            uid = tag.get("uid", "") if isinstance(tag, dict) else ""
-            if uid and uid not in uid_keys:
-                uid_keys.add(uid)
-
-        tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
-        await self.replay_buffer.remove.remote(batch.partition_id, list(uid_keys))
-
-        # Phase 2: Clear all sampled response keys (full cleanup)
-        tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
-        await self.replay_buffer.remove.remote(batch.partition_id, batch.keys)
 
     async def _fit_update_weights(self):
         if self.local_trigger_step != 1:

--- a/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer_tq.py
@@ -48,7 +48,7 @@ try:
     import transfer_queue as tq
     from transfer_queue import KVBatchMeta
 except ImportError:
-    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    print("Please install TQ by calling `pip install TransferQueue==0.1.8` and try again.")
     from verl.utils.transferqueue_utils import KVBatchMeta, tq
 
 logger = logging.getLogger(__name__)

--- a/verl/experimental/fully_async_policy/replay_buffer.py
+++ b/verl/experimental/fully_async_policy/replay_buffer.py
@@ -1,0 +1,512 @@
+# Copyright 2025 Meituan Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ReplayBuffer: Ray Actor for metadata channel + slot-based flow control in TQ fully async training.
+
+Architecture:
+- TQFullyAsyncRollouter: Calls acquire_slot() in _feed_samples, writes results to TQ with status=finish,
+  then calls release_slot() to release the slot after successful TQ write
+- TQFullyAsyncTrainer: Consumes finished samples via wait_and_sample(), reads data from TQ
+
+Status Flow:
+    (Rollouter writes status=finish) -> finish -> (Trainer consumes & removes)
+
+Slot Control:
+- acquire_slot(): Rollouter calls in _feed_samples BEFORE putting to pending_queue (blocking)
+- release_slot(): Called by Rollouter after successfully writing sample to TQ (normal path),
+  or on error/drop path (sample never written to TQ)
+- This replaces _should_pause_generation() + MessageQueue.queue_size backpressure
+
+Usage:
+    from verl.experimental.fully_async_policy_tq.replay_buffer import ReplayBuffer
+
+    rb = ReplayBuffer.remote(max_pending_slots=256)
+    # Rollouter side:
+    acquired = await asyncio.wrap_future(rb.acquire_slot.remote(timeout=None).future())
+    # ... write to TQ ...
+    await rb.release_slot.remote()  # release after successful TQ write
+    # Trainer side:
+    sampled = await asyncio.wrap_future(rb.wait_and_sample.remote("train", batch_size=64).future())
+"""
+
+import asyncio
+import logging
+import os
+import time
+from collections import defaultdict
+from pprint import pformat
+
+import ray
+
+try:
+    import transfer_queue as tq
+except ImportError:
+    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    from verl.utils.transferqueue_utils import tq
+
+from verl.experimental.fully_async_policy.detach_utils import safe_create_task
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+@ray.remote(max_concurrency=100)
+class ReplayBuffer:
+    """Ray Actor: metadata channel + slot-based flow control for TQ fully async training.
+
+    Replaces MessageQueue (data channel) in the original fully_async_policy.
+    Key responsibilities:
+    1. Slot-based backpressure: acquire_slot() blocks rollouter at dataloader source
+    2. Metadata storage: tracks status of each sample (updated by caller via update_metadata)
+    3. Consumer interface: wait_and_sample() for trainer to get finished samples
+    4. Version tracking: reset_staleness() for parameter sync coordination
+    """
+
+    def __init__(
+        self,
+        max_version_slots: int,
+        max_pending_slots: int = 256,
+        poll_interval: float = 1.0,
+    ):
+        # Partition -> {key: tags_dict}
+        self.idle_start_time = time.time()
+        self.step_start_time = time.time()
+
+        self.partitions: dict[str, dict[str, dict]] = defaultdict(dict)
+        self.poll_interval = poll_interval
+        self._finished = False
+
+        # ======== Layer 1: Physical slot control (concurrency / OOM guard) ========
+        # Limits simultaneous in-flight samples.
+        # Acquired in _feed_samples (Rollouter), released by release_slot() after TQ write.
+        # Maps to: max_concurrent_samples (e.g. TP * PP * 16)
+        self.max_pending_slots = max_pending_slots
+        self._pending_slots = 0  # acquired but not yet finish
+        # Condition for slot flow control: acquire_slot waits, release_slot/reset_staleness/signal_finish notify
+        self._slot_available = asyncio.Condition()
+        # Condition for data availability: wait_and_sample waits, _poll_from_tq/signal_finish notify
+        self._data_available = asyncio.Condition()
+
+        # ======== Layer 2: Version window control (staleness guard) ========
+        # Limits total samples (slots) per model version.
+        # When _version_slots >= max_version_slots, acquire_slot() blocks until
+        # reset_staleness() is called (after param sync).
+        # _version_slots is in SLOT granularity: 1 slot = 1 sample (prompt).
+        self.max_version_slots = max_version_slots
+        self._version_slots = 0  # cumulative slots issued in current version
+
+        # Initialize TQ in this actor process so _poll_from_tq can call tq.kv_list()
+        try:
+            import transfer_queue as tq
+
+            tq.init()
+            print("[ReplayBuffer] TQ initialized in RB actor process", flush=True)
+        except Exception as e:
+            print(f"[ReplayBuffer] TQ init warning: {e}", flush=True)
+
+        print(
+            f"[ReplayBuffer] initialized with "
+            f"max_pending_slots={max_pending_slots}, "
+            f"max_version_slots={max_version_slots}, "
+            f"poll_interval={poll_interval}"
+        )
+
+        # Start background tasks immediately
+        self._poll_task = safe_create_task(self._poll_from_tq(), name="poll_tq_task")
+        self._monitor_task = safe_create_task(self._monitor_loop(), name="monitor_task")
+        print("[ReplayBuffer] Background poll & monitor tasks started (asyncio)", flush=True)
+
+    async def _poll_from_tq(self):
+        """Background asyncio task that polls TQ for metadata updates.
+
+        Each poll replaces self.partitions with a fresh TQ snapshot (not in-place mutation).
+        This ensures self.partitions is always consistent with TQ's current state,
+        avoiding stale/corrupted data from incremental merge + concurrent remove().
+
+        UID integrity check:
+            When TQ deletion errors occur, orphaned keys may remain whose meta.uid
+            does not match the key's prefix. For example:
+            - Normal:   key='sample_1_13247_10_0', meta.uid='sample_1_13247'  → key starts with uid ✓
+            - Orphaned: key='sample_1_10885_13_0', meta.uid='sample_1_11114' → key does NOT start with uid ✗
+            Such entries are detected, logged as ABNORMAL, and deleted from TQ to prevent
+            corrupting the uid→response_keys mapping used by wait_and_sample().
+        """
+        try:
+            while not self._finished:
+                data = tq.kv_list()
+                if data is not None:
+                    # Build a fresh snapshot from TQ, then atomically replace self.partitions
+                    new_partitions: dict[str, dict[str, dict]] = defaultdict(dict)
+                    for partition_id, items in data.items():
+                        for key, meta in items.items():
+                            new_partitions[partition_id][key] = meta
+                    # Update self.partitions atomically
+                    async with self._data_available:
+                        self.partitions = new_partitions
+                        self._data_available.notify_all()
+                await asyncio.sleep(self.poll_interval)
+        except Exception as e:
+            print(f"[ReplayBuffer] _poll_from_tq error: {e}", flush=True)
+            import traceback
+
+            traceback.print_exc()
+            os._exit(1)
+
+    async def _monitor_loop(self):
+        """Background asyncio task that periodically logs buffer statistics."""
+
+        monitor_interval = 60.0
+        while not self._finished:
+            await asyncio.sleep(monitor_interval)
+            if self._finished:
+                break
+            try:
+                stats = await self.get_statistics()
+                print(f"[ReplayBuffer][Monitor] {pformat(stats)}")
+            except Exception as e:
+                logger.error(f"[ReplayBuffer] _monitor_loop error: {e}")
+
+    # ======== Public API ========
+
+    async def acquire_slot(self, timeout: float | None = None, uid="") -> bool:
+        """Acquire a slot before processing a dataloader sample.
+
+        Layer 1 (Physical): ``_pending_slots < max_pending_slots``
+            Limits simultaneous in-flight samples to prevent OOM / GPU overload.
+            Slot is released by calling release_slot() after writing to TQ.
+
+        Layer 2 (Version window): ``_version_slots < max_version_slots``
+            Limits total slots issued per model version to control staleness.
+            When the version window is full, acquire_slot() blocks until
+            reset_staleness() is called after parameter synchronization.
+            Only enforced if max_version_slots is set (via set_version_config()).
+
+        Both conditions must be satisfied for a slot to be issued.
+        """
+        _wait_forever = timeout is None
+        _deadline_abs = None if _wait_forever else (asyncio.get_event_loop().time() + timeout)
+
+        async with self._slot_available:
+            while True:
+                # Check termination first
+                if self._finished:
+                    return False
+
+                # Layer 1: Physical concurrency limit
+                physical_ok = self._pending_slots < self.max_pending_slots
+
+                # Layer 2: Version window limit (staleness control)
+                version_ok = self.max_version_slots is None or self._version_slots < self.max_version_slots
+
+                if physical_ok and version_ok:
+                    self._pending_slots += 1
+                    self._version_slots += 1
+                    logger.debug(
+                        f"[ReplayBuffer][acquire_slot] Acquiring slot, "
+                        f"pending_slots={self._pending_slots}, "
+                        f"version_slots={self._version_slots}, "
+                        f"uid={uid}"
+                    )
+                    return True
+
+                # Wait for notification (slot release, reset_staleness, or signal_finish)
+                if not _wait_forever:
+                    remaining = _deadline_abs - asyncio.get_event_loop().time()
+                    if remaining <= 0:
+                        return False
+                    try:
+                        await asyncio.wait_for(
+                            self._slot_available.wait(),
+                            timeout=remaining,
+                        )
+                    except TimeoutError:
+                        return False
+                else:
+                    await self._slot_available.wait()
+
+    async def release_slot(self):
+        """Release a slot after processing.
+
+        When all slots are released (_pending_slots == 0), record the idle start time.
+        This means the rollouter has finished all in-flight work but may be blocked
+        from acquiring new slots (e.g., version window full, dataloader exhausted).
+        Mirrors fully_async_rollouter.py:886 idle tracking.
+        """
+        async with self._slot_available:
+            self._pending_slots = max(0, self._pending_slots - 1)
+            logger.debug(
+                f"[ReplayBuffer][release_slot] Releasing slot, "
+                f"pending_slots={self._pending_slots}, "
+                f"version_slots={self._version_slots}"
+            )
+            # Record idle start when all slots are released (rollouter has no work)
+            if self._pending_slots == 0:
+                self.idle_start_time = time.time()
+            self._slot_available.notify_all()
+
+    async def sample(
+        self,
+        partition_id: str,
+        sample_size: int,
+        rollout_n: int,
+    ) -> list[tuple[str, dict]] | None:
+        """Block until enough finish samples (uids) are ready or production is fully complete.
+
+        Args:
+            partition_id: Partition to sample from (e.g. 'train').
+            sample_size: Number of **samples (uids)** to wait for, not number of response keys.
+                        Each sample/uid may have multiple response keys (e.g. n=16 responses per prompt).
+            rollout_n: Number of response keys per uid (e.g. n=16 responses per prompt).
+
+        Strategy:
+        1. Find uid-level keys with status 'finished' (written by _run_prompt after all n responses done)
+        2. Extract uids from these uid-level keys
+        3. For each uid, find ALL matching response keys (e.g. 'sample_0_190_0', ..., 'sample_0_190_15')
+           from the partition — integrity check: skip uids whose response keys haven't been
+           fully synced by _poll_from_tq yet (race between uid "finished" and response key arrival)
+        4. Return all collected response keys for up to sample_size *complete* uids
+        """
+        async with self._data_available:
+            while True:
+                # Check termination first
+                if self._finished:
+                    return None
+
+                # Check if enough finish samples (uids) are ready
+                part = self.partitions.get(partition_id)
+                if part is not None:
+                    # Step 1: Find finished uids from uid-level keys with status 'finished'
+                    finished_uids: set[str] = set()
+                    for key, meta in part.items():
+                        status = meta.get("status", "")
+                        if status == "finished":
+                            finished_uids.add(key)
+
+                    # Step 2: Check if we have enough finished uids
+                    if len(finished_uids) >= sample_size:
+                        # Step 3: Count response keys per uid (integrity check)
+                        # Build uid -> [response_keys] mapping from ALL non-uid-level entries
+                        uid_response_keys: dict[str, list[tuple[str, dict]]] = {}
+                        for key, meta in part.items():
+                            uid = meta.get("uid", "")
+                            if uid and uid in finished_uids:
+                                # This is a response key (has uid tag) belonging to a finished uid
+                                uid_response_keys.setdefault(uid, []).append((key, meta))
+
+                        normal_eq_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) == rollout_n]
+                        abnormal_gt_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) > rollout_n]
+                        abnormal_lt_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) < rollout_n]
+
+                        # For abnormal_gt_uids: check key vs meta.uid consistency,
+                        # remove mismatched keys from in-memory partition (not TQ),
+                        # then promote to normal_eq_uids if remaining count == rollout_n
+                        if abnormal_gt_uids:
+                            promoted_uids: list[str] = []
+                            detail_lines: list[str] = []
+                            for uid in abnormal_gt_uids:
+                                keys_and_metas = uid_response_keys[uid]
+                                matched_keys: list[tuple[str, dict]] = []
+                                removed_keys: list[str] = []
+                                for key, meta in keys_and_metas:
+                                    meta_uid = meta.get("uid", "") if isinstance(meta, dict) else ""
+                                    if meta_uid and key.startswith(meta_uid):
+                                        matched_keys.append((key, meta))
+                                    else:
+                                        part.pop(key, None)
+                                        removed_keys.append(key)
+
+                                if matched_keys and len(matched_keys) == rollout_n:
+                                    promoted_uids.append(uid)
+                                    uid_response_keys[uid] = matched_keys
+                                    detail_lines.append(
+                                        f"  uid='{uid}': {len(keys_and_metas)}->{len(matched_keys)} keys, "
+                                        f"removed={removed_keys}"
+                                    )
+
+                            if detail_lines:
+                                print(
+                                    f"[ReplayBuffer][sample] ✂️ Cleaned {len(abnormal_gt_uids)} abnormal_gt uids "
+                                    f"(promoted {len(promoted_uids)} to normal_eq, "
+                                    f"remaining abnormal={len(abnormal_gt_uids) - len(promoted_uids)})\n"
+                                    + "\n".join(detail_lines),
+                                    flush=True,
+                                )
+
+                            normal_eq_uids.extend(promoted_uids)
+                            abnormal_gt_uids = [u for u in abnormal_gt_uids if u not in set(promoted_uids)]
+
+                        if len(normal_eq_uids) >= sample_size:
+                            selected_uids = normal_eq_uids[:sample_size]
+                            all_response_keys: list[tuple[str, dict]] = []
+                            for uid in selected_uids:
+                                all_response_keys.extend(uid_response_keys[uid])
+
+                            expected_keys = sample_size * rollout_n
+
+                            if len(all_response_keys) != expected_keys:
+                                print(
+                                    f"len(all_response_keys)={len(all_response_keys)} != expected_keys={expected_keys}"
+                                )
+                                continue
+
+                            print(
+                                f"[ReplayBuffer][wait_and_sample][{partition_id}] Returning {len(all_response_keys)} "
+                                f"response keys from {len(selected_uids)} uids "
+                                f"(sample_size={sample_size}, "
+                                f"total_finished={len(finished_uids)}, "
+                                f"normal_eq_uids={len(normal_eq_uids)}, "
+                                f"abnormal_gt_uids={len(abnormal_gt_uids)}, "
+                                f"abnormal_lt_uids={len(abnormal_lt_uids)})",
+                                flush=True,
+                            )
+
+                            return all_response_keys
+                    else:
+                        print(
+                            f"[ReplayBuffer][wait_and_sample][{partition_id}] ready: "
+                            f"{len(finished_uids)} uids, need={sample_size}",
+                        )
+
+                # Wait for _poll_from_tq to write new metadata or signal_finish
+                await self._data_available.wait()
+
+    async def remove(self, partition_id: str, keys: list[str]):
+        """Remove consumed samples from the metadata store."""
+        async with self._data_available:
+            part = self.partitions.get(partition_id)
+            size_before = len(part) if part is not None else 0
+            if part is not None:
+                for key in keys:
+                    part.pop(key, None)
+            size_after = len(part) if part is not None else 0
+
+        logger.debug(
+            f"[ReplayBuffer][remove] partition={partition_id}: "
+            f"size {size_before} -> {size_after} "
+            f"(removed {len(keys)} keys, actually_deleted={size_before - size_after})",
+        )
+
+    async def reset_staleness(self) -> dict:
+        """Reset the version window after parameter synchronization.
+
+        Mirrors FullyAsyncRollouter.reset_staleness() timing logic:
+        - version_time: wall-clock time since last reset (i.e., this param sync cycle duration)
+        - active_time: actual work time within the cycle (version_time minus idle periods)
+        - idle_ratio: fraction of time the rollouter was idle during the cycle
+        """
+        async with self._slot_available:
+            # Compute current partition status counts for state reset
+            partition_stats = await self.compute_partition_stats()
+            prev_version_slots = self._version_slots
+
+            data = tq.kv_list()
+            tq_keys = sum(len(items) for items in data.values()) if data else 0
+
+            # Use partition_stats["train"]["success"] as the unconsumed backlog count
+            # This reflects samples written to TQ (status=success) but not yet consumed by trainer
+            train_stats = partition_stats.get("train", {})
+            train_finished_slots = train_stats.get("finished", 0)
+
+            # _version_slots = pending_slots (in-flight) + success_backlog (unconsumed in partitions)
+            # Uses partition_stats which is the source of truth for what trainer has not yet consumed
+            self._version_slots = self._pending_slots + train_finished_slots
+
+            # Timing metrics
+            # |step_start_time          |idle_start_time
+            #
+            # |<----- active_time ----->|<------ idle time ------>|
+            # |<------------- version_time ---------------------->|
+            now = time.time()
+            if self.step_start_time is None:
+                self.step_start_time = now
+                self.idle_start_time = now
+
+            rollout_version_time = max(now - self.step_start_time, 1e-6)
+            if self.idle_start_time is not None and self.idle_start_time > self.step_start_time:
+                rollout_active_time = self.idle_start_time - self.step_start_time
+                idle_ratio = 1.0 - rollout_active_time / rollout_version_time
+            else:
+                rollout_active_time = rollout_version_time
+                idle_ratio = 0.0
+
+            timing_raw = {
+                "fully_async/rollouter/active_time": rollout_active_time,
+                "fully_async/rollouter/version_time": rollout_version_time,
+                "fully_async/rollouter/idle_ratio": idle_ratio,
+            }
+
+            print(
+                f"[ReplayBuffer][reset_staleness] "
+                f"version_slots: {prev_version_slots} -> {self._version_slots} "
+                f"pending_slots={self._pending_slots}, "
+                f"train_finished_slots={train_finished_slots}, "
+                f"tq_keys={tq_keys}), "
+                f"idle_ratio: {idle_ratio:.4f}, ",
+                f"partition_stats: {partition_stats}",
+                flush=True,
+            )
+
+            # Reset timers for next cycle (mirrors fully_async_rollouter.py:600)
+            self.step_start_time = now
+            self.idle_start_time = now
+
+            # Wake up acquire_slot waiters blocked on version window
+            self._slot_available.notify_all()
+
+        return timing_raw
+
+    async def signal_finish(self):
+        """Signal that production is fully complete — all samples are done."""
+        # Wake up acquire_slot waiters (return False)
+        async with self._slot_available:
+            self._finished = True
+            self._slot_available.notify_all()
+        # Wake up wait_and_sample waiters (drain remaining)
+        async with self._data_available:
+            self._data_available.notify_all()
+
+    # ======== Statistics ========
+    async def compute_partition_stats(self) -> dict[str, dict[str, int]]:
+        """Compute per-partition status counts. Lock-free read.
+
+        Returns:
+            dict mapping partition_id -> {status_type: count, ...}
+            e.g. {"train": {"success": 64, "finished": 2}}
+        """
+        async with self._data_available:
+            partition_stats: dict[str, dict[str, int]] = {}
+            for pid, part in self.partitions.items():
+                stats: dict[str, int] = {"success": 0, "finished": 0, "failure": 0, "unknown": 0}
+                for v in part.values():
+                    status = v.get("status", "unknown")
+                    if status in stats:
+                        stats[status] += 1
+                partition_stats[pid] = stats
+            return partition_stats
+
+    async def get_statistics(self) -> dict:
+        """Return statistics about the buffer state. Lock-free read."""
+        partition_stats = await self.compute_partition_stats()
+
+        return {
+            "partitions": partition_stats,
+            # Layer 1: Physical slot control
+            "pending_slots": self._pending_slots,
+            "max_pending_slots": self.max_pending_slots,
+            "available_physical_slots": max(0, self.max_pending_slots - self._pending_slots),
+            # Layer 2: Version window control
+            "version_slots": self._version_slots,
+            "max_version_slots": self.max_version_slots,
+            "available_version_slots": max(0, (self.max_version_slots or 0) - self._version_slots),
+        }

--- a/verl/experimental/fully_async_policy/replay_buffer.py
+++ b/verl/experimental/fully_async_policy/replay_buffer.py
@@ -17,27 +17,29 @@
 Architecture:
 - TQFullyAsyncRollouter: Calls acquire_slot() in _feed_samples, writes results to TQ with status=finish,
   then calls release_slot() to release the slot after successful TQ write
-- TQFullyAsyncTrainer: Consumes finished samples via wait_and_sample(), reads data from TQ
+- TQFullyAsyncTrainer: Consumes finished samples via sample(), reads data from TQ
 
 Status Flow:
     (Rollouter writes status=finish) -> finish -> (Trainer consumes & removes)
 
-Slot Control:
-- acquire_slot(): Rollouter calls in _feed_samples BEFORE putting to pending_queue (blocking)
-- release_slot(): Called by Rollouter after successfully writing sample to TQ (normal path),
-  or on error/drop path (sample never written to TQ)
-- This replaces _should_pause_generation() + MessageQueue.queue_size backpressure
+Slot Control (Dual-Layer):
+    Layer 1 (Physical):  acquire_slot() / release_slot()
+        Limits simultaneous in-flight samples to prevent OOM/GPU overload.
+        Maps to max_concurrent_samples (e.g. TP * PP * 16).
+    Layer 2 (Version):  acquire_slot() blocks / reset_staleness() unblocks
+        Limits total slots per model version to control staleness.
+        Maps to required_samples * trigger_parameter_sync_step.
 
 Usage:
-    from verl.experimental.fully_async_policy_tq.replay_buffer import ReplayBuffer
+    from verl.experimental.fully_async_policy.replay_buffer import ReplayBuffer
 
-    rb = ReplayBuffer.remote(max_pending_slots=256)
+    rb = ReplayBuffer.remote(max_pending_slots=256, max_version_slots=2176)
     # Rollouter side:
     acquired = await asyncio.wrap_future(rb.acquire_slot.remote(timeout=None).future())
     # ... write to TQ ...
     await rb.release_slot.remote()  # release after successful TQ write
     # Trainer side:
-    sampled = await asyncio.wrap_future(rb.wait_and_sample.remote("train", batch_size=64).future())
+    sampled = await rb.sample.remote(partition_id="train", sample_size=32)
 """
 
 import asyncio
@@ -61,196 +63,134 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
+_DEFAULT_MONITOR_INTERVAL_S = 60.0
+
+
 @ray.remote(max_concurrency=100)
 class ReplayBuffer:
-    """Ray Actor: metadata channel + slot-based flow control for TQ fully async training.
+    """Ray Actor: metadata channel + dual-layer slot-based flow control for TQ fully async training.
 
     Replaces MessageQueue (data channel) in the original fully_async_policy.
+
     Key responsibilities:
-    1. Slot-based backpressure: acquire_slot() blocks rollouter at dataloader source
-    2. Metadata storage: tracks status of each sample (updated by caller via update_metadata)
-    3. Consumer interface: wait_and_sample() for trainer to get finished samples
-    4. Version tracking: reset_staleness() for parameter sync coordination
+      1. **Slot-based backpressure** – ``acquire_slot()`` blocks rollouter at dataloader source
+      2. **Metadata storage** – tracks status of each sample (synced from TQ via background poll)
+      3. **Consumer interface** – ``sample()`` for trainer to get finished samples
+      4. **Version tracking** – ``reset_staleness()`` for parameter sync coordination
     """
+
+    # ------------------------------------------------------------------
+    # Construction & lifecycle
+    # ------------------------------------------------------------------
 
     def __init__(
         self,
         max_version_slots: int,
         max_pending_slots: int = 256,
         poll_interval: float = 1.0,
-    ):
-        # Partition -> {key: tags_dict}
-        self.idle_start_time = time.time()
-        self.step_start_time = time.time()
+    ) -> None:
+        # --- Timing ---
+        self.idle_start_time: float = time.time()
+        self.step_start_time: float = time.time()
 
+        # --- Metadata store ---
         self.partitions: dict[str, dict[str, dict]] = defaultdict(dict)
         self.poll_interval = poll_interval
-        self._finished = False
+        self._finished: bool = False
 
-        # ======== Layer 1: Physical slot control (concurrency / OOM guard) ========
-        # Limits simultaneous in-flight samples.
-        # Acquired in _feed_samples (Rollouter), released by release_slot() after TQ write.
-        # Maps to: max_concurrent_samples (e.g. TP * PP * 16)
-        self.max_pending_slots = max_pending_slots
-        self._pending_slots = 0  # acquired but not yet finish
-        # Condition for slot flow control: acquire_slot waits, release_slot/reset_staleness/signal_finish notify
-        self._slot_available = asyncio.Condition()
-        # Condition for data availability: wait_and_sample waits, _poll_from_tq/signal_finish notify
-        self._data_available = asyncio.Condition()
+        # --- Layer 1: Physical slot control (concurrency / OOM guard) ---
+        self.max_pending_slots: int = max_pending_slots
+        self._pending_slots: int = 0
 
-        # ======== Layer 2: Version window control (staleness guard) ========
-        # Limits total samples (slots) per model version.
-        # When _version_slots >= max_version_slots, acquire_slot() blocks until
-        # reset_staleness() is called (after param sync).
-        # _version_slots is in SLOT granularity: 1 slot = 1 sample (prompt).
-        self.max_version_slots = max_version_slots
-        self._version_slots = 0  # cumulative slots issued in current version
+        # --- Layer 2: Version window control (staleness guard) ---
+        self.max_version_slots: int = max_version_slots
+        self._version_slots: int = 0
 
-        # Initialize TQ in this actor process so _poll_from_tq can call tq.kv_list()
-        try:
-            import transfer_queue as tq
+        # --- Condition for slot availability ---
+        self._slot_available: asyncio.Condition = asyncio.Condition()
 
-            tq.init()
-            print("[ReplayBuffer] TQ initialized in RB actor process", flush=True)
-        except Exception as e:
-            print(f"[ReplayBuffer] TQ init warning: {e}", flush=True)
+        # --- Condition for data availability ---
+        self._data_available: asyncio.Condition = asyncio.Condition()
+
+        # --- TQ init ---
+        self._init_tq()
+
+        # --- Background tasks ---
+        self._monitor_task = safe_create_task(self._monitor_loop(), name="monitor_task")
 
         print(
-            f"[ReplayBuffer] initialized with "
-            f"max_pending_slots={max_pending_slots}, "
-            f"max_version_slots={max_version_slots}, "
-            f"poll_interval={poll_interval}"
+            f"[ReplayBuffer] initialized  max_pending={max_pending_slots}, max_version={max_version_slots}, ",
+            flush=True,
         )
+        print("[ReplayBuffer] Background monitor task started", flush=True)
 
-        # Start background tasks immediately
-        self._poll_task = safe_create_task(self._poll_from_tq(), name="poll_tq_task")
-        self._monitor_task = safe_create_task(self._monitor_loop(), name="monitor_task")
-        print("[ReplayBuffer] Background poll & monitor tasks started (asyncio)", flush=True)
-
-    async def _poll_from_tq(self):
-        """Background asyncio task that polls TQ for metadata updates.
-
-        Each poll replaces self.partitions with a fresh TQ snapshot (not in-place mutation).
-        This ensures self.partitions is always consistent with TQ's current state,
-        avoiding stale/corrupted data from incremental merge + concurrent remove().
-
-        UID integrity check:
-            When TQ deletion errors occur, orphaned keys may remain whose meta.uid
-            does not match the key's prefix. For example:
-            - Normal:   key='sample_1_13247_10_0', meta.uid='sample_1_13247'  → key starts with uid ✓
-            - Orphaned: key='sample_1_10885_13_0', meta.uid='sample_1_11114' → key does NOT start with uid ✗
-            Such entries are detected, logged as ABNORMAL, and deleted from TQ to prevent
-            corrupting the uid→response_keys mapping used by wait_and_sample().
-        """
-        try:
-            while True:
-                data = tq.kv_list()
-                if data is not None:
-                    # Build a fresh snapshot from TQ, then atomically replace self.partitions
-                    new_partitions: dict[str, dict[str, dict]] = defaultdict(dict)
-                    for partition_id, items in data.items():
-                        for key, meta in items.items():
-                            new_partitions[partition_id][key] = meta
-                    # Update self.partitions atomically
-                    async with self._data_available:
-                        self.partitions = new_partitions
-                        self._data_available.notify_all()
-                await asyncio.sleep(self.poll_interval)
-        except Exception as e:
-            print(f"[ReplayBuffer] _poll_from_tq error: {e}", flush=True)
-            import traceback
-
-            traceback.print_exc()
-            os._exit(1)
-
-    async def _monitor_loop(self):
-        """Background asyncio task that periodically logs buffer statistics."""
-
-        monitor_interval = 60.0
-        while not self._finished:
-            await asyncio.sleep(monitor_interval)
-            if self._finished:
-                break
+    async def _monitor_loop(self) -> None:
+        """Background task: periodically log buffer statistics."""
+        while True:
             try:
                 stats = await self.get_statistics()
                 print(f"[ReplayBuffer][Monitor] {pformat(stats)}")
-            except Exception as e:
-                logger.error(f"[ReplayBuffer] _monitor_loop error: {e}")
+                await asyncio.sleep(_DEFAULT_MONITOR_INTERVAL_S)
+            except Exception as exc:
+                logger.error("[ReplayBuffer] _monitor_loop error: %s", exc)
 
-    # ======== Public API ========
-
-    async def acquire_slot(self, timeout: float | None = None, uid="") -> bool:
+    async def acquire_slot(self, timeout: float | None = None, uid: str = "") -> bool:
         """Acquire a slot before processing a dataloader sample.
 
-        Layer 1 (Physical): ``_pending_slots < max_pending_slots``
-            Limits simultaneous in-flight samples to prevent OOM / GPU overload.
-            Slot is released by calling release_slot() after writing to TQ.
+        Both layer conditions must hold:
 
-        Layer 2 (Version window): ``_version_slots < max_version_slots``
-            Limits total slots issued per model version to control staleness.
-            When the version window is full, acquire_slot() blocks until
-            reset_staleness() is called after parameter synchronization.
-            Only enforced if max_version_slots is set (via set_version_config()).
+        - **Layer 1 (Physical)**: ``_pending_slots < max_pending_slots``
+          Prevents OOM / GPU overload from too many in-flight samples.
+        - **Layer 2 (Version)**: ``_version_slots < max_version_slots``
+          Controls staleness; blocks until ``reset_staleness()`` after param sync.
 
-        Both conditions must be satisfied for a slot to be issued.
+        Returns ``True`` if acquired, ``False`` if timed out or ``_finished``.
         """
-        _wait_forever = timeout is None
-        _deadline_abs = None if _wait_forever else (asyncio.get_event_loop().time() + timeout)
+        wait_forever = timeout is None
+        deadline = None if wait_forever else asyncio.get_event_loop().time() + timeout
 
         async with self._slot_available:
-            while True:
-                # Check termination first
-                if self._finished:
-                    return False
-
-                # Layer 1: Physical concurrency limit
+            while not self._finished:
                 physical_ok = self._pending_slots < self.max_pending_slots
-
-                # Layer 2: Version window limit (staleness control)
-                version_ok = self.max_version_slots is None or self._version_slots < self.max_version_slots
+                version_ok = self._version_slots < self.max_version_slots
 
                 if physical_ok and version_ok:
                     self._pending_slots += 1
                     self._version_slots += 1
                     logger.debug(
-                        f"[ReplayBuffer][acquire_slot] Acquiring slot, "
-                        f"pending_slots={self._pending_slots}, "
-                        f"version_slots={self._version_slots}, "
-                        f"uid={uid}"
+                        "[acquire_slot] ok  pending=%d  version=%d  uid=%s",
+                        self._pending_slots,
+                        self._version_slots,
+                        uid,
                     )
                     return True
 
-                # Wait for notification (slot release, reset_staleness, or signal_finish)
-                if not _wait_forever:
-                    remaining = _deadline_abs - asyncio.get_event_loop().time()
+                # Block until slot released, staleness reset, or signal_finish
+                if not wait_forever:
+                    remaining = deadline - asyncio.get_event_loop().time()
                     if remaining <= 0:
                         return False
                     try:
-                        await asyncio.wait_for(
-                            self._slot_available.wait(),
-                            timeout=remaining,
-                        )
+                        await asyncio.wait_for(self._slot_available.wait(), timeout=remaining)
                     except TimeoutError:
                         return False
                 else:
                     await self._slot_available.wait()
+            return False
 
-    async def release_slot(self):
-        """Release a slot after processing.
+    async def release_slot(self) -> None:
+        """Release a slot after processing (success or failure).
 
-        When all slots are released (_pending_slots == 0), record the idle start time.
-        This means the rollouter has finished all in-flight work but may be blocked
-        from acquiring new slots (e.g., version window full, dataloader exhausted).
-        Mirrors fully_async_rollouter.py:886 idle tracking.
+        When all slots are released (``_pending_slots == 0``), records
+        ``idle_start_time`` so ``reset_staleness()`` can compute idle ratio.
         """
         async with self._slot_available:
             self._pending_slots = max(0, self._pending_slots - 1)
             logger.debug(
-                f"[ReplayBuffer][release_slot] Releasing slot, "
-                f"pending_slots={self._pending_slots}, "
-                f"version_slots={self._version_slots}"
+                "[release_slot]  pending=%d  version=%d",
+                self._pending_slots,
+                self._version_slots,
             )
-            # Record idle start when all slots are released (rollouter has no work)
             if self._pending_slots == 0:
                 self.idle_start_time = time.time()
             self._slot_available.notify_all()
@@ -259,258 +199,107 @@ class ReplayBuffer:
         self,
         partition_id: str,
         sample_size: int,
-        rollout_n: int,
     ) -> list[tuple[str, dict]] | None:
-        """Block until enough finish samples (uids) are ready or production is fully complete.
+        """Block until *sample_size* complete UIDs are ready, or return ``None`` on termination.
 
         Args:
-            partition_id: Partition to sample from (e.g. 'train').
-            sample_size: Number of **samples (uids)** to wait for, not number of response keys.
-                        Each sample/uid may have multiple response keys (e.g. n=16 responses per prompt).
-            rollout_n: Number of response keys per uid (e.g. n=16 responses per prompt).
-
-        Strategy:
-        1. Find uid-level keys with status 'finished' (written by _run_prompt after all n responses done)
-        2. Extract uids from these uid-level keys
-        3. For each uid, find ALL matching response keys (e.g. 'sample_0_190_0', ..., 'sample_0_190_15')
-           from the partition — integrity check: skip uids whose response keys haven't been
-           fully synced by _poll_from_tq yet (race between uid "finished" and response key arrival)
-        4. Return all collected response keys for up to sample_size *complete* uids
+            partition_id: Partition to consume (e.g. ``'train'``, ``'val'``).
+            sample_size:   Number of **UIDs** (not response keys) to collect.
 
         Returns:
-            list of (key, meta) tuples when enough samples are available, or
-            None when _finished is True and no more samples will be produced (termination signal)
+            A list of ``(key, meta)`` tuples for the selected response keys, or
+            ``None`` when ``_finished`` is True and no more data will arrive.
         """
         async with self._data_available:
             while True:
-                # Check termination first: refresh TQ snapshot to get latest state
-                if self._finished:
-                    data = tq.kv_list()
-                    if data is not None:
-                        # Build a fresh snapshot from TQ, then atomically replace self.partitions
-                        new_partitions: dict[str, dict[str, dict]] = defaultdict(dict)
-                        for pid, items in data.items():
-                            for key, meta in items.items():
-                                new_partitions[pid][key] = meta
-                        # Update self.partitions atomically
-                        self.partitions = new_partitions
+                # Always pull fresh TQ snapshot — we are the sole reader of TQ metadata.
+                # No background poll task; this loop IS the sync point.
+                self._refresh_partitions_from_tq()
 
-                # Check if enough finish samples (uids) are ready
+                # Early exit: finished + empty → signal trainer to stop
                 part = self.partitions.get(partition_id)
+                result = self._try_sample_partition(part, partition_id, sample_size)
 
-                # Termination check: if _finished and no data available, return None to signal trainer to stop
-                if self._finished and (part is None or len(part) == 0):
-                    print(
-                        f"[ReplayBuffer][sample][{partition_id}] _finished=True, no data remaining, returning None (termination)",
-                        flush=True,
-                    )
+                if result is not None:
+                    return result
+
+                # Not enough data yet — check termination before waiting
+                if self._finished:
                     return None
 
-                if part is not None:
-                    # Step 1: Find finished uids from uid-level keys with status 'finished'
-                    finished_uids: set[str] = set()
-                    for key, meta in part.items():
-                        status = meta.get("status", "")
-                        if status == "finished":
-                            finished_uids.add(key)
-
-                    # Step 2: Check if we have enough finished uids
-                    if len(finished_uids) >= sample_size:
-                        # Step 3: Count response keys per uid (integrity check)
-                        # Build uid -> [response_keys] mapping from ALL non-uid-level entries
-                        uid_response_keys: dict[str, list[tuple[str, dict]]] = {}
-                        for key, meta in part.items():
-                            uid = meta.get("uid", "")
-                            if uid and uid in finished_uids:
-                                # This is a response key (has uid tag) belonging to a finished uid
-                                uid_response_keys.setdefault(uid, []).append((key, meta))
-
-                        normal_eq_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) == rollout_n]
-                        abnormal_gt_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) > rollout_n]
-                        abnormal_lt_uids = [uid for uid, keys in uid_response_keys.items() if len(keys) < rollout_n]
-
-                        # For abnormal_gt_uids: check key vs meta.uid consistency,
-                        # remove mismatched keys from in-memory partition (not TQ),
-                        # then promote to normal_eq_uids if remaining count == rollout_n
-                        if abnormal_gt_uids:
-                            promoted_uids: list[str] = []
-                            detail_lines: list[str] = []
-                            for uid in abnormal_gt_uids:
-                                keys_and_metas = uid_response_keys[uid]
-                                matched_keys: list[tuple[str, dict]] = []
-                                removed_keys: list[str] = []
-                                for key, meta in keys_and_metas:
-                                    meta_uid = meta.get("uid", "") if isinstance(meta, dict) else ""
-                                    if meta_uid and key.startswith(meta_uid):
-                                        matched_keys.append((key, meta))
-                                    else:
-                                        part.pop(key, None)
-                                        removed_keys.append(key)
-
-                                if matched_keys and len(matched_keys) == rollout_n:
-                                    promoted_uids.append(uid)
-                                    uid_response_keys[uid] = matched_keys
-                                    detail_lines.append(
-                                        f"  uid='{uid}': {len(keys_and_metas)}->{len(matched_keys)} keys, "
-                                        f"removed={removed_keys}"
-                                    )
-
-                            if detail_lines:
-                                print(
-                                    f"[ReplayBuffer][sample] ✂️ Cleaned {len(abnormal_gt_uids)} abnormal_gt uids "
-                                    f"(promoted {len(promoted_uids)} to normal_eq, "
-                                    f"remaining abnormal={len(abnormal_gt_uids) - len(promoted_uids)})\n"
-                                    + "\n".join(detail_lines),
-                                    flush=True,
-                                )
-
-                            normal_eq_uids.extend(promoted_uids)
-                            abnormal_gt_uids = [u for u in abnormal_gt_uids if u not in set(promoted_uids)]
-
-                        if len(normal_eq_uids) >= sample_size:
-                            selected_uids = normal_eq_uids[:sample_size]
-                            all_response_keys: list[tuple[str, dict]] = []
-                            for uid in selected_uids:
-                                all_response_keys.extend(uid_response_keys[uid])
-
-                            expected_keys = sample_size * rollout_n
-
-                            if len(all_response_keys) != expected_keys:
-                                print(
-                                    f"len(all_response_keys)={len(all_response_keys)} != expected_keys={expected_keys}"
-                                )
-                                continue
-
-                            print(
-                                f"[ReplayBuffer][wait_and_sample][{partition_id}] Returning {len(all_response_keys)} "
-                                f"response keys from {len(selected_uids)} uids "
-                                f"(sample_size={sample_size}, "
-                                f"total_finished={len(finished_uids)}, "
-                                f"normal_eq_uids={len(normal_eq_uids)}, "
-                                f"abnormal_gt_uids={len(abnormal_gt_uids)}, "
-                                f"abnormal_lt_uids={len(abnormal_lt_uids)})",
-                                flush=True,
-                            )
-
-                            return all_response_keys
-                    else:
-                        print(
-                            f"[ReplayBuffer][wait_and_sample][{partition_id}] ready: "
-                            f"{len(finished_uids)} uids, need={sample_size}",
-                        )
-                        if self._finished:
-                            return None
-
-                # Wait for _poll_from_tq to write new metadata or signal_finish
-                await self._data_available.wait()
-
-    async def remove(self, partition_id: str, keys: list[str]):
-        """Remove consumed samples from the metadata store."""
-        async with self._data_available:
-            part = self.partitions.get(partition_id)
-            size_before = len(part) if part is not None else 0
-            if part is not None:
-                for key in keys:
-                    part.pop(key, None)
-            size_after = len(part) if part is not None else 0
-
-        logger.debug(
-            f"[ReplayBuffer][remove] partition={partition_id}: "
-            f"size {size_before} -> {size_after} "
-            f"(removed {len(keys)} keys, actually_deleted={size_before - size_after})",
-        )
+                await asyncio.sleep(self.poll_interval)
 
     async def reset_staleness(self) -> dict:
         """Reset the version window after parameter synchronization.
 
-        Mirrors FullyAsyncRollouter.reset_staleness() timing logic:
-        - version_time: wall-clock time since last reset (i.e., this param sync cycle duration)
-        - active_time: actual work time within the cycle (version_time minus idle periods)
-        - idle_ratio: fraction of time the rollouter was idle during the cycle
+        Computes timing metrics (active_time, version_time, idle_ratio) that
+        mirror ``FullyAsyncRollouter.reset_staleness()``, then wakes up any
+        ``acquire_slot()`` callers blocked on the version window.
         """
         async with self._slot_available:
-            # Compute current partition status counts for state reset
             partition_stats = await self.compute_partition_stats()
             prev_version_slots = self._version_slots
 
             data = tq.kv_list()
             tq_keys = sum(len(items) for items in data.values()) if data else 0
 
-            # Use partition_stats["train"]["success"] as the unconsumed backlog count
-            # This reflects samples written to TQ (status=success) but not yet consumed by trainer
             train_stats = partition_stats.get("train", {})
             train_finished_slots = train_stats.get("finished", 0)
 
-            # _version_slots = pending_slots (in-flight) + success_backlog (unconsumed in partitions)
-            # Uses partition_stats which is the source of truth for what trainer has not yet consumed
+            # Recompute version slots: in-flight + unconsumed backlog
             self._version_slots = self._pending_slots + train_finished_slots
 
             # Timing metrics
-            # |step_start_time          |idle_start_time
-            #
-            # |<----- active_time ----->|<------ idle time ------>|
-            # |<------------- version_time ---------------------->|
-            now = time.time()
-            if self.step_start_time is None:
-                self.step_start_time = now
-                self.idle_start_time = now
-
-            rollout_version_time = max(now - self.step_start_time, 1e-6)
-            if self.idle_start_time is not None and self.idle_start_time > self.step_start_time:
-                rollout_active_time = self.idle_start_time - self.step_start_time
-                idle_ratio = 1.0 - rollout_active_time / rollout_version_time
-            else:
-                rollout_active_time = rollout_version_time
-                idle_ratio = 0.0
-
-            timing_raw = {
-                "fully_async/rollouter/active_time": rollout_active_time,
-                "fully_async/rollouter/version_time": rollout_version_time,
-                "fully_async/rollouter/idle_ratio": idle_ratio,
-            }
+            timing = self._compute_timing_metrics()
 
             print(
                 f"[ReplayBuffer][reset_staleness] "
-                f"version_slots: {prev_version_slots} -> {self._version_slots} "
-                f"pending_slots={self._pending_slots}, "
-                f"train_finished_slots={train_finished_slots}, "
-                f"tq_keys={tq_keys}), "
-                f"idle_ratio: {idle_ratio:.4f}, ",
+                f"version_slots: {prev_version_slots} -> {self._version_slots}  "
+                f"pending={self._pending_slots}, "
+                f"train_finished={train_finished_slots}, "
+                f"tq_keys={tq_keys}, "
+                f"idle_ratio: {timing['fully_async/rollouter/idle_ratio']:.4f}, "
                 f"partition_stats: {partition_stats}",
                 flush=True,
             )
 
-            # Reset timers for next cycle (mirrors fully_async_rollouter.py:600)
+            # Reset timers for next cycle
+            now = time.time()
             self.step_start_time = now
             self.idle_start_time = now
 
-            # Wake up acquire_slot waiters blocked on version window
+            # Unblock acquire_slot waiters on version window
             self._slot_available.notify_all()
 
-        return timing_raw
+        return timing
 
-    async def signal_finish(self):
-        """Signal that production is fully complete — all samples are done."""
-        # Wake up acquire_slot waiters (return False)
+    async def signal_finish(self) -> None:
+        """Signal that production is fully complete — no more samples will arrive."""
+        self._finished = True
         async with self._slot_available:
-            self._finished = True
             self._slot_available.notify_all()
-        # Wake up wait_and_sample waiters (drain remaining)
         async with self._data_available:
             self._data_available.notify_all()
 
-    # ======== Statistics ========
-    async def compute_partition_stats(self) -> dict[str, dict[str, int]]:
-        """Compute per-partition status counts. Lock-free read.
+    # ------------------------------------------------------------------
+    # Statistics
+    # ------------------------------------------------------------------
 
-        Returns:
-            dict mapping partition_id -> {status_type: count, ...}
-            e.g. {"train": {"success": 64, "finished": 2}}
+    async def compute_partition_stats(self) -> dict[str, dict[str, int]]:
+        """Per-partition status counts (lock-free read).
+
+        Returns e.g. ``{"train": {"success": 64, "finished": 2}}``
         """
         async with self._data_available:
+            self._refresh_partitions_from_tq()
             partition_stats: dict[str, dict[str, int]] = {}
             for pid, part in self.partitions.items():
-                stats: dict[str, int] = {"success": 0, "finished": 0, "failure": 0, "unknown": 0}
+                stats: dict[str, int] = {
+                    "success": 0,
+                    "finished": 0,
+                    "failure": 0,
+                    "unknown": 0,
+                }
                 for v in part.values():
                     status = v.get("status", "unknown")
                     if status in stats:
@@ -519,17 +308,144 @@ class ReplayBuffer:
             return partition_stats
 
     async def get_statistics(self) -> dict:
-        """Return statistics about the buffer state. Lock-free read."""
+        """Full buffer-state snapshot (lock-free read)."""
         partition_stats = await self.compute_partition_stats()
-
         return {
             "partitions": partition_stats,
-            # Layer 1: Physical slot control
+            # Layer 1
             "pending_slots": self._pending_slots,
             "max_pending_slots": self.max_pending_slots,
             "available_physical_slots": max(0, self.max_pending_slots - self._pending_slots),
-            # Layer 2: Version window control
+            # Layer 2
             "version_slots": self._version_slots,
             "max_version_slots": self.max_version_slots,
-            "available_version_slots": max(0, (self.max_version_slots or 0) - self._version_slots),
+            "available_version_slots": max(0, self.max_version_slots - self._version_slots),
         }
+
+    # ==================================================================
+    # Private helpers  (pure logic, no I/O / locks)
+    # ==================================================================
+
+    # -- TQ snapshot -------------------------------------------------------
+
+    def _init_tq(self) -> None:
+        """Initialize TransferQueue in this actor process."""
+        try:
+            tq.init()
+            print("[ReplayBuffer] TQ initialized in RB actor process", flush=True)
+        except Exception as exc:
+            print(f"[ReplayBuffer] TQ init warning: {exc}", flush=True)
+
+    def _refresh_partitions_from_tq(self):
+        """Atomically replace ``self.partitions`` with a fresh TQ snapshot."""
+        data = tq.kv_list()
+        if data is None:
+            self.partitions = None
+        else:
+            new_partitions: dict[str, dict[str, dict]] = defaultdict(dict)
+            for pid, items in data.items():
+                for key, meta in items.items():
+                    new_partitions[pid][key] = meta
+            self.partitions = new_partitions
+
+    # -- Sample logic -----------------------------------------------------
+
+    def _try_sample_partition(
+        self,
+        part: dict[str, dict],
+        partition_id: str,
+        sample_size: int,
+    ) -> list[tuple[str, dict]] | None:
+        """Try to extract *sample_size* complete UIDs from *part*.
+
+        Returns the list of ``(key, meta)`` tuples on success, or ``None`` if
+        there aren't enough complete UIDs yet (caller should wait/retry).
+        """
+        if not part:
+            return None
+
+        finished_uids = list({key for key, meta in part.items() if meta.get("status") == "finished"})
+
+        if len(finished_uids) < sample_size:
+            print(
+                f"[ReplayBuffer][sample][{partition_id}] ready: {len(finished_uids)} uids, need={sample_size}",
+            )
+            return None
+
+        uid_response_keys = self._build_uid_response_key_map(part, finished_uids)
+
+        selected_uids = finished_uids[:sample_size]
+        all_response_keys: list[tuple[str, dict]] = []
+        for uid in selected_uids:
+            all_response_keys.extend(uid_response_keys[uid])
+
+        print(
+            f"[ReplayBuffer][sample][{partition_id}] Returning {len(all_response_keys)} keys "
+            f"from {len(selected_uids)} uids "
+            f"(sample_size={sample_size}, total_finished={len(finished_uids)}, ",
+            flush=True,
+        )
+
+        return all_response_keys
+
+    @staticmethod
+    def _build_uid_response_key_map(
+        part: dict[str, dict],
+        finished_uids: list[str],
+    ) -> dict[str, list[tuple[str, dict]]]:
+        """Map each finished UID → its response-key entries from *part*."""
+        mapping: dict[str, list[tuple[str, dict]]] = {}
+        for key, meta in part.items():
+            uid = meta.get("uid", "")
+            if uid and uid in finished_uids:
+                mapping.setdefault(uid, []).append((key, meta))
+        return mapping
+
+    # -- Timing -------------------------------------------------------------
+    def _compute_timing_metrics(self) -> dict[str, float]:
+        """Compute rollouter timing metrics for the just-completed version window.
+
+        |step_start_time          |idle_start_time          |
+        |<----- active_time ----->|<------ idle time ------>|
+        |<------------- version_time ---------------------->|
+        """
+
+        now = time.time()
+        if self.step_start_time is None:
+            self.step_start_time = now
+            self.idle_start_time = now
+
+        version_time = max(now - self.step_start_time, 1e-6)
+        if self.idle_start_time > self.step_start_time:
+            active_time = self.idle_start_time - self.step_start_time
+            idle_ratio = 1.0 - active_time / version_time
+        elif self.idle_start_time == self.step_start_time:
+            active_time = 0
+            idle_ratio = 1.0
+        else:
+            active_time = version_time
+            idle_ratio = 0.0
+
+        return {
+            "fully_async/rollouter/active_time": active_time,
+            "fully_async/rollouter/version_time": version_time,
+            "fully_async/rollouter/idle_ratio": idle_ratio,
+        }
+
+
+def tq_kv_clear(batch):
+    """Cleanup consumed batch from TQ and RB.
+
+    Two-phase cleanup:
+    1. Clear uid-level keys (deduplicated by uid from tags): removes uid status entries
+       like {'uid': {'status': 'finished'}} from both TQ and RB partitions.
+    2. Clear all sampled response keys: full cleanup of {uid}_{resp_idx} keys from TQ and RB.
+    """
+    uid_keys: set[str] = set()
+    for key, tag in zip(batch.keys, batch.tags, strict=False):
+        uid = tag.get("uid", "") if isinstance(tag, dict) else ""
+        if uid and uid not in uid_keys:
+            uid_keys.add(uid)
+
+    tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
+    tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)

--- a/verl/experimental/fully_async_policy/replay_buffer.py
+++ b/verl/experimental/fully_async_policy/replay_buffer.py
@@ -52,7 +52,7 @@ import ray
 try:
     import transfer_queue as tq
 except ImportError:
-    print("Please install TQ by calling `pip install TransferQueue==0.1.6` and try again.")
+    print("Please install TQ by calling `pip install TransferQueue==0.1.8` and try again.")
     from verl.utils.transferqueue_utils import tq
 
 from verl.experimental.fully_async_policy.detach_utils import safe_create_task
@@ -143,7 +143,7 @@ class ReplayBuffer:
             corrupting the uid→response_keys mapping used by wait_and_sample().
         """
         try:
-            while not self._finished:
+            while True:
                 data = tq.kv_list()
                 if data is not None:
                     # Build a fresh snapshot from TQ, then atomically replace self.partitions
@@ -276,15 +276,36 @@ class ReplayBuffer:
            from the partition — integrity check: skip uids whose response keys haven't been
            fully synced by _poll_from_tq yet (race between uid "finished" and response key arrival)
         4. Return all collected response keys for up to sample_size *complete* uids
+
+        Returns:
+            list of (key, meta) tuples when enough samples are available, or
+            None when _finished is True and no more samples will be produced (termination signal)
         """
         async with self._data_available:
             while True:
-                # Check termination first
+                # Check termination first: refresh TQ snapshot to get latest state
                 if self._finished:
-                    return None
+                    data = tq.kv_list()
+                    if data is not None:
+                        # Build a fresh snapshot from TQ, then atomically replace self.partitions
+                        new_partitions: dict[str, dict[str, dict]] = defaultdict(dict)
+                        for pid, items in data.items():
+                            for key, meta in items.items():
+                                new_partitions[pid][key] = meta
+                        # Update self.partitions atomically
+                        self.partitions = new_partitions
 
                 # Check if enough finish samples (uids) are ready
                 part = self.partitions.get(partition_id)
+
+                # Termination check: if _finished and no data available, return None to signal trainer to stop
+                if self._finished and (part is None or len(part) == 0):
+                    print(
+                        f"[ReplayBuffer][sample][{partition_id}] _finished=True, no data remaining, returning None (termination)",
+                        flush=True,
+                    )
+                    return None
+
                 if part is not None:
                     # Step 1: Find finished uids from uid-level keys with status 'finished'
                     finished_uids: set[str] = set()
@@ -377,6 +398,8 @@ class ReplayBuffer:
                             f"[ReplayBuffer][wait_and_sample][{partition_id}] ready: "
                             f"{len(finished_uids)} uids, need={sample_size}",
                         )
+                        if self._finished:
+                            return None
 
                 # Wait for _poll_from_tq to write new metadata or signal_finish
                 await self._data_available.wait()

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -294,15 +294,20 @@ class ReplayBuffer:
                     return KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
 
 
-@ray.remote
 class AgentLoopWorkerTQ(AgentLoopWorker):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         tq.init()
         self.background_tasks = set()
 
-    async def generate_sequences(self, batch: TensorDict) -> None:
-        """Spawn agent loop for each sample in the batch without waiting for the results."""
+    async def generate_sequences(self, batch: TensorDict, wait: bool = False) -> None:
+        """Spawn agent loop for each sample in the batch.
+
+        Args:
+            batch: Input batch containing prompts and metadata.
+            wait: If True, await all tasks before returning.
+                If False (default), fire-and-forget for backward compatibility.
+        """
         validate = batch["validate"] if "validate" in batch else False
         batch.pop("validate", None)
         config = self.config.actor_rollout_ref.rollout
@@ -327,6 +332,9 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
 
         trajectory_info = await get_trajectory_info(batch["global_steps"], batch["index"], validate)
 
+        # Track tasks for optional waiting
+        tasks = []
+
         # create background tasks for each sample in the batch
         for i in range(len(batch)):
             # TODO(wuxibin): add trace support
@@ -342,12 +350,22 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                 else:
                     logger.exception(f"Unsupported type {type(v)} for key {k}")
 
-            # “fire-and-forget” background tasks
             task = asyncio.create_task(
                 self._run_prompt(prompt, sampling_params, trajectory=trajectory_info[i], trace=trace_this_sample)
             )
-            self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
+            tasks.append(task)
+
+            if not wait:
+                # Fire-and-forget mode (backward compatible)
+                self.background_tasks.add(task)
+                task.add_done_callback(self.background_tasks.discard)
+
+        # Optional: wait for all tasks to complete
+        if wait:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    print(f"[AgentLoopWorkerTQ] Task {i} raised exception: {result}", flush=True)
 
     async def _run_prompt(self, prompt: dict, sampling_params: dict, trajectory: dict, trace: bool = False) -> None:
         """Spawn multiple agent loops in parallel according to rollout.n or rollout.val_kwargs.n."""
@@ -438,6 +456,9 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
                     "prompt_len": prompt_len,
                     "response_len": response_len,
                     "seq_len": prompt_len + response_len,
+                    "uid": uid,
+                    "min_global_steps": output.extra_fields.get("min_global_steps"),
+                    "max_global_steps": output.extra_fields.get("max_global_steps"),
                 }
             )
 
@@ -451,7 +472,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
 
 class AgentLoopManagerTQ(AgentLoopManager):
     def __init__(self, *args, replay_buffer: ReplayBuffer, **kwargs):
-        self.agent_loop_workers_class = AgentLoopWorkerTQ
+        self.agent_loop_workers_class = ray.remote(AgentLoopWorkerTQ)
         super().__init__(*args, **kwargs)
         self.replay_buffer = replay_buffer
 
@@ -1313,7 +1334,7 @@ class PPOTrainer:
             )
             data["old_log_probs"] = data.pop("rollout_log_probs")
             tq.kv_batch_put(keys=batch.keys, partition_id=batch.partition_id, fields=data)
-            return
+            return batch
 
         # 1. compute log probs
         batch.extra_info.update(
@@ -1670,6 +1691,18 @@ class PPOTrainer:
                     self._log_rollout_data(batch, timing_raw, rollout_data_dir)
 
                 # 7. cleanup transfer queue and replay buffer
+
+                # Clear uid status : 'uid': {'status': 'finished'} or  {'status': 'failure'}
+                uid_keys: set[str] = set()
+                for key, tag in zip(batch.keys, batch.tags, strict=False):
+                    uid = tag.get("uid", "") if isinstance(tag, dict) else ""
+                    if uid and uid not in uid_keys:
+                        uid_keys.add(uid)
+
+                # Clear uid-deduped keys from TQ and RB
+                tq.kv_clear(keys=list(uid_keys), partition_id=batch.partition_id)
+                self.replay_buffer.remove(batch.partition_id, list(uid_keys))
+
                 tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
                 self.replay_buffer.remove(batch.partition_id, batch.keys)
 


### PR DESCRIPTION
# Fully Async Policy with TransferQueue (TQ)

## Overview

This solution builds upon `fully_async_policy` by migrating the data transport channel from Ray **MessageQueue** to **TransferQueue (TQ)**,
while the training side reuses `main_ppo_sync.py`'s `PPOTrainer` via **multiple inheritance** to directly leverage TQ's native `KVBatchMeta` training pipeline.

### Core Design Principles

1. **Minimal Changes**: Keep `FullyAsyncAgentLoopManager` intact, preserving existing inference generation logic; only adapt lightly via `FullyAsyncAgentLoopManagerTQ`
2. **ReplayBuffer Flow Control**: Replace the original `_should_pause_generation` with ReplayBuffer (Ray Actor)'s Dual-Layer Slot mechanism
3. **TQ Replaces MessageQueue**: Data flows through TQ's zero-copy channel, metadata through ReplayBuffer
4. **Trainer Multiple Inheritance from PPOTrainer**: Reuse the TQ training pipeline via `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)`

### Core Objectives

1. **Zero-Copy Transport**: Use TQ instead of MessageQueue to avoid `ray.cloudpickle` serialization overhead
2. **Source-Level Flow Control**: Control production speed at dataloader data fetch (`_feed_samples`) via `acquire_slot()`
3. **Backpressure**: Dual-Layer Slot mechanism limits in-flight requests, eliminating the need for additional pause/resume logic
4. **Reuse Mature Code**: Trainer side uses multiple inheritance from PPOTrainer, directly using TQ's native batch training pipeline (`_compute_old_log_prob`, `_compute_advantage`, etc.)

## Architecture Comparison

### Existing Architecture (MessageQueue + SeparateRayPPOTrainer)

```mermaid
graph TB
    subgraph Rollouter[Rollouter - SeparateRayPPOTrainer]
        RM[FullyAsyncRollouter]
        ALM[FullyAsyncAgentLoopManager]
    end

    subgraph MQ[MessageQueue - Ray Actor]
        MQ_Q[deque - pickle serialization]
    end

    subgraph Trainer[Trainer - SeparateRayPPOTrainer]
        TM[FullyAsyncTrainer]
    end

    RM -->|_feed_samples| PQ[pending_queue]
    PQ -->|_processor_worker| ALM
    ALM -->|generate_sequences_single| RM
    RM -->|put_sample<br/>cloudpickle| MQ_Q
    MQ_Q -->|get_sample<br/>cloudpickle| TM
    TM -->|fit_step| TM
    RM -.->|_should_pause_generation<br/>check queue_size| MQ_Q
    RM -.->|staleness_samples<br/>manual counter| RM
```

**Problems**:

- Full data `ray.cloudpickle` serialization/deserialization overhead is significant
- Ray Actor single-point bottleneck (MessageQueue)
- `_should_pause_generation` pause logic is complex (drain → resume)
- Trainer (`SeparateRayPPOTrainer`) differs greatly from colocate training pipeline, requiring maintenance of two codebases

### New Architecture (TQ + ReplayBuffer + PPOTrainer Multiple Inheritance)

```mermaid
graph TB
    subgraph Rollouter["Rollouter (TQFullyAsyncRollouter)"]
        RM[TQFullyAsyncRollouter]
        ALM["FullyAsyncAgentLoopManager<br/>(+TQ adapter, wait=True)"]
    end

    subgraph RB["ReplayBuffer (Ray Actor)"]
        RB_SLOT["Layer1: Physical Slot<br/>acquire / release"]
        RB_VER["Layer2: Version Window<br/>reset_staleness resets to zero"]
        RB_META["Metadata + wait_and_sample"]
    end

    subgraph TQ[TransferQueue]
        TQ_DATA["Zero-Copy Tensor"]
    end

    subgraph Worker["AgentLoopWorkerTQ (main_ppo_sync.py)"]
        W_POST["_agent_loop_postprocess → tq.put"]
    end

    subgraph Trainer["Trainer (TQFullyAsyncTrainer)"]
        TM["Multi-inherit: PPOTrainer + FullyAsyncTrainer"]
    end

    RM -->|" 1. acquire_slot 🔒 "| RB_SLOT
    RM -->|" 2. processor "| ALM
    ALM -->|generate_sequences| Worker
    Worker -->|" 3. tq.put (status=success/finished) "| TQ_DATA
    TQ_DATA -->|kv_list poll| RB_META
    RM -->|" 4. release_slot ✅ "| RB_SLOT
    TM -->|" 5. wait_and_sample → KVBatchMeta "| RB_META
    TM -->|" 6. kv_batch_get → PPO pipeline "| TQ_DATA
    TM -->|" 7. kv_clear + remove "| TQ_DATA
    TM -->|" 8. reset_staleness "| RB_VER
```

**Core Changes**:

| Dimension | Existing Architecture | New Architecture |
|----------------------|------------------------------------------------|---------------------------------------------|
| **Data Channel** | MessageQueue (pickle) | TransferQueue (zero-copy) |
| **Metadata Channel** | None (mixed with data) | ReplayBuffer (Ray Actor) |
| **Flow Control** | `_should_pause_generation` + staleness_samples | `acquire_slot()` at `_feed_samples` source-level control |
| **Trainer Base Class** | `SeparateRayPPOTrainer` | `PPOTrainer` × `FullyAsyncTrainer` multiple inheritance |
| **Data Writer** | Rollouter._process_single_sample_streaming | `AgentLoopWorkerTQ._agent_loop_postprocess` |
| **AgentLoopManager** | `FullyAsyncAgentLoopManager` | `FullyAsyncAgentLoopManagerTQ` (lightweight subclass) |
| **Pause/Resume Logic** | paused + drain + resume | **Not needed** (slot blocking = flow control) |

## Core Components

### 1. ReplayBuffer (Ray Actor) — Metadata Channel + Dual-Layer Slot Flow Control

File: [`replay_buffer.py`](replay_buffer.py)

A lightweight Ray Actor that simultaneously handles **metadata storage** and **Dual-Layer Slot flow control**.

```python
@ray.remote(max_concurrency=100)
class ReplayBuffer:
    """Ray Actor: metadata channel + slot-based flow control for TQ fully async training.

    Replaces MessageQueue (data channel) in the original fully_async_policy.
    Key responsibilities:
    1. Dual-Layer slot backpressure: acquire_slot() blocks rollouter at dataloader source
    2. Metadata storage: tracks status of each sample via TQ kv_list polling
    3. Consumer interface: wait_and_sample() for trainer to get finished samples
    4. Version tracking: reset_staleness() for parameter sync coordination
    """

    def __init__(
            self,
            max_version_slots: int,  # Layer 2: staleness control
            max_pending_slots: int = 256,  # Layer 1: physical throttling
            poll_interval: float = 1.0,
    ):
```

#### Dual-Layer Slot Control Mechanism

`acquire_slot()` is the **single gatekeeping interface** between Rollouter and RB, simultaneously handling two responsibilities:

```
┌──────────────────────────────────────────────────────────────────────┐
│                    acquire_slot() Dual-Condition Check                │
│                                                                      │
│  Layer 1: Physical (Physical Throttling / OOM Protection)             │
│    Condition: _pending_slots < max_pending_slots                      │
│    Source: max_concurrent_samples (e.g., TP×PP×16)                    │
│    Purpose: Prevent OOM / GPU overload                                │
│    Release: release_slot() (called after Rollouter writes to TQ)      │
│                                                                      │
│  Layer 2: Version Window (Staleness Control / Stale Sample Protection)│
│    Condition: _version_slots < max_version_slots                      │
│    Source: required_samples × trigger_parameter_sync_step             │
│    Purpose: Prevent samples from having overly stale parameter versions│
│    Release: reset_staleness() resets to zero (called after Trainer   │
│             parameter sync)                                           │
│                                                                      │
│  ✅ Both conditions met → Grant slot (_pending_slots++, _version_slots++) │
│  ❌ Either condition fails → Block and wait                           │
└──────────────────────────────────────────────────────────────────────┘
```

State Transition:

```mermaid
stateDiagram-v2
    [*] --> Idle: Initialization
    Idle --> Acquired: acquire_slot() both conditions pass
    Acquired --> InFlight: Write to pending_queue
    InFlight --> Done: AgentLoopWorkerTQ writes to TQ status=success/finished
    Done --> Idle: release_slot()
    note right of Idle
        L1: pending_slots < max_pending_slots
        L2: _version_slots < max_version_slots
    end note
    note right of Acquired
        pending_slots++
        version_slots++
        Rollouter can continue processing data
    end note
    note right of InFlight
        Generating in progress
        Layer1 occupies 1 physical slot
        Layer2 occupies 1 version slot (cumulative)
    end note
    note right of Done
        Layer1: release_slot() → pending_slots--
        Layer2: unchanged (only reset_staleness resets to zero)
    end note
```

#### Core Interfaces

| Interface | Caller | Description |
|---------------------------------------------------------|--------------------------------------------|-------------------------------|
| `acquire_slot(timeout, uid)` | Rollouter._feed_samples | Acquire a write slot (blocking, dual-condition check) |
| `release_slot()` | Rollouter._process_single_sample_streaming | Release physical slot |
| `wait_and_sample(partition_id, sample_size, rollout_n)` | Trainer._get_keys_from_rb | Block until enough finished samples are available |
| `remove(partition_id, keys)` | Trainer._cleanup_batch | Remove metadata for consumed samples |
| `reset_staleness()` | Trainer._fit_reset_staleness | Reset version window after parameter sync, zero out _version_slots |
| `signal_finish()` | Rollouter._streaming_generation_main | Signal end of production |

#### Background Tasks

- **`_poll_from_tq()`**: Periodically polls `tq.kv_list()` to get a global TQ snapshot, atomically replacing `self.partitions`. Includes UID integrity check: detects orphan keys (meta.uid doesn't match key prefix) and auto-cleans them.
- **`_monitor_loop()`**: Prints buffer statistics every 60 seconds.

#### Usage Pattern

```python
# Rollouter side (inside Ray Actor, async)
acquired = await asyncio.wrap_future(self.replay_buffer.acquire_slot.remote(timeout=None, uid=sample_id).future())

# Trainer side (inside Ray Actor, async)
sampled_keys_meta = await self.replay_buffer.sample.remote(
    partition_id="train", sample_size=N, rollout_n=n
)
```

---

### 2. FullyAsyncAgentLoopManagerTQ — AgentLoop Lightweight Adapter

File: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)

**Key Points**:

- Worker class changed from default to `AgentLoopWorkerTQ` (defined in `main_ppo_sync.py`)
- `generate_sequences_single` adds `wait=True`: ensures Rollouter knows when generation completes, avoiding deadlocks
- `AgentLoopWorkerTQ._agent_loop_postprocess` directly writes results to TQ (`tq.async_kv_batch_put`), does not return data to Rollouter

**Lifecycle after writing to TQ**:

1. `AgentLoopWorkerTQ` writes `{uid}_{session_id}_{index}` response keys (status=success)
2. `AgentLoopWorkerTQ` writes `{uid}` uid-level key (status=finished)
3. ReplayBuffer `_poll_from_tq` discovers new keys via `tq.kv_list()`, updates `self.partitions`
4. ReplayBuffer `wait_and_sample` detects enough finished uids, returns to Trainer
5. Trainer reads complete data via `tq.kv_batch_get`, executes PPO training
6. After Trainer finishes training, `tq.kv_clear` + `rb.remove` cleanup

---

### 3. TQFullyAsyncRollouter — Rollouter Adapter

File: [`fully_async_rollouter_tq.py`](fully_async_rollouter_tq.py)

An incremental modification subclass based on `FullyAsyncRollouter`. Core changes are concentrated in three areas: data feeding, sample processing, and validation.

#### 3.1 `_feed_samples` — Source-Level Flow Control

**Key Differences from Base Class**:

- No longer calls `prepare_single_generation_data()` (no repeat(n)), instead injects `__rollout_n__` field so that `AgentLoopWorkerTQ._run_prompt` loops n times internally
- `batch_size=1` (bsz=1), each prompt processed individually
- `uid`/`__rollout_n__`/`sample_id`/`global_steps` injected as `np.array` into plain dict, becoming `NonTensorStack` after `tu.get_tensordict()`

#### 3.2 `_process_single_sample_streaming` — Simplified to generate + release

**Core Difference from Base Class**: The base class needs to manually put generation results to MessageQueue; in the TQ path, data writing is handled by `AgentLoopWorkerTQ._agent_loop_postprocess`, so Rollouter only needs to call generate then release_slot.

#### 3.3 Deleted/Disabled Methods

| Method | Handling | Reason |
|-------------------------------|------------|-----------------------------------|
| `_should_pause_generation()` | Returns `False` | Replaced by `acquire_slot` |
| `_async_monitor_loop()` | Empty implementation | Monitoring handled by ReplayBuffer._monitor_loop |

#### 3.4 Validation Flow `_validate`

Overrides base class validation method, using TQ + ReplayBuffer path.

---

### 4. TQFullyAsyncTrainer — Multi-Inheritance Trainer

File: [`fully_async_trainer_tq.py`](fully_async_trainer_tq.py)

**The most core design decision**: Use Python multiple inheritance `class FullyAsyncTrainerTQ(PPOTrainer, FullyAsyncTrainer)` to gain capabilities from both sides:

```python
"""
MRO: TQFullyAsyncTrainer → PPOTrainer → FullyAsyncTrainer → SeparateRayPPOTrainer → ...

Data flow:
    TQFullyAsyncRollouter --(tq.kv_batch_put)--> TransferQueue (status=finish)
        |
    TQFullyAsyncTrainer <-(RB.wait_and_sample)--+--(KVBatchMeta)--> [PPOTrainer pipeline]
                                                    |
                                              update_actor(KVBatchMeta)
"""
```

---

## Data Flow Details

### Complete Lifecycle Sequence Diagram

```mermaid
sequenceDiagram
    participant R as Rollouter<br/>(_feed_samples)
    participant RB as ReplayBuffer<br/>(Ray Actor)
    participant PQ as pending_queue
    participant P as processor<br/>(_processor_worker)
    participant ALM_TQ as ALM_TQ<br/>(DataProto→TensorDict)
    participant ALW as AgentLoopWorkerTQ<br/>(main_ppo_sync.py)
    participant TQ as TransferQueue
    participant T as Trainer<br/>(TQFullyAsyncTrainer)
    Note over R, T: === Phase 1: Rollouter Production (Source-Level Flow Control) ===
    loop dataloader iteration
        R ->> RB: acquire_slot(uid=sample_id) [may block🔒]
        RB -->> R: slot acquired (L1++, L2++)
        R ->> R: Inject uid/__rollout_n__/sample_id/global_steps
        R ->> R: tu.get_tensordict(batch_dict) → bsz=1 TensorDict
        R ->> PQ: put(RolloutSample{full_batch, sample_id})
    end
    R ->> PQ: put(None) [end signal]
    Note over R, T: === Phase 2: Generation (ALM_TQ Adapter + Worker Writes TQ) ===
    loop processor worker
        P ->> PQ: get()
        P ->> ALM_TQ: generate_sequences_single(batch, wait=True)
        ALM_TQ ->> ALM_TQ: Select worker (round-robin)
        ALM_TQ ->> ALW: generate_sequences.remote(batch, wait=True)
        ALW ->> ALW: _run_prompt loops __rollout_n__ times
        ALW ->> ALW: _compute_score (reward model)
        ALW ->> TQ: tq.async_kv_batch_put(response keys, status=success)
        ALW ->> TQ: tq.async_kv_batch_put(uid key, status=finished)
        ALW -->> ALM_TQ: return (wait=True ensures completion)
        ALM_TQ -->> P: return
        P ->> RB: release_slot() ✅ (L1--)
        RB -->> R: (wake up waiting acquire_slot)
    end

    Note over R, T: === Phase 3: Trainer Consumption + PPO Training ===
    loop fit_step (per step)
        T ->> RB: wait_and_sample(sample_size=N, rollout_n=n) [block⏳]
        RB -->> T: [(key1,tag1), ..., (keyN,tagN)] (KVBatchMeta)
        T ->> TQ: kv_batch_get(keys) [called internally by various _compute_* methods]
        TQ -->> T: Complete tensor data (prompts, responses, log_probs, ...)
        T ->> T: _balance_batch → _compute_old_log_prob
        T ->> TQ: kv_batch_put(old_log_prob, ...) [write back to TQ]
        T ->> T: _compute_advantage → _update_actor
        T ->> TQ: kv_batch_put(advantages, returns, ...)
        T ->> TQ: kv_clear(response keys + uid keys)
        T ->> RB: remove(keys)
    end

    Note over R, T: === Phase 4: Parameter Sync (every trigger_parameter_sync_step steps) ===
    T ->> T: _fit_update_weights(): checkpoint_manager.update_weights()
    T ->> RB: reset_staleness(): _version_slots reset to zero, unblock L2
```

### Dual-Layer Slot Control Detailed Semantics

| Original Concept (MessageQueue Path) | New Implementation (TQ Path) |
|-------------------------------|-------------------------------------|
| `MessageQueue.queue_size` | `RB._pending_slots` (Layer 1: Physical Throttling) |
| `max_queue_size` | `max_pending_slots` (Layer 1) |
| `_should_pause_generation()` | **Removed** — `acquire_slot()` dual-condition = flow control |
| `staleness_samples` (manual counter) | `RB._version_slots` (Layer 2: Cumulative Counter) |
| `max_required_samples` | `max_version_slots` (Layer 2) |
| `paused` + `drain` + `resume` | **Preserved but no longer triggers throttling** — only used for safe drain during parameter sync |

**Before vs After Comparison**:

```
Before (Dual Throttling, Complex State Machine):
  1. _should_pause_generation(): queue_size >= max_queue_size → pause
  2. _should_pause_generation(): staleness_samples >= max_required_samples → pause
  → Need paused/drain/resume state machine

After (acquire_slot Single Interface, Dual Conditions):
  1. _feed_samples(): acquire_slot()
     → Layer 1 not met? block (physically full)
     → Layer 2 not met? block (version window full, wait for reset_staleness)
     → Both met? proceed
  → Clean token-bucket semantics, no extra state machine needed
```

**Parameter Sync Flow**:

```
Trainer.fit_step:
  1. wait_and_sample(batch_size) → get finished samples from RB
  2. ... PPO training pipeline (_compute_* / _update_*) ...
  3. update_weights() → NCCL sync weights to Rollouter GPUs
  4. reset_staleness():
       a. _version_slots = _pending_slots + train_finished_slots (recalculate)
       b. Reset timers (step_start_time, idle_start_time)
       c. Notify _slot_available → unblock acquire_slot's Layer 2
```

## Usage

### Launch Script Example

Key configuration points:

```bash
# ====== Required fully_async configuration ======
fully_async=(
  data.train_batch_size=0                 # Invalid in TQ mode, defaults to 0
  data.gen_batch_size=1                   # Streaming item-by-item generation
  trainer.test_freq=-1                     # Validation handled by rollouter
  actor_rollout_ref.hybrid_engine=False    # Decoupled architecture
  actor_rollout_ref.rollout.calculate_log_probs=True  # Use rollout log_prob
  rollout.total_rollout_steps=$(((512*100)))          # Total generation samples
  trainer.nnodes=1                         # Number of Trainer nodes
  trainer.n_gpus_per_node=4                # GPUs per Trainer node
  rollout.nnodes=1                         # Number of Rollouter nodes
  rollout.n_gpus_per_node=4                # GPUs per Rollouter node
  async_training.staleness_threshold=0.5   # Staleness threshold
  async_training.trigger_parameter_sync_step=4  # Parameter sync frequency
  async_training.require_batches=1         # Batches per fetch
  async_training.partial_rollout=True       # Support partial rollout
)

# ====== TQ-specific configuration ======
transfer_queue=(
  transfer_queue.enable=True               # ★ Enable TQ mode
)
```

### Dependency Installation

```bash
pip install TransferQueue==0.1.8
```

All TQ-related code has fallback behavior: when `import transfer_queue` fails, the mock implementation in `verl.utils.transferqueue_utils` is automatically used.



### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
