### PR TITLE
[reward] fix: add optional per-sample compute_score timeout to NaiveRewardManager

### DIFF
--- a/tests/workers/reward_manager/test_naive_on_cpu.py
+++ b/tests/workers/reward_manager/test_naive_on_cpu.py
@@ -1,0 +1,102 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for NaiveRewardManager's per-sample compute_score timeout."""
+
+import time
+
+import numpy as np
+import pytest
+import torch
+
+from verl import DataProto
+from verl.workers.reward_manager.naive import NaiveRewardManager, _score_timeout
+
+
+class _DummyTokenizer:
+    def decode(self, token_ids, skip_special_tokens=True):
+        return "dummy"
+
+
+def _make_minimal_data(batch_size=1, prompt_len=2, response_len=2):
+    total = prompt_len + response_len
+    return DataProto.from_single_dict(
+        {
+            "prompts": torch.zeros((batch_size, prompt_len), dtype=torch.long),
+            "responses": torch.zeros((batch_size, response_len), dtype=torch.long),
+            "attention_mask": torch.ones((batch_size, total), dtype=torch.long),
+            "data_source": np.array(["dummy"] * batch_size, dtype=object),
+            "reward_model": np.array([{"ground_truth": "1"} for _ in range(batch_size)], dtype=object),
+        }
+    )
+
+
+def test_score_timeout_allows_fast_calls():
+    with _score_timeout(2.0):
+        result = 1 + 1
+    assert result == 2
+
+
+def test_score_timeout_raises_on_slow_calls():
+    with pytest.raises(TimeoutError):
+        with _score_timeout(0.5):
+            time.sleep(5)
+
+
+def test_score_timeout_disabled_is_noop():
+    # None or 0 disables the timeout (no SIGALRM is installed).
+    with _score_timeout(None):
+        time.sleep(0.05)
+    with _score_timeout(0):
+        time.sleep(0.05)
+
+
+def test_naive_reward_manager_times_out_slow_score():
+    """A hanging compute_score (e.g. ReDoS / slow sympy) must not block the loop."""
+
+    def slow_compute_score(data_source, solution_str, ground_truth, extra_info=None):
+        time.sleep(10)
+        return 1.0
+
+    manager = NaiveRewardManager(
+        tokenizer=_DummyTokenizer(),
+        num_examine=0,
+        compute_score=slow_compute_score,
+        compute_score_timeout=1.0,
+    )
+    data = _make_minimal_data()
+
+    start = time.time()
+    out = manager(data, return_dict=True)
+    elapsed = time.time() - start
+
+    assert elapsed < 5.0, f"reward manager did not time out (took {elapsed:.1f}s)"
+    # Timed-out sample is assigned reward 0.0 instead of hanging.
+    assert out["reward_tensor"].sum().item() == 0.0
+
+
+def test_naive_reward_manager_no_timeout_by_default():
+    """Without compute_score_timeout, behavior is unchanged."""
+
+    def fast_compute_score(data_source, solution_str, ground_truth, extra_info=None):
+        return 0.5
+
+    manager = NaiveRewardManager(
+        tokenizer=_DummyTokenizer(),
+        num_examine=0,
+        compute_score=fast_compute_score,
+    )
+    data = _make_minimal_data()
+    out = manager(data, return_dict=True)
+    assert out["reward_tensor"].sum().item() == pytest.approx(0.5)

--- a/verl/workers/reward_manager/naive.py
+++ b/verl/workers/reward_manager/naive.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import signal
 from collections import defaultdict
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Optional
 
 import torch
 
@@ -23,11 +25,49 @@ from verl.workers.reward_manager import register
 from verl.workers.reward_manager.abstract import AbstractRewardManager
 
 
+@contextmanager
+def _score_timeout(seconds: Optional[float]):
+    """Raise ``TimeoutError`` if the wrapped block runs longer than ``seconds``.
+
+    A single ``compute_score`` call on a pathological model output (e.g. a long,
+    degenerate RL rollout that triggers catastrophic regex backtracking or a slow
+    symbolic comparison) can run for a very long time. Because ``NaiveRewardManager``
+    scores samples serially in the driver process, one such call blocks the entire
+    training loop. This guard bounds the wall-clock time of each call.
+
+    Implemented with ``SIGALRM``, so it only takes effect on the main thread. If a
+    handler cannot be installed (e.g. called from a non-main thread), it degrades to
+    a no-op so reward computation still runs -- just without the timeout.
+    """
+    if not seconds or seconds <= 0:
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise TimeoutError(f"compute_score timed out after {seconds}s")
+
+    try:
+        old_handler = signal.signal(signal.SIGALRM, _handler)
+    except ValueError:
+        # Not in the main thread -> SIGALRM is unavailable; run without a timeout.
+        yield
+        return
+
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, old_handler)
+
+
 @register("naive")
 class NaiveRewardManager(AbstractRewardManager):
     """The reward manager."""
 
-    def __init__(self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source") -> None:
+    def __init__(
+        self, tokenizer, num_examine, compute_score=None, reward_fn_key="data_source", compute_score_timeout=None
+    ) -> None:
         """
         Initialize the NaiveRewardManager instance.
 
@@ -37,11 +77,15 @@ class NaiveRewardManager(AbstractRewardManager):
             compute_score: A function to compute the reward score. If None, `default_compute_score` will be used.
             reward_fn_key: The key used to access the data source in the non-tensor batch data. Defaults to
                 "data_source".
+            compute_score_timeout: Optional per-sample timeout (in seconds) for `compute_score`. If set, a single
+                scoring call that exceeds this limit is aborted, assigned a reward of 0.0, and training continues,
+                instead of blocking the whole loop. Defaults to None (no timeout, unchanged behavior).
         """
         self.tokenizer = tokenizer  # Store the tokenizer for decoding token IDs
         self.num_examine = num_examine  # the number of batches of decoded responses to print to the console
         self.compute_score = compute_score or default_compute_score
         self.reward_fn_key = reward_fn_key  # Store the key for accessing the data source
+        self.compute_score_timeout = compute_score_timeout  # per-sample timeout (seconds) for compute_score
 
     def __call__(self, data: DataProto, return_dict: bool = False) -> torch.Tensor | dict[str, Any]:
         """We will expand this function gradually based on the available datasets"""
@@ -82,12 +126,21 @@ class NaiveRewardManager(AbstractRewardManager):
             extra_info["num_turns"] = num_turns
             extra_info["rollout_reward_scores"] = rollout_reward_scores
 
-            score = self.compute_score(
-                data_source=data_source,
-                solution_str=response_str,
-                ground_truth=ground_truth,
-                extra_info=extra_info,
-            )
+            try:
+                with _score_timeout(self.compute_score_timeout):
+                    score = self.compute_score(
+                        data_source=data_source,
+                        solution_str=response_str,
+                        ground_truth=ground_truth,
+                        extra_info=extra_info,
+                    )
+            except TimeoutError:
+                print(
+                    f"[NaiveRewardManager] compute_score exceeded "
+                    f"{self.compute_score_timeout}s for data_source={data_source}; "
+                    f"assigning reward 0.0 and continuing."
+                )
+                score = 0.0
 
             if isinstance(score, dict):
                 reward = score["score"]


### PR DESCRIPTION
### What does this PR do?

While running a multi-teacher on-policy distillation job (reverse-KL distillation of a 4B student), training reliably froze after ~5-8 steps: all GPUs dropped to 0% util and it looked like an sglang/NCCL deadlock.

sglang/NCCL turned out to be a red herring — the NCCL watchdog never fired, and the sglang scheduler was just idle-spinning in its `recv_requests()` loop waiting for the next request. A `SIGABRT` + `faulthandler` dump showed the **driver** was actually stuck in reward scoring:

```
ray_trainer.fit
 -> trainer/ppo/reward.py: compute_reward
 -> workers/reward_manager/naive.py: NaiveRewardManager.__call__
 -> utils/reward_score/math_dapo.py: compute_score -> is_correct_minerva -> normalize_final_answer
```

The student had drifted into generating long, degenerate responses, and one such sample made a single `compute_score` call extremely slow inside `normalize_final_answer`. Because `NaiveRewardManager` scores samples **serially in the driver process with no timeout**, that one stuck call blocks the entire training loop with no recovery. Swapping `compute_score` for a no-op made the deterministic hang disappear, confirming reward computation was the blocker.

`PrimeRewardManager` already guards against this with a per-task timeout; `NaiveRewardManager` does not. This PR adds an **opt-in** per-sample timeout to `NaiveRewardManager`. Default is `None` (no timeout), so existing behavior is unchanged.

Related: #2236, #4318

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+reward+timeout
- [x] Title formatted as `[reward] fix: ...`

### Test

Added CPU unit tests in `tests/workers/reward_manager/test_naive_on_cpu.py`:

- `_score_timeout` raises `TimeoutError` on a slow block and is a no-op when disabled (`None`/`0`).
- `NaiveRewardManager` with a 10s mock `compute_score` and `compute_score_timeout=1.0` returns in ~1s with reward `0.0` instead of blocking.
- Default (no timeout) behavior is unchanged.

```
pytest tests/workers/reward_manager/test_naive_on_cpu.py -v   # 5 passed
ruff check / ruff format --check                              # clean
```

Also verified in verl's actual execution context: running the patched `NaiveRewardManager` inside a **Ray actor** with a 30s mock `compute_score` and `compute_score_timeout=2.0` returns in ~2.0s with reward `0.0`. This confirms the `SIGALRM`-based timeout fires in the Ray actor's main thread, which is where the reward manager runs in the training loop.

### API and Usage Example

New optional kwarg `compute_score_timeout` (seconds), settable via `reward_model.reward_kwargs`:

```python
NaiveRewardManager(tokenizer, num_examine, compute_score=fn, compute_score_timeout=10.0)
```

When a sample exceeds the timeout it is assigned reward `0.0` (with a warning) and training continues.

### Design & Code Changes

- `_score_timeout(seconds)`: a context manager built on `SIGALRM`. It degrades to a no-op off the main thread (where `SIGALRM` is unavailable), so it never crashes.
- `NaiveRewardManager.__init__` gains `compute_score_timeout=None`.
- The per-sample `compute_score` call is wrapped; on `TimeoutError` the sample gets reward `0.0` + a warning, and the loop continues.

Note: `SIGALRM` only fires on the main thread, which is where `NaiveRewardManager` runs today. Happy to switch to a process-pool approach (like `PrimeRewardManager`) if maintainers prefer a thread-agnostic mechanism.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`ruff` clean).
- [ ] Update docs — not needed; the new kwarg is opt-in and defaults to current behavior.
- [x] Add unit tests (`tests/workers/reward_manager/test_naive_on_cpu.py`).
