### PR TITLE
[vllm, trainer, megatron] fix: fix vLLM pipeline parallel on NPU bug and fix MindSpeed repatch config issues

### DIFF
--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,6 +18,7 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
+from verl.utils.device import is_torch_npu_available
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
@@ -167,6 +168,7 @@ class RolloutConfig(BaseConfig):
         "response_length",
         "expert_parallel_size",
         "moe_tensor_parallel_size",
+        "pipeline_model_parallel_size",
     }
 
     name: Optional[str] = MISSING
@@ -322,8 +324,33 @@ class RolloutConfig(BaseConfig):
                     f"tensor_model_parallel_size={self.tensor_model_parallel_size})"
                 )
 
+        if self.name == "vllm" and is_torch_npu_available(check_device=False):
+            vllm_engine_kwargs = (self.engine_kwargs or {}).get("vllm") or {}
+            pp_from_engine_kwargs = vllm_engine_kwargs.get("pipeline_parallel_size")
+            if pp_from_engine_kwargs is not None:
+                pp_from_engine_kwargs = int(pp_from_engine_kwargs)
+                if self.pipeline_model_parallel_size not in (1, pp_from_engine_kwargs):
+                    raise ValueError(
+                        "Conflicting pipeline parallel sizes: "
+                        f"rollout.pipeline_model_parallel_size="
+                        f"{self.pipeline_model_parallel_size} vs "
+                        f"engine_kwargs.vllm.pipeline_parallel_size="
+                        f"{pp_from_engine_kwargs}. On NPU, configure PP via "
+                        "+actor_rollout_ref.rollout.engine_kwargs.vllm.pipeline_parallel_size only."
+                    )
+                if self.pipeline_model_parallel_size == 1:
+                    object.__setattr__(
+                        self,
+                        "pipeline_model_parallel_size",
+                        pp_from_engine_kwargs,
+                    )
+
         if self.pipeline_model_parallel_size > 1:
-            if self.name == "vllm" or self.name == "sglang" or self.name == "trtllm":
+            if self.name == "sglang" or self.name == "trtllm":
+                raise NotImplementedError(
+                    f"Current rollout {self.name=} not implemented pipeline_model_parallel_size > 1 yet."
+                )
+            if self.name == "vllm" and not is_torch_npu_available(check_device=False):
                 raise NotImplementedError(
                     f"Current rollout {self.name=} not implemented pipeline_model_parallel_size > 1 yet."
                 )
@@ -351,3 +378,31 @@ class RolloutConfig(BaseConfig):
                 f"rollout.disaggregation.enabled=True is currently only supported with "
                 f"rollout.name='sglang'; got {self.name!r}. (vLLM PD is a tracked follow-up.)"
             )
+
+
+def ensure_rollout_config(config) -> RolloutConfig:
+    """Coerce rollout config to RolloutConfig (NPU: syncs PP from engine_kwargs)."""
+    if isinstance(config, RolloutConfig):
+        return config
+    from verl.utils.config import omega_conf_to_dataclass
+
+    return omega_conf_to_dataclass(config, dataclass_type=RolloutConfig)
+
+
+def get_rollout_parallel_world_size(config) -> int:
+    """Return rollout TP * DP * PP (NPU: PP synced from engine_kwargs.vllm)."""
+    rollout_config = ensure_rollout_config(config)
+    disagg = rollout_config.disaggregation
+    if disagg.enabled:
+        prefill_tp = rollout_config.tensor_model_parallel_size
+        decode_tp = disagg.decode_tensor_model_parallel_size or prefill_tp
+        return (
+            (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
+            * rollout_config.data_parallel_size
+            * rollout_config.pipeline_model_parallel_size
+        )
+    return (
+        rollout_config.tensor_model_parallel_size
+        * rollout_config.data_parallel_size
+        * rollout_config.pipeline_model_parallel_size
+    )

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -380,13 +380,42 @@ class RolloutConfig(BaseConfig):
             )
 
 
-def ensure_rollout_config(config) -> RolloutConfig:
-    """Coerce rollout config to RolloutConfig (NPU: syncs PP from engine_kwargs)."""
+def ensure_rollout_config(
+    config,
+    *,
+    root_config=None,
+    config_path: Optional[str] = None,
+) -> RolloutConfig:
+    """Coerce rollout config to RolloutConfig (NPU: syncs PP from engine_kwargs).
+
+    Rollout YAML fields such as ``n_gpus_per_node`` and ``mtp`` use ``oc.select``
+    against sibling nodes (e.g. ``trainer``). Passing ``root_config`` and
+    ``config_path`` resolves those interpolations in the full Hydra tree before
+    converting to a dataclass. Without root context the sub-config is detached and
+    ``oc.select`` fallbacks (e.g. ``n_gpus_per_node=8``, ``mtp=null``) apply.
+    """
     if isinstance(config, RolloutConfig):
         return config
+
+    from omegaconf import OmegaConf, open_dict
+
     from verl.utils.config import omega_conf_to_dataclass
 
-    return omega_conf_to_dataclass(config, dataclass_type=RolloutConfig)
+    if root_config is not None and config_path is not None:
+        cfg_node = OmegaConf.select(root_config, config_path)
+        if cfg_node is not None:
+            cfg = OmegaConf.create(OmegaConf.to_container(cfg_node, resolve=True))
+        else:
+            cfg = OmegaConf.create(config)
+    else:
+        cfg = OmegaConf.create(config)
+
+    # rollout.yaml uses oc.select(..., null) for mtp; null cannot merge into non-optional MtpConfig.
+    if cfg.get("mtp") is None:
+        with open_dict(cfg):
+            cfg.pop("mtp", None)
+
+    return omega_conf_to_dataclass(cfg, dataclass_type=RolloutConfig)
 
 
 def get_rollout_parallel_world_size(config) -> int:

--- a/verl/workers/engine/mindspeed/transformer_impl.py
+++ b/verl/workers/engine/mindspeed/transformer_impl.py
@@ -44,8 +44,15 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 def _mindspeed_repatch(engine_config):
     if repatch is not None:
-        repatch_config = dict(engine_config.get("override_transformer_config", {}))
-        repatch_config.setdefault("use_flash_attn", True)
+        from verl.utils.megatron_utils import mapping_string_to_attn_backend
+
+        repatch_config = mapping_string_to_attn_backend(dict(engine_config.get("override_transformer_config", {})))
+        # flash-attn-npu batch-invariant replaces DotProductAttention.forward; fusion attention
+        # registers the same patch when use_flash_attn=True and causes "the patch of forward exist".
+        if repatch_config.get("use_flash_attn_npu_batch_invariant"):
+            repatch_config["use_flash_attn"] = False
+        else:
+            repatch_config.setdefault("use_flash_attn", True)
         if engine_config.context_parallel_size > 1:
             repatch_config["context_parallel_size"] = engine_config.context_parallel_size
         repatch(repatch_config)

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -243,7 +243,11 @@ class LLMServerManager:
     ):
         self.config = config
         if is_torch_npu_available(check_device=False):
-            self.rollout_config = ensure_rollout_config(config.actor_rollout_ref.rollout)
+            self.rollout_config = ensure_rollout_config(
+                config.actor_rollout_ref.rollout,
+                root_config=config,
+                config_path="actor_rollout_ref.rollout",
+            )
         else:
             self.rollout_config = config.actor_rollout_ref.rollout
         self.model_config = config.actor_rollout_ref.model

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -29,8 +29,10 @@ from cachetools import LRUCache
 from omegaconf import DictConfig
 
 from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
+from verl.utils.device import is_torch_npu_available
 from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
+from verl.workers.config.rollout import ensure_rollout_config, get_rollout_parallel_world_size
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
 from verl.workers.rollout.utils import update_prometheus_config
 
@@ -240,7 +242,10 @@ class LLMServerManager:
         rollout_resource_pool: RayResourcePool = None,
     ):
         self.config = config
-        self.rollout_config = config.actor_rollout_ref.rollout
+        if is_torch_npu_available(check_device=False):
+            self.rollout_config = ensure_rollout_config(config.actor_rollout_ref.rollout)
+        else:
+            self.rollout_config = config.actor_rollout_ref.rollout
         self.model_config = config.actor_rollout_ref.model
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
@@ -273,33 +278,48 @@ class LLMServerManager:
                 Ray named-actor collisions when hybrid and standalone replicas
                 coexist.
         """
-        rollout_world_size = (
-            self.rollout_config.tensor_model_parallel_size
-            * self.rollout_config.data_parallel_size
-            * self.rollout_config.pipeline_model_parallel_size
-        )
-        # PD inflates per-replica footprint; miss this and init_hybrid slices
-        # past worker_group → empty workers on replica_rank>=1.
-        disagg = getattr(self.rollout_config, "disaggregation", None)
-        if disagg is not None and getattr(disagg, "enabled", False):
-            prefill_tp = self.rollout_config.tensor_model_parallel_size
-            # Inline decode_tp default: OmegaConf/Ray serialization drops dataclass methods.
-            decode_tp = (
-                disagg.decode_tensor_model_parallel_size
-                if disagg.decode_tensor_model_parallel_size is not None
-                else prefill_tp
+        if is_torch_npu_available(check_device=False):
+            rollout_world_size = get_rollout_parallel_world_size(self.rollout_config)
+            world_size = (
+                self.worker_group.world_size
+                if self.worker_group
+                else self.rollout_config.n_gpus_per_node * self.rollout_config.nnodes
             )
+            if world_size % rollout_world_size != 0:
+                raise ValueError(
+                    f"Total worker count ({world_size}) must be divisible by rollout parallel "
+                    f"world size ({rollout_world_size}). Check tensor_model_parallel_size and "
+                    f"engine_kwargs.vllm.pipeline_parallel_size."
+                )
+            num_replicas = world_size // rollout_world_size
+        else:
             rollout_world_size = (
-                (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
+                self.rollout_config.tensor_model_parallel_size
                 * self.rollout_config.data_parallel_size
                 * self.rollout_config.pipeline_model_parallel_size
             )
-        world_size = (
-            self.worker_group.world_size
-            if self.worker_group
-            else self.rollout_config.n_gpus_per_node * self.rollout_config.nnodes
-        )
-        num_replicas = world_size // rollout_world_size
+            # PD inflates per-replica footprint; miss this and init_hybrid slices
+            # past worker_group → empty workers on replica_rank>=1.
+            disagg = getattr(self.rollout_config, "disaggregation", None)
+            if disagg is not None and getattr(disagg, "enabled", False):
+                prefill_tp = self.rollout_config.tensor_model_parallel_size
+                # Inline decode_tp default: OmegaConf/Ray serialization drops dataclass methods.
+                decode_tp = (
+                    disagg.decode_tensor_model_parallel_size
+                    if disagg.decode_tensor_model_parallel_size is not None
+                    else prefill_tp
+                )
+                rollout_world_size = (
+                    (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
+                    * self.rollout_config.data_parallel_size
+                    * self.rollout_config.pipeline_model_parallel_size
+                )
+            world_size = (
+                self.worker_group.world_size
+                if self.worker_group
+                else self.rollout_config.n_gpus_per_node * self.rollout_config.nnodes
+            )
+            num_replicas = world_size // rollout_world_size
 
         self.rollout_replicas = [
             self.rollout_replica_class(

--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -27,6 +27,7 @@ from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, Ra
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import is_torch_npu_available
 from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.config.rollout import ensure_rollout_config
 
 logger = logging.getLogger(__file__)
 
@@ -101,7 +102,10 @@ class RolloutReplica(ABC):
         name_suffix: str = "",
     ) -> None:
         self.replica_rank = replica_rank
-        self.config: RolloutConfig = omega_conf_to_dataclass(config)
+        if is_torch_npu_available(check_device=False):
+            self.config: RolloutConfig = ensure_rollout_config(config)
+        else:
+            self.config: RolloutConfig = omega_conf_to_dataclass(config)
         self.model_config: HFModelConfig = model_config
 
         self.world_size = (

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -36,6 +36,7 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_resource_name, get_visible_devices_keyword, is_torch_npu_available
+from verl.workers.config.rollout import ensure_rollout_config
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_vllm_profiler_args
 from verl.utils.tokenizer import normalize_token_ids
@@ -302,14 +303,30 @@ class vLLMHttpServer:
             args["speculative_config"] = speculative_config
 
         if self.config.data_parallel_size > 1:
-            assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
-                "gpus_per_node should be divisible by tensor_model_parallel_size"
-            )
-            data_parallel_size_local = self.gpus_per_node // self.config.tensor_model_parallel_size
-            assert len(self.workers) == data_parallel_size_local * self.config.tensor_model_parallel_size, (
-                f"num workers ({len(self.workers)}) should be equal to "
-                f"dp_size_local ({data_parallel_size_local}) * tp_size ({self.config.tensor_model_parallel_size})"
-            )
+            if is_torch_npu_available(check_device=False):
+                model_parallel_size_per_dp_group = (
+                    self.config.tensor_model_parallel_size * self.config.pipeline_model_parallel_size
+                )
+                assert self.gpus_per_node % model_parallel_size_per_dp_group == 0, (
+                    "gpus_per_node should be divisible by "
+                    "tensor_model_parallel_size * pipeline_model_parallel_size"
+                )
+                data_parallel_size_local = self.gpus_per_node // model_parallel_size_per_dp_group
+                assert len(self.workers) == data_parallel_size_local * model_parallel_size_per_dp_group, (
+                    f"num workers ({len(self.workers)}) should be equal to "
+                    f"dp_size_local ({data_parallel_size_local}) * model_parallel_size_per_dp_group "
+                    f"({model_parallel_size_per_dp_group})"
+                )
+            else:
+                assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
+                    "gpus_per_node should be divisible by tensor_model_parallel_size"
+                )
+                data_parallel_size_local = self.gpus_per_node // self.config.tensor_model_parallel_size
+                assert len(self.workers) == data_parallel_size_local * self.config.tensor_model_parallel_size, (
+                    f"num workers ({len(self.workers)}) should be equal to "
+                    f"dp_size_local ({data_parallel_size_local}) * tp_size "
+                    f"({self.config.tensor_model_parallel_size})"
+                )
             dp_args = {
                 "data_parallel_size": self.config.data_parallel_size,
                 "data_parallel_size_local": data_parallel_size_local,
@@ -801,6 +818,8 @@ class vLLMHttpServer:
 
     def _init_config(self, config):
         """Initialise config. Override when a specific dataclass_type is needed."""
+        if is_torch_npu_available(check_device=False):
+            return ensure_rollout_config(config)
         return omega_conf_to_dataclass(config)
 
     def _init_model_config(self, model_config):

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -36,12 +36,12 @@ from vllm.v1.engine.async_llm import AsyncLLM
 
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_resource_name, get_visible_devices_keyword, is_torch_npu_available
-from verl.workers.config.rollout import ensure_rollout_config
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_vllm_profiler_args
 from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
+from verl.workers.config.rollout import ensure_rollout_config
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
 from verl.workers.rollout.vllm_rollout.utils import (
@@ -308,8 +308,7 @@ class vLLMHttpServer:
                     self.config.tensor_model_parallel_size * self.config.pipeline_model_parallel_size
                 )
                 assert self.gpus_per_node % model_parallel_size_per_dp_group == 0, (
-                    "gpus_per_node should be divisible by "
-                    "tensor_model_parallel_size * pipeline_model_parallel_size"
+                    "gpus_per_node should be divisible by tensor_model_parallel_size * pipeline_model_parallel_size"
                 )
                 data_parallel_size_local = self.gpus_per_node // model_parallel_size_per_dp_group
                 assert len(self.workers) == data_parallel_size_local * model_parallel_size_per_dp_group, (


### PR DESCRIPTION
### What does this PR do?

1. fix Pipeline Parallel (PP) bug for vLLM rollout on NPU
Background: On NPU, vLLM configures PP via engine_kwargs.vllm.pipeline_parallel_size, but verl originally rejected pipeline_model_parallel_size > 1 during RolloutConfig validation, and replica/worker splitting did not account for PP, preventing NPU + vLLM PP from starting correctly.

Changes:

Sync pipeline_model_parallel_size from engine_kwargs.vllm.pipeline_parallel_size on NPU

Relax the restriction for vLLM PP > 1 (NPU only)

Fix rollout world size, replica count, and DP worker validation logic

2. Fix MindSpeed repatch configuration bugs
Background: During NPU Megatron actor initialization with MindSpeed batch‑invariant training (e.g., batch_invariant_mode + use_flash_attn_npu_batch_invariant), two issues occurred:

Attention backend type mismatch: Hydra passes attention_backend="flash" as a string, but MindSpeed injects repatch args into TransformerConfig before verl's mapping_string_to_attn_backend() runs, causing "Batch invariant mode only supports FlashAttention" error even when flash is configured.

Duplicate patch registration: repatch defaults use_flash_attn=True, which registers DotProductAttention.forward via fusion attention. When use_flash_attn_npu_batch_invariant=True, batch‑invariant registers the same forward patch and fails with RuntimeError: the patch of forward exist !.

Changes:

Convert attention_backend to AttnBackend enum before _mindspeed_repatch()

Disable use_flash_attn when NPU batch‑invariant flash attention is enabled

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
