### PR TITLE
[trainer, megatron] fix: fix MindSpeed repatch config bug

### DIFF
--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -44,8 +44,15 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 def _mindspeed_repatch(engine_config):
     if repatch is not None:
-        repatch_config = dict(engine_config.get("override_transformer_config", {}))
-        repatch_config.setdefault("use_flash_attn", True)
+        from verl.utils.megatron_utils import mapping_string_to_attn_backend
+
+        repatch_config = mapping_string_to_attn_backend(dict(engine_config.get("override_transformer_config", {})))
+        # flash-attn-npu batch-invariant replaces DotProductAttention.forward; fusion attention
+        # registers the same patch when use_flash_attn=True and causes "the patch of forward exist".
+        if repatch_config.get("use_flash_attn_npu_batch_invariant"):
+            repatch_config["use_flash_attn"] = False
+        else:
+            repatch_config.setdefault("use_flash_attn", True)
         if engine_config.context_parallel_size > 1:
             repatch_config["context_parallel_size"] = engine_config.context_parallel_size
         repatch(repatch_config)


### PR DESCRIPTION
### What does this PR do?

Fix NPU Megatron actor initialization when using MindSpeed batch-invariant training (`batch_invariant_mode` + `use_flash_attn_npu_batch_invariant`), e.g. true-on-policy / train-inference consistency recipes.
Two issues are addressed in `_mindspeed_repatch()`:
1. **`attention_backend` type mismatch**: Hydra passes `attention_backend=flash` as a string, but MindSpeed injects repatch args into `TransformerConfig` before verl's `mapping_string_to_attn_backend()` runs in `_build_tf_config()`. This caused `Batch invariant mode only supports FlashAttention` even when flash was configured.
2. **Duplicate MindSpeed patch registration**: repatch defaulted `use_flash_attn=True`, which registers `DotProductAttention.forward` via fusion attention. When `use_flash_attn_npu_batch_invariant=True`, batch-invariant registers the same forward patch and fails with `RuntimeError: the patch of forward exist !`.
This PR converts `attention_backend` to `AttnBackend` enum before `repatch()`, and disables `use_flash_attn` when NPU batch-invariant flash attention is enabled.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
