### PR TITLE
[megatron] fix: preserve router replay fallback config flag

### DIFF
--- a/tests/utils/megatron/test_router_replay_patch_config_on_cpu.py
+++ b/tests/utils/megatron/test_router_replay_patch_config_on_cpu.py
@@ -1,0 +1,121 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+from importlib import util
+from pathlib import Path
+
+
+def _install_fake_megatron(monkeypatch, include_mla_config=True):
+    class TransformerConfig:
+        num_layers = None
+        hidden_size = None
+        num_attention_heads = None
+
+        def __init__(self, num_layers, hidden_size, num_attention_heads):
+            self.num_layers = num_layers
+            self.hidden_size = hidden_size
+            self.num_attention_heads = num_attention_heads
+
+    class MLATransformerConfig(TransformerConfig):
+        def __init__(self, num_layers, hidden_size, num_attention_heads):
+            self.num_layers = num_layers
+            self.hidden_size = hidden_size
+            self.num_attention_heads = num_attention_heads
+
+    class TopKRouter:
+        def __init__(self, config=None):
+            self.config = config
+
+        def routing(self, *args, **kwargs):
+            raise NotImplementedError
+
+    class MoEAlltoAllTokenDispatcher:
+        def preprocess(self, routing_map):
+            return routing_map
+
+    megatron = types.ModuleType("megatron")
+    core = types.ModuleType("megatron.core")
+    transformer = types.ModuleType("megatron.core.transformer")
+    transformer_config = types.ModuleType("megatron.core.transformer.transformer_config")
+    moe = types.ModuleType("megatron.core.transformer.moe")
+    moe_utils = types.ModuleType("megatron.core.transformer.moe.moe_utils")
+    router = types.ModuleType("megatron.core.transformer.moe.router")
+    token_dispatcher = types.ModuleType("megatron.core.transformer.moe.token_dispatcher")
+
+    transformer.TransformerConfig = TransformerConfig
+    if include_mla_config:
+        transformer.MLATransformerConfig = MLATransformerConfig
+    transformer_config.TransformerConfig = TransformerConfig
+    router.TopKRouter = TopKRouter
+    token_dispatcher.MoEAlltoAllTokenDispatcher = MoEAlltoAllTokenDispatcher
+
+    moe_utils.apply_router_token_dropping = lambda *args, **kwargs: None
+    moe_utils.compute_routing_scores_for_aux_loss = lambda *args, **kwargs: None
+    moe_utils.group_limited_topk = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer", transformer)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.transformer_config", transformer_config)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.moe", moe)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.moe.moe_utils", moe_utils)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.moe.router", router)
+    monkeypatch.setitem(sys.modules, "megatron.core.transformer.moe.token_dispatcher", token_dispatcher)
+
+    monkeypatch.delitem(sys.modules, "verl.utils.megatron.router_replay_patch", raising=False)
+
+    return TransformerConfig, MLATransformerConfig
+
+
+def _construct_after_config_converter_filter(config_cls):
+    config = {
+        "num_layers": 1,
+        "hidden_size": 128,
+        "num_attention_heads": 1,
+        "enable_routing_replay": True,
+    }
+    filtered_config = {key: value for key, value in config.items() if hasattr(config_cls, key)}
+    return config_cls(**filtered_config)
+
+
+def _load_router_replay_patch():
+    repo_root = Path(__file__).resolve().parents[3]
+    module_path = repo_root / "verl/utils/megatron/router_replay_patch.py"
+    spec = util.spec_from_file_location("router_replay_patch_under_test", module_path)
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_router_replay_patch_exposes_config_flag_for_converter_filter(monkeypatch):
+    config_classes = _install_fake_megatron(monkeypatch)
+    router_replay_patch = _load_router_replay_patch()
+
+    router_replay_patch.apply_router_replay_patch()
+
+    for config_cls in config_classes:
+        config = _construct_after_config_converter_filter(config_cls)
+        assert config.enable_routing_replay is True
+
+
+def test_router_replay_patch_supports_megatron_without_mla_config(monkeypatch):
+    transformer_config, _ = _install_fake_megatron(monkeypatch, include_mla_config=False)
+    router_replay_patch = _load_router_replay_patch()
+
+    router_replay_patch.apply_router_replay_patch()
+
+    config = _construct_after_config_converter_filter(transformer_config)
+    assert config.enable_routing_replay is True

--- a/verl/utils/megatron/router_replay_patch.py
+++ b/verl/utils/megatron/router_replay_patch.py
@@ -29,8 +29,13 @@ try:
 except ImportError:
     warnings.warn("NPU not support router replay for now.", stacklevel=2)
     MoEAlltoAllTokenDispatcher = None
+from megatron.core.transformer import TransformerConfig
 from megatron.core.transformer.moe.router import TopKRouter
-from megatron.core.transformer.transformer_config import TransformerConfig
+
+try:
+    from megatron.core.transformer import MLATransformerConfig
+except ImportError:
+    MLATransformerConfig = None
 
 # https://github.com/THUDM/slime/blob/main/slime/utils/routing_replay.py
 
@@ -337,62 +342,59 @@ def patched_routing(self, logits: torch.Tensor, *args, **kwargs):
 def apply_router_replay_patch():
     """
     Applies the monkey patch for MoE Router Replay functionality.
-    This patch dynamically adds the 'enable_routing_replay' attribute to TransformerConfig
+    This patch dynamically adds the 'enable_routing_replay' attribute to Megatron config classes
     and modifies the TopKRouter to support recording and replaying of routing decisions.
     """
     print("Applying Router Replay Patch...")
     # Clear router instances to avoid state leakage between model initializations.
     RouterReplay.router_instances.clear()
-    # Step 1: Patch TransformerConfig to include the feature flag
+    # Step 1: Patch config classes to include the feature flag.
 
-    try:
-        sig = inspect.signature(TransformerConfig.__init__)
-        native_params = sig.parameters
-        params = list(sig.parameters.values())
-    except Exception:
-        sig = None
-        native_params = {}
-        params = []
-
-    ext_attrs = ["enable_routing_replay"]
-
-    # Update __signature__ to prevent NPU/MindSpeed wrappers from filtering out or blocking custom parameters.
-    for attr in ext_attrs:
-        if attr not in native_params:
-            if sig:
-                new_param = inspect.Parameter(attr, inspect.Parameter.KEYWORD_ONLY, default=False)
-                if params and params[-1].kind == inspect.Parameter.VAR_KEYWORD:
-                    params.insert(-1, new_param)
-                else:
-                    params.append(new_param)
-
-    if sig:
+    def patch_config_class(config_cls):
         try:
-            TransformerConfig.__init__.__signature__ = sig.replace(parameters=params)
-        except Exception as e:
-            print(f"Failed to update signature metadata: {e}")
+            sig = inspect.signature(config_cls.__init__)
+            native_params = sig.parameters
+            params = list(sig.parameters.values())
+        except Exception:
+            sig = None
+            native_params = {}
+            params = []
 
-    if not hasattr(TransformerConfig, "_verl_router_patched"):
-        # Store original __init__ method
-        original_tf_config_init = TransformerConfig.__init__
+        # Update __signature__ to prevent wrappers from filtering out or blocking custom parameters.
+        if "enable_routing_replay" not in native_params and sig:
+            new_param = inspect.Parameter("enable_routing_replay", inspect.Parameter.KEYWORD_ONLY, default=False)
+            if params and params[-1].kind == inspect.Parameter.VAR_KEYWORD:
+                params.insert(-1, new_param)
+            else:
+                params.append(new_param)
 
-        # Define new __init__ method that safely handles enable_routing_replay parameter
-        @wraps(original_tf_config_init)
-        def patched_tf_config_init(self, *args, **kwargs):
-            # Simple solution: remove the unknown parameter before calling original constructor
-            enable_routing_replay = kwargs.get("enable_routing_replay", False)
-            if "enable_routing_replay" not in native_params:
-                enable_routing_replay = kwargs.pop("enable_routing_replay", False)
+            try:
+                config_cls.__init__.__signature__ = sig.replace(parameters=params)
+            except Exception as e:
+                print(f"Failed to update signature metadata for {config_cls.__name__}: {e}")
 
-            # Call original constructor with remaining kwargs
-            original_tf_config_init(self, *args, **kwargs)
+        if "_verl_router_patched" not in config_cls.__dict__:
+            original_config_init = config_cls.__init__
 
-            # Set the instance attribute
-            self.enable_routing_replay = enable_routing_replay
+            @wraps(original_config_init)
+            def patched_config_init(self, *args, **kwargs):
+                enable_routing_replay = kwargs.get("enable_routing_replay", False)
+                if "enable_routing_replay" not in native_params:
+                    enable_routing_replay = kwargs.pop("enable_routing_replay", False)
 
-        # Apply the patch
-        TransformerConfig.__init__ = patched_tf_config_init
-        TransformerConfig._verl_router_patched = True
+                original_config_init(self, *args, **kwargs)
+                self.enable_routing_replay = enable_routing_replay
+
+            config_cls.__init__ = patched_config_init
+            config_cls._verl_router_patched = True
+
+        # config_converter filters kwargs with hasattr(cls, key), so expose a class-level default.
+        if "enable_routing_replay" not in config_cls.__dict__:
+            config_cls.enable_routing_replay = False
+
+    patch_config_class(TransformerConfig)
+    if MLATransformerConfig is not None:
+        patch_config_class(MLATransformerConfig)
 
     # Step 2: Patch TopKRouter only once to ensure idempotency.
     if hasattr(TopKRouter, "_router_replay_patched"):


### PR DESCRIPTION
### What does this PR do?

Preserve the router replay fallback feature flag when Megatron config construction filters override kwargs with `hasattr(cls, key)`.

`apply_router_replay_patch()` now patches both `TransformerConfig` and `MLATransformerConfig`, exposes a class-level `enable_routing_replay = False` default for the converter filter, and still wraps config constructors so the flag can be accepted even when native Megatron versions do not define it.

### Root cause

`check_and_construct_configs()` removes override keys that are not visible as class attributes on the target Megatron config class. The router replay patch previously adjusted the constructor signature, but it did not expose `enable_routing_replay` at the class level and did not cover `MLATransformerConfig`, so the fallback flag could be silently dropped before construction.

### Test

- `PYTHONPATH=. pytest tests/utils/megatron/test_router_replay_patch_config_on_cpu.py -q`
- `python -m ruff check verl/utils/megatron/router_replay_patch.py tests/utils/megatron/test_router_replay_patch_config_on_cpu.py`
- `python -m py_compile verl/utils/megatron/router_replay_patch.py tests/utils/megatron/test_router_replay_patch_config_on_cpu.py`
- `git diff --check HEAD~1..HEAD`
- GitHub CI: `cpu_unit_tests`, `pre-commit`, `sanity`, `type-coverage-check`, `doc_test`, title/secrets checks pass.

### API and Usage Example

No user-facing API or usage changes. This only preserves the existing router replay fallback config path for Megatron versions that do not expose a native `moe_enable_routing_replay` field.

### Design & Code Changes

- Preserve `enable_routing_replay` through verl Megatron config filtering by exposing it as a class-level fallback attribute.
- Apply the fallback patch to both `TransformerConfig` and `MLATransformerConfig`.
- Add CPU-only regression coverage for the fallback path, without adding internal end-to-end scripts.

### Checklist Before Starting

- [x] Searched similar PRs/issues: https://github.com/verl-project/verl/pulls?q=router+replay and related #6647 / #5884.
- [x] PR title follows the verl format: `[megatron] fix: ...`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Applied pre-commit/lint checks: GitHub `pre-commit` passes; focused local `ruff`, `py_compile`, and whitespace checks also pass.
- [x] Documentation is not updated because this fixes internal Megatron config plumbing and does not change user-facing APIs.
- [x] Added CPU-only unit regression coverage under `tests/utils/megatron/`; it is covered by the existing `cpu_unit_tests` workflow.
- [x] CI has already run on GitHub. Core relevant checks pass; remaining red jobs appear unrelated to this patch path and are summarized in the PR discussion.
- [x] Recipe submodule is not affected.

### Notes

This keeps the PR scoped to the core fix and a CPU-only focused regression test. Internal end-to-end R3 smoke scripts are intentionally not included.