### PR TITLE
feat(rollout): conditionally enable tower connector LoRA for VLMs

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -342,6 +342,20 @@ class vLLMHttpServer:
             }
             if self.model_config.lora.get("fully_sharded_loras", False):
                 lora_args["fully_sharded_loras"] = True
+
+            # Enable tower connector LoRA for VLMs when vision components are trainable.
+            # Detection follows the same pattern as trtllm_async_server.py: check if
+            # hf_config has a vision_config attribute. The freeze flags are read from
+            # the lora dict with defaults matching megatron_peft.py (True = frozen),
+            # so non-VLM models or VLMs with frozen vision towers are unaffected.
+            # Note: enable_tower_connector_lora requires vLLM >= 0.14.0.
+            is_vlm = hasattr(self.model_config.hf_config, "vision_config")
+            if is_vlm and _VLLM_VERSION >= version.parse("0.14.0"):
+                vision_frozen = self.model_config.lora.get("freeze_vision_model", True) and \
+                                self.model_config.lora.get("freeze_vision_projection", True)
+                if not vision_frozen:
+                    lora_args["enable_tower_connector_lora"] = True
+
             args.update(lora_args)
 
         if self.config.enable_rollout_routing_replay:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -350,10 +350,18 @@ class vLLMHttpServer:
             # so non-VLM models or VLMs with frozen vision towers are unaffected.
             # Note: enable_tower_connector_lora requires vLLM >= 0.14.0.
             is_vlm = hasattr(self.model_config.hf_config, "vision_config")
-            if is_vlm and _VLLM_VERSION >= version.parse("0.14.0"):
+            if is_vlm:
                 vision_frozen = self.model_config.lora.get("freeze_vision_model", True) and \
                                 self.model_config.lora.get("freeze_vision_projection", True)
                 if not vision_frozen:
+                    if _VLLM_VERSION < version.parse("0.14.0"):
+                        raise ValueError(
+                            "enable_tower_connector_lora requires vLLM >= 0.14.0, "
+                            f"but got vLLM {vllm.__version__}. "
+                            "Please upgrade vLLM, or remove 'freeze_vision_model=False' and "
+                            "'freeze_vision_projection=False' from your config to skip "
+                            "vision tower LoRA training."
+                        )
                     lora_args["enable_tower_connector_lora"] = True
 
             args.update(lora_args)

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -385,6 +385,20 @@ class vLLMHttpServer:
             }
             if self.model_config.lora.get("fully_sharded_loras", False):
                 lora_args["fully_sharded_loras"] = True
+
+            # Enable tower connector LoRA for VLMs when vision components are trainable.
+            # Detection follows the same pattern as trtllm_async_server.py: check if
+            # hf_config has a vision_config attribute. The freeze flags are read from
+            # the lora dict with defaults matching megatron_peft.py (True = frozen),
+            # so non-VLM models or VLMs with frozen vision towers are unaffected.
+            # Note: enable_tower_connector_lora requires vLLM >= 0.14.0.
+            is_vlm = hasattr(self.model_config.hf_config, "vision_config")
+            if is_vlm and _VLLM_VERSION >= version.parse("0.14.0"):
+                vision_frozen = self.model_config.lora.get("freeze_vision_model", True) and \
+                                self.model_config.lora.get("freeze_vision_projection", True)
+                if not vision_frozen:
+                    lora_args["enable_tower_connector_lora"] = True
+
             args.update(lora_args)
 
         if self.config.enable_rollout_routing_replay:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -393,10 +393,18 @@ class vLLMHttpServer:
             # so non-VLM models or VLMs with frozen vision towers are unaffected.
             # Note: enable_tower_connector_lora requires vLLM >= 0.14.0.
             is_vlm = hasattr(self.model_config.hf_config, "vision_config")
-            if is_vlm and _VLLM_VERSION >= version.parse("0.14.0"):
+            if is_vlm:
                 vision_frozen = self.model_config.lora.get("freeze_vision_model", True) and \
                                 self.model_config.lora.get("freeze_vision_projection", True)
                 if not vision_frozen:
+                    if _VLLM_VERSION < version.parse("0.14.0"):
+                        raise ValueError(
+                            "enable_tower_connector_lora requires vLLM >= 0.14.0, "
+                            f"but got vLLM {vllm.__version__}. "
+                            "Please upgrade vLLM, or remove 'freeze_vision_model=False' and "
+                            "'freeze_vision_projection=False' from your config to skip "
+                            "vision tower LoRA training."
+                        )
                     lora_args["enable_tower_connector_lora"] = True
 
             args.update(lora_args)


### PR DESCRIPTION
## Summary

This PR adds conditional support for enabling vLLM's `enable_tower_connector_lora` flag in the vLLM rollout server, allowing LoRA training on vision components (vision tower + vision projection) of vision-language models (VLMs) during RL training.

## Motivation

  By default, verl only supports LoRA for the language model. When users want to train the vision part of a VLM via LoRA (by setting `freeze_vision_model=False` / `freeze_vision_projection=False`), the vLLM rollout server also needs to be aware of this via the `enable_tower_connector_lora` engine arg. Previously this had to be hard-coded, which would incorrectly apply to non-VLM models as well.

## Changes

  - Modified `verl/workers/rollout/vllm_rollout/vllm_async_server.py` to conditionally add `enable_tower_connector_lora=True` when:
    1. The model is a VLM (detected via `hasattr(hf_config, "vision_config")`, consistent with `trtllm_async_server.py`)
    2. At least one of `freeze_vision_model` or `freeze_vision_projection` is set to `False`

 ## Backward Compatibility

  - **Non-VLM models**: Unaffected — no `vision_config` attribute, so the flag is never set
  - **VLMs with frozen vision (default)**: Unaffected — both freeze flags default to `True` per `megatron_peft.py`
  - **VLMs with trainable vision**: Now correctly passes `enable_tower_connector_lora=True` to vLLM

## Usage Example

  ```yaml
  actor_rollout_ref:
    actor:
      freeze_vision_tower: False
    model:
      lora:
        freeze_vision_model: False
        freeze_vision_projection: False
  ```

  Related

  Detection pattern follows existing VLM detection in:
  - verl/workers/rollout/trtllm_rollout/trtllm_async_server.py:93-95
  - verl/workers/engine/fsdp/transformer_impl.py:919

  Checklist

  - [ ] Code follows existing code style
  - [ ] Tested with a VLM (e.g., Qwen3.5-9B, a native VLM) with trainable vision LoRA
  - [ ] Tested with a VLM with frozen vision tower (default behavior preserved)

### Co-Authored-By: XuAn@cpic