### PR TITLE
[hardware] feat: add ROCm/HIP platform backend (PlatformROCm)

### DIFF
--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -28,6 +28,7 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "verl/utils/torch_functional.py",  # import flash_attn only on cuda
     "verl/plugin/platform/platform_base.py",  # docstring mentions torch.cuda
     "verl/plugin/platform/platform_cuda.py",  # CUDA platform implementation
+    "verl/plugin/platform/platform_rocm.py",  # ROCm platform reuses torch.cuda via hipify
     "verl/plugin/platform/platform_manager.py",  # platform auto-detection probes torch.cuda
     "verl/utils/profiler/nvtx_profile.py",  # appear in NsightSystemsProfiler
     "verl/utils/profiler/torch_profile.py",  # appear in TorchProfiler

--- a/verl/plugin/platform/platform_cuda.py
+++ b/verl/plugin/platform/platform_cuda.py
@@ -41,6 +41,10 @@ class PlatformCUDA(PlatformBase):
     def is_platform_available(self, use_smi_check=False) -> bool:
         if not hasattr(torch, "cuda"):
             return False
+        # On ROCm, torch.cuda is present too; defer to PlatformROCm so that
+        # auto-detection does not pick CUDA on AMD hardware.
+        if torch.version.hip is not None:
+            return False
         if use_smi_check:
             # In CPU-only Ray actors, torch.cuda.is_available() may return False
             # even though the cluster has GPUs. Fall back to nvidia-smi check,

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -171,3 +171,4 @@ def set_platform(platform: PlatformBase) -> None:
 # ---------------------------------------------------------------------------
 from .platform_cuda import PlatformCUDA  # noqa: E402, F401
 from .platform_npu import PlatformNPU  # noqa: E402, F401
+from .platform_rocm import PlatformROCm  # noqa: E402, F401

--- a/verl/plugin/platform/platform_rocm.py
+++ b/verl/plugin/platform/platform_rocm.py
@@ -8,6 +8,8 @@ on ROCm, following a "CUDA base + ROCm extensions" model (always extend the
 parent via ``super()`` rather than re-implementing it).
 """
 
+import os
+
 import torch
 
 from .platform_cuda import PlatformCUDA
@@ -35,7 +37,12 @@ class PlatformROCm(PlatformCUDA):
     def rollout_env_vars(self) -> dict[str, str]:
         # Extend CUDA's rollout env vars with ROCm-specific ones. SGLANG_USE_AITER
         # routes SGLang's non-attention kernels (RMSNorm/RoPE/MoE/quant) through AITER.
-        return {**super().rollout_env_vars(), "SGLANG_USE_AITER": "1"}
+        # Default to "1" but honor an explicit user override (e.g. SGLANG_USE_AITER=0
+        # to fall back to vLLM kernels).
+        return {
+            **super().rollout_env_vars(),
+            "SGLANG_USE_AITER": os.environ.get("SGLANG_USE_AITER", "1"),
+        }
 
     def ray_noset_envvars(self) -> list[str]:
         # On ROCm, HIP_VISIBLE_DEVICES takes precedence over CUDA_VISIBLE_DEVICES,

--- a/verl/plugin/platform/platform_rocm.py
+++ b/verl/plugin/platform/platform_rocm.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""AMD ROCm/HIP platform implementation.
+
+ROCm is largely CUDA-compatible: PyTorch on ROCm reuses the ``torch.cuda.*``
+API surface via hipify, so most of ``PlatformCUDA`` works unchanged. This class
+therefore subclasses ``PlatformCUDA`` and only overrides the parts that differ
+on ROCm, following a "CUDA base + ROCm extensions" model (always extend the
+parent via ``super()`` rather than re-implementing it).
+"""
+
+import torch
+
+from .platform_cuda import PlatformCUDA
+from .platform_manager import PlatformRegistry
+
+
+@PlatformRegistry.register(platform="amd")
+class PlatformROCm(PlatformCUDA):
+    """Platform backend for AMD ROCm/HIP GPUs (reuses PlatformCUDA where compatible)."""
+
+    @property
+    def vendor_name(self) -> str:
+        # NOTE: device_name stays 'cuda' on purpose — PyTorch ROCm exposes the
+        # device type string as "cuda" (torch.device("cuda") works via hipify).
+        return "amd"
+
+    def is_available(self) -> bool:
+        return torch.cuda.is_available() and torch.version.hip is not None
+
+    def is_platform_available(self, use_smi_check=False) -> bool:
+        # ROCm is identified by torch being a HIP build; does not depend on
+        # nvidia-smi / rocm-smi being on PATH.
+        return torch.version.hip is not None
+
+    def rollout_env_vars(self) -> dict[str, str]:
+        # Extend CUDA's rollout env vars with ROCm-specific ones. SGLANG_USE_AITER
+        # routes SGLang's non-attention kernels (RMSNorm/RoPE/MoE/quant) through AITER.
+        return {**super().rollout_env_vars(), "SGLANG_USE_AITER": "1"}
+
+    def ray_noset_envvars(self) -> list[str]:
+        # On ROCm, HIP_VISIBLE_DEVICES takes precedence over CUDA_VISIBLE_DEVICES,
+        # and ROCR_VISIBLE_DEVICES is also relevant, so tell Ray not to manage them.
+        return super().ray_noset_envvars() + [
+            "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
+            "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+        ]


### PR DESCRIPTION
Add a dedicated PlatformROCm that subclasses PlatformCUDA, since ROCm is largely CUDA-compatible via hipify (torch.cuda.* works) and only needs to override the parts that differ:
- vendor_name -> "amd" (device_name stays "cuda", which is what PyTorch ROCm exposes)
- is_available / is_platform_available gated on torch.version.hip
- rollout_env_vars extends CUDA's with SGLANG_USE_AITER=1
- ray_noset_envvars adds HIP/ROCR NOSET vars on top of CUDA's

Also make PlatformCUDA.is_platform_available defer (return False) when torch.version.hip is set, so auto-detection picks PlatformROCm on AMD hardware, and register the new platform in platform_manager. Whitelist platform_rocm.py in the device-api-usage sanity check (it reuses torch.cuda via hipify, like platform_cuda.py).

AI assistance (Cursor) was used; the change was reviewed line-by-line.

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
