### PR TITLE
[ci, hardware] feat: add AMD ROCm (MI300) e2e_ppo_trainer workflow

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
@@ -102,12 +102,7 @@ jobs:
     runs-on: [self-hosted, rocm-mi300]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
-      # NOTE: container.image cannot reference the `env` context, so the image is
-      # hardcoded here (the `env` context is unavailable for jobs.<id>.container).
       image: "verlai/verl:rocm702-vllm020-te210-20260518"
-      # Mirrors the local `docker run` used for ROCm MI300 dev. Note: --network,
-      # --name, -w/--workdir and -itd are managed by the Actions runner and must
-      # NOT be set here (the runner forces its own network/workdir/detach).
       options: >-
         --device /dev/kfd
         --device /dev/dri
@@ -128,7 +123,6 @@ jobs:
       HOME: "/root"
     steps:
       - name: Check ROCm and GPU info
-      # TODO: confirm the ROCm tooling available in the image.
         run: |
           rocm-smi || true
           rocminfo || true
@@ -187,4 +181,93 @@ jobs:
         run: |
           ray stop --force
           CUSTOM_REWARD_FN=True ADV_ESTIMATOR=grpo USE_KL=True bash tests/special_e2e/ppo_trainer/run_function_reward.sh
-      # TODO: LoRA tests， not supported on ROCm yet
+      - name: Clean up
+        run: |
+          rm -rf checkpoints
+
+  e2e_ppo_trainer_megatron-moe-expert-parallel_rocm:
+    # TODO: change back to 'verl-project' before upstreaming. Set to your fork
+    # owner so the job runs during local validation.
+    if: github.repository_owner == 'PeterYang12'
+    # Must match a label you give the self-hosted runner during `config.sh`.
+    runs-on: [self-hosted, rocm-mi300]
+    timeout-minutes: 60 # Increase this timeout value as needed
+    container:
+      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --privileged
+        --group-add video
+        --cap-add SYS_PTRACE
+        --security-opt seccomp=unconfined
+        --shm-size 2048g
+        --ulimit memlock=-1
+        --ulimit stack=67108864
+        -v /data/models:/root/models
+        -v /data/data:/root/data
+    env:
+      HF_HUB_ENABLE_HF_TRANSFER: "0"
+      HOME: "/root"
+    steps:
+      - name: Check ROCm and GPU info
+        run: |
+          rocm-smi || true
+          rocminfo || true
+      - name: Check initial pip list from image
+        run: |
+          pip list
+      - name: Checkout verl-project/verl repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: true
+      - name: Install the current repository
+        run: |
+          pip install --no-deps -e .
+      - name: Check final pip list
+        run: |
+          pip list
+      - name: Prepare GSM8K dataset
+        run: |
+          ray stop --force
+          python3 examples/data_preprocess/gsm8k.py --local_dir ${HOME}/models/hf_data/gsm8k
+      - name: Running GSM8K E2E training tests with 3D parallelism on 8 MI300 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
+        run: |
+          ray stop --force
+          ADV_ESTIMATOR=grpo USE_DUMMY_MODEL=True DUMMY_MODEL_CONFIG_PATH=tests/special_e2e/ppo_trainer/expert_parallel/qwen2moe_minimal.json \
+          PPO_MAX_TOKEN_LEN=1024 FWD_MAX_TOKEN_LEN=1024 \
+          MAX_PROMPT_LENGTH=512 MAX_RESPONSE_LENGTH=512 \
+          MODEL_ID=Qwen/Qwen3-30B-A3B-Instruct-2507 USE_MBRIDGE=True VANILLA_MBRIDGE=True VALUE_VANILLA_MBRIDGE=True \
+          COMMON_PP=2 COMMON_VPP=null COMMON_CP=1 COMMON_TP=4 COMMON_EP=4 COMMON_ETP=1 INFER_TP=8 \
+          USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 \
+          bash tests/special_e2e/run_ppo_trainer_megatron.sh \
+          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null
+      - name: Running GSM8K E2E training tests with 3D parallelism with FP8 rollout on 8 MI300 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
+        run: |
+          ray stop --force
+          ADV_ESTIMATOR=grpo USE_DUMMY_MODEL=True DUMMY_MODEL_CONFIG_PATH=tests/special_e2e/ppo_trainer/expert_parallel/qwen2moe_minimal.json \
+          PPO_MAX_TOKEN_LEN=1024 FWD_MAX_TOKEN_LEN=1024 \
+          MAX_PROMPT_LENGTH=512 MAX_RESPONSE_LENGTH=512 \
+          MODEL_ID=Qwen/Qwen3-30B-A3B-Instruct-2507 USE_MBRIDGE=True VANILLA_MBRIDGE=True VALUE_VANILLA_MBRIDGE=True \
+          COMMON_PP=2 COMMON_VPP=null COMMON_CP=1 COMMON_TP=4 COMMON_EP=4 COMMON_ETP=1 INFER_TP=2 \
+          USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 ROLLOUT_QUANTIZATION=fp8 \
+          bash tests/special_e2e/run_ppo_trainer_megatron.sh \
+          global_profiler.tool=null actor_rollout_ref.actor.profiler.tool=null actor_rollout_ref.ref.profiler.tool=null actor_rollout_ref.rollout.profiler.tool=null critic.profiler.tool=null
+      - name: clean up
+        run: |
+          rm -rf checkpoints
+
+  cleanup_rocm:
+    needs:
+      - e2e_ppo_trainer_fsdp_vllm_rocm
+      - e2e_ppo_trainer_megatron-moe-expert-parallel_rocm
+    # TODO: change back to "always() && github.repository_owner == 'verl-project'"
+    if: ${{ always() && github.repository_owner == 'PeterYang12' }}
+    runs-on: [self-hosted, rocm-mi300]
+    container:
+      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+    steps:
+      - name: Clean up leftover checkpoints
+        run: |
+          rm -rf checkpoints

--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
@@ -1,0 +1,190 @@
+# # Tests layout
+
+# Each folder under tests/ corresponds to a test category for a sub-namespace in verl. For instance:
+# - `tests/trainer` for testing functionality related to `verl/trainer`
+# - `tests/models` for testing functionality related to `verl/models`
+# - ...
+
+# There are a few folders with `special_` prefix, created for special purposes:
+# - `special_distributed`: unit tests that must run with multiple GPUs
+# - `special_e2e`: end-to-end tests with training/generation scripts
+# - `special_npu`: tests for NPUs
+# - `special_sanity`: a suite of quick sanity tests
+# - `special_standalone`: a set of test that are designed to run in dedicated environments
+
+# Accelerators for tests
+# - By default tests are run with GPU available, except for the ones under `special_npu`, and any test script whose name ends with `on_cpu.py`.
+# - For test scripts with `on_cpu.py` name suffix would be tested on CPU resources in linux environment.
+
+# # Workflow layout
+
+# All CI tests are configured by yaml files in `.github/workflows/`. Here's an overview of all test configs:
+# 1. A list of always triggered CPU sanity tests: `check-pr-title.yml`, `secrets_scan.yml`, `check-pr-title,yml`, `pre-commit.yml`, `doc.yml`
+# 2. Some heavy multi-GPU unit tests, such as `model.yml`, `vllm.yml`, `sgl.yml`
+# 3. End-to-end tests: `e2e_*.yml`
+# 4. Unit tests
+#   - `cpu_unit_tests.yml`, run pytest on all scripts with file name pattern `tests/**/test_*_on_cpu.py`
+#   - `gpu_unit_tests.yml`, run pytest on all scripts with file without the `on_cpu.py` suffix.
+#   - Since cpu/gpu unit tests by default runs all tests under `tests`, please make sure tests are manually excluded in them when
+#     - new workflow yaml is added to `.github/workflows`
+#     - new tests are added to workflow mentioned in 2.
+
+name: e2e_ppo_trainer_megatron_vllm_rocm
+
+on:
+  # Allow manually triggering the workflow from the Actions tab while validating
+  # on a personal fork. TODO: remove before upstreaming to verl-project/verl.
+  workflow_dispatch:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch.
+  # For push, for now only anti-patterns are specified so it is more conservative
+  # and achieves higher coverage.
+  push:
+    branches:
+      - main
+      - v0.*
+      - ci/rocm-e2e # TODO: temporary, remove before upstreaming (fork validation)
+    paths:
+      - "**/*.py"
+      # TODO: temporary, remove before upstreaming. Lets yml-only edits on the
+      # ci/rocm-e2e branch trigger the workflow during fork validation.
+      - ".github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml"
+      # Other entrypoints
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      # FSDP
+      - "!verl/workers/**/*dp_*.py"
+      - "!verl/utils/fsdp_utils.py"
+      - "!verl/utils/checkpoint/fsdp_checkpoint_manager.py"
+      - "!verl/model_merger/fsdp_model_merger.py"
+  pull_request:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "**/*.py"
+      # Other entrypoints
+      - "!docker/**"
+      # Docs
+      - "!**/*.md"
+      - "!docs/**"
+      - "!examples/**"
+      - "!tests/**"
+      - "!verl/trainer/main_*.py"
+      - "!verl/trainer/fsdp_sft_trainer.py"
+      # FSDP
+      - "!verl/workers/**/*dp_*.py"
+      - "!verl/utils/fsdp_utils.py"
+      - "!verl/utils/checkpoint/fsdp_checkpoint_manager.py"
+      - "!verl/model_merger/fsdp_model_merger.py"
+      # Entrypoints
+      - ".github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml"
+      - "examples/data_preprocess/gsm8k.py"
+      - "examples/data_preprocess/geo3k.py"
+      - "tests/special_e2e/run_ppo_trainer_megatron.sh"
+      - "verl/trainer/main_ppo.py"
+      - "verl/trainer/config/ppo_megatron_trainer.yaml"
+
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare permissions just read content.
+permissions:
+  contents: read
+
+jobs:
+  e2e_ppo_trainer_fsdp_vllm_rocm:
+    # TODO: change back to 'verl-project' before upstreaming. Set to your fork
+    # owner so the job runs during local validation.
+    if: github.repository_owner == 'PeterYang12'
+    # Must match a label you give the self-hosted runner during `config.sh`.
+    runs-on: [self-hosted, rocm-mi300]
+    timeout-minutes: 60 # Increase this timeout value as needed
+    container:
+      # NOTE: container.image cannot reference the `env` context, so the image is
+      # hardcoded here (the `env` context is unavailable for jobs.<id>.container).
+      image: "verlai/verl:rocm702-vllm020-te210-20260518"
+      # Mirrors the local `docker run` used for ROCm MI300 dev. Note: --network,
+      # --name, -w/--workdir and -itd are managed by the Actions runner and must
+      # NOT be set here (the runner forces its own network/workdir/detach).
+      options: >-
+        --device /dev/kfd
+        --device /dev/dri
+        --privileged
+        --group-add video
+        --cap-add SYS_PTRACE
+        --security-opt seccomp=unconfined
+        --shm-size 2048g
+        --ulimit memlock=-1
+        --ulimit stack=67108864
+        -v /data/models:/root/models
+        -v /data/data:/root/data
+    env:
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+      # GitHub container jobs force HOME=/github/home. Our data is mounted under
+      # /root and the verl scripts reference $HOME, so pin HOME back to /root to
+      # match the local `docker run` behavior and the volume mounts above.
+      HOME: "/root"
+    steps:
+      - name: Check ROCm and GPU info
+      # TODO: confirm the ROCm tooling available in the image.
+        run: |
+          rocm-smi || true
+          rocminfo || true
+      - name: Check initial pip list from image
+        run: |
+          pip list
+      - name: Checkout verl-project/verl repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: true
+      - name: Install the current repository
+        run: |
+          pip install --no-deps -e .
+      - name: Check final pip list
+        run: |
+          pip list
+      - name: Prepare GSM8K dataset
+        run: |
+          ray stop --force
+          python3 examples/data_preprocess/gsm8k.py --local_dir ${HOME}/models/hf_data/gsm8k
+      # Function RM
+      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (FSDP_SIZE=8)
+        run: |
+          ray stop --force
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm after resuming
+        run: |
+          ray stop --force
+          RESUME_MODE=auto VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      - name: Test merging FSDP checkpoints (Qwen Actor)
+        run: |
+          exp_name="qwen2.5-0.5b-function-reward-minimal-fsdp-size8"
+          python -m verl.model_merger test --backend fsdp --local_dir checkpoints/verl-test/${exp_name}/global_step_1/actor --test_hf_dir checkpoints/verl-test/${exp_name}/global_step_1/actor/huggingface
+      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (DDP_SIZE=2, FSDP_SIZE=4)
+        run: |
+          ray stop --force
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True FSDP_SIZE=4 USE_KL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      - name: Test merging DDP+FSDP checkpoints (Qwen Actor)
+        run: |
+          exp_name="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4"
+          python -m verl.model_merger test --backend fsdp --local_dir checkpoints/verl-test/${exp_name}/global_step_1/actor --test_hf_dir checkpoints/verl-test/${exp_name}/global_step_1/actor/huggingface
+      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (FSDP2)
+        run: |
+          ray stop --force
+          VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8" STRATEGY=fsdp2 bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      - name: Test merging FSDP2 checkpoints (Qwen Actor)
+        run: |
+          exp_name="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8"
+          python -m verl.model_merger test --backend fsdp --local_dir checkpoints/verl-test/${exp_name}/global_step_1/actor --test_hf_dir checkpoints/verl-test/${exp_name}/global_step_1/actor/huggingface
+      - name: Running GSM8K E2E without rmpad using function rm
+        run: |
+          ray stop --force
+          RM_PAD=False bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm (GRPO)
+        run: |
+          ray stop --force
+          CUSTOM_REWARD_FN=True ADV_ESTIMATOR=grpo USE_KL=True bash tests/special_e2e/ppo_trainer/run_function_reward.sh
+      # TODO: LoRA tests， not supported on ROCm yet

--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml
@@ -32,9 +32,6 @@
 name: e2e_ppo_trainer_megatron_vllm_rocm
 
 on:
-  # Allow manually triggering the workflow from the Actions tab while validating
-  # on a personal fork. TODO: remove before upstreaming to verl-project/verl.
-  workflow_dispatch:
   # Trigger the workflow on push or pull request,
   # but only for the main branch.
   # For push, for now only anti-patterns are specified so it is more conservative
@@ -43,12 +40,8 @@ on:
     branches:
       - main
       - v0.*
-      - ci/rocm-e2e # TODO: temporary, remove before upstreaming (fork validation)
     paths:
       - "**/*.py"
-      # TODO: temporary, remove before upstreaming. Lets yml-only edits on the
-      # ci/rocm-e2e branch trigger the workflow during fork validation.
-      - ".github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml"
       # Other entrypoints
       - "!verl/trainer/fsdp_sft_trainer.py"
       # FSDP
@@ -95,11 +88,8 @@ permissions:
 
 jobs:
   e2e_ppo_trainer_fsdp_vllm_rocm:
-    # TODO: change back to 'verl-project' before upstreaming. Set to your fork
-    # owner so the job runs during local validation.
-    if: github.repository_owner == 'PeterYang12'
-    # Must match a label you give the self-hosted runner during `config.sh`.
-    runs-on: [self-hosted, rocm-mi300]
+    if: github.repository_owner == 'verl-project'
+    runs-on: [rocm-mi300]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
       image: "verlai/verl:rocm702-vllm020-te210-20260518"
@@ -145,11 +135,11 @@ jobs:
           ray stop --force
           python3 examples/data_preprocess/gsm8k.py --local_dir ${HOME}/models/hf_data/gsm8k
       # Function RM
-      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (FSDP_SIZE=8)
+      - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (FSDP_SIZE=8)
         run: |
           ray stop --force
           VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
-      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm after resuming
+      - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm after resuming
         run: |
           ray stop --force
           RESUME_MODE=auto VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp-size8" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
@@ -157,7 +147,7 @@ jobs:
         run: |
           exp_name="qwen2.5-0.5b-function-reward-minimal-fsdp-size8"
           python -m verl.model_merger test --backend fsdp --local_dir checkpoints/verl-test/${exp_name}/global_step_1/actor --test_hf_dir checkpoints/verl-test/${exp_name}/global_step_1/actor/huggingface
-      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (DDP_SIZE=2, FSDP_SIZE=4)
+      - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (DDP_SIZE=2, FSDP_SIZE=4)
         run: |
           ray stop --force
           VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True FSDP_SIZE=4 USE_KL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4" bash tests/special_e2e/ppo_trainer/run_function_reward.sh
@@ -165,7 +155,7 @@ jobs:
         run: |
           exp_name="qwen2.5-0.5b-function-reward-minimal-ddp-size2-fsdp-size4"
           python -m verl.model_merger test --backend fsdp --local_dir checkpoints/verl-test/${exp_name}/global_step_1/actor --test_hf_dir checkpoints/verl-test/${exp_name}/global_step_1/actor/huggingface
-      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm with validation and saving (FSDP2)
+      - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm with validation and saving (FSDP2)
         run: |
           ray stop --force
           VAL_BEFORE_TRAIN=True TEST_FREQ=1 SAVE_FREQ=1 SAVE_HF_MODEL=True VERL_EXP_NAME="qwen2.5-0.5b-function-reward-minimal-fsdp2-size8" STRATEGY=fsdp2 bash tests/special_e2e/ppo_trainer/run_function_reward.sh
@@ -177,7 +167,7 @@ jobs:
         run: |
           ray stop --force
           RM_PAD=False bash tests/special_e2e/ppo_trainer/run_function_reward.sh
-      - name: Running GSM8K E2E training tests on 8 L20 GPUs with rmpad using function rm (GRPO)
+      - name: Running GSM8K E2E training tests on 8 MI300 GPUs with rmpad using function rm (GRPO)
         run: |
           ray stop --force
           CUSTOM_REWARD_FN=True ADV_ESTIMATOR=grpo USE_KL=True bash tests/special_e2e/ppo_trainer/run_function_reward.sh
@@ -186,11 +176,8 @@ jobs:
           rm -rf checkpoints
 
   e2e_ppo_trainer_megatron-moe-expert-parallel_rocm:
-    # TODO: change back to 'verl-project' before upstreaming. Set to your fork
-    # owner so the job runs during local validation.
-    if: github.repository_owner == 'PeterYang12'
-    # Must match a label you give the self-hosted runner during `config.sh`.
-    runs-on: [self-hosted, rocm-mi300]
+    if: github.repository_owner == 'verl-project'
+    runs-on: [rocm-mi300]
     timeout-minutes: 60 # Increase this timeout value as needed
     container:
       image: "verlai/verl:rocm702-vllm020-te210-20260518"
@@ -262,9 +249,8 @@ jobs:
     needs:
       - e2e_ppo_trainer_fsdp_vllm_rocm
       - e2e_ppo_trainer_megatron-moe-expert-parallel_rocm
-    # TODO: change back to "always() && github.repository_owner == 'verl-project'"
-    if: ${{ always() && github.repository_owner == 'PeterYang12' }}
-    runs-on: [self-hosted, rocm-mi300]
+    if: ${{ always() && github.repository_owner == 'verl-project' }}
+    runs-on: [rocm-mi300]
     container:
       image: "verlai/verl:rocm702-vllm020-te210-20260518"
     steps:


### PR DESCRIPTION
### What does this PR do?

Add a new GitHub Actions workflow `.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml`
that runs end-to-end PPO trainer tests on AMD ROCm (MI300) using a self-hosted,
container-based runner. It mirrors the existing NVIDIA
(`e2e_ppo_trainer_megatron_vllm_2.yml`) and Ascend (`..._2_ascend.yml`) workflows and adds:

- `e2e_ppo_trainer_fsdp_vllm_rocm`: FSDP / FSDP2 / DDP GSM8K function-reward runs + checkpoint merging.
- `e2e_ppo_trainer_megatron-moe-expert-parallel_rocm`: Megatron-Bridge 3D-parallel MoE runs (incl. FP8 rollout).
- `cleanup_rocm`: an `if: always()` job that removes leftover checkpoints after the test jobs.

The job runs inside the ROCm image `verlai/verl:rocm702-vllm020-te210-20260518` with the
required ROCm device mounts (`/dev/kfd`, `/dev/dri`) and host volume mounts for models/data.


### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+rocm+mi300
  (Only #6619 touches ROCm, and it is Dockerfile/README only — no CI overlap.)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated on a personal fork (`PeterYang12/verl`) using a self-hosted AMD MI300 runner; the
workflow is triggered and the targeted e2e jobs were exercised on real MI300 hardware. In the
upstream repo this requires the verl-project MI300 runner to be available.

AI assistance: this workflow was drafted with AI assistance (Cursor); all lines were reviewed
by me and the fork runs above were executed and verified by me.

### API and Usage Example

No API changes. New CI workflow only.

### Design & Code Changes

- New file: `.github/workflows/e2e_ppo_trainer_megatron_vllm_rocm.yml`.
- Container-job pattern (like the Ascend workflow) on a self-hosted ROCm MI300 runner.
- `HOME` pinned to `/root` to match the local `docker run` env and the mounted data volumes.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply pre-commit checks (will run locally before merge).
- [ ] Add / Update documentation (n/a — CI only).
- [x] Add end-to-end test(s) to the CI workflow (this PR *is* the CI workflow).
- [ ] Once ready for CI, send a message in the `ci-request` Slack channel.
- [ ] recipe submodule: n/a.