### PR TITLE
[tool] feat: verl add rl insight

### DIFF
--- a/docs/advance/rl_insight.md
+++ b/docs/advance/rl_insight.md
@@ -1,0 +1,156 @@
+# Use RL-Insight to Monitor Training
+
+Last updated: 07/15/2026.
+
+[RL-Insight](https://github.com/verl-project/rl-insight) provides online observability for RL training. In verl, it can receive trainer scalar metrics, async rollout engine metrics, TransferQueue metrics, and rollout state traces, then show them in Grafana dashboards managed by the RL-Insight server.
+
+## When to Use
+
+Use RL-Insight when you want one monitor view for:
+
+- trainer metrics such as rewards, losses, and throughput
+- async vLLM or SGLang rollout server metrics
+- TransferQueue metrics when TransferQueue is enabled
+- RL state timelines around rollout generation
+- CPU, memory, network, and Ascend NPU hardware metrics
+
+## Step 1: Install and Start RL-Insight
+
+Install RL-Insight in the environment where the monitor server runs. Prefer the latest source version:
+
+```bash
+pip install "git+https://github.com/verl-project/rl-insight.git"
+```
+
+Or install a released package:
+
+```bash
+pip install "rl-insight>=0.2.0"
+```
+
+### Install monitor services
+
+`rl-insight server install` downloads Prometheus, Tempo, and Grafana into `~/.rl-insight/services`. The machine that runs this command needs network access to **GitHub release assets** and **`dl.grafana.com`**.
+
+If that machine can reach those hosts:
+
+```bash
+rl-insight server install
+rl-insight server start
+```
+
+If it cannot (common in air-gapped or restricted clusters), download the archives on a networked machine first, copy them to the RL-Insight host, then install from a local directory that contains all three archives. `/path/to/archives` below is only an example path — use any directory you choose, as long as the three packages are placed together in that directory.
+
+Default download URLs for `linux-amd64` (installer versions):
+
+| Service | Version | Download URL |
+| --- | --- | --- |
+| Prometheus | `2.54.1` | https://github.com/prometheus/prometheus/releases/download/v2.54.1/prometheus-2.54.1.linux-amd64.tar.gz |
+| Tempo | `2.6.1` | https://github.com/grafana/tempo/releases/download/v2.6.1/tempo_2.6.1_linux_amd64.tar.gz |
+| Grafana | `13.0.0` | https://dl.grafana.com/oss/release/grafana-13.0.0.linux-amd64.tar.gz |
+
+For `linux-arm64`, replace `amd64` with `arm64` in the filenames and URLs (Tempo uses `linux_arm64` in the archive name). Filenames must match exactly.
+
+```bash
+rl-insight server install --local-archive /path/to/archives
+rl-insight server start
+```
+
+`rl-insight server start` prints the detected server IP, Grafana URL, and related endpoints. Use that printed IP in the steps below. By default, RL-Insight uses:
+
+| Service | Default port | Purpose |
+| --- | --- | --- |
+| RL-Insight server | `18080` | Receives metrics and trace registrations |
+| Prometheus | `9090` | Stores and queries metrics |
+| Tempo | `3200` | Stores traces |
+| Grafana | `3000` | Shows dashboards |
+
+## Step 2: Enable RL-Insight in verl
+
+Set the RL-Insight server address before submitting the training job. `<server-ip>` must be the IP of the machine where you ran `rl-insight server start` (the address printed by that command), and it must be reachable from the training processes:
+
+```bash
+export RL_INSIGHT_SERVER_URL="http://<server-ip>:18080"
+```
+
+For a multi-node Ray cluster, add the variable to the runtime environment file submitted with the verl job, typically `verl/trainer/runtime_env.yaml`. This propagates the RL-Insight server address to workers on every node:
+
+```yaml
+env_vars:
+  RL_INSIGHT_SERVER_URL: "http://<server-ip>:18080"
+```
+
+If your launch script passes another file through `ray job submit --runtime-env`, add the variable to that file instead.
+
+Add `rl_insight` to `trainer.logger`. When `rl_insight` is enabled, verl sets `VERL_RL_INSIGHT_ENABLE=1` and initializes the RL-Insight client in each process that uses it.
+
+```bash
+python3 -m verl.trainer.main_ppo \
+    trainer.logger='["console","rl_insight"]' \
+    trainer.project_name=verl \
+    trainer.experiment_name=ppo_rl_insight \
+    ...
+```
+
+Trainer scalar metrics are reported to RL-Insight automatically through the logger backend.
+
+## Step 3: Monitor Rollout and TransferQueue Metrics
+
+For rollout engine metrics and TransferQueue metrics, keep rollout stats enabled and expose the TransferQueue metrics endpoint:
+
+```bash
+python3 -m verl.trainer.main_ppo \
+    trainer.logger='["console","rl_insight"]' \
+    actor_rollout_ref.rollout.disable_log_stats=False \
+    transfer_queue.metrics.enabled=True \
+    ...
+```
+
+When rollout replicas or TransferQueue metrics endpoints start, verl registers them with RL-Insight. The generation path is also wrapped with RL-Insight state traces for vLLM and SGLang rollout workers.
+
+## Step 4: Add Hardware Metrics (Optional)
+
+To monitor CPU, memory, network, or Ascend NPU metrics, follow the [RL-Insight Hardware Monitoring guide](https://github.com/verl-project/rl-insight/blob/main/docs/monitor/hardware/index.md). The guide explains how to install or reuse the exporters and register their monitoring endpoints with RL-Insight.
+
+## View Dashboards
+
+1. Check the terminal output of `rl-insight server start` and open the printed Grafana URL. By default it is `http://<server-ip>:3000`, where `<server-ip>` is the RL-Insight host.
+2. Log in with the default credentials:
+   - username: `admin`
+   - password: `admin`
+3. In the left navigation, open **Dashboards**, then open the **RL-Insight** folder.
+4. Select the dashboard that matches your run, for example:
+   - `verl_trainer_v1_with_vllm_engine` for vLLM rollout
+   - `verl_trainer_v1_with_sglang_engine` for SGLang rollout
+5. Set the time range to a recent window such as **Last 5 minutes** / **Last 15 minutes** while training is still running.
+
+The dashboards should include training metrics, rollout metrics, TransferQueue metrics if enabled, and rollout state timelines. Example views:
+
+**RL state timeline (sync mode)**
+
+![sync timeline](https://github.com/mengchengTang/verl-data/raw/master/sync_timeline.png)
+
+**RL state timeline (separate async mode)**
+
+![separate async timeline](https://github.com/mengchengTang/verl-data/raw/master/separate_async_timeline.png)
+
+**Inference engine metrics across replicas**
+
+![infer engine metric of all replicas](https://github.com/mengchengTang/verl-data/raw/master/infer_engine_metric_of_all_replica.png)
+
+**TransferQueue metrics**
+
+![transfer queue metric](https://github.com/mengchengTang/verl-data/raw/master/transfer_queue_metric.png)
+
+**CPU hardware metrics**
+
+![CPU hardware metrics](https://github.com/mengchengTang/verl-data/blob/master/cpu%E6%8C%87%E6%A0%87.png?raw=1)
+
+## Troubleshooting
+
+- If trainer metrics do not appear, check that `trainer.logger` contains `rl_insight` and `RL_INSIGHT_SERVER_URL` points to the machine that runs `rl-insight server start`.
+- If rollout metrics do not appear, check that `actor_rollout_ref.rollout.disable_log_stats=False` is set.
+- If TransferQueue metrics do not appear, check that `transfer_queue.metrics.enabled=True` is set.
+- If `server install` fails to download packages, use the offline `--local-archive` path above.
+
+For more RL-Insight server installation details, see the [RL-Insight server installation guide](https://github.com/verl-project/rl-insight/blob/main/docs/monitor/server_installation.md) and [quick start](https://github.com/verl-project/rl-insight/blob/main/docs/monitor/quick_start.md).

--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -606,7 +606,7 @@ Trainer
 - ``trainer.total_epochs``: Number of epochs in training.
 - ``trainer.project_name``: For wandb, swanlab, mlflow
 - ``trainer.experiment_name``: For wandb, swanlab, mlflow
-- ``trainer.logger``: Support console and wandb, swanlab, mlflow, tensorboard, trackio
+- ``trainer.logger``: Support console, wandb, swanlab, mlflow, tensorboard, trackio, and rl_insight.
 - ``trainer.log_val_generations``: The number of logged generation during validation (default ``0``)
 - ``trainer.nnodes``: Number of nodes used in the training.
 - ``trainer.n_gpus_per_node``: Number of GPUs per node.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,7 @@ verl is fast with:
    advance/dpo_extension
    examples/sandbox_fusion_example
    advance/rollout_trace.rst
+   advance/rl_insight.md
    advance/skip_manager.rst
    advance/agent_loop
    advance/reward_loop

--- a/tests/utils/test_rl_insight_logger_on_cpu.py
+++ b/tests/utils/test_rl_insight_logger_on_cpu.py
@@ -1,0 +1,132 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from verl.utils.tracking import RLInsightLogger
+
+
+@pytest.fixture(autouse=True)
+def _reset_rl_insight_logger():
+    RLInsightLogger._init_done = False
+    RLInsightLogger._rl_insight_module = None
+    RLInsightLogger._registered_metrics.clear()
+    yield
+    RLInsightLogger._init_done = False
+    RLInsightLogger._rl_insight_module = None
+    RLInsightLogger._registered_metrics.clear()
+
+
+@pytest.fixture
+def mock_rl_insight(monkeypatch):
+    module = MagicMock()
+    module.metric_gauge = MagicMock()
+
+    @contextmanager
+    def _trace_state(*args, **kwargs):
+        yield
+
+    module.trace_state.side_effect = _trace_state
+    monkeypatch.setattr(RLInsightLogger, "_get_rl_insight", classmethod(lambda cls: module))
+    return module
+
+
+def test_apis_are_noops_when_env_disabled(monkeypatch, mock_rl_insight):
+    monkeypatch.delenv(RLInsightLogger.ENABLE_ENV, raising=False)
+
+    RLInsightLogger.init(
+        project_name="p", experiment_name="e", config={"transfer_queue": {"metrics": {"enabled": True}}}
+    )
+    RLInsightLogger.log({"reward/mean": 1.0}, step=1)
+    with RLInsightLogger.trace_state("rollout", state_lane_id="replica_0"):
+        pass
+    RLInsightLogger.register_metrics(["127.0.0.1:8000"], "vllm", [{"replica": 0}])
+    RLInsightLogger.finish()
+
+    mock_rl_insight.init.assert_not_called()
+    mock_rl_insight.metric_gauge.assert_not_called()
+    mock_rl_insight.trace_state.assert_not_called()
+    mock_rl_insight.update_prometheus_config.assert_not_called()
+    mock_rl_insight.finish.assert_not_called()
+    assert RLInsightLogger._init_done is False
+
+
+def test_init_registers_transfer_queue_after_client_init(monkeypatch, mock_rl_insight):
+    monkeypatch.setenv(RLInsightLogger.ENABLE_ENV, "1")
+    config = {
+        "trainer": {"rl_insight": {"server": {"url": "http://127.0.0.1:18080"}}},
+        "transfer_queue": {"metrics": {"enabled": True}},
+    }
+    fake_tq = MagicMock()
+    fake_tq.get_metrics_endpoint.return_value = "127.0.0.1:9000"
+    monkeypatch.setitem(__import__("sys").modules, "transfer_queue", fake_tq)
+
+    RLInsightLogger.init(project_name="proj", experiment_name="exp", config=config)
+
+    mock_rl_insight.init.assert_called_once_with(
+        project="proj",
+        experiment_name="exp",
+        config=config["trainer"]["rl_insight"],
+    )
+    mock_rl_insight.update_prometheus_config.assert_called_once_with(["127.0.0.1:9000"], "transfer_queue", None)
+    assert RLInsightLogger._init_done is True
+
+
+def test_log_lazy_inits_and_writes_gauge(monkeypatch, mock_rl_insight):
+    monkeypatch.setenv(RLInsightLogger.ENABLE_ENV, "1")
+
+    RLInsightLogger.log({"reward/mean": 1.25, "bad": object()}, step=3)
+
+    mock_rl_insight.init.assert_called_once_with()
+    mock_rl_insight.metric_gauge.assert_called_once_with("reward_mean", 1.25)
+    assert RLInsightLogger._init_done is True
+
+
+def test_trace_state_lazy_inits_once_under_concurrent_async_tasks(monkeypatch, mock_rl_insight):
+    monkeypatch.setenv(RLInsightLogger.ENABLE_ENV, "1")
+
+    async def _one(i: int):
+        with RLInsightLogger.trace_state(f"state_{i}", state_lane_id=f"lane_{i}", step=i):
+            await asyncio.sleep(0)
+
+    async def _run():
+        await asyncio.gather(*[_one(i) for i in range(16)])
+
+    asyncio.run(_run())
+
+    mock_rl_insight.init.assert_called_once_with()
+    assert mock_rl_insight.trace_state.call_count == 16
+    assert RLInsightLogger._init_done is True
+
+
+def test_register_metrics_dedups_and_finish_resets(monkeypatch, mock_rl_insight):
+    monkeypatch.setenv(RLInsightLogger.ENABLE_ENV, "1")
+    addresses = ["127.0.0.1:8000", "127.0.0.1:8001"]
+    labels = [{"replica": 0}, {"replica": 1}]
+
+    RLInsightLogger.register_metrics(addresses, "vllm", labels)
+    RLInsightLogger.register_metrics(addresses, "vllm", labels)
+    mock_rl_insight.update_prometheus_config.assert_called_once_with(addresses, "vllm", labels)
+
+    RLInsightLogger._init_done = True
+    RLInsightLogger.finish()
+    mock_rl_insight.finish.assert_called_once_with()
+    assert RLInsightLogger._init_done is False
+    assert not RLInsightLogger._registered_metrics

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -102,6 +102,6 @@ def get_ppo_ray_runtime_env(config=None):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)
     # Always forward these at call-time, not import-time.
-    for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT"):
+    for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT", "VERL_RL_INSIGHT_ENABLE"):
         runtime_env["env_vars"][key] = os.environ.get(key, "0")
     return runtime_env

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -48,6 +48,10 @@ def run_ppo(config, task_runner_class) -> None:
         os.environ["VLLM_BATCH_INVARIANT"] = "1"
         os.environ["PYTHONHASHSEED"] = str(rollout_cfg.seed)
 
+    trainer_logger = config.trainer.get("logger", [])
+    if "rl_insight" in ([trainer_logger] if isinstance(trainer_logger, str) else trainer_logger or []):
+        os.environ["VERL_RL_INSIGHT_ENABLE"] = "1"
+
     # Check if Ray is not initialized
     if not ray.is_initialized():
         # Initialize Ray with a local cluster configuration

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -15,6 +15,7 @@
 import functools
 from typing import Callable, Optional
 
+from ..tracking import RLInsightLogger
 from .config import ProfilerConfig
 
 
@@ -89,6 +90,7 @@ class DistProfiler:
         if tool_config is None:
             tool_config = config.tool_config
 
+        self.rank = rank
         self.config = config
         self.tool_config = tool_config
 
@@ -191,25 +193,26 @@ class DistProfiler:
             @functools.wraps(func)
             def wrapper(self_instance, *args, **kwargs_inner):
                 profiler = getattr(self_instance, "profiler", None)
-                if (
-                    not profiler
-                    or not profiler.check_enable()
-                    or not profiler.check_this_step()
-                    or not profiler.check_this_rank()
-                ):
+                if profiler is None:
                     return func(self_instance, *args, **kwargs_inner)
 
-                impl = profiler._impl
-                if hasattr(impl, "annotate"):
-                    try:
-                        actual_decorator = impl.annotate(
-                            message=message, color=color, domain=domain, category=category, **kwargs_outer
-                        )
-
-                        return actual_decorator(func)(self_instance, *args, **kwargs_inner)
-                    except Exception:
+                with RLInsightLogger.trace_state(
+                    kwargs_outer.get("role", func.__qualname__), state_lane_id=f"rank_{profiler.rank}"
+                ):
+                    if not profiler.check_enable() or not profiler.check_this_step() or not profiler.check_this_rank():
                         return func(self_instance, *args, **kwargs_inner)
-                return func(self_instance, *args, **kwargs_inner)
+
+                    impl = profiler._impl
+                    if hasattr(impl, "annotate"):
+                        try:
+                            actual_decorator = impl.annotate(
+                                message=message, color=color, domain=domain, category=category, **kwargs_outer
+                            )
+
+                            return actual_decorator(func)(self_instance, *args, **kwargs_inner)
+                        except Exception:
+                            return func(self_instance, *args, **kwargs_inner)
+                    return func(self_instance, *args, **kwargs_inner)
 
             return wrapper
 

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -19,6 +19,7 @@ import dataclasses
 import json
 import logging
 import os
+from contextlib import contextmanager
 from enum import Enum
 from functools import partial
 from pathlib import Path
@@ -53,6 +54,7 @@ class Tracking:
         "clearml",
         "trackio",
         "file",
+        "rl_insight",
     ]
 
     def __init__(self, project_name, experiment_name, default_backend: str | list[str] = "console", config=None):
@@ -180,6 +182,9 @@ class Tracking:
         if "file" in default_backend:
             self.logger["file"] = FileLogger(project_name, experiment_name)
 
+        if "rl_insight" in default_backend:
+            self.logger["rl_insight"] = RLInsightLogger(project_name, experiment_name, config)
+
     def log(self, data, step, backend=None):
         for default_backend, logger_instance in self.logger.items():
             if backend is None or default_backend in backend:
@@ -200,6 +205,138 @@ class Tracking:
             self.logger["trackio"].finish()
         if "file" in self.logger:
             self.logger["file"].finish()
+        if "rl_insight" in self.logger:
+            self.logger["rl_insight"].finish()
+
+
+class RLInsightLogger:
+    """Logger backend that exports scalar metrics and rl-insight runtime signals."""
+
+    ENABLE_ENV = "VERL_RL_INSIGHT_ENABLE"
+    _init_done = False
+    _rl_insight_module = None
+    _registered_metrics: set[tuple[str | None, tuple[str, ...], str | None]] = set()
+
+    def __init__(self, project_name, experiment_name, config=None):
+        self.init(project_name=project_name, experiment_name=experiment_name, config=config)
+
+    @classmethod
+    def _get_rl_insight(cls):
+        if cls._rl_insight_module is None:
+            import rl_insight
+
+            cls._rl_insight_module = rl_insight
+        return cls._rl_insight_module
+
+    @classmethod
+    def enabled(cls) -> bool:
+        """Return whether rl-insight is globally enabled in this process."""
+        return os.getenv(cls.ENABLE_ENV) == "1"
+
+    @classmethod
+    def init(cls, project_name=None, experiment_name=None, config=None):
+        if not cls.enabled() or cls._init_done:
+            return
+
+        rl_insight_config = {}
+        if config is not None:
+            try:
+                rl_insight_config = config.get("trainer", {}).get("rl_insight", {}) or {}
+            except (AttributeError, KeyError, TypeError):
+                pass
+        cls._get_rl_insight().init(project=project_name, experiment_name=experiment_name, config=rl_insight_config)
+        cls._init_done = True
+        if config is not None:
+            cls.register_transfer_queue_metrics(config)
+
+    @classmethod
+    def log(cls, data, step):
+        if not cls.enabled():
+            return
+        if not cls._init_done:
+            cls._get_rl_insight().init()
+            cls._init_done = True
+        metric_gauge = cls._get_rl_insight().metric_gauge
+
+        for key, value in data.items():
+            try:
+                scalar = float(value)
+            except (TypeError, ValueError):
+                continue
+            metric_gauge(str(key).replace("/", "_"), scalar)
+
+    @classmethod
+    def finish(cls):
+        if not cls._init_done:
+            return
+
+        cls._get_rl_insight().finish()
+        cls._init_done = False
+        cls._registered_metrics.clear()
+
+    @classmethod
+    @contextmanager
+    def trace_state(
+        cls,
+        state_name: str,
+        *,
+        state_lane_id: str | int | None = None,
+        **labels: Any,
+    ):
+        if not cls.enabled():
+            yield
+            return
+
+        if not cls._init_done:
+            cls._get_rl_insight().init()
+            cls._init_done = True
+        with cls._get_rl_insight().trace_state(state_name, state_lane_id=state_lane_id, **labels):
+            yield
+
+    @classmethod
+    def register_rollout_metrics(
+        cls,
+        server_addresses: list[str],
+        rollout_name: str | None,
+        labels: list[dict[str, Any] | None] | None = None,
+    ) -> None:
+        cls.register_metrics(server_addresses, rollout_name, labels)
+
+    @classmethod
+    def register_transfer_queue_metrics(cls, config) -> None:
+        if not (config or {}).get("transfer_queue", {}).get("metrics", {}).get("enabled", False):
+            return
+
+        try:
+            import transfer_queue as tq
+
+            endpoint = tq.get_metrics_endpoint()
+        except Exception:
+            logger.exception("[rl-insight] Failed to get transfer_queue metrics endpoint")
+            return
+
+        if endpoint:
+            cls.register_metrics([endpoint], "transfer_queue", None)
+
+    @classmethod
+    def register_metrics(
+        cls,
+        server_addresses: list[str],
+        job_name: str | None = None,
+        labels: list[dict[str, Any] | None] | None = None,
+    ) -> None:
+        if not cls.enabled():
+            return
+
+        metric_key = (job_name, tuple(server_addresses), repr(labels))
+        if metric_key in cls._registered_metrics:
+            return
+
+        try:
+            cls._get_rl_insight().update_prometheus_config(server_addresses, job_name, labels)
+            cls._registered_metrics.add(metric_key)
+        except Exception:
+            logger.exception("[rl-insight] Failed to register metrics endpoint")
 
 
 class ClearMLLogger:

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -33,6 +33,7 @@ from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
 from verl.utils import normalize_token_ids
 from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
+from verl.utils.tracking import RLInsightLogger
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
 from verl.workers.rollout.utils import update_prometheus_config
 
@@ -469,11 +470,22 @@ class LLMServerManager:
         self.server_addresses = [server._server_address for server in self.rollout_replicas]
         print(f"LLMServerManager: {self.server_addresses}")
 
-        # Update Prometheus configuration with server addresses
-        if self.rollout_config.prometheus.enable:
-            if self.rollout_config.disable_log_stats:
-                raise ValueError("PROMETHEUS needs disable_log_stats==False, but it is currently True.")
-            update_prometheus_config(self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name)
+        # Update Prometheus / rl-insight metrics with server addresses
+        needs_metrics = self.rollout_config.prometheus.enable or RLInsightLogger.enabled()
+        if self.rollout_config.disable_log_stats:
+            if needs_metrics:
+                raise ValueError("Metrics monitoring requires disable_log_stats=False, but it is currently True.")
+        if not self.rollout_config.disable_log_stats:
+            if self.rollout_config.prometheus.enable:
+                update_prometheus_config(
+                    self.rollout_config.prometheus, self.server_addresses, self.rollout_config.name
+                )
+            if RLInsightLogger.enabled():
+                RLInsightLogger.register_rollout_metrics(
+                    self.server_addresses,
+                    self.rollout_config.name,
+                    labels=[{"replica": server.replica_rank} for server in self.rollout_replicas],
+                )
 
     async def _init_global_load_balancer(self) -> None:
         self.global_load_balancer = GlobalRequestLoadBalancer.remote(

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -47,6 +47,7 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.device import get_visible_devices_keyword
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_sglang_profiler_args
+from verl.utils.tracking import RLInsightLogger
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
 from verl.workers.rollout.sglang_rollout.sglang_rollout import _set_envs_and_config
@@ -328,7 +329,7 @@ class SGLangHttpServer:
             )
             args["dist_init_addr"] = dist_init_addr
 
-        if self.config.prometheus.enable:
+        if self.config.prometheus.enable or RLInsightLogger.enabled():
             if self.config.prometheus.served_model_name:
                 # Extract model name from path if it's a full path
                 served_model_name = self.config.prometheus.served_model_name
@@ -612,7 +613,8 @@ class SGLangHttpServer:
         if self.model_config.lora_rank > 0:
             generate_request.lora_path = SGLANG_LORA_NAME
 
-        output = await self.tokenizer_manager.generate_request(generate_request, None).__anext__()
+        with RLInsightLogger.trace_state("sglang_generate", state_lane_id=f"replica_{self.replica_rank}"):
+            output = await self.tokenizer_manager.generate_request(generate_request, None).__anext__()
         meta_info = output.get("meta_info", {})
         finish_reason = meta_info.get("finish_reason")
         finish_reason = finish_reason["type"] if finish_reason else None

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -41,6 +41,7 @@ from verl.utils.device import get_resource_name, get_visible_devices_keyword, is
 from verl.utils.net_utils import get_free_port, is_valid_ipv6_address
 from verl.utils.profiler import DistProfiler, build_vllm_profiler_args
 from verl.utils.tokenizer import normalize_token_ids
+from verl.utils.tracking import RLInsightLogger
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
 from verl.workers.config import HFModelConfig, RolloutConfig
 from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
@@ -631,19 +632,20 @@ class vLLMHttpServer:
                     lora_name=VLLM_LORA_NAME, lora_int_id=VLLM_LORA_INT_ID, lora_path=VLLM_LORA_PATH
                 )
 
-        generator = self.engine.generate(
-            prompt=prompt,
-            sampling_params=sampling_params,
-            request_id=request_id,
-            lora_request=lora_request,
-            priority=priority,
-        )
+        with RLInsightLogger.trace_state("vllm_generate", state_lane_id=f"replica_{self.replica_rank}"):
+            generator = self.engine.generate(
+                prompt=prompt,
+                sampling_params=sampling_params,
+                request_id=request_id,
+                lora_request=lora_request,
+                priority=priority,
+            )
 
-        # Get final response
-        final_res: Optional[RequestOutput] = None
-        async for output in generator:
-            final_res = output
-        assert final_res is not None
+            # Get final response
+            final_res: Optional[RequestOutput] = None
+            async for output in generator:
+                final_res = output
+            assert final_res is not None
 
         extra_fields = {"global_steps": self.global_steps}
         # Handle abort case: when the request is aborted by pause_generation(abort),


### PR DESCRIPTION
### What does this PR do?

1. Integrates [RL-Insight](https://github.com/verl-project/rl-insight) into verl to provide online observability for distributed RL training: training metrics, RL state traces, and rollout / transfer queue subsystem metrics are aggregated into unified Grafana dashboards.

<img width="1200" height="760" alt="image" src="https://github.com/user-attachments/assets/2d47394a-35ca-4302-844b-38501817bfeb" />


2. **Core idea**:add rl_insight to trainer.logger and set RL_INSIGHT_SERVER_URL. verl handles the rest — env propagation across Ray workers, lazy init, and auto-registration of collection hooks — with no changes to the training main loop.                                                      


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

1.sync with vllm

https://github.com/user-attachments/assets/b0f05f3e-8b21-4813-8ba6-4796aa844d62

2.sync with sglang

https://github.com/user-attachments/assets/bc30ec55-24c9-49fa-ab53-3a2a9963442c


3.spearte async with vllm

https://github.com/user-attachments/assets/d0ef242d-e108-468f-afa5-ec9a5321f0e8

4. performance test
    performance test by @12138flash

**Results**
Average step time over 100 steps

rl-sight disabled: 13.40 s/step
rl-sight enabled: 12.68 s/step
Average step time over 5 steps (earlier short-run observation)

rl-sight disabled: 17.83 s/step
rl-sight enabled: 18.30 s/step
Across these two measurements, the runtime difference is within normal run-to-run fluctuation, and there is no stable/significant overhead introduced by rl-sight.

Conclusion: the time overhead of rl-sight is negligible; the observed differences are most likely due to normal experimental variance.

Full experiment script
```
python3 -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    data.train_files=$HOME/data/gsm8k/train.parquet \
    data.val_files=$HOME/data/gsm8k/test.parquet \
    data.train_batch_size=1 \
    data.max_prompt_length=512 \
    data.max_response_length=128 \
    data.filter_overlong_prompts=True \
    data.truncation='error' \
    actor_rollout_ref.model.path=/home/youjinlin/models/Qwen2.5-0.5B-Instruct \
    actor_rollout_ref.actor.optim.lr=5e-7 \
    actor_rollout_ref.model.use_remove_padding=True \
    actor_rollout_ref.actor.use_dynamic_bsz=False \
    actor_rollout_ref.actor.entropy_coeff=0.001 \
    actor_rollout_ref.actor.ppo_mini_batch_size=1 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
    actor_rollout_ref.model.enable_gradient_checkpointing=True \
    actor_rollout_ref.actor.fsdp_config.param_offload=False \
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.rollout.enable_chunked_prefill=False \
    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.enforce_eager=True \
    actor_rollout_ref.rollout.disable_log_stats=False \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
    actor_rollout_ref.rollout.n=4 \
    actor_rollout_ref.rollout.calculate_log_probs=True \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.ref.fsdp_config.param_offload=True \
    actor_rollout_ref.rollout.agent.num_workers=4 \
    algorithm.kl_ctrl.kl_coef=0.001 \
    trainer.balance_batch=False \
    trainer.val_before_train=False \
    trainer.critic_warmup=0 \
    trainer.logger='[console,file,rl_insight]' \
    trainer.project_name='verl_grpo_example_math' \
    trainer.experiment_name='qwen2_7b_function_rm_rlsight' \
    trainer.n_gpus_per_node=1 \
    trainer.nnodes=1 \
    trainer.save_freq=-1 \
    trainer.test_freq=1000 \
    trainer.total_epochs=1 \
    trainer.total_training_steps=100 \
    trainer.use_v1=False \
    $@
```


### API and Usage Example

**Usage Example**

1. Start the RL-Insight server
```
pip install rl-insight
rl-insight server install
rl-insight server start
export RL_INSIGHT_SERVER_URL=http://<server-ip>:18080
```

2. Enable in verl training (coexists with wandb / console, etc.)

```
python3 -m verl.trainer.main_ppo \
    trainer.logger='[console,rl_insight]' \
    trainer.project_name='verl_grpo_example' \
    trainer.experiment_name='qwen2_5_0_5b' \
    transfer_queue.metrics.enabled=true \   
    actor_rollout_ref.rollout.disable_log_stats=False \
    ...
```

3. Optional: override rl-insight settings when needed
**Only required for non-default server URL or other custom settings — not part of the standard yaml config:**
```
trainer:
  logger: [console, rl_insight]
  project_name: verl_grpo_example
  experiment_name: qwen2_5_0_5b
  rl_insight:
    server:
      url: http://<server-ip>:18080
```

**API changes**

New trainer.logger backend: rl_insight
- _VERL_RL_INSIGHT_ENABLE is set internally for multi-process propagation; trainer.rl_insight is optional and only needed when overriding defaults._

### Design & Code Changes

Design principles

- **Low intrusion:** no changes to the training main loop; hooks only at logger / profiler / rollout boundaries

- **Zero cost when disabled**: all collection points gated by VERL_RL_INSIGHT_ENABLE; no-op when off

- **Low user cost:** add one entry to trainer.logger; orthogonal to and composable with other loggers

- **Ray multi-process aware**: env var propagated via runtime_env; each process lazy-inits independently, avoiding cross-process class variable issues

the design:
<img width="1036" height="883" alt="image" src="https://github.com/user-attachments/assets/725f025a-4b89-4c5c-90a8-4dec48a6341e" />


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
