### PR TITLE
[ray] fix: add CPU resource check to prevent silent placement group scheduling deadlock

### DIFF
--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -241,6 +241,16 @@ class ResourcePoolManager:
                 f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}"
             )
 
+        # check total required cpus can be satisfied
+        total_available_cpus = sum(node_info.get("CPU", 0) for node_info in node_available_resources.values())
+        total_required_cpus = total_required_gpus * self.max_colocate_count
+        if total_available_cpus < total_required_cpus:
+            raise ValueError(
+                f"Total available CPUs {total_available_cpus} is less than total required CPUs {total_required_cpus} "
+                f"({total_required_gpus} GPUs × {self.max_colocate_count} max_colocate_count per bundle). "
+                f"Other Ray actors may have consumed CPU resources before placement group creation."
+            )
+
 
 def extract_pg_from_exist(
     resource_pools: dict[str, RayResourcePool], src_role_names: list[str], resource_pool: RayResourcePool

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -224,32 +224,51 @@ class ResourcePoolManager:
         return sum([n_gpus for process_on_nodes in self.resource_pool_spec.values() for n_gpus in process_on_nodes])
 
     def _check_resource_available(self):
-        """Check if the resource pool can be satisfied in this ray cluster."""
+        """Check if the resource pool can be satisfied in this ray cluster.
+
+        Uses a per-node First-Fit Decreasing heuristic to verify that each
+        placement group (STRICT_PACK) can find a node with enough GPUs and CPUs.
+        This prevents silent scheduling deadlocks where ``ray.get([pg.ready() ...])``
+        hangs indefinitely because other Ray actors have consumed CPU resources.
+        """
         node_available_resources = ray._private.state.available_resources_per_node()
-        node_available_gpus = {
-            node: node_info.get("GPU", 0) if "GPU" in node_info else node_info.get("NPU", 0)
-            for node, node_info in node_available_resources.items()
-        }
 
-        # check total required gpus can be satisfied
-        total_available_gpus = sum(node_available_gpus.values())
-        total_required_gpus = sum(
-            [n_gpus for process_on_nodes in self.resource_pool_spec.values() for n_gpus in process_on_nodes]
-        )
-        if total_available_gpus < total_required_gpus:
-            raise ValueError(
-                f"Total available GPUs {total_available_gpus} is less than total desired GPUs {total_required_gpus}"
-            )
+        nodes = []
+        for node, node_info in node_available_resources.items():
+            gpu_resource = node_info.get("GPU", 0) if "GPU" in node_info else node_info.get("NPU", 0)
+            cpu_resource = node_info.get("CPU", 0)
+            nodes.append({"node": node, "gpu": gpu_resource, "cpu": cpu_resource})
 
-        # check total required cpus can be satisfied
-        total_available_cpus = sum(node_info.get("CPU", 0) for node_info in node_available_resources.values())
-        total_required_cpus = total_required_gpus * self.max_colocate_count
-        if total_available_cpus < total_required_cpus:
-            raise ValueError(
-                f"Total available CPUs {total_available_cpus} is less than total required CPUs {total_required_cpus} "
-                f"({total_required_gpus} GPUs × {self.max_colocate_count} max_colocate_count per bundle). "
-                f"Other Ray actors may have consumed CPU resources before placement group creation."
-            )
+        requirements = []
+        for resource_pool_name, process_on_nodes in self.resource_pool_spec.items():
+            for process_count in process_on_nodes:
+                requirements.append({
+                    "pool": resource_pool_name,
+                    "gpu": process_count,
+                    "cpu": process_count * self.max_colocate_count,
+                })
+
+        requirements.sort(key=lambda x: (x["gpu"], x["cpu"]), reverse=True)
+
+        for req in requirements:
+            matched_node = None
+            for node in nodes:
+                if node["gpu"] >= req["gpu"] and node["cpu"] >= req["cpu"]:
+                    matched_node = node
+                    break
+            if matched_node is None:
+                max_node_gpu = max((n["gpu"] for n in nodes), default=0)
+                max_node_cpu = max((n["cpu"] for n in nodes), default=0)
+                raise ValueError(
+                    f"Cannot satisfy placement group requirement for pool '{req['pool']}' requiring "
+                    f"{req['gpu']} GPUs and {req['cpu']} CPUs on a single node. "
+                    f"Max available on any single node: {max_node_gpu} GPUs, {max_node_cpu} CPUs. "
+                    f"This can cause a silent scheduling deadlock. Please check if other Ray actors "
+                    f"or tasks are consuming resources on the GPU nodes."
+                )
+            else:
+                matched_node["gpu"] -= req["gpu"]
+                matched_node["cpu"] -= req["cpu"]
 
 
 def extract_pg_from_exist(


### PR DESCRIPTION
### What does this PR do?

When `max_colocate_count` CPUs per GPU bundle are required but insufficient CPUs are available (e.g., due to TransferQueue actors consuming CPU resources), `ray.get([pg.ready() for pg in pgs])` hangs indefinitely with no error message. GPU utilization stays at 0% and the user has no way to diagnose the issue.

This PR adds a CPU availability check in `ResourcePoolManager._check_resource_available` (which already checks GPU availability) to fail fast with a clear error message instead of silently deadlocking.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

On a 32-CPU node, enable TransferQueue (9 CPUs) with `max_colocate_count=3` and 8 GPUs. The placement group needs 24 CPUs but only 23 are available, causing an infinite hang.

```bash
bash examples/remax_trainer/run_qwen2.5_math_7b_sync_fsdp.sh
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
