### PR TITLE
[reward] fix: skip reward placement for empty responses

### DIFF
--- a/tests/workers/reward_manager/test_zero_length_response_on_cpu.py
+++ b/tests/workers/reward_manager/test_zero_length_response_on_cpu.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from verl import DataProto
+from verl.workers.reward_manager.batch import BatchRewardManager
+from verl.workers.reward_manager.dapo import DAPORewardManager
+from verl.workers.reward_manager.naive import NaiveRewardManager
+from verl.workers.reward_manager.prime import PrimeRewardManager
+
+
+class FakeTokenizer:
+    eos_token = "<eos>"
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        return " ".join(str(token.item()) for token in token_ids)
+
+    def batch_decode(self, token_ids, skip_special_tokens=True):
+        return [self.decode(row, skip_special_tokens=skip_special_tokens) for row in token_ids]
+
+
+def fixed_score(**kwargs):
+    return {"score": 3.0, "acc": 1.0}
+
+
+def fixed_batch_scores(**kwargs):
+    return [{"score": 3.0, "acc": 1.0}, {"score": 4.0, "acc": 1.0}]
+
+
+def make_data():
+    return DataProto.from_dict(
+        tensors={
+            "prompts": torch.tensor([[1, 2], [3, 4]]),
+            "responses": torch.tensor([[0, 0, 0], [5, 6, 0]]),
+            # The first sample has no valid response tokens; the second has two.
+            "attention_mask": torch.tensor([[1, 1, 0, 0, 0], [1, 1, 1, 1, 0]]),
+        },
+        non_tensors={
+            "reward_model": np.array([{"ground_truth": "a"}, {"ground_truth": "b"}], dtype=object),
+            "data_source": np.array(["unit", "unit"], dtype=object),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "manager",
+    [
+        NaiveRewardManager(FakeTokenizer(), num_examine=0, compute_score=fixed_score),
+        DAPORewardManager(FakeTokenizer(), num_examine=0, compute_score=fixed_score),
+    ],
+)
+def test_token_reward_managers_skip_zero_length_response(manager):
+    reward_tensor = manager(make_data())
+
+    assert reward_tensor[0].tolist() == [0.0, 0.0, 0.0]
+    assert reward_tensor[1].tolist() == [0.0, 3.0, 0.0]
+
+
+def test_prime_reward_manager_skips_zero_length_response(monkeypatch):
+    manager = PrimeRewardManager(FakeTokenizer(), num_examine=0)
+    monkeypatch.setattr(manager, "verify", lambda data: [3.0, 4.0])
+
+    reward_tensor = manager(make_data())
+
+    assert reward_tensor[0].tolist() == [0.0, 0.0, 0.0]
+    assert reward_tensor[1].tolist() == [0.0, 4.0, 0.0]
+
+
+def test_dapo_reward_manager_skips_zero_length_response_with_overlong_buffer():
+    manager = DAPORewardManager(
+        FakeTokenizer(),
+        num_examine=0,
+        compute_score=fixed_score,
+        max_resp_len=3,
+        overlong_buffer_cfg=SimpleNamespace(enable=True, len=1, penalty_factor=1.0, log=True),
+    )
+
+    result = manager(make_data(), return_dict=True)
+
+    assert result["reward_tensor"][0].tolist() == [0.0, 0.0, 0.0]
+    assert result["reward_tensor"][1].tolist() == [0.0, 3.0, 0.0]
+    assert result["reward_extra_info"]["overlong"] == [False, False]
+
+
+def test_batch_reward_manager_skips_zero_length_response():
+    manager = BatchRewardManager(FakeTokenizer(), num_examine=0, compute_score=fixed_batch_scores)
+
+    reward_tensor = manager(make_data())
+
+    assert reward_tensor[0].tolist() == [0.0, 0.0, 0.0]
+    assert reward_tensor[1].tolist() == [0.0, 4.0, 0.0]

--- a/verl/workers/reward_manager/batch.py
+++ b/verl/workers/reward_manager/batch.py
@@ -107,7 +107,8 @@ class BatchRewardManager(AbstractRewardManager):
                 reward = score
 
             rewards.append(reward)
-            reward_tensor[i, length - 1] = reward
+            if length > 0:
+                reward_tensor[i, length - 1] = reward
 
             data_source = data_sources[i]
             if already_printed.get(data_source, 0) < self.num_examine:

--- a/verl/workers/reward_manager/dapo.py
+++ b/verl/workers/reward_manager/dapo.py
@@ -79,7 +79,7 @@ class DAPORewardManager(AbstractRewardManager):
             valid_prompt_ids = prompt_ids[-valid_prompt_length:]
 
             response_ids = data_item.batch["responses"]
-            valid_response_length = data_item.batch["attention_mask"][prompt_length:].sum()
+            valid_response_length = int(data_item.batch["attention_mask"][prompt_length:].sum().item())
             valid_response_ids = response_ids[:valid_response_length]
 
             # decode
@@ -118,18 +118,19 @@ class DAPORewardManager(AbstractRewardManager):
 
             reward = score
 
-            if self.overlong_buffer_cfg.enable:
+            if self.overlong_buffer_cfg is not None and self.overlong_buffer_cfg.enable:
                 overlong_buffer_len = self.overlong_buffer_cfg.len
                 expected_len = self.max_resp_len - overlong_buffer_len
                 exceed_len = valid_response_length - expected_len
                 overlong_penalty_factor = self.overlong_buffer_cfg.penalty_factor
-                overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
+                overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0.0)
                 reward += overlong_reward
                 if self.overlong_buffer_cfg.log:
                     reward_extra_info["overlong_reward"].append(overlong_reward)
                     reward_extra_info["overlong"].append(overlong_reward < 0)
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -97,7 +97,8 @@ class NaiveRewardManager(AbstractRewardManager):
             else:
                 reward = score
 
-            reward_tensor[i, valid_response_length - 1] = reward
+            if valid_response_length > 0:
+                reward_tensor[i, valid_response_length - 1] = reward
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -171,10 +171,13 @@ class PrimeRewardManager(AbstractRewardManager):
         data_sources = data.non_tensor_batch["data_source"]
 
         scores = self.verify(data)
+        valid_response_lengths = valid_response_length.tolist()
 
         for i in range(len(data)):
             data_source = data_sources[i]
-            reward_tensor[i, valid_response_length[i].item() - 1] = scores[i]
+            response_length = valid_response_lengths[i]
+            if response_length > 0:
+                reward_tensor[i, response_length - 1] = scores[i]
 
             if data_source not in already_print_data_sources:
                 already_print_data_sources[data_source] = 0


### PR DESCRIPTION
### What does this PR do?

Fixes #6476.

This prevents reward managers from placing a reward at index `-1` when a sample has zero valid response tokens. The patched managers now leave the reward tensor row at zero for empty responses and continue placing rewards on the last valid response token for normal responses.

Also fixes DAPO's default `overlong_buffer_cfg=None` path by checking the config before reading `.enable`.

### Checklist Before Starting

- [x] Search for similar PRs. Queries:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6476+in%3Abody
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+reward+manager+valid_response_length
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully-padded+reward
- [x] Format the PR title as `[{modules}] {type}: {description}`.

Similar PR note: #5613 is related to fully padded responses, but it changes GDPO advantage logic in `verl/trainer/ppo/core_algos.py`. This PR fixes reward placement in `verl/workers/reward_manager`.

AI assistance was used to prepare this PR; I reviewed the changed lines and ran the tests below.

### Test

```bash
PYTHONPATH=. uv run --no-project --python 3.12 --with pytest --with numpy==1.26.4 --with torch --with 'tensordict>=0.8.0,<=0.10.0,!=0.9.0' --with packaging --with ray --with transformers --with psutil --with hydra-core pytest tests/workers/reward_manager -q
# 12 passed

uv run --no-project --python 3.12 --with ruff ruff check verl/workers/reward_manager/batch.py verl/workers/reward_manager/naive.py verl/workers/reward_manager/dapo.py verl/workers/reward_manager/prime.py tests/workers/reward_manager/test_zero_length_response_on_cpu.py
# All checks passed

uv run --no-project --python 3.12 --with ruff ruff format --check verl/workers/reward_manager/batch.py verl/workers/reward_manager/naive.py verl/workers/reward_manager/dapo.py verl/workers/reward_manager/prime.py tests/workers/reward_manager/test_zero_length_response_on_cpu.py
# 5 files already formatted
```

I also ran a local grep check to verify the remaining `- 1` reward placements in `verl/workers/reward_manager` are all guarded by a positive response-length check.

### API and Usage Example

No API changes.

### Design & Code Changes

- Guard reward placement in `batch`, `naive`, `dapo`, and `prime` reward managers so zero-length responses do not write to the final padded position.
- Preserve existing behavior for non-empty responses.
- Add CPU unit coverage for zero-length and non-zero response rows across all patched managers, including DAPO with and without overlong-buffer config.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply full pre-commit checks. I ran targeted ruff check/format and reward-manager CPU tests above; full repo pre-commit was not run locally.
- [ ] Add / Update documentation. Not applicable: bug fix with no API or user-facing docs change.
- [x] Add unit tests to cover the code.
- [ ] Once the PR is ready for CI, send a message in the `ci-request` channel. I do not have access to the verl Slack/Feishu CI request channel from this environment.
