### PR TITLE
[megatron] fix YaRN rope config with mBridge

### DIFF
--- a/tests/utils/megatron/test_yarn_rope_config_on_cpu.py
+++ b/tests/utils/megatron/test_yarn_rope_config_on_cpu.py
@@ -1,0 +1,121 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_rope_config_module():
+    module_path = Path(__file__).parents[3] / "verl" / "utils" / "megatron" / "rope_config.py"
+    spec = importlib.util.spec_from_file_location("rope_config", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extracts_yarn_runtime_config_from_legacy_rope_scaling():
+    hf_config = SimpleNamespace(
+        rope_theta=1000000.0,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+        },
+    )
+
+    rope_config = _load_rope_config_module()
+
+    assert rope_config.get_hf_yarn_rope_config(hf_config, {}) == {
+        "position_embedding_type": "yarn",
+        "rotary_base": 1000000.0,
+        "yarn_rotary_scaling_factor": 4.0,
+        "yarn_original_max_position_embeddings": 32768,
+        "yarn_beta_fast": 32.0,
+        "yarn_beta_slow": 1.0,
+        "yarn_mscale": 1.0,
+        "yarn_mscale_all_dim": 0.0,
+        "yarn_correction_range_round_to_int": True,
+    }
+
+
+def test_prefers_nested_rope_parameters_over_rope_scaling():
+    hf_config = SimpleNamespace(
+        rope_theta=10000.0,
+        rope_scaling={"type": "linear", "factor": 2.0},
+        rope_parameters={
+            "short": {"rope_type": "default", "rope_theta": 10000.0},
+            "long": {
+                "rope_type": "yarn",
+                "rope_theta": 500000.0,
+                "factor": 8.0,
+                "original_max_position_embeddings": 65536,
+                "beta_fast": 48.0,
+                "beta_slow": 2.0,
+            },
+        },
+    )
+
+    rope_config = _load_rope_config_module()
+
+    yarn_config = rope_config.get_hf_yarn_rope_config(hf_config, {})
+
+    assert yarn_config["position_embedding_type"] == "yarn"
+    assert yarn_config["rotary_base"] == 500000.0
+    assert yarn_config["yarn_rotary_scaling_factor"] == 8.0
+    assert yarn_config["yarn_original_max_position_embeddings"] == 65536
+    assert yarn_config["yarn_beta_fast"] == 48.0
+    assert yarn_config["yarn_beta_slow"] == 2.0
+
+
+def test_explicit_override_values_take_precedence_without_mutating_input():
+    hf_config = SimpleNamespace(
+        rope_scaling={
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 32768,
+        },
+    )
+    override_transformer_config = {
+        "attention_backend": "flash",
+        "rotary_base": 123456.0,
+        "yarn_rotary_scaling_factor": 16.0,
+        "yarn_mscale": 0.5,
+    }
+
+    rope_config = _load_rope_config_module()
+
+    yarn_config = rope_config.get_hf_yarn_rope_config(hf_config, override_transformer_config)
+
+    assert yarn_config["rotary_base"] == 123456.0
+    assert yarn_config["yarn_rotary_scaling_factor"] == 16.0
+    assert yarn_config["yarn_mscale"] == 0.5
+    assert rope_config.without_yarn_runtime_config(override_transformer_config) == {"attention_backend": "flash"}
+    assert override_transformer_config == {
+        "attention_backend": "flash",
+        "rotary_base": 123456.0,
+        "yarn_rotary_scaling_factor": 16.0,
+        "yarn_mscale": 0.5,
+    }
+
+
+def test_non_yarn_rope_config_is_noop():
+    hf_config = SimpleNamespace(
+        rope_theta=10000.0,
+        rope_scaling={"type": "linear", "factor": 2.0},
+    )
+
+    rope_config = _load_rope_config_module()
+
+    assert rope_config.get_hf_yarn_rope_config(hf_config, {}) == {}

--- a/verl/utils/megatron/rope_config.py
+++ b/verl/utils/megatron/rope_config.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+YARN_RUNTIME_CONFIG_KEYS = {
+    "position_embedding_type",
+    "rotary_base",
+    "yarn_rotary_scaling_factor",
+    "yarn_original_max_position_embeddings",
+    "yarn_beta_fast",
+    "yarn_beta_slow",
+    "yarn_mscale",
+    "yarn_mscale_all_dim",
+    "yarn_correction_range_round_to_int",
+}
+
+
+def _get_value(config: Any, key: str, default: Any = None) -> Any:
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _get_hf_value(hf_config: Any, key: str, default: Any = None) -> Any:
+    value = getattr(hf_config, key, default)
+    if value is not default:
+        return value
+
+    text_config = getattr(hf_config, "text_config", None)
+    if text_config is not None:
+        return getattr(text_config, key, default)
+    return default
+
+
+def _get_rope_config(hf_config: Any) -> Any:
+    rope_config = _get_hf_value(hf_config, "rope_parameters", None)
+    if rope_config is None:
+        rope_config = _get_hf_value(hf_config, "rope_scaling", None)
+
+    if isinstance(rope_config, dict) and "rope_type" not in rope_config and "type" not in rope_config:
+        for value in rope_config.values():
+            rope_type = _get_value(value, "rope_type", _get_value(value, "type"))
+            if rope_type == "yarn":
+                return value
+    return rope_config
+
+
+def get_hf_yarn_rope_config(hf_config: Any, override_transformer_config: dict[str, Any] | None) -> dict[str, Any]:
+    """Extract YaRN fields that GPTModel reads after Megatron config construction."""
+    rope_config = _get_rope_config(hf_config)
+    yarn_config: dict[str, Any] = {}
+
+    if rope_config is not None:
+        rope_type = _get_value(rope_config, "rope_type", _get_value(rope_config, "type"))
+        if rope_type == "yarn":
+            yarn_config = {
+                "position_embedding_type": "yarn",
+                "rotary_base": _get_value(rope_config, "rope_theta", _get_hf_value(hf_config, "rope_theta", None)),
+                "yarn_rotary_scaling_factor": _get_value(rope_config, "factor"),
+                "yarn_original_max_position_embeddings": _get_value(
+                    rope_config, "original_max_position_embeddings"
+                ),
+                "yarn_beta_fast": _get_value(rope_config, "beta_fast", 32.0),
+                "yarn_beta_slow": _get_value(rope_config, "beta_slow", 1.0),
+                "yarn_mscale": _get_value(rope_config, "mscale", 1.0),
+                "yarn_mscale_all_dim": _get_value(rope_config, "mscale_all_dim", 0.0),
+                "yarn_correction_range_round_to_int": _get_value(
+                    rope_config, "correction_range_round_to_int", True
+                ),
+            }
+            yarn_config = {key: value for key, value in yarn_config.items() if value is not None}
+
+    if override_transformer_config:
+        for key in YARN_RUNTIME_CONFIG_KEYS:
+            if key in override_transformer_config:
+                yarn_config[key] = override_transformer_config[key]
+    return yarn_config
+
+
+def without_yarn_runtime_config(override_transformer_config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in override_transformer_config.items() if key not in YARN_RUNTIME_CONFIG_KEYS}

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -164,6 +164,7 @@ class MegatronEngine(BaseEngine):
         )
 
     def _build_tf_config(self):
+        from verl.utils.megatron.rope_config import get_hf_yarn_rope_config, without_yarn_runtime_config
         from verl.utils.megatron_utils import mapping_string_to_attn_backend
         from verl.utils.torch_dtypes import PrecisionType
 
@@ -181,6 +182,10 @@ class MegatronEngine(BaseEngine):
             # but it does not affect the functionality of dynamic CP, so we can use it to avoid the coupling.
             override_transformer_config["dynamic_context_parallel"] = False
             override_transformer_config["context_parallel_size"] = mpu.get_data_parallel_world_size()
+        self.yarn_runtime_config = get_hf_yarn_rope_config(
+            self.model_config.hf_config, override_transformer_config
+        )
+        bridge_transformer_config = without_yarn_runtime_config(override_transformer_config)
         self.provider = None
         self.vanilla_bridge = self.engine_config.vanilla_mbridge
 
@@ -188,8 +193,10 @@ class MegatronEngine(BaseEngine):
             from verl.models.mcore.mbridge import AutoBridge
 
             bridge = AutoBridge.from_config(self.model_config.hf_config, dtype=self.param_dtype)
-            bridge.set_extra_args(**override_transformer_config)
+            bridge.set_extra_args(**bridge_transformer_config)
             tf_config = bridge.config
+            for key, value in self.yarn_runtime_config.items():
+                setattr(tf_config, key, value)
             tf_config.fp16 = self.param_dtype == torch.float16
             tf_config.bf16 = self.param_dtype == torch.bfloat16
         else:
@@ -218,7 +225,7 @@ class MegatronEngine(BaseEngine):
                 "moe_token_dispatcher_type": "alltoall",
                 "moe_router_load_balancing_type": "none",
             }
-            for key, value in override_transformer_config.items():
+            for key, value in bridge_transformer_config.items():
                 provider_overrides[key] = value
             if self.enable_routing_replay:
                 if hasattr(provider, "moe_enable_routing_replay"):
@@ -231,10 +238,14 @@ class MegatronEngine(BaseEngine):
 
                 provider.transformer_layer_spec = modelopt_transformer_layer_spec
 
+            for key, value in self.yarn_runtime_config.items():
+                setattr(provider, key, value)
             provider.apply_overrides_and_finalize(
                 dtype=self.param_dtype,
                 overrides=provider_overrides,
             )
+            for key, value in self.yarn_runtime_config.items():
+                setattr(provider, key, value)
             self.provider = provider
             tf_config = None  # Will be set after model creation
         self.bridge = bridge
@@ -290,6 +301,8 @@ class MegatronEngine(BaseEngine):
             peft_cls=self.peft_cls,
             peft_config=self.model_config.get("lora", None),
         )
+        for key, value in self.yarn_runtime_config.items():
+            setattr(updated_tf_config, key, value)
         self.tf_config = updated_tf_config
         print(f"module: {len(module)}")
 


### PR DESCRIPTION
## Summary

This PR is scoped to the current verl Megatron integration path, not a replacement for the generic Megatron-Bridge YaRN mapping.

- preserve HF YaRN runtime fields for the current verl mBridge path, especially the default `vanilla_mbridge=True` path that uses `ISEEKYAN/mbridge`
- support both legacy `rope_scaling` and Transformers 5-style `rope_parameters`, including nested layouts
- keep YaRN runtime-only keys out of bridge constructor/override kwargs, then apply them back to the final Megatron config/provider consumed by GPTModel
- keep explicit `override_transformer_config` YaRN values taking precedence over HF config values
- add CPU-only regression coverage for legacy, nested, override, and non-YaRN cases

## Why

Megatron-Bridge already has upstream mapping for `rope_scaling.type == "yarn"` on the non-vanilla Megatron-Bridge path. This PR is narrower: it fills the remaining verl-side integration gap while verl still defaults to `vanilla_mbridge=True` and forwards `override_transformer_config` through its own bridge/config construction path.

YaRN fields such as `position_embedding_type`, `rotary_base`, `yarn_rotary_scaling_factor`, and `yarn_original_max_position_embeddings` are runtime config fields read by GPTModel. In the current verl path, passing them as ordinary constructor/override kwargs can be rejected or filtered before GPTModel sees them. This patch extracts the HF YaRN settings, avoids passing runtime-only fields through constructor kwargs, and restores them on the final config/provider.

This is useful beyond a private model config: [YaRN](https://arxiv.org/abs/2309.00071) is a published RoPE-based method for extending model context windows, and the [Qwen2 Technical Report](https://arxiv.org/abs/2407.10671) reports using YaRN together with Dual Chunk Attention to support long-context processing up to 131,072 tokens. Preserving these HF YaRN fields lets the current verl Megatron/mBridge path load mainstream long-context model configs without losing the runtime RoPE settings.

This shim can become unnecessary once verl defaults to, or pins, a bridge stack that preserves `rope_scaling` / `rope_parameters` and `override_transformer_config` YaRN fields end-to-end.

## Tests

- `PYTHONPATH=. pytest tests/utils/megatron/test_yarn_rope_config_on_cpu.py -q`
- `python -m py_compile verl/utils/megatron/rope_config.py verl/workers/engine/megatron/transformer_impl.py tests/utils/megatron/test_yarn_rope_config_on_cpu.py`
- `python -m ruff check verl/utils/megatron/rope_config.py verl/workers/engine/megatron/transformer_impl.py tests/utils/megatron/test_yarn_rope_config_on_cpu.py`
- `git diff --check HEAD~1..HEAD`
