### PR TITLE
[megatron] fix: Fix Megatron optimizer offloading when `use_precision_aware_optimizer=True`

### DIFF
--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from megatron.core import parallel_state as mpu
+from megatron.core.distributed import DistributedDataParallel as McoreDDP
+from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
+from megatron.core.optimizer.optimizer import ChainedOptimizer
+from megatron.core.pipeline_parallel import get_forward_backward_func
+from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
+from megatron.core.transformer.transformer_config import TransformerConfig
+
+from verl.utils.megatron_utils import load_megatron_optimizer, offload_megatron_optimizer
+
+# ==== Helper functions === #
+
+MICROBATCH_SIZE = 32
+SEQUENCE_LENGTH = 64
+
+
+@pytest.fixture
+def initialize_distributed_env():
+    """Bring up and tear down torch.distributed + Megatron parallel state
+    before / after each test."""
+
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29500")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+
+    torch.cuda.set_device(0)
+    assert not dist.is_initialized()
+    dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+    mpu.initialize_model_parallel()
+    model_parallel_cuda_manual_seed(123)
+
+    try:
+        yield
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+        mpu.destroy_model_parallel()
+
+
+def init_data_iterator():
+    """A data iterator that yields dummy data for the test."""
+
+    device = torch.cuda.current_device()
+    input_tokens = torch.zeros(
+        (MICROBATCH_SIZE, SEQUENCE_LENGTH),
+        dtype=torch.int64,
+        device=device,
+    )
+    position_ids = (
+        torch.arange(SEQUENCE_LENGTH, dtype=torch.int64, device=device)
+        .unsqueeze(0)
+        .expand(MICROBATCH_SIZE, SEQUENCE_LENGTH)
+    )
+    attention_mask = (
+        torch.triu(
+            torch.ones(SEQUENCE_LENGTH, SEQUENCE_LENGTH, dtype=torch.bool, device=device),
+            diagonal=1,
+        )
+        .view(1, 1, SEQUENCE_LENGTH, SEQUENCE_LENGTH)
+        .expand(MICROBATCH_SIZE, 1, -1, -1)
+    )
+    while True:
+        yield (input_tokens, position_ids, attention_mask)
+
+
+def init_model():
+    """Initialize a small GPT model for the test, wrapped in Megatron DDP."""
+
+    transformer_config = TransformerConfig(
+        num_layers=2,
+        hidden_size=512,
+        num_attention_heads=4,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+    )
+    gpt_model = GPTModel(
+        config=transformer_config,
+        transformer_layer_spec=get_gpt_layer_local_spec(),
+        vocab_size=128,
+        max_sequence_length=SEQUENCE_LENGTH,
+    ).cuda()
+
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
+    model_chunk = McoreDDP(transformer_config, ddp_config, gpt_model)
+    return [model_chunk]
+
+
+def init_optimizer(model, use_precision_aware_optimizer):
+    """Initialize an optimizer for the model."""
+
+    optimizer_config = OptimizerConfig(
+        optimizer="adam",
+        lr=1e-6,
+        min_lr=1e-6,
+        clip_grad=1.0,
+        weight_decay=0.0,
+        use_distributed_optimizer=True,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        use_precision_aware_optimizer=use_precision_aware_optimizer,
+    )
+    return get_megatron_optimizer(optimizer_config, model)
+
+
+def train_step(data_iterator, model, optimizer):
+    """Run a single train step on `model` with `optimizer` using data from
+    `data_iterator`.
+
+    Megatron optimizers may lazily initialize optimizer state, so we always run
+    a train_step between offloading / loading optimizer state in tests."""
+
+    forward_backward_func = get_forward_backward_func()
+
+    def forward_step(data_iterator, model_chunk):
+        input_tokens, position_ids, attention_mask = next(data_iterator)
+        output_tensor = model_chunk(input_tokens, position_ids, attention_mask)
+
+        def loss_func(output_tensor):
+            return torch.mean(output_tensor.float()), {}
+
+        return output_tensor, loss_func
+
+    with torch.cuda.amp.autocast():
+        losses = forward_backward_func(
+            forward_step_func=forward_step,
+            data_iterator=data_iterator,
+            model=model,
+            num_microbatches=1,
+            seq_length=SEQUENCE_LENGTH,
+            micro_batch_size=MICROBATCH_SIZE,
+            forward_only=False,
+        )
+
+        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+
+    for chunk in model:
+        chunk.zero_grad_buffer()
+
+    assert update_successful
+
+    return losses
+
+
+def optimizer_state_is_on_device(
+    optimizer,
+    device,
+    use_precision_aware_optimizer,
+):
+    """Check that all tensors inside optimizer_state are on the specified device."""
+
+    opts = optimizer.chained_optimizers if isinstance(optimizer, ChainedOptimizer) else [optimizer]
+
+    # First validate that all optimizer have the fields assumed by VeRL's host
+    # offloading code.
+    for opt in opts:
+        assert hasattr(opt, "shard_fp32_from_float16_groups")
+        if use_precision_aware_optimizer:
+            expected_tensor_state_keys = ["exp_avg", "exp_avg_sq", "master_param"]
+            # If use_precision_aware_optimizer=True, 'master' params should be
+            # managed by the wrapped TE FusedAdam optimizer, not the wrapper
+            # DistributedOptimizer.
+            for group in opt.shard_fp32_from_float16_groups:
+                for param in group:
+                    assert param is None
+        else:
+            expected_tensor_state_keys = ["exp_avg", "exp_avg_sq"]
+        # For each parameter, check that only expected_tensor_state_keys are
+        # stored.
+        param_to_param_opt_state = opt.optimizer.state
+        for param_state in param_to_param_opt_state.values():
+            tensor_state = {k: v for k, v in param_state.items() if isinstance(v, torch.Tensor)}
+            assert sorted(list(tensor_state.keys())) == sorted(expected_tensor_state_keys)
+
+    # Check device placement of optimizer state.
+    for opt in opts:
+        # Check if master params are on the requested device when
+        # use_precision_aware_optimizer=True.
+        if not use_precision_aware_optimizer:
+            for group in opt.shard_fp32_from_float16_groups:
+                for param in group:
+                    if isinstance(param, torch.Tensor) and param.device != device:
+                        return False
+        # Check whether any parameters are not on the expected device.
+        param_to_param_opt_state = opt.optimizer.state
+        for param_state in param_to_param_opt_state.values():
+            for v in param_state.values():
+                if isinstance(v, torch.Tensor) and v.device != device:
+                    return False
+
+    return True
+
+
+# ==== Tests ==== #
+
+
+@pytest.mark.parametrize("use_precision_aware_optimizer", [False, True])
+def test_distributed_optimizer_offload_and_load(
+    initialize_distributed_env,
+    use_precision_aware_optimizer,
+):
+    # Initialize data iterator, model, and optimizer.
+    data_iterator = init_data_iterator()
+    model = init_model()
+    optimizer = init_optimizer(model, use_precision_aware_optimizer)
+
+    # Run a train step to fully initialize the optimizer state.
+    train_step(data_iterator, model, optimizer)
+
+    # Offload optimizer state.
+    offload_megatron_optimizer(optimizer)
+
+    # Make sure everything has been offloaded.
+    assert optimizer_state_is_on_device(
+        optimizer,
+        torch.device("cpu"),
+        use_precision_aware_optimizer,
+    )
+
+    # Load optimizer state.
+    load_megatron_optimizer(optimizer)
+
+    # Make sure everything has been loaded.
+    assert optimizer_state_is_on_device(
+        optimizer,
+        torch.device("cuda:0"),
+        use_precision_aware_optimizer,
+    )

--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-import pytest
 import torch
 import torch.distributed as dist
 from megatron.core import parallel_state as mpu
@@ -34,30 +31,6 @@ from verl.utils.megatron_utils import load_megatron_optimizer, offload_megatron_
 
 
 SEQUENCE_LENGTH = 64
-
-
-@pytest.fixture
-def initialize_distributed_env():
-    """Bring up and tear down torch.distributed + Megatron parallel state
-    before / after each test."""
-
-    os.environ.setdefault("MASTER_ADDR", "localhost")
-    os.environ.setdefault("MASTER_PORT", "29500")
-    os.environ.setdefault("RANK", "0")
-    os.environ.setdefault("WORLD_SIZE", "1")
-
-    torch.cuda.set_device(0)
-    assert not dist.is_initialized()
-    dist.init_process_group(backend="cpu:gloo,cuda:nccl")
-    mpu.initialize_model_parallel()
-    model_parallel_cuda_manual_seed(123)
-
-    try:
-        yield
-    finally:
-        dist.barrier()
-        mpu.destroy_model_parallel()
-        dist.destroy_process_group()
 
 
 def init_model():
@@ -131,33 +104,51 @@ def precision_aware_optimizer_is_on_device(optimizer, device):
 # ==== Tests ==== #
 
 
-def test_precision_aware_optimizer_offload_and_load(initialize_distributed_env):
-    # Initialize model and optimizer.
-    model_chunks = init_model()
-    optimizer = init_precision_aware_optimizer(model_chunks)
+def test_precision_aware_optimizer_offload_and_load(tmp_path):
+    # Initialize torch distributed and Megatron parallel state.
+    rendezvous_file = tmp_path / "rdzv_optimizer"
 
-    # Fully initialize the optimizer state by calling optimizer.step() on
-    # dummy gradients set to 0.
-    for model_chunk in model_chunks:
-        model_chunk.zero_grad_buffer()
-    optimizer.zero_grad(set_to_none=False)
-    update_successful, _, _ = optimizer.step()
-    assert update_successful
-
-    # Offload optimizer state.
-    offload_megatron_optimizer(optimizer)
-
-    # Make sure everything has been offloaded.
-    assert precision_aware_optimizer_is_on_device(
-        optimizer,
-        torch.device("cpu"),
+    torch.cuda.set_device(0)
+    dist.init_process_group(
+        backend="cpu:gloo,cuda:nccl",
+        init_method=f"file://{rendezvous_file}",
+        rank=0,
+        world_size=1,
     )
+    mpu.initialize_model_parallel()
+    model_parallel_cuda_manual_seed(123)
 
-    # Load optimizer state.
-    load_megatron_optimizer(optimizer)
+    try:
+        # Initialize model and optimizer.
+        model_chunks = init_model()
+        optimizer = init_precision_aware_optimizer(model_chunks)
 
-    # Make sure everything has been loaded.
-    assert precision_aware_optimizer_is_on_device(
-        optimizer,
-        torch.device("cuda:0"),
-    )
+        # Fully initialize the optimizer state by calling optimizer.step() on
+        # dummy gradients set to 0.
+        for model_chunk in model_chunks:
+            model_chunk.zero_grad_buffer()
+        optimizer.zero_grad(set_to_none=False)
+        update_successful, _, _ = optimizer.step()
+        assert update_successful
+
+        # Offload optimizer state.
+        offload_megatron_optimizer(optimizer)
+
+        # Make sure everything has been offloaded.
+        assert precision_aware_optimizer_is_on_device(
+            optimizer,
+            torch.device("cpu"),
+        )
+
+        # Load optimizer state.
+        load_megatron_optimizer(optimizer)
+
+        # Make sure everything has been loaded.
+        assert precision_aware_optimizer_is_on_device(
+            optimizer,
+            torch.device("cuda:0"),
+        )
+    finally:
+        # Tear down MPU state and torch.distributed.
+        mpu.destroy_model_parallel()
+        dist.destroy_process_group()

--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -56,8 +56,8 @@ def initialize_distributed_env():
         yield
     finally:
         dist.barrier()
-        dist.destroy_process_group()
         mpu.destroy_model_parallel()
+        dist.destroy_process_group()
 
 
 def init_model():

--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -25,13 +25,13 @@ from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
 from megatron.core.optimizer.optimizer import ChainedOptimizer
-from megatron.core.pipeline_parallel import get_forward_backward_func
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.transformer_config import TransformerConfig
 
 from verl.utils.megatron_utils import load_megatron_optimizer, offload_megatron_optimizer
 
-# ==== Helper functions === #
+# ==== Helper functions ==== #
+
 
 MICROBATCH_SIZE = 32
 SEQUENCE_LENGTH = 64
@@ -59,32 +59,6 @@ def initialize_distributed_env():
         dist.barrier()
         dist.destroy_process_group()
         mpu.destroy_model_parallel()
-
-
-def init_data_iterator():
-    """A data iterator that yields dummy data for the test."""
-
-    device = torch.cuda.current_device()
-    input_tokens = torch.zeros(
-        (MICROBATCH_SIZE, SEQUENCE_LENGTH),
-        dtype=torch.int64,
-        device=device,
-    )
-    position_ids = (
-        torch.arange(SEQUENCE_LENGTH, dtype=torch.int64, device=device)
-        .unsqueeze(0)
-        .expand(MICROBATCH_SIZE, SEQUENCE_LENGTH)
-    )
-    attention_mask = (
-        torch.triu(
-            torch.ones(SEQUENCE_LENGTH, SEQUENCE_LENGTH, dtype=torch.bool, device=device),
-            diagonal=1,
-        )
-        .view(1, 1, SEQUENCE_LENGTH, SEQUENCE_LENGTH)
-        .expand(MICROBATCH_SIZE, 1, -1, -1)
-    )
-    while True:
-        yield (input_tokens, position_ids, attention_mask)
 
 
 def init_model():
@@ -127,46 +101,6 @@ def init_optimizer(model, use_precision_aware_optimizer):
     return get_megatron_optimizer(optimizer_config, model)
 
 
-def train_step(data_iterator, model, optimizer):
-    """Run a single train step on `model` with `optimizer` using data from
-    `data_iterator`.
-
-    Megatron optimizers may lazily initialize optimizer state, so we always run
-    a train_step between offloading / loading optimizer state in tests."""
-
-    forward_backward_func = get_forward_backward_func()
-
-    def forward_step(data_iterator, model_chunk):
-        input_tokens, position_ids, attention_mask = next(data_iterator)
-        output_tensor = model_chunk(input_tokens, position_ids, attention_mask)
-
-        def loss_func(output_tensor):
-            return torch.mean(output_tensor.float()), {}
-
-        return output_tensor, loss_func
-
-    with torch.cuda.amp.autocast():
-        losses = forward_backward_func(
-            forward_step_func=forward_step,
-            data_iterator=data_iterator,
-            model=model,
-            num_microbatches=1,
-            seq_length=SEQUENCE_LENGTH,
-            micro_batch_size=MICROBATCH_SIZE,
-            forward_only=False,
-        )
-
-        update_successful, grad_norm, num_zeros_in_grad = optimizer.step()
-        optimizer.zero_grad(set_to_none=True)
-
-    for chunk in model:
-        chunk.zero_grad_buffer()
-
-    assert update_successful
-
-    return losses
-
-
 def optimizer_state_is_on_device(
     optimizer,
     device,
@@ -176,26 +110,17 @@ def optimizer_state_is_on_device(
 
     opts = optimizer.chained_optimizers if isinstance(optimizer, ChainedOptimizer) else [optimizer]
 
-    # First validate that all optimizer have the fields assumed by VeRL's host
-    # offloading code.
-    for opt in opts:
-        assert hasattr(opt, "shard_fp32_from_float16_groups")
-        if use_precision_aware_optimizer:
-            expected_tensor_state_keys = ["exp_avg", "exp_avg_sq", "master_param"]
-            # If use_precision_aware_optimizer=True, 'master' params should be
-            # managed by the wrapped TE FusedAdam optimizer, not the wrapper
-            # DistributedOptimizer.
+    # If use_precision_aware_optimizer=True, verify that "master_param" is
+    # populated for each parameter and not shard_fp32_from_float16_groups
+    # (this is an assumption made by VeRL's optimizer offloading code).
+    if use_precision_aware_optimizer:
+        for opt in opts:
             for group in opt.shard_fp32_from_float16_groups:
                 for param in group:
                     assert param is None
-        else:
-            expected_tensor_state_keys = ["exp_avg", "exp_avg_sq"]
-        # For each parameter, check that only expected_tensor_state_keys are
-        # stored.
-        param_to_param_opt_state = opt.optimizer.state
-        for param_state in param_to_param_opt_state.values():
-            tensor_state = {k: v for k, v in param_state.items() if isinstance(v, torch.Tensor)}
-            assert sorted(list(tensor_state.keys())) == sorted(expected_tensor_state_keys)
+            param_to_param_opt_state = opt.optimizer.state
+            for param_state in param_to_param_opt_state.values():
+                assert param_state.get("master_param", None) is not None
 
     # Check device placement of optimizer state.
     for opt in opts:
@@ -224,13 +149,17 @@ def test_distributed_optimizer_offload_and_load(
     initialize_distributed_env,
     use_precision_aware_optimizer,
 ):
-    # Initialize data iterator, model, and optimizer.
-    data_iterator = init_data_iterator()
-    model = init_model()
-    optimizer = init_optimizer(model, use_precision_aware_optimizer)
+    # Initialize model and optimizer.
+    model_chunks = init_model()
+    optimizer = init_optimizer(model_chunks, use_precision_aware_optimizer)
 
-    # Run a train step to fully initialize the optimizer state.
-    train_step(data_iterator, model, optimizer)
+    # Fully initialize the optimizer state by calling optimizer.step() on
+    # dummy gradients set to 0.
+    for model_chunk in model_chunks:
+        model_chunk.zero_grad_buffer()
+    optimizer.zero_grad(set_to_none=False)
+    update_successful, _, _ = optimizer.step()
+    assert update_successful
 
     # Offload optimizer state.
     offload_megatron_optimizer(optimizer)

--- a/tests/utils/megatron/test_optimizer_offload_and_load.py
+++ b/tests/utils/megatron/test_optimizer_offload_and_load.py
@@ -33,7 +33,6 @@ from verl.utils.megatron_utils import load_megatron_optimizer, offload_megatron_
 # ==== Helper functions ==== #
 
 
-MICROBATCH_SIZE = 32
 SEQUENCE_LENGTH = 64
 
 
@@ -84,8 +83,8 @@ def init_model():
     return [model_chunk]
 
 
-def init_optimizer(model, use_precision_aware_optimizer):
-    """Initialize an optimizer for the model."""
+def init_precision_aware_optimizer(model):
+    """Initialize a precision-aware optimizer for the model."""
 
     optimizer_config = OptimizerConfig(
         optimizer="adam",
@@ -96,42 +95,30 @@ def init_optimizer(model, use_precision_aware_optimizer):
         use_distributed_optimizer=True,
         bf16=True,
         params_dtype=torch.bfloat16,
-        use_precision_aware_optimizer=use_precision_aware_optimizer,
+        use_precision_aware_optimizer=True,
     )
     return get_megatron_optimizer(optimizer_config, model)
 
 
-def optimizer_state_is_on_device(
-    optimizer,
-    device,
-    use_precision_aware_optimizer,
-):
-    """Check that all tensors inside optimizer_state are on the specified device."""
+def precision_aware_optimizer_is_on_device(optimizer, device):
+    """Check that all optimizer state tracked by a given precision-aware
+    optimizer is on the specified device."""
 
     opts = optimizer.chained_optimizers if isinstance(optimizer, ChainedOptimizer) else [optimizer]
 
-    # If use_precision_aware_optimizer=True, verify that "master_param" is
-    # populated for each parameter and not shard_fp32_from_float16_groups
-    # (this is an assumption made by VeRL's optimizer offloading code).
-    if use_precision_aware_optimizer:
-        for opt in opts:
-            for group in opt.shard_fp32_from_float16_groups:
-                for param in group:
-                    assert param is None
-            param_to_param_opt_state = opt.optimizer.state
-            for param_state in param_to_param_opt_state.values():
-                assert param_state.get("master_param", None) is not None
+    # Verify that "master_param" is populated for each parameter and not
+    # shard_fp32_from_float16_groups (this is an assumption made by VeRL's
+    # optimizer offloading code).
+    for opt in opts:
+        for group in opt.shard_fp32_from_float16_groups:
+            for param in group:
+                assert param is None
+        param_to_param_opt_state = opt.optimizer.state
+        for param_state in param_to_param_opt_state.values():
+            assert param_state.get("master_param", None) is not None
 
     # Check device placement of optimizer state.
     for opt in opts:
-        # Check if master params are on the requested device when
-        # use_precision_aware_optimizer=True.
-        if not use_precision_aware_optimizer:
-            for group in opt.shard_fp32_from_float16_groups:
-                for param in group:
-                    if isinstance(param, torch.Tensor) and param.device != device:
-                        return False
-        # Check whether any parameters are not on the expected device.
         param_to_param_opt_state = opt.optimizer.state
         for param_state in param_to_param_opt_state.values():
             for v in param_state.values():
@@ -144,14 +131,10 @@ def optimizer_state_is_on_device(
 # ==== Tests ==== #
 
 
-@pytest.mark.parametrize("use_precision_aware_optimizer", [False, True])
-def test_distributed_optimizer_offload_and_load(
-    initialize_distributed_env,
-    use_precision_aware_optimizer,
-):
+def test_precision_aware_optimizer_offload_and_load(initialize_distributed_env):
     # Initialize model and optimizer.
     model_chunks = init_model()
-    optimizer = init_optimizer(model_chunks, use_precision_aware_optimizer)
+    optimizer = init_precision_aware_optimizer(model_chunks)
 
     # Fully initialize the optimizer state by calling optimizer.step() on
     # dummy gradients set to 0.
@@ -165,18 +148,16 @@ def test_distributed_optimizer_offload_and_load(
     offload_megatron_optimizer(optimizer)
 
     # Make sure everything has been offloaded.
-    assert optimizer_state_is_on_device(
+    assert precision_aware_optimizer_is_on_device(
         optimizer,
         torch.device("cpu"),
-        use_precision_aware_optimizer,
     )
 
     # Load optimizer state.
     load_megatron_optimizer(optimizer)
 
     # Make sure everything has been loaded.
-    assert optimizer_state_is_on_device(
+    assert precision_aware_optimizer_is_on_device(
         optimizer,
         torch.device("cuda:0"),
-        use_precision_aware_optimizer,
     )

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -733,6 +733,11 @@ def offload_megatron_optimizer(optimizers):
                         v["exp_avg"] = v["exp_avg"].to("cpu", non_blocking=True)
                     if "exp_avg_sq" in v:
                         v["exp_avg_sq"] = v["exp_avg_sq"].to("cpu", non_blocking=True)
+                    # Offload fp32 'master' params that are stored in
+                    # optimizer state under "master_param" attribute when
+                    # use_precision_aware_optimizer=True.
+                    if "master_param" in v:
+                        v["master_param"] = v["master_param"].to("cpu", non_blocking=True)
 
         try:
             # Free TransformerEngine's dummy weight gradients cache
@@ -771,6 +776,11 @@ def load_megatron_optimizer(optimizers):
                         v["exp_avg"] = v["exp_avg"].to(get_device_id(), non_blocking=True)
                     if "exp_avg_sq" in v:
                         v["exp_avg_sq"] = v["exp_avg_sq"].to(get_device_id(), non_blocking=True)
+                    # Load fp32 'master' params that are stored in
+                    # optimizer state under "master_param" attribute when
+                    # use_precision_aware_optimizer=True.
+                    if "master_param" in v:
+                        v["master_param"] = v["master_param"].to(get_device_id(), non_blocking=True)
         gc.collect()
         get_torch_device().empty_cache()
 

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -733,9 +733,8 @@ def offload_megatron_optimizer(optimizers):
                         v["exp_avg"] = v["exp_avg"].to("cpu", non_blocking=True)
                     if "exp_avg_sq" in v:
                         v["exp_avg_sq"] = v["exp_avg_sq"].to("cpu", non_blocking=True)
-                    # Offload fp32 'master' params that are stored in
-                    # optimizer state under "master_param" attribute when
-                    # use_precision_aware_optimizer=True.
+                    # Offload additional optimizer state that is stored under
+                    # "master_param" when use_precision_aware_optimizer=True.
                     if "master_param" in v:
                         v["master_param"] = v["master_param"].to("cpu", non_blocking=True)
 
@@ -776,9 +775,8 @@ def load_megatron_optimizer(optimizers):
                         v["exp_avg"] = v["exp_avg"].to(get_device_id(), non_blocking=True)
                     if "exp_avg_sq" in v:
                         v["exp_avg_sq"] = v["exp_avg_sq"].to(get_device_id(), non_blocking=True)
-                    # Load fp32 'master' params that are stored in
-                    # optimizer state under "master_param" attribute when
-                    # use_precision_aware_optimizer=True.
+                    # Load additional optimizer state that is stored under
+                    # "master_param" when use_precision_aware_optimizer=True.
                     if "master_param" in v:
                         v["master_param"] = v["master_param"].to(get_device_id(), non_blocking=True)
         gc.collect()


### PR DESCRIPTION
### What does this PR do?

This PR fixes optimizer offloading code for the Megatron backend so that the Megatron backend can be initialized with `use_precision_aware_optimizer=True`. Users can enable this like so:

```
...
    +actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True \
...
```

When turning on `use_precision_aware_optimizer`, the 32-bit master parameters / 16-bit remainders are stored in the optimizer state under the `"master_param"` key. But VeRL's current optimizer offloading code does not offload this field of the Megatron optimizer.

This PR modifies VeRL's optimizer offloading code so that optimizer state stored under `"master_param"` is also offloaded when using the Megatron optimizer.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: Searching for `use precision aware optimizer offload` did not yield recent PRs / GitHub issues referencing this problem.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Unit test: Added a unit test for Megatron optimizer offloading in `tests/utils/megatron/test_optimizer_offload_and_load.py`.

End-to-end test: Verified that [this config](https://gist.github.com/rao-ashish/69b1d263104784dc7982311d4548fc55) OOMs without this fix, but runs with this fix active.

### API and Usage Example

[This config](https://gist.github.com/rao-ashish/69b1d263104784dc7982311d4548fc55#file-precision_aware_optimizer_test-sh-L116) shows an example usage of `use_precision_aware_optimizer=True`. Users can enable this by adding:

```
...
    +actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True \
...
```

### Design & Code Changes

This PR modifies `offload_megatron_optimizer` in `megatron_utils.py` to offload the state maintained in `master_param` if it is populated.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: (NOTE: should be automatically included by `gpu_unit_tests.yml`, which sweeps over the `tests/` directory).
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.