### PR TITLE
[trainer] fix: fail closed on incomplete agent-loop rollouts

### DIFF
--- a/tests/trainer/test_main_ppo_sync_replay_buffer_on_cpu.py
+++ b/tests/trainer/test_main_ppo_sync_replay_buffer_on_cpu.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+from collections import defaultdict
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from verl.trainer import main_ppo_sync
+from verl.trainer.main_ppo_sync import AgentLoopManagerTQ, ReplayBuffer, _get_transfer_queue_cleanup_keys
+from verl.utils import tensordict_utils as tu
+
+
+class FakeKVBatchMeta:
+    def __init__(self, partition_id: str, keys: list[str], tags: list[dict]):
+        self.partition_id = partition_id
+        self.keys = keys
+        self.tags = tags
+        self.extra_info = {}
+
+
+@pytest.fixture(autouse=True)
+def mock_kv_batch_meta(monkeypatch):
+    monkeypatch.setattr(main_ppo_sync, "KVBatchMeta", FakeKVBatchMeta)
+
+
+@pytest.fixture
+def replay_buffer():
+    buffer = ReplayBuffer.__new__(ReplayBuffer)
+    buffer.partitions = defaultdict(dict)
+    buffer.poll_interval = 0
+    buffer.lock = threading.Lock()
+    return buffer
+
+
+def test_replay_buffer_returns_complete_rollout_batch(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "train",
+        {
+            "prompt_a": {"global_steps": 1, "status": "finished", "expected_rollouts": 2},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+            "prompt_a_0_1": {"global_steps": 1, "status": "success"},
+            "prompt_a_1_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    batch = replay_buffer.sample(partition_id="train", global_steps=1)
+
+    assert batch.partition_id == "train"
+    assert batch.keys == ["prompt_a_0_0", "prompt_a_0_1", "prompt_a_1_0"]
+    assert batch.extra_info["rollout_root_keys"] == ["prompt_a"]
+
+
+def test_replay_buffer_cleanup_keys_include_success_rows_and_root_markers(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "val",
+        {
+            "prompt_a": {"global_steps": 1, "status": "finished", "expected_rollouts": 1},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    batch = replay_buffer.sample(partition_id="val", global_steps=1)
+
+    assert _get_transfer_queue_cleanup_keys(batch) == ["prompt_a_0_0", "prompt_a"]
+
+
+def test_replay_buffer_allows_two_complete_val_batches_at_same_step_after_cleanup(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "val",
+        {
+            "prompt_a": {"global_steps": 1, "status": "finished", "expected_rollouts": 1},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+    batch = replay_buffer.sample(partition_id="val", global_steps=1)
+    replay_buffer.remove(batch.partition_id, _get_transfer_queue_cleanup_keys(batch))
+
+    replay_buffer.add(
+        "val",
+        {
+            "prompt_b": {"global_steps": 1, "status": "finished", "expected_rollouts": 1},
+            "prompt_b_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    batch = replay_buffer.sample(partition_id="val", global_steps=1)
+
+    assert batch.keys == ["prompt_b_0_0"]
+    assert batch.extra_info["rollout_root_keys"] == ["prompt_b"]
+
+
+def test_replay_buffer_fails_on_terminal_prompt_failure(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "train",
+        {
+            "prompt_a": {"global_steps": 1, "status": "failure", "expected_rollouts": 2},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="terminal failures: prompt_a=failure"):
+        replay_buffer.sample(partition_id="train", global_steps=1)
+
+
+def test_replay_buffer_fails_on_terminal_prompt_failure_without_expected_rollouts(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "train",
+        {
+            "prompt_a": {"global_steps": 1, "status": "failure"},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="terminal failures: prompt_a=failure"):
+        replay_buffer.sample(partition_id="train", global_steps=1)
+
+
+def test_replay_buffer_fails_when_finished_prompt_has_missing_rollout(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "train",
+        {
+            "prompt_a": {"global_steps": 1, "status": "finished", "expected_rollouts": 2},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match=r"prompt_a: expected 2, got 1"):
+        replay_buffer.sample(partition_id="train", global_steps=1)
+
+
+def test_replay_buffer_counts_unique_sessions_not_output_rows(replay_buffer: ReplayBuffer):
+    replay_buffer.add(
+        "train",
+        {
+            "prompt_a": {"global_steps": 1, "status": "finished", "expected_rollouts": 2},
+            "prompt_a_0_0": {"global_steps": 1, "status": "success"},
+            "prompt_a_0_1": {"global_steps": 1, "status": "success"},
+        },
+    )
+
+    with pytest.raises(RuntimeError, match=r"prompt_a: expected 2, got 1"):
+        replay_buffer.sample(partition_id="train", global_steps=1)
+
+
+def test_agent_loop_manager_records_default_expected_rollouts():
+    manager = AgentLoopManagerTQ.__new__(AgentLoopManagerTQ)
+    manager.rollout_config = SimpleNamespace(n=2, val_kwargs=SimpleNamespace(n=4))
+    prompts = tu.get_tensordict({"uid": np.array(["prompt_a", "prompt_b"], dtype=object)})
+
+    assert manager._get_expected_rollouts(prompts, partition_id="train") == [2, 2]
+    assert manager._get_expected_rollouts(prompts, partition_id="val") == [4, 4]
+
+
+def test_agent_loop_manager_records_per_prompt_expected_rollouts():
+    manager = AgentLoopManagerTQ.__new__(AgentLoopManagerTQ)
+    manager.rollout_config = SimpleNamespace(n=2, val_kwargs=SimpleNamespace(n=4))
+    prompts = tu.get_tensordict(
+        {
+            "uid": np.array(["prompt_a", "prompt_b"], dtype=object),
+            "__rollout_n__": np.array([1, 3], dtype=np.int64),
+        }
+    )
+
+    assert manager._get_expected_rollouts(prompts, partition_id="train") == [1, 3]

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -119,6 +119,45 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 # ======================================= USER SECTION BEGIN =======================================
 
 
+def _parse_agent_loop_output_key(key: str) -> tuple[str, str] | None:
+    """Parse agent-loop output keys formatted as ``{uid}_{session_id}_{index}``."""
+    parts = key.rsplit("_", 2)
+    if len(parts) != 3:
+        return None
+    uid, session_id, index = parts
+    if not session_id.isdigit() or not index.isdigit():
+        return None
+    return uid, session_id
+
+
+def _format_rollout_batch_error(
+    partition_id: str,
+    global_steps: int,
+    failures: dict[str, dict],
+    incomplete_rollouts: dict[str, tuple[int, int]],
+) -> str:
+    details = []
+    if failures:
+        failed_roots = ", ".join(f"{key}={tag.get('status')}" for key, tag in sorted(failures.items()))
+        details.append(f"terminal failures: {failed_roots}")
+    if incomplete_rollouts:
+        incomplete_roots = ", ".join(
+            f"{key}: expected {expected}, got {actual}"
+            for key, (expected, actual) in sorted(incomplete_rollouts.items())
+        )
+        details.append(f"incomplete rollouts: {incomplete_roots}")
+    reason = "; ".join(details)
+    return (
+        f"Incomplete rollout batch for partition={partition_id!r}, global_steps={global_steps}: {reason}. "
+        "Failing closed because partial agent-loop rollout groups can skew advantage computation."
+    )
+
+
+def _get_transfer_queue_cleanup_keys(batch: KVBatchMeta) -> list[str]:
+    root_keys = batch.extra_info.get("rollout_root_keys", [])
+    return list(dict.fromkeys([*batch.keys, *root_keys]))
+
+
 def compute_advantage_for_multi_trajectories(
     data: DataProto,
     batch_keys: list[str],
@@ -279,19 +318,53 @@ class ReplayBuffer:
             with self.lock:
                 keys, tags = [], []
                 should_wait = False
+                failures = {}
+                expected_rollouts = {}
+                root_keys = []
+                successful_sessions = defaultdict(set)
                 partition = self.partitions[partition_id]
                 for key, tag in partition.items():
                     if tag["global_steps"] == global_steps:
-                        if tag["status"] == "running":
+                        status = tag["status"]
+                        if status == "running":
                             should_wait = True
                             break
-                        elif tag["status"] == "success":
+                        elif status == "success":
                             keys.append(key)
                             tags.append(tag)
+                            parsed_key = _parse_agent_loop_output_key(key)
+                            if parsed_key is not None:
+                                uid, session_id = parsed_key
+                                successful_sessions[uid].add(session_id)
+                        elif status == "finished":
+                            expected = tag.get("expected_rollouts")
+                            if expected is not None:
+                                expected_rollouts[key] = int(expected)
+                                root_keys.append(key)
+                            else:
+                                logger.debug(f"Unknown status {status} for key {key}")
+                        elif status == "failure":
+                            failures[key] = tag
                         else:
-                            logger.debug(f"Unknown status {tag['status']} for key {key}")
+                            logger.debug(f"Unknown status {status} for key {key}")
                 if not should_wait:
-                    return KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
+                    incomplete_rollouts = {
+                        key: (expected, len(successful_sessions[key]))
+                        for key, expected in expected_rollouts.items()
+                        if len(successful_sessions[key]) < expected
+                    }
+                    if failures or incomplete_rollouts:
+                        raise RuntimeError(
+                            _format_rollout_batch_error(
+                                partition_id=partition_id,
+                                global_steps=global_steps,
+                                failures=failures,
+                                incomplete_rollouts=incomplete_rollouts,
+                            )
+                        )
+                    batch = KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
+                    batch.extra_info["rollout_root_keys"] = root_keys
+                    return batch
 
 
 @ray.remote
@@ -472,6 +545,13 @@ class AgentLoopManagerTQ(AgentLoopManager):
         await instance._init_agent_loop_workers()
         return instance
 
+    def _get_expected_rollouts(self, prompts: TensorDict, partition_id: str) -> list[int]:
+        if "__rollout_n__" in prompts:
+            return [int(rollout_n) for rollout_n in prompts["__rollout_n__"]]
+
+        default_n = self.rollout_config.n if partition_id == "train" else self.rollout_config.val_kwargs.n
+        return [int(default_n)] * len(prompts["uid"])
+
     def generate_sequences(self, prompts: TensorDict) -> None:
         """
         Dispatch input batch to agent loop workers without blocking. Workers should put agent loop outputs
@@ -483,7 +563,11 @@ class AgentLoopManagerTQ(AgentLoopManager):
         # mark prompts as pending in replay buffer
         global_steps = prompts["global_steps"]
         partition_id = "train" if "validate" not in prompts else "val"
-        items = {uid: {"global_steps": global_steps, "status": "running"} for uid in prompts["uid"]}
+        expected_rollouts = self._get_expected_rollouts(prompts, partition_id)
+        items = {
+            uid: {"global_steps": global_steps, "status": "running", "expected_rollouts": expected_rollout}
+            for uid, expected_rollout in zip(prompts["uid"], expected_rollouts, strict=True)
+        }
         self.replay_buffer.add(partition_id, items)
 
         chunkes = prompts.chunk(len(self.agent_loop_workers))
@@ -962,8 +1046,9 @@ class PPOTrainer:
             dump_all_keys.extend(batch.keys)
 
             # 5. cleanup transfer queue and replay buffer
-            tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
-            self.replay_buffer.remove(batch.partition_id, batch.keys)
+            cleanup_keys = _get_transfer_queue_cleanup_keys(batch)
+            tq.kv_clear(keys=cleanup_keys, partition_id=batch.partition_id)
+            self.replay_buffer.remove(batch.partition_id, cleanup_keys)
 
         # logger to wandb
         self._maybe_log_val_generations(inputs=sample_inputs, outputs=sample_outputs, scores=sample_scores)
@@ -1670,8 +1755,9 @@ class PPOTrainer:
                     self._log_rollout_data(batch, timing_raw, rollout_data_dir)
 
                 # 7. cleanup transfer queue and replay buffer
-                tq.kv_clear(keys=batch.keys, partition_id=batch.partition_id)
-                self.replay_buffer.remove(batch.partition_id, batch.keys)
+                cleanup_keys = _get_transfer_queue_cleanup_keys(batch)
+                tq.kv_clear(keys=cleanup_keys, partition_id=batch.partition_id)
+                self.replay_buffer.remove(batch.partition_id, cleanup_keys)
 
                 self.logger.log(data=metrics, step=self.global_steps)
                 progress_bar.update(1)


### PR DESCRIPTION
### What does this PR do?

Fixes #6437.

This PR makes `main_ppo_sync` fail closed when agent-loop rollout batches finish with missing rollout sessions.

Previously, `ReplayBuffer.sample()` waited only for `status="running"` markers to disappear, collected `status="success"` rows, and silently ignored terminal root statuses such as `finished` and `failure`. This could let training continue on a partial rollout group after an agent-loop failure or empty output.

This PR:
- records the expected rollout session count on each root prompt marker;
- detects terminal prompt failures;
- detects `finished` prompts with fewer successful rollout sessions than expected;
- cleans up sampled root prompt markers together with child output rows;
- raises a clear error instead of returning a partial `KVBatchMeta`;
- adds CPU regression tests.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+6437+in%3Abody
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+ReplayBuffer+partial+rollout+failure+main_ppo_sync
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
.venv/bin/python -m pytest tests/trainer/test_main_ppo_sync_replay_buffer_on_cpu.py -q
# 9 passed

.venv/bin/python -m pytest tests/trainer/test_multi_trajectories_advantage.py -q
# 2 passed

.venv/bin/pre-commit run ruff --files verl/trainer/main_ppo_sync.py tests/trainer/test_main_ppo_sync_replay_buffer_on_cpu.py
# Passed

.venv/bin/pre-commit run ruff-format --files verl/trainer/main_ppo_sync.py tests/trainer/test_main_ppo_sync_replay_buffer_on_cpu.py
# Passed

git diff --check
# Passed
```

During commit, the local `check-naming-conventions` pre-commit hook was skipped because it scans `.venv` and false-positives on Ray's installed `ServeRLlibRLModule`. Running the same grep check with `.venv` excluded found no matches in the repository files.

### API and Usage Example

No public API or usage changes.

### Design & Code Changes

`AgentLoopManagerTQ.generate_sequences()` now records `expected_rollouts` on each root prompt marker before dispatching agent-loop workers.

`ReplayBuffer.sample()` now:
- waits while any matching prompt is still `running`;
- collects successful child output rows as before;
- counts unique successful rollout sessions per prompt using child keys formatted as `{uid}_{session_id}_{index}`;
- carries the sampled root prompt keys in `KVBatchMeta.extra_info` so cleanup removes both root markers and child rows;
- raises `RuntimeError` if a root prompt reaches `failure`;
- raises `RuntimeError` if a `finished` root prompt has fewer successful sessions than `expected_rollouts`.

The child-key parser uses `rsplit("_", 2)` because `uid` can contain underscores. The check counts unique sessions rather than output rows, because one agent-loop session can emit multiple output rows.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] This PR is not related to the `recipe` submodule.

AI assistance disclosure: this PR was developed with AI assistance. I reviewed the changed lines and ran the tests above.
