### PR TITLE
[megatron] fix: official moe_enable_routing_replay flag in addition

### DIFF
--- a/verl/utils/megatron/router_replay_patch.py
+++ b/verl/utils/megatron/router_replay_patch.py
@@ -400,11 +400,14 @@ def apply_router_replay_patch():
 
     original_init = TopKRouter.__init__
 
+    def _router_replay_enabled(config):
+        return getattr(config, "enable_routing_replay", False) or getattr(config, "moe_enable_routing_replay", False)
+
     # Step 3: Define the new __init__ method
     def patched_init(self, *args, **kwargs):
         original_init(self, *args, **kwargs)
         self.router_replay = None
-        if getattr(self.config, "enable_routing_replay", False):
+        if _router_replay_enabled(self.config):
             self.router_replay = RouterReplay()
 
     # Step 4: Patch MoEAlltoAllTokenDispatcher.preprocess to handle router replay
@@ -420,7 +423,7 @@ def apply_router_replay_patch():
 
             # Fix num_out_tokens when router replay is enabled
             if (
-                getattr(self.config, "enable_routing_replay", False)
+                _router_replay_enabled(self.config)
                 and not self.drop_and_pad
                 and self.config.moe_expert_capacity_factor is None
                 and not (

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -221,7 +221,10 @@ class MegatronEngine(BaseEngine):
             for key, value in override_transformer_config.items():
                 provider_overrides[key] = value
             if self.enable_routing_replay:
-                provider_overrides["enable_routing_replay"] = True
+                if hasattr(provider, "moe_enable_routing_replay"):
+                    provider_overrides["moe_enable_routing_replay"] = True
+                else:
+                    provider_overrides["enable_routing_replay"] = True
 
             if self._qat_enabled:
                 from megatron.bridge.models.gpt_provider import modelopt_transformer_layer_spec


### PR DESCRIPTION
### What does this PR do?

mcore uses `moe_enable_routing_replay` instead of `enable_routing_replay` officially:
https://github.com/NVIDIA/Megatron-LM/commit/db6b895c69b71d2db7f5fd58d3f6de76ed40a619

### Checklist Before Starting

- [X] Search for similar PRs. Paste at least one query link here: ...
- [X] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [X] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [X] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [X] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [X] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [X] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [X] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
