### PR TITLE
[rollout, sglang] feat: support sglang ROCm backend via aiter defaults and ray init env

### DIFF
--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -15,6 +15,7 @@
 import json
 import os
 
+import torch
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 
 from verl.utils.device import get_device_capability
@@ -26,6 +27,14 @@ _major, _ = get_device_capability()
 _gb200_nccl_env = {}
 if (_major or 0) >= 10 and os.environ.get("TLLM_DISABLE_NVLS_MNNVL", "0") == "1":
     _gb200_nccl_env = {"NCCL_NVLS_ENABLE": "0", "NCCL_MNNVL_ENABLE": "0"}
+
+# On ROCm, Ray 2.x force-clears accelerator visibility for num_gpus=0 actors
+# (e.g. the SGLang server actor), leaving them unable to see any GPU. Disable
+# that override so the actor keeps its HIP visibility. Scoped to ROCm to avoid
+# changing Ray's default behavior on other platforms.
+_rocm_ray_env = {}
+if torch.version.hip is not None:
+    _rocm_ray_env = {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"}
 
 PPO_RAY_RUNTIME_ENV = {
     "env_vars": {
@@ -43,6 +52,7 @@ PPO_RAY_RUNTIME_ENV = {
         "HCCL_NPU_SOCKET_PORT_RANGE": "auto",
         "HSA_NO_SCRATCH_RECLAIM": "1",
         **_gb200_nccl_env,
+        **_rocm_ray_env,
     },
 }
 

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -42,6 +42,7 @@ from sglang.srt.managers.io_struct import (
 )
 from sglang.srt.managers.tokenizer_manager import ServerStatus
 
+from verl.plugin.platform import get_platform
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_visible_devices_keyword
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
@@ -256,9 +257,11 @@ class SGLangHttpServer:
         attention_backend = engine_kwargs.pop("attention_backend", None)
         mm_attention_backend = engine_kwargs.pop("mm_attention_backend", None)
         if attention_backend is None:
-            # FA3 CUDA-graph capture is broken on sglang>=0.5.12 (#22800);
-            # default to flashinfer (users can opt into fa4 via engine_kwargs).
-            if version.parse(sglang.__version__) >= version.parse("0.5.12"):
+            if torch.version.hip is not None:
+                attention_backend = "aiter"
+            elif version.parse(sglang.__version__) >= version.parse("0.5.12"):
+                # FA3 CUDA-graph capture is broken on sglang>=0.5.12 (#22800);
+                # default to flashinfer (users can opt into fa4 via engine_kwargs).
                 attention_backend = "flashinfer"
             else:
                 attention_backend = "fa3"
@@ -791,7 +794,12 @@ class SGLangReplica(RolloutReplica):
                     node_id=node_id,
                     soft=False,
                 ),
-                runtime_env={"env_vars": {f"RAY_EXPERIMENTAL_NOSET_{visible_devices_keyword}": "1"}},
+                runtime_env={
+                    "env_vars": {
+                        **{var: "1" for var in get_platform().ray_noset_envvars()},
+                        **get_platform().rollout_env_vars(),
+                    }
+                },
                 name=name,
                 max_concurrency=self.max_concurrency,
             ).remote(


### PR DESCRIPTION
### What does this PR do?

Enable the SGLang rollout backend to run out-of-the-box on AMD ROCm GPUs.

On ROCm (`torch.version.hip is not None`), this PR:

1. **Defaults the SGLang attention backend to `aiter`** when the user has not explicitly set one (previously it fell through to `flashinfer`/`fa3`).
2. **Routes the non-attention kernels (RMSNorm / RoPE / MoE / quant) through AITER via `SGLANG_USE_AITER`**, injected through the platform abstraction (`PlatformROCm.rollout_env_vars()`) rather than `os.environ.setdefault`. The SGLang server actor's `runtime_env` now consumes `get_platform().rollout_env_vars()` + `ray_noset_envvars()`, mirroring the vLLM/trtllm rollout servers. (Addresses review feedback to keep platform-specific env vars in the platform layer.)
3. **Injects `RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0` into `PPO_RAY_RUNTIME_ENV`** so Ray 2.x does not force-clear accelerator visibility for the `num_gpus=0` SGLang server actor (otherwise the actor sees no GPU).

All three are **scoped to ROCm** and remain **user-overridable**: an explicit `engine_kwargs.sglang.attention_backend` or an exported `SGLANG_USE_AITER` still win, and CUDA / NPU behavior is unchanged.


### Checklist Before Starting

- [x] Search for similar PRs. Query links:
  - https://github.com/volcengine/verl/pulls?q=is%3Apr+is%3Aopen+SGLANG_USE_AITER (0 results)
  - https://github.com/volcengine/verl/pulls?q=is%3Apr+RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO (no related PR)
- [x] Format the PR title as `[{modules}] {type}: {description}`
  - Title: `[rollout, sglang] feat: support sglang ROCm backend via aiter defaults and ray init env`
  - Not a breaking change: defaults only apply when unset, and existing explicit settings keep working.

### Test

Validated on AMD ROCm (MI3xx). Both rollout integration paths train end-to-end:

- **Colocate** (`main_ppo`, GRPO + SGLang): smoke run completes 3 training steps.
- **Fully async** (`fully_async_policy`, SGLang): smoke run completes training steps including a parameter sync back to the rollout workers.

In both paths, the SGLang server actor processes have the platform-injected env vars set, e.g. `SGLANG_USE_AITER=1`, `NCCL_CUMEM_ENABLE=0`, and `RAY_EXPERIMENTAL_NOSET_{CUDA,HIP,ROCR}_VISIBLE_DEVICES=1`, and the rollout uses the AITER path.

> CI does not cover this change because it requires ROCm hardware (AITER kernels + HIP visibility); the existing CPU/CUDA CI cannot exercise the ROCm path.

### API and Usage Example

No API changes. The new behavior is automatic on ROCm and overridable:

```bash
# Default on ROCm: attention_backend=aiter, SGLANG_USE_AITER=1 (auto)

# Override the attention backend (SGLANG_USE_AITER still defaults to 1):
... +actor_rollout_ref.rollout.engine_kwargs.sglang.attention_backend=triton

# Fall back to vLLM RMSNorm/RoPE kernels by disabling AITER explicitly:
export SGLANG_USE_AITER=0
```

### Design & Code Changes

- `verl/workers/rollout/sglang_rollout/async_sglang_server.py`
  - ROCm -> default `attention_backend="aiter"` when unset.
  - The SGLang server actor's `runtime_env` now consumes `get_platform().ray_noset_envvars()` + `get_platform().rollout_env_vars()` (same pattern as the vLLM/trtllm servers), so `SGLANG_USE_AITER` and the ROCm NOSET vars come from `PlatformROCm` instead of an inline `os.environ.setdefault`.
- `verl/trainer/constants_ppo.py`
  - On ROCm, add `RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0` to `PPO_RAY_RUNTIME_ENV` (conditional dict, mirroring the existing `_gb200_nccl_env` pattern). This is a job-level env var inherited by `TaskRunner` and all downstream actors, which is required because `TaskRunner` itself is a `num_gpus=0` actor and imports sglang (triggering HIP init) before any rollout actor is created.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`pre-commit run --files <changed files> --show-diff-on-failure --color=always`): all hooks pass.
- [x] Add / Update the documentation. — No docs change; behavior is auto + overridable and described above.
- [x] Add unit or end-to-end test(s) ... If not feasible, explain why: requires ROCm hardware; validated manually (see Test).
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Not related to the `recipe` submodule.
