### PR TITLE
[rollout, vllm] fix: preserve MTP drafter weights during hybrid sleep

### DIFF
--- a/tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_spec_decode_metrics_on_cpu.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+pytest.importorskip("ray")
+
+from verl.trainer.ppo.ray_trainer import compute_spec_decode_metrics
+
+
+def test_spec_decode_metrics_detect_drafts_with_zero_acceptance():
+    metrics = compute_spec_decode_metrics(
+        spec_drafts=np.array([3, 3, 3]),
+        spec_accepts=np.array([0, 0, 0]),
+        spec_verifies=np.array([1, 1, 1]),
+    )
+
+    assert metrics["rollout/spec_accept_rate"] == 0.0
+    assert metrics["rollout/spec_accept_length"] == 1.0
+
+
+def test_spec_decode_metrics_report_nonzero_acceptance_after_recovery():
+    metrics = compute_spec_decode_metrics(
+        spec_drafts=np.array([3, 3, 3]),
+        spec_accepts=np.array([3, 2, 1]),
+        spec_verifies=np.array([1, 1, 1]),
+    )
+
+    assert metrics["rollout/spec_accept_rate"] > 0.0
+    assert metrics["rollout/spec_accept_length"] > 1.0
+
+
+def test_spec_decode_metrics_drop_padded_placeholders():
+    metrics = compute_spec_decode_metrics(
+        spec_drafts=np.array([3, 3, 3]),
+        spec_accepts=np.array([3, 0, 0]),
+        spec_verifies=np.array([1, 1, 1]),
+        non_padding_mask=np.array([True, False, False]),
+    )
+
+    assert metrics["rollout/spec_accept_rate"] == 1.0
+    assert metrics["rollout/spec_accept_length"] == 4.0

--- a/tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
+++ b/tests/workers/rollout/rollout_vllm/test_mtp_hybrid_sleep_acceptance_on_cpu.py
@@ -1,0 +1,70 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("ray")
+pytest.importorskip("vllm")
+
+from verl.trainer.ppo.ray_trainer import compute_spec_decode_metrics
+from verl.workers.rollout.vllm_rollout import vllm_async_server
+
+
+class _FakeMtpEngine:
+    """Minimal model of the MTP failure mode seen in hybrid sleep."""
+
+    def __init__(self):
+        self.mtp_drafter_available = True
+        self.sleep_levels_that_discard_mtp_drafter = {2}
+
+    async def sleep(self, level: int):
+        if level in self.sleep_levels_that_discard_mtp_drafter:
+            self.mtp_drafter_available = False
+
+    async def reset_encoder_cache(self):
+        pass
+
+    def sync_actor_weights(self):
+        pass
+
+    def generate_spec_decode_stats(self):
+        num_draft_tokens = 3
+        num_accepted_tokens = num_draft_tokens if self.mtp_drafter_available else 0
+        num_verify_steps = 1
+        return num_draft_tokens, num_accepted_tokens, num_verify_steps
+
+
+def test_mtp_hybrid_sleep_keeps_drafter_available_for_nonzero_acceptance(monkeypatch):
+    monkeypatch.setattr(vllm_async_server, "is_torch_npu_available", lambda check_device=False: False)
+
+    server = object.__new__(vllm_async_server.vLLMHttpServer)
+    server.config = SimpleNamespace(mtp=SimpleNamespace(enable=True, enable_rollout=True))
+    server.model_config = SimpleNamespace(lora_rank=0, lora={})
+    server.engine = _FakeMtpEngine()
+
+    asyncio.run(server._sleep_hybrid())
+    server.engine.sync_actor_weights()
+    drafts, accepts, verifies = server.engine.generate_spec_decode_stats()
+    metrics = compute_spec_decode_metrics(
+        spec_drafts=np.array([drafts]),
+        spec_accepts=np.array([accepts]),
+        spec_verifies=np.array([verifies]),
+    )
+
+    assert metrics["rollout/spec_accept_rate"] > 0.0
+    assert metrics["rollout/spec_accept_length"] > 1.0

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -944,7 +944,7 @@ class vLLMHttpServer:
         return ["kv_cache", "weights"]
 
     async def _sleep_hybrid(self):
-        """HYBRID sleep: lora adapters only need level=1; full weights need level=2.
+        """HYBRID sleep: adapters and MTP need level=1; full weights need level=2.
 
         Uses engine.sleep() instead of engine.collective_rpc("sleep") to ensure
         that sleep is properly propagated to all data-parallel worker processes.
@@ -952,9 +952,17 @@ class vLLMHttpServer:
         leaving other DP shards' weights unreleased, which causes OOM during
         FSDP training backward when DP > 1.
         """
+        mtp_config = getattr(self.config, "mtp", None)
+        mtp_rollout_enabled = (
+            mtp_config is not None
+            and getattr(mtp_config, "enable", False)
+            and getattr(mtp_config, "enable_rollout", False)
+        )
+        # MTP drafter-only weights are initialized by vLLM and are not guaranteed
+        # to be restored by actor weight sync after level 2 sleep discards them.
         # lora only update adapter weights, so set sleep level to 1
         # vllm_ascend not support sleep_level now. Enabling EP during training may lead to accuracy issues.
-        if self.lora_as_adapter or is_torch_npu_available(check_device=False):
+        if mtp_rollout_enabled or self.lora_as_adapter or is_torch_npu_available(check_device=False):
             sleep_level = 1
         else:
             sleep_level = 2


### PR DESCRIPTION
### What does this PR do?

Fixes vLLM hybrid sleep when MTP rollout is enabled. The current hybrid path uses sleep level 2 for full-weight rollouts. With MTP, the drafter has vLLM-owned drafter-only weights initialized from the checkpoint; after level 2 sleep discards model weights, the later actor weight sync does not guarantee restoring all drafter-only state. In colocated train/rollout jobs with `free_cache_engine=True`, this can leave MTP producing draft tokens but accepting zero tokens after sleep/wake/weight-sync.

This PR uses sleep level 1 when `mtp.enable=True` and `mtp.enable_rollout=True`, while preserving the existing level 2 behavior for normal full-weight rollout.

### Checklist Before Starting

- [x] Search for similar PRs. Query links: https://github.com/verl-project/verl/pulls?q=is%3Apr+mtp+sleep and https://github.com/verl-project/verl/issues?q=mtp+drafter+sleep
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- [x] `python3 -m compileall -q verl/workers/rollout/vllm_rollout/vllm_async_server.py`
- [x] Local 8xH100 Qwen3.5-27B GRPO validation with vLLM MTP rollout and hybrid sleep:
  - Before the fix: draft tokens were produced, but accepted tokens stayed at 0 after sleep/wake/weight-sync.
  - After the fix: MTP acceptance recovered. Over steps 2-6, acceptance was approximately mtp1 0.893, mtp2 0.828, mtp3 0.767, mtp4 0.700.
  - End-to-end training remained stable in the benchmark run.

### API and Usage Example

No API change. Existing MTP rollout configs continue to work:

```bash
actor_rollout_ref.model.mtp.enable=True actor_rollout_ref.model.mtp.enable_rollout=True actor_rollout_ref.rollout.free_cache_engine=True
```

### Design & Code Changes

The change is intentionally scoped to the hybrid sleep lifecycle. When MTP rollout is enabled, `_sleep_hybrid()` selects vLLM sleep level 1 so the drafter weights are preserved across the rollout/training stage switch. Non-MTP full-weight rollout keeps the previous level 2 behavior.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed: no user-facing API/config change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: this is a vLLM hybrid sleep integration path requiring a vLLM MTP model and multi-GPU colocated rollout/training lifecycle; validated with the 8xH100 experiment above.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.
