### PR TITLE
[rollout, trainer] fix: handle empty token sequences in _pad_token_ids and metric timing

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -306,3 +306,59 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
     torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
     assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0
     assert torch.count_nonzero(internal.routed_experts[:, 6:]) == 0
+
+
+class _FakeTokenizerCustomPad:
+    """A minimal tokenizer with a non-zero pad_token_id for testing."""
+
+    pad_token_id = 42
+    padding_side = "right"
+
+    def pad(
+        self,
+        encoded_inputs: dict[str, list[int]],
+        *,
+        padding: str,
+        max_length: int,
+        return_tensors: str,
+        return_attention_mask: bool,
+    ) -> dict[str, torch.Tensor]:
+        del padding, return_tensors
+        input_ids = encoded_inputs["input_ids"]
+        pad_len = max_length - len(input_ids)
+        padded_ids = input_ids + [0] * pad_len
+        attention_mask = [1] * len(input_ids) + [0] * pad_len
+        output = {"input_ids": torch.tensor([padded_ids], dtype=torch.long)}
+        if return_attention_mask:
+            output["attention_mask"] = torch.tensor([attention_mask], dtype=torch.long)
+        return output
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_pad_token_ids_empty_with_non_zero_pad_id():
+    """Regression test: empty token list uses tokenizer's pad_token_id (not hardcoded 0)."""
+    worker = type(
+        "_DummyWorker",
+        (),
+        {
+            "_pad_token_ids": AgentLoopWorker._pad_token_ids,
+            "tokenizer": _FakeTokenizerCustomPad(),
+            "processor": None,
+            "mm_processor_kwargs": {},
+        },
+    )()
+
+    result = worker._pad_token_ids(
+        tokens=[],
+        max_length=8,
+        padding_side="right",
+        return_attention_mask=True,
+    )
+
+    # input_ids should use the tokenizer's pad_token_id (42), not 0
+    expected_input_ids = torch.full((1, 8), 42, dtype=torch.long)
+    torch.testing.assert_close(result["input_ids"], expected_input_ids)
+
+    # attention_mask should be all zeros
+    expected_attention_mask = torch.zeros((1, 8), dtype=torch.long)
+    torch.testing.assert_close(result["attention_mask"], expected_attention_mask)

--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -400,6 +400,32 @@ class TestComputeTimingMetrics(unittest.TestCase):
         self.assertAlmostEqual(metrics["timing_per_token_ms/ref"], 0.3 * 1000 / 12, places=5)
         self.assertAlmostEqual(metrics["timing_per_token_ms/values"], 0.2 * 1000 / 12, places=5)
 
+    @patch("verl.trainer.ppo.metric_utils._compute_response_info")
+    def test_compute_timing_metrics_zero_tokens(self, mock_compute_response_info):
+        """Regression test: zero tokens should return 0.0, not crash or report misleading values."""
+        zero_response_info = {
+            "prompt_length": torch.tensor([0.0, 0.0]),
+            "response_length": torch.tensor([0.0, 0.0]),
+            "response_mask": torch.zeros((2, 3)),
+        }
+        mock_compute_response_info.return_value = zero_response_info
+
+        timing_raw = {
+            "gen": 0.5,
+            "ref": 0.3,
+            "values": 0.2,
+        }
+
+        metrics = compute_timing_metrics(self.batch, timing_raw)
+
+        # All per-token metrics should be 0.0 when there are no tokens
+        self.assertEqual(metrics["timing_per_token_ms/gen"], 0.0)
+        self.assertEqual(metrics["timing_per_token_ms/ref"], 0.0)
+        self.assertEqual(metrics["timing_per_token_ms/values"], 0.0)
+
+        # Raw timing should still be reported
+        self.assertEqual(metrics["timing_s/gen"], 0.5)
+
 
 class TestComputeThroughputMetrics(unittest.TestCase):
     """Tests for the compute_throughout_metrics function."""

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -609,6 +609,14 @@ class AgentLoopWorker:
         return_attention_mask: bool,
     ) -> dict[str, torch.Tensor]:
         """Right/left pad a flat list of token ids to a ``(1, max_length)`` tensor."""
+        # tokenizer.pad() with empty input returns dict with list values
+        # instead of tensors, which breaks downstream .dim() calls.
+        if not tokens:
+            pad_id = self.tokenizer.pad_token_id if self.tokenizer.pad_token_id is not None else 0
+            result = {"input_ids": torch.full((1, max_length), pad_id, dtype=torch.long)}
+            if return_attention_mask:
+                result["attention_mask"] = torch.zeros((1, max_length), dtype=torch.long)
+            return result
         self.tokenizer.padding_side = padding_side
         padded = self.tokenizer.pad(
             {"input_ids": tokens},

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -304,7 +304,9 @@ def compute_timing_metrics(batch: DataProto, timing_raw: dict[str, float]) -> di
     return {
         **{f"timing_s/{name}": value for name, value in timing_raw.items()},
         **{
-            f"timing_per_token_ms/{name}": timing_raw[name] * 1000 / num_tokens_of_section[name]
+            f"timing_per_token_ms/{name}": (
+                timing_raw[name] * 1000 / num_tokens_of_section[name] if num_tokens_of_section[name] > 0 else 0.0
+            )
             for name in set(num_tokens_of_section.keys()) & set(timing_raw.keys())
         },
     }


### PR DESCRIPTION
### What does this PR do?

Fix two crashes triggered by empty token sequences when `async_training.partial_rollout=False` and parameter synchronization aborts in-flight vLLM requests during prefill:

  1. **`_pad_token_ids` in agent_loop.py** — `tokenizer.pad()` with empty input returns a dict with list values instead of tensors, even when `return_tensors="pt"` is set, causing `AttributeError:
  'list' object has no attribute 'dim'`.
  2. **`compute_timing_metrics` in metric_utils.py** — An empty response batch yields zero token counts, causing `ZeroDivisionError`.

  Both are valid edge cases: `partial_rollout=False` is a supported configuration, and the code should handle aborted requests that return no generated tokens.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

  - Tested with `partial_rollout=False` + vLLM dump enabled (slows inference, increases abort probability). Without the fix, both crashes reproduce consistently. With the fix, training runs to 
  completion without errors.
  - Metric output shows `timing_per_token_ms/*` values as `0` when zero tokens are processed, instead of crashing.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
