### PR TITLE
[worker] fix actor offload before rollout weight resume

### DIFF
--- a/tests/workers/test_engine_workers_lora_sync.py
+++ b/tests/workers/test_engine_workers_lora_sync.py
@@ -54,27 +54,44 @@ async def _update_weights(
         per_tensor_param, _ = actor_engine.get_per_tensor_param()
         return
 
-    # 1. resume weights (conditional on sleep_level)
-    if free_cache_engine:
-        if getattr(rollout, "sleep_level", 2) != 1:
-            await rollout.resume(tags=["weights"])
+    def materialize_weights_to_cpu(weights):
+        return [
+            (name, tensor.detach().cpu() if hasattr(tensor, "detach") else tensor)
+            for name, tensor in weights
+        ]
 
-    # 2. probe adapter-mode params first so we can discover peft_config
+    # 1. probe adapter-mode params first so we can discover peft_config
     per_tensor_param, peft_config = actor_engine.get_per_tensor_param(
         layered_summon=layered_summon, base_sync_done=True
     )
 
-    # 3. determine base sync need
+    # 2. determine base sync need
     do_lora_base_sync = False
     if not peft_merge and peft_config is not None:
         rollout.sleep_level = 1
         do_lora_base_sync = not base_sync_done
 
-    # 4. sync weights
+    # 3. prepare base sync params before actor offload
+    per_tensor_param_base = None
     if do_lora_base_sync:
-        per_tensor_param_base, peft_config = actor_engine.get_per_tensor_param(
+        per_tensor_param_base, peft_config_base = actor_engine.get_per_tensor_param(
             layered_summon=layered_summon, base_sync_done=False
         )
+        peft_config = peft_config_base
+
+    # 4. offload actor model before rollout weight resume
+    if actor_engine.is_param_offload_enabled:
+        per_tensor_param = materialize_weights_to_cpu(per_tensor_param)
+        if per_tensor_param_base is not None:
+            per_tensor_param_base = materialize_weights_to_cpu(per_tensor_param_base)
+        actor_engine.to("cpu", model=True, optimizer=False, grad=False)
+
+    # 5. resume weights after actor offload
+    if free_cache_engine:
+        await rollout.resume(tags=["weights"])
+
+    # 6. sync weights
+    if do_lora_base_sync:
         await rollout.update_weights(
             per_tensor_param_base, peft_config=peft_config, base_sync_done=False, global_steps=global_steps
         )
@@ -83,7 +100,7 @@ async def _update_weights(
         per_tensor_param, peft_config=peft_config, base_sync_done=True, global_steps=global_steps
     )
 
-    # 5. resume kv_cache
+    # 7. resume kv_cache
     if free_cache_engine:
         await rollout.resume(tags=["kv_cache"])
 
@@ -105,6 +122,7 @@ def _make_mocks(peft_config=None, params_by_base_sync_done=None):
         params_by_base_sync_done = {False: "fake_params", True: "fake_params"}
 
     actor_engine = MagicMock()
+    actor_engine.is_param_offload_enabled = False
 
     def _get_per_tensor_param(*args, **kwargs):
         base_sync_done = kwargs.get("base_sync_done", True)
@@ -234,8 +252,8 @@ class TestAdapterModeSubsequentIterations:
         assert rollout.update_weights.call_count == 1
         assert rollout.update_weights.call_args.kwargs["base_sync_done"] is True
 
-    def test_skips_weight_resume(self):
-        """With sleep_level=1, weight resume is skipped."""
+    def test_resumes_weight_memory(self):
+        """Weight memory is resumed before adapter deltas are synced."""
         peft_cfg = MagicMock()
         rollout, engine = _make_mocks(peft_config=peft_cfg)
         rollout.sleep_level = 1
@@ -250,9 +268,8 @@ class TestAdapterModeSubsequentIterations:
             )
         )
 
-        # Only kv_cache resume, no weight resume
         resume_calls = rollout.resume.call_args_list
-        assert call(tags=["weights"]) not in resume_calls
+        assert call(tags=["weights"]) in resume_calls
         assert call(tags=["kv_cache"]) in resume_calls
 
 
@@ -410,6 +427,53 @@ class TestEdgeCases:
         # Filter to only resume and update_weights calls
         actual = [c for c in rollout.mock_calls if c[0] in ("resume", "update_weights")]
         assert actual == expected
+
+    def test_actor_offload_before_weight_resume(self):
+        """Actor params are offloaded before rollout wakes weight memory."""
+        events = []
+
+        class FakeTensor:
+            def detach(self):
+                return self
+
+            def cpu(self):
+                events.append("materialize_weight")
+                return self
+
+        def fake_weights():
+            events.append("consume_generator")
+            yield "weight", FakeTensor()
+
+        rollout, engine = _make_mocks(
+            peft_config=None,
+            params_by_base_sync_done={False: fake_weights(), True: fake_weights()},
+        )
+        engine.is_param_offload_enabled = True
+        engine.to.side_effect = lambda *args, **kwargs: events.append(("actor_offload", args, kwargs))
+
+        async def _resume(*args, **kwargs):
+            events.append(("rollout_resume", args, kwargs))
+
+        rollout.resume.side_effect = _resume
+
+        asyncio.run(
+            _update_weights(
+                rollout=rollout,
+                actor_engine=engine,
+                peft_merge=False,
+                base_sync_done=True,
+                free_cache_engine=True,
+            )
+        )
+
+        assert events[0] == "consume_generator"
+        assert events[1] == "materialize_weight"
+        assert events[2] == (
+            "actor_offload",
+            ("cpu",),
+            {"model": True, "optimizer": False, "grad": False},
+        )
+        assert events[3] == ("rollout_resume", (), {"tags": ["weights"]})
 
     def test_global_steps_forwarded(self):
         """Verify global_steps is passed through to update_weights."""

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -700,14 +700,12 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             return
 
         set_expandable_segments(False)
-        log_gpu_memory_usage("Before resume weights", logger=logger)
 
-        # 1. resume rollout memory (weights were released during sleep)
-        if self.config.rollout.free_cache_engine:
-            await self.rollout.resume(tags=["weights"])
-        log_gpu_memory_usage("After resume weights", logger=logger)
+        def materialize_weights_to_cpu(weights):
+            # Consume lazy weight generators before actor offload without retaining full weights on device.
+            return [(name, tensor.detach().cpu()) for name, tensor in weights]
 
-        # 2. determine if we need a base weight sync (adapter path only)
+        # 1. determine if we need a base weight sync (adapter path only)
         per_tensor_param, peft_config = self.actor.engine.get_per_tensor_param(
             layered_summon=self.layered_summon, base_sync_done=True
         )
@@ -717,11 +715,29 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             self.rollout.sleep_level = 1
             do_lora_base_sync = not self.base_sync_done
 
-        # 3. sync weights: For SGLang, we need base first (when needed), then adapter/merged
+        # 2. prepare base sync params before actor offload: For SGLang, we need base first (when needed)
+        per_tensor_param_base = None
         if do_lora_base_sync:
-            per_tensor_param_base, peft_config = self.actor.engine.get_per_tensor_param(
+            per_tensor_param_base, peft_config_base = self.actor.engine.get_per_tensor_param(
                 layered_summon=self.layered_summon, base_sync_done=False
             )
+            peft_config = peft_config_base
+
+        # 3. offload actor model before rollout weight resume to reduce peak device memory
+        if self.actor.engine.is_param_offload_enabled:
+            per_tensor_param = materialize_weights_to_cpu(per_tensor_param)
+            if per_tensor_param_base is not None:
+                per_tensor_param_base = materialize_weights_to_cpu(per_tensor_param_base)
+            self.actor.engine.to("cpu", model=True, optimizer=False, grad=False)
+        aggressive_empty_cache(force_sync=True)
+
+        # 4. resume rollout memory (weights were released during sleep)
+        if self.config.rollout.free_cache_engine:
+            await self.rollout.resume(tags=["weights"])
+        log_gpu_memory_usage("After resume weights", logger=logger)
+
+        # 5. sync weights: base first (when needed), then adapter/merged
+        if do_lora_base_sync:
             await self.rollout.update_weights(
                 per_tensor_param_base, peft_config=peft_config, base_sync_done=False, global_steps=global_steps
             )
@@ -732,12 +748,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
 
         log_gpu_memory_usage("After update_weights", logger=logger)
 
-        # 3. offload model to cpu
-        if self.actor.engine.is_param_offload_enabled:
-            self.actor.engine.to("cpu", model=True, optimizer=False, grad=False)
-        aggressive_empty_cache(force_sync=True)
-
-        # 4. resume kv_cache
+        # 6. resume kv_cache
         if self.config.rollout.free_cache_engine:
             await self.rollout.resume(tags=["kv_cache"])
         log_gpu_memory_usage("After resume kv_cache", logger=logger)


### PR DESCRIPTION
### What

This PR changes the colocated actor/rollout weight-sync ordering in `ActorRolloutRefWorker.update_weights` to reduce peak device memory before rollout weight memory is resumed.

The new order is:

1. Build the actor weight generators needed for rollout update.
2. Consume those generators before actor offload and materialize tensors on CPU.
3. Offload actor parameters to CPU and clear cached device memory.
4. Resume rollout weight memory.
5. Sync rollout weights.
6. Resume rollout KV cache.

### Why

In colocated actor/rollout deployments with `free_cache_engine=True`, `rollout.resume(tags=["weights"])` wakes rollout weight memory. If this happens before actor parameters are offloaded, rollout weights and actor parameters can overlap in device memory and cause OOM.

I observed this on NPU/Ascend hardware with 64G per card, where memory headroom is smaller and this peak is easier to trigger.

### Historical context:

PR #5031 (`ef6eaa05`, `[ckpt] feat: add CheckpointEngineManager`) replaced the old direct `sleep()` / `wake_up()` rollout transition with the current `update_weights()` path in `ActorRolloutRefWorker`.

In that path, rollout weight memory is resumed before actor parameters are offloaded:

1. `rollout.resume(tags=["weights"])`
2. `actor.engine.get_per_tensor_param(...)`
3. `rollout.update_weights(...)`
4. `actor.engine.to("cpu", model=True, optimizer=False, grad=False)`
5. `rollout.resume(tags=["kv_cache"])`

This ordering can make rollout weights and actor parameters overlap in device memory. On NPU/Ascend 64G cards, this peak can trigger OOM. This PR keeps the weight-sync semantics but moves actor offload/cache cleanup before rollout weight resume.

### Generator handling

`get_per_tensor_param()` returns generators for several engines. To avoid lazy generator evaluation after actor offload, this PR consumes the generators before actor placement changes.

Instead of using `list(generator)` directly and retaining full model tensors on device, tensors are materialized as CPU copies via `tensor.detach().cpu()`. This keeps the weight stream independent from actor placement while preserving the lower device-memory peak.

### LoRA / SGLang behavior

The SGLang LoRA adapter path keeps the required base-first ordering:

1. Prepare adapter/merged params.
2. Prepare base params when base sync is needed.
3. Offload actor and resume rollout weight memory.
4. Sync base weights first, then adapter/merged weights.

### Tests

- `py -3.12 -m py_compile verl/workers/engine_workers.py tests/workers/test_engine_workers_lora_sync.py`
- `PYTHONUTF8=1 uv run --with pytest --no-project pytest tests/workers/test_engine_workers_lora_sync.py -q`
  - `17 passed`

### Notes

AI assistance was used to prepare and verify this change.