### PR TITLE
[reward] fix: restrict reward model router endpoints

### DIFF
--- a/tests/experimental/reward_loop/test_naive_router_on_cpu.py
+++ b/tests/experimental/reward_loop/test_naive_router_on_cpu.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from fastapi.responses import JSONResponse
+from starlette.requests import Request
+
+from verl.experimental.reward_loop.router.naive_router import NaiveRouter
+
+
+async def _empty_receive():
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_request(method: str = "POST") -> Request:
+    return Request({"type": "http", "method": method, "path": "/", "headers": []}, receive=_empty_receive)
+
+
+def test_naive_router_allows_reward_model_endpoints():
+    router = NaiveRouter(worker_urls=["http://127.0.0.1:8000"])
+
+    assert router._is_endpoint_allowed("classify")
+    assert router._is_endpoint_allowed("/classify")
+    assert router._is_endpoint_allowed("v1/embeddings")
+    assert router._is_endpoint_allowed("v1/chat/completions")
+    assert router._is_endpoint_allowed("/v1/completions")
+
+
+def test_naive_router_supports_prefix_wildcard_endpoints():
+    router = NaiveRouter(worker_urls=["http://127.0.0.1:8000"], allowed_endpoints=["v1/*", "custom/*"])
+
+    assert router._is_endpoint_allowed("v1/chat/completions")
+    assert router._is_endpoint_allowed("/v1/embeddings")
+    assert router._is_endpoint_allowed("custom/endpoint")
+    assert not router._is_endpoint_allowed("classify")
+
+
+@pytest.mark.parametrize("allowed_endpoint", ["*", "/*"])
+def test_naive_router_supports_catch_all_wildcard(allowed_endpoint):
+    router = NaiveRouter(worker_urls=["http://127.0.0.1:8000"], allowed_endpoints=[allowed_endpoint])
+
+    assert router._is_endpoint_allowed("classify")
+    assert router._is_endpoint_allowed("generate")
+    assert router._is_endpoint_allowed("any/random/path")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["generate", "flush_cache", "abort_request", "metrics", "v1/models"])
+async def test_naive_router_rejects_internal_control_endpoints(endpoint):
+    router = NaiveRouter(worker_urls=["http://127.0.0.1:8000"])
+
+    response = await router._make_async_request(request=_make_request(), endpoint=endpoint)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 403

--- a/verl/experimental/reward_loop/router/naive_router.py
+++ b/verl/experimental/reward_loop/router/naive_router.py
@@ -30,6 +30,13 @@ from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+DEFAULT_ALLOWED_ENDPOINTS = (
+    "classify",
+    "v1/embeddings",
+    "v1/chat/completions",
+    "v1/completions",
+)
+
 
 async def _read_async_response(resp: aiohttp.ClientResponse) -> dict[str, Any]:
     if resp.status == 204 or (resp.content_length == 0):
@@ -50,6 +57,7 @@ async def _read_async_response(resp: aiohttp.ClientResponse) -> dict[str, Any]:
 
 def launch_router_process(
     worker_urls: list[str],
+    allowed_endpoints: list[str] | tuple[str, ...] | None = None,
 ):
     router_ip = ray.util.get_node_ip_address().strip("[]")
     router_port, _ = get_free_port(router_ip)
@@ -63,6 +71,7 @@ def launch_router_process(
             router_ip,
             router_port,
             worker_urls,
+            allowed_endpoints,
         ),
     )
     router_process.daemon = True
@@ -74,8 +83,13 @@ def launch_router_process(
     return router_address, router_process
 
 
-def run_router(router_ip: str, router_port: int, worker_urls: list[str]):
-    router = NaiveRouter(worker_urls=worker_urls, verbose=False)
+def run_router(
+    router_ip: str,
+    router_port: int,
+    worker_urls: list[str],
+    allowed_endpoints: list[str] | tuple[str, ...] | None = None,
+):
+    router = NaiveRouter(worker_urls=worker_urls, allowed_endpoints=allowed_endpoints, verbose=False)
     uvicorn.run(router.app, host=router_ip, port=router_port, log_level="warning")
 
 
@@ -87,11 +101,11 @@ class NaiveRouter:
         timeout: int = 60,
         max_attempts: int = 3,
         retry_delay: float = 2.0,
+        allowed_endpoints: list[str] | tuple[str, ...] | None = None,
         verbose: bool = False,
     ) -> None:
         """A minimal async load-balancing router."""
         self.verbose = verbose
-        self.app = FastAPI()
         self.worker_urls = worker_urls
         self.request_counts = {url: 0 for url in worker_urls}
 
@@ -99,6 +113,9 @@ class NaiveRouter:
         self.timeout = timeout
         self.max_attempts = max_attempts
         self.retry_delay = retry_delay
+        self.allowed_endpoints = self._normalize_allowed_endpoints(
+            allowed_endpoints if allowed_endpoints is not None else DEFAULT_ALLOWED_ENDPOINTS
+        )
 
         self.app = FastAPI()
 
@@ -111,6 +128,28 @@ class NaiveRouter:
 
         # Placeholder for aiohttp client
         self.client = None
+
+    @staticmethod
+    def _normalize_allowed_endpoints(allowed_endpoints: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+        normalized_endpoints = []
+        for endpoint in allowed_endpoints:
+            endpoint = endpoint.strip().strip("/")
+            if endpoint:
+                normalized_endpoints.append(endpoint)
+        return tuple(normalized_endpoints)
+
+    def _is_endpoint_allowed(self, endpoint: str) -> bool:
+        endpoint = endpoint.strip("/")
+        for allowed in self.allowed_endpoints:
+            if allowed == "*":
+                return True
+            elif allowed.endswith("/*"):
+                prefix = allowed[:-1]
+                if endpoint.startswith(prefix):
+                    return True
+            elif endpoint == allowed:
+                return True
+        return False
 
     async def _on_startup(self):
         """Initialize aiohttp client safely inside the event loop"""
@@ -134,6 +173,9 @@ class NaiveRouter:
 
     async def _make_async_request(self, request: Request, endpoint: str):
         """Proxy single request to a worker URL."""
+        if not self._is_endpoint_allowed(endpoint):
+            return JSONResponse(status_code=403, content={"error": f"Endpoint '{endpoint}' is not allowed"})
+
         if not self.worker_urls:
             return JSONResponse(status_code=503, content={"error": "No available workers"})
 


### PR DESCRIPTION

### What does this PR do?

Restricts the naive reward model router to known reward-model endpoints instead of proxying every GET/POST path to internal reward model workers.

Currently, `NaiveRouter` registers a catch-all `/{endpoint:path}` route and forwards arbitrary paths to reward model worker HTTP servers. This can unintentionally expose internal worker endpoints through the reward router. This PR keeps the existing reward paths working while returning `403` for unexpected endpoints.

Allowed by default:

- `/classify`
- `/v1/embeddings`
- `/v1/chat/completions`
- `/v1/completions`

Blocked examples covered by tests:

- `/generate`
- `/flush_cache`
- `/abort_request`
- `/metrics`
- `/v1/models`

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+naive_router+reward+router
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```text
pytest: 6 passed
ruff check: passed
ruff format --check: passed
pre-commit on changed files: passed
```

Commands run:

```bash
/tmp/verl-pr-check-venv/bin/python -m pytest -q tests/experimental/reward_loop/test_naive_router_on_cpu.py
/tmp/verl-pr-check-venv/bin/ruff check verl/experimental/reward_loop/router/naive_router.py tests/experimental/reward_loop/test_naive_router_on_cpu.py
/tmp/verl-pr-check-venv/bin/ruff format --check verl/experimental/reward_loop/router/naive_router.py tests/experimental/reward_loop/test_naive_router_on_cpu.py
PATH=/tmp/verl-pr-check-venv/bin:$PATH /tmp/verl-pr-check-venv/bin/pre-commit run --files verl/experimental/reward_loop/router/naive_router.py tests/experimental/reward_loop/test_naive_router_on_cpu.py --show-diff-on-failure --color=always
```

### API and Usage Example

No user-facing API change.

### Design & Code Changes

- Adds a default allowlist for reward model router endpoints.
- Checks the requested endpoint before selecting a worker or reading/forwarding the request body.
- Returns `403` for endpoints outside the allowlist.
- Adds CPU tests for allowed reward endpoints and blocked internal/control endpoints.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks on changed files.
- [x] Add unit tests to cover the router allowlist behavior.
- [ ] Send a message in the `ci-request` channel once the PR is ready for CI.
