### PR TITLE
[data] fix: support path multimodal placeholders

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import json
 import os
+from copy import deepcopy
+from pathlib import Path
 
 import pytest
 import torch
@@ -23,6 +25,16 @@ from torch.utils.data import DataLoader
 from verl import DataProto
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
+
+
+def _mock_rlhf_dataset():
+    dataset = RLHFDataset.__new__(RLHFDataset)
+    dataset.prompt_key = "prompt"
+    dataset.image_key = "images"
+    dataset.video_key = "videos"
+    dataset.audio_key = "audios"
+    dataset.processor = object()
+    return dataset
 
 
 def get_gsm8k_data():
@@ -78,6 +90,101 @@ def test_rl_dataset_with_max_samples():
     )
     dataset = RLHFDataset(data_files=local_path, tokenizer=tokenizer, config=config, max_samples=5)
     assert len(dataset) == 5
+
+
+def test_build_messages_accepts_image_path():
+    dataset = _mock_rlhf_dataset()
+    image_path = "file:///tmp/image.jpg"
+    example = {
+        "prompt": [{"role": "user", "content": "Describe <image>"}],
+        "images": [image_path],
+    }
+
+    messages = dataset._build_messages(example, key=dataset.prompt_key)
+
+    assert messages[0]["content"] == [
+        {"type": "text", "text": "Describe "},
+        {"type": "image", "image": image_path},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("videos", "expected_video"),
+    [
+        (["file:///tmp/video.mp4"], "file:///tmp/video.mp4"),
+        ([["file:///tmp/frame1.jpg", "file:///tmp/frame2.jpg"]], ["file:///tmp/frame1.jpg", "file:///tmp/frame2.jpg"]),
+        ([[Path("/tmp/frame1.jpg"), Path("/tmp/frame2.jpg")]], ["/tmp/frame1.jpg", "/tmp/frame2.jpg"]),
+    ],
+)
+def test_build_messages_accepts_video_path_or_frame_list(videos, expected_video):
+    dataset = _mock_rlhf_dataset()
+    example = {
+        "prompt": [{"role": "user", "content": "Describe <video>"}],
+        "videos": videos,
+    }
+
+    messages = dataset._build_messages(example, key=dataset.prompt_key)
+
+    assert messages[0]["content"] == [
+        {"type": "text", "text": "Describe "},
+        {"type": "video", "video": expected_video},
+    ]
+
+
+def test_maybe_filter_out_long_prompts_accepts_image_path(monkeypatch):
+    class FakeDataFrame(list):
+        def filter(self, fn, num_proc=None, desc=None):
+            return FakeDataFrame([doc for doc in self if fn(doc)])
+
+    class FakeProcessor:
+        def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=False, **kwargs):
+            return "formatted prompt"
+
+        def __call__(self, **kwargs):
+            assert kwargs["images"] == ["processed-image"]
+            return {"input_ids": [[1, 2, 3]]}
+
+    captured = {}
+
+    def fake_process_multi_modal_info(cls, messages, image_patch_size, config):
+        captured["messages"] = deepcopy(messages)
+        return ["processed-image"], None, None
+
+    monkeypatch.setattr(
+        RLHFDataset,
+        "_process_multi_modal_info",
+        classmethod(fake_process_multi_modal_info),
+    )
+
+    dataset = _mock_rlhf_dataset()
+    dataset.processor = FakeProcessor()
+    dataset.tokenizer = None
+    dataset.filter_overlong_prompts = True
+    dataset.apply_chat_template_kwargs = {}
+    dataset.tool_schemas = None
+    dataset.image_patch_size = 14
+    dataset.config = OmegaConf.create({})
+    dataset.max_prompt_length = 10
+    dataset.mm_processor_kwargs = {}
+    dataset.num_workers = None
+
+    image_path = "file:///tmp/image.jpg"
+    dataframe = FakeDataFrame(
+        [
+            {
+                "prompt": [{"role": "user", "content": "Describe <image>"}],
+                "images": [image_path],
+            }
+        ]
+    )
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert len(filtered) == 1
+    assert captured["messages"][0]["content"] == [
+        {"type": "text", "text": "Describe "},
+        {"type": "image", "image": image_path},
+    ]
 
 
 def test_image_rl_data():

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -299,9 +299,9 @@ class RLHFDataset(Dataset):
         """Replace multimodal placeholders in messages with structured content.
 
         This is required by processor.apply_chat_template.
-        - <image>: {"type": "image", **image}
-        - <video>: {"type": "video", **video}
-        - <audio>: {"type": "audio", **audio}
+        - <image>: {"type": "image", "image": image} or {"type": "image", **image}
+        - <video>: {"type": "video", "video": video} or {"type": "video", **video}
+        - <audio>: {"type": "audio", "audio": audio} or {"type": "audio", **audio}
 
         Args:
             example: Row dictionary from dataframe.
@@ -339,12 +339,27 @@ class RLHFDataset(Dataset):
                         if "bytes" in image:
                             image["image"] = Image.open(BytesIO(image["bytes"]))
                         content_list.append({"type": "image", **image})
+                    elif isinstance(image, str | os.PathLike):
+                        content_list.append({"type": "image", "image": os.fspath(image)})
                     else:
-                        raise TypeError(f"image must be dict or PIL.Image, unsupported image type: {type(image)}")
+                        raise TypeError(
+                            f"image must be dict, PIL.Image, or path-like, unsupported image type: {type(image)}"
+                        )
                     image_offset += 1
                 elif segment == "<video>":
                     assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
-                    content_list.append({"type": "video", **videos[video_offset]})
+                    video = videos[video_offset]
+                    if isinstance(video, dict):
+                        content_list.append({"type": "video", **video})
+                    elif isinstance(video, str | os.PathLike):
+                        content_list.append({"type": "video", "video": os.fspath(video)})
+                    elif isinstance(video, list):
+                        video = [os.fspath(frame) if isinstance(frame, os.PathLike) else frame for frame in video]
+                        content_list.append({"type": "video", "video": video})
+                    else:
+                        raise TypeError(
+                            f"video must be dict, list, or path-like, unsupported video type: {type(video)}"
+                        )
                     video_offset += 1
                 elif segment == "<audio>":
                     assert audio_offset < len(audios), f"audio_offset {audio_offset} >= len(audios) {len(audios)}"


### PR DESCRIPTION
### What does this PR do?

Fixes #6623.

`RLHFDataset._build_messages()` now wraps image/video path-like inputs into processor content instead of assuming every image/video item is a dict. This lets prompt-length filtering build the same message content format that `qwen_vl_utils.process_vision_info` already accepts.

No files are read in `_build_messages()`; image/video loading still happens in the existing multimodal processing path.

AI assistance was used for this PR.

### Checklist Before Starting

- [x] Search for similar PRs. Query link: https://github.com/verl-project/verl/pulls?q=6623+in%3Abody
  - Also checked `gh pr list --repo verl-project/verl --state open --search "6623 in:body"`: no results.
  - Also checked `gh pr list --repo verl-project/verl --state open --search "maybe_filter_out_long_prompts image path"`: no results.
  - Also checked both queries with `--state all`: no results.
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `python -m pytest tests/utils/dataset/test_rl_dataset_on_cpu.py::test_build_messages_accepts_image_path tests/utils/dataset/test_rl_dataset_on_cpu.py::test_build_messages_accepts_video_path_or_frame_list tests/utils/dataset/test_rl_dataset_on_cpu.py::test_maybe_filter_out_long_prompts_accepts_image_path -q` -> 5 passed
- `python -m pytest tests/utils/test_audio_input_support_on_cpu.py::test_build_messages_replaces_audio_placeholder -q` -> 1 passed
- `pre-commit run --files verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py --show-diff-on-failure --color=always` -> passed
- `pre-commit run --all-files --show-diff-on-failure --color=always` -> passed
- `git diff --check` -> passed
- Ad-hoc verification: built messages from a temporary PNG file path and passed them to `qwen_vl_utils.process_vision_info`; it returned a `PIL.Image.Image`.

### API and Usage Example

No API change.

```python
# Before this PR, these inputs raise TypeError in _build_messages().
example = {
    "prompt": [{"role": "user", "content": "Describe <image> and <video>"}],
    "images": ["file:///tmp/image.jpg"],
    "videos": ["file:///tmp/video.mp4"],
}
```

### Design & Code Changes

- Keep existing dict and `PIL.Image.Image` handling for images.
- Add image path-like handling: `{"type": "image", "image": path}`.
- Keep existing dict handling for videos.
- Add video path-like/list handling: `{"type": "video", "video": value}`.
- Add CPU tests for `_build_messages()` and `maybe_filter_out_long_prompts()` without a GPU, model, or real media file.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed: no public API, config, or doc behavior changes.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). Not done.
- [ ] If this PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not related.

