### PR TITLE
[model, fsdp] fix: support Qwen3.5 linear attention under Ulysses SP

### DIFF
--- a/tests/models/test_fsdp_no_padding_on_gpu.py
+++ b/tests/models/test_fsdp_no_padding_on_gpu.py
@@ -137,6 +137,36 @@ def test_prepare_model_inputs_uses_full_sequence_attention_mask_on_gpu():
     assert output_args["input_ids_rmpad_rolled"].shape == (8,)
 
 
+def test_prepare_model_inputs_passes_declared_packed_sequence_boundaries_on_gpu():
+    from verl.utils import tensordict_utils as tu
+    from verl.utils.dataset.dataset_utils import DatasetPadMode
+
+    device = "cuda"
+    FSDPEngineWithLMHead = _fsdp_engine_with_lm_head_cls()
+    engine = FSDPEngineWithLMHead.__new__(FSDPEngineWithLMHead)
+    engine.use_ulysses_sp = False
+    engine.pass_packed_cu_seqlens = True
+    micro_batch = _make_micro_batch(device)
+    tu.assign_non_tensor(
+        micro_batch,
+        use_remove_padding=True,
+        use_fused_kernels=False,
+        pad_mode=DatasetPadMode.NO_PADDING,
+        pad_token_id=0,
+        max_response_len=2,
+        max_response_length=2,
+    )
+
+    model_inputs, output_args = engine.prepare_model_inputs(micro_batch)
+
+    expected_cu_seqlens = torch.tensor([0, 5, 8], device=device, dtype=torch.long)
+    torch.testing.assert_close(model_inputs["cu_seqlens"], expected_cu_seqlens)
+    torch.testing.assert_close(model_inputs["cu_seqlens_cpu"], expected_cu_seqlens.cpu())
+    assert model_inputs["input_ids"].shape == (1, 8)
+    assert model_inputs["attention_mask"] is None
+    assert output_args["input_ids_rmpad_rolled"].shape == (8,)
+
+
 def test_prepare_model_outputs_can_be_sliced_back_to_response_shape_on_gpu():
     from verl.utils.torch_functional import logprobs_from_logits
     from verl.workers.utils.padding import no_padding_2_padding

--- a/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
+++ b/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
@@ -24,12 +24,13 @@ import pytest
 import torch
 import torch.distributed as dist
 
+from verl.models.transformers.qwen3_5 import qwen3_5_decoder_layer_forward, qwen3_5_gated_delta_net_forward
+from verl.utils.ulysses import set_ulysses_sequence_parallel_group
+
 pytest.importorskip("fla")
 qwen35_config_mod = pytest.importorskip("transformers.models.qwen3_5.configuration_qwen3_5")
 qwen35_modeling_mod = pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
 
-from verl.models.transformers.qwen3_5 import qwen3_5_decoder_layer_forward, qwen3_5_gated_delta_net_forward
-from verl.utils.ulysses import set_ulysses_sequence_parallel_group
 
 Qwen3_5TextConfig = qwen35_config_mod.Qwen3_5TextConfig
 Qwen3_5DecoderLayer = qwen35_modeling_mod.Qwen3_5DecoderLayer

--- a/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
+++ b/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
@@ -163,7 +163,12 @@ def _run_case(case_name: str, lengths: list[int], layer: Qwen3_5DecoderLayer, de
     assert grad_err_ratio < 2e-3
 
 
-def test_qwen35_linear_attention_matches_full_forward_under_ulysses_sp():
+@pytest.mark.parametrize(
+    "use_causal_conv1d_fn",
+    [True, False],
+    ids=["causal_conv1d_fn", "torch_conv1d_fallback"],
+)
+def test_qwen35_linear_attention_matches_full_forward_under_ulysses_sp(use_causal_conv1d_fn: bool):
     assert torch.cuda.is_available(), "CUDA is required"
     if not dist.is_initialized():
         dist.init_process_group("nccl")
@@ -176,6 +181,10 @@ def test_qwen35_linear_attention_matches_full_forward_under_ulysses_sp():
     Qwen3_5GatedDeltaNet.forward = qwen3_5_gated_delta_net_forward
 
     layer = _make_layer(device)
+    if not use_causal_conv1d_fn:
+        for module in layer.modules():
+            if isinstance(module, Qwen3_5GatedDeltaNet):
+                module.causal_conv1d_fn = None
     _broadcast_params(layer)
 
     for case_name, lengths in _cases_for_world_size(dist.get_world_size()):

--- a/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
+++ b/tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
@@ -1,0 +1,184 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qwen3.5 linear-attention regression test for packed Ulysses SP.
+
+Run on GPUs, for example:
+    torchrun --nproc_per_node=8 -m pytest -svv \
+        tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+
+pytest.importorskip("fla")
+qwen35_config_mod = pytest.importorskip("transformers.models.qwen3_5.configuration_qwen3_5")
+qwen35_modeling_mod = pytest.importorskip("transformers.models.qwen3_5.modeling_qwen3_5")
+
+from verl.models.transformers.qwen3_5 import qwen3_5_decoder_layer_forward, qwen3_5_gated_delta_net_forward
+from verl.utils.ulysses import set_ulysses_sequence_parallel_group
+
+Qwen3_5TextConfig = qwen35_config_mod.Qwen3_5TextConfig
+Qwen3_5DecoderLayer = qwen35_modeling_mod.Qwen3_5DecoderLayer
+Qwen3_5GatedDeltaNet = qwen35_modeling_mod.Qwen3_5GatedDeltaNet
+
+pytestmark = pytest.mark.skipif("LOCAL_RANK" not in os.environ, reason="run with torchrun")
+
+PROBE_HIDDEN_SIZE = 512
+PROBE_HEAD_DIM = 128
+
+
+def _err_ratio(ref: torch.Tensor, actual: torch.Tensor) -> float:
+    err = (ref.detach() - actual.detach()).flatten().float().square().mean().sqrt().item()
+    base = ref.detach().flatten().float().square().mean().sqrt().item()
+    return err / (base + 1e-8)
+
+
+def _make_layer(device: torch.device) -> Qwen3_5DecoderLayer:
+    config = Qwen3_5TextConfig(
+        vocab_size=128,
+        hidden_size=PROBE_HIDDEN_SIZE,
+        intermediate_size=1024,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=PROBE_HEAD_DIM,
+        linear_key_head_dim=PROBE_HEAD_DIM,
+        linear_value_head_dim=PROBE_HEAD_DIM,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        linear_conv_kernel_dim=4,
+        layer_types=["linear_attention"],
+        dtype=torch.bfloat16,
+    )
+    torch.manual_seed(1234)
+    layer = Qwen3_5DecoderLayer(config, 0).to(device=device, dtype=torch.bfloat16)
+    layer.eval()
+    return layer
+
+
+def _broadcast_params(model: torch.nn.Module):
+    for param in model.parameters():
+        dist.broadcast(param.data, src=0)
+
+
+def _all_gather_seq(x: torch.Tensor) -> torch.Tensor:
+    world_size = dist.get_world_size()
+    gathered = [torch.empty_like(x) for _ in range(world_size)]
+    dist.all_gather(gathered, x.contiguous())
+    return torch.cat(gathered, dim=1)
+
+
+def _cases_for_world_size(world_size: int) -> list[tuple[str, list[int]]]:
+    total = 8 * world_size
+    if world_size == 2:
+        return [
+            ("boundary_aligned", [8, 8]),
+            ("sequence_cut", [6, 10]),
+            ("single_sequence", [16]),
+            ("many_short_sequences", [3, 4, 5, 4]),
+        ]
+    if world_size == 4:
+        return [
+            ("boundary_aligned", [8, 8, 8, 8]),
+            ("sequence_cut", [20, 12]),
+            ("single_sequence", [32]),
+            ("many_short_sequences", [5, 7, 9, 11]),
+        ]
+    if world_size == 8:
+        return [
+            ("boundary_aligned", [128, 128, 128, 128, 128, 128, 128, 128]),
+            ("sequence_cut", [700, 324]),
+            ("single_sequence", [1024]),
+            ("many_short_sequences", [100, 150, 200, 250, 124, 100, 100]),
+        ]
+    return [("single_sequence", [total])]
+
+
+def _run_case(case_name: str, lengths: list[int], layer: Qwen3_5DecoderLayer, device: torch.device):
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    total_tokens = sum(lengths)
+    if total_tokens % world_size != 0:
+        raise RuntimeError(f"{case_name}: total tokens {total_tokens} must divide world_size {world_size}.")
+
+    cu_seqlens = torch.tensor([0] + torch.cumsum(torch.tensor(lengths), 0).tolist(), device=device, dtype=torch.long)
+    cu_seqlens_cpu = cu_seqlens.cpu()
+    position_embeddings = (torch.empty(0, device=device), torch.empty(0, device=device))
+
+    torch.manual_seed(5678 + total_tokens + len(lengths))
+    full_hidden = torch.randn(1, total_tokens, PROBE_HIDDEN_SIZE, device=device, dtype=torch.bfloat16)
+
+    set_ulysses_sequence_parallel_group(None)
+    full_hidden_ref = full_hidden.detach().clone().requires_grad_(True)
+    ref_out = layer(
+        full_hidden_ref,
+        position_embeddings=position_embeddings,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=cu_seqlens_cpu,
+    )
+    ref_out.sum().backward()
+    ref_grad = full_hidden_ref.grad.detach()
+    layer.zero_grad(set_to_none=True)
+
+    set_ulysses_sequence_parallel_group(dist.group.WORLD)
+    local_seq_len = total_tokens // world_size
+    start = rank * local_seq_len
+    local_hidden = full_hidden[:, start : start + local_seq_len].detach().clone().requires_grad_(True)
+    sp_out_local = layer(
+        local_hidden,
+        position_embeddings=position_embeddings,
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=cu_seqlens_cpu,
+    )
+    sp_out_local.sum().backward()
+
+    sp_out = _all_gather_seq(sp_out_local.detach())
+    sp_grad = _all_gather_seq(local_hidden.grad.detach())
+
+    max_out_diff = (sp_out - ref_out.detach()).abs().max().item()
+    max_grad_diff = (sp_grad - ref_grad).abs().max().item()
+    out_err_ratio = _err_ratio(ref_out.detach(), sp_out)
+    grad_err_ratio = _err_ratio(ref_grad, sp_grad)
+    if rank == 0:
+        print(
+            f"{case_name}: max_out_diff={max_out_diff:.6f} max_grad_diff={max_grad_diff:.6f} "
+            f"out_err_ratio={out_err_ratio:.6f} grad_err_ratio={grad_err_ratio:.6f}"
+        )
+
+    torch.testing.assert_close(sp_out, ref_out.detach(), atol=2e-2, rtol=2e-2)
+    assert grad_err_ratio < 2e-3
+
+
+def test_qwen35_linear_attention_matches_full_forward_under_ulysses_sp():
+    assert torch.cuda.is_available(), "CUDA is required"
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+
+    Qwen3_5DecoderLayer.forward = qwen3_5_decoder_layer_forward
+    Qwen3_5GatedDeltaNet.forward = qwen3_5_gated_delta_net_forward
+
+    layer = _make_layer(device)
+    _broadcast_params(layer)
+
+    for case_name, lengths in _cases_for_world_size(dist.get_world_size()):
+        _run_case(case_name, lengths, layer, device)
+
+    set_ulysses_sequence_parallel_group(None)

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -514,8 +514,8 @@ def apply_monkey_patch(
         from verl.models.transformers.qwen3_5 import (
             fast_pos_embed_interpolate,
             forward_with_normal_backend,
-            qwen3_5_decoder_layer_forward,
             qwen3_5_base_forward,
+            qwen3_5_decoder_layer_forward,
             qwen3_5_gated_delta_net_forward,
         )
 

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -495,13 +495,17 @@ def apply_monkey_patch(
     elif model.config.model_type in ["qwen3_5", "qwen3_5_moe"]:
         # Step 1: patch model to support image-text mixed data
         from transformers.models.qwen3_5.modeling_qwen3_5 import (
+            Qwen3_5DecoderLayer,
             Qwen3_5ForConditionalGeneration,
+            Qwen3_5GatedDeltaNet,
             Qwen3_5Model,
             Qwen3_5TextModel,
             Qwen3_5VisionModel,
         )
         from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+            Qwen3_5MoeDecoderLayer,
             Qwen3_5MoeForConditionalGeneration,
+            Qwen3_5MoeGatedDeltaNet,
             Qwen3_5MoeModel,
             Qwen3_5MoeTextModel,
             Qwen3_5MoeVisionModel,
@@ -510,11 +514,17 @@ def apply_monkey_patch(
         from verl.models.transformers.qwen3_5 import (
             fast_pos_embed_interpolate,
             forward_with_normal_backend,
+            qwen3_5_decoder_layer_forward,
             qwen3_5_base_forward,
+            qwen3_5_gated_delta_net_forward,
         )
 
         Qwen3_5Model.forward = qwen3_5_base_forward
         Qwen3_5MoeModel.forward = qwen3_5_base_forward
+        Qwen3_5DecoderLayer.forward = qwen3_5_decoder_layer_forward
+        Qwen3_5MoeDecoderLayer.forward = qwen3_5_decoder_layer_forward
+        Qwen3_5GatedDeltaNet.forward = qwen3_5_gated_delta_net_forward
+        Qwen3_5MoeGatedDeltaNet.forward = qwen3_5_gated_delta_net_forward
         Qwen3_5ForConditionalGeneration.forward = forward_with_normal_backend
         Qwen3_5MoeForConditionalGeneration.forward = forward_with_normal_backend
         print(f"Monkey patch {model.__class__.__name__} model forward")

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -15,9 +15,13 @@
 import logging
 import os
 from dataclasses import dataclass
+from importlib import import_module
+from inspect import signature
 from typing import Optional
 
 import torch
+import torch.distributed as dist
+import torch.nn.functional as F
 from torch.distributed.tensor import DTensor
 from transformers.models.qwen3_5.modeling_qwen3_5 import (
     Qwen3_5CausalLMOutputWithPast,
@@ -25,12 +29,335 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import (
 )
 
 from verl.utils.ulysses import (
+    get_ulysses_sequence_parallel_group,
     get_ulysses_sequence_parallel_world_size,
     ulysses_pad_and_slice_inputs,
 )
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def _call_accepts_kwarg(fn, name: str) -> bool:
+    try:
+        params = signature(fn).parameters
+    except (TypeError, ValueError):
+        return True
+    return name in params or any(param.kind == param.VAR_KEYWORD for param in params.values())
+
+
+def _prepare_packed_seq_idx(cu_seqlens: torch.LongTensor, cu_seqlens_cpu: Optional[torch.LongTensor]):
+    try:
+        from fla.ops.utils import prepare_sequence_ids
+
+        return prepare_sequence_ids(cu_seqlens, cu_seqlens_cpu=cu_seqlens_cpu).to(torch.int32).unsqueeze(0)
+    except Exception:
+        offsets = (cu_seqlens_cpu if cu_seqlens_cpu is not None else cu_seqlens.detach().cpu()).tolist()
+        seq_idx = [
+            torch.full((end - start,), i, device=cu_seqlens.device, dtype=torch.int32)
+            for i, (start, end) in enumerate(zip(offsets[:-1], offsets[1:], strict=True))
+        ]
+        return torch.cat(seq_idx, dim=0).unsqueeze(0)
+
+
+def _split_packed_args(cu_seqlens: torch.LongTensor, tensors: tuple[torch.Tensor, ...]):
+    offsets = cu_seqlens.detach().cpu().tolist()
+    for start, end in zip(offsets[:-1], offsets[1:], strict=True):
+        yield tuple(tensor[:, start:end] for tensor in tensors)
+
+
+class _ConvPrefixExchange(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, tails: torch.Tensor, group: dist.ProcessGroup):
+        from fla.ops.cp.comm import conv_cp_send_recv_fwd
+
+        ctx.group = group
+        return conv_cp_send_recv_fwd(tails.contiguous(), group)
+
+    @staticmethod
+    def backward(ctx, grad_prefix: torch.Tensor):
+        from fla.ops.cp.comm import conv_cp_send_recv_bwd
+
+        return conv_cp_send_recv_bwd(grad_prefix.contiguous(), ctx.group), None
+
+
+def _build_fla_cp_context(
+    cu_seqlens: torch.LongTensor,
+    cu_seqlens_cpu: Optional[torch.LongTensor],
+    conv_kernel_size: int,
+):
+    group = get_ulysses_sequence_parallel_group()
+    if group is None:
+        return None
+    from fla.ops.cp.context import build_cp_context
+
+    return build_cp_context(
+        cu_seqlens=cu_seqlens,
+        cu_seqlens_cpu=cu_seqlens_cpu,
+        group=group,
+        conv1d_kernel_size=conv_kernel_size,
+    )
+
+
+def _prepend_cp_conv_prefix(mixed_qkv: torch.Tensor, cp_context) -> tuple[torch.Tensor, int]:
+    prefix_len = max(int(cp_context.conv1d_kernel_size or 0) - 1, 0)
+    if prefix_len == 0:
+        return mixed_qkv, 0
+
+    if mixed_qkv.shape[-1] >= prefix_len:
+        tails = mixed_qkv[..., -prefix_len:]
+    else:
+        tails = F.pad(mixed_qkv, (prefix_len - mixed_qkv.shape[-1], 0))
+
+    prefix = _ConvPrefixExchange.apply(tails, cp_context.group)
+    valid_prefix_len = min(prefix_len, int(cp_context.pre_num_conv_tokens or 0))
+    if valid_prefix_len < prefix_len:
+        prefix = prefix.clone()
+        prefix[..., : prefix_len - valid_prefix_len] = 0
+    return torch.cat((prefix, mixed_qkv), dim=-1), prefix_len
+
+
+def _as_channel_last_conv1d_input(x: torch.Tensor) -> torch.Tensor:
+    if x.stride(1) == 1:
+        return x
+    return x.transpose(1, 2).contiguous().transpose(1, 2)
+
+
+def _prepare_cp_conv_seq_idx(
+    cu_seqlens: torch.LongTensor,
+    cu_seqlens_cpu: Optional[torch.LongTensor],
+    prefix_len: int,
+):
+    seq_idx = _prepare_packed_seq_idx(cu_seqlens, cu_seqlens_cpu)
+    if prefix_len == 0:
+        return seq_idx
+    prefix_idx = seq_idx[:, :1].expand(seq_idx.shape[0], prefix_len)
+    return torch.cat((prefix_idx, seq_idx), dim=1)
+
+
+def _packed_causal_conv1d_fallback(self, mixed_qkv: torch.Tensor, cu_seqlens: torch.LongTensor):
+    outputs = []
+    for (segment,) in _split_packed_args(cu_seqlens, (mixed_qkv,)):
+        outputs.append(F.silu(self.conv1d(segment)[:, :, : segment.shape[-1]]))
+    return torch.cat(outputs, dim=-1)
+
+
+def _packed_chunk_gated_delta_rule(self, query, key, value, g, beta, cu_seqlens, cu_seqlens_cpu, cp_context=None):
+    kwargs = {
+        "g": g,
+        "beta": beta,
+        "initial_state": None,
+        "output_final_state": False,
+        "use_qk_l2norm_in_kernel": True,
+    }
+    if cu_seqlens is None:
+        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+
+    if cp_context is not None:
+        if not _call_accepts_kwarg(self.chunk_gated_delta_rule, "cp_context"):
+            raise NotImplementedError("Qwen3.5 Ulysses SP requires FLA chunk_gated_delta_rule cp_context support.")
+        kwargs["cp_context"] = cp_context
+        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+
+    if _call_accepts_kwarg(self.chunk_gated_delta_rule, "cu_seqlens"):
+        kwargs["cu_seqlens"] = cu_seqlens
+        if _call_accepts_kwarg(self.chunk_gated_delta_rule, "cu_seqlens_cpu"):
+            kwargs["cu_seqlens_cpu"] = cu_seqlens_cpu
+        return self.chunk_gated_delta_rule(query, key, value, **kwargs)
+
+    outputs = []
+    for q_i, k_i, v_i, g_i, beta_i in _split_packed_args(cu_seqlens, (query, key, value, g, beta)):
+        split_kwargs = dict(kwargs)
+        split_kwargs["g"] = g_i
+        split_kwargs["beta"] = beta_i
+        out_i, _ = self.chunk_gated_delta_rule(q_i, k_i, v_i, **split_kwargs)
+        outputs.append(out_i)
+    return torch.cat(outputs, dim=1), None
+
+
+def qwen3_5_gated_delta_net_forward(
+    self,
+    hidden_states: torch.Tensor,
+    cache_params=None,
+    attention_mask: Optional[torch.Tensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
+):
+    if cu_seqlens is not None and cache_params is not None:
+        raise NotImplementedError("Packed Qwen3.5 linear attention does not support cached forward.")
+
+    module = import_module(self.__class__.__module__)
+    hidden_states = module.apply_mask_to_padding_states(hidden_states, attention_mask)
+
+    batch_size, seq_len, _ = hidden_states.shape
+    cp_context = None
+    model_cu_seqlens = cu_seqlens
+    model_cu_seqlens_cpu = cu_seqlens_cpu
+    if cu_seqlens is not None:
+        if batch_size != 1:
+            raise ValueError("Packed Qwen3.5 linear attention expects batch size 1.")
+        total_seq_len = int(cu_seqlens[-1].item())
+        ulysses_sp_size = get_ulysses_sequence_parallel_world_size()
+        if total_seq_len != seq_len:
+            if (
+                ulysses_sp_size <= 1
+                or total_seq_len % ulysses_sp_size != 0
+                or seq_len != total_seq_len // ulysses_sp_size
+            ):
+                raise ValueError(f"Packed cu_seqlens end {total_seq_len} does not match seq_len {seq_len}.")
+            cp_context = _build_fla_cp_context(cu_seqlens, cu_seqlens_cpu, self.conv_kernel_size)
+            model_cu_seqlens = cp_context.cu_seqlens
+            model_cu_seqlens_cpu = cp_context.cu_seqlens_cpu
+
+    use_precomputed_states = cache_params is not None and cache_params.has_previous_state and seq_len == 1
+    if cache_params is not None:
+        conv_state = cache_params.conv_states[self.layer_idx]
+        recurrent_state = cache_params.recurrent_states[self.layer_idx]
+
+    mixed_qkv = self.in_proj_qkv(hidden_states)
+    mixed_qkv = mixed_qkv.transpose(1, 2)
+
+    z = self.in_proj_z(hidden_states)
+    z = z.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+    b = self.in_proj_b(hidden_states)
+    a = self.in_proj_a(hidden_states)
+
+    if use_precomputed_states:
+        mixed_qkv = self.causal_conv1d_update(
+            mixed_qkv,
+            conv_state,
+            self.conv1d.weight.squeeze(1),
+            self.conv1d.bias,
+            self.activation,
+        )
+    else:
+        if cache_params is not None:
+            conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
+            cache_params.conv_states[self.layer_idx] = conv_state
+        if self.causal_conv1d_fn is not None:
+            conv_prefix_len = 0
+            conv_input = mixed_qkv
+            if cp_context is not None:
+                conv_input, conv_prefix_len = _prepend_cp_conv_prefix(mixed_qkv, cp_context)
+            if model_cu_seqlens is not None:
+                conv_input = _as_channel_last_conv1d_input(conv_input)
+            seq_idx = (
+                _prepare_cp_conv_seq_idx(model_cu_seqlens, model_cu_seqlens_cpu, conv_prefix_len)
+                if model_cu_seqlens is not None
+                else None
+            )
+            conv_output = self.causal_conv1d_fn(
+                x=conv_input,
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                seq_idx=seq_idx,
+            )
+            mixed_qkv = conv_output[..., conv_prefix_len:] if conv_prefix_len else conv_output
+        elif model_cu_seqlens is not None:
+            if cp_context is not None:
+                mixed_qkv, conv_prefix_len = _prepend_cp_conv_prefix(mixed_qkv, cp_context)
+                model_cu_seqlens = model_cu_seqlens + conv_prefix_len
+                model_cu_seqlens[0] = 0
+                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens)[..., conv_prefix_len:]
+            else:
+                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens)
+        else:
+            mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+
+    mixed_qkv = mixed_qkv.transpose(1, 2)
+    query, key, value = torch.split(
+        mixed_qkv,
+        [
+            self.key_dim,
+            self.key_dim,
+            self.value_dim,
+        ],
+        dim=-1,
+    )
+
+    query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
+
+    beta = b.sigmoid()
+    g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+    if self.num_v_heads // self.num_k_heads > 1:
+        query = query.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+        key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
+
+    if not use_precomputed_states:
+        core_attn_out, last_recurrent_state = _packed_chunk_gated_delta_rule(
+            self, query, key, value, g, beta, model_cu_seqlens, model_cu_seqlens_cpu, cp_context
+        )
+    else:
+        core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+            query,
+            key,
+            value,
+            g=g,
+            beta=beta,
+            initial_state=recurrent_state,
+            output_final_state=cache_params is not None,
+            use_qk_l2norm_in_kernel=True,
+        )
+
+    if cache_params is not None:
+        cache_params.recurrent_states[self.layer_idx] = last_recurrent_state
+
+    core_attn_out = core_attn_out.reshape(-1, self.head_v_dim)
+    z = z.reshape(-1, self.head_v_dim)
+    core_attn_out = self.norm(core_attn_out, z)
+    core_attn_out = core_attn_out.reshape(batch_size, seq_len, -1)
+
+    output = self.out_proj(core_attn_out)
+    return output
+
+
+def qwen3_5_decoder_layer_forward(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_values=None,
+    **kwargs,
+):
+    cu_seqlens = kwargs.pop("cu_seqlens", None)
+    cu_seqlens_cpu = kwargs.pop("cu_seqlens_cpu", None)
+    residual = hidden_states
+
+    hidden_states = self.input_layernorm(hidden_states)
+
+    if self.layer_type == "linear_attention":
+        hidden_states = self.linear_attn(
+            hidden_states=hidden_states,
+            cache_params=past_key_values,
+            attention_mask=attention_mask,
+            cu_seqlens=cu_seqlens,
+            cu_seqlens_cpu=cu_seqlens_cpu,
+        )
+    elif self.layer_type == "full_attention":
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = self.mlp(hidden_states)
+    if isinstance(hidden_states, tuple):
+        hidden_states, _ = hidden_states
+    hidden_states = residual + hidden_states
+
+    return hidden_states
 
 
 def fast_pos_embed_interpolate(self, grid_thw):
@@ -230,7 +557,7 @@ def forward_with_torch_backend(
         vocab_weights = vocab_weights.full_tensor()
 
     ulysses_sequence_parallel_size = get_ulysses_sequence_parallel_world_size()
-    if ulysses_sequence_parallel_size > 1:
+    if shift_labels is None and ulysses_sequence_parallel_size > 1:
         rolled_labels, _, _ = ulysses_pad_and_slice_inputs(
             rolled_labels, position_ids_rmpad=None, sp_size=ulysses_sequence_parallel_size
         )
@@ -272,7 +599,7 @@ def forward_with_triton_backend(
     else:
         raise RuntimeError("To use forward_with_triton_backend, either labels or input_ids must be provided.")
     ulysses_sequence_parallel_size = get_ulysses_sequence_parallel_world_size()
-    if ulysses_sequence_parallel_size > 1:
+    if shift_labels is None and ulysses_sequence_parallel_size > 1:
         rolled_labels, _, _ = ulysses_pad_and_slice_inputs(
             rolled_labels, position_ids_rmpad=None, sp_size=ulysses_sequence_parallel_size
         )

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -536,8 +536,14 @@ def forward_with_normal_backend(
     input_ids: torch.LongTensor = None,
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
+    if cu_seqlens is not None:
+        kwargs["cu_seqlens"] = cu_seqlens
+    if cu_seqlens_cpu is not None:
+        kwargs["cu_seqlens_cpu"] = cu_seqlens_cpu
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
     logits = self.lm_head(hidden_states)
@@ -553,10 +559,16 @@ def forward_with_torch_backend(
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
     shift_labels: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
+    if cu_seqlens is not None:
+        kwargs["cu_seqlens"] = cu_seqlens
+    if cu_seqlens_cpu is not None:
+        kwargs["cu_seqlens_cpu"] = cu_seqlens_cpu
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 
@@ -601,10 +613,16 @@ def forward_with_triton_backend(
     labels: Optional[torch.LongTensor] = None,
     temperature: float = 1.0,
     shift_labels: Optional[torch.LongTensor] = None,
+    cu_seqlens: Optional[torch.LongTensor] = None,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
+    if cu_seqlens is not None:
+        kwargs["cu_seqlens"] = cu_seqlens
+    if cu_seqlens_cpu is not None:
+        kwargs["cu_seqlens_cpu"] = cu_seqlens_cpu
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
 

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -39,10 +39,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def _call_accepts_kwarg(fn, name: str) -> bool:
-    try:
-        params = signature(fn).parameters
-    except (TypeError, ValueError):
-        return True
+    params = signature(fn).parameters
     return name in params or any(param.kind == param.VAR_KEYWORD for param in params.values())
 
 
@@ -60,10 +57,21 @@ def _prepare_packed_seq_idx(cu_seqlens: torch.LongTensor, cu_seqlens_cpu: Option
         return torch.cat(seq_idx, dim=0).unsqueeze(0)
 
 
-def _split_packed_args(cu_seqlens: torch.LongTensor, tensors: tuple[torch.Tensor, ...]):
-    offsets = cu_seqlens.detach().cpu().tolist()
+def _split_packed_args(
+    cu_seqlens: torch.LongTensor,
+    tensors: tuple[torch.Tensor, ...],
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
+    dim: int = 1,
+):
+    offsets = (cu_seqlens_cpu if cu_seqlens_cpu is not None else cu_seqlens.detach().cpu()).tolist()
     for start, end in zip(offsets[:-1], offsets[1:], strict=True):
-        yield tuple(tensor[:, start:end] for tensor in tensors)
+        chunks = []
+        for tensor in tensors:
+            split_dim = dim if dim >= 0 else tensor.ndim + dim
+            slices = [slice(None)] * tensor.ndim
+            slices[split_dim] = slice(start, end)
+            chunks.append(tensor[tuple(slices)])
+        yield tuple(chunks)
 
 
 class _ConvPrefixExchange(torch.autograd.Function):
@@ -135,9 +143,14 @@ def _prepare_cp_conv_seq_idx(
     return torch.cat((prefix_idx, seq_idx), dim=1)
 
 
-def _packed_causal_conv1d_fallback(self, mixed_qkv: torch.Tensor, cu_seqlens: torch.LongTensor):
+def _packed_causal_conv1d_fallback(
+    self,
+    mixed_qkv: torch.Tensor,
+    cu_seqlens: torch.LongTensor,
+    cu_seqlens_cpu: Optional[torch.LongTensor] = None,
+):
     outputs = []
-    for (segment,) in _split_packed_args(cu_seqlens, (mixed_qkv,)):
+    for (segment,) in _split_packed_args(cu_seqlens, (mixed_qkv,), cu_seqlens_cpu=cu_seqlens_cpu, dim=2):
         outputs.append(F.silu(self.conv1d(segment)[:, :, : segment.shape[-1]]))
     return torch.cat(outputs, dim=-1)
 
@@ -166,7 +179,9 @@ def _packed_chunk_gated_delta_rule(self, query, key, value, g, beta, cu_seqlens,
         return self.chunk_gated_delta_rule(query, key, value, **kwargs)
 
     outputs = []
-    for q_i, k_i, v_i, g_i, beta_i in _split_packed_args(cu_seqlens, (query, key, value, g, beta)):
+    for q_i, k_i, v_i, g_i, beta_i in _split_packed_args(
+        cu_seqlens, (query, key, value, g, beta), cu_seqlens_cpu=cu_seqlens_cpu
+    ):
         split_kwargs = dict(kwargs)
         split_kwargs["g"] = g_i
         split_kwargs["beta"] = beta_i
@@ -260,9 +275,14 @@ def qwen3_5_gated_delta_net_forward(
                 mixed_qkv, conv_prefix_len = _prepend_cp_conv_prefix(mixed_qkv, cp_context)
                 model_cu_seqlens = model_cu_seqlens + conv_prefix_len
                 model_cu_seqlens[0] = 0
-                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens)[..., conv_prefix_len:]
+                if model_cu_seqlens_cpu is not None:
+                    model_cu_seqlens_cpu = model_cu_seqlens_cpu + conv_prefix_len
+                    model_cu_seqlens_cpu[0] = 0
+                mixed_qkv = _packed_causal_conv1d_fallback(
+                    self, mixed_qkv, model_cu_seqlens, model_cu_seqlens_cpu
+                )[..., conv_prefix_len:]
             else:
-                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens)
+                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens, model_cu_seqlens_cpu)
         else:
             mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
 

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -278,9 +278,9 @@ def qwen3_5_gated_delta_net_forward(
                 if model_cu_seqlens_cpu is not None:
                     model_cu_seqlens_cpu = model_cu_seqlens_cpu + conv_prefix_len
                     model_cu_seqlens_cpu[0] = 0
-                mixed_qkv = _packed_causal_conv1d_fallback(
-                    self, mixed_qkv, model_cu_seqlens, model_cu_seqlens_cpu
-                )[..., conv_prefix_len:]
+                mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens, model_cu_seqlens_cpu)[
+                    ..., conv_prefix_len:
+                ]
             else:
                 mixed_qkv = _packed_causal_conv1d_fallback(self, mixed_qkv, model_cu_seqlens, model_cu_seqlens_cpu)
         else:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -937,6 +937,8 @@ class FSDPEngineWithLMHead(FSDPEngine):
         multi_modal_inputs = extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", []))
         input_ids = micro_batch["input_ids"]
         position_ids = micro_batch["position_ids"]
+        hf_model_type = getattr(self.model_config.hf_config, "model_type", None)
+        pass_packed_cu_seqlens = hf_model_type in {"qwen3_5", "qwen3_5_moe"}
 
         if not isinstance(temperature, torch.Tensor):
             temperature = torch.tensor([temperature] * input_ids.shape[0], device=input_ids.device)
@@ -953,9 +955,11 @@ class FSDPEngineWithLMHead(FSDPEngine):
             # input_ids (bsz, j1)
             temperature_rmpad = verl_F.expand_as_nested(temperature, input_ids).values()  # (total_nnz,)
             temperature_rmpad = temperature_rmpad.unsqueeze(0)  # (1, total_nnz)
+            packed_cu_seqlens = None
 
             if pad_mode == DatasetPadMode.NO_PADDING:
                 input_ids_rmpad = input_ids.values().unsqueeze(0)  # (1, total_nnz)
+                packed_cu_seqlens = input_ids.offsets().to(device=input_ids_rmpad.device, dtype=torch.long)
                 if position_ids.dim() == 3:
                     position_ids_rmpad = position_ids.values().unsqueeze(1)  # (4, 1, total_nnz)
                 else:
@@ -967,6 +971,8 @@ class FSDPEngineWithLMHead(FSDPEngine):
             input_ids_rmpad_rolled = torch.roll(input_ids_rmpad, shifts=-1, dims=1)  # (1, total_nnz)
 
             # pad and slice the inputs if sp > 1
+            sp_pad_size = 0
+            is_vlm_model = False
             if self.use_ulysses_sp:
                 is_vlm_model = hasattr(getattr(self.module, "module", self.module).config, "vision_config")
                 if is_vlm_model:
@@ -994,6 +1000,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 )
 
                 output_args["pad_size"] = pad_size
+                sp_pad_size = pad_size
 
             input_ids_rmpad_rolled = input_ids_rmpad_rolled.squeeze(0)  # ((total_nnz / sp) + pad)
             temperature_rmpad = temperature_rmpad.squeeze(0)
@@ -1007,6 +1014,18 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 "attention_mask": None,
                 "position_ids": position_ids_rmpad,
             }
+            if packed_cu_seqlens is not None and pass_packed_cu_seqlens:
+                model_cu_seqlens = packed_cu_seqlens
+                if self.use_ulysses_sp and sp_pad_size:
+                    padded_total = int(model_cu_seqlens[-1].item()) + int(sp_pad_size)
+                    model_cu_seqlens = torch.cat(
+                        [
+                            model_cu_seqlens,
+                            model_cu_seqlens.new_tensor([padded_total]),
+                        ]
+                    )
+                model_inputs["cu_seqlens"] = model_cu_seqlens
+                model_inputs["cu_seqlens_cpu"] = model_cu_seqlens.cpu()
 
         else:
             if pad_mode == DatasetPadMode.NO_PADDING:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -20,6 +20,7 @@ import logging
 import os
 import warnings
 from contextlib import nullcontext
+from inspect import signature
 from typing import Callable, ContextManager, Optional
 
 import torch
@@ -545,6 +546,10 @@ class FSDPEngine(BaseEngine):
 
         # Load base model with specified configuration and dtype
         module = self._build_module()
+        try:
+            self.pass_packed_cu_seqlens = "cu_seqlens" in signature(module.forward).parameters
+        except (TypeError, ValueError):
+            self.pass_packed_cu_seqlens = False
         # Apply LoRA adapters if low-rank adaptation is enabled
         if self._is_lora:
             module = self._build_lora_module(module)
@@ -937,8 +942,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
         multi_modal_inputs = extract_multi_modal_inputs(micro_batch.get("multi_modal_inputs", []))
         input_ids = micro_batch["input_ids"]
         position_ids = micro_batch["position_ids"]
-        hf_model_type = getattr(self.model_config.hf_config, "model_type", None)
-        pass_packed_cu_seqlens = hf_model_type in {"qwen3_5", "qwen3_5_moe"}
+        pass_packed_cu_seqlens = getattr(self, "pass_packed_cu_seqlens", False)
 
         if not isinstance(temperature, torch.Tensor):
             temperature = torch.tensor([temperature] * input_ids.shape[0], device=input_ids.device)


### PR DESCRIPTION
### What does this PR do?

Current Qwen3.5/Qwen3.5-MoE training with FSDP remove-padding + Ulysses SP does not pass packed sequence boundaries into linear attention, so packed samples can share linear-attention state across sequence boundaries; the Qwen3.5 fused PPO loss can also re-slice already SP-sliced labels. This PR fixes those paths.

This PR:
- passes packed `cu_seqlens` into Qwen3.5 remove-padding forwards so linear attention does not cross packed sequence boundaries
- patches Qwen3.5 decoder/GatedDeltaNet forwards to use FLA packed kernels and CP context under Ulysses SP
- avoids re-slicing pre-sliced `shift_labels` in Qwen3.5 fused PPO loss
- adds a small distributed regression test for packed Qwen3.5 linear attention under Ulysses SP, including the torch conv1d fallback path

### Checklist Before Starting

- [x] Search for similar PRs. Query link: https://github.com/verl-project/verl/pulls?q=is%3Apr+qwen3_5+ulysses+sp
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

Environment used for Qwen3.5 validation: 8x H100, FLA 0.5.1 at commit `c525f49`, transfer-queue 0.1.7, transformers 5.3.0.dev0.

- `python3 -m compileall -q verl/models/transformers/qwen3_5.py verl/models/transformers/monkey_patch.py verl/workers/engine/fsdp/transformer_impl.py tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py` -> passed
- `python3 -m pytest -q tests/models/test_fused_kernels_ulysses_sp_on_cpu.py` -> 21 passed
- `torchrun --nproc_per_node=8 -m pytest -svv tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py` -> 2 passed, covering both `causal_conv1d_fn` and `torch_conv1d_fallback`
  - causal conv1d path: sequence-cut output err ratio `3.61e-4`, grad err ratio `8.39e-4`; many-short output err ratio `5.58e-4`, grad err ratio `1.30e-3`
  - torch conv1d fallback: sequence-cut output err ratio `3.76e-4`, grad err ratio `9.05e-4`; many-short output err ratio `5.44e-4`, grad err ratio `1.319e-3`
- 8x H100 Qwen3.5-27B GRPO sanity run: batch size 64, rollout `n=8`, response length 8192, PPO mini-batch 16, `ppo_max_token_len_per_gpu=16384`, vLLM TP=4, gpu memory util 0.75, raw rollout logprobs/bypass. SP8 completed without OOM; reward step2-9 mean `0.948`, step time `215.8s`, throughput `595 tokens/s`.

### API and Usage Example

No public API changes. Existing FSDP + Ulysses SP configs can be used with Qwen3.5, for example:

```bash
actor_rollout_ref.actor.use_remove_padding=True actor_rollout_ref.actor.use_fused_kernels=True actor_rollout_ref.actor.fused_kernel_options.impl_backend=torch actor_rollout_ref.actor.ulysses_sequence_parallel_size=8
```

### Design & Code Changes

- `verl/workers/engine/fsdp/transformer_impl.py`: pass packed `cu_seqlens`/`cu_seqlens_cpu` for Qwen3.5/Qwen3.5-MoE remove-padding forwards, including padded total length under SP.
- `verl/models/transformers/qwen3_5.py`: add packed Qwen3.5 linear-attention forward support for FLA packed/CP kernels, preserve packed sequence boundaries for fallback paths, and avoid double slicing `shift_labels`.
- `verl/models/transformers/monkey_patch.py`: install the Qwen3.5 decoder and GatedDeltaNet forward patches.
- `tests/special_distributed/test_qwen35_linear_attention_ulysses_sp.py`: compare full forward vs Ulysses SP forward on boundary-aligned, sequence-cut, single-sequence, and many-short packed cases, and check output/input-gradient error ratios.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): not run because the validation Docker image does not include `pre_commit`/`ruff`; targeted `compileall` and pytest checks are listed above.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). No docs update needed; this fixes existing Qwen3.5 model support and does not add a user-facing API.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Added a GPU distributed regression test under `tests/special_distributed`; it requires `torchrun` + GPUs + FLA, so it may need to run in the special distributed/GPU test environment rather than CPU CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). Not requested from this environment.
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not recipe-related.
