### PR TITLE
[veomni] fix: pass mixed precision config to veomni

### DIFF
--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -279,11 +279,13 @@ class VeOmniEngine(FSDPEngine):
             load_balancing_loss_implementation=self.engine_config.load_balancing_loss_implementation,
         )
 
+        veomni_mixed_precision_config = MixedPrecisionConfig(enable=self.engine_config.mixed_precision)
+
         # Load base model with specified configuration and dtype
         module = build_foundation_model(
             config_path=self._get_model_config_path(),
             weights_path=self.model_config.local_path,
-            torch_dtype="float32" if self.engine_config.mixed_precision else "bfloat16",
+            torch_dtype="float32" if veomni_mixed_precision_config.enable else "bfloat16",
             attn_implementation=self.engine_config.attn_implementation,
             ops_implementation=ops_implementation,
             init_device=self.engine_config.init_device,
@@ -292,16 +294,12 @@ class VeOmniEngine(FSDPEngine):
 
         # Applies parallel strategies to the model.
         log_gpu_memory_usage("Before parallelize model", logger=logger)
-        mixed_precision = self.engine_config.mixed_precision
-        if isinstance(mixed_precision, bool):
-            mixed_precision = MixedPrecisionConfig(enable=mixed_precision)
-
         module = build_parallelize_model(
             module,
             init_device=self.engine_config.init_device,
             weights_path=self.model_config.local_path,
             enable_full_shard=self.engine_config.enable_full_shard,
-            mixed_precision=mixed_precision,
+            mixed_precision=veomni_mixed_precision_config,
             enable_gradient_checkpointing=self.model_config.enable_gradient_checkpointing,
             enable_fsdp_offload=self.engine_config.enable_fsdp_offload,
             basic_modules=list(

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -21,7 +21,7 @@ import torch
 import torch.distributed as dist
 from tensordict import TensorDict
 from torch.distributed.tensor import DTensor
-from veomni.arguments import OpsImplementationConfig
+from veomni.arguments import MixedPrecisionConfig, OpsImplementationConfig
 from veomni.distributed import parallel_state
 from veomni.distributed.offloading import build_activation_offloading_context
 from veomni.distributed.torch_parallelize import build_parallelize_model
@@ -292,12 +292,16 @@ class VeOmniEngine(FSDPEngine):
 
         # Applies parallel strategies to the model.
         log_gpu_memory_usage("Before parallelize model", logger=logger)
+        mixed_precision = self.engine_config.mixed_precision
+        if isinstance(mixed_precision, bool):
+            mixed_precision = MixedPrecisionConfig(enable=mixed_precision)
+
         module = build_parallelize_model(
             module,
             init_device=self.engine_config.init_device,
             weights_path=self.model_config.local_path,
             enable_full_shard=self.engine_config.enable_full_shard,
-            enable_mixed_precision=self.engine_config.mixed_precision,
+            mixed_precision=mixed_precision,
             enable_gradient_checkpointing=self.model_config.enable_gradient_checkpointing,
             enable_fsdp_offload=self.engine_config.enable_fsdp_offload,
             basic_modules=list(


### PR DESCRIPTION
### What does this PR do?

Fix VeOmni engine mixed precision setup to pass VeOmni's `MixedPrecisionConfig` object into `build_parallelize_model`, while using the same config to decide the base model load dtype.

Root cause: the VeOmni API expects `mixed_precision` instead of the old `enable_mixed_precision` boolean. The previous branch fix converted the boolean only at parallelization time; this keeps dtype selection and the VeOmni API argument aligned.

Duplicate-work check: searched open PRs for `veomni mixed precision config setup`, `VeOmni MixedPrecisionConfig build_parallelize_model`, and `mixed_precision veomni`. No open PR was found that addresses this specific fix. The only broad config-related hit was https://github.com/verl-project/verl/pull/6505, which adds missing config fields and does not cover this API adaptation.

AI assistance was used for this PR.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+veomni+mixed_precision
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

- `pre-commit run --files verl/workers/engine/veomni/transformer_impl.py` passed
- `python -m py_compile verl/workers/engine/veomni/transformer_impl.py` passed

### API and Usage Example

No public API change.

### Design & Code Changes

- Convert `engine_config.mixed_precision` into `MixedPrecisionConfig` once in `VeOmniEngine._build_model_optimizer`.
- Use `veomni_mixed_precision_config.enable` for model load dtype selection.
- Pass `mixed_precision=veomni_mixed_precision_config` to `build_parallelize_model`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit run --files verl/workers/engine/veomni/transformer_impl.py`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: internal bug fix only.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: covered by existing VeOmni CI paths; local validation is limited because this environment does not have VeOmni installed.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.
