### PR TITLE
[Doc] Add Google-style docstrings for verl/utils modules (#1345)

### DIFF
--- a/verl/utils/activation_offload.py
+++ b/verl/utils/activation_offload.py
@@ -38,13 +38,35 @@ def _get_unique_tensor_key(tensor):
 
 
 class FSDPParameterFilter:
+    """Tensor filter that excludes tracked FSDP model parameters from being offloaded.
+
+    Attributes:
+        model_parameters_storage (set): Storage data pointers of the tracked model parameters.
+
+    """
+
     def __init__(self):
         self.model_parameters_storage = set()
 
     def __call__(self, tensor):
+        """Return whether the tensor should be offloaded.
+
+        Args:
+            tensor (torch.Tensor): The candidate tensor to check.
+
+        Returns:
+            bool: True if the tensor is not a tracked model parameter, otherwise False.
+
+        """
         return tensor.untyped_storage().data_ptr() not in self.model_parameters_storage
 
     def update_model_parameters(self, model):
+        """Refresh the set of tracked model parameter storages.
+
+        Args:
+            model (torch.nn.Module): The model whose parameter storages are recorded.
+
+        """
         new_storage = set()
         for p in model.parameters():
             new_storage.add(p.data.untyped_storage().data_ptr())
@@ -79,10 +101,28 @@ class CpuOffloadHookWithOffloadHandler:
         torch._C._autograd._pop_saved_tensors_default_hooks()
 
     def on_save_for_backward(self, tensor: torch.Tensor) -> Any:
+        """Offload a tensor saved for backward and return its retrieval identifier.
+
+        Args:
+            tensor (torch.Tensor): The tensor saved for the backward pass.
+
+        Returns:
+            Any: An identifier used later to recover the tensor.
+
+        """
         retrieve_identifier = self.offload_handler.tensor_push(tensor, **self.handler_extra_kwargs)
         return retrieve_identifier
 
     def on_get_saved_tensor(self, saved_state: Any) -> torch.Tensor:
+        """Recover a previously offloaded tensor for the backward pass.
+
+        Args:
+            saved_state (Any): The identifier returned by ``on_save_for_backward``.
+
+        Returns:
+            torch.Tensor: The recovered tensor.
+
+        """
         tensor = self.offload_handler.tensor_pop(saved_state, **self.handler_extra_kwargs)
         return tensor
 
@@ -117,7 +157,17 @@ class GroupCommitFunction(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, tensor, cpu_offload_handler):
-        # pylint: disable=missing-function-docstring
+        """Mark a forward group-commit point and pass the input tensor through.
+
+        Args:
+            ctx: Autograd context used to store the offload handler.
+            tensor (torch.Tensor): The input tensor, returned unchanged.
+            cpu_offload_handler: The handler that performs the group commit.
+
+        Returns:
+            torch.Tensor: The identical input tensor.
+
+        """
         cpu_offload_handler.on_group_commit_forward()
         ctx.cpu_offload_handler = cpu_offload_handler
         # return the identical tensor
@@ -125,7 +175,16 @@ class GroupCommitFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        # pylint: disable=missing-function-docstring
+        """Mark a backward group-commit point and pass the gradient through.
+
+        Args:
+            ctx: Autograd context holding the offload handler.
+            grad_output (torch.Tensor): The incoming gradient, returned unchanged.
+
+        Returns:
+            tuple: The gradient w.r.t. the input tensor and ``None`` for the handler.
+
+        """
         cpu_offload_handler = ctx.cpu_offload_handler
         cpu_offload_handler.on_group_commit_backward()
         return grad_output, None
@@ -261,6 +320,16 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
         self.h2d_stream = get_torch_device().Stream()
 
     def tensor_push(self, tensor: torch.Tensor, **kwargs) -> Any:
+        """Register a tensor for offloading and return its tracking tag.
+
+        Args:
+            tensor (torch.Tensor): The tensor to track and potentially offload.
+            **kwargs: Additional handler-specific options.
+
+        Returns:
+            Any: A tag identifying the stored tensor, or the tensor itself when not offloaded.
+
+        """
         torch_stray_tensor = isinstance(
             tensor,
             torch._subclasses.fake_tensor.FakeTensor | torch._subclasses.functional_tensor.FunctionalTensor,
@@ -371,6 +440,7 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
                     self.tensor_tag_to_state[tensor_label] = recovered_tensor
 
     def on_group_commit_backward(self):
+        """Reload offloaded groups and synchronize streams during the backward pass."""
         # first decrement the current group.
         # after last commit in forward, the group will +1; in backward it -1.
         # Finally it should be decremented to 0.
@@ -398,6 +468,19 @@ class AsyncDoubleBufferGroupOffloadHandler(SynchronizedGroupOffloadHandler):
 def get_activation_offload_context(
     num_layers: int = 1, model_layers: int = 1, tensor_need_offloading_checker=(lambda t: True)
 ):
+    """Create a CPU activation offloading context and its group-commit function.
+
+    Args:
+        num_layers (int): Number of layer groups to offload. Defaults to 1.
+        model_layers (int): Total number of model layers. Defaults to 1.
+        tensor_need_offloading_checker (Callable): Predicate deciding whether a
+            tensor should be offloaded. Defaults to always True.
+
+    Returns:
+        tuple: A ``(CpuOffloadHookWithOffloadHandler, group_prefetch_offload_commit_async)``
+        pair used to enable and synchronize activation offloading.
+
+    """
     cpu_offload_handler = AsyncDoubleBufferGroupOffloadHandler(
         num_offload_group=num_layers,
         num_model_group=model_layers,
@@ -405,6 +488,15 @@ def get_activation_offload_context(
     )
 
     def group_prefetch_offload_commit_async(tensor):
+        """Commit an asynchronous group prefetch/offload for the given tensor.
+
+        Args:
+            tensor (torch.Tensor): The tensor marking the group-commit point.
+
+        Returns:
+            torch.Tensor: The tensor passed through after the commit.
+
+        """
         return group_prefetch_offload_commit(tensor, cpu_offload_handler)
 
     return (
@@ -414,6 +506,16 @@ def get_activation_offload_context(
 
 
 class ActivationHandler:
+    """Manage activation offloading and optional checkpointing around a module's forward pass.
+
+    Args:
+        offload_ctx: The context manager that performs activation offloading.
+        sync_func (Callable): Function that marks the group-commit synchronization point.
+        tensor_filter (FSDPParameterFilter): Filter deciding which tensors to offload.
+        enable_ckpt (bool): Whether activation checkpointing is enabled.
+
+    """
+
     def __init__(self, offload_ctx, sync_func, tensor_filter, enable_ckpt):
         self._offload_ctx = offload_ctx
         self._sync_func = sync_func
@@ -426,11 +528,23 @@ class ActivationHandler:
             )
 
     def pre_forward(self, module):
+        """Enter the offload context before a training forward pass.
+
+        Args:
+            module (torch.nn.Module): The module about to run its forward pass.
+
+        """
         if module.training:
             self._offload_ctx.__enter__()
             self._tensor_filter.update_model_parameters(module)
 
     def post_forward(self, module):
+        """Exit the offload context after a training forward pass.
+
+        Args:
+            module (torch.nn.Module): The module that finished its forward pass.
+
+        """
         if module.training:
             self._offload_ctx.__exit__(None, None, None)
 
@@ -455,6 +569,7 @@ class ActivationHandler:
         flat_args, kwarg_keys = self._pack_kwargs(*args, **kwargs)
 
         def my_function(*inputs):
+            """Unpack flattened inputs and invoke the original forward method."""
             # unpack back into args and kwargs
             nonlocal forward_method, kwarg_keys
             unpacked_args, unpacked_kwargs = self._unpack_kwargs(inputs, kwarg_keys)
@@ -467,6 +582,18 @@ class ActivationHandler:
         )
 
     def forward(self, module, forward_method, *args, **kwargs):
+        """Run the module forward pass with optional checkpointing and offload sync.
+
+        Args:
+            module (torch.nn.Module): The module being executed.
+            forward_method (Callable): The original forward method to invoke.
+            *args: Positional arguments forwarded to ``forward_method``.
+            **kwargs: Keyword arguments forwarded to ``forward_method``.
+
+        Returns:
+            Any: The output of ``forward_method``, with the group-commit sync applied.
+
+        """
         if not module.training:
             return forward_method(*args, **kwargs)
         if not self._enable_ckpt:
@@ -483,11 +610,18 @@ class ActivationHandler:
         return final_ret
 
     def wrap_module_forward_method(self, module):
+        """Wrap a module's forward method to apply activation offloading hooks.
+
+        Args:
+            module (torch.nn.Module): The module whose forward method is wrapped in place.
+
+        """
         orig_method = module.forward
         handler = self
 
         @functools.wraps(orig_method)
         def wrapped_method(model_self, *args, **kwargs):
+            """Run pre/post forward offload hooks around the original forward method."""
             nonlocal handler
             handler.pre_forward(model_self)
             out = handler.forward(model_self, orig_method, *args, **kwargs)
@@ -522,6 +656,12 @@ def enable_activation_offloading(model, strategy, enable_ckpt=False):
     layers = []
 
     def get_layers(module):
+        """Recursively collect FSDP-wrapped transformer layers eligible for offloading.
+
+        Args:
+            module (torch.nn.Module): The module to traverse for FSDP-wrapped layers.
+
+        """
         for name, child in module.named_children():
             if not isinstance(child, FSDP | FSDP2):
                 get_layers(child)

--- a/verl/utils/chat_template.py
+++ b/verl/utils/chat_template.py
@@ -20,6 +20,7 @@ def initialize_system_prompt(tokenizer, **apply_chat_template_kwargs) -> list[in
 
     Returns:
         List of token IDs for the system prompt, or empty list if not supported
+
     """
     token1 = normalize_token_ids(
         tokenizer.apply_chat_template(
@@ -40,6 +41,18 @@ def initialize_system_prompt(tokenizer, **apply_chat_template_kwargs) -> list[in
 
 
 def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs):
+    """Extract the system prompt and generation prompt token ids from a tokenizer's chat template.
+
+    Args:
+        tokenizer: The tokenizer whose chat template is inspected.
+        **apply_chat_template_kwargs: Extra keyword arguments forwarded to ``apply_chat_template``.
+
+    Returns:
+        A tuple ``(system_prompt, generate_prompt)`` of token id lists, where ``system_prompt``
+        holds the tokens prepended before user messages and ``generate_prompt`` holds the tokens
+        appended to trigger generation.
+
+    """
     token1 = normalize_token_ids(
         tokenizer.apply_chat_template(
             [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
@@ -90,6 +103,7 @@ def apply_chat_template(
 
     Returns:
         list[int] | str: tokenized ids or text string.
+
     """
     try:
         return processor.apply_chat_template(

--- a/verl/utils/checkpoint/checkpoint_handler.py
+++ b/verl/utils/checkpoint/checkpoint_handler.py
@@ -31,6 +31,15 @@ from verl.workers.engine import BaseEngine
 
 
 def extract_step(path):
+    """Extract the global step number from a checkpoint path.
+
+    Args:
+        path: A filesystem path containing a ``global_step_<N>`` segment.
+
+    Returns:
+        The integer step number, or None if no match is found.
+
+    """
     match = re.search(r"global_step_(\d+)", path)
     if match:
         return int(match.group(1))
@@ -42,6 +51,8 @@ logger.setLevel(os.getenv("VERL_SFT_LOGGING_LEVEL", "WARN"))
 
 
 class OrchestrationMode(Enum):
+    """Orchestration modes for checkpoint handling."""
+
     SPMD = 0
     RAY = 1
 
@@ -141,6 +152,16 @@ class CheckpointHandler:
             torch.distributed.barrier()
 
     def load_checkpoint(self):
+        """Load a checkpoint and return the resumed global step.
+
+        Determine the resume path from configuration, load model and
+        dataloader states, and return the step number to resume from.
+
+        Returns:
+            The global step to resume training from, or 0 if no checkpoint
+            is found.
+
+        """
         # Determine resume path based on configuration
         checkpoint_path = self._determine_resume_path()
 

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -127,19 +127,52 @@ class BaseCheckpointManager:
         return "hf_model" in self.checkpoint_load_contents
 
     def load_checkpoint(self, local_path: str, hdfs_path: str = None, del_local_after_load: bool = False):
+        """Load a checkpoint from the given path.
+
+        Args:
+            local_path: Local directory containing the checkpoint.
+            hdfs_path: Optional HDFS path to download from.
+            del_local_after_load: If True, delete the local copy after loading.
+
+        """
         raise NotImplementedError
 
     def save_checkpoint(
         self, local_path: str, hdfs_path: str = None, global_step: int = 0, max_ckpt_to_keep: int = None
     ):
+        """Save a checkpoint to the given path.
+
+        Args:
+            local_path: Local directory to save the checkpoint.
+            hdfs_path: Optional HDFS path to upload to.
+            global_step: The current global training step.
+            max_ckpt_to_keep: Maximum number of checkpoints to retain.
+
+        """
         raise NotImplementedError
 
     @staticmethod
     def checkpath(local_path: str, hdfs_path: str):
+        """Validate and resolve the checkpoint path.
+
+        Args:
+            local_path: Local filesystem path.
+            hdfs_path: HDFS path.
+
+        Returns:
+            A tuple of (is_local, resolved_path).
+
+        """
         assert local_path is not None or hdfs_path is not None, "local_path and hdfs_path cannot be both None"
         return local_path is not None, local_path if local_path is not None else hdfs_path
 
     def remove_previous_save_local_path(self, path):
+        """Remove previously saved checkpoint directories from disk.
+
+        Args:
+            path: A single path string or list of paths to remove.
+
+        """
         if isinstance(path, str):
             path = [path]
         for p in path:
@@ -181,6 +214,12 @@ class BaseCheckpointManager:
 
     @staticmethod
     def get_rng_state():
+        """Collect the current RNG states for CPU, numpy, random, and device.
+
+        Returns:
+            A dictionary mapping source names to their RNG state objects.
+
+        """
         rng_state = {
             "cpu": torch.get_rng_state(),
             "numpy": np.random.get_state(),
@@ -194,6 +233,12 @@ class BaseCheckpointManager:
 
     @staticmethod
     def load_rng_state(rng_state):
+        """Restore RNG states from a previously saved state dict.
+
+        Args:
+            rng_state: A dictionary mapping source names to their RNG state objects.
+
+        """
         torch.set_rng_state(rng_state["cpu"])
         np.random.set_state(rng_state["numpy"])
         random.setstate(rng_state["random"])
@@ -214,6 +259,7 @@ def find_latest_ckpt_path(path, directory_format="global_step_{}"):
     Returns:
         str or None: Full path to the latest checkpoint directory, or
         None if the tracker or checkpoint folder is missing.
+
     """
     if path is None:
         return None
@@ -250,6 +296,7 @@ def should_save_ckpt_esi(max_steps_duration: float, save_ckpt_duration: float = 
         max_steps_duration: Max estimated time (seconds) required to complete one training step
         save_ckpt_duration: Estimated time (seconds) required to save checkpoint (default: 60)
         redundant_time: Additional buffer time (seconds) for unexpected delays (default: 0)
+
     """
     exp_ts_mlp = os.getenv("MLP_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP")  # vemlp
     exp_ts_aws = os.getenv("SAGEMAKER_CURRENT_CAPACITY_BLOCK_EXPIRATION_TIMESTAMP")  # aws

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -48,6 +48,7 @@ class FSDPConfig:
     Args:
         FSDP_version (int): Version of FSDP being used.
         world_size (int): Number of processes in the distributed training setup.
+
     """
 
     FSDP_version: int
@@ -72,6 +73,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             - 'load': Components to load; must contain 'model'. Defaults to ['model', 'optimizer', 'extra'].
             - 'save': Components to save; must contain 'model'. Defaults to ['model', 'optimizer', 'extra'].
         trust_remote_code: Whether to trust_remote_code when loading the model configuration
+
     """
 
     def __init__(
@@ -147,6 +149,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             local_path: Directory with per-rank checkpoint files.
             hdfs_path: Unused (for API compatibility).
             del_local_after_load: Remove local files after loading.
+
         """
         if local_path is None:
             return
@@ -234,6 +237,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             hdfs_path: Unused (for API compatibility).
             global_step: Current training step (used for bookkeeping).
             max_ckpt_to_keep: Number of recent checkpoints to retain.
+
         """
         if local_path is None:
             return

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -151,6 +151,30 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             shards for the ``model`` slot. Mirrors ``*.megatron.use_dist_checkpointing``.
         bridge: mbridge / Megatron-Bridge instance for HF save/load; required whenever
             checkpoint contents request HF-format model weights.
+
+    Attributes:
+        model: Reference to the Megatron model being checkpointed
+        optimizer: Reference to the optimizer (if provided)
+        lr_scheduler: Reference to the learning rate scheduler (if provided)
+        rank: Current process rank in the distributed setup
+
+    Example:
+        ```python
+        checkpoint_manager = MegatronCheckpointManager(
+            model=megatron_model,
+            optimizer=optimizer,
+            lr_scheduler=scheduler
+        )
+
+        checkpoint_manager.save_checkpoint(
+            local_path="checkpoints/step_1000",
+            global_step=1000
+        )
+
+        checkpoint_manager.load_checkpoint(
+            local_path="checkpoints/step_1000"
+        )
+        ```
     """
 
     def __init__(
@@ -808,6 +832,14 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         return None
 
     def load_rng_states(self, rng_states, data_parallel_random_init=False, use_dist_ckpt=True):
+        """Restore random number generator states from a checkpoint.
+
+        Args:
+            rng_states: The saved RNG state dict or sharded object.
+            data_parallel_random_init: If True, use per-DP-rank RNG states.
+            use_dist_ckpt: Whether distributed checkpointing format is used.
+
+        """
         if self.use_megatron_fsdp:
             pp_rank = mpu.get_pipeline_model_parallel_rank()
             tp_rank = mpu.get_tensor_model_parallel_rank()
@@ -860,6 +892,11 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         ``optimizer/dist_ckpt/``, ``extra/dist_ckpt/``) is loaded
         independently, and any pre-v2 layout is rejected upfront with a
         pointer at the migration script.
+
+        Args:
+            local_path: Local directory containing the checkpoint.
+            hdfs_path: Optional HDFS path (unused during load).
+            del_local_after_load: If True, delete the local checkpoint after loading.
         """
         if local_path is not None:
             assert os.path.exists(local_path), f"Checkpoint path {local_path} does not exist."
@@ -1189,7 +1226,14 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         fully-complete save (including async dist_checkpointing writes).
         See ``docs/advance/checkpoint.rst`` ("Locating saved contents") for
         the manifest schema.
+
+        Args:
+            local_path: Local directory to save the checkpoint.
+            hdfs_path: Optional HDFS path to upload the checkpoint to.
+            global_step: The current global training step.
+            max_ckpt_to_keep: Maximum number of checkpoints to retain.
         """
+        # record the previous global step
         self.previous_global_step = global_step
 
         if not self.checkpoint_config.async_save:

--- a/verl/utils/config.py
+++ b/verl/utils/config.py
@@ -31,6 +31,7 @@ def omega_conf_to_dataclass(config: DictConfig | dict, dataclass_type: Optional[
 
     Returns:
         The dataclass instance.
+
     """
     # Got an empty config
     if not config:
@@ -66,6 +67,13 @@ def omega_conf_to_dataclass(config: DictConfig | dict, dataclass_type: Optional[
 
 
 def update_dict_with_config(dictionary: dict, config: DictConfig):
+    """Update dictionary values in-place from a DictConfig for matching keys.
+
+    Args:
+        dictionary: Target dictionary to update.
+        config: Source DictConfig whose attributes override matching keys.
+
+    """
     for key in dictionary:
         if hasattr(config, key):
             dictionary[key] = getattr(config, key)
@@ -82,6 +90,7 @@ def validate_config(
         config (DictConfig): The OmegaConf DictConfig to validate.
         use_reference_policy (bool): is ref policy needed
         use_critic (bool): is critic needed
+
     """
     # number of GPUs total
     n_gpus = config.trainer.n_gpus_per_node * config.trainer.nnodes
@@ -127,6 +136,7 @@ def validate_config(
 
         Raises:
             ValueError: If both parameters are set or neither is set.
+
         """
         settings = {
             "actor_rollout_ref.ref": "log_prob_micro_batch_size",

--- a/verl/utils/dataset/dataset_utils.py
+++ b/verl/utils/dataset/dataset_utils.py
@@ -40,6 +40,18 @@ class SFTTensorCollator:
         self.pad_mode = pad_mode
 
     def __call__(self, batch: list[dict[str, any]]) -> dict[str, any]:
+        """Collate a list of samples into a batch according to the configured pad mode.
+
+        Args:
+            batch: A list of dictionary samples from the dataset.
+
+        Returns:
+            A dictionary representing the batched data.
+
+        Raises:
+            NotImplementedError: If the configured ``pad_mode`` is not supported.
+
+        """
         if self.pad_mode == DatasetPadMode.NO_PADDING:
             return self.collate_variable_batch(batch)
         elif self.pad_mode in [DatasetPadMode.RIGHT, DatasetPadMode.LEFT_RIGHT]:
@@ -59,6 +71,7 @@ class SFTTensorCollator:
         Returns:
             A dictionary representing the batched data, with variable-length
             sequences converted to NestedTensors.
+
         """
 
         final_batch = {}

--- a/verl/utils/dataset/multiturn_sft_dataset.py
+++ b/verl/utils/dataset/multiturn_sft_dataset.py
@@ -80,6 +80,7 @@ class MultiTurnSFTDataset(Dataset):
         config (DictConfig): Options like cache_dir, prompt_key, max_prompt_length, truncation, etc.
         processor (ProcessorMixin, optional): Multimodal preprocessor for images/videos.
         max_samples (int, optional): Limit the number of samples. Defaults to -1 (use all).
+
     """
 
     def __init__(
@@ -198,13 +199,13 @@ class MultiTurnSFTDataset(Dataset):
         Args:
             index: turn index in the conversation
             message: A single message dictionary
-            images: List of images to be used
-            videos: List of videos to be used
+            full_message: The full conversation message list for context
             tools: List of tools to be used
             enable_thinking: Whether to enable thinking mode
 
         Returns:
             Tuple of (input_ids, loss_mask, attention_mask, dict[str, torch.Tensor])
+
         """
         processor = self.processor if self.processor is not None else self.tokenizer
         apply_chat_template_kwargs = {**self.apply_chat_template_kwargs}
@@ -251,6 +252,7 @@ class MultiTurnSFTDataset(Dataset):
 
         Returns:
             messages: List of messages with replaced placeholder.
+
         """
         messages: list = convert_nested_value_to_list_recursive(example[self.messages_key])
         images = example[self.image_key] if self.image_key in example else []

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def collate_fn(data_list: list[dict]) -> dict:
-    """
+    r"""
     Collate a batch of sample dicts into batched tensors and arrays.
 
     Args:
@@ -48,6 +48,7 @@ def collate_fn(data_list: list[dict]) -> dict:
         Dict where tensor entries are stacked into a torch.Tensor of shape
         (batch_size, \\*dims) and non-tensor entries are converted to
         np.ndarray of dtype object with shape (batch_size,).
+
     """
     tensors = defaultdict(list)
     non_tensors = defaultdict(list)
@@ -83,6 +84,7 @@ class RLHFDataset(Dataset):
         tokenizer (PreTrainedTokenizer): For the tokenization of text to token IDs.
         config (DictConfig): Options like cache_dir, prompt_key, max_prompt_length, truncation, etc.
         processor (ProcessorMixin, optional): Multimodal preprocessor for images/videos.
+
     """
 
     def __init__(
@@ -194,6 +196,7 @@ class RLHFDataset(Dataset):
         self.dataframe = self.maybe_filter_out_long_prompts(self.dataframe)
 
     def maybe_filter_out_long_prompts(self, dataframe: datasets.Dataset = None):
+        """Filter out prompts exceeding the maximum prompt length."""
         # filter out too long prompts
         if self.filter_overlong_prompts:
             tokenizer = self.tokenizer
@@ -274,6 +277,7 @@ class RLHFDataset(Dataset):
         return dataframe
 
     def resume_dataset_state(self):
+        """Resume dataset state from checkpoint by re-downloading and re-tokenizing."""
         self.serialize_dataset = not hasattr(self, "original_data_files")
         # resume dataframe if not it's serialized in data.pt
         if not self.serialize_dataset:
@@ -305,9 +309,11 @@ class RLHFDataset(Dataset):
 
         Args:
             example: Row dictionary from dataframe.
+            key: The key in the example dict that contains the messages list.
 
         Returns:
             messages: List of messages with replaced placeholder.
+
         """
         messages: list = example[key]
         # When concatenating multimodal datasets, get will return None for samples without a modality column.
@@ -437,6 +443,7 @@ class RLHFDataset(Dataset):
         Returns:
             images: List of images.
             videos: List of videos, each video is a tuple of (video_tensor, video_metadata).
+
         """
         from qwen_vl_utils import process_vision_info
 
@@ -491,6 +498,7 @@ class RLHFDataset(Dataset):
         image_patch_size,
         config: DictConfig,
     ) -> tuple[list[Image.Image], list[Any], list[Any]]:
+        """Extract images, videos, and audios from messages asynchronously."""
         return cls._process_multi_modal_info(messages, image_patch_size=image_patch_size, config=config)
 
     def split(self, num_splits: int):
@@ -557,6 +565,7 @@ def get_dataset_class(data_config: DictConfig):
 
     Returns:
         dataset_cls: The dataset class.
+
     """
 
     # Check if a custom dataset class is specified in the data configuration

--- a/verl/utils/dataset/rm_dataset.py
+++ b/verl/utils/dataset/rm_dataset.py
@@ -24,6 +24,15 @@ from verl.utils import hf_tokenizer
 
 
 def download_files_distributed(download_fn):
+    """Run a download function once across distributed ranks.
+
+    When torch distributed is initialized, only rank 0 executes ``download_fn`` and all other ranks
+    wait at a barrier. Otherwise the function is executed unconditionally.
+
+    Args:
+        download_fn: A zero-argument callable that performs the download.
+
+    """
     import torch.distributed
 
     if torch.distributed.is_initialized():
@@ -38,6 +47,8 @@ def download_files_distributed(download_fn):
 
 
 class RMDataset(Dataset):
+    """Dataset for reward model training with chosen/rejected response pairs."""
+
     def __init__(
         self,
         parquet_files: str | list[str],

--- a/verl/utils/dataset/vision_utils.py
+++ b/verl/utils/dataset/vision_utils.py
@@ -20,6 +20,17 @@ from PIL import Image
 
 
 def process_image(image: dict | Image.Image, image_patch_size: int = 14) -> Image.Image:
+    """Normalize an image specification into a PIL image.
+
+    Args:
+        image: Either a PIL image or a dict describing the image (e.g. containing ``bytes`` or an
+            ``image`` field) as accepted by ``qwen_vl_utils.fetch_image``.
+        image_patch_size: The patch size used when fetching and resizing the image.
+
+    Returns:
+        The processed PIL image.
+
+    """
     from qwen_vl_utils import fetch_image
 
     if isinstance(image, Image.Image):
@@ -107,6 +118,24 @@ def process_video(
 
 
 def process_multi_modal_inputs_for_minicpmo(input_ids, attention_mask, position_ids, cu_seqlens, multi_modal_inputs):
+    """Reshape multi-modal inputs into the layout expected by MiniCPM-o.
+
+    Image bounds are shifted to account for left padding and cumulative sequence lengths, and
+    pixel values, target sizes, and image bounds are flattened/stacked for vision-language
+    alignment.
+
+    Args:
+        input_ids: The batched input token ids.
+        attention_mask: The attention mask used to determine left padding lengths.
+        position_ids: The position ids for the batch.
+        cu_seqlens: Cumulative sequence lengths used to offset image bounds.
+        multi_modal_inputs: A dict of multi-modal inputs containing ``image_bound``,
+            ``pixel_values``, and ``tgt_sizes``.
+
+    Returns:
+        A dict with a single ``data`` key holding the reshaped multi-modal inputs.
+
+    """
     # Adjust image bounds based on left padding and cumulative sequence lengths
     # This is necessary for MiniCPM-o's vision-language alignment
     left_padding_length = torch.argmax(attention_mask, dim=1)

--- a/verl/utils/debug/metrics.py
+++ b/verl/utils/debug/metrics.py
@@ -21,6 +21,17 @@ logger = logging.getLogger(__file__)
 
 
 def calculate_token_list_diff(tensor1: torch.Tensor, tensor2: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Calculate per-sample token difference counts between two tensors under a mask.
+
+    Args:
+        tensor1: First token tensor.
+        tensor2: Second token tensor.
+        mask: Binary mask indicating valid positions.
+
+    Returns:
+        Tensor of per-sample counts of differing tokens.
+
+    """
     # verify inputs
     if tensor1.numel() == 0 or tensor2.numel() == 0:
         return torch.zeros(tensor1.shape[0], dtype=torch.long, device=tensor1.device)
@@ -46,6 +57,19 @@ def calculate_token_list_diff(tensor1: torch.Tensor, tensor2: torch.Tensor, mask
 
 
 def pearson_correlation_coefficient(tensor1: torch.Tensor, tensor2: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Compute the Pearson correlation coefficient between two tensors under a mask.
+
+    Reference: https://arxiv.org/pdf/2506.13585
+
+    Args:
+        tensor1: First value tensor.
+        tensor2: Second value tensor.
+        mask: Boolean mask selecting valid positions.
+
+    Returns:
+        Scalar Pearson correlation coefficient, or 0 if shapes mismatch.
+
+    """
     # implemention of https://arxiv.org/pdf/2506.13585
     if tensor1.shape != tensor2.shape or mask.shape != tensor1.shape or mask.shape != tensor2.shape:
         return 0
@@ -56,6 +80,17 @@ def pearson_correlation_coefficient(tensor1: torch.Tensor, tensor2: torch.Tensor
 
 
 def calculate_log_prob_diff(log_probs1: torch.Tensor, log_probs2: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    """Compute the absolute log-probability differences at masked positions.
+
+    Args:
+        log_probs1: First log-probability tensor.
+        log_probs2: Second log-probability tensor.
+        mask: Boolean mask selecting valid positions.
+
+    Returns:
+        1-D tensor of absolute differences at masked positions.
+
+    """
     full_diff = torch.abs(log_probs1 - log_probs2)
     return torch.masked_select(full_diff, mask)
 
@@ -78,6 +113,7 @@ def calculate_debug_metrics(data: DataProto) -> dict:
             "training/rollout_probs_diff_mean": mean value of logprob diff of rollout vs. actor
             "training/rollout_probs_diff_std": std value of logprob diff of rollout vs. actor
             "training/rollout_actor_probs_pearson_corr": logprob's pearson corrcoef of rollout vs. actor, reference to https://arxiv.org/pdf/2506.13585
+
     """
 
     rollout_old_log_probs = data.batch["rollout_log_probs"]

--- a/verl/utils/debug/trajectory_tracker.py
+++ b/verl/utils/debug/trajectory_tracker.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Trajectory tracker can be inserted into code to save the intermediate results.
-The results will be dump to hdfs for offline comparison.
-Each process will have a client that first move all the tensors to CPU
+"""Trajectory tracker for saving intermediate results to HDFS.
+
+The tracker can be inserted into training code to persist tensors for
+offline comparison. Each process communicates with a Ray actor that
+serializes data and uploads it to HDFS.
 """
 
 import io
@@ -32,6 +33,18 @@ remote_copy = ray.remote(copy)
 
 @ray.remote
 def save_to_hdfs(data: io.BytesIO, name, hdfs_dir, verbose):
+    """Save a serialized tensor buffer to HDFS.
+
+    This is a Ray remote function that writes the buffer to a local temp file
+    and then copies it to the specified HDFS directory.
+
+    Args:
+        data: A BytesIO buffer containing the serialized tensor data.
+        name: Base name for the output file (without extension).
+        hdfs_dir: Target HDFS directory path.
+        verbose: Whether to print progress information.
+
+    """
     filename = name + ".pth"
     with tempfile.TemporaryDirectory() as tmpdirname:
         local_filepath = os.path.join(tmpdirname, filename)
@@ -49,7 +62,16 @@ def save_to_hdfs(data: io.BytesIO, name, hdfs_dir, verbose):
 
 @ray.remote
 class TrajectoryTracker:
+    """Ray actor that manages asynchronous tensor uploads to HDFS."""
+
     def __init__(self, hdfs_dir, verbose) -> None:
+        """Initialize the tracker.
+
+        Args:
+            hdfs_dir: HDFS directory where tensors will be stored.
+            verbose: Whether to print upload progress.
+
+        """
         self.hdfs_dir = hdfs_dir
         makedirs(hdfs_dir)
         self.verbose = verbose
@@ -57,16 +79,34 @@ class TrajectoryTracker:
         self.handle = deque()
 
     def dump(self, data: io.BytesIO, name):
+        """Submit a buffer for asynchronous upload to HDFS.
+
+        Args:
+            data: A BytesIO buffer containing serialized tensor data.
+            name: Base name for the output file.
+
+        """
         # get a temp file and write to it
         self.handle.append(save_to_hdfs.remote(data, name, self.hdfs_dir, self.verbose))
 
     def wait_for_hdfs(self):
+        """Block until all pending HDFS uploads have completed."""
         while len(self.handle) != 0:
             future = self.handle.popleft()
             ray.get(future)
 
 
 def dump_data(data, name):
+    """Serialize and upload data to HDFS via the global tracker.
+
+    This is a no-op unless the ``VERL_ENABLE_TRACKER`` environment variable
+    is set to ``"1"``.
+
+    Args:
+        data: Arbitrary data serializable by ``torch.save``.
+        name: Identifier used as the HDFS filename.
+
+    """
     enable = os.getenv("VERL_ENABLE_TRACKER", "0") == "1"
     if not enable:
         return
@@ -77,6 +117,17 @@ def dump_data(data, name):
 
 
 def get_trajectory_tracker():
+    """Get or create the global TrajectoryTracker Ray actor.
+
+    The actor is configured via environment variables:
+
+    - ``VERL_TRACKER_HDFS_DIR``: Target HDFS directory (required).
+    - ``VERL_TRACKER_VERBOSE``: Set to ``"1"`` for verbose output.
+
+    Returns:
+        TrajectoryTracker: A handle to the named Ray actor.
+
+    """
     hdfs_dir = os.getenv("VERL_TRACKER_HDFS_DIR", default=None)
     verbose = os.getenv("VERL_TRACKER_VERBOSE", default="0") == "1"
     assert hdfs_dir is not None
@@ -93,6 +144,7 @@ if __name__ == "__main__":
 
     @ray.remote
     def process(iter):
+        """Simulate a training process that dumps random tensor data."""
         data = {"obs": torch.randn(10, 20)}
         dump_data(data, f"process_{iter}_obs")
 

--- a/verl/utils/device.py
+++ b/verl/utils/device.py
@@ -44,6 +44,7 @@ def is_torch_npu_available(check_device=True) -> bool:
 
     Returns:
         bool: True if NPU is available, False otherwise.
+
     """
     try:
         if not hasattr(torch, "npu"):
@@ -106,6 +107,7 @@ def get_torch_device():
 
     Returns:
         module: The PyTorch device module (torch.cuda, torch.npu, etc.).
+
     """
     return get_platform().device_module
 
@@ -115,6 +117,7 @@ def get_device_id() -> int:
 
     Returns:
         int: The current device index (e.g., 0 for 'cuda:0').
+
     """
     return get_platform().current_device()
 
@@ -152,6 +155,7 @@ def auto_set_device(config) -> None:
 
     Args:
         config: Configuration object with trainer.device attribute.
+
     """
     if config and hasattr(config, "trainer") and hasattr(config.trainer, "device"):
         detected = get_platform().device_name
@@ -190,6 +194,7 @@ def get_npu_versions() -> tuple[str, str]:
 
     Raises:
         RuntimeError: If unable to retrieve version information
+
     """
     # Check npu-smi software version
     try:
@@ -283,6 +288,7 @@ def check_ipc_version_support(software_version: str, cann_version: str) -> bool:
 
     Raises:
         RuntimeError: If version format is invalid
+
     """
     # For software_version like "25.3.rc1.2", "25.5.0", or "25.5.t3.b001",
     # we need to extract the base version
@@ -330,6 +336,7 @@ def is_support_ipc() -> bool:
 
     Returns:
         bool: True if IPC is supported, False otherwise.
+
     """
     return get_platform().is_ipc_supported()
 

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -26,6 +26,13 @@ from verl.utils.net_utils import is_ipv6
 
 
 def set_numa_affinity():
+    """Bind the current process to the NUMA node of its local accelerator.
+
+    Use ``libnuma`` and ``pynvml`` to set the CPU affinity of the current process
+    according to the local device index. The call is skipped on NPU platforms and
+    degrades gracefully if the required libraries are unavailable.
+
+    """
     if is_npu_available:
         # TODO (FightingZhen) libnuma.so is not available in e2e_ascend CI image, remove this code after image update.
         return
@@ -58,6 +65,16 @@ def set_numa_affinity():
 
 
 def initialize_global_process_group(timeout_second=36000):
+    """Initialize the global distributed process group from environment variables.
+
+    Args:
+        timeout_second (int): Timeout in seconds for collective operations.
+            Defaults to 36000.
+
+    Returns:
+        tuple: A ``(local_rank, rank, world_size)`` tuple read from the environment.
+
+    """
     torch.distributed.init_process_group(
         get_nccl_backend(),
         timeout=timedelta(seconds=timeout_second),
@@ -73,11 +90,21 @@ def initialize_global_process_group(timeout_second=36000):
 
 
 def destroy_global_process_group():
+    """Destroy the global distributed process group if it has been initialized."""
     if torch.distributed.is_initialized():
         torch.distributed.destroy_process_group()
 
 
 def initialize_global_process_group_ray(timeout_second=None, backend=None):
+    """Initialize the global process group for use within a Ray environment.
+
+    Args:
+        timeout_second (int, optional): Timeout in seconds for collective
+            operations. Defaults to None, which uses the backend default.
+        backend (str, optional): The distributed backend specification. Defaults
+            to None, which selects a CPU/accelerator backend automatically.
+
+    """
     # in current ray environment, LOCAL_RANK is always zero.
 
     import torch.distributed

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -85,6 +85,13 @@ def _fused_linear_for_ppo_bwd(
 
 
 class FusedLinearForPPOFunction(torch.autograd.Function):
+    """Custom autograd function for memory-efficient fused linear PPO computation.
+
+    Computes per-token log probabilities and entropy in a chunked manner to
+    reduce peak memory usage when the vocabulary size is large.
+
+    """
+
     @staticmethod
     def forward(
         ctx,
@@ -94,6 +101,21 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
         temperature: float = 1.0,
         chunk_size: int = 512,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
+        """Compute per-token log probabilities and entropy in a chunked, memory-efficient manner.
+
+        Args:
+            ctx: The autograd context used to stash tensors for the backward pass.
+            hidden_states: Hidden states of shape ``[T, D]`` or ``[B, T, D]``.
+            vocab_weights: The output (vocabulary) projection weights.
+            input_ids: Target token ids matching the leading dimensions of ``hidden_states``.
+            temperature: Temperature applied to the logits before computing log probabilities.
+            chunk_size: Number of tokens processed per chunk to bound memory usage.
+
+        Returns:
+            A tuple ``(log_probs, entropy)`` with shapes matching the (flattened) token layout of
+            the inputs.
+
+        """
         ctx.set_materialize_grads(False)
 
         # Cast to a 2D tensor of the shape [T, D] for ease of working
@@ -143,6 +165,18 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dlog_probs: Optional[torch.FloatTensor], dentropy: Optional[torch.FloatTensor]):
+        """Compute gradients for the fused linear PPO forward pass.
+
+        Args:
+            ctx: The autograd context holding tensors saved during the forward pass.
+            dlog_probs: Upstream gradient w.r.t. the log probabilities, or None.
+            dentropy: Upstream gradient w.r.t. the entropy, or None.
+
+        Returns:
+            A tuple of gradients aligned with the forward inputs:
+            ``(dhidden_states, dvocab_weights, None, None, None)``.
+
+        """
         assert dlog_probs is not None or dentropy is not None
 
         hidden_states, vocab_weights, input_ids = ctx.saved_tensors
@@ -207,6 +241,13 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
 
 
 class FusedLinearForPPO(torch.nn.Module):
+    """Module wrapper for chunked fused linear PPO log-probability and entropy computation.
+
+    Args:
+        chunk_size: Number of tokens processed per chunk to bound memory usage.
+
+    """
+
     def __init__(self, chunk_size: int = 512):
         super().__init__()
 
@@ -219,6 +260,18 @@ class FusedLinearForPPO(torch.nn.Module):
         input_ids: torch.LongTensor,
         temperature: float = 1.0,
     ) -> tuple[torch.FloatTensor, torch.FloatTensor]:
+        """Compute per-token log probabilities and entropy using the chunked fused kernel.
+
+        Args:
+            hidden_states: Hidden states of shape ``[T, D]`` or ``[B, T, D]``.
+            vocab_weights: The output (vocabulary) projection weights.
+            input_ids: Target token ids matching the leading dimensions of ``hidden_states``.
+            temperature: Temperature applied to the logits before computing log probabilities.
+
+        Returns:
+            A tuple ``(log_probs, entropy)``.
+
+        """
         input_ids = input_ids.to(torch.int64)
         return FusedLinearForPPOFunction.apply(
             hidden_states,

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -52,10 +52,12 @@ def get_device_flops(unit="T", device_name=None):
             "G" - Giga (1e9)
             "T" - Tera (1e12, default)
             "P" - Peta (1e15)
+        device_name (str): Optional device name to look up FLOPS for; defaults to the current device when None.
 
     Returns:
         float: The theoretical FLOPS capacity of the current device in the specified unit.
         Returns float('inf') for unknown GPU types.
+
     """
 
     def unit_convert(number, level):
@@ -591,10 +593,12 @@ class FlopsCounter:
             batch_seqlens (List[int]): A list where each element represents the number of valid tokens in the
                 current batch.
             delta_time (float): The time taken to process the batch, in seconds.
+            **kargs: Additional keyword arguments forwarded to the model-specific FLOPS estimation function.
 
         Returns:
             estimated_flops (float): The estimated FLOPS based on the input tokens and time.
             promised_flops (float): The expected FLOPS of the current device.
+
         """
         tokens_sum = sum(batch_seqlens)
         func = ESTIMATE_FUNC.get(self.config.model_type, _estimate_unknown_flops)

--- a/verl/utils/fp8_utils.py
+++ b/verl/utils/fp8_utils.py
@@ -26,6 +26,8 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 
 class FP8QuantizerHelper:
+    """Base helper for determining which model parameters should be FP8-quantized."""
+
     def __init__(self, quant_config):
         self.quant_config = quant_config
 
@@ -93,6 +95,7 @@ class FP8QuantizerHelper:
 
         Yields:
             Tuples of (name, tensor) for each weight and its scale
+
         """
         if isinstance(self.quant_config, dict):
             weight_block_size = self.quant_config.get("weight_block_size")

--- a/verl/utils/fs.py
+++ b/verl/utils/fs.py
@@ -39,6 +39,7 @@ def is_non_local(path):
 
     Returns:
         bool: True if the path is an HDFS path, False otherwise.
+
     """
     return path.startswith(_HDFS_PREFIX)
 
@@ -54,6 +55,7 @@ def md5_encode(path: str) -> str:
 
     Returns:
         str: The hexadecimal MD5 hash of the path.
+
     """
     return hashlib.md5(path.encode()).hexdigest()
 
@@ -70,6 +72,7 @@ def get_local_temp_path(hdfs_path: str, cache_dir: str) -> str:
     Returns:
         str: Absolute local filesystem path in format:
             {cache_dir}/{md5(hdfs_path)}/{basename(hdfs_path)}
+
     """
     # make a base64 encoding of hdfs_path to avoid directory conflict
     encoded_hdfs_path = md5_encode(hdfs_path)
@@ -85,6 +88,7 @@ def verify_copy(src: str, dest: str) -> bool:
 
     return:
         bool: True if the copy is verified, False otherwise.
+
     """
     if not os.path.exists(src):
         return False
@@ -207,6 +211,7 @@ def copy_to_local(
 
     Returns:
         str: Local filesystem path to copied resource
+
     """
     # Save to a local path for persistence.
     local_path = copy_local_path_from_hdfs(src, cache_dir, filelock, verbose, always_recopy)
@@ -281,6 +286,7 @@ def local_mkdir_safe(path):
 
     Args:
         path (str): The path to create a directory at.
+
     """
 
     from filelock import FileLock

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -54,6 +54,15 @@ else:
 
 
 def init_fn(x: torch.nn.Module):
+    """Initialize a module on non-rank-0 processes by moving it to an empty device tensor.
+
+    Args:
+        x: The module to initialize.
+
+    Returns:
+        The initialized module.
+
+    """
     if torch.distributed.get_rank() != 0:
         x = x.to_empty(device=get_device_id(), recurse=False)
         get_torch_device().empty_cache()
@@ -61,6 +70,16 @@ def init_fn(x: torch.nn.Module):
 
 
 def get_init_weight_context_manager(use_meta_tensor=True, mesh: DeviceMesh = None):
+    """Return a context manager for initializing model weights.
+
+    Args:
+        use_meta_tensor: Whether to use meta tensors for non-rank-0 processes.
+        mesh: Optional device mesh for determining rank.
+
+    Returns:
+        A context manager for weight initialization.
+
+    """
     from accelerate import init_empty_weights
 
     cpu_init_weights = lambda: torch.device("cpu")
@@ -83,6 +102,7 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
         module: The module to get wrap policy for
         config: Configuration for wrap policy
         is_lora: Whether to enable lambda policy for LoRA modules
+
     """
     if config is None:
         config = {}
@@ -113,6 +133,15 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
     if is_lora:
 
         def lambda_policy_fn(module):
+            """Return whether the leaf module has a trainable weight (e.g. a LoRA module).
+
+            Args:
+                module (torch.nn.Module): The module to evaluate.
+
+            Returns:
+                bool: True if the module is a trainable leaf with a weight, otherwise False.
+
+            """
             return bool(
                 len(list(module.named_children())) == 0
                 and getattr(module, "weight", None) is not None
@@ -165,6 +194,13 @@ def get_fsdp_wrap_policy(module, config=None, is_lora=False):
 
 @torch.no_grad()
 def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
+    """Offload FSDP model parameters from GPU to CPU.
+
+    Args:
+        model: The FSDP-wrapped model to offload.
+        empty_cache: Whether to empty the device cache after offloading.
+
+    """
     if fsdp_version(model) == 2 or fsdp_version(model) == 0:
         offload_fsdp2_model_to_cpu(model, empty_cache)
         return
@@ -192,6 +228,13 @@ def offload_fsdp_model_to_cpu(model: FSDP, empty_cache: bool = True):
 
 @torch.no_grad()
 def offload_fsdp2_model_to_cpu(model, empty_cache: bool = True):
+    """Offload an FSDP2 model to CPU.
+
+    Args:
+        model: The FSDP2 model to offload.
+        empty_cache: Whether to empty the device cache after offloading.
+
+    """
     model.cpu()
     if empty_cache:
         get_torch_device().empty_cache()
@@ -199,6 +242,12 @@ def offload_fsdp2_model_to_cpu(model, empty_cache: bool = True):
 
 @torch.no_grad()
 def load_fsdp_model_to_gpu(model: FSDP):
+    """Load FSDP model parameters from CPU back to GPU.
+
+    Args:
+        model: The FSDP-wrapped model to load onto GPU.
+
+    """
     if fsdp_version(model) == 2 or fsdp_version(model) == 0:
         load_fsdp2_model_to_gpu(model)
         return
@@ -219,12 +268,24 @@ def load_fsdp_model_to_gpu(model: FSDP):
 
 @torch.no_grad()
 def load_fsdp2_model_to_gpu(model):
+    """Load an FSDP2 model to GPU.
+
+    Args:
+        model: The FSDP2 model to load onto GPU.
+
+    """
     device = get_device_id()
     model.to(device)
 
 
 @torch.no_grad()
 def offload_fsdp_optimizer(optimizer):
+    """Offload optimizer state tensors from GPU to CPU.
+
+    Args:
+        optimizer: The optimizer whose state should be offloaded.
+
+    """
     if not optimizer.state:
         return
     for param_group in optimizer.param_groups:
@@ -237,6 +298,13 @@ def offload_fsdp_optimizer(optimizer):
 
 @torch.no_grad()
 def load_fsdp_optimizer(optimizer, device_id):
+    """Load optimizer state tensors from CPU back to the specified device.
+
+    Args:
+        optimizer: The optimizer whose state should be loaded.
+        device_id: The target device identifier.
+
+    """
     if not optimizer.state:
         return
     for param_group in optimizer.param_groups:
@@ -261,6 +329,14 @@ def meta_device_init():
     registered = set()
 
     def register_empty_parameter(module, name, param):
+        """Register a parameter and move newly seen ones to the meta device.
+
+        Args:
+            module (torch.nn.Module): The module owning the parameter.
+            name (str): The parameter name.
+            param (torch.nn.Parameter): The parameter being registered.
+
+        """
         old_register_parameter(module, name, param)
         # we will skip register shared parameters as it
         # is already registered previously
@@ -346,6 +422,7 @@ def parallel_init_module_fn(module: torch.nn.Module, shard_states: dict[str, tor
 
     Returns:
         init_fn (Callable): a function to initialize sub-modules in the `module` with `shard_states`
+
     """
 
     state2fqn = {}
@@ -359,6 +436,17 @@ def parallel_init_module_fn(module: torch.nn.Module, shard_states: dict[str, tor
 
     @torch.no_grad()
     def create_and_sync_state(param_name, state, is_param):
+        """Create a parameter/buffer and broadcast its values from the owning rank.
+
+        Args:
+            param_name (str): The fully qualified name of the state to create.
+            state (torch.Tensor): The meta tensor describing the target shape and dtype.
+            is_param (bool): Whether the state is a parameter (True) or buffer (False).
+
+        Returns:
+            torch.Tensor: The materialized and synchronized parameter or buffer.
+
+        """
         assert param_name in shard_states, f"{param_name} not loaded"
         device = get_device_id()
         if is_param:
@@ -378,6 +466,16 @@ def parallel_init_module_fn(module: torch.nn.Module, shard_states: dict[str, tor
         return param
 
     def init_fn(sub_mod: torch.nn.Module, recurse: bool = True):
+        """Materialize meta parameters and buffers of a sub-module from shard states.
+
+        Args:
+            sub_mod (torch.nn.Module): The sub-module to initialize.
+            recurse (bool): Whether to recurse into child modules. Defaults to True.
+
+        Returns:
+            torch.nn.Module: The initialized sub-module.
+
+        """
         param_and_buffers = tuple(sub_mod.named_parameters(recurse=False)) + tuple(sub_mod.named_buffers(recurse=False))
         # param_and_buffers = sorted(sub_mod.named_parameters(recurse=False), key=lambda x: x[0])
         for name, state in param_and_buffers:
@@ -420,6 +518,15 @@ def parallel_init_module_fn(module: torch.nn.Module, shard_states: dict[str, tor
 
 
 def fsdp_version(model):
+    """Return the FSDP version used by the model.
+
+    Args:
+        model: The model to check.
+
+    Returns:
+        1 for FSDP v1, 2 for FSDP v2 (FSDPModule), or 0 otherwise.
+
+    """
     if isinstance(model, FSDP):
         return 1
     elif isinstance(model, FSDPModule):
@@ -429,6 +536,18 @@ def fsdp_version(model):
 
 
 def get_fsdp_state_ctx(model, state_type, state_cfg, optim_cfg):
+    """Return the appropriate state dict context manager for the model's FSDP version.
+
+    Args:
+        model: The FSDP model.
+        state_type: The state dict type.
+        state_cfg: The state dict configuration.
+        optim_cfg: The optimizer state dict configuration.
+
+    Returns:
+        A context manager for state dict operations.
+
+    """
     if fsdp_version(model) == 1:
         return FSDP.state_dict_type(model, state_type, state_cfg, optim_cfg)
     else:
@@ -449,6 +568,7 @@ def get_fsdp_full_state_dict(model: torch.nn.Module, offload_to_cpu: bool = True
 
     Raises:
         NotImplementedError: If the FSDP version is unknown
+
     """
     if fsdp_version(model) == 1:
         from torch.distributed.fsdp import FullStateDictConfig, StateDictType
@@ -479,6 +599,9 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
     Args:
         model (`torch.nn.Module`): The model to load the state dict into
         full_state (`dict`): The full state dict to load, can only be on rank 0
+        device_mesh: Optional device mesh describing the sharding layout of the model.
+        cpu_offload: Optional CPU offload setting controlling whether parameters are offloaded to CPU.
+
     """
 
     if version.parse(torch.__version__) >= version.parse("2.7.0"):
@@ -515,6 +638,15 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
 
 @contextmanager
 def maybe_patch_fsdp_module(model):
+    """Temporarily patch FSDPModule to support ABC-based models if needed.
+
+    Args:
+        model: The model that may require FSDPModule patching.
+
+    Yields:
+        None
+
+    """
     if fully_shard_module is None:
         yield
         return
@@ -522,6 +654,8 @@ def maybe_patch_fsdp_module(model):
     orig_fsdp_module = fully_shard_module.FSDPModule
 
     class FSDPModuleABC(ABC, orig_fsdp_module):
+        """FSDPModule subclass mixing in ABC so abstract FSDP models pass isinstance checks."""
+
         pass
 
     try:
@@ -603,6 +737,15 @@ def get_shard_placement_fn(fsdp_size):
     """Choose the dimension that can divide fsdp_size to avoid padding"""
 
     def shard_placement_fn(param):
+        """Pick a shard dimension divisible by fsdp_size to avoid padding.
+
+        Args:
+            param (torch.Tensor): The parameter to be sharded.
+
+        Returns:
+            Shard: The placement specifying the chosen shard dimension.
+
+        """
         shape = list(param.shape)
         for i in range(len(shape)):
             if shape[i] % fsdp_size == 0:
@@ -629,6 +772,15 @@ def fsdp2_clip_grad_norm_(parameters, max_norm, norm_type=2.0, error_if_nonfinit
 
 
 def layered_summon_lora_params(fsdp_module) -> OrderedDict:
+    """Extract LoRA parameters layer-by-layer from an FSDP module to reduce memory usage.
+
+    Args:
+        fsdp_module: The FSDP-wrapped module containing LoRA adapters.
+
+    Returns:
+        An ordered dictionary mapping parameter names to CPU tensors.
+
+    """
     from peft.utils.save_and_load import get_peft_model_state_dict
 
     def __prefix_submodules(module, prefix):
@@ -736,9 +888,11 @@ def replace_lora_wrapper(k, peft_config):
 
     Args:
         k (str): Original parameter key name.
+        peft_config: The PEFT/LoRA configuration used to identify target and excluded modules.
 
     Returns:
         str: Transformed parameter key for base layer.
+
     """
     stacked_params = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
     if k.endswith(".weight"):
@@ -766,6 +920,7 @@ def set_reshard_after_forward(module: FSDPModule, reshard_after_forward: bool, r
     to ``True`` for training.
 
     Args:
+        module (FSDPModule): The FSDP module whose reshard-after-forward behavior is set.
         reshard_after_forward (bool): Whether to reshard parameters after
             forward.
         recurse (bool): Whether to set for all FSDP submodules or just the
@@ -774,6 +929,7 @@ def set_reshard_after_forward(module: FSDPModule, reshard_after_forward: bool, r
     ---
     Copied from https://github.com/pytorch/pytorch/blob/main/torch/distributed/fsdp/_fully_shard/_fully_shard.py to
     address the absence of the set_reshard_after_forward function in torch versions earlier than 2.8.0.
+
     """
 
     if not isinstance(reshard_after_forward, bool):
@@ -819,6 +975,7 @@ def _merge_or_unmerge_lora_(module, merge: bool):
     Args:
         module: The module containing LoRA layers
         merge: If True, merge LoRA into base model; if False, unmerge LoRA
+
     """
     from peft.tuners.lora import LoraLayer
 
@@ -854,6 +1011,7 @@ def fsdp_merge_unmerge(module: nn.Module, do_merge: bool):
     Args:
         module: The FSDP module to merge/unmerge LoRA adapters
         do_merge: If True, merge LoRA into base model; if False, unmerge LoRA
+
     """
     version = fsdp_version(module)
     assert version in [1, 2], f"fsdp_merge_unmerge requires FSDP module, got version {version}"
@@ -890,6 +1048,7 @@ def collect_merged_lora_params(module: nn.Module) -> OrderedDict:
 
     Returns:
         OrderedDict mapping HF parameter names to CPU tensors.
+
     """
     ver = fsdp_version(module)
     assert ver in [1, 2], f"collect_merged_lora_params requires FSDP module, got version {ver}"
@@ -969,6 +1128,7 @@ def backup_base_model_weights(module):
 
     Returns:
         dict: Dictionary mapping parameter name to CPU tensor backup of base model weights
+
     """
     from peft import PeftModel
 
@@ -998,6 +1158,7 @@ def restore_base_model_weights(module, backup):
     Args:
         module: The PEFT model with LoRA adapters
         backup: Dictionary mapping parameter name to CPU tensor backup of base model weights
+
     """
     with torch.no_grad():
         for name, param in module.named_parameters():
@@ -1020,6 +1181,7 @@ def merged_lora_context(actor, backup_adapters=False):
 
     Yields:
         None
+
     """
     base_weights_backup = None
     if backup_adapters:
@@ -1054,6 +1216,7 @@ def fsdp2_sharded_save_to_cpu(
         cpu_sharded_state: Dictionary of CPU shards for the current process.
                           Key = parameter name, Value = (CPU shard tensor, original DTensorSpec)
         global_spec: DTensorSpec of the first parameter (used to verify global rules during loading)
+
     """
     cpu_sharded_state = {}
     global_spec = None  # Record global sharding rules (all parameters follow the same spec)
@@ -1097,6 +1260,7 @@ def fsdp2_sharded_load_from_cpu(
         cpu_sharded_state: Shard data read from CPU memory by the current process
                           (from fsdp2_sharded_save_to_cpu)
         target_spec: Global DTensorSpec from saving (used to verify sharding rule consistency)
+
     """
     # Verify device_mesh consistency (core: ensure loaded shards map to original GPUs)
     current_device_mesh = None

--- a/verl/utils/groupwise.py
+++ b/verl/utils/groupwise.py
@@ -36,6 +36,7 @@ Notes:
 - group_mean_std: pure-PyTorch per-group mean/std with Bessel correction for variance
   (denominator max(count-1, 1)). Singleton groups fallback to mean=0, std=1 for
   compatibility with common “native” conventions.
+
 """
 
 from __future__ import annotations
@@ -98,6 +99,7 @@ def as_torch_index(index: Any, device: torch.device | str | None = None) -> torc
 
     Returns:
         torch.LongTensor with shape (N,)
+
     """
     target = _resolve_device(device)
 
@@ -185,6 +187,7 @@ def group_mean_std(
         mean_g: (G,) float32
         std_g : (G,) float32
         count : (G,) float32
+
     """
     target = _resolve_device(device)
 

--- a/verl/utils/hdfs_io.py
+++ b/verl/utils/hdfs_io.py
@@ -31,9 +31,11 @@ def exists(path: str, **kwargs) -> bool:
 
     Args:
         path (str): path to test
+        **kwargs: Additional keyword arguments passed to the underlying implementation.
 
     Returns:
         bool: True if the path exists, False otherwise
+
     """
     if _is_non_local(path):
         return _exists(path, **kwargs)

--- a/verl/utils/import_utils.py
+++ b/verl/utils/import_utils.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Utilities to check if packages are available.
+"""Utilities to check if packages are available.
+
 We assume package availability won't change during runtime.
 """
 
@@ -26,6 +26,12 @@ from typing import Optional
 
 @cache
 def is_megatron_core_available():
+    """Check whether Megatron-Core is installed and importable.
+
+    Returns:
+        bool: True if ``megatron.core`` can be found, False otherwise.
+
+    """
     try:
         mcore_spec = importlib.util.find_spec("megatron.core")
     except ModuleNotFoundError:
@@ -35,6 +41,12 @@ def is_megatron_core_available():
 
 @cache
 def is_vllm_available():
+    """Check whether vLLM is installed and importable.
+
+    Returns:
+        bool: True if ``vllm`` can be found, False otherwise.
+
+    """
     try:
         vllm_spec = importlib.util.find_spec("vllm")
     except ModuleNotFoundError:
@@ -44,6 +56,12 @@ def is_vllm_available():
 
 @cache
 def is_sglang_available():
+    """Check whether SGLang is installed and importable.
+
+    Returns:
+        bool: True if ``sglang`` can be found, False otherwise.
+
+    """
     try:
         sglang_spec = importlib.util.find_spec("sglang")
     except ModuleNotFoundError:
@@ -53,6 +71,12 @@ def is_sglang_available():
 
 @cache
 def is_nvtx_available():
+    """Check whether NVTX is installed and importable.
+
+    Returns:
+        bool: True if ``nvtx`` can be found, False otherwise.
+
+    """
     try:
         nvtx_spec = importlib.util.find_spec("nvtx")
     except ModuleNotFoundError:
@@ -62,6 +86,12 @@ def is_nvtx_available():
 
 @cache
 def is_trl_available():
+    """Check whether TRL is installed and importable.
+
+    Returns:
+        bool: True if ``trl`` can be found, False otherwise.
+
+    """
     try:
         trl_spec = importlib.util.find_spec("trl")
     except ModuleNotFoundError:
@@ -71,6 +101,12 @@ def is_trl_available():
 
 @cache
 def is_msprobe_available():
+    """Check whether msprobe is installed and importable.
+
+    Returns:
+        bool: True if ``msprobe`` can be found, False otherwise.
+
+    """
     try:
         msprobe_spec = importlib.util.find_spec("msprobe")
     except ModuleNotFoundError:
@@ -79,6 +115,13 @@ def is_msprobe_available():
 
 
 def import_external_libs(external_libs=None):
+    """Import one or more external libraries by name.
+
+    Args:
+        external_libs: A single module name or a list of module names to import.
+            If None, this function is a no-op.
+
+    """
     if external_libs is None:
         return
     if not isinstance(external_libs, list):
@@ -107,6 +150,7 @@ def load_module(module_path: str, module_name: Optional[str] = None) -> object:
         module_name (str, optional):
             The name of the module to added to ``sys.modules``. If not provided, the module will not be added,
                 thus will not be cached and directly ``import``able.
+
     """
     if not module_path:
         return None
@@ -155,7 +199,7 @@ def _get_qualified_name(func):
 
 
 def deprecated(replacement: str = ""):
-    """Decorator to mark functions or classes as deprecated."""
+    """Mark a function or class as deprecated."""
 
     def decorator(obj):
         qualified_name = _get_qualified_name(obj)
@@ -196,6 +240,7 @@ def load_extern_object(module_path: str, object_name: str) -> object:
         module_path (str): See :func:`load_module`.
         object_name (str):
             The name of the object to load with ``getattr(module, object_name)``.
+
     """
     module = load_module(module_path)
 
@@ -223,6 +268,7 @@ def load_class_from_fqn(fqn: str, description: str = "class") -> type:
     Example:
         >>> cls = load_class_from_fqn("verl.experimental.agent_loop.AgentLoopManager")
         >>> instance = cls(config=config, ...)
+
     """
     if "." not in fqn:
         raise ValueError(
@@ -240,5 +286,5 @@ def load_class_from_fqn(fqn: str, description: str = "class") -> type:
 
 @deprecated(replacement="load_module(file_path); getattr(module, type_name)")
 def load_extern_type(file_path: str, type_name: str) -> type:
-    """DEPRECATED. Directly use `load_extern_object` instead."""
+    """Load an external type (deprecated, use ``load_extern_object`` instead)."""
     return load_extern_object(file_path, type_name)

--- a/verl/utils/kernel/fp8_kernel.py
+++ b/verl/utils/kernel/fp8_kernel.py
@@ -127,6 +127,7 @@ if _TRITON_AVAILABLE:
                 - quantized_tensor: FP8 quantized tensor of shape (M, N)
                 - scale_tensor: Per-block scale factors of shape (ceil(M/BLOCK_M), ceil(N/BLOCK_N))
                                This is the inverse scale (multiply to dequantize).
+
         """
         assert x.dim() == 2, f"Expected 2D tensor, got {x.dim()}D"
 
@@ -190,6 +191,7 @@ def scaled_fp8_blockwise_triton(
 
     Raises:
         RuntimeError: If Triton is not available.
+
     """
     if not _TRITON_AVAILABLE:
         raise RuntimeError("Triton is required for scaled_fp8_blockwise_triton but is not available")
@@ -243,6 +245,7 @@ def _scaled_fp8_blockwise_pytorch(
         Tuple of (fp8_data, descale):
             - fp8_data: FP8 quantized tensor
             - descale: Per-block descale factors for dequantization
+
     """
     block_size0 = weight_block_size[0]
     block_size1 = weight_block_size[1]
@@ -330,6 +333,7 @@ def scaled_fp8_blockwise(
         Tuple of (fp8_data, descale):
             - fp8_data: FP8 quantized tensor
             - descale: Per-block descale factors for dequantization
+
     """
     assert len(data_hp.shape) == 2, "Only 2d input tensor is supported"
 

--- a/verl/utils/kernel/kernels.py
+++ b/verl/utils/kernel/kernels.py
@@ -59,6 +59,7 @@ if not HAVE_TRITON:
 
     @contextmanager
     def null_decorator(*args, **kwargs):
+        """Provide a no-op decorator fallback when Triton is unavailable."""
         if len(kwargs) == 0 and len(args) == 1 and callable(args[0]):
             return args[0]
         else:
@@ -76,6 +77,17 @@ if not HAVE_TRITON:
 elif SUPPORT_CUDA_TMA:
     # TMA descriptors require a global memory allocation
     def alloc_fn(size: int, alignment: int, stream: typing.Optional[int]):
+        """Allocate device memory for Triton TMA descriptors.
+
+        Args:
+            size: Number of bytes to allocate.
+            alignment: Required memory alignment in bytes.
+            stream: Optional CUDA stream for the allocation.
+
+        Returns:
+            A byte tensor allocated on the current device.
+
+        """
         return torch.empty(size, device=get_device_name(), dtype=torch.int8)
 
     # https://github.com/triton-lang/triton/commit/43625fc968b693ab51884ca95adbcf3e43483fd0
@@ -163,6 +175,7 @@ class Config:
     Args:
         _backward (BackwardEnum): Backward computation method. Defaults to BackwardEnum._Split_Dlogits_N.
         _use_triton (bool): Whether to use Triton kernels for computation. Defaults to True.
+
     """
 
     _backward: BackwardEnum = BackwardEnum._Split_Dlogits_N
@@ -464,6 +477,7 @@ def efficient_entropy_triton_kernel_epilogue_tp(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
 ):
+    """Perform forward epilogue reduction for tensor-parallel cross entropy."""
     pid_m = tl.program_id(axis=0)
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -532,6 +546,7 @@ def efficient_entropy_triton_epilogue_tp_update(
     reduction: int,
     BLOCK_SIZE_M: tl.constexpr,
 ):
+    """Update log-probabilities and entropy after tensor-parallel all-reduce."""
     pid_m = tl.program_id(axis=0)
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -1137,6 +1152,7 @@ def efficient_entropy_backward_kernel_d_weight(
     BLOCK_SIZE_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
 ):
+    """Compute backward gradient with respect to the weight matrix."""
     pid = tl.program_id(axis=0)
     num_pid_n = tl.cdiv(vocab_size, BLOCK_SIZE_N)
     pid_n = pid % num_pid_n
@@ -1421,6 +1437,7 @@ def efficient_entropy_backward_kernel_general_d_logits_split_N(
     GROUP_SIZE_M: tl.constexpr,
     USE_TMA: tl.constexpr,
 ):
+    """Compute backward d_logits with vocabulary split along the N dimension."""
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(num_tokens, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(vocab_per_split, BLOCK_SIZE_N)

--- a/verl/utils/kernel/linear_cross_entropy.py
+++ b/verl/utils/kernel/linear_cross_entropy.py
@@ -36,6 +36,8 @@ import torch.distributed as dist
 
 
 class LinearCrossEntropy(torch.autograd.Function):
+    """Fused linear projection and cross-entropy loss with Triton kernels."""
+
     @staticmethod
     def forward(
         ctx,
@@ -46,19 +48,20 @@ class LinearCrossEntropy(torch.autograd.Function):
         reduction: typing.Optional[str] = "none",
         dist_process_group: typing.Optional[dist.ProcessGroup] = None,
     ) -> list[torch.Tensor]:
-        """_summary_
+        """Compute fused linear cross-entropy loss in the forward pass.
 
         Args:
-            ctx (_type_): _description_
-            hidden (torch.Tensor): (batch_size, num_tokens, hidden_size) -> (batch_size * num_tokens, hidden_size)
-            weight (torch.Tensor): (vocab_size, hidden_size)
-            labels (torch.Tensor): (batch_size, num_tokens) -> (batch_size * num_tokens, )
-            temperature (typing.Optional[float], optional): _description_. Defaults to 1.0.
-            reduction (typing.Optional[str], optional): _description_. Defaults to "none".
-            dist_process_group (typing.Optional[dist.ProcessGroup], optional): _description_. Defaults to None.
+            ctx: Autograd context for saving tensors.
+            hidden: Hidden states, shape ``(batch_size, num_tokens, hidden_size)``.
+            weight: Vocabulary projection weights, shape ``(vocab_size, hidden_size)``.
+            labels: Ground-truth token ids, shape ``(batch_size, num_tokens)``.
+            temperature: Softmax temperature scaling factor.
+            reduction: Reduction mode (``"none"``, ``"mean"``, or ``"sum"``).
+            dist_process_group: Optional process group for distributed vocab parallelism.
 
         Returns:
-            typing.List[torch.Tensor]: _description_
+            Tuple of log-probabilities and entropy tensors.
+
         """
 
         assert isinstance(temperature, float), f"temperature must be a float, but got {type(temperature)}"
@@ -88,6 +91,17 @@ class LinearCrossEntropy(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, dlogprobs: torch.Tensor, dentropy: torch.Tensor) -> list[torch.Tensor]:
+        """Compute gradients for the linear cross entropy operation.
+
+        Args:
+            ctx: Autograd context with saved tensors from the forward pass.
+            dlogprobs: Gradient with respect to the log-probabilities output.
+            dentropy: Gradient with respect to the entropy output.
+
+        Returns:
+            Gradients for hidden, weight, and None for non-differentiable inputs.
+
+        """
         from . import kernels
 
         with torch.cuda.nvtx.range("LinearCrossEntropy-backward"):

--- a/verl/utils/logger/aggregate_logger.py
+++ b/verl/utils/logger/aggregate_logger.py
@@ -24,6 +24,16 @@ import torch
 
 
 def concat_dict_to_str(dict: dict, step):
+    """Concatenate numeric values of a dict into a single log string.
+
+    Args:
+        dict (dict): Mapping of metric names to values; only numeric values are included.
+        step: The current step prefixed at the start of the output string.
+
+    Returns:
+        str: A formatted string joining the step and numeric metrics with ``-``.
+
+    """
     output = [f"step:{step}"]
     for k, v in dict.items():
         if isinstance(v, numbers.Number):
@@ -38,15 +48,28 @@ class LocalLogger:
 
     Args:
         print_to_console (bool): Whether to print to the console.
+
     """
 
     def __init__(self, print_to_console=True):
         self.print_to_console = print_to_console
 
     def flush(self):
+        """Flush the logger.
+
+        This is a no-op for the local logger and exists for interface compatibility.
+
+        """
         pass
 
     def log(self, data, step):
+        """Log the given data for a step to the console.
+
+        Args:
+            data (dict): Mapping of metric names to values to log.
+            step: The current step associated with the data.
+
+        """
         if self.print_to_console:
             print(concat_dict_to_str(data, step=step), flush=True)
 
@@ -61,6 +84,7 @@ class DecoratorLoggerBase:
         level (int): The logging level.
         rank (int): The rank of the process.
         log_only_rank_0 (bool): If True, only log for rank 0.
+
     """
 
     def __init__(
@@ -76,10 +100,25 @@ class DecoratorLoggerBase:
             self.logging_function = self.log_by_print
 
     def log_by_print(self, log_str):
+        """Log a message by printing it to standard output.
+
+        Args:
+            log_str (str): The message to print, prefixed with the logger role.
+
+        """
         if not self.log_only_rank_0 or self.rank == 0:
             print(f"{self.role} {log_str}", flush=True)
 
     def log_by_logging(self, log_str):
+        """Log a message using the configured logging.Logger instance.
+
+        Args:
+            log_str (str): The message to log, prefixed with the logger role.
+
+        Raises:
+            ValueError: If the logger has not been initialized.
+
+        """
         if self.logger is None:
             raise ValueError("Logger is not initialized")
         if not self.log_only_rank_0 or self.rank == 0:
@@ -104,6 +143,7 @@ def print_with_rank(message: str, rank: int = 0, log_only_rank_0: bool = False):
         message (str): _description_
         rank (int, optional): _description_. Defaults to 0.
         log_only_rank_0 (bool, optional): _description_. Defaults to False.
+
     """
     if not log_only_rank_0 or rank == 0:
         print(f"[Rank {rank}] {message}", flush=True)
@@ -118,6 +158,7 @@ def print_with_rank_and_timer(message: str, rank: int = 0, log_only_rank_0: bool
         message (str): _description_
         rank (int, optional): _description_. Defaults to 0.
         log_only_rank_0 (bool, optional): _description_. Defaults to False.
+
     """
     now = datetime.datetime.now()
     message = f"[{now.strftime('%Y-%m-%d %H:%M:%S')}] [Rank {rank}] {message}"
@@ -135,6 +176,7 @@ def log_with_rank(message: str, rank, logger: logging.Logger, level=logging.INFO
         logger (logging.Logger): The logger instance to use for logging.
         level (int, optional): The logging level. Defaults to logging.INFO.
         log_only_rank_0 (bool, optional): If True, only log for rank 0. Defaults to False.
+
     """
     if not log_only_rank_0 or rank == 0:
         logger.log(level, f"[Rank {rank}] {message}")

--- a/verl/utils/logging_utils.py
+++ b/verl/utils/logging_utils.py
@@ -26,6 +26,12 @@ def set_basic_config(level):
 
 
 def log_to_file(string):
+    """Print a string and append it to a per-rank log file under ``logs/``.
+
+    Args:
+        string: The message to print and log.
+
+    """
     print(string)
     if os.path.isdir("logs"):
         with open(f"logs/log_{torch.distributed.get_rank()}", "a+") as f:

--- a/verl/utils/megatron/dist_checkpointing.py
+++ b/verl/utils/megatron/dist_checkpointing.py
@@ -32,6 +32,7 @@ def save_dist_checkpointing(
     async_save=False,
     content_metadata=None,
 ):
+    """Save a sharded state dict using Megatron distributed checkpointing."""
     validate_sharding_integrity = True
     # Get checkpointing strategies
     save_strategy = get_default_save_sharded_strategy("torch_dist")
@@ -54,6 +55,7 @@ def save_dist_checkpointing(
 
 
 def load_dist_checkpointing(sharded_state_dict, ckpt_dir):
+    """Load a sharded state dict from a Megatron distributed checkpoint directory."""
     # Get checkpointing strategies
     load_strategy = get_default_load_sharded_strategy(ckpt_dir)
     load_strategy = FullyParallelLoadStrategyWrapper(

--- a/verl/utils/megatron/memory.py
+++ b/verl/utils/megatron/memory.py
@@ -18,6 +18,8 @@ from verl.utils.device import get_device_id
 
 
 class MemoryBuffer:
+    """Pre-allocated GPU buffer for contiguous gradient or parameter storage."""
+
     def __init__(self, numel, numel_padded, dtype):
         self.numel = numel
         self.numel_padded = numel_padded

--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -24,6 +24,7 @@ from verl.utils.logger import print_rank_0
 def init_megatron_optim_config(
     optim_config: dict, use_distributed_optimizer: bool = True, fp16: bool = False
 ) -> OptimizerConfig:
+    """Build a Megatron ``OptimizerConfig`` from a user-facing config dict."""
     optim_args = {
         "optimizer": optim_config.optimizer,
         "lr": optim_config.lr,
@@ -66,6 +67,7 @@ def get_megatron_optimizer(
     model,
     config: OptimizerConfig,
 ):
+    """Create a Megatron-native optimizer for the given model chunks."""
     # Base optimizer.
     return get_megatron_optimizer_native(
         config=config,

--- a/verl/utils/megatron/pipeline_parallel.py
+++ b/verl/utils/megatron/pipeline_parallel.py
@@ -20,6 +20,7 @@ from .sequence_parallel import pad_to_sequence_parallel
 
 
 def compute_transformers_input_shapes(batches, meta_info):
+    """Compute per-microbatch input shapes for pipeline-parallel transformer stages."""
     from flash_attn.bert_padding import unpad_input  # flash 2 is a must for Megatron
 
     # pre-compute input shapes for each micro-batch at each pp stage
@@ -60,6 +61,7 @@ def make_batch_generator(batches, vpp_size):
 
     Returns:
         An iterator or a list of iterators over the micro-batches.
+
     """
     if vpp_size > 1:
         # has vpp

--- a/verl/utils/megatron/router_replay_patch.py
+++ b/verl/utils/megatron/router_replay_patch.py
@@ -36,6 +36,8 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 
 
 class RouterReplayAction(Enum):
+    """Enumeration of possible router replay actions for MoE routing."""
+
     RECORD = "record"
     REPLAY_FORWARD = "replay_forward"
     REPLAY_BACKWARD = "replay_backward"
@@ -267,12 +269,16 @@ def patched_routing(self, logits: torch.Tensor, *args, **kwargs):
     """Top-k routing function
 
     Args:
+        self: The router module instance.
         logits (torch.Tensor): Logits tensor after gating.
+        *args: Positional arguments passed to the routing function.
+        **kwargs: Additional keyword arguments passed to the routing function.
 
     Returns:
         probs (torch.Tensor): The probabilities of token to experts assignment.
         routing_map (torch.Tensor): The mapping of token to experts assignment,
             with shape [num_tokens, num_experts].
+
     """
     seq_length, bsz = logits.shape[:2]
     logits = logits.view(-1, self.config.num_moe_experts)

--- a/verl/utils/megatron/router_replay_utils.py
+++ b/verl/utils/megatron/router_replay_utils.py
@@ -60,6 +60,7 @@ def get_num_layers_to_build(
 
     Returns:
         int: The number of layers to be built for the current pipeline stage.
+
     """
     # If we have a custom PP layout, straightforwardly
     # return the number of decoders in the layout array.
@@ -174,6 +175,7 @@ def get_num_layers_to_build(
 
 
 def is_moe_layer(tf_config, layer_idx):
+    """Determine whether the layer at *layer_idx* is a Mixture-of-Experts layer."""
     moe_layer_freq = getattr(tf_config, "moe_layer_freq", None)
 
     if isinstance(moe_layer_freq, int):
@@ -197,6 +199,7 @@ def get_moe_num_layers_to_build(
         pp_rank: Pipeline-parallel rank (None defaults to current).
     Returns:
         Number of MoE layers on the specified rank/stage.
+
     """
     total_layers = get_num_layers_to_build(config, vp_stage=vp_stage, pp_rank=pp_rank)
 
@@ -235,6 +238,7 @@ def merge_router_topk_indices(attention_mask, input_ids, mini_layer_topk_idx_lis
     Returns:
         None: The function has side effects only; it appends a tensor of shape
         [1, dynamic_bs_all, layer_num, topk] to mini_layer_topk_idx_list.
+
     """
     with torch.no_grad():
         router_instances_list = RouterReplayHelper.get_micro_batch_router_list(tf_config, vp_rank)
@@ -291,6 +295,7 @@ def set_router_replay_data(layers_topk_idx, attention_mask, tf_config, vp_rank=N
 
     Returns:
         None: The function updates internal RouterReplay instances in-place.
+
     """
     with torch.no_grad():
         fp8 = tf_config.fp8
@@ -365,6 +370,7 @@ def reorder_and_merge_vpp_layers(
     Raises:
         ValueError: If input tensor dimensionality or expected sizes do not match.
         RuntimeError: If the computed output shape is unexpected or the schedule length mismatches.
+
     """
     # 1) Build schedule table: map each virtual_microbatch_id -> (microbatch_id, model_chunk_id)
     schedule_table = get_schedule_table(num_microbatches, vpp_size, microbatch_group_size_per_vp_stage)
@@ -401,6 +407,7 @@ def get_current_rank_layer_info(tf_config, vp_rank=None):
     Returns:
         Tuple[dict, dict]: A tuple of (local_assignment, all_assignments) where local_assignment contains
         keys {"start", "end", "count"} for the current (pp_rank, vp_stage).
+
     """
     if vp_rank is None:
         vp_rank = 0
@@ -431,6 +438,7 @@ def pp_gather(local_layers_router_map, tf_config):
 
     Returns:
         torch.Tensor: Global router map of shape [bs, max_seq_len, num_layers, topk] placed on CPU.
+
     """
     pp_size = tf_config.pipeline_model_parallel_size
     if pp_size <= 1:
@@ -502,6 +510,7 @@ class RouterReplayHelper:
                 rank from Megatron parallel state is used when available.
         Returns:
             list: A contiguous sublist of RouterReplay.router_instances for the local layer range.
+
         """
         vp_size = tf_config.virtual_pipeline_model_parallel_size
         if vp_size is not None:

--- a/verl/utils/megatron/sequence_parallel.py
+++ b/verl/utils/megatron/sequence_parallel.py
@@ -19,10 +19,12 @@ from megatron.core import parallel_state as mpu
 
 
 def mark_parameter_as_sequence_parallel(parameter):
+    """Tag a parameter as belonging to a sequence-parallel partition."""
     parameter.sequence_parallel = True
 
 
 def is_sequence_parallel_param(param):
+    """Check whether a parameter is marked as sequence-parallel."""
     return hasattr(param, "sequence_parallel") and param.sequence_parallel
 
 

--- a/verl/utils/megatron/tensor_parallel.py
+++ b/verl/utils/megatron/tensor_parallel.py
@@ -28,11 +28,13 @@ if TYPE_CHECKING:
 
 
 def update_kwargs_with_config(dictionary: dict, config: "ModelParallelConfig"):
+    """Insert a ModelParallelConfig into a kwargs dictionary and return it."""
     dictionary["config"] = config
     return dictionary
 
 
 def get_default_kwargs_for_model_parallel_config():
+    """Return default kwargs for constructing a ``ModelParallelConfig``."""
     model_parallel_config_kwargs = {
         "params_dtype": torch.float32,
         "use_cpu_initialization": False,
@@ -44,12 +46,14 @@ def get_default_kwargs_for_model_parallel_config():
 
 
 def get_default_model_parallel_config():
+    """Create a ``ModelParallelConfig`` with default settings."""
     from megatron.core import ModelParallelConfig
 
     return ModelParallelConfig(**get_default_kwargs_for_model_parallel_config())
 
 
 def get_common_default_kwargs_for_parallel_linear():
+    """Return common default kwargs shared by column and row parallel linear layers."""
     default_model_parallel_config = get_default_model_parallel_config()
     common_default_kwargs = {
         "init_method": init.xavier_normal_,
@@ -61,6 +65,7 @@ def get_common_default_kwargs_for_parallel_linear():
 
 
 def get_default_kwargs_for_column_parallel_linear():
+    """Return default kwargs for ``ColumnParallelLinear``."""
     from megatron.core import ModelParallelConfig
 
     model_parallel_config_kwargs = get_default_kwargs_for_model_parallel_config()
@@ -77,11 +82,13 @@ def get_default_kwargs_for_column_parallel_linear():
 
 
 def get_default_kwargs_for_row_parallel_linear():
+    """Return default kwargs for ``RowParallelLinear``."""
     common_default_kwargs = get_common_default_kwargs_for_parallel_linear()
     return common_default_kwargs
 
 
 def get_default_kwargs_for_parallel_embedding():
+    """Return default kwargs for ``VocabParallelEmbedding``."""
     from megatron.core import ModelParallelConfig
 
     model_parallel_config_kwargs = get_default_kwargs_for_model_parallel_config()
@@ -93,15 +100,18 @@ def get_default_kwargs_for_parallel_embedding():
 
 
 def is_tensor_parallel_param(param):
+    """Check whether a parameter is marked as tensor-parallel."""
     return hasattr(param, "tensor_model_parallel") and param.tensor_model_parallel
 
 
 def get_tensor_parallel_partition_dim(param):
+    """Return the partition dimension of a tensor-parallel parameter."""
     assert is_tensor_parallel_param(param)
     return param.partition_dim
 
 
 def get_tensor_parallel_partition_stride(param):
+    """Return the partition stride of a tensor-parallel parameter."""
     assert is_tensor_parallel_param(param)
     return param.partition_stride
 
@@ -109,6 +119,8 @@ def get_tensor_parallel_partition_stride(param):
 class _VocabParallelEntropy(torch.autograd.Function):
     @staticmethod
     def forward(ctx, vocab_parallel_logits: torch.Tensor) -> torch.Tensor:
+        """Compute entropy from TP-sharded logits using numerically stable softmax."""
+
         @torch.compile(dynamic=True)
         def mul_reduce(a, b):
             return (a * b).sum(dim=-1, keepdim=True)
@@ -128,6 +140,7 @@ class _VocabParallelEntropy(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor) -> torch.Tensor:
+        """Compute gradient of entropy with respect to the TP-sharded logits."""
         vocab_parallel_logits, softmax_logits, sum_softmax_times_logits = ctx.saved_tensors
         # reuse softmax_logits as grad
         vocab_parallel_logits.sub_(sum_softmax_times_logits)
@@ -165,6 +178,7 @@ def vocab_parallel_sum_pi_squared(vocab_parallel_logits: torch.Tensor) -> torch.
     Implementation is non-destructive (does not mutate ``vocab_parallel_logits``) so it
     can be safely called before ``vocab_parallel_entropy`` / ``vocab_parallel_log_probs``
     which would otherwise consume the same tensor.
+
     """
     tp_group = mpu.get_tensor_model_parallel_group()
 

--- a/verl/utils/megatron_peft_utils.py
+++ b/verl/utils/megatron_peft_utils.py
@@ -76,6 +76,7 @@ def count_adapter_parameters(model):
 
     Returns:
         Tuple of (adapter_params, total_params, percentage)
+
     """
     from verl.utils.megatron_utils import unwrap_model
 
@@ -117,6 +118,7 @@ def convert_megatron_to_hf_target_modules(megatron_modules: list[str]) -> list[s
 
     Returns:
         List of HF-style module names with duplicates removed.
+
     """
     hf_target_modules = []
     for module in megatron_modules:
@@ -136,6 +138,7 @@ def build_peft_config_for_vllm(lora_config: dict) -> dict:
 
     Returns:
         A dictionary compatible with vLLM's PEFTHelper.from_dict().
+
     """
     from peft import TaskType
 
@@ -165,6 +168,7 @@ def add_base_layer_suffix(
     Args:
         params: Iterator of (param_name, tensor)
         model_type: The type of the model (e.g., "llama").
+
     """
     stacked_params = STACKED_PARAMS
     # TODO: other models may have more special treatment, or integrate this into Megatron-Bridge

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -52,6 +52,15 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def get_model_config(model):
+    """Return the config attribute of a (possibly wrapped) Megatron model.
+
+    Args:
+        model: The model whose ``config`` attribute is retrieved, even if wrapped.
+
+    Returns:
+        The model configuration object.
+
+    """
     return get_attr_wrapped_model(model, "config", allow_none=False)
 
 
@@ -222,6 +231,23 @@ def make_megatron_module(
     peft_cls: Any = None,
     peft_config: Any = None,
 ):
+    """Build a Megatron module from the given wrapper and transformer configs.
+
+    Args:
+        wrap_config: Configuration describing how to wrap the module (e.g. value model flag).
+        tf_config: The Megatron ``TransformerConfig`` for the module.
+        hf_config: The HuggingFace ``PretrainedConfig`` for the underlying model.
+        bridge: Optional Megatron-Bridge instance used to construct the model.
+        provider: Optional model provider used together with ``bridge``.
+        override_model_config: Optional dict of model config overrides.
+        override_ddp_config: Optional dict of DDP config overrides.
+        peft_cls: Optional PEFT callable applied before DDP wrapping.
+        peft_config: Optional PEFT configuration.
+
+    Returns:
+        The constructed (and optionally wrapped) Megatron module.
+
+    """
     from verl.models.mcore.config_converter import get_hf_rope_theta
 
     hf_config.rope_theta = get_hf_rope_theta(hf_config)
@@ -372,6 +398,16 @@ except ImportError:
 
 
 def unwrap_model(model, module_instances=ALL_MODULE_WRAPPER_CLASSNAMES):
+    """Unwrap a model (or list of models) from known Megatron wrapper classes.
+
+    Args:
+        model: A single model or list of models that may be wrapped.
+        module_instances: The wrapper classes to unwrap from.
+
+    Returns:
+        The unwrapped model, or a list of unwrapped models if a list was given.
+
+    """
     return_list = True
     if not isinstance(model, list):
         model = [model]
@@ -395,6 +431,7 @@ def convert_config(hf_config: PretrainedConfig, megatron_config) -> TransformerC
 
     Returns:
         TransformerConfig: _description_
+
     """
 
     warnings.warn("[deprecated] use config converter for more model support", stacklevel=2)
@@ -446,6 +483,16 @@ def mcore_model_parallel_config(
     sequence_parallel: bool,
     params_dtype: torch.dtype,
 ) -> ModelParallelConfig:
+    """Build a Megatron ``ModelParallelConfig`` from the current parallel state.
+
+    Args:
+        sequence_parallel: Whether sequence parallelism is enabled.
+        params_dtype: The dtype used for model parameters.
+
+    Returns:
+        A populated ``ModelParallelConfig``.
+
+    """
     # WARNING: Code should not reach this point. This function is deprecated and will be removed.
     # Please use hf_to_mcore_config_dense() from verl.models.mcore.config_converter instead.
     warnings.warn(
@@ -582,6 +629,7 @@ def load_megatron_model_to_gpu(models, load_grad=True, load_frozen_params=True):
         models: The model to load.
         load_grad: Whether to load gradients.
         load_frozen_params: Whether to load frozen parameters.
+
     """
     for model_chunk in models:
         if isinstance(model_chunk, DDP):
@@ -630,6 +678,7 @@ def offload_megatron_copy_params(optimizers):
 
     Args:
         optimizers: The optimizer or ChainedOptimizer instance.
+
     """
 
     def _iter_opts(opt):
@@ -670,6 +719,7 @@ def load_megatron_copy_params(optimizers):
 
     Args:
         optimizers: Optimizer or ChainedOptimizer instance.
+
     """
 
     def _iter_opts(opt):
@@ -706,6 +756,13 @@ def load_megatron_copy_params(optimizers):
 
 @torch.no_grad()
 def offload_megatron_optimizer(optimizers):
+    """Offload Megatron optimizer parameters and states to CPU memory.
+
+    Args:
+        optimizers: A Megatron optimizer or ``ChainedOptimizer`` whose state is moved to CPU.
+
+    """
+
     def _iter_opts(opt):
         if isinstance(opt, ChainedOptimizer):
             return opt.chained_optimizers
@@ -756,6 +813,13 @@ def offload_megatron_optimizer(optimizers):
 
 @torch.no_grad()
 def load_megatron_optimizer(optimizers):
+    """Load Megatron optimizer parameters and states back onto the device.
+
+    Args:
+        optimizers: A Megatron optimizer or ``ChainedOptimizer`` whose state is moved to the device.
+
+    """
+
     def _iter_opts(opt):
         if isinstance(opt, ChainedOptimizer):
             return opt.chained_optimizers
@@ -1067,6 +1131,18 @@ def convert_megatron_model_to_transformers_model(
 
 
 def broadcast_from_megatron_pp(tensor: torch.Tensor):
+    """Broadcast a tensor from the single pipeline-parallel rank that holds it.
+
+    Args:
+        tensor: The tensor on the owning pipeline rank, or None on all other ranks.
+
+    Returns:
+        The broadcast tensor, materialized on every pipeline-parallel rank.
+
+    Raises:
+        ValueError: If the tensor exists on more than one pipeline rank.
+
+    """
     # tensor is not None only in one of the pp ranks
     if tensor is not None:
         shape = tensor.shape
@@ -1104,6 +1180,18 @@ def broadcast_from_megatron_pp(tensor: torch.Tensor):
 
 
 def broadcast_str_from_megatron_pp(obj: Any):
+    """Broadcast a picklable object from the single pipeline-parallel rank that holds it.
+
+    Args:
+        obj: The object on the owning pipeline rank, or None on all other ranks.
+
+    Returns:
+        The broadcast object, available on every pipeline-parallel rank.
+
+    Raises:
+        ValueError: If the object exists on more than one pipeline rank.
+
+    """
     obj_output = [None] * mpu.get_pipeline_model_parallel_world_size()
     torch.distributed.all_gather_object(object_list=obj_output, obj=obj, group=mpu.get_pipeline_model_parallel_group())
 
@@ -1219,6 +1307,23 @@ def per_tensor_generator(
     layer_name_mapping,
     convert_qkv_gate_up_by_simple_split=True,
 ):
+    """Yield HuggingFace-format ``(name, tensor)`` pairs from a Megatron model.
+
+    Parameters are gathered across tensor/expert parallel groups and converted into the
+    HuggingFace layout one tensor at a time to bound peak memory usage.
+
+    Args:
+        actor_module: The (virtual) pipeline list of Megatron model chunks.
+        model_config: The model configuration.
+        weight_converter: Converter that maps Megatron weights to the HuggingFace layout.
+        transformer_config: The Megatron transformer configuration.
+        layer_name_mapping: Mapping between Megatron and HuggingFace layer names.
+        convert_qkv_gate_up_by_simple_split: Whether to split fused QKV/gate-up weights simply.
+
+    Yields:
+        Tuples of ``(name, tensor)`` in HuggingFace naming and layout.
+
+    """
     from megatron.core import parallel_state as mpu
 
     pp_rank = mpu.get_pipeline_model_parallel_rank()
@@ -1502,6 +1607,13 @@ def get_transformer_layer_offset(pipeline_rank, vp_stage, config: TransformerCon
 
 
 def register_megatron_training_hooks(model: list[torch.nn.Module], optimizer):
+    """Register Megatron grad-scale, grad-sync, and param-sync callbacks on the model config.
+
+    Args:
+        model: The list of Megatron model chunks to configure.
+        optimizer: The optimizer providing loss scaling and config used to set up the hooks.
+
+    """
     from megatron.core.distributed import finalize_model_grads
     from megatron.core.utils import get_model_config
 
@@ -1540,6 +1652,15 @@ def register_megatron_training_hooks(model: list[torch.nn.Module], optimizer):
 
 
 def mapping_string_to_attn_backend(args: dict) -> dict:
+    """Convert a string ``attention_backend`` entry into its ``AttnBackend`` enum value.
+
+    Args:
+        args: A dict that may contain an ``attention_backend`` key holding a string.
+
+    Returns:
+        The same dict with ``attention_backend`` converted to the enum when applicable.
+
+    """
     if "attention_backend" in args and isinstance(args["attention_backend"], str):
         from megatron.core.transformer.enums import AttnBackend
 
@@ -1548,6 +1669,15 @@ def mapping_string_to_attn_backend(args: dict) -> dict:
 
 
 def get_megatron_mtp_loss(n_micro_batch):
+    """Compute multi-token-prediction (MTP) loss metrics for logging.
+
+    Args:
+        n_micro_batch: The number of micro-batches used to scale the MTP loss.
+
+    Returns:
+        A dict mapping ``mtp_losses/<name>`` keys to scalar loss values.
+
+    """
     # Calculate MTP loss scale similar to Megatron-LM implementation
     mtp_loss_scale = 1.0 / n_micro_batch
 
@@ -1571,6 +1701,15 @@ def get_megatron_mtp_loss(n_micro_batch):
 
 
 def get_megatron_module_device(models: list[Any]) -> str:
+    """Determine the device type on which the Megatron model parameters reside.
+
+    Args:
+        models: The list of Megatron model chunks to inspect.
+
+    Returns:
+        The device type string (e.g. ``"gpu"`` or ``"cpu"``).
+
+    """
     if not models:
         return "cpu"
 
@@ -1741,6 +1880,7 @@ def patch_engine_mtp(module, model_config):
     Args:
         module: The model module to patch. Can be a single module or a list of modules.
         model_config: The model configuration containing MTP settings.
+
     """
     logger.warning("Applying mtp patch...")
     from verl.models.mcore.mtp_patch import (
@@ -1771,6 +1911,7 @@ def copy_megatron_model_to_cpu(models):
 
     Returns:
         dict: CPU state containing copied parameters and buffers
+
     """
     cpu_state = {}
 
@@ -1815,6 +1956,7 @@ def restore_megatron_model_from_cpu(models, cpu_state):
     Args:
         models: List of model chunks to restore to
         cpu_state: CPU state dict returned from copy_megatron_model_to_cpu
+
     """
     for model_idx, model_chunk in enumerate(models):
         chunk_key = f"model_chunk_{model_idx}"

--- a/verl/utils/memory_utils.py
+++ b/verl/utils/memory_utils.py
@@ -36,6 +36,7 @@ def aggressive_empty_cache(force_sync: bool = True, max_retries: int = 3) -> Non
     Args:
         force_sync: Whether to force device synchronization
         max_retries: Maximum number of retries
+
     """
     device = get_torch_device()
     if not device.is_available():
@@ -173,6 +174,7 @@ def enable_memory_visualize(
             memory history. `None` enables it for the current default device.
         record_context (bool): Whether to record context information for
             allocations. Required by older PyTorch versions.
+
     """
     # Memory history recording is accelerator-specific functionality
     device = get_torch_device()
@@ -239,6 +241,13 @@ def enable_memory_visualize(
 
 
 def clear_memory_history(trace_alloc_max_entries: int = 200_000, stack_depth: int = 32):
+    """Clear memory history and re-enable recording with fresh settings.
+
+    Args:
+        trace_alloc_max_entries: Maximum number of allocation entries to trace.
+        stack_depth: Maximum stack depth to record for each allocation.
+
+    """
     device = get_torch_device()
     if not device.is_available():
         logger.warning("[memory_visualize] Memory history recording is only available on accelerator devices")
@@ -260,6 +269,7 @@ class MemorySnapshotSampler:
     Args:
         out_dir (str): The directory where the snapshots will be saved.
         tag (str): A tag for the snapshot filenames.
+
     """
 
     def __init__(self, out_dir: str = "./mem_snapshots", tag: str = "periodic"):
@@ -277,6 +287,7 @@ class MemorySnapshotSampler:
                 The directory is created if it does not exist.
             tag (str): A string tag to prepend to the filename for easier identification.
             sub_dir (str): A subdirectory to place the snapshot file in.
+
         """
         if sub_dir is None:
             timestamp = datetime.now().strftime("%Y%m%d-%H%M")

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -45,6 +45,7 @@ def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, 
         ... }
         >>> reduce_metrics(metrics)
         {"loss": 2.0, "accuracy": 0.8, "max_reward": 8.0, "min_error": 0.05}
+
     """
     for key, val in metrics.items():
         if isinstance(val, Metric):
@@ -59,6 +60,8 @@ def reduce_metrics(metrics: dict[str, Union["Metric", list[Any]]]) -> dict[str, 
 
 
 class AggregationType(Enum):
+    """Supported aggregation strategies for metric reduction."""
+
     MEAN = "mean"
     SUM = "sum"
     MIN = "min"
@@ -87,6 +90,7 @@ class Metric:
         >>> metric.append(3.0)
         >>> metric.aggregate()
         2.0
+
     """
 
     def __init__(self, aggregation: str | AggregationType, value: Optional[Numeric | list[Numeric]] = None) -> None:
@@ -101,6 +105,7 @@ class Metric:
             self.append(value)
 
     def append(self, value: Union[Numeric, "Metric"]) -> None:
+        """Append a numeric value or merge another Metric instance."""
         if isinstance(value, Metric):
             self.extend(value)
             return
@@ -113,6 +118,7 @@ class Metric:
         self.values.append(value)
 
     def extend(self, values: Union["Metric", list[Numeric]]) -> None:
+        """Extend this metric with values from another Metric or a list."""
         if isinstance(values, Metric):
             if values.aggregation != self.aggregation:
                 raise ValueError(f"Aggregation type mismatch: {self.aggregation} != {values.aggregation}")
@@ -121,6 +127,7 @@ class Metric:
             self.append(value)
 
     def aggregate(self) -> float:
+        """Compute and return the aggregated value."""
         return self._aggregate(self.values, self.aggregation)
 
     @classmethod
@@ -137,6 +144,7 @@ class Metric:
 
     @classmethod
     def aggregate_dp(cls, metric_lists: list["Metric"]) -> float:
+        """Aggregate metrics across data-parallel ranks."""
         if not metric_lists:
             raise ValueError("Cannot aggregate an empty list of metrics.")
         value_lists = [ml.values for ml in metric_lists]
@@ -157,7 +165,9 @@ class Metric:
 
     @classmethod
     def from_dict(cls, data: dict[str, Numeric], aggregation: str | AggregationType) -> dict[str, "Metric"]:
+        """Create a dictionary of Metric instances from a dictionary of values."""
         return {key: cls(value=value, aggregation=aggregation) for key, value in data.items()}
 
     def init_list(self) -> "Metric":
+        """Return a new empty Metric with the same aggregation type."""
         return Metric(aggregation=self.aggregation)

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -60,15 +60,19 @@ _VARLEN_MULTI_MODAL_KEYS = {"input_features", "feature_attention_mask"}
 
 
 class LambdaLayer(nn.Module):
+    """Wrap an arbitrary callable as a ``torch.nn.Module``."""
+
     def __init__(self, fn):
         super().__init__()
         self.fn = fn
 
     def forward(self, *args, **kwargs):
+        """Apply the wrapped function to the inputs."""
         return self.fn(*args, **kwargs)
 
 
 def squeeze(x):
+    """Squeeze the last dimension of a tensor."""
     return torch.squeeze(x, dim=-1)
 
 
@@ -77,6 +81,7 @@ def update_model_config(module_config, override_config_kwargs):
     Args:
         module_config: The module config from Huggingface Transformers.
         override_config_kwargs: The kwargs to override the module config.
+
     """
     for key, val in override_config_kwargs.items():
         if isinstance(val, dict):
@@ -86,6 +91,17 @@ def update_model_config(module_config, override_config_kwargs):
 
 
 def get_huggingface_actor_config(model_name: str, override_config_kwargs=None, trust_remote_code=False) -> dict:
+    """Load a HuggingFace model config and apply optional overrides.
+
+    Args:
+        model_name: HuggingFace model name or path.
+        override_config_kwargs: Dict of config attributes to override.
+        trust_remote_code: Whether to trust remote code in the model repo.
+
+    Returns:
+        The modified ``PretrainedConfig`` object.
+
+    """
     if override_config_kwargs is None:
         override_config_kwargs = {}
     assert isinstance(override_config_kwargs, dict), (
@@ -101,6 +117,16 @@ def get_generation_config(
     model: str,
     trust_remote_code: bool = False,
 ) -> Optional[GenerationConfig]:
+    """Load a GenerationConfig for the given model, returning None if unavailable.
+
+    Args:
+        model: HuggingFace model name or path.
+        trust_remote_code: Whether to trust remote code in the model repo.
+
+    Returns:
+        GenerationConfig or None: The generation config if found.
+
+    """
     try:
         return GenerationConfig.from_pretrained(model)
     except OSError:  # Not found
@@ -118,8 +144,9 @@ def create_huggingface_actor(model_name: str, override_config_kwargs=None, autom
     """
 
     Args:
-        model_name:
-        override_config_kwargs:
+        model_name: The name or path of the HuggingFace pretrained model.
+        override_config_kwargs: Optional dict of config fields to override on the model config.
+        automodel_kwargs: Optional dict of keyword arguments passed to ``AutoModelForCausalLM.from_config``.
 
     Returns:
 
@@ -142,8 +169,9 @@ def create_huggingface_critic(model_name: str, override_config_kwargs=None, auto
     """
 
     Args:
-        model_name:
-        override_config_kwargs:
+        model_name: The name or path of the HuggingFace pretrained model.
+        override_config_kwargs: Optional dict of config fields to override on the model config.
+        automodel_kwargs: Optional dict of keyword arguments passed to ``AutoModelForCausalLM.from_config``.
 
     Returns:
 
@@ -161,6 +189,16 @@ def create_huggingface_critic(model_name: str, override_config_kwargs=None, auto
 
 
 def get_model_size(model: nn.Module, scale="auto"):
+    """Compute the number of parameters in a model with human-readable scaling.
+
+    Args:
+        model: The PyTorch model to measure.
+        scale: One of ``"auto"``, ``"B"``, ``"M"``, ``"K"``, or ``""``.
+
+    Returns:
+        tuple: A tuple of (scaled_param_count, scale_suffix).
+
+    """
     n_params = sum(p.numel() for p in model.parameters())
 
     if scale == "auto":
@@ -188,6 +226,13 @@ def get_model_size(model: nn.Module, scale="auto"):
 
 
 def print_model_size(model: nn.Module, name: str = None):
+    """Print the number of parameters in a model to stdout.
+
+    Args:
+        model: The PyTorch model to measure.
+        name: Display name for the model. Defaults to the class name.
+
+    """
     n_params, scale = get_model_size(model, scale="auto")
     if name is None:
         name = model.__class__.__name__
@@ -209,6 +254,9 @@ def create_random_mask(
     Args:
         input_ids:
             shape (batch_size, seq_len)
+        max_ratio_of_valid_token: Maximum fraction of the sequence length allowed to be valid (non-padding) tokens.
+        max_ratio_of_left_padding: Maximum fraction of the sequence length allowed to be left padding.
+        min_ratio_of_valid_token: Minimum fraction of the sequence length required to be valid tokens.
 
     Returns:
 
@@ -238,10 +286,29 @@ def create_random_mask(
 
 
 def compute_position_id_with_mask(mask):
+    """Compute position IDs from an attention mask via cumulative sum.
+
+    Args:
+        mask: Binary attention mask of shape (batch_size, seq_len).
+
+    Returns:
+        torch.Tensor: Position IDs of the same shape, starting from 0.
+
+    """
     return torch.clip(torch.cumsum(mask, dim=-1) - 1, min=0, max=None)
 
 
 def convert_weight_keys(state_dict: dict[str, torch.Tensor], model: PreTrainedModel):
+    """Convert state dict keys using the model's checkpoint conversion mapping.
+
+    Args:
+        state_dict: Original state dict with potentially new-format keys.
+        model: A HuggingFace model that may define ``_checkpoint_conversion_mapping``.
+
+    Returns:
+        dict[str, torch.Tensor]: State dict with keys converted to the model's expected format.
+
+    """
     # convert state dict keys: https://github.com/huggingface/transformers/pull/38385
     if not hasattr(model, "_checkpoint_conversion_mapping"):
         return state_dict
@@ -273,6 +340,7 @@ def check_exclude_modules(config, key: str) -> bool:
 
     Returns:
         True of match object if key matches any exclude modules from config, False if no match found
+
     """
     if hasattr(config, "exclude_modules") and config.exclude_modules:
         if isinstance(config.exclude_modules, str):
@@ -296,6 +364,7 @@ def check_target_modules(config, key: str) -> bool:
 
     Returns:
         True of match object if key matches any target modules from config, False if no match found
+
     """
     if isinstance(config.target_modules, str):
         target_module_found = re.fullmatch(config.target_modules, key)
@@ -384,6 +453,20 @@ def normalize_pp_vpp_params(params, num_hidden_layers, layer_name="layers"):
 def get_parallel_model_from_config(
     config, megatron_config, pre_process=None, post_process=None, share_embeddings_and_output_weights=False, value=False
 ):
+    """Create a parallel model from a HuggingFace config and Megatron parallel config.
+
+    Args:
+        config: HuggingFace ``PretrainedConfig``.
+        megatron_config: Megatron ``ModelParallelConfig``.
+        pre_process: Whether this rank handles input embedding.
+        post_process: Whether this rank handles the output layer.
+        share_embeddings_and_output_weights: Whether to tie embedding and output weights.
+        value: If True, create a value model (scalar output).
+
+    Returns:
+        nn.Module: The instantiated parallel model.
+
+    """
     from megatron.core import ModelParallelConfig
 
     assert isinstance(megatron_config, ModelParallelConfig)
@@ -467,6 +550,15 @@ def _load_hf_model(config, model_config, is_value_model):
 
 
 def get_hf_model_path(config):
+    """Resolve the local path for a HuggingFace model, downloading from HDFS if needed.
+
+    Args:
+        config: Configuration object with ``config.model.path``.
+
+    Returns:
+        str: Local filesystem path to the model.
+
+    """
     if config.model.path.startswith("hdfs:"):
         from verl.utils.fs import copy_to_local
 
@@ -522,6 +614,7 @@ def pad_packed_inputs(unpad_tokens: torch.Tensor, cu_seqlens, max_seqlen_in_batc
         unpad_tokens: (total_nnz, ...). Tokens after removing padding
         cu_seqlens: (total_nnz + 1,)
         max_seqlen_in_batch: int
+        size: The divisor that the total token length is padded to be a multiple of.
 
     Returns:
 
@@ -548,6 +641,15 @@ def pad_packed_inputs(unpad_tokens: torch.Tensor, cu_seqlens, max_seqlen_in_batc
 
 
 def load_mcore_dist_weights(parallel_model, dist_weight_path, is_value_model=False, prefix=""):
+    """Load distributed checkpoint weights into a Megatron-Core parallel model.
+
+    Args:
+        parallel_model: List of model chunks (one per virtual pipeline stage).
+        dist_weight_path: Path to the distributed checkpoint directory.
+        is_value_model: If True, skip loading the output layer.
+        prefix: Optional prefix for the sharded state dict keys.
+
+    """
     from megatron.core import dist_checkpointing
     from megatron.core.dist_checkpointing.serialization import StrictHandling
 
@@ -569,6 +671,20 @@ def load_mcore_dist_weights(parallel_model, dist_weight_path, is_value_model=Fal
 def get_parallel_gptmodel_from_config(
     tfconfig, hf_config, pre_process=None, post_process=None, share_embeddings_and_output_weights=False, value=False
 ):
+    """Create a Megatron-Core GPTModel from transformer and HuggingFace configs.
+
+    Args:
+        tfconfig: Megatron ``TransformerConfig``.
+        hf_config: HuggingFace ``PretrainedConfig`` for vocab/position info.
+        pre_process: Whether this rank handles input embedding.
+        post_process: Whether this rank handles the output layer.
+        share_embeddings_and_output_weights: Whether to tie embedding and output weights.
+        value: If True, replace the output layer with a scalar head.
+
+    Returns:
+        GPTModel: The instantiated Megatron-Core GPT model.
+
+    """
     from megatron.core.models.gpt.gpt_layer_specs import get_gpt_decoder_block_spec
     from megatron.core.models.gpt.gpt_model import GPTModel
 
@@ -605,6 +721,12 @@ def get_parallel_gptmodel_from_config(
 
 
 def patch_valuehead_model(model) -> None:
+    """Patch a TRL value-head model to work with verl's weight saving and generation.
+
+    Args:
+        model: An ``AutoModelForCausalLMWithValueHead`` instance to patch.
+
+    """
     from types import MethodType
 
     from transformers import PreTrainedModel
@@ -635,6 +757,18 @@ def patch_valuehead_model(model) -> None:
 
 
 def load_valuehead_model(local_path, torch_dtype, model_config, trust_remote_code):
+    """Load a value/reward model, falling back to TRL's value-head wrapper if needed.
+
+    Args:
+        local_path: Local path to the pretrained model.
+        torch_dtype: Torch dtype for model weights.
+        model_config: HuggingFace model configuration.
+        trust_remote_code: Whether to trust remote code.
+
+    Returns:
+        nn.Module: The loaded value model.
+
+    """
     from transformers import AutoModelForCausalLM, AutoModelForTokenClassification
 
     try:
@@ -684,6 +818,15 @@ _architecture_to_auto_class = {
 
 
 def get_hf_auto_model_class(hf_config):
+    """Determine the appropriate HuggingFace AutoModel class for a given config.
+
+    Args:
+        hf_config: A HuggingFace ``PretrainedConfig`` with architecture info.
+
+    Returns:
+        type: The AutoModel class (e.g., ``AutoModelForCausalLM``).
+
+    """
     has_remote_code = hasattr(hf_config, "auto_map") and any(
         hf_config.architectures[0] in val for val in hf_config.auto_map.values()
     )
@@ -815,6 +958,7 @@ def get_lora_rank_from_adapter(adapter_path: str | os.PathLike) -> int:
     Raises:
         FileNotFoundError: If adapter path or config file doesn't exist
         ValueError: If config file is invalid or missing rank
+
     """
     adapter_path = os.path.abspath(os.path.expanduser(str(adapter_path)))
 
@@ -839,5 +983,7 @@ def get_lora_rank_from_adapter(adapter_path: str | os.PathLike) -> int:
 
 @dataclass
 class CausalLMOutputForPPO(CausalLMOutputWithPast):
+    """Extend ``CausalLMOutputWithPast`` with log-probabilities and entropy for PPO."""
+
     log_probs: Optional[torch.FloatTensor] = None
     entropy: Optional[torch.FloatTensor] = None

--- a/verl/utils/modelopt/vllm_modelopt_patch.py
+++ b/verl/utils/modelopt/vllm_modelopt_patch.py
@@ -203,6 +203,7 @@ class ModelOptParamMetaDict(dict):
         return False
 
     def get(self, key: str, default=None):
+        """Retrieve a parameter by key, returning default if not found."""
         try:
             return self[key]
         except KeyError:
@@ -495,8 +496,8 @@ def _modelopt_kv_process_weights(self, layer) -> None:
     else:
         prob_scale = 1.0
 
-    is_singleton_float = (
-        lambda x: isinstance(x, float) or isinstance(x, torch.Tensor) and x.numel() == 1 and x.is_floating_point()
+    is_singleton_float = lambda x: (
+        isinstance(x, float) or isinstance(x, torch.Tensor) and x.numel() == 1 and x.is_floating_point()
     )
     if not is_singleton_float(q_scale) or not is_singleton_float(prob_scale):
         raise ValueError("Only support per-tensor scaling factor for fp8-quantized Q/prob")

--- a/verl/utils/net_utils.py
+++ b/verl/utils/net_utils.py
@@ -37,6 +37,7 @@ def is_ipv4(ip_str: str) -> bool:
 
     Returns:
         bool: Returns True if it's an IPv4 address, False otherwise
+
     """
     try:
         ipaddress.IPv4Address(ip_str)
@@ -54,6 +55,7 @@ def is_ipv6(ip_str: str) -> bool:
 
     Returns:
         bool: Returns True if it's an IPv6 address, False otherwise
+
     """
     try:
         ipaddress.IPv6Address(ip_str)
@@ -63,6 +65,15 @@ def is_ipv6(ip_str: str) -> bool:
 
 
 def is_valid_ipv6_address(address: str) -> bool:
+    """Check whether the given string is a valid IPv6 address.
+
+    Args:
+        address: The string to validate as an IPv6 address.
+
+    Returns:
+        True if the string is a valid IPv6 address, False otherwise.
+
+    """
     try:
         ipaddress.IPv6Address(address)
         return True

--- a/verl/utils/npu_flash_attn_utils.py
+++ b/verl/utils/npu_flash_attn_utils.py
@@ -20,8 +20,21 @@ from einops import rearrange, repeat
 
 # Copied from https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/bert_padding.py
 class IndexFirstAxis(torch.autograd.Function):
+    """Autograd function that gathers rows from the first axis by indices."""
+
     @staticmethod
     def forward(ctx, input, indices):
+        """Gather rows of the first axis of ``input`` at the given ``indices``.
+
+        Args:
+            ctx: Autograd context used to save tensors for the backward pass.
+            input (torch.Tensor): Input tensor of shape ``(first_axis_dim, ...)``.
+            indices (torch.Tensor): 1D tensor of row indices to gather.
+
+        Returns:
+            torch.Tensor: The gathered rows reshaped to ``(len(indices), ...)``.
+
+        """
         ctx.save_for_backward(indices)
         assert input.ndim >= 2
         ctx.first_axis_dim, other_shape = input.shape[0], input.shape[1:]
@@ -34,6 +47,16 @@ class IndexFirstAxis(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        """Scatter the gradient back to the original first-axis positions.
+
+        Args:
+            ctx: Autograd context holding the saved ``indices``.
+            grad_output (torch.Tensor): Gradient w.r.t. the gathered output.
+
+        Returns:
+            tuple: Gradient w.r.t. ``input`` and ``None`` for ``indices``.
+
+        """
         (indices,) = ctx.saved_tensors
         assert grad_output.ndim >= 2
         other_shape = grad_output.shape[1:]
@@ -54,8 +77,22 @@ index_first_axis = IndexFirstAxis.apply
 
 # Copied from https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/bert_padding.py
 class IndexPutFirstAxis(torch.autograd.Function):
+    """Autograd function that scatters values into the first axis by indices."""
+
     @staticmethod
     def forward(ctx, values, indices, first_axis_dim):
+        """Place ``values`` into a zero tensor at the given first-axis ``indices``.
+
+        Args:
+            ctx: Autograd context used to save tensors for the backward pass.
+            values (torch.Tensor): Values to scatter, of shape ``(len(indices), ...)``.
+            indices (torch.Tensor): 1D tensor of target row indices.
+            first_axis_dim (int): Size of the first axis of the output tensor.
+
+        Returns:
+            torch.Tensor: Output tensor of shape ``(first_axis_dim, ...)``.
+
+        """
         ctx.save_for_backward(indices)
         assert indices.ndim == 1
         assert values.ndim >= 2
@@ -67,6 +104,16 @@ class IndexPutFirstAxis(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        """Gather the gradient at the positions that were scattered in forward.
+
+        Args:
+            ctx: Autograd context holding the saved ``indices``.
+            grad_output (torch.Tensor): Gradient w.r.t. the scattered output.
+
+        Returns:
+            tuple: Gradient w.r.t. ``values`` and ``None`` for the other inputs.
+
+        """
         (indices,) = ctx.saved_tensors
         # TD [2022-03-04] For some reason torch.gather is a bit faster than indexing.
         grad_values = grad_output[indices]
@@ -87,6 +134,7 @@ def pad_input(hidden_states, indices, batch, seqlen):
         seqlen: int, maximum sequence length for the padded sequence.
     Return:
         hidden_states: (batch, seqlen, ...)
+
     """
     # dim = hidden_states.shape[-1]
     # output = torch.zeros((batch * seqlen), dim, device=hidden_states.device, dtype=hidden_states.dtype)
@@ -108,6 +156,7 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
         cu_seqlens: (batch + 1), the cumulative sequence lengths, used to index into hidden_states.
         max_seqlen_in_batch: int
         seqused: (batch), returns the number of tokens selected in attention_mask + unused_mask.
+
     """
     all_masks = (attention_mask + unused_mask) if unused_mask is not None else attention_mask
     seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -75,6 +75,7 @@ class TorchMemoryToolConfig(BaseConfig):
     Args:
         trace_alloc_max_entries (int): Maximum number of memory allocation entries to track.
         stack_depth (int): Stack trace depth for memory allocations.
+
     """
 
     trace_alloc_max_entries: int = 100_000
@@ -173,6 +174,7 @@ class ProfilerConfig(BaseConfig):
         all_ranks (bool): Whether to profile all ranks.
         ranks (list[int]): The ranks that will be profiled. Defaults to [].
         global_tool_config (Any): Global tool configuration for all profiling tools.
+
     """
 
     tool: Optional[str] = MISSING
@@ -184,6 +186,15 @@ class ProfilerConfig(BaseConfig):
     global_tool_config: Optional[Any] = None  # Global tool configuration for all profiling tools
 
     def union(self, other: "ProfilerConfig") -> "ProfilerConfig":
+        """Merge two configs, enabling profiling if either config enables it.
+
+        Args:
+            other: The other configuration to merge with.
+
+        Returns:
+            A new :class:`ProfilerConfig` with combined settings.
+
+        """
         assert self.tool == other.tool, f"Cannot union ProfilerConfig with different tools: {self.tool} vs {other.tool}"
         return ProfilerConfig(
             tool=self.tool,
@@ -196,6 +207,15 @@ class ProfilerConfig(BaseConfig):
         )
 
     def intersect(self, other: "ProfilerConfig") -> "ProfilerConfig":
+        """Intersect two configs, enabling profiling only if both configs enable it.
+
+        Args:
+            other: The other configuration to intersect with.
+
+        Returns:
+            A new :class:`ProfilerConfig` with intersected settings.
+
+        """
         assert self.tool == other.tool, (
             f"Cannot intersect ProfilerConfig with different tools: {self.tool} vs {other.tool}"
         )
@@ -230,6 +250,7 @@ def build_vllm_profiler_args(profiler_config: ProfilerConfig, tool_config: BaseC
 
     Returns:
         dict: A dictionary of arguments to be passed to vLLM's start_profile method.
+
     """
     if not profiler_config or not tool_config or not hasattr(tool_config, "contents"):
         return {}
@@ -283,6 +304,7 @@ def build_sglang_profiler_args(profiler_config: ProfilerConfig, tool_config: Bas
 
     Returns:
         dict: A dictionary of arguments suitable for starting the SGLang profiler.
+
     """
     if not profiler_config or not tool_config or not hasattr(tool_config, "contents"):
         return {}

--- a/verl/utils/profiler/empty_annotations.py
+++ b/verl/utils/profiler/empty_annotations.py
@@ -21,10 +21,25 @@ def mark_start_range(
     domain: Optional[str] = None,
     category: Optional[str] = None,
 ) -> None:
+    """Start a profiling range marker (no-op placeholder).
+
+    Args:
+        message: Message to associate with the range marker.
+        color: Color for the marker visualization.
+        domain: Domain for the marker.
+        category: Category for the marker.
+
+    """
     pass
 
 
 def mark_end_range(range_id: str) -> None:
+    """End a profiling range marker (no-op placeholder).
+
+    Args:
+        range_id: Identifier of the range to end.
+
+    """
     pass
 
 
@@ -34,6 +49,19 @@ def mark_annotate(
     domain: Optional[str] = None,
     category: Optional[str] = None,
 ) -> Callable:
+    """Decorate a function with profiling annotation (no-op placeholder).
+
+    Args:
+        message: Message to associate with the annotation.
+        color: Color for the marker visualization.
+        domain: Domain for the marker.
+        category: Category for the marker.
+
+    Returns:
+        A decorator that returns the original function unchanged.
+
+    """
+
     def decorator(func):
         return func
 

--- a/verl/utils/profiler/mstx_profile.py
+++ b/verl/utils/profiler/mstx_profile.py
@@ -33,6 +33,7 @@ def mark_start_range(message: Optional[str] = None) -> None:
     Args:
         message (str, optional):
             The message to be displayed in the profiler. Defaults to None.
+
     """
     return mstx.range_start(message=message)
 
@@ -43,6 +44,7 @@ def mark_end_range(range_id: str) -> None:
     Args:
         range_id (str):
             The id of the mark range to end.
+
     """
     return mstx.range_end(range_id)
 
@@ -53,6 +55,7 @@ def mark_annotate(message: Optional[str] = None) -> Callable:
     Args:
         message (str, optional):
             The message to be displayed in the profiler. Defaults to None.
+
     """
 
     def decorator(func):
@@ -72,9 +75,12 @@ def marked_timer(name: str, timing_raw: dict[str, float], *args: Any, **kwargs: 
     Args:
         name (str): The name/identifier for this timing measurement.
         timing_raw (Dict[str, float]): Dictionary to store timing information.
+        *args: Additional positional arguments (unused).
+        **kwargs: Additional keyword arguments (unused).
 
     Yields:
         None: This is a context manager that yields control back to the code block.
+
     """
     if args:
         logging.warning(f"Args are not supported in mstx_profile, but received: {args}")
@@ -112,6 +118,7 @@ def get_npu_profiler(
             The role of the current data collection. Defaults to None.
         profile_step(str, optional):
             The current training step. Defaults to None.
+
     """
     if profile_level == "level_none":
         level = torch_npu.profiler.ProfilerLevel.Level_none
@@ -173,6 +180,8 @@ class NPUProfiler(DistProfiler):
             rank (int): The rank of the current process.
             config (Optional[ProfilerConfig]): Configuration for the profiler. If None, a default configuration is used.
             tool_config (NPUToolConfig): The config to control npu profiler behavior.
+            **kwargs: Additional keyword arguments (unused).
+
         """
         if not config:
             config = ProfilerConfig(ranks=[], enable=False)
@@ -186,6 +195,12 @@ class NPUProfiler(DistProfiler):
         self.analysis = tool_config.analysis
 
     def start(self, **kwargs):
+        """Start the NPU profiler in continuous mode.
+
+        Args:
+            **kwargs: Keyword arguments; ``role`` specifies the profiling role.
+
+        """
         role = kwargs.get("role", None)
         if not self.discrete and NPUProfiler._define_count == 0:
             self.profile_npu = get_npu_profiler(
@@ -199,6 +214,7 @@ class NPUProfiler(DistProfiler):
             NPUProfiler._define_count += 1
 
     def stop(self):
+        """Stop the NPU profiler and export the trace in continuous mode."""
         if not self.discrete and NPUProfiler._define_count == 1:
             self.profile_npu.step()
             self.profile_npu.stop()
@@ -215,6 +231,8 @@ class NPUProfiler(DistProfiler):
                 The message to be displayed in the profiler. Defaults to None.
             role (str, optional):
                 The role of the current data collection. Defaults to None.
+            **kwargs_outer: Additional keyword arguments (unused).
+
         """
 
         def decorator(func):

--- a/verl/utils/profiler/nvtx_profile.py
+++ b/verl/utils/profiler/nvtx_profile.py
@@ -42,6 +42,7 @@ def mark_start_range(
             The domain of the range. Defaults to None.
         category (str, optional):
             The category of the range. Defaults to None.
+
     """
     return nvtx.start_range(message=message, color=color, domain=domain, category=category)
 
@@ -52,6 +53,7 @@ def mark_end_range(range_id: str) -> None:
     Args:
         range_id (str):
             The id of the mark range to end.
+
     """
     return nvtx.end_range(range_id)
 
@@ -73,6 +75,7 @@ def mark_annotate(
             The domain of the range. Defaults to None.
         category (str, optional):
             The category of the range. Defaults to None.
+
     """
 
     def decorator(func):
@@ -104,6 +107,7 @@ def marked_timer(
 
     Yields:
         None: This is a context manager that yields control back to the code block.
+
     """
     mark_range = mark_start_range(message=name, color=color, domain=domain, category=category)
     from .performance import _timer
@@ -121,6 +125,9 @@ class NsightSystemsProfiler(DistProfiler):
         Args:
             rank (int): The rank of the current process.
             config (Optional[ProfilerConfig]): Configuration for the profiler. If None, a default configuration is used.
+            tool_config (Optional[NsightToolConfig]): Nsight tool-specific configuration.
+            **kwargs: Additional keyword arguments.
+
         """
         # If no configuration is provided, create a default ProfilerConfig with an empty list of ranks
         if not config:
@@ -130,10 +137,17 @@ class NsightSystemsProfiler(DistProfiler):
         self.discrete: bool = tool_config.discrete
 
     def start(self, **kwargs):
+        """Start the CUDA profiler in continuous mode.
+
+        Args:
+            **kwargs: Additional keyword arguments (unused).
+
+        """
         if not self.discrete:
             get_platform().profiler_start()
 
     def stop(self):
+        """Stop the CUDA profiler in continuous mode."""
         if not self.discrete:
             get_platform().profiler_stop()
 
@@ -159,6 +173,8 @@ class NsightSystemsProfiler(DistProfiler):
                 The domain of the range. Defaults to None.
             category (str, optional):
                 The category of the range. Defaults to None.
+            **kwargs_outer: Additional keyword arguments passed to the decorator.
+
         """
 
         def decorator(func):

--- a/verl/utils/profiler/performance.py
+++ b/verl/utils/profiler/performance.py
@@ -38,6 +38,7 @@ def _get_current_mem_info(unit: str = "GB", precision: int = 2) -> tuple[str]:
     Returns:
         tuple[str]: A tuple containing memory allocated, memory reserved, memory used, and memory total
         in the specified unit.
+
     """
     assert unit in ["GB", "MB", "KB"]
     device = get_torch_device()
@@ -68,6 +69,7 @@ def log_gpu_memory_usage(head: str, logger: logging.Logger = None, level=logging
         logger (logging.Logger, optional): Logger instance to use for logging. If None, prints to stdout.
         level: Logging level to use. Defaults to logging.DEBUG.
         rank (int): The rank of the process to log memory for. Defaults to 0.
+
     """
     if (not dist.is_initialized()) or (rank is None) or (dist.get_rank() == rank):
         mem_allocated, mem_reserved, mem_used, mem_total = _get_current_mem_info()
@@ -91,6 +93,7 @@ class GPUMemoryLogger(DecoratorLoggerBase):
         >>> def update_actor(self, batch):
         ...     # real actor update logics
         ...     return
+
     """
 
     def __init__(self, role: str, logger: logging.Logger = None, level=logging.DEBUG, log_only_rank_0: bool = True):
@@ -101,12 +104,30 @@ class GPUMemoryLogger(DecoratorLoggerBase):
         super().__init__(role, logger, level, rank, log_only_rank_0)
 
     def __call__(self, decorated_function: callable):
+        """Wrap a function to log GPU memory usage around its execution.
+
+        Args:
+            decorated_function: The function to decorate with memory logging.
+
+        """
+
         def f(*args, **kwargs):
             return self.log(decorated_function, *args, **kwargs)
 
         return f
 
     def log(self, func, *args, **kwargs):
+        """Log GPU memory usage before and after executing a function.
+
+        Args:
+            func: The function to execute and log around.
+            *args: Positional arguments forwarded to *func*.
+            **kwargs: Keyword arguments forwarded to *func*.
+
+        Returns:
+            The return value of *func*.
+
+        """
         name = func.__name__
         mem_allocated, mem_reserved, mem_used, mem_total = _get_current_mem_info()
         message = (
@@ -128,6 +149,12 @@ class GPUMemoryLogger(DecoratorLoggerBase):
 
 
 def log_print(ctn: Any):
+    """Print a message with timestamp, filename, line number, and function name.
+
+    Args:
+        ctn: The content to print.
+
+    """
     current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
     frame = inspect.currentframe().f_back
@@ -143,6 +170,7 @@ def _timer(name: str, timing_raw: dict[str, float]):
     Args:
         name (str): The name/identifier for this timing measurement.
         timing_raw (Dict[str, float]): Dictionary to store timing information.
+
     """
     with Timer(name=name, logger=None) as timer:
         yield
@@ -164,6 +192,7 @@ def simple_timer(name: str, timing_raw: dict[str, float]):
 
     Yields:
         None: This is a context manager that yields control back to the code block.
+
     """
     yield from _timer(name, timing_raw)
 
@@ -191,6 +220,7 @@ def marked_timer(
 
     Yields:
         None: This is a context manager that yields control back to the code block.
+
     """
     yield from _timer(name, timing_raw)
 
@@ -205,9 +235,11 @@ def reduce_timing(
 
     Args:
         timing_raw (Dict[str, float]): Dictionary containing timing information.
+        reduce_op (torch.distributed.ReduceOp): The reduction operation to apply. Defaults to AVG.
 
     Returns:
         Dict[str, float]: Reduced timing information.
+
     """
     if not dist.is_initialized():
         return timing_raw
@@ -241,6 +273,15 @@ def topk_reduce_ratio_min_max(timing: float, k: int = 10) -> tuple[float, float,
 
 
 def gather_timing(timing_raw: dict[str, float]) -> dict[str, list[float]]:
+    """Gather timing information from all ranks into per-key lists.
+
+    Args:
+        timing_raw: Dictionary mapping timer names to elapsed seconds.
+
+    Returns:
+        A dictionary mapping each timer name to a list of values from all ranks.
+
+    """
     if not dist.is_initialized():
         return {k: [v] for k, v in timing_raw.items()}
 

--- a/verl/utils/profiler/precision_debugger_profile.py
+++ b/verl/utils/profiler/precision_debugger_profile.py
@@ -167,6 +167,18 @@ class PrecisionDebuggerProfiler:
         return True
 
     def start(self, stage: Optional[str] = None, global_step: Optional[int] = None, model=None, **kwargs) -> bool:
+        """Start precision debugging for the given stage and model.
+
+        Args:
+            stage: The training stage name (e.g. ``actor_update``).
+            global_step: The current global training step.
+            model: The model to attach the debugger to.
+            **kwargs: Additional keyword arguments including ``profile_step``.
+
+        Returns:
+            True if the debugger was successfully started.
+
+        """
         profile_step = kwargs.get("global_step", kwargs.get("profile_step"))
         if profile_step is not None:
             self._current_global_step = profile_step
@@ -213,6 +225,12 @@ class PrecisionDebuggerProfiler:
             return False
 
     def stop(self, started: bool = False) -> None:
+        """Stop the precision debugger and reset its internal state.
+
+        Args:
+            started: Whether the debugger was actually started; skip if False.
+
+        """
         if not started:
             return
         if not self._available:
@@ -230,6 +248,19 @@ class PrecisionDebuggerProfiler:
         category: Optional[str] = None,
         **kwargs_outer,
     ):
+        """Decorate a function to automatically start/stop precision debugging.
+
+        Args:
+            message: Unused; kept for interface compatibility.
+            color: Unused; kept for interface compatibility.
+            domain: Unused; kept for interface compatibility.
+            category: Unused; kept for interface compatibility.
+            **kwargs_outer: Must include ``role`` to identify the stage.
+
+        Returns:
+            A decorator that wraps the function with precision debugging.
+
+        """
         _ = (message, color, domain, category)
         stage = self._normalize_stage(kwargs_outer.get("role"))
         if stage is None:

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -31,6 +31,7 @@ def mark_start_range(
         color (Optional[str]): Color for the marker visualization.
         domain (Optional[str]): Domain for the marker.
         category (Optional[str]): Category for the marker.
+
     """
     pass
 
@@ -40,6 +41,7 @@ def mark_end_range(range_id: str) -> None:
 
     Args:
         range_id (str): Identifier of the range to end.
+
     """
     pass
 
@@ -60,6 +62,7 @@ def mark_annotate(
 
     Returns:
         Callable: Decorator function that returns the original function unchanged.
+
     """
 
     def decorator(func):
@@ -185,6 +188,16 @@ class DistProfiler:
 
         The wrapped function is executed directly if profiling is disabled,
         not selected for current rank/step, or backend annotate fails.
+
+        Args:
+            message: Annotation message for the profiling marker.
+            color: Color for the profiling marker visualization.
+            domain: Domain name for grouping profiling annotations.
+            category: Category for the profiling annotation.
+            **kwargs_outer: Additional keyword arguments passed to the profiler.
+
+        Returns:
+            A decorator that wraps the method with profiling annotations.
         """
 
         def decorator(func):
@@ -217,10 +230,14 @@ class DistProfiler:
 
 
 class _NoOpProfiler:
+    """A no-op profiler used as a fallback when no tool is configured."""
+
     def start(self, **kwargs):
+        """No-op start."""
         return
 
     def stop(self):
+        """No-op stop."""
         return
 
 
@@ -234,6 +251,7 @@ class DistProfilerExtension:
 
     Args:
         profiler (DistProfiler): The base distributed profiler instance to extend
+
     """
 
     def __init__(self, profiler: DistProfiler):

--- a/verl/utils/profiler/torch_profile.py
+++ b/verl/utils/profiler/torch_profile.py
@@ -30,6 +30,20 @@ def get_torch_profiler(
     save_file_prefix: Optional[str] = None,
     rank: int = 0,
 ):
+    """Create a configured PyTorch profiler instance.
+
+    Args:
+        contents: List of profiling options (e.g. ``cpu``, ``cuda``, ``memory``,
+            ``shapes``, ``stack``).
+        save_path: Directory path to save the profiling trace.
+        role: Optional role name used as a subdirectory.
+        save_file_prefix: Optional prefix for the trace filename.
+        rank: The rank of the current process.
+
+    Returns:
+        A ``torch.profiler.profile`` context manager ready to be started.
+
+    """
     if role:
         save_path = os.path.join(save_path, role)
 
@@ -77,6 +91,7 @@ class Profiler(DistProfiler):
 
     Args:
         config: Configuration object containing profiling parameters
+
     """
 
     _define_count = 0
@@ -105,9 +120,16 @@ class Profiler(DistProfiler):
         self.discrete = getattr(self.tool_config, "discrete", False)
 
     def check(self):
+        """Return whether the profiler is currently active."""
         return self.prof is not None
 
     def start(self, **kwargs):
+        """Start the torch profiler for the current rank.
+
+        Args:
+            **kwargs: Keyword arguments; ``role`` specifies the profiling role.
+
+        """
         role = kwargs.get("role", None)
         if not self.discrete and Profiler._define_count == 0:
             self.prof = get_torch_profiler(
@@ -122,10 +144,12 @@ class Profiler(DistProfiler):
             Profiler._define_count += 1
 
     def step(self):
+        """Signal a profiler step boundary."""
         if self.check():
             self.prof.step()
 
     def stop(self):
+        """Stop the torch profiler and export the trace."""
         if not self.discrete and Profiler._define_count == 1:
             self.step()
             print(f"[Profiler] stopped for rank {self.rank}")
@@ -143,6 +167,8 @@ class Profiler(DistProfiler):
                 The message to be displayed in the profiler. Defaults to None.
             role (str, optional):
                 The role of the current data collection. Defaults to None.
+            **kwargs_outer: Additional keyword arguments passed to the decorator.
+
         """
 
         def decorator(func):

--- a/verl/utils/py_functional.py
+++ b/verl/utils/py_functional.py
@@ -70,6 +70,7 @@ def timeout_limit(seconds: float, use_signals: bool = False):
         TimeoutError: If the function execution exceeds the specified time.
         RuntimeError: If the child process exits with an error (multiprocessing mode).
         NotImplementedError: If the OS is not POSIX (signals are only supported on POSIX).
+
     """
 
     def decorator(func):
@@ -152,10 +153,11 @@ def union_two_dict(dict1: dict, dict2: dict):
     """Union two dict. Will throw an error if there is an item not the same object with the same key.
 
     Args:
-        dict1:
-        dict2:
+        dict1 (dict): The base dictionary to merge into.
+        dict2 (dict): The dictionary to merge from.
 
     Returns:
+        dict: The merged dictionary.
 
     """
     for key, val in dict2.items():
@@ -193,9 +195,11 @@ def append_to_dict(data: dict, new_data: dict, prefix: str = ""):
     Args:
         data (Dict): The target dictionary containing lists as values.
         new_data (Dict): The source dictionary with values to append.
+        prefix (str): Optional prefix to prepend to keys from new_data.
 
     Returns:
         None: The function modifies data in-place.
+
     """
     for key, val in new_data.items():
         new_key = f"{prefix}{key}" if not key.startswith(prefix) else key
@@ -221,6 +225,7 @@ class NestedNamespace(SimpleNamespace):
     Args:
         dictionary: The dictionary to convert to a nested namespace.
         **kwargs: Additional attributes to set on the namespace.
+
     """
 
     def __init__(self, dictionary, **kwargs):
@@ -233,6 +238,8 @@ class NestedNamespace(SimpleNamespace):
 
 
 class DynamicEnumMeta(type):
+    """Metaclass enabling iteration, containment checks, and subscript access on enum classes."""
+
     def __iter__(cls) -> Iterator[Any]:
         return iter(cls._registry.values())
 
@@ -250,13 +257,17 @@ class DynamicEnumMeta(type):
         return getattr, (importlib.import_module(cls.__module__), cls.__name__)
 
     def names(cls):
+        """Return a list of all registered member names."""
         return list(cls._registry.keys())
 
     def values(cls):
+        """Return a list of all registered member instances."""
         return list(cls._registry.values())
 
 
 class DynamicEnum(metaclass=DynamicEnumMeta):
+    """Enum-like class supporting dynamic member registration at runtime."""
+
     _registry: dict[str, "DynamicEnum"] = {}
     _next_value: int = 0
 
@@ -278,6 +289,18 @@ class DynamicEnum(metaclass=DynamicEnumMeta):
 
     @classmethod
     def register(cls, name: str) -> "DynamicEnum":
+        """Register a new member with the given name.
+
+        Args:
+            name: The member name (will be uppercased).
+
+        Returns:
+            DynamicEnum: The newly created member.
+
+        Raises:
+            ValueError: If the name is already registered.
+
+        """
         key = name.upper()
         if key in cls._registry:
             raise ValueError(f"{key} already registered")
@@ -289,6 +312,15 @@ class DynamicEnum(metaclass=DynamicEnumMeta):
 
     @classmethod
     def remove(cls, name: str):
+        """Remove a registered member by name.
+
+        Args:
+            name: The member name to remove (will be uppercased).
+
+        Returns:
+            DynamicEnum: The removed member.
+
+        """
         key = name.upper()
         member = cls._registry.pop(key)
         delattr(cls, key)
@@ -296,6 +328,15 @@ class DynamicEnum(metaclass=DynamicEnumMeta):
 
     @classmethod
     def from_name(cls, name: str) -> Optional["DynamicEnum"]:
+        """Look up a member by name, returning None if not found.
+
+        Args:
+            name: The member name to look up (will be uppercased).
+
+        Returns:
+            DynamicEnum or None: The member if found, otherwise None.
+
+        """
         return cls._registry.get(name.upper())
 
 
@@ -318,6 +359,7 @@ def temp_env_var(key: str, value: str):
         ...     # MY_VAR is set to "test_value"
         ...     do_something()
         ... # MY_VAR is restored to its original value or removed if it didn't exist
+
     """
     original = os.environ.get(key)
     os.environ[key] = value
@@ -344,6 +386,15 @@ def convert_to_regular_types(obj):
 
 
 def convert_nested_value_to_list_recursive(data_item):
+    """Recursively convert numpy arrays to nested Python lists.
+
+    Args:
+        data_item: A nested structure of dicts, lists, and numpy arrays.
+
+    Returns:
+        The same structure with all numpy arrays converted to Python lists.
+
+    """
     if isinstance(data_item, dict):
         return {k: convert_nested_value_to_list_recursive(v) for k, v in data_item.items()}
     elif isinstance(data_item, list):
@@ -357,6 +408,15 @@ def convert_nested_value_to_list_recursive(data_item):
 
 
 def list_of_dict_to_dict_of_list(list_of_dict: list[dict]):
+    """Transpose a list of dicts into a dict of lists.
+
+    Args:
+        list_of_dict: A list of dictionaries with identical keys.
+
+    Returns:
+        dict: A dictionary mapping each key to a list of corresponding values.
+
+    """
     if len(list_of_dict) == 0:
         return {}
     keys = list_of_dict[0].keys()

--- a/verl/utils/qat/linear.py
+++ b/verl/utils/qat/linear.py
@@ -178,10 +178,32 @@ class STEFP4QuantTriton(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, x: torch.Tensor, global_amax: torch.Tensor, block_size: int) -> torch.Tensor:
+        """Apply FP4 fake quantization in the forward pass.
+
+        Args:
+            ctx: Autograd context (unused).
+            x: Input tensor to quantize.
+            global_amax: Global absolute maximum for scaling.
+            block_size: Block size for quantization.
+
+        Returns:
+            Fake-quantized tensor with the same shape as ``x``.
+
+        """
         return fp4_fake_quant_weight(x, global_amax=global_amax, block_size=block_size)
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor) -> tuple:
+        """Pass gradients straight through (STE).
+
+        Args:
+            ctx: Autograd context (unused).
+            grad_output: Upstream gradient.
+
+        Returns:
+            Tuple of gradient for ``x`` and None for non-differentiable inputs.
+
+        """
         return grad_output, None, None
 
 
@@ -378,6 +400,7 @@ class QATLinear(nn.Linear):
         return F.linear(x_fq, weight_fq, self.bias)
 
     def extra_repr(self) -> str:
+        """Return a string representation of the module configuration."""
         return (
             f"in_features={self.in_features}, out_features={self.out_features}, "
             f"bias={self.bias is not None}, mode={self.mode.value}, "

--- a/verl/utils/qat/vllm_patch.py
+++ b/verl/utils/qat/vllm_patch.py
@@ -52,6 +52,7 @@ class ParamMetaDict(dict):
         Args:
             model: vLLM model (may be wrapped in ModelRunner)
             device: Device for created parameters
+
         """
         super().__init__()
         self.device = device
@@ -119,6 +120,7 @@ class ParamMetaDict(dict):
 
         Returns:
             Rebuilt parameter or None if cannot rebuild
+
         """
         # Extract layer name and param name
         parts = key.rsplit(".", 1)
@@ -760,6 +762,7 @@ def prepare_qat_for_load_weights(model, device=None):
     Args:
         model: vLLM model
         device: Device for created parameters
+
     """
     inner_model = model
     if hasattr(model, "model"):

--- a/verl/utils/ray_utils.py
+++ b/verl/utils/ray_utils.py
@@ -26,6 +26,15 @@ import ray
 
 
 def ray_noset_visible_devices(env_vars=os.environ):
+    """Check whether any Ray NOSET_VISIBLE_DEVICES environment variable is set.
+
+    Args:
+        env_vars: Mapping of environment variables to inspect.
+
+    Returns:
+        True if any Ray no-set visible devices env var is truthy.
+
+    """
     # Refer to
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
@@ -60,6 +69,7 @@ def parallel_put(data_list: list[Any], max_workers: Optional[int] = None):
     Returns:
         List[ray.ObjectRef]: A list of Ray object references corresponding to the input data_list,
                              maintaining the original order.
+
     """
     assert len(data_list) > 0, "data_list must not be empty"
 
@@ -85,6 +95,12 @@ def parallel_put(data_list: list[Any], max_workers: Optional[int] = None):
 
 
 def get_event_loop():
+    """Return the current asyncio event loop, creating one if none exists.
+
+    Returns:
+        The current or newly created asyncio event loop.
+
+    """
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:

--- a/verl/utils/rendezvous/ray_backend.py
+++ b/verl/utils/rendezvous/ray_backend.py
@@ -33,14 +33,26 @@ def _get_collective_module():
 
 @ray.remote
 class NCCLIDStore:
+    """Ray actor that holds and serves an NCCL unique ID for rendezvous."""
+
     def __init__(self, nccl_id):
         self._nccl_id = nccl_id
 
     def get(self):
+        """Return the stored NCCL unique identifier."""
         return self._nccl_id
 
 
 def get_nccl_id_store_by_name(name):
+    """Look up a named NCCLIDStore Ray actor by its registered name.
+
+    Args:
+        name: The registered actor name to search for.
+
+    Returns:
+        The actor handle if exactly one match is found, otherwise None.
+
+    """
     all_actors = list_named_actors(all_namespaces=True)
     matched_actors = [actor for actor in all_actors if actor.get("name", None) == name]
     if len(matched_actors) == 1:
@@ -56,6 +68,18 @@ def get_nccl_id_store_by_name(name):
 def create_nccl_communicator_in_ray(
     rank: int, world_size: int, group_name: str, max_retries: int = 100, interval_s: int = 5
 ):
+    """Create an NCCL communicator across Ray workers using a shared ID store.
+
+    Args:
+        rank: The rank of the current process in the communicator.
+        world_size: Total number of processes in the communicator.
+        group_name: Name used to register the NCCL ID store actor.
+        max_retries: Maximum number of retries for non-rank-0 processes.
+        interval_s: Sleep interval in seconds between retries.
+
+    Returns:
+        An initialized NcclCommunicator instance.
+    """
     collective = _get_collective_module()
     NcclCommunicator = collective.NcclCommunicator
     get_unique_id = collective.get_unique_id

--- a/verl/utils/reward_score/__init__.py
+++ b/verl/utils/reward_score/__init__.py
@@ -33,6 +33,10 @@ def default_compute_score(
         solution_str (str): The solution string to be evaluated.
         ground_truth (str): The ground truth answer for comparison.
         extra_info (dict, optional): Additional information that might be needed for scoring. Defaults to None.
+        sandbox_fusion_url (str, optional): URL for the sandbox fusion service.
+        concurrent_semaphore (asyncio.Semaphore, optional): Semaphore for concurrency control.
+        memory_limit_mb (int, optional): Memory limit in megabytes for sandbox execution.
+        **kwargs: Additional keyword arguments forwarded to the scoring function.
 
     Returns:
         float: The computed score as a floating point number. If the result is a dictionary,
@@ -40,6 +44,7 @@ def default_compute_score(
 
     Raises:
         NotImplementedError: If the reward function is not implemented for the given data source.
+
     """
     if data_source == "openai/gsm8k":
         from . import gsm8k

--- a/verl/utils/reward_score/geo3k.py
+++ b/verl/utils/reward_score/geo3k.py
@@ -17,12 +17,34 @@ from mathruler.grader import extract_boxed_content, grade_answer
 
 
 def format_reward(predict_str: str) -> float:
+    r"""Compute a format reward based on whether the output follows the expected structure.
+
+    Checks that the prediction contains ``<think>...</think>`` followed by a ``\boxed{}``.
+
+    Args:
+        predict_str: The model-generated prediction string.
+
+    Returns:
+        1.0 if the format matches, else 0.0.
+
+    """
     pattern = re.compile(r"<think>.*</think>.*\\boxed\{.*\}.*", re.DOTALL)
     match_result = re.fullmatch(pattern, predict_str)
     return 1.0 if match_result else 0.0
 
 
 def acc_reward(predict_str: str, ground_truth: str, use_boxed: bool = True) -> float:
+    r"""Compute an accuracy reward by grading the extracted answer.
+
+    Args:
+        predict_str: The model-generated prediction string.
+        ground_truth: The expected ground truth answer.
+        use_boxed: If True, extract the answer from a ``\boxed{}`` wrapper.
+
+    Returns:
+        1.0 if the answer is correct, else 0.0.
+
+    """
     if use_boxed:
         answer = extract_boxed_content(predict_str)
     else:
@@ -31,6 +53,18 @@ def acc_reward(predict_str: str, ground_truth: str, use_boxed: bool = True) -> f
 
 
 def compute_score(predict_str: str, ground_truth: str, use_boxed: bool = True, format_score: float = 0.1) -> float:
+    r"""Compute a weighted score combining accuracy and format rewards.
+
+    Args:
+        predict_str: The model-generated prediction string.
+        ground_truth: The expected ground truth answer.
+        use_boxed: If True, extract the answer from a ``\boxed{}`` wrapper.
+        format_score: Weight allocated to the format reward component.
+
+    Returns:
+        A float score blending accuracy and format rewards.
+
+    """
     return (1.0 - format_score) * acc_reward(predict_str, ground_truth, use_boxed) + format_score * format_reward(
         predict_str
     )

--- a/verl/utils/reward_score/gsm8k.py
+++ b/verl/utils/reward_score/gsm8k.py
@@ -18,6 +18,17 @@ _SOLUTION_CLIP_CHARS = 300
 
 
 def extract_solution(solution_str, method="strict"):
+    """Extract the numeric answer from a GSM8k-style solution string.
+
+    Args:
+        solution_str: The solution text, potentially very long.
+        method: Extraction strategy — ``'strict'`` looks for ``#### <number>``,
+            ``'flexible'`` finds the last number in the string.
+
+    Returns:
+        The extracted answer string, or None if no answer is found.
+
+    """
     assert method in ["strict", "flexible"]
 
     # Optimization: Regular expression matching on very long strings can be slow.
@@ -61,6 +72,7 @@ def compute_score(solution_str, ground_truth, method="strict", format_score=0.0,
         method: the method to extract the solution, choices are 'strict' and 'flexible'
         format_score: the score for the format
         score: the score for the correct answer
+
     """
     answer = extract_solution(solution_str=solution_str, method=method)
     if answer is None:

--- a/verl/utils/reward_score/math_dapo.py
+++ b/verl/utils/reward_score/math_dapo.py
@@ -25,6 +25,7 @@ def last_boxed_only_string(string: str) -> Optional[str]:
 
     Returns:
         The last boxed expression or None if not found
+
     """
     idx = string.rfind("\\boxed{")
     if idx < 0:
@@ -48,13 +49,14 @@ def last_boxed_only_string(string: str) -> Optional[str]:
 
 
 def remove_boxed(s: str) -> str:
-    """Remove the LaTeX boxed command from a string.
+    r"""Remove the LaTeX boxed command from a string.
 
     Args:
         s: String with format "\\boxed{content}"
 
     Returns:
         The content inside the boxed command
+
     """
     left = "\\boxed{"
     assert s[: len(left)] == left, f"box error: {s}"
@@ -129,6 +131,7 @@ def normalize_final_answer(final_answer: str) -> str:
 
     Returns:
         Normalized answer string
+
     """
     final_answer = final_answer.split("=")[-1]
 
@@ -175,6 +178,7 @@ def is_correct_minerva(
 
     Returns:
         Tuple of (is_correct, normalized_prediction)
+
     """
     # Extract answer from solution
     match = re.findall(answer_pattern, solution_str)
@@ -202,6 +206,7 @@ def is_correct_strict_box(
 
     Returns:
         Tuple of (score, extracted_prediction)
+
     """
     # Extract the relevant part of the prediction
     if pause_tokens_index is not None:
@@ -230,6 +235,7 @@ def verify(
 
     Returns:
         True if the solution is correct, False otherwise
+
     """
     if strict_box_verify:
         correct, pred = is_correct_strict_box(solution_str, answer, pause_tokens_index)
@@ -255,6 +261,7 @@ def compute_score(
 
     Returns:
         Reward score (1.0 for correct, -1.0 for incorrect)
+
     """
     # Limit solution length for efficiency
     solution_str = solution_str[-300:]  # The longest answer in MATH-500 has 159 characters

--- a/verl/utils/reward_score/math_reward.py
+++ b/verl/utils/reward_score/math_reward.py
@@ -15,6 +15,16 @@
 
 
 def compute_score(solution_str, ground_truth) -> float:
+    """Compute a binary score for a math solution by checking the boxed answer.
+
+    Args:
+        solution_str: The model-generated solution string.
+        ground_truth: The expected ground truth answer.
+
+    Returns:
+        1.0 if the extracted boxed answer is equivalent to the ground truth, else 0.0.
+
+    """
     retval = 0.0
     try:
         string_in_last_boxed = last_boxed_only_string(solution_str)
@@ -30,6 +40,17 @@ def compute_score(solution_str, ground_truth) -> float:
 
 # string normalization from https://github.com/EleutherAI/lm-evaluation-harness/blob/master/lm_eval/tasks/hendrycks_math.py
 def is_equiv(str1, str2, verbose=False):
+    """Determine whether two math answer strings are equivalent after normalization.
+
+    Args:
+        str1: First answer string.
+        str2: Second answer string.
+        verbose: If True, print the stripped strings for debugging.
+
+    Returns:
+        True if the normalized strings are equal.
+
+    """
     if str1 is None and str2 is None:
         print("WARNING: Both None")
         return True
@@ -47,6 +68,15 @@ def is_equiv(str1, str2, verbose=False):
 
 
 def remove_boxed(s):
+    r"""Remove the ``\boxed{}`` wrapper and return the inner content.
+
+    Args:
+        s: A LaTeX string starting with ``\boxed{`` or ``\boxed ``.
+
+    Returns:
+        The content inside the boxed command.
+
+    """
     if "\\boxed " in s:
         left = "\\boxed "
         assert s[: len(left)] == left
@@ -61,6 +91,15 @@ def remove_boxed(s):
 
 
 def last_boxed_only_string(string):
+    r"""Extract the last ``\boxed{...}`` expression from a string.
+
+    Args:
+        string: The full solution string potentially containing boxed answers.
+
+    Returns:
+        The last boxed substring, or None if no boxed expression is found.
+
+    """
     idx = string.rfind("\\boxed")
     if "\\boxed " in string:
         return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
@@ -88,6 +127,17 @@ def last_boxed_only_string(string):
 
 
 def fix_fracs(string):
+    r"""Normalize shorthand ``\frac`` notation to proper brace-delimited form.
+
+    Converts patterns like ``\frac12`` to ``\frac{1}{2}``.
+
+    Args:
+        string: A LaTeX math string.
+
+    Returns:
+        The string with fractions in canonical ``\frac{a}{b}`` form.
+
+    """
     substrs = string.split("\\frac")
     new_str = substrs[0]
     if len(substrs) > 1:
@@ -120,6 +170,17 @@ def fix_fracs(string):
 
 
 def fix_a_slash_b(string):
+    r"""Convert a simple ``a/b`` fraction to ``\frac{a}{b}`` notation.
+
+    Only converts when both parts are integers.
+
+    Args:
+        string: A potential fraction string like ``3/4``.
+
+    Returns:
+        The LaTeX fraction form if applicable, otherwise the original string.
+
+    """
     if len(string.split("/")) != 2:
         return string
     a = string.split("/")[0]
@@ -135,6 +196,15 @@ def fix_a_slash_b(string):
 
 
 def remove_right_units(string):
+    r"""Remove unit annotations (``\text{ ... }``) from the right side of an expression.
+
+    Args:
+        string: A LaTeX math string potentially containing unit text.
+
+    Returns:
+        The string with trailing unit text removed.
+
+    """
     # "\\text{ " only ever occurs (at least in the val set) when describing units
     if "\\text{ " in string:
         splits = string.split("\\text{ ")
@@ -145,6 +215,17 @@ def remove_right_units(string):
 
 
 def fix_sqrt(string):
+    r"""Normalize shorthand ``\sqrt`` notation to brace-delimited form.
+
+    Converts ``\sqrt3`` to ``\sqrt{3}``.
+
+    Args:
+        string: A LaTeX math string.
+
+    Returns:
+        The string with square roots in canonical ``\sqrt{x}`` form.
+
+    """
     if "\\sqrt" not in string:
         return string
     splits = string.split("\\sqrt")
@@ -160,6 +241,19 @@ def fix_sqrt(string):
 
 
 def strip_string(string):
+    """Normalize a LaTeX math string for equivalence comparison.
+
+    Applies a series of transformations including removing whitespace,
+    fixing fractions and square roots, removing units, and standardizing
+    common notation variants.
+
+    Args:
+        string: A raw LaTeX math answer string.
+
+    Returns:
+        A normalized string suitable for direct equality comparison.
+
+    """
     # linebreaks
     string = string.replace("\n", "")
 

--- a/verl/utils/reward_score/math_verify.py
+++ b/verl/utils/reward_score/math_verify.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
 
     class TimeoutException(Exception):
-        pass
+        """Fallback timeout exception when math_verify is not installed."""
 
     print("To use Math-Verify, please install it first by running `pip install math-verify`.")
 
@@ -55,6 +55,20 @@ def _verify_in_subprocess(ground_truth_boxed: str, model_output: str) -> float:
 
 
 def compute_score(model_output: str, ground_truth: str, timeout_score: float = 0, timeout: float = 30.0) -> float:
+    r"""Compute a reward score using the math-verify library in a subprocess.
+
+    Runs verification in a separate process to allow signal-based timeouts.
+
+    Args:
+        model_output: The model-generated solution text.
+        ground_truth: The expected answer (without ``\boxed{}`` wrapper).
+        timeout_score: Score to return when verification times out.
+        timeout: Maximum seconds to wait for verification.
+
+    Returns:
+        1.0 if the answer is verified correct, *timeout_score* on timeout, else 0.0.
+
+    """
     ret_score = 0.0
     ground_truth_boxed = "\\boxed{" + ground_truth + "}"
     try:

--- a/verl/utils/reward_score/prime_code/__init__.py
+++ b/verl/utils/reward_score/prime_code/__init__.py
@@ -19,6 +19,22 @@ from .utils import check_correctness as apps_check_correctness
 
 
 def compute_score(completion, test_cases, continuous=False):
+    """Evaluate a code completion against test cases.
+
+    Extract the Python solution from the completion and run it against the
+    provided input/output test cases.
+
+    Args:
+        completion: The model-generated code completion string.
+        test_cases: A dict (or JSON string) with ``inputs`` and ``outputs`` lists.
+        continuous: If True, compute a fractional score over the first 10 test
+            cases instead of a binary pass/fail.
+
+    Returns:
+        A tuple of (success, metadata) where *success* is a bool or float and
+        *metadata* contains execution details.
+
+    """
     # try to get code solution from completion. if the completion is pure code, this will not take effect.
     solution = completion.split("```python")[-1].split("```")[0]
     try:

--- a/verl/utils/reward_score/prime_code/testing_util.py
+++ b/verl/utils/reward_score/prime_code/testing_util.py
@@ -37,6 +37,17 @@ from pyext import RuntimeModule
 
 
 def truncatefn(s, length=300):
+    """Truncate a string to a maximum length, keeping head and tail.
+
+    Args:
+        s: Input string to truncate.
+        length: Maximum allowed length before truncation.
+
+    Returns:
+        The original string if within length, otherwise a truncated version
+        with head and tail joined by an ellipsis marker.
+
+    """
     assert isinstance(s, str)
     if len(s) <= length:
         return s
@@ -45,6 +56,8 @@ def truncatefn(s, length=300):
 
 
 class CODE_TYPE(Enum):
+    """Enumeration of code execution types for test evaluation."""
+
     call_based = 0
     standard_input = 1
 
@@ -53,6 +66,12 @@ class CODE_TYPE(Enum):
 # from https://stackoverflow.com/a/16571630/6416660
 # alternative use redirect_stdout() from contextlib
 class Capturing(list):
+    """Context manager that captures stdout output into a list.
+
+    Redirects sys.stdout to a StringIO buffer and appends the captured
+    content to the list upon exiting the context.
+    """
+
     def __enter__(self):
         self._stdout = sys.stdout
         sys.stdout = self._stringio = StringIO()
@@ -67,18 +86,30 @@ class Capturing(list):
 
 
 def only_int_check(val):
+    """Check whether a value is strictly an integer type."""
     return isinstance(val, int)
 
 
 def string_int_check(val):
+    """Check whether a value is a string representation of a non-negative integer."""
     return isinstance(val, str) and val.isdigit()
 
 
 def combined_int_check(val):
+    """Check whether a value is an integer or a string of digits."""
     return only_int_check(val) or string_int_check(val)
 
 
 def clean_traceback(error_traceback):
+    """Clean a traceback string to start from the generated code frame.
+
+    Args:
+        error_traceback: Raw traceback string from the executed code.
+
+    Returns:
+        A cleaned traceback starting from the ``File "<string>"`` frame.
+
+    """
     file_start = error_traceback.find('File "<string>"')
     # print(file_start)
     error_traceback = "Traceback (most recent call last):\n  " + error_traceback[file_start:]
@@ -554,6 +585,16 @@ def run_test(in_outs, test=None, debug=False, timeout=15):
 
 
 def custom_compare_(output, ground_truth):
+    """Compare output lines against ground truth using stripped string matching.
+
+    Args:
+        output: Captured output, typically a list of strings.
+        ground_truth: Expected output string.
+
+    Returns:
+        True if the joined and stripped output matches the ground truth.
+
+    """
     if isinstance(output, list):
         output_1 = "\n".join(output)
         if stripped_string_compare(output_1, ground_truth):
@@ -569,12 +610,23 @@ def custom_compare_(output, ground_truth):
 
 
 def stripped_string_compare(s1, s2):
+    """Compare two strings after stripping leading and trailing whitespace."""
     s1 = s1.lstrip().rstrip()
     s2 = s2.lstrip().rstrip()
     return s1 == s2
 
 
 def call_method(method, inputs):
+    """Invoke a method with mocked stdin and builtins.open for standard-input problems.
+
+    Args:
+        method: The callable to invoke (typically the generated ``code()`` function).
+        inputs: Input data as a string or list of strings to feed via stdin.
+
+    Returns:
+        The return value of the invoked method.
+
+    """
     if isinstance(inputs, list):
         inputs = "\n".join(inputs)
 
@@ -610,6 +662,7 @@ def reliability_guard(maximum_memory_bytes=None):
     generated code, should not be blindly executed outside of one. See the
     Codex paper for more information about OpenAI's code sandbox, and proceed
     with caution.
+
     """
 
     if maximum_memory_bytes is not None:

--- a/verl/utils/reward_score/prime_math/__init__.py
+++ b/verl/utils/reward_score/prime_math/__init__.py
@@ -191,6 +191,17 @@ def _normalize(expr: str) -> str:
 
 
 def count_unknown_letters_in_expr(expr: str):
+    """Count the number of distinct alphabetic characters in an expression.
+
+    Ignores common function names (``sqrt``, ``frac``) before counting.
+
+    Args:
+        expr: The mathematical expression string.
+
+    Returns:
+        The number of unique letters remaining in the expression.
+
+    """
     expr = expr.replace("sqrt", "")
     expr = expr.replace("frac", "")
     letters_in_expr = set([x for x in expr if x.isalpha()])
@@ -198,6 +209,18 @@ def count_unknown_letters_in_expr(expr: str):
 
 
 def should_allow_eval(expr: str):
+    """Determine whether an expression is safe to evaluate with sympy.
+
+    Reject expressions with more than two unknown letters or containing
+    patterns known to cause sympy to hang.
+
+    Args:
+        expr: The expression string to check.
+
+    Returns:
+        True if the expression is safe to evaluate.
+
+    """
     # we don't want to try parsing unknown text or functions of more than two variables
     if count_unknown_letters_in_expr(expr) > 2:
         return False
@@ -211,6 +234,16 @@ def should_allow_eval(expr: str):
 
 @timeout_limit(seconds=10)
 def are_equal_under_sympy(ground_truth_normalized: str, given_normalized: str):
+    """Check whether two normalized expressions are equal under sympy simplification.
+
+    Args:
+        ground_truth_normalized: The normalized ground truth expression.
+        given_normalized: The normalized predicted expression.
+
+    Returns:
+        True if sympy simplifies their difference to zero.
+
+    """
     are_equal = False
     try:
         expr = f"({ground_truth_normalized})-({given_normalized})"
@@ -305,6 +338,15 @@ def grade_answer(given_answer: str, ground_truth: str) -> bool:
 
 
 def remove_boxed(s):
+    r"""Remove the ``\boxed{}`` wrapper from a LaTeX string.
+
+    Args:
+        s: The string expected to be wrapped in ``\boxed{...}``.
+
+    Returns:
+        The inner content, or None if the format does not match.
+
+    """
     left = "\\boxed{"
     try:
         assert s[: len(left)] == left
@@ -345,6 +387,18 @@ def _last_boxed_only_string(string):
 
 
 def match_answer(response):
+    r"""Extract the final answer from a model response using heuristic markers.
+
+    Look for common answer indicators (e.g. "answer is", ``\boxed{}``) and
+    extract the relevant substring.
+
+    Args:
+        response: The full model response string.
+
+    Returns:
+        A tuple of (is_matched, extracted_answer).
+
+    """
     is_matched = False
     for ans_marker in ["answer:", "answer is", "answers are"]:
         ans_idx = response.lower().rfind(ans_marker)
@@ -387,6 +441,19 @@ def match_answer(response):
 
 
 def compute_score(model_output: str, ground_truth: str) -> bool:
+    """Score a model output against the ground truth using math grading.
+
+    Attempt simple algebra grading first, then fall back to symbolic
+    equality with optional pi substitution.
+
+    Args:
+        model_output: The raw model output string.
+        ground_truth: The expected ground truth answer.
+
+    Returns:
+        A tuple of (is_correct, format_correctness, extracted_output).
+
+    """
     model_output = str(model_output)
     ground_truth = str(ground_truth)
 

--- a/verl/utils/reward_score/prime_math/grader.py
+++ b/verl/utils/reward_score/prime_math/grader.py
@@ -107,6 +107,17 @@ from verl.utils.py_functional import timeout_limit
 
 
 def is_digit(s):
+    """Check whether a value can be interpreted as a number.
+
+    Handles comma-formatted numbers (e.g. ``1{,}000``).
+
+    Args:
+        s: The value to check.
+
+    Returns:
+        A tuple of (is_numeric, parsed_float).
+
+    """
     try:
         if "{,}" in str(s):
             num = float(str(s).replace("{,}", ""))
@@ -119,6 +130,16 @@ def is_digit(s):
 
 
 def normalize(answer, pi) -> str:
+    r"""Normalize an answer by removing currency symbols, percentages, and handling pi.
+
+    Args:
+        answer: The raw answer value.
+        pi: The numeric value to substitute for ``\pi``.
+
+    Returns:
+        The normalized answer as a string or numeric value.
+
+    """
     # checking if answer is $<number> and removing $ in that case to compare
     if isinstance(answer, str) and bool(re.match(r"\$\d+(\.\d+)?", answer)):
         return answer[1:]
@@ -139,6 +160,15 @@ def normalize(answer, pi) -> str:
 
 
 def handle_base(x) -> str:
+    """Strip base notation (e.g. ``10_2``) and return the numeric prefix.
+
+    Args:
+        x: The value to process.
+
+    Returns:
+        The integer prefix if base notation is detected, otherwise *x* unchanged.
+
+    """
     if isinstance(x, str) and "_" in x:
         # Due to base
         x = x.split("_")[0]
@@ -148,6 +178,16 @@ def handle_base(x) -> str:
 
 
 def handle_pi(string, pi):
+    r"""Replace ``\pi`` occurrences with a numeric value and evaluate the expression.
+
+    Args:
+        string: The expression string potentially containing ``\pi``.
+        pi: The numeric value to substitute for ``\pi``.
+
+    Returns:
+        The evaluated result if successful, otherwise the modified string.
+
+    """
     if isinstance(string, str) and "\\pi" in string:
         # Find the first occurrence of "\pi"
         idx = string.find("\\pi")
@@ -322,6 +362,22 @@ def math_equal(
 
 
 def symbolic_equal(a, b, tolerance, timeout=10.0):
+    """Check symbolic equality of two expressions using sympy.
+
+    Attempt to parse both expressions and verify that their difference
+    simplifies to zero or that their numeric evaluations are close.
+
+    Args:
+        a: First expression string.
+        b: Second expression string.
+        tolerance: Relative tolerance for numeric comparison.
+        timeout: Maximum seconds for each parsing/simplification step.
+
+    Returns:
+        True if the expressions are symbolically or numerically equal.
+
+    """
+
     def _parse(s):
         for f in [parse_expr, parse_latex]:
             try:
@@ -360,6 +416,15 @@ def symbolic_equal(a, b, tolerance, timeout=10.0):
 
 
 def format_intervals(prediction):
+    """Convert sympy Interval notation to standard bracket notation.
+
+    Args:
+        prediction: The prediction string potentially using sympy Interval syntax.
+
+    Returns:
+        The prediction with Interval expressions converted to bracket form.
+
+    """
     patterns = {
         "Interval(": r"^Interval\((.*)\)$",
         "Interval.Ropen(": r"^Interval\.Ropen\((.*)\)$",

--- a/verl/utils/reward_score/prime_math/math_normalize.py
+++ b/verl/utils/reward_score/prime_math/math_normalize.py
@@ -42,6 +42,18 @@ from typing import Optional
 
 
 def normalize_answer(answer: Optional[str]) -> Optional[str]:
+    r"""Normalize a math answer string for comparison.
+
+    Strip whitespace, remove enclosing ``\text{}``, and apply various
+    LaTeX simplifications (fractions, square roots, units, etc.).
+
+    Args:
+        answer: The raw answer string, or None.
+
+    Returns:
+        The normalized answer string, or None if the input is None.
+
+    """
     if answer is None:
         return None
     answer = answer.strip()

--- a/verl/utils/reward_score/rlla.py
+++ b/verl/utils/reward_score/rlla.py
@@ -44,6 +44,24 @@ def match_score(list1, list2):
 def customize_format_reward_func(
     completions, answer, step, max_possible_reward, min_possible_reward, do_print, **kwargs
 ):
+    """Compute format rewards based on structural compliance of responses.
+
+    Check whether each response follows the expected XML-like format
+    (``<think>``, ``<response>``, ``<tool_call>``) matching the ground truth.
+
+    Args:
+        completions: List of completion message lists.
+        answer: List of ground truth answer strings.
+        step: The current training step (unused).
+        max_possible_reward: Reward for correct format.
+        min_possible_reward: Reward for incorrect format.
+        do_print: If True, print debug information.
+        **kwargs: Additional keyword arguments (unused).
+
+    Returns:
+        A list of reward floats, one per completion.
+
+    """
     rewards = []
     responses = [completion[0]["content"] for completion in completions]
 
@@ -98,6 +116,22 @@ def customize_format_reward_func(
 
 
 def compute_tool_call_reward(gt_tools, pd_tools, max_possible_reward, min_possible_reward, do_print):
+    """Compute a reward for tool call correctness by comparing predicted and ground truth tools.
+
+    Score is based on name matching, parameter key overlap, and parameter
+    value correctness, normalized to the reward range.
+
+    Args:
+        gt_tools: List of ground truth tool dicts with ``name`` and ``parameters``.
+        pd_tools: List of predicted tool dicts with ``name`` and ``parameters``.
+        max_possible_reward: Maximum reward value.
+        min_possible_reward: Minimum reward value.
+        do_print: If True, print scoring details.
+
+    Returns:
+        A float reward in [min_possible_reward, max_possible_reward].
+
+    """
     if gt_tools == pd_tools:
         if do_print:
             print("Max possible score:", "Exact Match!")
@@ -155,6 +189,24 @@ def compute_tool_call_reward(gt_tools, pd_tools, max_possible_reward, min_possib
 def customize_correctness_reward_tool(
     completions, answer, step, max_possible_reward, min_possible_reward, do_print, **kwargs
 ):
+    """Compute correctness rewards for tool call predictions.
+
+    Parse tool calls from each response and compare against the ground truth
+    using :func:`compute_tool_call_reward`.
+
+    Args:
+        completions: List of completion message lists.
+        answer: List of ground truth answer strings containing tool calls.
+        step: The current training step (unused).
+        max_possible_reward: Maximum reward value.
+        min_possible_reward: Minimum reward value.
+        do_print: If True, print debug information.
+        **kwargs: Additional keyword arguments (unused).
+
+    Returns:
+        A list of reward floats, one per completion.
+
+    """
     responses = [completion[0]["content"] for completion in completions]
     rewards = []
 
@@ -203,11 +255,15 @@ def compute_score(data_source, solution_str, ground_truth, extra_info, step=0):
     Computational Linguistics (Volume 1: Long Papers). 2024.
 
     Args:
+        data_source: the data source identifier
         solution_str: the solution text
         ground_truth: the ground truth
+        extra_info: additional information dict (e.g., experiment_name)
+        step: the current step number (default 0)
         method: the method to extract the solution, choices are 'strict' and 'flexible'
         format_score: the score for the format
         score: the score for the correct answer
+
     """
     exp_name = extra_info.get("experiment_name", "")
     if "llama" in exp_name:

--- a/verl/utils/reward_score/sandbox_fusion/__init__.py
+++ b/verl/utils/reward_score/sandbox_fusion/__init__.py
@@ -33,7 +33,8 @@ def compute_score(
 
     Args:
         sandbox_fusion_url: The URL of the sandbox_fusion service, eg: "https://<your service endpoint>/run_code"
-
+        concurrent_semaphore: A threading semaphore to limit concurrent sandbox API calls.
+        memory_limit_mb: Memory limit in megabytes for sandbox execution.
         completion: The completion string containing the code.
         test_cases: JSON string or dictionary containing "inputs" and "outputs".
         continuous: Whether to compute a continuous score (based on the first N test cases).
@@ -43,6 +44,7 @@ def compute_score(
         A tuple (score, metadata_list).
         score: Float score (0.0 to 1.0).
         metadata_list: List containing execution metadata for each test case.
+
     """
     solution = completion
     if "```python" in completion:

--- a/verl/utils/reward_score/sandbox_fusion/utils.py
+++ b/verl/utils/reward_score/sandbox_fusion/utils.py
@@ -83,12 +83,14 @@ def call_sandbox_api(
         stdin: The standard input string.
         compile_timeout: Compile timeout in seconds.
         run_timeout: Run timeout in seconds.
+        memory_limit_mb: Memory limit in megabytes for sandbox execution.
         language: The programming language of the code (e.g., "python", "cpp", "java"). Defaults to "python".
 
     Returns:
         A tuple (response_json, error_message).
         If successful, response_json is the API's returned JSON object, error_message is None.
         If failed after retries, response_json is None, error_message contains the error information.
+
     """
     request_id = str(uuid.uuid4())  # <-- Generate request_id internally
     log_prefix = f"[Request ID: {request_id}] "  # <-- Create log prefix
@@ -464,7 +466,9 @@ def check_correctness(
         in_outs: Dictionary containing "inputs" and "outputs" lists.
         generation: The generated code string.
         timeout: Timeout for each test case (compile and run share this timeout).
+        memory_limit_mb: Memory limit in megabytes for sandbox execution.
         language: The programming language of the code.
+        concurrent_semaphore: Optional threading semaphore to limit concurrent sandbox API calls.
 
     Returns:
         A tuple (results, metadata_list).
@@ -473,6 +477,7 @@ def check_correctness(
                  Results are ordered corresponding to the inputs.
         metadata_list: A list containing metadata dictionaries for each test case,
                        ordered corresponding to the inputs.
+
     """
     logger.info("Starting correctness check for generation.")
 

--- a/verl/utils/reward_score/search_r1_like_qa_em.py
+++ b/verl/utils/reward_score/search_r1_like_qa_em.py
@@ -21,6 +21,16 @@ import string
 
 
 def normalize_answer(s):
+    """Normalize an answer string by lowercasing, removing articles and punctuation.
+
+    Args:
+        s: The raw answer string.
+
+    Returns:
+        The normalized answer string.
+
+    """
+
     def remove_articles(text):
         return re.sub(r"\b(a|an|the)\b", " ", text)
 
@@ -38,6 +48,16 @@ def normalize_answer(s):
 
 
 def em_check(prediction, golden_answers):
+    """Check exact match between a prediction and a set of golden answers.
+
+    Args:
+        prediction: The predicted answer string.
+        golden_answers: A single answer string or list of acceptable answers.
+
+    Returns:
+        1 if any golden answer matches exactly, else 0.
+
+    """
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)
@@ -51,6 +71,16 @@ def em_check(prediction, golden_answers):
 
 
 def subem_check(prediction, golden_answers):
+    """Check whether any golden answer is a substring of the prediction.
+
+    Args:
+        prediction: The predicted answer string.
+        golden_answers: A single answer string or list of acceptable answers.
+
+    Returns:
+        1 if any golden answer is found within the prediction, else 0.
+
+    """
     if isinstance(golden_answers, str):
         golden_answers = [golden_answers]
     normalized_prediction = normalize_answer(prediction)
@@ -87,6 +117,15 @@ def extract_solution(solution_str):
 
 
 def count_answer_tags(text):
+    """Count the number of ``<answer>`` and ``</answer>`` tags in a text.
+
+    Args:
+        text: The text to scan.
+
+    Returns:
+        A tuple of (opening_count, closing_count).
+
+    """
     opening_tags = text.count("<answer>")
     closing_tags = text.count("</answer>")
 
@@ -102,6 +141,7 @@ def compute_score(solution_str, ground_truth, method="strict", format_score=0.0,
         method: the method to extract the solution, choices are 'strict' and 'flexible'
         format_score: the score for the format
         score: the score for the correct answer
+
     """
     answer = extract_solution(solution_str=solution_str)
     open_count, close_count = count_answer_tags(solution_str)
@@ -137,6 +177,7 @@ def compute_score_subem(solution_str, ground_truth, method="strict", format_scor
         method: the method to extract the solution, choices are 'strict' and 'flexible'
         format_score: the score for the format
         score: the score for the correct answer
+
     """
     answer = extract_solution(solution_str=solution_str)
     do_print = random.randint(1, 64) == 1

--- a/verl/utils/rollout_trace.py
+++ b/verl/utils/rollout_trace.py
@@ -44,6 +44,7 @@ class RolloutTraceConfig:
             per worker per step. If None, all samples are traced. If set, each worker will randomly
             select up to this many unique samples to trace (including all their rollouts for GRPO).
             Total traces = max_samples_per_step_per_worker * num_workers * n_rollouts_per_sample.
+
     """
 
     _instance: Optional["RolloutTraceConfig"] = None
@@ -56,6 +57,7 @@ class RolloutTraceConfig:
     max_samples_per_step_per_worker: int | None = None
 
     def __new__(cls, *args, **kwargs):
+        """Create or return the singleton instance."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._initialized = False
@@ -63,6 +65,7 @@ class RolloutTraceConfig:
 
     @classmethod
     def get_instance(cls) -> "RolloutTraceConfig":
+        """Return the singleton configuration instance, creating it if needed."""
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
@@ -76,6 +79,16 @@ class RolloutTraceConfig:
         token2text: bool = False,
         max_samples_per_step_per_worker: int | None = None,
     ):
+        """Initialize the rollout trace configuration with the specified backend.
+
+        Args:
+            project_name: Name of the tracing project.
+            experiment_name: Name of the experiment.
+            backend: Tracing backend identifier ('weave', 'mlflow', or None).
+            token2text: Whether to convert tokens to text in traces.
+            max_samples_per_step_per_worker: Maximum unique samples to trace per worker per step.
+
+        """
         config = cls.get_instance()
         if config._initialized:
             return
@@ -114,18 +127,22 @@ class RolloutTraceConfig:
 
     @classmethod
     def get_backend(cls) -> str | None:
+        """Return the configured tracing backend name."""
         return cls.get_instance().backend
 
     @classmethod
     def get_client(cls) -> object | None:
+        """Return the tracing client instance for the configured backend."""
         return cls.get_instance().client
 
     @classmethod
     def enable_token2text(cls) -> bool | None:
+        """Return whether token-to-text conversion is enabled."""
         return cls.get_instance().token2text
 
     @classmethod
     def reset(cls):
+        """Reset the singleton instance, allowing re-initialization."""
         cls._instance = None
 
 
@@ -142,6 +159,7 @@ def rollout_trace_attr(
         name: Name for the trace span (used by mlflow backend).
         validate: Whether this is a validation run.
         trace: If False, disables tracing for the duration of the context.
+
     """
     backend = RolloutTraceConfig.get_backend()
 
@@ -316,6 +334,16 @@ def _current_trace_attributes():
 
 
 def rollout_trace_op(func):
+    """Decorate a method to emit trace spans for rollout operations.
+
+    Args:
+        func: The async or sync method to instrument with tracing.
+
+    Returns:
+        A wrapped function that records inputs and outputs as trace spans.
+
+    """
+
     @functools.wraps(func)
     async def async_wrapper(self, *args, **kwargs):
         if not _trace_enabled.get():

--- a/verl/utils/sglang/sglang_fp8_utils.py
+++ b/verl/utils/sglang/sglang_fp8_utils.py
@@ -17,5 +17,7 @@ from verl.utils.fp8_utils import FP8QuantizerHelper
 
 
 class SGLangFP8QuantizerHelper(FP8QuantizerHelper):
+    """FP8 quantization helper specialized for the SGLang inference backend."""
+
     def __init__(self, quant_config):
         super().__init__(quant_config)

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -40,6 +40,7 @@ def assign_non_tensor_data(tensor_dict: TensorDict, key, val):
     Example:
         >>> td = TensorDict({"obs": torch.randn(3, 4)}, batch_size=[3])
         >>> assign_non_tensor_data(td, "experiment_name", "run_001")
+
     """
     assert isinstance(tensor_dict, TensorDict), "input dict must be a TensorDict"
     tensor_dict[key] = NonTensorData(val)
@@ -65,6 +66,7 @@ def assign_non_tensor_stack(tensor_dict: TensorDict, key, val: list):
         >>> turn_scores = [[], [0.5, 0.8], [0.9]]
         >>> assign_non_tensor_stack(td, "turn_scores", turn_scores)
         >>> # Now td["turn_scores"] contains the nested data
+
     """
     # Convert list to NonTensorStack to handle nested structures
     # This wraps each item in NonTensorData to preserve complex objects
@@ -93,6 +95,7 @@ def assign_non_tensor(tensor_dict: TensorDict, **kwargs):
         ...     metadata="experiment_1",  # Simple value
         ...     turn_scores=[[], [0.5, 0.8], [0.9]]  # Nested list
         ... )
+
     """
     assert isinstance(tensor_dict, TensorDict), "input dict must be a TensorDict"
     for key, val in kwargs.items():
@@ -126,6 +129,7 @@ def unwrap_non_tensor_data(data):
         'hello'
         >>> unwrap_non_tensor_data(42)  # Non-wrapped value
         42
+
     """
     if isinstance(data, NonTensorData):
         return data.data
@@ -154,12 +158,14 @@ def get_non_tensor_data(data: TensorDict, key: str, default):
         {'lr': 0.01}
         >>> get_non_tensor_data(td, "missing", "default_value")
         'default_value'
+
     """
     output = data.get(key, default)
     return unwrap_non_tensor_data(output)
 
 
 def nested_tensor_from_tensor_list(tensors: list[torch.Tensor], ragged_idx: int | None = None) -> torch.Tensor:
+    """Create a jagged nested tensor from a list of tensors with varying sizes."""
     assert len(tensors) > 0, "Must provide at least one tensor"
     sample_dim = tensors[0].dim()
     if ragged_idx is None:
@@ -205,6 +211,7 @@ def concat_nested_tensors(tensors: list[torch.Tensor]) -> torch.Tensor:
         >>> t2 = torch.nested.as_nested_tensor([torch.randn(2), torch.randn(4)], layout=torch.jagged)
         >>> result = concat_nested_tensors([t1, t2])
         >>> # result contains 4 rows: lengths [3, 5, 2, 4]
+
     """
     for tensor in tensors:
         assert tensor.is_nested and tensor.is_contiguous()
@@ -237,6 +244,7 @@ def concat_tensordict_with_none_bsz(data: list[TensorDict]):
     Note:
         This is used internally by concat_tensordict when handling
         TensorDicts that contain only non-tensor metadata.
+
     """
     for d in data:
         assert len(d.batch_size) == 0
@@ -266,6 +274,7 @@ def concat_tensordict(data: list[TensorDict]) -> TensorDict:
         - For TensorDicts with empty batch_size, returns the first one
         - Nested tensors are handled specially via concat_nested_tensors
         - Regular tensors use TensorDict.cat for efficient concatenation
+
     """
     assert len(data) > 0, "Must have at least one tensordict"
 
@@ -337,6 +346,7 @@ def chunk_tensordict(td: TensorDict, chunks: int) -> list[TensorDict]:
         NestedTensors using the original ragged lengths from ``offsets``.
 
         See https://github.com/pytorch/pytorch/issues/153238
+
     """
     assert isinstance(td, TensorDict) and len(td) % chunks == 0, (
         f"expecting td with length divisible by chunks, but got {len(td)} and {chunks}"
@@ -398,6 +408,7 @@ def get_tensordict(tensor_dict: dict[str, torch.Tensor | list], non_tensor_dict:
         ...     },
         ...     non_tensor_dict={"experiment": "test"}
         ... )
+
     """
     tensor_dict = tensor_dict.copy()
     if non_tensor_dict is None:
@@ -478,6 +489,7 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
         - Nested tensors are unbound, indexed, and rebound
         - NonTensorStack is indexed by batch dimension
         - NonTensorData (scalar metadata) is preserved unchanged
+
     """
     if isinstance(indices, list):
         indices = torch.tensor(indices)
@@ -534,6 +546,7 @@ def union_tensor_dict(tensor_dict1: TensorDict, tensor_dict2: TensorDict) -> Ten
         >>> result = union_tensor_dict(td1, td2)
         >>> list(result.keys())
         ['a', 'b']
+
     """
     assert tensor_dict1.batch_size == tensor_dict2.batch_size, (
         f"Two tensor dict must have identical batch size. Got {tensor_dict1.batch_size} and {tensor_dict2.batch_size}"
@@ -582,6 +595,7 @@ def make_iterator(tensordict: TensorDict, mini_batch_size, epochs, seed=None, da
         >>> for batch in make_iterator(td, mini_batch_size=10, epochs=2):
         ...     # batch is a TensorDict with batch_size=[10]
         ...     pass
+
     """
     from torch.utils.data import DataLoader
 
@@ -631,6 +645,7 @@ def assert_tensordict_eq(tensordict1: TensorDict, tensordict2: TensorDict):
         - Regular tensors are compared element-wise
         - Nested tensors are unbound and compared component by component
         - Non-tensor values are compared with standard equality
+
     """
     tensordict1_key_set = set(tensordict1.keys())
     tensordict2_key_set = set(tensordict2.keys())
@@ -681,6 +696,7 @@ def get(tensordict: TensorDict, key: str, default=None) -> Any:
         >>> get(td, "obs")  # Returns torch.Tensor
         >>> get(td, "labels")  # Returns ["a", "b", "c"] as a list
         >>> get(td, "missing", "default")  # Returns "default"
+
     """
     if key not in tensordict:
         return default
@@ -716,6 +732,7 @@ def get_keys(tensordict: TensorDict, keys: Iterable[str]) -> TensorDict:
         >>> subset = get_keys(td, ["a", "c"])
         >>> list(subset.keys())
         ['a', 'c']
+
     """
     tensor_output = {}
     non_tensor_output = {}
@@ -754,6 +771,7 @@ def pop(tensordict: TensorDict, key: str, default=None) -> Any:
         >>> labels = pop(td, "labels")  # Returns ["a", "b", "c"], removes from td
         >>> "labels" in td.keys()
         False
+
     """
     _sentinel = object()
     output = tensordict.pop(key, _sentinel)
@@ -792,6 +810,7 @@ def pop_keys(tensordict: TensorDict, keys: Iterable[str]) -> TensorDict:
         ['b']
         >>> list(popped.keys())
         ['a', 'c']
+
     """
     tensor_output = {}
     non_tensor_output = {}
@@ -836,6 +855,7 @@ def pad_to_divisor(data: TensorDict, size_divisor: int):
         12
         >>> pad_size
         2
+
     """
     assert isinstance(data, TensorDict), "data must be a TensorDict"
     if len(data) % size_divisor != 0:
@@ -874,6 +894,7 @@ def unpad(data: TensorDict, pad_size):
         >>> unpadded = unpad(td, pad_size=2)
         >>> len(unpadded)
         10
+
     """
     if pad_size != 0:
         data = data[:-pad_size]
@@ -908,6 +929,7 @@ def contiguous(data: TensorDict) -> TensorDict:
 
 
 def maybe_fix_3d_position_ids(data: TensorDict):
+    """Fix ragged index for 3D nested position_ids after pickle roundtrip."""
     # note for tensordict with pickle/unpickle. nested tensor in tensordict after consolidate and pickle/unpickle
     # will incur indexing error for ragged tensor. This only happens when using 3D position ids in VLMs.
     # This is likely a bug in tensordict. As a workaround, we manually set _ragged_index.

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -153,13 +153,12 @@ def hf_tokenizer(name_or_path, correct_pad_token=True, correct_gemma2=True, **kw
     """Create a huggingface pretrained tokenizer which correctness handles eos and pad tokens.
 
     Args:
-
-        name (str): The name of the tokenizer.
+        name_or_path (str): The name or path of the pretrained tokenizer.
         correct_pad_token (bool): Whether to correct the pad token id.
         correct_gemma2 (bool): Whether to correct the gemma2 tokenizer.
+        **kwargs: Additional keyword arguments passed to AutoTokenizer.from_pretrained.
 
     Returns:
-
         transformers.PreTrainedTokenizer: The pretrained tokenizer.
 
     """
@@ -184,11 +183,13 @@ def hf_processor(name_or_path, **kwargs):
 
     Args:
         name_or_path (str): The name of the processor.
+        **kwargs: Additional keyword arguments passed to AutoProcessor.from_pretrained.
 
     Returns:
         Optional[transformers.ProcessorMixin]: The pretrained multimodal processor.
         Returns ``None`` for text-only models (including AutoProcessor fallbacks to
         tokenizer backends such as ``TokenizersBackend``).
+
     """
     from transformers import AutoConfig, AutoProcessor, PreTrainedTokenizerBase
 

--- a/verl/utils/torch_dtypes.py
+++ b/verl/utils/torch_dtypes.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Adapted from Cruise.
+"""Precision type utilities adapted from Cruise.
+
+Provides helpers to convert between string/int precision identifiers and
+``torch.dtype`` objects.
 """
 
 import torch
@@ -39,26 +41,80 @@ class PrecisionType:
 
     @staticmethod
     def supported_type(precision: str | int) -> bool:
+        """Check if a precision value is supported.
+
+        Args:
+            precision: The precision identifier to check.
+
+        Returns:
+            bool: True if the precision is recognized.
+
+        """
         return any(x == precision for x in PrecisionType)
 
     @staticmethod
     def supported_types() -> list[str]:
+        """Return a list of all supported precision type strings.
+
+        Returns:
+            list[str]: Supported precision type values.
+
+        """
         return [x.value for x in PrecisionType]
 
     @staticmethod
     def is_fp16(precision):
+        """Check if precision represents float16.
+
+        Args:
+            precision: A precision identifier (int, str, or torch.dtype).
+
+        Returns:
+            bool: True if precision corresponds to float16.
+
+        """
         return precision in HALF_LIST
 
     @staticmethod
     def is_fp32(precision):
+        """Check if precision represents float32.
+
+        Args:
+            precision: A precision identifier (int, str, or torch.dtype).
+
+        Returns:
+            bool: True if precision corresponds to float32.
+
+        """
         return precision in FLOAT_LIST
 
     @staticmethod
     def is_bf16(precision):
+        """Check if precision represents bfloat16.
+
+        Args:
+            precision: A precision identifier (int, str, or torch.dtype).
+
+        Returns:
+            bool: True if precision corresponds to bfloat16.
+
+        """
         return precision in BFLOAT_LIST
 
     @staticmethod
     def to_dtype(precision):
+        """Convert a precision identifier to the corresponding ``torch.dtype``.
+
+        Args:
+            precision: A precision identifier (int, str, or torch.dtype).
+
+        Returns:
+            torch.dtype: The corresponding PyTorch dtype.
+
+        Raises:
+            RuntimeError: If the precision is not recognized.
+
+        """
         if precision in HALF_LIST:
             return torch.float16
         elif precision in FLOAT_LIST:
@@ -70,6 +126,18 @@ class PrecisionType:
 
     @staticmethod
     def to_str(precision):
+        """Convert a ``torch.dtype`` to its short string representation.
+
+        Args:
+            precision: A ``torch.dtype`` value.
+
+        Returns:
+            str: One of ``"fp16"``, ``"fp32"``, or ``"bf16"``.
+
+        Raises:
+            RuntimeError: If the precision is not recognized.
+
+        """
         if precision == torch.float16:
             return "fp16"
         elif precision == torch.float32:

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -41,6 +41,7 @@ class Tracking:
     Attributes:
         supported_backend: List of supported tracking backends.
         logger: Dictionary of initialized logger instances for each backend.
+
     """
 
     supported_backend = [
@@ -181,6 +182,15 @@ class Tracking:
             self.logger["file"] = FileLogger(project_name, experiment_name)
 
     def log(self, data, step, backend=None):
+        """Log data to the configured tracking backends at the given step.
+
+        Args:
+            data: Mapping of metric names to values to log.
+            step: The current step or iteration associated with the data.
+            backend: Optional collection of backend names to restrict logging to. If None,
+                logs to all configured backends.
+
+        """
         for default_backend, logger_instance in self.logger.items():
             if backend is None or default_backend in backend:
                 logger_instance.log(data=data, step=step)
@@ -203,6 +213,15 @@ class Tracking:
 
 
 class ClearMLLogger:
+    """Tracking backend that logs metrics and tables to ClearML.
+
+    Args:
+        project_name: The ClearML project name.
+        experiment_name: The ClearML task/experiment name.
+        config: Hyperparameter configuration to attach to the task.
+
+    """
+
     def __init__(self, project_name: str, experiment_name: str, config):
         self.project_name = project_name
         self.experiment_name = experiment_name
@@ -222,6 +241,13 @@ class ClearMLLogger:
         return self._task.get_logger()
 
     def log(self, data, step):
+        """Log scalar and table data to ClearML at the given step.
+
+        Args:
+            data: Mapping of "title/series" keys to scalar or DataFrame values.
+            step: The current step or iteration associated with the data.
+
+        """
         import numpy as np
         import pandas as pd
 
@@ -251,6 +277,7 @@ class ClearMLLogger:
                 )
 
     def finish(self):
+        """Close the ClearML task and finalize logging."""
         self._task.close()
 
 
@@ -269,6 +296,14 @@ class _TrackioLoggingAdapter:
 
 
 class FileLogger:
+    """Tracking backend that appends metrics as JSON lines to a local file.
+
+    Args:
+        project_name: The project name used to construct the log directory.
+        experiment_name: The experiment name used as the log filename.
+
+    """
+
     def __init__(self, project_name: str, experiment_name: str):
         self.project_name = project_name
         self.experiment_name = experiment_name
@@ -283,10 +318,18 @@ class FileLogger:
         self.fp = open(self.filepath, "wb", buffering=0)
 
     def log(self, data, step):
+        """Append the data as a JSON line to the log file.
+
+        Args:
+            data: Mapping of metric names to values to log.
+            step: The current step or iteration associated with the data.
+
+        """
         data = {"step": step, "data": data}
         self.fp.write(orjson.dumps(data, option=orjson.OPT_SERIALIZE_NUMPY) + b"\n")
 
     def finish(self):
+        """Close the underlying log file."""
         self.fp.close()
 
 
@@ -302,10 +345,18 @@ class _TensorboardAdapter:
         self.writer = SummaryWriter(tensorboard_dir)
 
     def log(self, data, step):
+        """Log scalar metrics to TensorBoard.
+
+        Args:
+            data: Mapping of metric names to scalar values.
+            step: The current step or iteration.
+
+        """
         for key in data:
             self.writer.add_scalar(key, data[key], step)
 
     def finish(self):
+        """Close the TensorBoard SummaryWriter."""
         self.writer.close()
 
 
@@ -344,6 +395,13 @@ class _MlflowLoggingAdapter:
         return sanitized
 
     def log(self, data, step):
+        """Log metrics to MLflow with automatic key sanitization and retry logic.
+
+        Args:
+            data: Mapping of metric names to numeric values.
+            step: The current step or iteration.
+
+        """
         import mlflow
 
         results = {self._sanitize_key(k): v for k, v in data.items()}
@@ -398,10 +456,26 @@ def _flatten_dict(raw: dict[str, Any], *, sep: str) -> dict[str, Any]:
 
 @dataclasses.dataclass
 class ValidationGenerationsLogger:
+    """Logger for validation generation samples across multiple tracking backends.
+
+    Attributes:
+        project_name: The project name for backend initialization.
+        experiment_name: The experiment name for backend initialization.
+
+    """
+
     project_name: str = None
     experiment_name: str = None
 
     def log(self, loggers, samples, step):
+        """Log validation generation samples to the requested backends.
+
+        Args:
+            loggers: Collection of backend names to log the samples to.
+            samples: The validation generation samples to log.
+            step: The current step or iteration associated with the samples.
+
+        """
         if "wandb" in loggers:
             self.log_generations_to_wandb(samples, step)
         if "swanlab" in loggers:
@@ -420,11 +494,25 @@ class ValidationGenerationsLogger:
             self.log_generations_to_vemlp_wandb(samples, step)
 
     def log_generations_to_vemlp_wandb(self, samples, step):
+        """Log generation samples to VeMLP WandB as a table.
+
+        Args:
+            samples: The validation generation samples to log.
+            step: The current step or iteration associated with the samples.
+
+        """
         from volcengine_ml_platform import wandb as vemlp_wandb
 
         self._log_generations_to_wandb(samples, step, vemlp_wandb)
 
     def log_generations_to_wandb(self, samples, step):
+        """Log generation samples to WandB as a table.
+
+        Args:
+            samples: The validation generation samples to log.
+            step: The current step or iteration associated with the samples.
+
+        """
         import wandb
 
         self._log_generations_to_wandb(samples, step, wandb)

--- a/verl/utils/transferqueue_utils.py
+++ b/verl/utils/transferqueue_utils.py
@@ -41,9 +41,13 @@ try:
 except ImportError:
 
     class BatchMeta:
+        """Fallback placeholder for transfer_queue.BatchMeta when the package is not installed."""
+
         pass
 
     class KVBatchMeta:
+        """Fallback placeholder for transfer_queue.KVBatchMeta when the package is not installed."""
+
         pass
 
     # Mock transfer_queue module when not installed
@@ -82,12 +86,22 @@ def _run_async_in_temp_loop(async_func: Callable[..., Any], *args, **kwargs) -> 
     )
 
     def run_coroutine(coroutine):
+        """Run a coroutine on the temporary event loop and return its result.
+
+        Args:
+            coroutine: The coroutine to schedule on the temporary event loop.
+
+        Returns:
+            The result produced by the coroutine.
+
+        """
         if not thread.is_alive():
             thread.start()
         future = asyncio.run_coroutine_threadsafe(coroutine, tmp_event_loop)
         return future.result()
 
     async def stop_loop():
+        """Stop the temporary event loop."""
         tmp_event_loop.stop()
 
     try:
@@ -182,6 +196,7 @@ def _compute_need_collect(dispatch_mode: "dict | Dispatch", args: list) -> bool:
         Otherwise, returns True. For the lazy compute case, checks the worker's
         data parallel rank for the mesh specified in collect_fn.args[0] to determine
         if this worker should collect data.
+
     """
     from verl.single_controller.base.decorator import Dispatch
     from verl.single_controller.base.worker import Worker
@@ -237,6 +252,7 @@ def _postprocess_common(output, put_data, need_collect):
         This function is used in the tqbridge decorator to normalize return values
         across different execution paths and avoid redundant data operations in
         distributed scenarios.
+
     """
     from verl.protocol import DataProto
 
@@ -251,6 +267,7 @@ def _postprocess_common(output, put_data, need_collect):
 
 
 async def async_kv_batch_meta2batch_meta(meta: KVBatchMeta) -> BatchMeta:
+    """Convert a KVBatchMeta to a BatchMeta asynchronously."""
     global TQ_INITIALIZED
     if not TQ_INITIALIZED:
         tq.init()
@@ -268,10 +285,12 @@ async def async_kv_batch_meta2batch_meta(meta: KVBatchMeta) -> BatchMeta:
 
 
 def kv_batch_meta2batch_meta(meta: KVBatchMeta):
+    """Convert a KVBatchMeta to a BatchMeta synchronously."""
     return _run_async_in_temp_loop(async_kv_batch_meta2batch_meta, meta)
 
 
 async def async_batch_meta2kv_batch_meta(meta: BatchMeta) -> KVBatchMeta:
+    """Convert a BatchMeta to a KVBatchMeta asynchronously."""
     global TQ_INITIALIZED
     if not TQ_INITIALIZED:
         tq.init()
@@ -292,6 +311,7 @@ async def async_batch_meta2kv_batch_meta(meta: BatchMeta) -> KVBatchMeta:
 
 
 def batch_meta2kv_batch_meta(meta: BatchMeta):
+    """Convert a BatchMeta to a KVBatchMeta synchronously."""
     return _run_async_in_temp_loop(async_batch_meta2kv_batch_meta, meta)
 
 
@@ -312,6 +332,7 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
 
     Returns:
         A decorator function used to decorate target functions (synchronous or asynchronous).
+
     """
     # TODO: move to the top
     from verl.single_controller.base.decorator import _check_dispatch_mode
@@ -320,10 +341,20 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
         _check_dispatch_mode(dispatch_mode)
 
     def decorator(func):
+        """Wrap the target function with TransferQueue bridging logic.
+
+        Args:
+            func: The target function (sync or async) to decorate.
+
+        Returns:
+            The wrapped function with meta/TensorDict conversion applied.
+
+        """
         pid = os.getpid()
 
         @wraps(func)
         def inner(*args, **kwargs):
+            """Synchronous wrapper that bridges BatchMeta and TensorDict around the target function."""
             batch_meta = _find_meta(*args, **kwargs)
             if batch_meta is None:
                 return func(*args, **kwargs)
@@ -371,6 +402,7 @@ def tqbridge(dispatch_mode: "dict | Dispatch" = None):
 
         @wraps(func)
         async def async_inner(*args, **kwargs):
+            """Asynchronous wrapper that bridges BatchMeta and TensorDict around the target function."""
             batch_meta = _find_meta(*args, **kwargs)
             if batch_meta is None:
                 return await func(*args, **kwargs)

--- a/verl/utils/transformers_compat.py
+++ b/verl/utils/transformers_compat.py
@@ -38,6 +38,19 @@ except ImportError:
 
 @lru_cache
 def is_transformers_version_in_range(min_version: Optional[str] = None, max_version: Optional[str] = None) -> bool:
+    """Check whether the installed transformers version is within the given range.
+
+    Args:
+        min_version: Inclusive lower bound for the version. If None, no lower bound is enforced.
+        max_version: Inclusive upper bound for the version. If None, no upper bound is enforced.
+
+    Returns:
+        True if the installed transformers version satisfies both bounds, False otherwise.
+
+    Raises:
+        ModuleNotFoundError: If the transformers package is not installed.
+
+    """
     try:
         # Get the installed version of the transformers library
         transformers_version_str = importlib.metadata.version("transformers")

--- a/verl/utils/trtllm/trtllm_fp8_utils.py
+++ b/verl/utils/trtllm/trtllm_fp8_utils.py
@@ -17,5 +17,7 @@ from verl.utils.fp8_utils import FP8QuantizerHelper
 
 
 class TRTLLMFP8QuantizerHelper(FP8QuantizerHelper):
+    """FP8 quantization helper specialized for the TensorRT-LLM inference backend."""
+
     def __init__(self, quant_config):
         super().__init__(quant_config)

--- a/verl/utils/ulysses.py
+++ b/verl/utils/ulysses.py
@@ -119,6 +119,19 @@ def _unpad_tensor(x: Tensor, dim: int, padding_size: int) -> Tensor:
 
 
 def slice_input_tensor(x: Tensor, dim: int, padding: bool = True, group: ProcessGroup = None) -> Tensor:
+    """Slice the local shard of a tensor along ``dim`` for the current sequence parallel rank.
+
+    Args:
+        x (Tensor): Input tensor to slice.
+        dim (int): Dimension along which to slice.
+        padding (bool): Whether to pad the tensor to be divisible by the SP world size
+            before slicing. Defaults to True.
+        group (ProcessGroup, optional): Process group. If None, uses the Ulysses SP group.
+
+    Returns:
+        Tensor: The contiguous local shard for the current rank.
+
+    """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     sp_world_size = dist.get_world_size(group)
     sp_rank = get_ulysses_sequence_parallel_rank()
@@ -141,6 +154,19 @@ def all_to_all_tensor(
     group: Optional[dist.ProcessGroup] = None,
     async_op: bool = False,
 ):
+    """Perform an all-to-all on a tensor, scattering one dimension and gathering another.
+
+    Args:
+        local_input (Tensor): Local input tensor.
+        scatter_dim (int): Dimension to scatter across ranks.
+        gather_dim (int): Dimension to gather across ranks.
+        group (ProcessGroup, optional): Process group. If None, uses the Ulysses SP group.
+        async_op (bool): Whether to perform the communication asynchronously. Defaults to False.
+
+    Returns:
+        Tensor: The redistributed tensor, or a ``wait`` callable returning it when ``async_op``.
+
+    """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     seq_world_size = dist.get_world_size(group)
     input_list = [t.contiguous() for t in torch.tensor_split(local_input, seq_world_size, scatter_dim)]
@@ -149,6 +175,7 @@ def all_to_all_tensor(
     if async_op:
 
         def wait():
+            """Wait for the async all-to-all to finish and return the gathered tensor."""
             comm.wait()
             return torch.cat(output_list, dim=gather_dim).contiguous()
 
@@ -157,6 +184,17 @@ def all_to_all_tensor(
 
 
 def all_gather_tensor(local_tensor: Tensor, group: Optional[dist.ProcessGroup] = None, async_op: bool = False):
+    """All-gather a tensor along the first dimension across the process group.
+
+    Args:
+        local_tensor (Tensor): Local tensor to gather.
+        group (ProcessGroup, optional): Process group. If None, uses the Ulysses SP group.
+        async_op (bool): Whether to perform the communication asynchronously. Defaults to False.
+
+    Returns:
+        Tensor: The gathered tensor.
+
+    """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     sp_world_size = dist.get_world_size(group=group)
     output_shape = list(local_tensor.shape)
@@ -167,6 +205,8 @@ def all_gather_tensor(local_tensor: Tensor, group: Optional[dist.ProcessGroup] =
 
 
 class SeqAllToAll(torch.autograd.Function):
+    """Autograd function performing an all-to-all sequence redistribution with gradient support."""
+
     @staticmethod
     def forward(
         ctx: Any,
@@ -176,6 +216,7 @@ class SeqAllToAll(torch.autograd.Function):
         gather_dim: int,
         async_op: bool = False,
     ) -> Tensor:
+        """Apply an all-to-all redistribution in the forward pass."""
         ctx.group = group
         ctx.scatter_dim = scatter_dim
         ctx.gather_dim = gather_dim
@@ -184,6 +225,7 @@ class SeqAllToAll(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, *grad_output: Tensor) -> tuple[None, Tensor, None, None]:
+        """Apply the inverse all-to-all redistribution on the gradient."""
         input_t = torch.cat(grad_output[1:], dim=ctx.gather_dim).contiguous() if ctx.async_op else grad_output[0]
         return (
             None,
@@ -196,6 +238,8 @@ class SeqAllToAll(torch.autograd.Function):
 
 
 class Gather(torch.autograd.Function):
+    """Autograd function that all-gathers tensors across ranks with gradient support."""
+
     @staticmethod
     def forward(
         ctx: Any,
@@ -205,6 +249,7 @@ class Gather(torch.autograd.Function):
         grad_scaler: bool = True,
         async_op=False,
     ) -> Tensor:
+        """All-gather the local tensor along ``gather_dim`` in the forward pass."""
         ctx.group = group
         ctx.gather_dim = gather_dim
         ctx.grad_scaler = grad_scaler
@@ -226,6 +271,7 @@ class Gather(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> Any:
+        """Scatter the gradient back to the local shard, optionally scaling it."""
         if ctx.grad_scaler:
             grad_output = grad_output * ctx.sp_world_size
         return (
@@ -239,6 +285,7 @@ class Gather(torch.autograd.Function):
 
 
 def gather_outpus_and_unpad(*args, **kwargs):
+    """Raise an error directing callers to the correctly spelled ``gather_outputs_and_unpad``."""
     raise RuntimeError(
         "please use verl.utils.ulysses.gather_outputs_and_unpad instead of verl.utils.ulysses.gather_outpus_and_unpad"
     )
@@ -266,6 +313,7 @@ def gather_outputs_and_unpad(
 
     Returns:
         Tensor: The gathered tensor, with padding removed if requested.
+
     """
     group = get_ulysses_sequence_parallel_group() if group is None else group
     if group is None:
@@ -282,6 +330,18 @@ def gather_outputs_and_unpad(
 def ulysses_pad(
     input_ids_rmpad: torch.Tensor, position_ids_rmpad: Optional[torch.Tensor] = None, sp_size: int = 1, pad_value=0
 ):
+    """Pad input_ids and position_ids so their sequence length is divisible by ``sp_size``.
+
+    Args:
+        input_ids_rmpad (torch.Tensor): Input ids of shape [bsz, seqlen].
+        position_ids_rmpad (torch.Tensor, optional): Position ids of shape [bsz, seqlen].
+        sp_size (int): Ulysses sequence parallelism size. Defaults to 1.
+        pad_value: Value used to pad ``input_ids_rmpad``. Defaults to 0.
+
+    Returns:
+        tuple: The padded input_ids, padded position_ids, and the pad size.
+
+    """
     if position_ids_rmpad is not None:
         assert position_ids_rmpad.size(-2) == 1
         assert input_ids_rmpad.size(-1) == position_ids_rmpad.size(-1)
@@ -319,11 +379,13 @@ def ulysses_pad_and_slice_inputs(
         position_ids_rmpad: shape of [bsz, seqlen], where bsz must be 1
         sp_size (int): ulysses sequence parallelism size
         skip_position_ids_rmpad: whether to skip position_ids_rmpad for VeOmniEngine
+        pad_value (int): The value used for padding. Defaults to 0.
 
     Returns:
         torch.Tensor: padded and sliced input_ids
         torch.Tensor: padded and sliced position_ids
         int: pad size
+
     """
     input_ids_rmpad, position_ids_rmpad, pad_size = ulysses_pad(
         input_ids_rmpad, position_ids_rmpad, sp_size, pad_value=pad_value
@@ -335,6 +397,7 @@ def ulysses_pad_and_slice_inputs(
 
 
 def validate_ulysses_config(num_heads, ulysses_sequence_size):
+    """Validate that ``num_heads`` is divisible by the Ulysses sequence parallelism size."""
     if ulysses_sequence_size > 1:
         assert num_heads % ulysses_sequence_size == 0, (
             f"num_heads ({num_heads}) must be divisible by ulysses sequence size({ulysses_sequence_size})"
@@ -354,9 +417,11 @@ class BaseShardingManager:
         pass
 
     def preprocess_data(self, data: "DataProto") -> "DataProto":
+        """Preprocess data before computation. Returns the data unchanged by default."""
         return data
 
     def postprocess_data(self, data: "DataProto") -> "DataProto":
+        """Postprocess data after computation. Returns the data unchanged by default."""
         return data
 
 

--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -22,6 +22,16 @@ from verl.utils.device import is_torch_npu_available
 
 
 def vllm_ascend_v011_select_moe_comm_method_wrapper(fn):
+    """Wrap the v0.11 MoE communication method selector for Ascend A2 compatibility.
+
+    Args:
+        fn: The original select_moe_comm_method function to wrap.
+
+    Returns:
+        A wrapped function that overrides MC2 on A2 hardware.
+
+    """
+
     @wraps(fn)
     def wrapper(self, num_tokens, with_prefill):
         moe_comm_method = fn(self, num_tokens, with_prefill)
@@ -51,6 +61,16 @@ def vllm_ascend_v011_select_moe_comm_method_wrapper(fn):
 
 
 def vllm_ascend_v011_matmul_and_reduce_wrapper(fn):
+    """Wrap the v0.11 matmul_and_reduce to disable MMRS fusion on Ascend A2.
+
+    Args:
+        fn: The original matmul_and_reduce function to wrap.
+
+    Returns:
+        A wrapped function that disables MMRS fusion on A2 hardware.
+
+    """
+
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
         from vllm_ascend.utils import AscendSocVersion, get_ascend_soc_version
@@ -72,6 +92,12 @@ def vllm_ascend_v011_matmul_and_reduce_wrapper(fn):
 
 
 def check_vllm_ascend_before_server_launch():
+    """Validate Ascend environment settings before launching the vLLM server.
+
+    Raises:
+        AssertionError: If unsupported configuration is detected on A2 hardware.
+
+    """
     import torch_npu
     import vllm
 
@@ -122,6 +148,16 @@ def check_vllm_ascend_before_server_launch():
 
 
 def vllm_ascend_v013_select_moe_comm_method_wrapper(fn):
+    """Wrap the v0.13 MoE communication method selector for Ascend A2 compatibility.
+
+    Args:
+        fn: The original select_moe_comm_method function to wrap.
+
+    Returns:
+        A wrapped function that overrides MC2 on A2 hardware.
+
+    """
+
     @wraps(fn)
     def wrapper(*args, **kwargs):
         moe_comm_method = fn(*args, **kwargs)
@@ -140,6 +176,16 @@ def vllm_ascend_v013_select_moe_comm_method_wrapper(fn):
 
 
 def vllm_ascend_v013_matmul_and_reduce_wrapper(fn):
+    """Wrap the v0.13 matmul_and_reduce to disable MMRS fusion on Ascend A2.
+
+    Args:
+        fn: The original matmul_and_reduce function to wrap.
+
+    Returns:
+        A wrapped function that disables MMRS fusion on A2 hardware.
+
+    """
+
     @wraps(fn)
     def wrapper(self, *args, **kwargs):
         from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
@@ -161,6 +207,16 @@ def vllm_ascend_v013_matmul_and_reduce_wrapper(fn):
 
 
 def vllm_v013_weight_loader_method_wrapper(fn):
+    """Wrap the v0.13 FusedMoE weight_loader to transpose weights before loading.
+
+    Args:
+        fn: The original weight_loader method to wrap.
+
+    Returns:
+        A wrapped function that transposes expert weight dimensions as needed.
+
+    """
+
     @wraps(fn)
     def wrapper(self, param, loaded_weight, weight_name, shard_id, expert_id, return_success=False):
         if (shard_id in ("w1", "w3") and param.shape[1] == self.hidden_size) or (
@@ -173,6 +229,7 @@ def vllm_v013_weight_loader_method_wrapper(fn):
 
 
 def patch_vllm013_rotary_emb():
+    """Patch the vLLM 0.13 rotary embedding to disable flash_attn on NPU."""
     from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
 
     def vllm013_npu_rotary_embedding_init_impl(

--- a/verl/utils/vllm/patch.py
+++ b/verl/utils/vllm/patch.py
@@ -75,6 +75,12 @@ except ImportError:
 
 
 def patch_vllm_moe_model_weight_loader(model):
+    """Patch vLLM MoE model to attach weight_loader to expert parameters.
+
+    Args:
+        model: The vLLM model whose MoE expert weights need patching.
+
+    """
     # this is a work around to load the weight of vllm fused moe model
     # it is from a bug from vllm 0.8.2
     # all the weights are supposed to have a weight_loader, but the moe weights

--- a/verl/utils/vllm/utils.py
+++ b/verl/utils/vllm/utils.py
@@ -29,13 +29,25 @@ from verl.third_party.vllm import get_version
 
 
 class TensorLoRARequest(LoRARequest):
+    """Extended LoRA request that carries adapter tensors in memory.
+
+    Attributes:
+        peft_config: The PEFT configuration dictionary for the adapter.
+        lora_tensors: Mapping of parameter names to in-memory LoRA weight tensors.
+
+    """
+
     peft_config: dict = field(default=None)
     lora_tensors: dict = field(default=None)
 
 
 class VLLMHijack:
+    """Utility for monkey-patching vLLM to support tensor-based LoRA loading."""
+
     @staticmethod
     def hijack():
+        """Apply monkey-patches to vLLM LoRA manager for tensor-based adapter loading."""
+
         def hijack__load_adapter(self, lora_request: TensorLoRARequest) -> LoRAModel:
             """
             based on vllm.lora.worker_manager.WorkerLoRAManager._load_adapter, support load adapter with lora tensors

--- a/verl/utils/vllm/vllm_fp8_utils.py
+++ b/verl/utils/vllm/vllm_fp8_utils.py
@@ -36,6 +36,15 @@ logger = logging.getLogger(__name__)
 # Ref: https://github.com/NVIDIA-NeMo/RL/commit/bc24887c72a6e1b2699a228bc87c588546dfe6b7
 @dataclass()
 class FP8State:
+    """Cache of FP8 parameter metadata and vLLM patches used during FP8 weight handling.
+
+    Attributes:
+        seen_params (set): Parameter names that have already been inspected.
+        fp8_param_names (set): Parameter names identified as FP8 weights.
+        vllm_patches (list): Applied vLLM patches related to FP8 support.
+
+    """
+
     # A cache of fp8 parameter names, we can check this cache to see if a
     # param name corresponds to a fp8 weight
     seen_params: set = field(default_factory=lambda: set())
@@ -47,6 +56,15 @@ fp8_state: FP8State = FP8State()
 
 
 def is_fp8_model(vllm_config):
+    """Check whether the given vLLM config uses FP8 quantization.
+
+    Args:
+        vllm_config: The vLLM configuration object to inspect.
+
+    Returns:
+        True if the model uses FP8 quantization, False otherwise.
+
+    """
     from vllm.model_executor.layers.quantization.fp8 import Fp8Config
 
     if hasattr(vllm_config, "quant_config"):
@@ -59,6 +77,16 @@ def is_fp8_model(vllm_config):
 
 
 def get_module_from_param_name(model, name: str):
+    """Retrieve the module corresponding to a given parameter name in the model.
+
+    Args:
+        model: The model to traverse.
+        name: Dot-separated parameter name (e.g., 'layers.0.self_attn.q_proj.weight').
+
+    Returns:
+        The module that owns the specified parameter.
+
+    """
     # Split the name into parts (e.g., 'layers', '0', 'self_attn', 'q_proj', 'weight')
     # The module path is all but the last part (the parameter's own name)
     path_parts = name.split(".")
@@ -89,6 +117,16 @@ def get_module_from_param_name(model, name: str):
 
 
 def is_fp8_weight(name, model):
+    """Determine whether a named parameter is an FP8-quantized weight.
+
+    Args:
+        name: The parameter name to check.
+        model: The model used for module lookup.
+
+    Returns:
+        True if the parameter is an FP8 weight, False otherwise.
+
+    """
     if name not in fp8_state.seen_params:
         fp8_state.seen_params.add(name)
         # Filter out bias params
@@ -106,6 +144,15 @@ def is_fp8_weight(name, model):
 
 
 def is_mxfp8_vllm_ascend(quant_config):
+    """Check whether the quantization config is an Ascend MXFP8 configuration.
+
+    Args:
+        quant_config: The quantization configuration object to inspect.
+
+    Returns:
+        True if the config is an Ascend MXFP8 configuration, False otherwise.
+
+    """
     try:
         from vllm_ascend.quantization.modelslim_config import AscendModelSlimConfig
 
@@ -119,6 +166,12 @@ def is_mxfp8_vllm_ascend(quant_config):
 
 
 def restore_mxfp8_weights_for_loading(model):
+    """Restore MXFP8 weight shapes to their original layout before reloading.
+
+    Args:
+        model: The model whose MXFP8-transformed modules should be restored.
+
+    """
     for name, module in model.named_modules():
         if (
             hasattr(module, "_mxfp8_transformed")
@@ -165,6 +218,7 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
 
     Yields:
         Tuples of (name, tensor) for each weight and its scale
+
     """
 
     fp8_state.seen_params.clear()
@@ -214,6 +268,17 @@ def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
 
 
 def load_quanted_weights(weights, model_runner, is_drafter=False):
+    """Load and quantize weights into a vLLM model runner.
+
+    Args:
+        weights: Generator or iterable of (name, tensor) weight pairs.
+        model_runner: The vLLM model runner containing model and config.
+        is_drafter: If True, load weights into the drafter model
+            (``model_runner.drafter.model``) instead of the main model.
+
+    Returns:
+        The set of parameter names that were successfully loaded.
+    """
     if is_drafter:
         drafter = getattr(model_runner, "drafter", None)
         model = drafter.model if drafter is not None and hasattr(drafter, "model") else None
@@ -622,6 +687,13 @@ def process_weights_after_loading_moe_for_vllm11(self, layer) -> None:
 
 
 def process_weights_after_loading_moe_for_vllm14(self, layer) -> None:
+    """Process FusedMoE weights after loading for vLLM >= 0.14.
+
+    Args:
+        self: The Fp8MoEMethod instance.
+        layer: The FusedMoE layer whose weights are being processed.
+
+    """
     # removed the reentrancy guard here for refit
     from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
         convert_to_fp8_moe_kernel_format,
@@ -698,6 +770,7 @@ def process_weights_after_loading_moe_for_vllm14(self, layer) -> None:
 
 
 def apply_vllm_fp8_patches():
+    """Apply monkey-patches for FP8 blockwise quantization in vLLM."""
     logger.info("Applying vllm fp8 patches for blockwise quantization")
     vllm_ver = version.parse(vllm.__version__)
     if fp8_state.vllm_patches:


### PR DESCRIPTION
### What does this PR do?

Adds comprehensive Google-style docstrings to **87 files** across the entire `verl/utils/` subpackage, as part of the docstring standardization effort tracked in #1345.

This is a systematic, package-wide documentation pass covering all public classes and functions in `verl/utils/`. Every sub-module (checkpoint, dataset, debug, kernel, logger, megatron, metric, profiler, qat, rendezvous, reward_score, sglang, trtllm, vllm, and top-level utilities) now has standardized documentation following the Google style convention.

Related issue: #1345

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+utils+docstring
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

This is a documentation-only change (+2559/−38 lines); no functional code is modified, so no unit-test regressions are expected. Formatting and style were verified with the project's pre-commit hooks:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

### API and Usage Example

N/A — no API changes. This is a documentation-only PR.

### Design & Code Changes

All added docstrings follow the **Google style** convention (Args, Returns, Raises, Note, Attributes sections where applicable), consistent with the existing codebase and the standard established in #1345.

**Files changed by sub-module (87 total):**

| Sub-module | Count | Key files |
|-----------|-------|-----------|
| top-level | 29 | `tracking.py`, `config.py`, `fsdp_utils.py`, `model.py`, `distributed.py`, `megatron_utils.py`, `activation_offload.py`, `ulysses.py`, `torch_dtypes.py`, `py_functional.py`, etc. |
| reward_score | 15 | `gsm8k.py`, `math_reward.py`, `geo3k.py`, `rlla.py`, `prime_code/`, `prime_math/`, `sandbox_fusion/` |
| profiler | 8 | `config.py`, `performance.py`, `torch_profile.py`, `mstx_profile.py`, `nvtx_profile.py`, etc. |
| megatron | 8 | `tensor_parallel.py`, `pipeline_parallel.py`, `sequence_parallel.py`, `router_replay_patch.py`, etc. |
| dataset | 5 | `dataset_utils.py`, `rl_dataset.py`, `rm_dataset.py`, `vision_utils.py` |
| vllm | 4 | `utils.py`, `vllm_fp8_utils.py`, `patch.py`, `npu_vllm_patch.py` |
| checkpoint | 4 | `checkpoint_handler.py`, `checkpoint_manager.py`, `megatron_checkpoint_manager.py` |
| kernel | 3 | `linear_cross_entropy.py`, `fp8_kernel.py`, `kernels.py` |
| qat | 2 | `linear.py`, `vllm_patch.py` |
| debug | 2 | `metrics.py`, `trajectory_tracker.py` |
| others | 6 | `trtllm/`, `sglang/`, `rendezvous/`, `modelopt/`, `metric/`, `logger/`, `experimental/` |

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). — N/A (this PR *is* the documentation improvement)
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. — N/A (no logic change, docstrings only)
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). — N/A (documentation-only PR, no logic to test)

### Note

AI assistance (Claude) was used for drafting docstrings. All changes have been reviewed and validated by the submitter. Commit includes `Co-authored-by: Claude` attribution trailer per project guidelines.


