### PR TITLE
[fully_async, trainer] fix: sync optimizer total steps before trainer initialization

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 import hydra
 import ray
-from omegaconf import OmegaConf, open_dict
+from omegaconf import OmegaConf
 
 from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
 from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
@@ -77,7 +77,7 @@ class FullyAsyncTaskRunner:
         self._init_rollouter_before_trainer(config)
 
         optim_total_train_steps = ray.get(self.components["rollouter"].get_optim_total_train_steps.remote())
-        self._set_total_training_steps_for_optimizer(config, optim_total_train_steps)
+        FullyAsyncTrainer.set_total_training_steps_for_optimizer(config, optim_total_train_steps)
 
         print("[ASYNC MAIN] Creating FullyAsyncTrainer first (needed for hybrid worker group injection)...")
         self._create_trainer(config)
@@ -118,17 +118,6 @@ class FullyAsyncTaskRunner:
             ray.get(self.components["trainer"]._fit_validate.remote(True))
 
         print("[ASYNC MAIN] All components initialized successfully")
-
-    def _set_total_training_steps_for_optimizer(self, config, optim_total_train_steps):
-        try:
-            OmegaConf.set_struct(config, True)
-            with open_dict(config):
-                if OmegaConf.select(config, "actor_rollout_ref.actor.optim"):
-                    config.actor_rollout_ref.actor.optim.total_training_steps = optim_total_train_steps
-                if OmegaConf.select(config, "critic.optim"):
-                    config.critic.optim.total_training_steps = optim_total_train_steps
-        except Exception as e:
-            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
 
     def _init_rollouter_before_trainer(self, config) -> None:
         """

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 import hydra
 import ray
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, open_dict
 
 from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
 from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
@@ -74,6 +74,11 @@ class FullyAsyncTaskRunner:
         self.components["role_worker_mapping"] = role_worker_mapping
         self.components["ray_worker_group_cls"] = ray_worker_group_cls
 
+        self._init_rollouter_before_trainer(config)
+
+        optim_total_train_steps = ray.get(self.components["rollouter"].get_optim_total_train_steps.remote())
+        self._set_total_training_steps_for_optimizer(config, optim_total_train_steps)
+
         print("[ASYNC MAIN] Creating FullyAsyncTrainer first (needed for hybrid worker group injection)...")
         self._create_trainer(config)
 
@@ -89,7 +94,7 @@ class FullyAsyncTaskRunner:
         # sync total_train_steps between rollouter and trainer
         total_train_steps = ray.get(self.components["rollouter"].get_total_train_steps.remote())
         print(f"total_train_steps {total_train_steps}")
-        ray.get(self.components["trainer"].set_total_train_steps.remote(total_train_steps))
+        ray.get(self.components["trainer"].set_total_train_steps_for_progress_bar.remote(total_train_steps))
 
         # max_queue_size
         max_queue_size = ray.get(self.components["rollouter"].get_max_queue_size.remote())
@@ -114,14 +119,39 @@ class FullyAsyncTaskRunner:
 
         print("[ASYNC MAIN] All components initialized successfully")
 
-    def _create_rollouter(self, config) -> None:
-        print("[ASYNC MAIN] Starting create rollouter...")
+    def _set_total_training_steps_for_optimizer(self, config, optim_total_train_steps):
+        try:
+            OmegaConf.set_struct(config, True)
+            with open_dict(config):
+                if OmegaConf.select(config, "actor_rollout_ref.actor.optim"):
+                    config.actor_rollout_ref.actor.optim.total_training_steps = optim_total_train_steps
+                if OmegaConf.select(config, "critic.optim"):
+                    config.critic.optim.total_training_steps = optim_total_train_steps
+        except Exception as e:
+            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
+
+    def _init_rollouter_before_trainer(self, config) -> None:
+        """
+        Run __init__ for rollouter. Does NOT call init_workers or set_max_required_samples yet.
+        This must be called BEFORE _create_trainer so the trainer can read the correct
+        total_train_steps from the rollouter.
+        """
+        print("[ASYNC MAIN] Creating rollouter init (dataloader + compute total_train_steps)")
         rollouter = FullyAsyncRollouter.remote(
             config=config,
             tokenizer=self.components["tokenizer"],
             processor=self.components["processor"],
             device_name=config.trainer.device,
         )
+        self.components["rollouter"] = rollouter
+        print("[ASYNC MAIN] Rollouter init completed (dataloader created + total_train_steps computed)")
+
+    def _create_rollouter(self, config) -> None:
+        """
+        Complete rollouter setup: inject hybrid WG, init workers, set max required samples.
+        """
+        print("[ASYNC MAIN] Starting create rollouter...")
+        rollouter = self.components["rollouter"]
 
         # set_hybrid_worker_group must be called BEFORE init_workers() so that
         # _init_async_rollout_manager can pass the hybrid WG to ALM.create().
@@ -131,8 +161,6 @@ class FullyAsyncTaskRunner:
 
         ray.get(rollouter.init_workers.remote())
         ray.get(rollouter.set_max_required_samples.remote())
-
-        self.components["rollouter"] = rollouter
         print("[ASYNC MAIN] Rollouter created and initialized successfully")
 
     def _create_trainer(self, config) -> None:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -563,6 +563,9 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
     def get_total_train_steps(self):
         return self.total_train_steps
 
+    def get_optim_total_train_steps(self):
+        return int(self.total_rollout_steps / self.required_samples)
+
     async def reset_staleness(self):
         """
         Reset staleness samples after parameter update.

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -276,7 +276,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         if rollout_total_steps is None:
             return None
 
-        required_samples = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.async_training.require_batches
+        required_samples = (
+            self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.async_training.require_batches
+        )
         steps_per_sync = required_samples * self.config.async_training.trigger_parameter_sync_step
         return int(rollout_total_steps / steps_per_sync)
 
@@ -383,7 +385,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         total_training_steps = self._resolve_total_training_steps_before_init()
         if total_training_steps is not None:
             self._set_total_training_steps_in_config(total_training_steps)
-            
+
         self._init_resource_pools()
         self._create_worker_classes()
         self._init_worker_groups()

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -253,34 +253,9 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         await self._setup_checkpoint_manager()
         await self._setup_hybrid_checkpoint_manager()
 
-    def set_total_train_steps(self, total_training_steps):
+    def set_total_train_steps_for_progress_bar(self, total_training_steps):
         self.total_train_steps = total_training_steps
-
-        self._set_total_training_steps_in_config(total_training_steps)
-
         self.progress_bar = tqdm(total=self.total_train_steps, initial=0, desc="Training Progress")
-
-    def _set_total_training_steps_in_config(self, total_training_steps):
-        try:
-            OmegaConf.set_struct(self.config, True)
-            with open_dict(self.config):
-                if OmegaConf.select(self.config, "actor_rollout_ref.actor.optim"):
-                    self.config.actor_rollout_ref.actor.optim.total_training_steps = total_training_steps
-                if OmegaConf.select(self.config, "critic.optim"):
-                    self.config.critic.optim.total_training_steps = total_training_steps
-        except Exception as e:
-            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
-
-    def _resolve_total_training_steps_before_init(self):
-        rollout_total_steps = self.config.rollout.total_rollout_steps
-        if rollout_total_steps is None:
-            return None
-
-        required_samples = (
-            self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.async_training.require_batches
-        )
-        steps_per_sync = required_samples * self.config.async_training.trigger_parameter_sync_step
-        return int(rollout_total_steps / steps_per_sync)
 
     def get_actor_wg(self):
         """Get actor worker group"""
@@ -382,10 +357,6 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         1. Ray resource pools from configuration
         2. Worker groups for each role (actor, critic, etc.)
         """
-        total_training_steps = self._resolve_total_training_steps_before_init()
-        if total_training_steps is not None:
-            self._set_total_training_steps_in_config(total_training_steps)
-
         self._init_resource_pools()
         self._create_worker_classes()
         self._init_worker_groups()

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -253,6 +253,23 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         await self._setup_checkpoint_manager()
         await self._setup_hybrid_checkpoint_manager()
 
+    @staticmethod
+    def set_total_training_steps_for_optimizer(config, total_training_steps):
+
+        try:
+            OmegaConf.set_struct(config, True)
+            with open_dict(config):
+                if OmegaConf.select(config, "actor_rollout_ref.actor.optim"):
+                    config.actor_rollout_ref.actor.optim.total_training_steps = total_training_steps
+                if OmegaConf.select(config, "critic.optim"):
+                    config.critic.optim.total_training_steps = total_training_steps
+            print(
+                f"[FullyAsyncTrainer] set_total_training_steps_for_optimizer: "
+                f"config.optim.total_training_steps = {total_training_steps}"
+            )
+        except Exception as e:
+            print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
+
     def set_total_train_steps_for_progress_bar(self, total_training_steps):
         self.total_train_steps = total_training_steps
         self.progress_bar = tqdm(total=self.total_train_steps, initial=0, desc="Training Progress")

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -256,6 +256,11 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
     def set_total_train_steps(self, total_training_steps):
         self.total_train_steps = total_training_steps
 
+        self._set_total_training_steps_in_config(total_training_steps)
+
+        self.progress_bar = tqdm(total=self.total_train_steps, initial=0, desc="Training Progress")
+
+    def _set_total_training_steps_in_config(self, total_training_steps):
         try:
             OmegaConf.set_struct(self.config, True)
             with open_dict(self.config):
@@ -266,7 +271,14 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         except Exception as e:
             print(f"Warning: Could not set total_training_steps in config. Structure missing? Error: {e}")
 
-        self.progress_bar = tqdm(total=self.total_train_steps, initial=0, desc="Training Progress")
+    def _resolve_total_training_steps_before_init(self):
+        rollout_total_steps = self.config.rollout.total_rollout_steps
+        if rollout_total_steps is None:
+            return None
+
+        required_samples = self.config.actor_rollout_ref.actor.ppo_mini_batch_size * self.config.async_training.require_batches
+        steps_per_sync = required_samples * self.config.async_training.trigger_parameter_sync_step
+        return int(rollout_total_steps / steps_per_sync)
 
     def get_actor_wg(self):
         """Get actor worker group"""
@@ -368,6 +380,10 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         1. Ray resource pools from configuration
         2. Worker groups for each role (actor, critic, etc.)
         """
+        total_training_steps = self._resolve_total_training_steps_before_init()
+        if total_training_steps is not None:
+            self._set_total_training_steps_in_config(total_training_steps)
+            
         self._init_resource_pools()
         self._create_worker_classes()
         self._init_worker_groups()


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

It was observed in experiments that the learning rate (lr) was always 0. This issue does not occur when starting the script via main_ppo, and only emerges under fully async mode. Refer to the following for detailed problem description:https://github.com/verl-project/verl/issues/6683

In short, optim.total_training_steps is not assigned correctly during the initialization of trainer optim.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/a185b009-f98f-4901-9c0c-90897b9e4ddd" />

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

The simplest approach is to pass values through by configuring `actor_rollout_ref.actor.optim.total_training_steps`, yet the actual trainer step should be calculated as total_rollout_steps / (required_samples * trigger_parameter_sync_step)

Therefore, this PR provides a method to assign the corresponding value to optim.total_training_steps when creating the trainer.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully+async+lr
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

<img width="992" height="578" alt="image" src="https://github.com/user-attachments/assets/1864b381-e63f-4242-a969-a2a7d320f085" />


### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
