### PR TITLE
[Doc] Add Google-style docstrings for core modules (2/N) (#1345)

### DIFF
--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -56,6 +56,7 @@ class CheckpointEngineRegistry:
 
         Args:
             backend: The backend of the checkpoint engine.
+
         """
 
         def wrapper(cls: type["CheckpointEngine"]):
@@ -73,6 +74,7 @@ class CheckpointEngineRegistry:
 
         Returns:
             The checkpoint engine class.
+
         """
         return cls._registry[backend]
 
@@ -87,6 +89,7 @@ class CheckpointEngineRegistry:
 
         Returns:
             A new checkpoint engine instance.
+
         """
         if backend not in cls._registry:
             raise ValueError(f"Checkpoint engine {backend} not registered")
@@ -120,6 +123,7 @@ class CheckpointEngine(ABC):
 
         Returns:
             A dictionary that contains the metadata of the worker group.
+
         """
         raise NotImplementedError
 
@@ -148,6 +152,7 @@ class CheckpointEngine(ABC):
                 "master_metadata": [metadata[0]] * world_size,
             }
             ```
+
         """
         raise NotImplementedError
 
@@ -157,6 +162,7 @@ class CheckpointEngine(ABC):
 
         Args:
             **kwargs: Keyword arguments from `build_topology`.
+
         """
         raise NotImplementedError
 
@@ -181,6 +187,7 @@ class CheckpointEngine(ABC):
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
             global_steps: Optional trainer step/version associated with this weight update.
+
         """
         raise NotImplementedError
 
@@ -196,6 +203,7 @@ class CheckpointEngine(ABC):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         raise NotImplementedError
 
@@ -213,6 +221,7 @@ class CheckpointEngineWithCache(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         raise NotImplementedError
 
@@ -234,16 +243,20 @@ class ColocatedCheckpointEngine(CheckpointEngine):
         self.is_master = is_master
 
     def prepare(self):
+        """Prepare the colocated checkpoint engine."""
         raise NotImplementedError
 
     def init_process_group(self, **kwargs):
+        """Initialize process group for the colocated engine."""
         raise NotImplementedError
 
     def finalize(self):
+        """Finalize the colocated checkpoint engine."""
         raise NotImplementedError
 
     @classmethod
     def build_topology(cls, *args, **kwargs):
+        """Build communication topology for the colocated engine."""
         raise NotImplementedError
 
     def send_weights(
@@ -256,6 +269,7 @@ class ColocatedCheckpointEngine(CheckpointEngine):
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
             global_steps: Optional trainer step/version associated with this weight update.
+
         """
         self.weights = weights
 
@@ -270,6 +284,7 @@ class ColocatedCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         yield from self.weights
         self.weights = None
@@ -282,6 +297,7 @@ class CheckpointEngineWorker(Worker):
         rollout_config: The rollout configuration.
         model_config: The model configuration.
         server_adapter: The server adapter to update weights.
+
     """
 
     def __init__(
@@ -321,11 +337,13 @@ class CheckpointEngineWorker(Worker):
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL, blocking=False)
     async def update_weights(self, global_steps: int = None):
+        """Receive weights from the checkpoint engine and update the server adapter."""
         weights = self.checkpoint_engine.receive_weights(global_steps=global_steps)
         await self.server_adapter.update_weights(weights, global_steps=global_steps)
 
     @register(dispatch_mode=Dispatch.DP_COMPUTE, blocking=False)
     def execute_checkpoint_engine(self, method: str, *args, **kwargs):
+        """Execute a named method on the underlying checkpoint engine."""
         return getattr(self.checkpoint_engine, method)(*args, **kwargs)
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
@@ -369,6 +387,7 @@ class CheckpointEngineManager:
         config: The checkpoint engine config.
         trainer: The trainer worker group.
         replicas: The list of rollout replicas.
+
     """
 
     def __init__(
@@ -385,7 +404,12 @@ class CheckpointEngineManager:
         self.replicas = replicas
 
     def build_process_group(self, rollout: RayWorkerGroup):
-        """Build process group for trainer and rollout replicas."""
+        """Build process group for trainer and rollout replicas.
+
+        Args:
+            rollout: The rollout worker group to build communication with.
+
+        """
         trainer = self.trainer
 
         # 1. prepare all workers
@@ -416,6 +440,7 @@ class CheckpointEngineManager:
 
         Args:
             replicas: The list of rollout replicas to add.
+
         """
         self.replicas.extend(replicas)
 
@@ -424,6 +449,7 @@ class CheckpointEngineManager:
 
         Args:
             replicas: The list of rollout replicas to remove.
+
         """
         replicas_set = set(replicas)
         self.replicas = [r for r in self.replicas if r not in replicas_set]
@@ -472,6 +498,7 @@ class CheckpointEngineManager:
 
         Args:
             global_steps: The global steps of the trainer.
+
         """
 
         # 0. update weights for sync training with colocated trainer and rollout
@@ -525,6 +552,7 @@ async def split_weight_chunks(
 
     Yields:
         A tuple of the weight chunk metadata and the buffer.
+
     """
     async for name, weight in ensure_async_iterator(weights):
         buffer = weight.view(-1).view(torch.uint8)
@@ -554,6 +582,7 @@ async def merge_weight_chunks(
 
     Yields:
         A tuple of the name of the weight tensor and the tensor itself.
+
     """
     merge_name, merge_weight, merge_buffer, merge_offset = None, None, None, 0
     async for tensor_meta, chunk in chunks:

--- a/verl/checkpoint_engine/hccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/hccl_checkpoint_engine.py
@@ -52,6 +52,7 @@ class BroadcastOperation:
         metadata (dict[str, TensorMeta]): The metadata of the tensor.
         socket (zmq.Socket): The zeromq socket to communicate with master.
         topic (str): The topic to subscribe.
+
     """
 
     def __init__(
@@ -89,6 +90,7 @@ class BroadcastOperation:
 
         Returns:
             dict[str, TensorMeta]: The bucket meta after broadcast.
+
         """
         return self.metadata
 
@@ -104,6 +106,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
         rebuild_group (bool): Whether to rebuild the HCCL process group in each update. Defaults to False.
         is_master (bool): Whether the current process is the master process. Defaults to False.
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers. Defaults to torch.bfloat16.
+
     """
 
     def __init__(
@@ -129,6 +132,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
             self.dist_port, _ = get_free_port(self.ip)
 
     def prepare(self) -> MasterMetadata:
+        """Allocate send and recv buffers and return master metadata."""
         self.send_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="npu")
         self.recv_buf = torch.zeros(self.bucket_size, dtype=torch.uint8, device="npu")
 
@@ -153,6 +157,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        """Build a broadcast topology connecting trainer rank 0 to all rollout workers."""
         trainer_kwargs = {
             "rank": [0] + [-1] * (trainer_world_size - 1),
             "world_size": [rollout_world_size + 1] * trainer_world_size,
@@ -198,6 +203,8 @@ class HCCLCheckpointEngine(CheckpointEngine):
         Args:
             rank (int): The rank of the current process.
             world_size (int): The total number of processes.
+            master_metadata (MasterMetadata): Metadata of the master process used to set up the group.
+
         """
         # For trainer workers other than rank 0, their rank should be -1.
         if rank < 0:
@@ -236,6 +243,8 @@ class HCCLCheckpointEngine(CheckpointEngine):
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps (int, optional): The current global training step. Defaults to None.
+
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
@@ -312,6 +321,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         assert self.rank > 0, "Rank 0 should not receive weights."
         send_buf, recv_buf = self.send_buf, self.recv_buf

--- a/verl/checkpoint_engine/kimi_checkpoint_engine.py
+++ b/verl/checkpoint_engine/kimi_checkpoint_engine.py
@@ -41,6 +41,7 @@ def ckpt_get_named_tensor_buckets(
     rank_id: int,
     rollout_dtype: torch.dtype = torch.bfloat16,
 ) -> dict[str, torch.Tensor]:
+    """Yield buckets of named tensors assigned to the given rank."""
     if bucket_bytes <= 0:
         raise ValueError(f"bucket_bytes must be greater than 0, got {bucket_bytes}")
 
@@ -71,6 +72,7 @@ async def receive_tensor(
     bucket_size: int = 2 << 30,
     disable_h2d_buffer: bool = False,
 ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
+    """Receive tensors from remote ranks via broadcast and yield them."""
     assert len(self._current_global_parameter_metas) != 0, "parameter metas is empty"
     assert dist.is_initialized(), "process group is not initialized"
     assert self._p2p_store is not None, "p2p store is not initialized"
@@ -188,6 +190,7 @@ class BroadcastOperation:
         ranks_group (int): The process group's value.
         bucket (torch.Tensor): The tensor to broadcast.
         metadata (list[ParameterMeta]): The metadata of the tensor.
+
     """
 
     def __init__(
@@ -214,6 +217,7 @@ class BroadcastOperation:
 
         Returns:
             list[ParameterMeta]: The bucket meta after broadcast.
+
         """
         await self._task
         return self.metadata
@@ -229,6 +233,7 @@ class KIMICheckpointEngine(CheckpointEngine):
         rebuild_group (bool): Whether to rebuild the process group in each update. Defaults to False.
         is_master (bool): Whether the current process is the master process. Defaults to False.
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers. Defaults to torch.bfloat16.
+
     """
 
     def __init__(
@@ -246,6 +251,7 @@ class KIMICheckpointEngine(CheckpointEngine):
         self.checkpoint_name = "kimi_checkpoint_engine"
 
     def prepare(self) -> MasterMetadata:
+        """Prepare the master metadata for process group initialization."""
         if self.is_master:
             self.ip = ray.util.get_node_ip_address().strip("[]")
             self.listen_port, _ = get_free_port(self.ip)
@@ -266,6 +272,7 @@ class KIMICheckpointEngine(CheckpointEngine):
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        """Build a broadcast topology connecting all trainer and rollout workers."""
         trainer_kwargs = {
             "method": ["init_process_group"] * trainer_world_size,
             "rank": list(range(0, trainer_world_size)),
@@ -293,7 +300,10 @@ class KIMICheckpointEngine(CheckpointEngine):
 
         Args:
             rank (int): The rank of the current process.
-            world_size (int): The total number of processes.
+            trainer_world_size (int): The number of trainer processes.
+            rollout_world_size (int): The number of rollout processes.
+            master_metadata (MasterMetadata): Metadata of the master process used to set up the group.
+
         """
         self.rank = rank
         self.trainer_world_size = trainer_world_size
@@ -327,6 +337,8 @@ class KIMICheckpointEngine(CheckpointEngine):
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps (int, optional): The current global training step. Defaults to None.
+
         """
 
         def offload_cpu(name: str, tensor: torch.Tensor) -> tuple[str, torch.Tensor]:
@@ -371,6 +383,7 @@ class KIMICheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         self.parameter_server.gather_metas(self.checkpoint_name)
 

--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -40,6 +40,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         device (str): The device to use for the checkpoint engine, "cpu" or "cuda".
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers.
         device_name (str): Mooncake device name filter.
+
     """
 
     def __init__(
@@ -96,6 +97,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadatas: list[dict]):
+        """Build a point-to-point topology connecting trainer rank 0 to rollout workers."""
         trainer_kwargs = {
             "rank": [0] + [-1] * (trainer_world_size - 1),
             "world_size": [rollout_world_size + 1] * trainer_world_size,
@@ -109,6 +111,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         return trainer_kwargs, rollout_kwargs
 
     def init_process_group(self, rank: int, world_size: int, metadata: dict[str, Any]):
+        """Initialize the stateless process group and exchange buffer info."""
         self.rank = rank
         self.world_size = world_size
         if rank < 0:
@@ -140,6 +143,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         logger.info(f"finalize rank={self.rank}")
 
     async def wait_for_complete(self, buf: torch.Tensor):
+        """Wait until the magic bytes appear in the buffer indicating transfer completion."""
         magic = torch.tensor([0xAB, 0xDC, 0xEF, 0x88], dtype=torch.uint8, device=self.device)
         while True:
             if torch.equal(buf[:4], magic):

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -56,6 +56,7 @@ class BroadcastOperation:
         metadata (dict[str, TensorMeta]): The metadata of the tensor.
         socket (zmq.Socket): The zeromq socket to communicate with master.
         topic (str): The topic to subscribe.
+
     """
 
     def __init__(
@@ -94,6 +95,7 @@ class BroadcastOperation:
 
         Returns:
             dict[str, TensorMeta]: The bucket meta after broadcast.
+
         """
         await self._task
         return self.metadata
@@ -110,6 +112,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
         rebuild_group (bool): Whether to rebuild the NCCL process group in each update. Defaults to False.
         is_master (bool): Whether the current process is the master process. Defaults to False.
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers. Defaults to torch.bfloat16.
+
     """
 
     def __init__(
@@ -132,6 +135,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             self._start_zmq_server()
 
     def prepare(self) -> MasterMetadata:
+        """Allocate send and recv buffers and return master metadata."""
         # For master process, use cupy instead of torch to avoid memory register error
         # when `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
         if self.is_master:
@@ -158,6 +162,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        """Build a broadcast topology connecting trainer rank 0 to all rollout workers."""
         trainer_kwargs = {
             "rank": [0] + [-1] * (trainer_world_size - 1),
             "world_size": [rollout_world_size + 1] * trainer_world_size,
@@ -203,6 +208,8 @@ class NCCLCheckpointEngine(CheckpointEngine):
         Args:
             rank (int): The rank of the current process.
             world_size (int): The total number of processes.
+            master_metadata (MasterMetadata): Metadata of the master process used to set up the group.
+
         """
         # For trainer workers other than rank 0, their rank should be -1.
         if rank < 0:
@@ -236,6 +243,8 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps (int, optional): The current global training step. Defaults to None.
+
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
@@ -307,6 +316,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
             yield name, weight
@@ -316,6 +326,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the chunk itself.
+
         """
         assert self.rank > 0, "Rank 0 should not receive weights."
         send_buf, recv_buf = self.send_buf, self.recv_buf

--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -79,6 +79,7 @@ class NixlAgent:
             return attr
 
     def get_agent_metadata(self) -> NixlAgentMetadata:
+        """Return metadata describing this agent for remote connection."""
         return NixlAgentMetadata(
             agent_name=self.agent_name,
             agent_metadata=self.agent.get_agent_metadata(),
@@ -87,6 +88,7 @@ class NixlAgent:
         )
 
     def start_zmq_server(self):
+        """Start the ZeroMQ PULL server for receiving messages."""
         self.ip = ray.util.get_node_ip_address().strip("[]")
         self.listen_port, _ = get_free_port(self.ip)
 
@@ -101,6 +103,7 @@ class NixlAgent:
         self.socket.bind(address)
 
     def add_remote_agent(self, metadata: NixlAgentMetadata) -> str:
+        """Register a remote agent and establish a ZeroMQ connection to it."""
         agent_name = self.agent.add_remote_agent(metadata.agent_metadata).decode("utf-8")
         assert agent_name == metadata.agent_name, f"Agent name {agent_name} not equal to {metadata.agent_name}"
 
@@ -117,21 +120,25 @@ class NixlAgent:
         return agent_name
 
     def remove_remote_agent(self, agent_name: str):
+        """Remove a remote agent and close its ZeroMQ socket."""
         self.agent.remove_remote_agent(agent_name)
         socket = self.zmq_clients.pop(agent_name)
         socket.close()
 
     def send_message(self, agent_name, message: dict):
+        """Send a message to the specified remote agent via ZeroMQ."""
         socket = self.zmq_clients[agent_name]
         socket.send_pyobj((self.agent_name, message), zmq.DONTWAIT)
 
     async def read_message(self, agent_name: str) -> dict:
+        """Read a message from the specified remote agent asynchronously."""
         while len(self.messages[agent_name]) == 0:
             recv_agent_name, message = await self.socket.recv_pyobj()
             self.messages[recv_agent_name].append(message)
         return self.messages[agent_name].popleft()
 
     async def get_notification(self, remote_name: str) -> bytes:
+        """Wait for and return a notification from the specified remote agent."""
         while len(self.notifications[remote_name]) == 0:
             notifs = self.agent.get_new_notifs()
             for remote_name, notif in notifs.items():
@@ -151,6 +158,7 @@ class ReadableOperation:
         local_descs (nixl_bindings.nixlXferDList): The local transfer descriptors.
         metadata (dict): Metadata for the read operation.
         bucket_size (int): The size of the bucket in bytes.
+
     """
 
     def __init__(
@@ -185,6 +193,7 @@ class ReadOperation:
         remote_agent (str): The name of the remote agent.
         local_descs (nixl_bindings.nixlXferDList): The local transfer descriptors.
         bucket_size (int): The size of the bucket in bytes.
+
     """
 
     def __init__(self, agent: NixlAgent, remote_agent: str, local_descs: nixl_bindings.nixlXferDList, bucket_size: int):
@@ -202,6 +211,7 @@ class ReadOperation:
 
         Returns:
             dict: Metadata from the remote agent.
+
         """
         metadata = await self.agent.read_message(self.remote_agent)
         self.remote_descs = metadata.pop("remote_descs")
@@ -247,6 +257,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
             two buffer to send and recv weights at same time, so the device memory overhead is 2 * bucket_size.
         device (str): The device to use for the checkpoint engine, "cpu" or "cuda".
         rollout_dtype (torch.dtype): The dtype of the weights received from rollout workers. Defaults to torch.bfloat16.
+
     """
 
     def __init__(
@@ -267,6 +278,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
         Returns:
             NixlAgentMetadata: The metadata of the current nixl agent.
+
         """
         # For master process, use cupy instead of torch to avoid memory register error
         # when `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
@@ -287,6 +299,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
     @classmethod
     def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        """Build a chain topology connecting trainer rank 0 to all rollout workers."""
         trainer_kwargs = {
             "method": ["init_process_group"] * trainer_world_size,
             "rank": [0] + [-1] * (trainer_world_size - 1),
@@ -314,6 +327,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
             world_size (int): The total number of processes.
             prev_agent_metadata (NixlAgentMetadata): The metadata of the previous nixl agent.
             next_agent_metadata (NixlAgentMetadata): The metadata of the next nixl agent.
+
         """
         if rank < 0:
             assert not prev_agent_metadata and not next_agent_metadata, (
@@ -377,6 +391,8 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
         Args:
             weights: A generator that yields the name of the weight tensor and the tensor itself.
+            global_steps (int, optional): The current global training step. Defaults to None.
+
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
@@ -445,6 +461,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the name of the weight tensor and the tensor itself.
+
         """
         async for name, weight in merge_weight_chunks(self._receive_weight_chunks(), self.bucket_size):
             yield name, weight
@@ -454,6 +471,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
 
         Yields:
             A tuple of the chunk metadata and the chunk buffer view in send_buf.
+
         """
         assert self.prev_agent is not None, "Previous agent is not set."
         send_buf, recv_buf = self.send_buf, self.recv_buf

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -203,6 +203,7 @@ class AgentLoopBase(ABC):
         processor (AutoProcessor): Processor for process messages.
         dataset_cls (type[Dataset]): Dataset class for creating dataset, Defaults to RLHFDataset.
         data_config (DictConfigWrap): Dataset config.
+
     """
 
     def __init__(
@@ -248,6 +249,7 @@ class AgentLoopBase(ABC):
 
         Returns:
             dict: Multi-modal data with keys like "images", "videos" and "audios".
+
         """
         multi_modal_data = {}
         if self.processor is not None:
@@ -287,10 +289,13 @@ class AgentLoopBase(ABC):
             tools (list[dict], optional): Tools schemas. Defaults to None.
             images (list[Image.Image], optional): Input images. Defaults to None.
             videos (list[tuple[torch.Tensor, dict]], optional): Input videos. Defaults to None.
+            audios (list[Any], optional): Input audios. Defaults to None.
+            mm_processor_kwargs (dict[str, Any], optional): Extra kwargs for the multimodal processor. Defaults to None.
             remove_system_prompt (bool, optional): Whether to remove system prompt. Defaults to False.
 
         Returns:
             list[int]: Prompt token ids.
+
         """
         if self.processor is not None:
             raw_prompt = await self.loop.run_in_executor(
@@ -368,6 +373,7 @@ class AgentLoopBase(ABC):
 
         Returns:
             AgentLoopOutput: Agent loop output.
+
         """
         raise NotImplementedError
 
@@ -399,6 +405,7 @@ class AgentLoopWorker:
         llm_client (LLMServerClient): Client for the LLM server.
         teacher_client (dict[str, LLMServerClient]): Client for multiple teacher servers.
         reward_loop_worker_handles (List[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
+
     """
 
     def __init__(
@@ -491,6 +498,7 @@ class AgentLoopWorker:
             For multi-turn conversations:
             responses:     |<- LLM generation ->|<- tool_calls ->|<- LLM generation ->|<- padding ->|
             response_mask: | 1, 1, 1, ..., 1, 1 | 0, 0, .., 0, 0 | 1, 1, 1, ..., 1, 1 | 0, 0, ..., 0|
+
         """
         config = self.rollout_config
         validate = batch.meta_info.get("validate", False)
@@ -1030,6 +1038,7 @@ async def get_trajectory_info(step, index, validate):
 
     Returns:
         list: trajectory.
+
     """
     trajectory_info = []
     rollout_n = 0
@@ -1050,6 +1059,7 @@ class AgentLoopManager:
         llm_client (LLMServerClient): Client for the LLM server.
         teacher_client (dict[str, LLMServerClient]): Client for multiple teacher servers.
         reward_loop_worker_handles (List[ray.actor.ActorHandle]): Actor handles for streaming reward computation.
+
     """
 
     def __init__(
@@ -1109,6 +1119,7 @@ class AgentLoopManager:
 
         Returns:
             DataProto: Output batch.
+
         """
         chunkes = prompts.chunk(len(self.agent_loop_workers))
         outputs = await asyncio.gather(

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -36,6 +36,16 @@ class SingleTurnAgentLoop(AgentLoopBase):
 
     @rollout_trace_op
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        """Run a single-turn chat completion and return the agent loop output.
+
+        Args:
+            sampling_params (dict[str, Any]): Sampling parameters for generation.
+            **kwargs: Additional inputs such as ``raw_prompt``.
+
+        Returns:
+            AgentLoopOutput: The result of the single-turn rollout.
+
+        """
         messages = list(kwargs["raw_prompt"])
 
         # 1. extract multimodal inputs from messages

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -102,7 +102,10 @@ class ToolAgentLoop(AgentLoopBase):
         """Initialize the tool agent loop.
 
         Args:
+            *args: Positional arguments forwarded to the parent agent loop.
             tools: Tools to use for the tool agent loop.
+            **kwargs: Keyword arguments forwarded to the parent agent loop.
+
         """
         super().__init__(*args, **kwargs)
 
@@ -123,6 +126,16 @@ class ToolAgentLoop(AgentLoopBase):
 
     @rollout_trace_op
     async def run(self, sampling_params: dict[str, Any], **kwargs) -> AgentLoopOutput:
+        """Run the multi-turn tool-calling agent loop and return its output.
+
+        Args:
+            sampling_params (dict[str, Any]): Sampling parameters for generation.
+            **kwargs: Additional inputs such as ``raw_prompt`` and ``tools_kwargs``.
+
+        Returns:
+            AgentLoopOutput: The result of the multi-turn rollout.
+
+        """
         messages = list(kwargs["raw_prompt"])
 
         # extract multimodal inputs from messages

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -72,17 +72,30 @@ class ToolParser(ABC):
 
         Returns:
             Tuple[str, List[FunctionCall]]: Content and extracted tool calls.
+
         """
         raise NotImplementedError
 
     @classmethod
     def get_tool_parser(cls, name: str, tokenizer):
+        """Instantiate a registered tool parser by name.
+
+        Args:
+            name (str): The registered tool parser name.
+            tokenizer: The tokenizer passed to the parser constructor.
+
+        Returns:
+            ToolParser: An instance of the requested tool parser.
+
+        """
         if name not in cls._registry:
             raise ValueError(f"Unknown tool parser: {name}")
         return cls._registry[name](tokenizer)
 
     @classmethod
     def register(cls, name: str):
+        """Return a decorator that registers a tool parser subclass under ``name``."""
+
         def decorator(subclass: type[ToolParser]) -> type[ToolParser]:
             cls._registry[name] = subclass
             return subclass
@@ -105,6 +118,16 @@ class HermesToolParser(ToolParser):
     async def extract_tool_calls(
         self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
     ) -> tuple[str, list[FunctionCall]]:
+        """Extract content and tool calls from the decoded response ids.
+
+        Args:
+            responses_ids (list[int]): The ids of the responses.
+            tools (list[OpenAIFunctionToolSchema], optional): OpenAI function tool schema.
+
+        Returns:
+            tuple[str, list[FunctionCall]]: Content and extracted tool calls.
+
+        """
         loop = get_event_loop()
         text = await loop.run_in_executor(None, self.tokenizer.decode, responses_ids)
         if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
@@ -134,6 +157,7 @@ class GptOssToolParser(ToolParser):
 
     Args:
         tokenizer: The tokenizer to use.
+
     """
 
     def __init__(self, tokenizer) -> None:
@@ -154,6 +178,16 @@ class GptOssToolParser(ToolParser):
     async def extract_tool_calls(
         self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
     ) -> tuple[str, list[FunctionCall]]:
+        """Extract content and tool calls from the decoded response ids.
+
+        Args:
+            responses_ids (list[int]): The ids of the responses.
+            tools (list[OpenAIFunctionToolSchema], optional): OpenAI function tool schema.
+
+        Returns:
+            tuple[str, list[FunctionCall]]: Content and extracted tool calls.
+
+        """
         loop = get_event_loop()
         # We need to keep special tokens for gpt-oss model for better tool call extraction.
         text = await loop.run_in_executor(None, lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False))
@@ -191,6 +225,7 @@ class Qwen3XMLToolParser(ToolParser):
 
     Args:
         tokenizer: The tokenizer to use.
+
     """
 
     def __init__(self, tokenizer):
@@ -332,6 +367,16 @@ class Qwen3XMLToolParser(ToolParser):
     async def extract_tool_calls(
         self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
     ) -> tuple[str, list[FunctionCall]]:
+        """Extract content and tool calls from the decoded response ids.
+
+        Args:
+            responses_ids (list[int]): The ids of the responses.
+            tools (list[OpenAIFunctionToolSchema], optional): OpenAI function tool schema.
+
+        Returns:
+            tuple[str, list[FunctionCall]]: Content and extracted tool calls.
+
+        """
         loop = get_event_loop()
         text = await loop.run_in_executor(None, self.tokenizer.decode, responses_ids)
         if self.tool_call_start_token not in text:
@@ -409,6 +454,16 @@ class Gemma4ToolParser(ToolParser):
     async def extract_tool_calls(
         self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
     ) -> tuple[str, list[FunctionCall]]:
+        """Extract content and tool calls from the decoded response ids.
+
+        Args:
+            responses_ids (list[int]): The ids of the responses.
+            tools (list[OpenAIFunctionToolSchema], optional): OpenAI function tool schema.
+
+        Returns:
+            tuple[str, list[FunctionCall]]: Content and extracted tool calls.
+
+        """
         loop = get_event_loop()
         text = await loop.run_in_executor(None, lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False))
         if self.tokenizer.pad_token:

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -34,6 +34,7 @@ def resolve_config_path(config_path: str) -> str:
 
     Raises:
         FileNotFoundError: If the configuration file cannot be found
+
     """
     # Return absolute paths unchanged
     if os.path.isabs(config_path):
@@ -83,6 +84,7 @@ def format_gpt_oss_tool_response_manually(tool_response: str, tool_call_name: st
 
     Returns:
         Formatted tool response string
+
     """
     return f"<|start|>functions.{tool_call_name} to=assistant<|channel|>commentary<|message|>{tool_response}<|end|>"
 
@@ -94,6 +96,7 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
 
     Returns:
         Message content string with generation prompt
+
     """
     return message_content + "<|start|>assistant"
 

--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -46,6 +46,7 @@ def prepare_single_generation_data(batch_dict, config) -> DataProto:
 
     Returns:
         tuple: (original_batch_dict, gen_data_for_single_sample)
+
     """
 
     full_batch = DataProto.from_single_dict(batch_dict)
@@ -99,6 +100,7 @@ def assemble_batch_from_rollout_samples(
 
     Raises:
         ValueError: If rollout_samples is empty
+
     """
     start_time = time.time()
 
@@ -366,6 +368,7 @@ def safe_create_task(coro, name: str, task_set: set = None):
 
     Returns:
         The created asyncio.Task
+
     """
     task = asyncio.create_task(coro, name=name)
     task.add_done_callback(task_exception_handler)

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -44,6 +44,12 @@ class FullyAsyncTaskRunner:
         self.shutdown_event = threading.Event()
 
     def run(self, config):
+        """Initialize components and run the fully async PPO training loop.
+
+        Args:
+            config: The training configuration.
+
+        """
         print("[ASYNC MAIN] Starting fully async PPO training...")
         self._initialize_components(config)
         self._run_training_loop()
@@ -211,6 +217,7 @@ class FullyAsyncTaskRunner:
 
 @hydra.main(config_path="config", config_name="fully_async_ppo_trainer", version_base=None)
 def main(config):
+    """Hydra entrypoint that validates config and launches fully async PPO training."""
     from verl.trainer.main_ppo import run_ppo
 
     # Ensure async training config exists

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -79,6 +79,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
 
         Returns:
             TokenOutput: token output
+
         """
         prompt_ids = normalize_token_ids(prompt_ids)
 
@@ -238,6 +239,7 @@ class FullyAsyncLLMServerManager(LLMServerManager):
 
         Returns:
             Number of successfully activated replicas.
+
         """
         # Filter out already-active and missing replicas.
         servers_to_add: dict[str, ray.actor.ActorHandle] = {}
@@ -300,6 +302,7 @@ class FullyAsyncLLMServerManager(LLMServerManager):
 
         Returns:
             Number of successfully deactivated replicas.
+
         """
         # Filter out missing replicas and collect server addresses.
         server_ids_to_remove: list[str] = []
@@ -376,6 +379,7 @@ class FullyAsyncAgentLoopManager(AgentLoopManager):
             prompts (DataProto): Input batch. Single sample data
         Returns:
             DataProto: Output batch.
+
         """
         worker = self._select_best_worker()
         output_future = worker.generate_sequences.remote(prompts)
@@ -529,6 +533,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             self.message_queue_client = message_queue_client
 
     async def set_max_required_samples(self):
+        """Compute and set the sample/queue/step limits based on the current config."""
         async with self.lock:
             self.max_required_samples = int(
                 self.required_samples
@@ -558,9 +563,11 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         return self.llm_server_manager.get_replicas()
 
     def get_max_queue_size(self):
+        """Return the maximum message queue size."""
         return self.max_queue_size
 
     def get_total_train_steps(self):
+        """Return the total number of training steps."""
         return self.total_train_steps
 
     async def reset_staleness(self):
@@ -612,6 +619,12 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         return timing_raw | val_metrics
 
     async def save_checkpoint(self, local_global_step_folder: str):
+        """Save the rollouter checkpoint to the given folder.
+
+        Args:
+            local_global_step_folder (str): Destination folder for the checkpoint.
+
+        """
         # WARNING!: Due to the asynchronous nature, there are some in-flight samples
         # (pending/cancel/result queue and message queue).
         # Therefore, directly saving the state of the dataloader will result in losing these
@@ -1107,6 +1120,12 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         return False
 
     async def get_statistics(self) -> dict:
+        """Return runtime statistics about samples, queues, and configuration.
+
+        Returns:
+            dict: Mapping of monitor, counting, and static statistics.
+
+        """
         queue_stats = await self.message_queue_client.get_statistics()
 
         stats = {
@@ -1140,9 +1159,27 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         return self._hybrid_worker_group
 
     async def add_replicas(self, resource_ids: list[str]) -> int:
+        """Add rollout replicas for the given resource ids.
+
+        Args:
+            resource_ids (list[str]): Resource ids to add as replicas.
+
+        Returns:
+            int: The number of replicas added.
+
+        """
         return await self.llm_server_manager.add_replicas(resource_ids)
 
     async def remove_replicas(self, resource_ids: list[str]) -> int:
+        """Remove rollout replicas for the given resource ids.
+
+        Args:
+            resource_ids (list[str]): Resource ids to remove from replicas.
+
+        Returns:
+            int: The number of replicas removed.
+
+        """
         return await self.llm_server_manager.remove_replicas(resource_ids)
 
     def get_hybrid_replica(self, resource_id: str):

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -254,6 +254,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         await self._setup_hybrid_checkpoint_manager()
 
     def set_total_train_steps(self, total_training_steps):
+        """Set the total number of training steps and propagate it into the config.
+
+        Args:
+            total_training_steps: The total number of training steps.
+
+        """
         self.total_train_steps = total_training_steps
 
         try:
@@ -279,6 +285,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         Returns:
             tuple: (epoch, batch_dict, gen_batch_output)
+
         """
         print(
             f"[FullyAsyncTrainer] Requesting {self.required_samples} samples from queue",
@@ -420,6 +427,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         Args:
             batch_dict: Raw data dictionary
+
         """
         self.metrics = {"training/global_step": self.global_steps, "training/epoch": self.epoch}
         self.timing_raw = {}
@@ -696,6 +704,12 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
             f.write(str(self.current_param_version))
 
     async def load_checkpoint(self):
+        """Load the trainer checkpoint and return the resumed global step.
+
+        Returns:
+            int: The global step to resume from, or 0 if resuming is disabled.
+
+        """
         if self.config.trainer.resume_mode == "disable":
             return 0
 

--- a/verl/experimental/fully_async_policy/message_queue.py
+++ b/verl/experimental/fully_async_policy/message_queue.py
@@ -61,6 +61,7 @@ class MessageQueue:
 
         Returns:
             bool: Whether the sample was successfully put into the queue
+
         """
         async with self._lock:
             # If queue is full, remove the oldest sample (rarely happens)
@@ -88,6 +89,7 @@ class MessageQueue:
 
         Returns:
             Any: Single sample data or None if queue is closed
+
         """
         async with self._lock:
             while len(self.queue) == 0 and self.running:
@@ -166,10 +168,12 @@ class MessageQueue:
             }
 
     async def put_validate(self, data):
+        """Append validation data to the validation queue."""
         async with self._lock:
             self.val_queue.append(data)
 
     async def get_validate(self):
+        """Pop and return the next validation data, or None if the queue is empty."""
         async with self._lock:
             if self.val_queue:
                 return self.val_queue.popleft()
@@ -189,10 +193,12 @@ class MessageQueueClient:
         return await asyncio.wrap_future(future.future())
 
     async def put_validate(self, data: Any) -> bool:
+        """Put validation data into the queue actor (async)."""
         future = self.queue_actor.put_validate.remote(data)
         return await asyncio.wrap_future(future.future())
 
     def get_validate_sync(self) -> Any | None:
+        """Get validation data from the queue actor synchronously."""
         return ray.get(self.queue_actor.get_validate.remote())
 
     async def get_sample(self) -> Any | None:

--- a/verl/experimental/fully_async_policy/unittest/simple_streaming_demo.py
+++ b/verl/experimental/fully_async_policy/unittest/simple_streaming_demo.py
@@ -28,6 +28,7 @@ class SimpleStreamingSystem:
 
     # Data stream coroutine
     async def data_stream(self):
+        """Produce test data into the stream, simulating an ongoing data source."""
         # Add initial data
         # Prepare test data
         test_data = [{"id": f"task_{i}", "content": f"data_{i}"} for i in range(8)]

--- a/verl/experimental/one_step_off_policy/main_ppo.py
+++ b/verl/experimental/one_step_off_policy/main_ppo.py
@@ -34,6 +34,12 @@ from verl.utils.device import auto_set_device
 @ray.remote(num_cpus=10, max_concurrency=100)  # please make sure main_task is not scheduled on head
 class OneStepTaskRunner:
     def run(self, config):
+        """Run the one-step off-policy PPO training task.
+
+        Args:
+            config: The training configuration.
+
+        """
         # Print the initial configuration. `resolve=True` will evaluate symbolic values.
         from pprint import pprint
 
@@ -109,6 +115,7 @@ class OneStepTaskRunner:
 
 @hydra.main(config_path="config", config_name="one_step_off_ppo_trainer", version_base=None)
 def main(config):
+    """Hydra entrypoint that launches one-step off-policy PPO training."""
     from time import time
 
     from verl.trainer.main_ppo import run_ppo

--- a/verl/experimental/one_step_off_policy/ray_trainer.py
+++ b/verl/experimental/one_step_off_policy/ray_trainer.py
@@ -77,6 +77,7 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
             collate_fn: Function to collate data samples into batches.
             train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
             device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
+
         """
 
         # Store the tokenizer for text processing
@@ -331,6 +332,8 @@ class OneStepOffRayTrainer(SeparateRayPPOTrainer):
 
         Args:
             batch_data_future: batch future
+            continuous_iterator: iterator yielding batches across epochs
+
         """
         self.metrics = {"training/global_step": self.global_steps, "training/epoch": self.epoch}
         self.timing_raw = {}

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -111,6 +111,7 @@ class RewardLoopWorker:
         Args:
             config: DictConfig, the config for reward loop worker.
             reward_router_address: str, the address of reward router.
+
         """
         self.config = config
         self.reward_router_address = reward_router_address
@@ -136,6 +137,15 @@ class RewardLoopWorker:
         )
 
     async def compute_score_batch(self, data: DataProto) -> list[dict]:
+        """Compute reward scores for each sample in the batch concurrently.
+
+        Args:
+            data (DataProto): A batch of samples to score.
+
+        Returns:
+            list[dict]: One score dict per sample in the batch.
+
+        """
         tasks = []
         for i in range(len(data)):
             tasks.append(asyncio.create_task(self.compute_score(data[i : i + 1])))
@@ -143,6 +153,15 @@ class RewardLoopWorker:
         return outputs
 
     async def compute_score(self, data: DataProto) -> dict:
+        """Compute the reward score for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward score.
+
+        """
         if self.config.reward.custom_reward_function.path is not None:
             # directly use user-customized reward function
             return await self.reward_manager.run_single(data)
@@ -229,6 +248,15 @@ class RewardLoopWorker:
         return rm_prompt
 
     async def compute_score_disrm(self, data: DataProto) -> dict:
+        """Compute the reward score for a single sample using a discriminative reward model.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward score.
+
+        """
         disrm_prompt = await self._preprocess_reward_inputs(data)
         engine_name = self.config.reward.reward_model.rollout.name
         model_name = self.config.reward.reward_model.model_path
@@ -321,6 +349,15 @@ class RewardLoopManager:
             )
 
     def compute_rm_score(self, data: DataProto) -> DataProto:
+        """Compute reward model scores across reward loop workers.
+
+        Args:
+            data (DataProto): The batch of samples to score.
+
+        Returns:
+            DataProto: The samples annotated with reward model scores.
+
+        """
         if self.reward_model_manager is not None:
             self.reward_model_manager.wake_up()
 

--- a/verl/experimental/reward_loop/reward_manager/base.py
+++ b/verl/experimental/reward_loop/reward_manager/base.py
@@ -40,6 +40,8 @@ class RewardManagerBase(ABC):
         Args:
             config (DictConfig): YAML config.
             tokenizer (AutoTokenizer): Tokenizer for tokenize messages.
+            compute_score (RawRewardFn): Function used to compute the reward score.
+
         """
         self.config = config
         self.tokenizer = tokenizer
@@ -56,6 +58,15 @@ class RewardManagerBase(ABC):
 
     @abstractmethod
     async def run_single(self, data: DataProto):
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         raise NotImplementedError
 
     @classmethod
@@ -72,6 +83,7 @@ class RewardManagerBase(ABC):
         Returns:
             torch.Tensor: The ``rm_scores`` tensor with leading dimension equal to
             ``len(data)``.
+
         """
         prompt_length = data.batch["prompts"].size(1)
         valid_response_length = data.batch["attention_mask"][:, prompt_length:].sum(dim=1)

--- a/verl/experimental/reward_loop/reward_manager/dapo.py
+++ b/verl/experimental/reward_loop/reward_manager/dapo.py
@@ -50,6 +50,15 @@ class DAPORewardManager(RewardManagerBase):
             )
 
     async def run_single(self, data: DataProto) -> dict:
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]

--- a/verl/experimental/reward_loop/reward_manager/gdpo.py
+++ b/verl/experimental/reward_loop/reward_manager/gdpo.py
@@ -33,6 +33,15 @@ class GDPORewardManager(RewardManagerBase):
         self.reward_model_tokenizer = reward_model_tokenizer
 
     async def run_single(self, data: DataProto) -> dict:
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]

--- a/verl/experimental/reward_loop/reward_manager/limited.py
+++ b/verl/experimental/reward_loop/reward_manager/limited.py
@@ -78,6 +78,7 @@ class AsyncTokenBucket:
         3. If tokens >= num_tokens: consume tokens and return
         4. Otherwise: calculate wait_time = tokens_needed / rate_limit, then sleep
         5. Retry after sleep (loop back to step 1)
+
     """
 
     def __init__(self, rate_limit: float, max_tokens: float = None):
@@ -119,6 +120,7 @@ class AsyncTokenBucket:
             - Lock is released during sleep to allow other coroutines to proceed
             - Tokens are refilled continuously based on elapsed time
             - For requests > max_tokens, allows temporary negative balance
+
         """
         # Handle requests larger than max_tokens separately
         if num_tokens > self.max_tokens:
@@ -249,6 +251,7 @@ class RateLimitedRewardManager(RewardManagerBase):
         - AsyncTokenBucket: Token bucket implementation for rate limiting
         - RewardManagerBase: Base class for reward managers
         - verl.utils.reward_score.default_compute_score: Default scoring function
+
     """
 
     # Class-level state for global rate limiting
@@ -396,6 +399,15 @@ class RateLimitedRewardManager(RewardManagerBase):
             )
 
     async def run_single(self, data: DataProto) -> dict:
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
 
@@ -484,6 +496,7 @@ class RateLimitedRewardManager(RewardManagerBase):
                                 with rewards. If return_dict is True, returns a dict with:
                                 - reward_tensor: The reward tensor
                                 - reward_extra_info: Dict containing extra information about rewards
+
         """
         from collections import defaultdict
 

--- a/verl/experimental/reward_loop/reward_manager/naive.py
+++ b/verl/experimental/reward_loop/reward_manager/naive.py
@@ -32,6 +32,15 @@ class NaiveRewardManager(RewardManagerBase):
         self.reward_model_tokenizer = reward_model_tokenizer
 
     async def run_single(self, data: DataProto) -> dict:
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]

--- a/verl/experimental/reward_loop/reward_manager/registry.py
+++ b/verl/experimental/reward_loop/reward_manager/registry.py
@@ -27,6 +27,7 @@ def register(name: str) -> Callable[[type[RewardManagerBase]], type[RewardManage
     Args:
         name: `(str)`
             The name of the reward manager.
+
     """
 
     def decorator(cls: type[RewardManagerBase]) -> type[RewardManagerBase]:
@@ -47,6 +48,7 @@ def get_reward_manager_cls(name: str) -> type[RewardManagerBase]:
 
     Returns:
         `(type)`: The reward manager class.
+
     """
     if name not in REWARD_MANAGER:
         raise ValueError(f"Unknown reward manager: {name}")

--- a/verl/experimental/reward_loop/reward_manager/remote.py
+++ b/verl/experimental/reward_loop/reward_manager/remote.py
@@ -34,6 +34,7 @@ class RewardComputeWorker:
         self.compute_score_fn = compute_score_fn
 
     def compute_score(self, **kwargs) -> dict:
+        """Compute the reward score by delegating to the wrapped score function."""
         return self.compute_score_fn(**kwargs)
 
 
@@ -70,9 +71,19 @@ class RemoteRewardManager(RewardManagerBase):
         self.reward_worker_pool = itertools.cycle(self.reward_worker)
 
     def choose_reward_worker(self):
+        """Return the next reward worker from the round-robin pool."""
         return next(self.reward_worker_pool)
 
     async def run_single(self, data: DataProto) -> dict:
+        """Compute the reward for a single sample.
+
+        Args:
+            data (DataProto): A single-sample DataProto to score.
+
+        Returns:
+            dict: The computed reward result.
+
+        """
         data = data[-1:]  # for multi-sequence outputs, we only compute reward based on the last sequence
         data_item = data[0]
         response_ids = data_item.batch["responses"]

--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -38,6 +38,7 @@ class RewardModelManager:
         Args:
             config (RewardModelConfig): Reward model configuration.
             resource_pool (RayResourcePool, optional): Resource pool. Defaults to None.
+
         """
         self.config = config
         self.resource_pool = resource_pool
@@ -107,6 +108,7 @@ class RewardModelManager:
         self.router_address, _ = launch_router_process(worker_urls=worker_urls)
 
     def get_router_address(self):
+        """Return the address of the launched router."""
         return self.router_address
 
     def wake_up(self):

--- a/verl/experimental/reward_loop/router/inner_sglang_router.py
+++ b/verl/experimental/reward_loop/router/inner_sglang_router.py
@@ -33,6 +33,18 @@ def launch_router_process(
     max_wait_time: int = 300,
     timeout: int = 30,
 ) -> str:
+    """Launch an SGLang router process for the given worker URLs.
+
+    Args:
+        worker_urls (list[str]): URLs of the backend workers to route to.
+        request_timeout (int): Per-request timeout in seconds.
+        max_wait_time (int): Maximum time to wait for the router to start.
+        timeout (int): Connection timeout in seconds.
+
+    Returns:
+        str: The address of the launched router.
+
+    """
     router_ip = ray.util.get_node_ip_address().strip("[]")
     router_port, _ = get_free_port(router_ip)
     router_address = (

--- a/verl/experimental/reward_loop/router/naive_router.py
+++ b/verl/experimental/reward_loop/router/naive_router.py
@@ -51,6 +51,15 @@ async def _read_async_response(resp: aiohttp.ClientResponse) -> dict[str, Any]:
 def launch_router_process(
     worker_urls: list[str],
 ):
+    """Launch a naive router process for the given worker URLs.
+
+    Args:
+        worker_urls (list[str]): URLs of the backend workers to route to.
+
+    Returns:
+        tuple[str, multiprocessing.Process]: The router address and its process.
+
+    """
     router_ip = ray.util.get_node_ip_address().strip("[]")
     router_port, _ = get_free_port(router_ip)
     router_address = (
@@ -75,6 +84,14 @@ def launch_router_process(
 
 
 def run_router(router_ip: str, router_port: int, worker_urls: list[str]):
+    """Run the naive router server.
+
+    Args:
+        router_ip (str): IP address to bind the router to.
+        router_port (int): Port to bind the router to.
+        worker_urls (list[str]): URLs of the backend workers to route to.
+
+    """
     router = NaiveRouter(worker_urls=worker_urls, verbose=False)
     uvicorn.run(router.app, host=router_ip, port=router_port, log_level="warning")
 

--- a/verl/experimental/separation/engine_workers.py
+++ b/verl/experimental/separation/engine_workers.py
@@ -53,6 +53,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
             role: The role of the worker (e.g., 'actor', 'rollout', 'ref').
             distillation_config: Optional distillation configuration for OPD support.
             **kwargs: Additional arguments passed to ActorRolloutRefWorker.
+
         """
         ActorRolloutRefWorker.__init__(self, config, role, distillation_config=distillation_config, **kwargs)
         self._strategy_handlers = None
@@ -66,6 +67,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
         Raises:
             NotImplementedError: If the strategy is not supported.
+
         """
         if self._strategy_handlers is not None:
             return self._strategy_handlers
@@ -120,6 +122,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
         Args:
             n: Identifier/Key for the saved model state.
+
         """
         if not hasattr(self, "cpu_saved_models"):
             self.cpu_saved_models = {}
@@ -137,6 +140,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
         Args:
             n: Identifier/Key for the saved model state to restore.
+
         """
         if n in self.cpu_saved_models:
             strategy = self.config.actor.strategy
@@ -154,6 +158,7 @@ class DetachActorWorker(ActorRolloutRefWorker):
 
         Args:
             n: Identifier/Key for the saved model state to remove.
+
         """
         if n in self.cpu_saved_models:
             del self.cpu_saved_models[n]

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -341,6 +341,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
 
         Args:
             batch_dict: Raw data dictionary
+
         """
         self.metrics = {"training/global_step": self.global_steps, "training/epoch": self.epoch}
         self.timing_raw = {}

--- a/verl/experimental/separation/utils.py
+++ b/verl/experimental/separation/utils.py
@@ -29,6 +29,7 @@ def create_resource_pool_manager(config, roles: list) -> ResourcePoolManager:
 
     Returns:
         ResourcePoolManager: Resource pool manager
+
     """
     resource_pool_spec = {}
     mapping = {}
@@ -68,6 +69,7 @@ def create_role_worker_mapping(config):
 
     Returns:
         dict: Mapping from roles to worker classes
+
     """
     # Always use the unified model engine worker implementation.
     from verl.experimental.separation.engine_workers import DetachActorWorker

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -50,6 +50,7 @@ class TeacherModelManager:
             distillation_config (DistillationConfig): Distillation configuration.
             teacher_model_config (DistillationTeacherModelConfig): Teacher model configuration.
             resource_pool (RayResourcePool): Dedicated teacher resource pool.
+
         """
 
         # Need dataclass conversion for max_logprobs handling in post_init
@@ -165,6 +166,7 @@ class MultiTeacherModelManager:
         Args:
             config (DictConfig): Full configuration.
             resource_pool (RayResourcePool): Combined resource pool for all teachers.
+
         """
         self.config = config
         self.distillation_config: DistillationConfig = omega_conf_to_dataclass(config.distillation)

--- a/verl/model_merger/__main__.py
+++ b/verl/model_merger/__main__.py
@@ -50,6 +50,7 @@ from .base_model_merger import generate_config_from_args, parse_args
 
 
 def main():
+    """Run the model merger from command line arguments."""
     args = parse_args()
     config = generate_config_from_args(args)
     print(f"config: {config}")

--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -30,6 +30,12 @@ AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
 
 def parse_args():
+    """Parse command line arguments for the model merger.
+
+    Returns:
+        argparse.Namespace: The parsed command line arguments.
+
+    """
     parser = argparse.ArgumentParser(description="verl model merger")
     subparsers = parser.add_subparsers(dest="operation", required=True, help="Specify 'merge' or 'test' operation.")
 
@@ -98,6 +104,7 @@ class ModelMergerConfig:
         hf_model_config_path (Optional[str]): Path to HuggingFace model configuration files. Defaults to None.
         hf_upload (bool): Whether to upload to HuggingFace (computed automatically). Not for initialization.
         use_cpu_initialization (bool): Whether to use CPU initialization for large models. Defaults to False.
+
     """
 
     operation: str  # 'merge' or 'test'
@@ -138,6 +145,15 @@ def _default_hf_model_config_path(backend: str, local_dir: str) -> str:
 
 
 def generate_config_from_args(args: argparse.Namespace) -> ModelMergerConfig:
+    """Build a ModelMergerConfig from parsed command line arguments.
+
+    Args:
+        args (argparse.Namespace): The parsed command line arguments.
+
+    Returns:
+        ModelMergerConfig: The configuration constructed from the arguments.
+
+    """
     common_config_args = {
         "operation": args.operation,
         "backend": args.backend,
@@ -192,6 +208,7 @@ class BaseModelMerger(ABC):
         config (ModelMergerConfig): The configuration object passed during initialization.
         hf_model_config_path (str): Path to the HuggingFace model configuration files.
         model_config (PretrainedConfig): Loaded HuggingFace model configuration.
+
     """
 
     def __init__(self, config: ModelMergerConfig):
@@ -202,6 +219,12 @@ class BaseModelMerger(ABC):
         )
 
     def get_transformers_auto_model_class(self):
+        """Determine the appropriate transformers auto model class for the model.
+
+        Returns:
+            type: The transformers auto model class to use for loading the model.
+
+        """
         has_remote_code = hasattr(self.model_config, "auto_map") and any(
             self.model_config.architectures[0] in val for val in self.model_config.auto_map.values()
         )
@@ -297,6 +320,7 @@ class BaseModelMerger(ABC):
 
         Note:
             This function change the 'state_dict' in place.
+
         """
         lora_params_names = [name for name in state_dict.keys() if "lora_" in name]
 
@@ -388,6 +412,12 @@ class BaseModelMerger(ABC):
         return lora_path
 
     def save_hf_model_and_tokenizer(self, state_dict: dict[str, torch.Tensor]):
+        """Save the model and tokenizer in HuggingFace format to the target directory.
+
+        Args:
+            state_dict (dict[str, torch.Tensor]): The merged model state dict to save.
+
+        """
         auto_model_class = self.get_transformers_auto_model_class()
         with init_empty_weights():
             model = auto_model_class.from_config(
@@ -417,6 +447,7 @@ class BaseModelMerger(ABC):
             tokenizer.save_pretrained(self.config.target_dir)
 
     def upload_to_huggingface(self):
+        """Upload the merged model in the target directory to the HuggingFace Hub."""
         import requests
         from huggingface_hub import HfApi
         from huggingface_hub.utils import HfHubHTTPError, RepositoryNotFoundError
@@ -455,8 +486,10 @@ class BaseModelMerger(ABC):
 
     @abstractmethod
     def merge_and_save(self):
+        """Merge the model checkpoints and save the result."""
         raise NotImplementedError("Subclasses should implement this method")
 
     @abstractmethod
     def cleanup(self):
+        """Clean up any resources held by the merger."""
         raise NotImplementedError("Subclasses should implement this method to clean up resources if needed")

--- a/verl/model_merger/fsdp_model_merger.py
+++ b/verl/model_merger/fsdp_model_merger.py
@@ -63,6 +63,7 @@ class FSDPModelMerger(BaseModelMerger):
         merger = FSDPModelMerger(config)
         merger.merge_and_save()
         ```
+
     """
 
     def _get_world_size(self) -> int:
@@ -71,6 +72,7 @@ class FSDPModelMerger(BaseModelMerger):
 
         Returns:
             int: world size
+
         """
         config_path = Path(self.config.local_dir) / "fsdp_config.json"
         if not config_path.exists():
@@ -204,6 +206,7 @@ class FSDPModelMerger(BaseModelMerger):
         return state_dict
 
     def merge_and_save(self):
+        """Merge the FSDP sharded checkpoints and save the result."""
         world_size = self._get_world_size()
         rank_zero_state_dict = self._load_rank_zero_state_dict(world_size)
 

--- a/verl/model_merger/megatron_model_merger.py
+++ b/verl/model_merger/megatron_model_merger.py
@@ -51,6 +51,7 @@ from .base_model_merger import BaseModelMerger, ModelMergerConfig
 
 @contextmanager
 def noop_context() -> Any:
+    """Provide a context manager that does nothing."""
     yield
 
 
@@ -63,6 +64,7 @@ def get_dynamic_pipeline_shards(layer_num: int, pp_size: int) -> list[int]:
 
     Returns:
         layer number of each pp rank. Make the sharding of the pipeline as uniform as possible.
+
     """
     if layer_num < pp_size:
         raise ValueError(f"layer_num {layer_num} must be greater than pp_size {pp_size}.")
@@ -138,6 +140,7 @@ class MegatronModelMerger(BaseModelMerger):
         merger = MegatronModelMerger(config)
         merger.merge_and_save()
         ```
+
     """
 
     def __init__(self, config: ModelMergerConfig):
@@ -226,6 +229,7 @@ class MegatronModelMerger(BaseModelMerger):
 
         Returns:
             State dict containing the model parameters.
+
         """
 
         # init hf config
@@ -420,6 +424,12 @@ class MegatronModelMerger(BaseModelMerger):
         return state_dict
 
     def save_hf_model_and_tokenizer(self, merged_state_dict):
+        """Save the merged model and tokenizer in HuggingFace format.
+
+        Args:
+            merged_state_dict: The merged model state dict to save.
+
+        """
         if self.world_size == 1:
             return super().save_hf_model_and_tokenizer(merged_state_dict)
 
@@ -489,6 +499,7 @@ class MegatronModelMerger(BaseModelMerger):
                 tokenizer.save_pretrained(self.config.target_dir)
 
     def merge_and_save(self):
+        """Merge the Megatron distributed checkpoints and save the result."""
         from verl.utils.megatron_utils import get_model_dist_checkpoint_path
 
         model_ckpt_path = get_model_dist_checkpoint_path(self.config.local_dir)
@@ -543,4 +554,5 @@ class MegatronModelMerger(BaseModelMerger):
         return None  # Return None if no mapping found
 
     def cleanup(self):
+        """Destroy the distributed process group to free resources."""
         torch.distributed.destroy_process_group()

--- a/verl/models/mcore/config_converter.py
+++ b/verl/models/mcore/config_converter.py
@@ -45,6 +45,7 @@ def _get_base_transformer_config(
 
     Returns:
         TransformerConfig with common parameters
+
     """
 
     # Common parallel state parameters
@@ -113,6 +114,7 @@ def _get_mla_transformer_config(
 
     Returns:
         MLATransformerConfig with common parameters
+
     """
     base_config = _get_base_transformer_config(hf_config=hf_config, dtype=dtype, **override_transformer_config_kwargs)
     mla_config = {
@@ -142,9 +144,11 @@ def check_and_construct_configs(original_config: dict, cls: type[T]) -> T:
 
     Args:
         original_config (dict): The original model configuration.
+        cls (type[T]): The target dataclass type to validate against.
 
     Returns:
         dict: The updated model configuration with incompatible settings disabled.
+
     """
     removed_keys = []
     for key in original_config.keys():
@@ -167,6 +171,19 @@ def check_and_construct_configs(original_config: dict, cls: type[T]) -> T:
 def hf_to_mcore_config_dense(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> TransformerConfig:
+    """Convert a HuggingFace dense model config to a Megatron-Core TransformerConfig.
+
+    Supports dense architectures such as LlamaForCausalLM, Qwen2ForCausalLM and Qwen3.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core TransformerConfig.
+
+    """
     # for LlamaForCausalLM or Qwen2ForCausalLM
     qkv_bias = True if "Qwen2" in hf_config.architectures[0] else getattr(hf_config, "attention_bias", False)
     qk_layernorm = True if "Qwen3" in hf_config.architectures[0] else False
@@ -187,6 +204,17 @@ def hf_to_mcore_config_dense(
 def hf_to_mcore_config_qwen2moe(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> TransformerConfig:
+    """Convert a HuggingFace Qwen2 MoE config to a Megatron-Core TransformerConfig.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core TransformerConfig.
+
+    """
     args: dict = _get_base_transformer_config(
         hf_config=hf_config,
         dtype=dtype,
@@ -221,6 +249,17 @@ def hf_to_mcore_config_qwen2moe(
 def hf_to_mcore_config_mixtral(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> TransformerConfig:
+    """Convert a HuggingFace Mixtral MoE config to a Megatron-Core TransformerConfig.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core TransformerConfig.
+
+    """
     args: dict = _get_base_transformer_config(
         hf_config=hf_config,
         dtype=dtype,
@@ -307,6 +346,17 @@ def hf_to_mcore_config_qwen3moe(
 def hf_to_mcore_config_dpskv3(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> MLATransformerConfig:
+    """Convert a HuggingFace DeepSeek-V3 config to a Megatron-Core MLATransformerConfig.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core MLATransformerConfig.
+
+    """
     # DeepseekV3ForCausalLM
     from megatron.core.config import set_experimental_flag
     from megatron.core.transformer.enums import AttnBackend
@@ -391,6 +441,17 @@ def hf_to_mcore_config_dpskv3(
 def hf_to_mcore_config_qwen2_5_vl(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> TransformerConfig:
+    """Convert a HuggingFace Qwen2.5-VL config to a Megatron-Core TransformerConfig.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core TransformerConfig.
+
+    """
     # Qwen2_5_VLForConditionalGeneration
 
     args = _get_base_transformer_config(
@@ -410,11 +471,31 @@ def hf_to_mcore_config_qwen2_5_vl(
 def hf_to_mcore_config_llama4(
     hf_config: PretrainedConfig, dtype: torch.dtype, **override_transformer_config_kwargs
 ) -> TransformerConfig:
+    """Convert a HuggingFace Llama4 config to a Megatron-Core TransformerConfig.
+
+    Args:
+        hf_config: The HuggingFace model configuration.
+        dtype: The parameter dtype to use for the model.
+        **override_transformer_config_kwargs: Extra fields overriding the derived config.
+
+    Returns:
+        The corresponding Megatron-Core TransformerConfig.
+
+    """
     # Llama4ForConditionalGeneration
     raise NotImplementedError("Llama4ForConditionalGeneration is not supported yet")
 
 
 def mapping_string_to_attn_backend(args: dict) -> dict:
+    """Map a string ``attention_backend`` value in ``args`` to the AttnBackend enum.
+
+    Args:
+        args: A config kwargs dict that may contain a string ``attention_backend``.
+
+    Returns:
+        The same dict with ``attention_backend`` converted to an AttnBackend enum.
+
+    """
     if "attention_backend" in args and isinstance(args["attention_backend"], str):
         from megatron.core.transformer.enums import AttnBackend
 

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -36,6 +36,16 @@ from .util import (
 
 
 def model_forward_gen(vision_model: bool = False):
+    """Build a forward function for a (optionally vision) GPT model.
+
+    Args:
+        vision_model: Whether the target model is a vision-language model.
+
+    Returns:
+        A forward callable that runs the model with sequence packing.
+
+    """
+
     def model_forward(
         model,
         input_ids,
@@ -187,6 +197,7 @@ def _convert_to_nested_tensor(v, input_ids_lengths):
 
     Returns:
         Converted NestedTensor
+
     """
     if isinstance(v, NestedTensor):
         return v

--- a/verl/models/mcore/model_forward_1f1b_overlap.py
+++ b/verl/models/mcore/model_forward_1f1b_overlap.py
@@ -42,6 +42,24 @@ def gptmodel_forward_1f1b_overlap(
     logits_processor_args: Optional[dict] = None,
     temperature: float = 1.0,
 ) -> TransformerModelChunkSchedulePlan:
+    """Run a GPT model forward pass and build a 1f1b-overlap schedule plan.
+
+    Args:
+        model: The Megatron-Core GPT model to run.
+        input_ids: The input token ids.
+        position_ids: The position ids.
+        attention_mask: The attention mask.
+        labels: Optional target labels.
+        labels_mask: Optional mask selecting valid label positions.
+        multi_modal_inputs: Optional multimodal inputs for vision-language models.
+        logits_processor: Optional callable to post-process logits (fused kernel only).
+        logits_processor_args: Optional arguments for the logits processor.
+        temperature: The sampling temperature applied to the logits.
+
+    Returns:
+        The schedule plan for the model chunk supporting 1f1b overlap.
+
+    """
     pre_process: bool = unwrap_model(model).pre_process
     post_process: bool = unwrap_model(model).post_process
     assert logits_processor is None, "only support fused kernel"

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -50,6 +50,7 @@ def _get_patching_model(model: torch.nn.Module):
 
 
 def patch_fused_forward(model: torch.nn.Module):
+    """Patch the model's forward with the fused GPTModel forward implementation."""
     assert version.parse(mcore.__version__) >= version.parse("0.13.0"), (
         "Fused forward patching requires mecore >= 0.13.0"
     )
@@ -60,12 +61,23 @@ def patch_fused_forward(model: torch.nn.Module):
 
 
 def unpatch_fused_forward(model: torch.nn.Module):
+    """Restore the model's original forward, undoing a fused forward patch."""
     model = _get_patching_model(model)
     if model is not None:
         model.forward = model.forward_backup
 
 
 def fused_forward_model_gen(vision_model: bool = False):
+    """Build a fused forward function for a (optionally vision) GPT model.
+
+    Args:
+        vision_model: Whether the target model is a vision-language model.
+
+    Returns:
+        A forward callable that runs the model with sequence packing.
+
+    """
+
     def fused_forward_model(
         model,
         input_ids: Tensor,
@@ -138,6 +150,16 @@ def fused_forward_model_gen(vision_model: bool = False):
 
 
 def fused_forward_model_engine(vision_model: bool = False):
+    """Build a fused forward function for the engine-style (optionally vision) GPT model.
+
+    Args:
+        vision_model: Whether the target model is a vision-language model.
+
+    Returns:
+        A forward callable that runs the model with sequence packing.
+
+    """
+
     def fused_forward_model_engine_inner(
         model,
         input_ids: Tensor,

--- a/verl/models/mcore/model_initializer.py
+++ b/verl/models/mcore/model_initializer.py
@@ -63,9 +63,11 @@ class BaseModelInitializer(ABC):
             post_process (bool): including an output layer.
             share_embeddings_and_output_weights (bool): input embeddings and output logit weights are shared.
             value (bool): add an extra linear layer for classification or regression.
+            **extra_kwargs: Additional keyword arguments passed to the GPTModel constructor.
 
         Returns:
             GPTModel: An initialized GPT model instance
+
         """
         vp_stage = extra_kwargs.get("vp_stage", None)
         transformer_layer_spec = self.get_transformer_layer_spec(vp_stage=vp_stage)
@@ -100,6 +102,7 @@ class DenseModel(BaseModelInitializer):
     """Initializer for dense models like Llama and Qwen2."""
 
     def get_transformer_layer_spec(self, vp_stage=None):
+        """Build the transformer decoder block spec for the dense model."""
         assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
         extra_kwargs = {} if not self.has_vp_stage else {"vp_stage": vp_stage}
         return get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True, **extra_kwargs)
@@ -109,6 +112,7 @@ class Qwen2MoEModel(BaseModelInitializer):
     """Initializer for Qwen2 MoE models."""
 
     def get_transformer_layer_spec(self, vp_stage=None):
+        """Build the transformer decoder block spec with shared-expert gating enabled."""
         assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
         extra_kwargs = {} if not self.has_vp_stage else {"vp_stage": vp_stage}
         transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True, **extra_kwargs)
@@ -120,6 +124,7 @@ class Qwen2MoEModel(BaseModelInitializer):
         return transformer_layer_spec
 
     def initialize(self, **kwargs):
+        """Initialize the model and optionally freeze the MoE router weights."""
         # Qwen default freeze_moe_router: true
         model = super().initialize(**kwargs)
         freeze_moe_router = kwargs.get("freeze_moe_router", True)
@@ -133,12 +138,14 @@ class MixtralModel(BaseModelInitializer):
     """Initializer for Mixtral models."""
 
     def get_transformer_layer_spec(self, vp_stage=None):
+        """Build the transformer decoder block spec for the Mixtral model."""
         assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
         extra_kwargs = {} if not self.has_vp_stage else {"vp_stage": vp_stage}
         transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True, **extra_kwargs)
         return transformer_layer_spec
 
     def initialize(self, **kwargs):
+        """Initialize the model and optionally freeze the MoE router weights."""
         model = super().initialize(**kwargs)
         freeze_moe_router = kwargs.get("freeze_moe_router", False)
         if freeze_moe_router:
@@ -151,12 +158,14 @@ class Qwen3MoEModel(BaseModelInitializer):
     """Initializer for Qwen3 MoE models."""
 
     def get_transformer_layer_spec(self, vp_stage=None):
+        """Build the transformer decoder block spec for the Qwen3 MoE model."""
         assert self.tfconfig.normalization == "RMSNorm", "only RMSNorm is supported for now"
         extra_kwargs = {} if not self.has_vp_stage else {"vp_stage": vp_stage}
         transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True, **extra_kwargs)
         return transformer_layer_spec
 
     def initialize(self, **kwargs):
+        """Initialize the model and optionally freeze the MoE router weights."""
         # Qwen default freeze_moe_router: true
         model = super().initialize(**kwargs)
         freeze_moe_router = kwargs.get("freeze_moe_router", True)
@@ -170,6 +179,7 @@ class DeepseekV3Model(BaseModelInitializer):
     """Initializer for DeepseekV3 models."""
 
     def get_transformer_layer_spec(self, vp_stage=None):
+        """Build the transformer decoder block spec for the DeepSeek-V3 model."""
         extra_kwargs = {} if not self.has_vp_stage else {"vp_stage": vp_stage}
         transformer_layer_spec = get_gpt_decoder_block_spec(self.tfconfig, use_transformer_engine=True, **extra_kwargs)
         return transformer_layer_spec
@@ -183,6 +193,7 @@ class DeepseekV3Model(BaseModelInitializer):
         self,
         **kwargs,
     ):
+        """Initialize the model with optional MTP blocks and frozen MoE router."""
         vp_stage = kwargs.get("vp_stage", None)
         freeze_moe_router = kwargs.get("freeze_moe_router", True)
         if freeze_moe_router:

--- a/verl/models/mcore/mtp_patch.py
+++ b/verl/models/mcore/mtp_patch.py
@@ -56,6 +56,7 @@ def _get_patching_model(model: torch.nn.Module):
 
 
 def patch_postprocess(model: torch.nn.Module):
+    """Patch the model's _postprocess to support MTP and 1f1b overlap features."""
     model = _get_patching_model(model)
     if model is not None:
         model._postprocess_backup = model._postprocess
@@ -63,6 +64,7 @@ def patch_postprocess(model: torch.nn.Module):
 
 
 def unpatch_postprocess(model: torch.nn.Module):
+    """Restore the model's original _postprocess, undoing a postprocess patch."""
     model = _get_patching_model(model)
     if model is not None:
         model._postprocess = model._postprocess_backup

--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -18,6 +18,7 @@
 
 
 def apply_patch():
+    """Patch mcore 0.12 MLA attention to fix packed_seq_params handling."""
     import megatron.core
     import torch
     import torch.nn.functional as F
@@ -361,6 +362,7 @@ def apply_patch():
 
 
 def apply_patch_mbridge():
+    """Patch mcore utils to provide get_tensor_model_parallel_group_if_none for mbridge."""
     try:
         from megatron.core.utils import get_tensor_model_parallel_group_if_none
     except ImportError:
@@ -391,6 +393,7 @@ def apply_patch_mbridge():
 
 
 def apply_patch_megatron_v012_with_torch_v28_v29() -> None:
+    """Patch megatron v0.12 checkpoint writing to work with torch 2.8/2.9."""
     # Error due to missing serialization_format in _write_item of megatron v012;
     # resolved by using megatron v013's implementation.
     import inspect
@@ -429,14 +432,17 @@ def apply_patch_megatron_v012_with_torch_v28_v29() -> None:
         Performs actual data saving to storage.
 
         Args:
+            transform_list: list of transforms to apply before writing data.
             local_proc_idx (int): index of a local process that performs writing
             write_bucket (WriteBucket): data to write to storage
             results_queue (mp.Queue): queue to return the write results
                 to the proxy checkpoint process.
             count_queue (mp.JoinableQueue): queue to marks worker task as completed
             use_fsync (bool): if True, calls os.fsync at the end of saving
+            **kwargs: Additional keyword arguments (e.g., use_msc).
 
         Returns: None, the write result are put into the `queue`
+
         """
         logger = logging.getLogger(__name__)
         logger.debug(f"{local_proc_idx} started")
@@ -492,6 +498,7 @@ def apply_patch_megatron_v012_with_torch_v28_v29() -> None:
 
 
 def apply_mtp_inference_patch():
+    """Patch GPTModel postprocessing to disable MTP layers during inference."""
     from megatron.core.models.gpt.gpt_model import GPTModel
 
     _original_postprocess = GPTModel._postprocess
@@ -512,6 +519,7 @@ def apply_mtp_inference_patch():
 # input tensors and their grads will stay in gpu memory after forward_backward completes.
 # see https://github.com/NVIDIA/Megatron-LM/pull/3267
 def apply_patch_megatron_recomputation_backward():
+    """Patch megatron recomputation backward to free MoE input grads from GPU memory."""
     import megatron.core.tensor_parallel.random as rd
     import torch
 

--- a/verl/models/mcore/saver.py
+++ b/verl/models/mcore/saver.py
@@ -94,6 +94,7 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
     Returns:
         state_dict (dict):
             The merged state_dict in rank 0, and an empty dictionary in other ranks.
+
     """
     start_time = time.time()
 
@@ -478,20 +479,24 @@ def merge_megatron_ckpt_gptmodel(wrapped_models, config, dtype, is_value_model=F
 def merge_megatron_ckpt_gptmodel_qwen_moe(
     wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False
 ):
+    """Merge sharded Megatron checkpoint parameters for Qwen MoE models."""
     raise NotImplementedError("merge_megatron_ckpt_gptmodel_qwen_moe is not implemented")
 
 
 def merge_megatron_ckpt_gptmodel_qwen2_5_vl(
     wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False
 ):
+    """Merge sharded Megatron checkpoint parameters for Qwen2.5-VL models."""
     raise NotImplementedError("merge_megatron_ckpt_gptmodel_qwen2_5_vl is not implemented")
 
 
 def merge_megatron_ckpt_gptmodel_dpskv3(wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False):
+    """Merge sharded Megatron checkpoint parameters for DeepSeek-V3 models."""
     raise NotImplementedError("merge_megatron_ckpt_gptmodel_dpskv3 is not implemented")
 
 
 def merge_megatron_ckpt_gptmodel_mixtral(
     wrapped_models, config, dtype, is_value_model=False, tie_word_embeddings=False
 ):
+    """Merge sharded Megatron checkpoint parameters for Mixtral models."""
     raise NotImplementedError("merge_megatron_ckpt_gptmodel_mixtral is not implemented")

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -269,6 +269,7 @@ def postprocess_packed_seqs_for_dict_output(
     For fused kernels, the output is a dictionary with keys like 'log_probs', 'entropy', etc.
     This function post-processes each tensor in the output dictionary.
     Args:
+        labels_mask (torch.Tensor): Boolean mask indicating valid label positions.
         output (CausalLMOutputForPPO): _description_
         packed_seq_params (PackedSeqParams): _description_
         attention_mask (torch.Tensor): _description_
@@ -277,6 +278,7 @@ def postprocess_packed_seqs_for_dict_output(
         post_process (bool, optional): _description_. Defaults to True.
     Returns:
         CausalLMOutputForPPO: _description_
+
     """
     ret = {}
     output.entropy = output.entropy.view(1, -1)
@@ -292,6 +294,7 @@ def postprocess_packed_seqs_for_dict_output(
 
 
 def preprocess_for_mindspeed(input_ids, cu_seqlens_padded, seqlens_in_batch_padded, batch_size):
+    """Set the actual sequence lengths and position ids for MindSpeed on NPU."""
     if not is_npu_available:
         return
     try:
@@ -745,6 +748,16 @@ def postprocess_bshd_engine(
 
 
 def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
+    """Build a THD-layout padded input and attention mask for vision-language models.
+
+    Args:
+        input_ids: A nested tensor of token ids per sequence.
+        pad_token_id: The token id used for padding.
+
+    Returns:
+        A tuple of the padded input ids and the boolean attention mask.
+
+    """
     input_ids_rmpad = input_ids.to_padded_tensor(pad_token_id)
 
     if is_npu_available:
@@ -759,6 +772,17 @@ def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
 
 
 def build_vlm_attn_mask_bshd(input_ids: torch.Tensor, batch_size: int, pad_token_id: int = None):
+    """Build a BSHD-layout padded input and attention mask for vision-language models.
+
+    Args:
+        input_ids: A nested tensor of token ids per sequence.
+        batch_size: The number of sequences in the batch.
+        pad_token_id: The token id used for padding.
+
+    Returns:
+        A tuple of the padded input ids and the boolean attention mask.
+
+    """
     seqlens_in_batch = input_ids.offsets().diff()
     max_seqlen = seqlens_in_batch.max().item()
 

--- a/verl/models/mcore/weight_converter.py
+++ b/verl/models/mcore/weight_converter.py
@@ -28,6 +28,7 @@ class McoreToHFWeightConverterBase:
         self.mcore_config = mcore_config
 
     def convert_param(self, name: str, params_one_group: list[torch.Tensor]) -> torch.Tensor:
+        """Convert a Megatron-Core parameter group to HuggingFace format."""
         raise NotImplementedError
 
 
@@ -84,6 +85,16 @@ class McoreToHFWeightConverterDense(McoreToHFWeightConverterBase):
         return convert_names, params
 
     def convert_param(self, name: str, params_one_group: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
+        """Convert a Megatron-Core parameter group to HuggingFace names and tensors.
+
+        Args:
+            name: The Megatron-Core parameter name.
+            params_one_group: The tensors associated with the parameter name.
+
+        Returns:
+            A tuple of the HuggingFace parameter names and their tensors.
+
+        """
         direct_name_mapping = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "decoder.final_layernorm.weight": "model.norm.weight",
@@ -149,6 +160,16 @@ class McoreToHFWeightConverterQwen2Moe(McoreToHFWeightConverterDense):
 
 class McoreToHFWeightConverterQwen2_5_VL(McoreToHFWeightConverterDense):
     def convert_param(self, name: str, params_one_group: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
+        """Convert a Megatron-Core parameter group to HuggingFace names and tensors.
+
+        Args:
+            name: The Megatron-Core parameter name.
+            params_one_group: The tensors associated with the parameter name.
+
+        Returns:
+            A tuple of the HuggingFace parameter names and their tensors.
+
+        """
         direct_name_mapping = {
             "language_model.embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "language_model.decoder.final_layernorm.weight": "model.norm.weight",
@@ -402,6 +423,16 @@ class McoreToHFWeightConverterDpskv3(McoreToHFWeightConverterBase):
         return convert_names, params
 
     def convert_param(self, name: str, params_one_group: list[torch.Tensor]) -> tuple[list[str], list[torch.Tensor]]:
+        """Convert a Megatron-Core parameter group to HuggingFace names and tensors.
+
+        Args:
+            name: The Megatron-Core parameter name.
+            params_one_group: The tensors associated with the parameter name.
+
+        Returns:
+            A tuple of the HuggingFace parameter names and their tensors.
+
+        """
         direct_name_mapping = {
             "embedding.word_embeddings.weight": "model.embed_tokens.weight",
             "decoder.final_layernorm.weight": "model.norm.weight",

--- a/verl/models/registry.py
+++ b/verl/models/registry.py
@@ -43,6 +43,17 @@ _MODELS = {
 class ModelRegistry:
     @staticmethod
     def load_model_cls(model_arch: str, value=False) -> Optional[type[nn.Module]]:
+        """Load and return the model class for the given architecture.
+
+        Args:
+            model_arch: The model architecture name (e.g. ``"LlamaForCausalLM"``).
+            value: Whether to load the value-head variant (critic/rm) instead of
+                the actor/ref variant.
+
+        Returns:
+            The resolved model class, or ``None`` if the architecture is unsupported.
+
+        """
         if model_arch not in _MODELS:
             return None
 
@@ -59,4 +70,5 @@ class ModelRegistry:
 
     @staticmethod
     def get_supported_archs() -> list[str]:
+        """Return the list of supported model architecture names."""
         return list(_MODELS.keys())

--- a/verl/models/transformers/dense_common.py
+++ b/verl/models/transformers/dense_common.py
@@ -86,6 +86,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **loss_kwargs,
 ) -> tuple | CausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the fused torch backend."""
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = forward_base_model(
@@ -154,6 +155,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **loss_kwargs,
 ) -> tuple | CausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the Triton backend."""
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = forward_base_model(

--- a/verl/models/transformers/glm4v.py
+++ b/verl/models/transformers/glm4v.py
@@ -184,6 +184,7 @@ def get_rope_index(
 def prepare_fa2_from_position_ids(
     query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, position_ids: torch.Tensor
 ):
+    """Build cumulative sequence lengths from position ids for flash attention varlen."""
     assert position_ids.ndim == 2  # (batch_size, seq_length)
     query = query.contiguous().view(-1, query.size(-2), query.size(-1))
     key = key.contiguous().view(-1, key.size(-2), key.size(-1))
@@ -288,6 +289,7 @@ def glm4v_attn_forward(
     position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in v4.46
     **kwargs,
 ) -> tuple[torch.Tensor, None, None]:
+    """Compute the GLM4V attention forward pass with Ulysses-aware flash attention."""
     from transformers.models.glm4v.modeling_glm4v import apply_multimodal_rotary_pos_emb, repeat_kv
 
     bsz, q_len, _ = hidden_states.size()  # q_len = seq_length / sp_size
@@ -398,6 +400,7 @@ def _get_input_embeds(
 
 
 def process_position_ids(position_ids: torch.Tensor) -> torch.Tensor:
+    """Validate the 4D position ids tensor shape for GLM4V."""
     if position_ids.ndim != 3 or position_ids.size(0) != 4:
         # we concat the text position ids with the 3D vision position ids by default
         # see https://github.com/huggingface/transformers/pull/39447
@@ -423,6 +426,7 @@ def glm4v_base_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the GLM4V base model after embedding multimodal inputs."""
     kwargs["inputs_embeds"], kwargs["attention_mask"] = _get_input_embeds(
         self, input_ids, attention_mask, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw
     )  # avoid lora module having multiple keyword arguments
@@ -443,6 +447,7 @@ def glm4v_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the GLM4V model forward pass with processed position ids."""
     return self.model(
         input_ids=input_ids,
         attention_mask=attention_mask,
@@ -462,6 +467,7 @@ def forward_with_normal_backend(
     temperature: float = 1.0,
     **kwargs,
 ) -> "Glm4vCausalLMOutputWithPast":
+    """Compute logits using the standard (non-fused) backend."""
     outputs = glm4v_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
     logits = self.lm_head(hidden_states)
@@ -480,6 +486,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Glm4vCausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the fused torch backend."""
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = glm4v_forward(self, input_ids, **kwargs)
@@ -518,6 +525,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Glm4vCausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the Triton backend."""
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = glm4v_forward(self, input_ids, **kwargs)

--- a/verl/models/transformers/kimi_vl.py
+++ b/verl/models/transformers/kimi_vl.py
@@ -60,6 +60,7 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
             the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
     Returns:
         `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+
     """
     cos = cos[position_ids].unsqueeze(unsqueeze_dim)
     sin = sin[position_ids].unsqueeze(unsqueeze_dim)

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -105,7 +105,11 @@ def _ulysses_flash_attention_forward(
         query_states (torch.Tensor): (batch_size, seqlen/sp_size, nheads, head_dim)
         key_states (torch.Tensor): (batch_size, seqlen/sp_size, nheads_k, head_dim)
         value_states (torch.Tensor): (batch_size, seqlen/sp_size, nheads_k, head_dim)
+        attention_mask (Optional[torch.Tensor]): Attention mask for the forward pass.
+        query_length (int): Length of the query sequence after ulysses all2all.
+        *args: Additional positional arguments passed to the underlying attention.
         position_ids (torch.Tensor, optional): (batch_size, seqlen/sp_size)
+        **kwargs: Additional keyword arguments passed to the underlying attention.
 
     Returns:
         torch.Tensor: (batch_size, seqlen/sp_size, nheads, head_dim)
@@ -242,6 +246,7 @@ def patch_forward_with_backends(
         model (PreTrainedModel): The model to apply the monkey patch.
         use_fused_kernels (bool): Whether to use fused kernels.
         fused_kernels_backend (str): The backend to use for fused kernels.
+
     """
     if not use_fused_kernels or fused_kernels_backend not in ["triton", "torch"]:
         print(
@@ -310,8 +315,10 @@ def apply_monkey_patch(
         use_remove_padding: Whether to use remove padding.
         use_fused_kernels: Whether to use fused kernels.
         fused_kernels_backend: The backend to use for fused kernels.
+        use_prefix_grouper: Whether to enable the prefix grouper patch.
         use_tiled_mlp: Whether to use TiledMLP for memory-efficient MLP computation.
         tiled_mlp_shards: Number of shards for TiledMLP (higher = lower memory, slightly slower).
+
     """
 
     # Apply TiledMLP monkey patch for memory-efficient MLP computation

--- a/verl/models/transformers/npu_patch.py
+++ b/verl/models/transformers/npu_patch.py
@@ -57,10 +57,12 @@ def apply_rotary_pos_emb_npu(q, k, cos, sin, position_ids=None, unsqueeze_dim=1)
 
 
 def qwen3_next_rms_norm_forward_npu(self, x):
+    """NPU optimized RMSNorm forward for Qwen3-Next style gated norms."""
     return torch_npu.npu_rms_norm(x.float(), 1.0 + self.weight.float(), epsilon=self.eps)[0].type_as(x)
 
 
 def qwen3_next_rms_norm_forward_gated_npu(self, hidden_states, gate=None):
+    """NPU optimized gated RMSNorm forward for Qwen3-Next style norms."""
     input_dtype = hidden_states.dtype
     hidden_states = hidden_states.to(torch.float32)
     hidden_states = torch_npu.npu_rms_norm(hidden_states, self.weight.float(), epsilon=self.variance_epsilon)[0]
@@ -69,6 +71,7 @@ def qwen3_next_rms_norm_forward_gated_npu(self, hidden_states, gate=None):
 
 
 def qwen3_next_apply_rotary_pos_emb_npu(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """NPU optimized partial RoPE for Qwen3-Next style attention."""
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
 
@@ -91,11 +94,14 @@ class NPUGmmFunction(torch.autograd.Function):
         Grouped Matmul(GMM) for Ascend NPU.
 
         Args:
+            ctx: Autograd context for saving tensors needed in backward.
             x (torch.Tensor): Input tensor, shape (tokens_num * top_k, hidden_size)
             weight (torch.Tensor): Expert weights, shape (n_experts, hidden_size, intermediate_size)
             group_list (torch.Tensor): Expert token counts, shape (n_experts,)
                 - type 0: cumsum of tokens per expert
                 - type 1: direct tokens per expert (default)
+            group_list_type (int): Format of group_list (0=cumsum, 1=direct counts).
+
         """
         ctx.save_for_backward(x, weight)
         ctx.group_list = group_list
@@ -109,6 +115,7 @@ class NPUGmmFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
+        """Compute input and weight gradients for the grouped matmul."""
         x, weight = ctx.saved_tensors
         group_list = ctx.group_list
         group_list_type = ctx.group_list_type
@@ -142,6 +149,7 @@ def _qwen3_sparse_moe_routed_forward_npu(self, hidden_states: torch.Tensor):
 
     Returns:
         tuple: (flattened_input, routed_hidden_states, router_logits)
+
     """
     hidden_dim = hidden_states.shape[-1]
     hidden_states = hidden_states.view(-1, hidden_dim)
@@ -227,6 +235,7 @@ class NPUQwen3VLMoeTextExperts(nn.Module):
             router_indices (torch.Tensor): (batch_size * token_num, top_k)
         Returns:
             torch.Tensor
+
         """
         batch_size = hidden_states.shape[0]
         hidden_states = hidden_states.reshape(-1, self.hidden_size)  # (num_tokens, hidden_size)
@@ -273,6 +282,7 @@ class NPUQwen3VLMoeTextSparseMoeBlock(nn.Module):
         self.experts = NPUQwen3VLMoeTextExperts(config)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Route tokens to experts and compute the sparse MoE output on NPU."""
         batch_size = hidden_states.shape[0]
         hidden_states = hidden_states.reshape(-1, self.hidden_size)
         router_logits = self.gate(hidden_states)
@@ -292,6 +302,7 @@ def qwen3_5_moe_experts_forward_npu(
     top_k_index: torch.Tensor,
     top_k_weights: torch.Tensor,
 ) -> torch.Tensor:
+    """NPU optimized expert computation for Qwen3.5 MoE blocks."""
     selected_experts = top_k_index
     routing_weights = top_k_weights
     gate_up_proj = self.gate_up_proj.permute(0, 2, 1).contiguous()

--- a/verl/models/transformers/qwen2_vl.py
+++ b/verl/models/transformers/qwen2_vl.py
@@ -164,6 +164,7 @@ def get_rope_index(
 def prepare_fa2_from_position_ids(
     query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, position_ids: torch.Tensor
 ):
+    """Build cumulative sequence lengths from position ids for flash attention varlen."""
     assert position_ids.ndim == 2  # (batch_size, seq_length)
     query = query.contiguous().view(-1, query.size(-2), query.size(-1))
     key = key.contiguous().view(-1, key.size(-2), key.size(-1))
@@ -273,6 +274,7 @@ def qwen2_vl_attn_forward(
     position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in v4.46
     **kwargs,
 ) -> tuple[torch.Tensor, None, None]:
+    """Compute the Qwen2-VL attention forward pass with Ulysses-aware flash attention."""
     from transformers.models.qwen2_vl.modeling_qwen2_vl import apply_multimodal_rotary_pos_emb, repeat_kv
 
     bsz, q_len, _ = hidden_states.size()  # q_len = seq_length / sp_size
@@ -400,6 +402,7 @@ def _get_input_embeds(
 
 
 def process_position_ids(position_ids: torch.Tensor) -> torch.Tensor:
+    """Validate and normalize the 4D position ids for the configured transformers version."""
     if position_ids.ndim != 3 or position_ids.size(0) != 4:
         # we concat the text position ids with the 3D vision position ids by default
         # see https://github.com/huggingface/transformers/pull/39447
@@ -429,6 +432,7 @@ def qwen2_vl_base_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the Qwen2-VL base model after embedding multimodal inputs."""
     kwargs["inputs_embeds"], kwargs["attention_mask"] = _get_input_embeds(
         self, input_ids, attention_mask, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw
     )  # avoid lora module having multiple keyword arguments
@@ -446,6 +450,7 @@ def qwen2_vl_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the Qwen2-VL model forward pass, handling transformers version differences."""
     if is_transformers_version_in_range(min_version="4.52.0"):
         return self.model(
             input_ids=input_ids,
@@ -477,6 +482,7 @@ def forward_with_normal_backend(
     temperature: float = 1.0,
     **kwargs,
 ) -> "Qwen2VLCausalLMOutputWithPast":
+    """Compute logits using the standard (non-fused) backend."""
     outputs = qwen2_vl_forward(self, input_ids, **kwargs)
     hidden_states = outputs[0]
     logits = self.lm_head(hidden_states)
@@ -495,6 +501,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Qwen2VLCausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the fused torch backend."""
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = qwen2_vl_forward(self, input_ids, **kwargs)
@@ -533,6 +540,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> tuple | Qwen2VLCausalLMOutputForPPO:
+    """Compute log probs and entropy for PPO using the Triton backend."""
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = qwen2_vl_forward(self, input_ids, **kwargs)

--- a/verl/models/transformers/qwen3_5.py
+++ b/verl/models/transformers/qwen3_5.py
@@ -34,6 +34,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def fast_pos_embed_interpolate(self, grid_thw):
+    """Interpolate vision position embeddings for the given grid sizes."""
     grid_thw_list = grid_thw.tolist()
     grid_ts = [row[0] for row in grid_thw_list]
     grid_hs = [row[1] for row in grid_thw_list]
@@ -168,6 +169,7 @@ def qwen3_5_base_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the Qwen3.5 base model after embedding multimodal inputs."""
     input_kwargs = _get_input_embeds(
         self, input_ids, attention_mask, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw
     )  # avoid lora module having multiple keyword arguments
@@ -191,6 +193,7 @@ def forward_with_normal_backend(
     temperature: float = 1.0,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
+    """Compute logits using the standard (non-fused) backend."""
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
     logits = self.lm_head(hidden_states)
@@ -208,6 +211,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
+    """Compute log probs and entropy for PPO using the fused torch backend."""
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = self.model(input_ids, **kwargs)
@@ -256,6 +260,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3_5CausalLMOutputForPPO":
+    """Compute log probs and entropy for PPO using the Triton backend."""
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = self.model(input_ids, **kwargs)

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -31,6 +31,7 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 
 def fast_pos_embed_interpolate(self, grid_thw):
+    """Interpolate vision position embeddings for the given grid sizes."""
     grid_thw_list = grid_thw.tolist()
     grid_ts = [row[0] for row in grid_thw_list]
     grid_hs = [row[1] for row in grid_thw_list]
@@ -313,6 +314,7 @@ def qwen3_vl_base_forward(
     video_grid_thw: Optional[torch.LongTensor] = None,
     **kwargs,
 ):
+    """Run the Qwen3-VL base model after embedding multimodal inputs."""
     input_kwargs = _get_input_embeds(
         self, input_ids, attention_mask, pixel_values, pixel_values_videos, image_grid_thw, video_grid_thw
     )  # avoid lora module having multiple keyword arguments
@@ -330,6 +332,7 @@ def forward_with_normal_backend(
     temperature: float = 1.0,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
+    """Compute logits using the standard (non-fused) backend."""
     outputs = self.model(input_ids, **kwargs)
     hidden_states = outputs[0]
     logits = self.lm_head(hidden_states)
@@ -348,6 +351,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
+    """Compute log probs and entropy for PPO using the fused torch backend."""
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = self.model(input_ids, **kwargs)
@@ -387,6 +391,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
+    """Compute log probs and entropy for PPO using the Triton backend."""
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = self.model(input_ids, **kwargs)

--- a/verl/models/transformers/tiled_mlp.py
+++ b/verl/models/transformers/tiled_mlp.py
@@ -92,6 +92,7 @@ class TiledMLP(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, fn, module, x, shards, compute_params):
+        """Run the MLP forward pass in tiles to reduce peak memory usage."""
         ctx.fn = fn
         ctx.module = module
         ctx.shards = shards
@@ -107,6 +108,7 @@ class TiledMLP(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, *grads):
+        """Run the MLP backward pass in tiles, accumulating parameter gradients."""
         fn = ctx.fn
         (x,) = ctx.saved_tensors
         module = ctx.module
@@ -192,6 +194,7 @@ def apply_tiled_mlp_monkey_patch(
 
     Returns:
         List of patched class names.
+
     """
     if model_type is None:
         types_to_patch = list(_MODEL_TYPE_TO_MLP_CLASS.keys())

--- a/verl/models/weight_loader_registry.py
+++ b/verl/models/weight_loader_registry.py
@@ -14,6 +14,15 @@
 
 
 def get_weight_loader(arch: str):
+    """Return the Megatron weight loader function for the given model architecture.
+
+    Args:
+        arch: The model architecture name (e.g. ``"LlamaForCausalLM"``).
+
+    Returns:
+        The loader callable registered for the architecture.
+
+    """
     from verl.models.mcore.loader import load_state_dict_to_megatron_gptmodel
 
     _MODEL_WEIGHT_MEGATRON_LOADER_REGISTRY = {
@@ -30,6 +39,15 @@ def get_weight_loader(arch: str):
 
 
 def get_weight_saver(arch: str):
+    """Return the Megatron checkpoint saver function for the given model architecture.
+
+    Args:
+        arch: The model architecture name (e.g. ``"LlamaForCausalLM"``).
+
+    Returns:
+        The saver callable registered for the architecture.
+
+    """
     from verl.models.mcore.saver import (
         merge_megatron_ckpt_gptmodel,
         merge_megatron_ckpt_gptmodel_dpskv3,

--- a/verl/protocol.py
+++ b/verl/protocol.py
@@ -75,11 +75,13 @@ def pad_dataproto_to_divisor(data: "DataProto", size_divisor: int):
     """Pad a DataProto to size divisible by size_divisor
 
     Args:
+        data (DataProto): the DataProto to pad
         size_divisor (int): size divisor
 
     Returns:
         data: (DataProto): the padded DataProto
         pad_size (int)
+
     """
     assert isinstance(data, DataProto), "data must be a DataProto"
     if len(data) % size_divisor != 0:
@@ -131,9 +133,11 @@ def _array_equal(array1: np.ndarray, array2: np.ndarray, visited: set[int]) -> b
     Args:
         array1: The first NumPy array.
         array2: The second NumPy array.
+        visited: A set of object ids already visited, used to detect circular references.
 
     Returns:
         True if the arrays' dtypes, shapes, and all elements are equal.
+
     """
     # Check dtype and shape first, as this is the fastest failure path.
     if array1.dtype != array2.dtype or array1.shape != array2.shape:
@@ -355,6 +359,7 @@ class DataProto:
         Returns:
             DataProto: For all indexing types except single integers
             DataProtoItem: Only for single integer indices
+
         """
         # Case 1: Slice object - use the slice method
         if isinstance(item, slice):
@@ -424,16 +429,37 @@ class DataProto:
         self.meta_info = meta_info
 
     def save_to_disk(self, filepath):
+        """Serialize this DataProto to disk via pickle.
+
+        Args:
+            filepath: The path to write the serialized object to.
+
+        """
         with open(filepath, "wb") as f:
             pickle.dump(self, f)
 
     @staticmethod
     def load_from_disk(filepath) -> "DataProto":
+        """Load a DataProto previously serialized to disk.
+
+        Args:
+            filepath: The path to read the serialized object from.
+
+        Returns:
+            DataProto: The deserialized DataProto instance.
+
+        """
         with open(filepath, "rb") as f:
             data = pickle.load(f)
             return data
 
     def print_size(self, prefix=""):
+        """Print the memory size of the batch and non-tensor data.
+
+        Args:
+            prefix (str): An optional prefix to prepend to the printed message.
+
+        """
         size_of_tensordict = 0
         if self.batch is not None:
             for _, tensor in self.batch.items():
@@ -602,10 +628,13 @@ class DataProto:
 
         Args:
             batch_keys (list, optional): a list of strings indicating the keys in batch to select
+            non_tensor_batch_keys (list, optional): a list of keys indicating the non-tensor batch to select
             meta_info_keys (list, optional): a list of keys indicating the meta info to select
+            deepcopy (bool, optional): whether to deepcopy the selected non-tensor batch and meta info
 
         Returns:
             DataProto: the DataProto with the selected batch_keys and meta_info_keys
+
         """
         # TODO (zhangchi.usc1992) whether to copy
         if batch_keys is not None:
@@ -641,6 +670,7 @@ class DataProto:
 
         Returns:
             DataProto: A new DataProto containing only the selected indices
+
         """
         if isinstance(idxs, list):
             idxs = torch.tensor(idxs)
@@ -699,6 +729,7 @@ class DataProto:
 
             # Single index still returns DataProtoItem
             single_item = data_proto[5]
+
         """
         # Create a slice object
         slice_obj = slice(start, end, step)
@@ -723,10 +754,12 @@ class DataProto:
 
         Args:
             batch_keys (list, optional): a list of strings indicating the keys in batch to pop
+            non_tensor_batch_keys (list, optional): a list of keys indicating the non-tensor batch to pop
             meta_info_keys (list, optional): a list of keys indicating the meta info to pop
 
         Returns:
             DataProto: the DataProto with the poped batch_keys and meta_info_keys
+
         """
         if batch_keys is None:
             batch_keys = []
@@ -791,6 +824,7 @@ class DataProto:
 
         Returns:
             DataProto: the DataProto after union
+
         """
         self.batch = union_tensor_dict(self.batch, other.batch)
         self.non_tensor_batch = union_numpy_dict(self.non_tensor_batch, other.non_tensor_batch)
@@ -806,12 +840,14 @@ class DataProto:
             mini_batch_size (int): mini-batch size when iterating the dataset. We require that
                 ``batch.batch_size[0] % mini_batch_size == 0``.
             epochs (int): number of epochs when iterating the dataset.
+            seed (int, optional): random seed used to shuffle the dataloader. Defaults to None.
             dataloader_kwargs (Any): internally, it returns a DataLoader over the batch. The
                 dataloader_kwargs is the kwargs passed to the DataLoader.
 
         Returns:
             Iterator: an iterator that yields a mini-batch data at a time. The total number of iteration
                 steps is ``self.batch.batch_size * epochs // mini_batch_size``
+
         """
         assert self.batch.batch_size[0] % mini_batch_size == 0, f"{self.batch.batch_size[0]} % {mini_batch_size} != 0"
         # we can directly create a dataloader from TensorDict
@@ -842,6 +878,7 @@ class DataProto:
         Check if padding is enabled for the DataProto.
         Returns:
             bool: True if padding is enabled, False otherwise.
+
         """
         dataproto_specific_padding = self.meta_info.get(DataProtoConfig.auto_padding_key, False)
         return dataproto_specific_padding or DataProtoConfig.auto_padding
@@ -852,6 +889,7 @@ class DataProto:
         Args:
             padding_size (int): the number of repeated padding_candidate
             padding_candidate: the item to be repeated and appended to the DataProto, only supporting ["first", "last"]
+
         """
         if padding_size == 0:
             return
@@ -869,6 +907,7 @@ class DataProto:
 
         Returns:
             List[DataProto]: a list of DataProto after splitting
+
         """
         if not self.is_padding_enabled():
             assert len(self) % chunks == 0, (
@@ -910,6 +949,7 @@ class DataProto:
 
         Returns:
             List[DataProto]: a list of DataProto after splitting
+
         """
         return [self[i : i + split_size] for i in range(0, len(self), split_size)]
 
@@ -923,6 +963,7 @@ class DataProto:
 
         Returns:
             DataProto: concatenated DataProto
+
         """
         batch_lst = []
         for batch in data:
@@ -978,6 +1019,7 @@ class DataProto:
 
         Returns:
             DataProto: A new DataProto with repeated data.
+
         """
         if self.batch is not None:
             if interleave:
@@ -1060,6 +1102,7 @@ class DataProto:
 
         Returns:
             DataProto: A new DataProto with repeated data.
+
         """
         if isinstance(repeat_times, tuple):
             repeat_times = list(repeat_times)
@@ -1130,6 +1173,7 @@ class DataProto:
 
         Returns:
             str: Formatted string showing tensor details and recursive metadata types
+
         """
         info = ["batch"]
 

--- a/verl/single_controller/base/decorator.py
+++ b/verl/single_controller/base/decorator.py
@@ -36,6 +36,7 @@ class Dispatch(DynamicEnum):
 
 
 def init_predefined_dispatch_mode():
+    """Register the predefined dispatch modes in the Dispatch enum."""
     Dispatch.register("RANK_ZERO")
     Dispatch.register("ONE_TO_ALL")
     Dispatch.register("ALL_TO_ALL")
@@ -59,6 +60,7 @@ class Execute(DynamicEnum):
 
 
 def init_predefined_execute_mode():
+    """Register the predefined execute modes in the Execute enum."""
     Execute.register("ALL")
     Execute.register("RANK_ZERO")
 
@@ -118,20 +120,34 @@ def _split_args_kwargs_data_proto_with_auto_padding(chunks, *args, **kwargs):
 
 
 def dispatch_one_to_all(worker_group, *args, **kwargs):
+    """Broadcast the same arguments to every worker in the group.
+
+    Args:
+        worker_group: The worker group to dispatch to.
+        *args: Positional arguments to broadcast.
+        **kwargs: Keyword arguments to broadcast.
+
+    Returns:
+        A tuple of (args, kwargs) where each value is replicated for all workers.
+
+    """
     args = tuple([arg] * worker_group.world_size for arg in args)
     kwargs = {k: [v] * worker_group.world_size for k, v in kwargs.items()}
     return args, kwargs
 
 
 def dummy_direct_rollout_call(worker_group, *args, **kwargs):
+    """Raise an error to forbid direct rollout calls."""
     raise NotImplementedError("Direct rollout call is forbidden.")
 
 
 def dispatch_all_to_all(worker_group, *args, **kwargs):
+    """Pass arguments through unchanged for all-to-all dispatch."""
     return args, kwargs
 
 
 def collect_all_to_all(worker_group, output):
+    """Return the worker output unchanged for all-to-all collection."""
     return output
 
 
@@ -146,6 +162,17 @@ def _concat_data_proto_or_future(output: list):
 
 
 def dispatch_dp_compute(worker_group, *args, **kwargs):
+    """Dispatch arguments to workers for data-parallel computation.
+
+    Args:
+        worker_group: The worker group to dispatch to.
+        *args: Per-worker positional arguments sized to the world size.
+        **kwargs: Per-worker keyword arguments sized to the world size.
+
+    Returns:
+        A tuple of (args, kwargs) ready for data-parallel execution.
+
+    """
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -157,6 +184,7 @@ def dispatch_dp_compute(worker_group, *args, **kwargs):
 
 
 def collect_dp_compute(worker_group, output):
+    """Collect data-parallel outputs from all workers in the group."""
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -165,6 +193,7 @@ def collect_dp_compute(worker_group, output):
 
 
 def dispatch_dp_compute_data_proto(worker_group, *args, **kwargs):
+    """Dispatch DataProto arguments to workers with automatic padding."""
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -178,6 +207,17 @@ def dispatch_dp_compute_data_proto(worker_group, *args, **kwargs):
 
 
 def dispatch_dp_compute_data_proto_with_func(worker_group, *args, **kwargs):
+    """Dispatch DataProto arguments with a leading function to all workers.
+
+    Args:
+        worker_group: The worker group to dispatch to.
+        *args: The first argument must be the function, followed by DataProto args.
+        **kwargs: Keyword DataProto arguments to chunk across workers.
+
+    Returns:
+        A tuple of (args, kwargs) where the function is replicated for all workers.
+
+    """
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -189,6 +229,7 @@ def dispatch_dp_compute_data_proto_with_func(worker_group, *args, **kwargs):
 
 
 def collect_dp_compute_data_proto(worker_group, output):
+    """Collect and concatenate DataProto outputs from all workers."""
     from verl.protocol import BatchData
 
     assert BatchData(output).is_concatable(), (
@@ -200,6 +241,19 @@ def collect_dp_compute_data_proto(worker_group, output):
 
 
 def dispatch_nd_compute(dp_rank_mapping: list[int], dp_size, worker_group, *args, **kwargs):
+    """Dispatch arguments to workers based on an N-D data-parallel rank mapping.
+
+    Args:
+        dp_rank_mapping: Mapping from global rank to local data-parallel rank.
+        dp_size: Size of the data-parallel dimension.
+        worker_group: The worker group to dispatch to.
+        *args: Positional arguments to distribute across workers.
+        **kwargs: Keyword arguments to distribute across workers.
+
+    Returns:
+        A tuple of (args, kwargs) arranged per worker according to the mapping.
+
+    """
     import os
 
     from verl.single_controller.base.worker_group import WorkerGroup
@@ -234,6 +288,17 @@ def dispatch_nd_compute(dp_rank_mapping: list[int], dp_size, worker_group, *args
 
 
 def collect_nd_compute(collect_mask: list[bool], worker_group, output):
+    """Collect outputs from workers selected by an N-D collect mask.
+
+    Args:
+        collect_mask: Per-rank flags indicating which workers to collect from.
+        worker_group: The worker group to collect from.
+        output: The list of outputs from all workers.
+
+    Returns:
+        A list of outputs from the masked-in workers.
+
+    """
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -248,11 +313,13 @@ def collect_nd_compute(collect_mask: list[bool], worker_group, output):
 
 
 def dispatch_nd_compute_dataproto(dp_rank_mapping: list[int], dp_size, worker_group, *args, **kwargs):
+    """Chunk DataProto arguments and dispatch them using an N-D rank mapping."""
     splitted_args, splitted_kwargs = _split_args_kwargs_data_proto(dp_size, *args, **kwargs)
     return dispatch_nd_compute(dp_rank_mapping, dp_size, worker_group, *splitted_args, **splitted_kwargs)
 
 
 def collect_nd_compute_dataproto(collect_mask: list[bool], worker_group, output):
+    """Collect N-D worker outputs and concatenate them into a single DataProto."""
     output = collect_nd_compute(collect_mask, worker_group, output)
 
     from verl.protocol import BatchData
@@ -264,6 +331,7 @@ def collect_nd_compute_dataproto(collect_mask: list[bool], worker_group, output)
 
 
 def dispatch_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
+    """Dispatch DataProto arguments using lazily queried mesh dispatch info."""
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -280,6 +348,7 @@ def dispatch_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
 
 
 def collect_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
+    """Collect DataProto outputs using lazily queried mesh collect info."""
     from verl.single_controller.base.worker_group import WorkerGroup
 
     assert isinstance(worker_group, WorkerGroup)
@@ -298,6 +367,7 @@ def collect_lazy_compute_data_proto(mesh_name, worker_group, *args, **kwargs):
 
 
 def make_nd_compute_dataproto_dispatch_fn(mesh_name):
+    """Build dispatch and collect functions bound to a given mesh name."""
     return {
         "dispatch_fn": partial(dispatch_lazy_compute_data_proto, mesh_name),
         "collect_fn": partial(collect_lazy_compute_data_proto, mesh_name),
@@ -332,6 +402,7 @@ DISPATCH_MODE_FN_REGISTRY = {
 
 
 def get_predefined_dispatch_fn(dispatch_mode):
+    """Return the registered dispatch and collect functions for a dispatch mode."""
     return DISPATCH_MODE_FN_REGISTRY[dispatch_mode]
 
 
@@ -416,6 +487,7 @@ def register(dispatch_mode=Dispatch.ALL_TO_ALL, execute_mode=Execute.ALL, blocki
     Returns:
         A decorator that wraps the original function with distributed execution
         configuration.
+
     """
 
     _check_dispatch_mode(dispatch_mode=dispatch_mode)

--- a/verl/single_controller/base/worker.py
+++ b/verl/single_controller/base/worker.py
@@ -62,6 +62,7 @@ class WorkerHelper:
             return sock.getsockname()[1]
 
     def get_availale_master_addr_port(self):
+        """Return the master address and free port (deprecated, misspelled alias)."""
         warnings.warn(
             "This function is deprecated due to typo in name; Please use `get_available_master_addr_port` instead",
             stacklevel=2,
@@ -69,6 +70,7 @@ class WorkerHelper:
         return self.get_available_master_addr_port()
 
     def get_available_master_addr_port(self):
+        """Return the node IP address and an available free port for the master."""
         return self._get_node_ip().strip("[]"), str(self._get_free_port())
 
 
@@ -93,6 +95,7 @@ class Worker(WorkerHelper):
                 dp_rank to register for the given mesh name.
             is_collect (bool):
                 Whether the dp_rank is used for collect.
+
         """
         if mesh_name in self.__dispatch_dp_rank or mesh_name in self.__collect_dp_rank:
             raise ValueError(f"mesh_name {mesh_name} has been registered")
@@ -110,6 +113,7 @@ class Worker(WorkerHelper):
         Returns:
             int:
                 The dp_rank for the given mesh name.
+
         """
         assert mesh_name in self.__dispatch_dp_rank, f"{mesh_name} is not registered in {self.__class__.__name__}"
         # note that each rank store its own dp_rank
@@ -129,6 +133,7 @@ class Worker(WorkerHelper):
         Returns:
             bool:
                 Whether the dp_rank is used for collect.
+
         """
         assert mesh_name in self.__collect_dp_rank, f"{mesh_name} is not registered in {self.__class__.__name__}"
         return self.__collect_dp_rank[mesh_name]
@@ -141,6 +146,7 @@ class Worker(WorkerHelper):
                 A dictionary mapping mesh names to their dispatch dp_ranks.
             dict[str, bool]:
                 A dictionary mapping mesh names to whether they are used for collect.
+
         """
         return {"dispatch_dp_rank": self.__dispatch_dp_rank, "collect_dp_rank": self.__collect_dp_rank}
 
@@ -153,6 +159,7 @@ class Worker(WorkerHelper):
                 A dictionary mapping mesh names to their dispatch dp_ranks.
             collect_dp_rank (dict[str, bool]):
                 A dictionary mapping mesh names to whether they are used for collect.
+
         """
         assert mesh_name not in self.__dispatch_dp_rank, (
             f"{mesh_name} is already registered, {self.__dispatch_dp_rank.keys()}"
@@ -184,6 +191,7 @@ class Worker(WorkerHelper):
         Args:
             cuda_visible_devices (str, optional):
                 CUDA visible devices configuration. Defaults to None.
+
         """
         # construct a meta from environment variable. Note that the import must be inside the class because
         # it is executed remotely
@@ -225,6 +233,7 @@ class Worker(WorkerHelper):
         Args:
             worker_name (str):
                 Name of the worker to retrieve
+
         """
         return self.fused_worker_dict.get(worker_name, None)
 
@@ -328,6 +337,7 @@ class Worker(WorkerHelper):
                 Positional arguments for the function
             **kwargs:
                 Keyword arguments for the function
+
         """
         ret_proto = func(self, *args, **kwargs)
         return ret_proto
@@ -343,6 +353,7 @@ class Worker(WorkerHelper):
                 Positional arguments for the function
             **kwargs:
                 Keyword arguments for the function
+
         """
         result = func(*args, **kwargs)
         return result

--- a/verl/single_controller/base/worker_group.py
+++ b/verl/single_controller/base/worker_group.py
@@ -38,6 +38,7 @@ class ResourcePool:
             process_on_nodes (List[int], optional): List of process counts per node. Defaults to empty list.
             max_colocate_count (int, optional): Maximum number of processes that can be colocated. Defaults to 10.
             n_gpus_per_node (int, optional): Number of GPUs available per node. Defaults to 8.
+
         """
         if process_on_nodes is None:
             process_on_nodes = []
@@ -46,6 +47,7 @@ class ResourcePool:
         self.n_gpus_per_node = n_gpus_per_node  # this is left for future huawei GPU that contains 16 GPUs per node
 
     def add_node(self, process_count):
+        """Add a node with the given process count to the pool."""
         self._store.append(process_count)
 
     @property
@@ -54,10 +56,12 @@ class ResourcePool:
         return sum(self._store)
 
     def __call__(self) -> Any:
+        """Return the underlying list of process counts per node."""
         return self._store
 
     @property
     def store(self):
+        """The list of process counts per node."""
         return self._store
 
     def local_world_size_list(self) -> list[int]:
@@ -87,6 +91,7 @@ class ClassWithInitArgs:
             cls: The class to be instantiated later
             *args: Positional arguments for the class constructor
             **kwargs: Keyword arguments for the class constructor
+
         """
         self.cls = cls
         self.args = args
@@ -109,6 +114,7 @@ def check_workers_alive(workers: list, is_alive: Callable, gap_time: float = 1) 
             Function to check if a worker is alive
         gap_time (float):
             Time interval between checks
+
     """
     import time
 
@@ -168,6 +174,7 @@ class WorkerGroup:
 
         Args:
             every_n_seconds (int): Interval between aliveness checks
+
         """
         # before starting checking worker aliveness, make sure all workers are already alive
         self._block_until_all_workers_alive()
@@ -191,6 +198,7 @@ class WorkerGroup:
 
         Returns:
             List[str]: List of method names that were successfully bound
+
         """
         method_names = []
         for method_name in dir(user_defined_cls):

--- a/verl/single_controller/ray/base.py
+++ b/verl/single_controller/ray/base.py
@@ -283,6 +283,7 @@ def split_resource_pool(
 
     Returns:
         list[SubRayResourcePool]: A list of SubRayResourcePool after splitting.
+
     """
     # convert split_size to list[int]
     if isinstance(split_size, int):
@@ -355,6 +356,7 @@ class RayClassWithInitArgs(ClassWithInitArgs):
 
         Args:
             additional_resource: Dictionary specifying additional resource requirements
+
         """
         self._additional_resource = additional_resource
 
@@ -363,6 +365,7 @@ class RayClassWithInitArgs(ClassWithInitArgs):
 
         Args:
             options: Dictionary of options to update
+
         """
         self._options.update(options)
 
@@ -387,6 +390,7 @@ class RayClassWithInitArgs(ClassWithInitArgs):
 
         Returns:
             A Ray actor handle with the configured options
+
         """
         if sharing_with is not None:
             target_node_id = ray.get(sharing_with.get_node_id.remote())
@@ -444,8 +448,10 @@ class RayWorkerGroup(WorkerGroup):
             name_prefix: Prefix for worker names
             detached: Whether workers should be detached
             worker_names: Names of existing workers to attach to
+            worker_handles: Handles of existing Ray actors to attach to
             ray_wait_register_center_timeout: Timeout for waiting on register center
             **kwargs: Additional keyword arguments
+
         """
         self._master_addr = kwargs.pop("master_addr", None)
         self._master_port = kwargs.pop("master_port", None)
@@ -504,6 +510,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             bool: True if the worker is alive, False otherwise
+
         """
         worker_state_dict = get_actor(worker._actor_id.hex())
         return worker_state_dict.get("state", "undefined") == "ALIVE" if worker_state_dict is not None else False
@@ -550,6 +557,8 @@ class RayWorkerGroup(WorkerGroup):
             ray_cls_with_init: Class with initialization arguments for workers
             bin_pack: Whether to use strict bin packing for resource allocation
             detached: Whether workers should be detached
+            worker_env: Extra environment variables to set on each worker
+
         """
         self.resource_pool = resource_pool
         strategy = "PACK"
@@ -587,6 +596,8 @@ class RayWorkerGroup(WorkerGroup):
             ray_cls_with_init: Class with initialization arguments for workers
             bin_pack: Whether to use strict bin packing for resource allocation
             detached: Whether workers should be detached
+            worker_env: Extra environment variables to set on each worker
+
         """
         strategy = "PACK"
         if bin_pack:
@@ -700,10 +711,13 @@ class RayWorkerGroup(WorkerGroup):
         Args:
             name_prefix: Prefix for worker names
             worker_names: Names of existing workers to attach to
+            worker_handles: Handles of existing Ray actors to attach to
             ray_cls_with_init: Class with initialization arguments for workers
+            **kwargs: Additional keyword arguments forwarded to the constructor
 
         Returns:
             A new RayWorkerGroup instance
+
         """
         worker_group = cls(
             resource_pool=None,
@@ -723,6 +737,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Dictionary of worker groups keyed by prefix
+
         """
         if self.fused_worker_used:
             return self.spawn_fused(prefix_set)
@@ -758,6 +773,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Dictionary of worker groups keyed by prefix
+
         """
         wg_dict = dict()
         for key in prefix_set:
@@ -772,6 +788,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Args:
             prefix_set: Set of prefixes to fuse into the worker group
+
         """
         if self.wg_dict is None:
             self.wg_dict = self.spawn(prefix_set)
@@ -790,6 +807,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Remote object reference to the method execution
+
         """
         if self.fused_worker_used and method_name not in self.method_names:
             remote_call = getattr(worker, self.fused_worker_execute_fn_name)
@@ -808,6 +826,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Result of the method execution
+
         """
         return ray.get(self.execute_rank_zero_async(method_name, *args, **kwargs))
 
@@ -821,6 +840,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Remote object reference to the method execution
+
         """
         return self._execute_remote_single_worker(self._workers[0], method_name, *args, **kwargs)
 
@@ -834,6 +854,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             Remote object reference to the method execution
+
         """
         return self.execute_rank_zero_async(method_name, *args, **kwargs)
 
@@ -847,6 +868,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             List of remote object references to the method executions
+
         """
         return self.execute_all_async(method_name, *args, **kwargs)
 
@@ -860,6 +882,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             List of results from all workers
+
         """
         return ray.get(self.execute_all_async(method_name, *args, **kwargs))
 
@@ -873,6 +896,7 @@ class RayWorkerGroup(WorkerGroup):
 
         Returns:
             List of remote object references to the method executions
+
         """
         # Here, we assume that if all arguments in args and kwargs are lists,
         # and their lengths match len(self._workers), we'll distribute each

--- a/verl/tools/base_tool.py
+++ b/verl/tools/base_tool.py
@@ -41,6 +41,7 @@ class BaseTool:
         print(json.dumps(self.tool_schema.model_dump(exclude_unset=True, exclude_none=True), indent=2))
 
     def get_openai_tool_schema(self) -> OpenAIFunctionToolSchema:
+        """Return the OpenAI-format tool schema for this tool."""
         return self.tool_schema
 
     async def create(self, instance_id: Optional[str] = None, **kwargs) -> tuple[str, ToolResponse]:
@@ -48,10 +49,12 @@ class BaseTool:
 
         Args:
             instance_id: The instance id of the tool.
+            **kwargs: Additional keyword arguments for tool creation.
 
         Returns:
             The instance id of the tool.
             tool_creation_response: The response of the tool when creating the instance.
+
         """
         if instance_id is None:
             return str(uuid4()), ToolResponse()
@@ -65,11 +68,13 @@ class BaseTool:
         Args:
             instance_id: The instance id of the tool.
             parameters: The json string of the parameters of the tool.
+            **kwargs: Additional keyword arguments for tool execution.
 
         Returns: tool_response, tool_reward_score, tool_metrics
             tool_response: The ToolResponse object containing text, image, and/or video content.
             tool_reward_score: The step reward score of the tool.
             tool_metrics: The metrics of the tool.
+
         """
         return ToolResponse(text="Updated the tool state."), 0.0, {}
 
@@ -78,9 +83,11 @@ class BaseTool:
 
         Args:
             instance_id: The instance id of the tool.
+            **kwargs: Additional keyword arguments for reward calculation.
 
         Returns:
             The reward of the tool.
+
         """
         return 0.0
 
@@ -89,5 +96,7 @@ class BaseTool:
 
         Args:
             instance_id: The instance id of the tool.
+            **kwargs: Additional keyword arguments for releasing the tool.
+
         """
         pass

--- a/verl/tools/function_tool.py
+++ b/verl/tools/function_tool.py
@@ -98,6 +98,7 @@ def function_tool(
             ``OpenAIFunctionToolSchema`` (or a dict matching that shape) as-is.
             Use this only if your function's signature can't be expressed in
             JSON Schema -- the normal path is to fix the function.
+
     """
 
     def _make_decorator(tool_name_override: Optional[str]):

--- a/verl/tools/schemas.py
+++ b/verl/tools/schemas.py
@@ -73,6 +73,17 @@ class OpenAIFunctionCallSchema(BaseModel):
     def from_openai_function_parsed_schema(
         parsed_schema: OpenAIFunctionParsedSchema,
     ) -> tuple["OpenAIFunctionCallSchema", bool]:
+        """Build a call schema from a parsed OpenAI function schema.
+
+        Args:
+            parsed_schema (OpenAIFunctionParsedSchema): The parsed function schema
+                whose arguments are a JSON string.
+
+        Returns:
+            tuple[OpenAIFunctionCallSchema, bool]: The constructed call schema and a
+                flag indicating whether decoding the arguments failed.
+
+        """
         has_decode_error = False
         try:
             arguments = json.loads(parsed_schema.arguments)
@@ -105,6 +116,15 @@ class ToolResponse(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def initialize_request(cls, values):
+        """Validate that image and video fields are lists before model creation.
+
+        Args:
+            values: The raw input values passed to the model.
+
+        Returns:
+            The validated input values.
+
+        """
         if "image" in values and not isinstance(values["image"], list):
             raise ValueError(
                 f"Image must be a list, but got {type(values['image'])}. Please check the tool.execute(). "
@@ -121,7 +141,9 @@ class ToolResponse(BaseModel):
         return values
 
     def is_empty(self) -> bool:
+        """Return whether the response has no text, image, or video content."""
         return not self.text and not self.image and not self.video
 
     def is_text_only(self) -> bool:
+        """Return whether the response contains only text content."""
         return self.text and not self.image and not self.video

--- a/verl/tools/tool_registry.py
+++ b/verl/tools/tool_registry.py
@@ -39,6 +39,15 @@ class ToolType(Enum):
 
 
 def get_tool_class(cls_name):
+    """Import and return the tool class given its fully qualified name.
+
+    Args:
+        cls_name (str): The fully qualified class name (e.g. ``module.ClassName``).
+
+    Returns:
+        type: The resolved tool class.
+
+    """
     module_name, class_name = cls_name.rsplit(".", 1)
     if module_name not in sys.modules:
         spec = importlib.util.find_spec(module_name)

--- a/verl/trainer/config/algorithm.py
+++ b/verl/trainer/config/algorithm.py
@@ -31,6 +31,7 @@ class KLControlConfig(BaseConfig):
         kl_coef (float): Initial coefficient for KL penalty.
         horizon (int): Horizon value for adaptive controller.
         target_kl (float): Target KL divergence for adaptive controller.
+
     """
 
     type: str = "fixed"
@@ -49,6 +50,7 @@ class FilterGroupsConfig(BaseConfig):
         enable (bool): Whether to enable filter groups.
         metric (Optional[str]): Metric to use for filtering: "acc", "score", "seq_reward", "seq_final_reward", etc.
         max_num_gen_batches (int): Non-positive values mean no upper limit.
+
     """
 
     enable: bool = False
@@ -170,6 +172,7 @@ class RolloutCorrectionConfig(BaseConfig):
         Liu, Li, Fu, Wang, Liu, Shen (2025)
         "When Speed Kills Stability: Demystifying RL Collapse from the Training-Inference Mismatch"
         https://richardli.xyz/rl-collapse
+
     """
 
     rollout_is: Optional[str] = "sequence"
@@ -191,6 +194,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for decoupled mode with token-level IS
+
         """
         return cls(rollout_is="token", rollout_is_threshold=threshold, rollout_rs=None)
 
@@ -205,6 +209,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for decoupled mode with sequence-level IS
+
         """
         return cls(rollout_is="sequence", rollout_is_threshold=threshold, rollout_rs=None)
 
@@ -226,6 +231,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for decoupled mode with token-level IcePop
+
         """
         return cls(rollout_is="token", rollout_is_threshold=f"{threshold_lower}_{threshold}", rollout_rs=None)
 
@@ -246,6 +252,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for decoupled mode with sequence IS + RS
+
         """
         return cls(
             rollout_is="sequence",
@@ -270,6 +277,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for decoupled mode with Geo-RS
+
         """
         return cls(
             rollout_is=None,
@@ -288,6 +296,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with PPO-clip
+
         """
         return cls(
             rollout_is=None,
@@ -311,6 +320,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with PPO-clip + Geo-RS
+
         """
         return cls(
             rollout_is=None,
@@ -336,6 +346,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with PPO-clip + K3-RS
+
         """
         return cls(
             rollout_is=None,
@@ -357,6 +368,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with REINFORCE + IS
+
         """
         return cls(
             rollout_is="sequence",
@@ -383,6 +395,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with REINFORCE + token-level IcePop
+
         """
         return cls(
             rollout_is="token",
@@ -407,6 +420,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with REINFORCE + Geo-RS
+
         """
         return cls(
             rollout_is=None,
@@ -433,6 +447,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for Geo-RS-Seq-TIS
+
         """
         return cls(
             rollout_is="sequence",
@@ -458,6 +473,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for Geo-RS-Token-TIS
+
         """
         return cls(
             rollout_is="token",
@@ -484,6 +500,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with REINFORCE + Geo-RS + Seq-TIS
+
         """
         return cls(
             rollout_is="sequence",
@@ -514,6 +531,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for bypass mode with REINFORCE + Geo-RS + Token-TIS
+
         """
         return cls(
             rollout_is="token",
@@ -543,6 +561,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for K3 RS
+
         """
         return cls(
             rollout_is=None,
@@ -567,6 +586,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for K3-RS-Seq-TIS
+
         """
         return cls(
             rollout_is="sequence",
@@ -593,6 +613,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig configured for K3-RS-Token-TIS
+
         """
         return cls(
             rollout_is="token",
@@ -609,6 +630,7 @@ class RolloutCorrectionConfig(BaseConfig):
 
         Returns:
             RolloutCorrectionConfig with all correction disabled
+
         """
         return cls(rollout_is=None, rollout_rs=None)
 
@@ -646,6 +668,7 @@ class AlgoConfig(BaseConfig):
 
             For backward compatibility, you can still pass a dict, which will be converted to
             RolloutCorrectionConfig automatically.
+
     """
 
     gamma: float = 1.0

--- a/verl/trainer/config/config.py
+++ b/verl/trainer/config/config.py
@@ -36,6 +36,7 @@ class CheckpointConfig(BaseConfig):
         load_contents (list[str]): Contents to load from checkpoint. Defaults to same as save_contents.
         async_save (bool): Whether to save checkpoints asynchronously. Only implemented for Megatron as of now.
         strict (bool): Whether to perform strict validation during weight export
+
     """
 
     save_contents: list[str] = field(default_factory=lambda: ["model", "optimizer", "extra"])
@@ -55,6 +56,7 @@ class ProfileConfig(BaseConfig):
         step_start (int): Starting step for profiling.
         step_end (int): Ending step for profiling.
         save_path (Optional[str]): Path to save profiling results.
+
     """
 
     profile_ranks: Optional[list[int]] = None
@@ -75,6 +77,7 @@ class BaseModelConfig(BaseConfig):
         external_lib (Optional[str]): External model implementation (optional).
         trust_remote_code (bool): Whether to trust remote code from Hugging Face models.
         lora (dict[str, Any]): LoRA configuration dictionary.
+
     """
 
     path: str = "~/models/deepseek-llm-7b-chat"
@@ -94,6 +97,7 @@ class ModuleConfig(BaseConfig):
         name (str, optional): Name of the module to ``import``. Format: ``"import.path.to.module"``.
             If ``None``, the module will be loaded with a hased name and
                 will not be added to ``sys.modules``, thus can not be ``import``ed as ``name``.
+
     """
 
     path: Optional[str] = None

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -42,6 +42,7 @@ def _chunked_topk_log_probs(
 
     Returns:
         [B, T, K] tensor with the same dtype as `logits`.
+
     """
     B, T, V = logits.shape
     K = topk_ids.shape[-1]
@@ -85,12 +86,14 @@ def compute_forward_kl_topk(
         student_logits: (bsz, seqlen/sp_size, vocab_size).
         teacher_topk_log_probs: (bsz, seqlen, topk).
         teacher_topk_ids: (bsz, seqlen, topk).
+        config: DistillationConfig controlling the distillation loss behavior.
         data_format: "thd" or "bshd", models not support THD format, e.g GPT-OSS, Qwen3.5
 
     Returns:
     - distillation_losses: (bsz, seqlen/sp_size)
     - student_mass: (bsz, seqlen/sp_size)
     - teacher_mass: (bsz, seqlen/sp_size)
+
     """
     assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
     teacher_topk_log_probs = teacher_topk_log_probs.values().unsqueeze(0)  # (1, total_nnz, topk)

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -52,6 +52,7 @@ class DistillationLossSettings(BaseConfig):
         names (str | list[str]): Name(s) to register the distillation loss function under.
         use_topk (bool): Whether the loss function uses top-k log probabilities.
         use_estimator (bool): Whether the loss function uses single-sample KL estimators.
+
     """
 
     names: str | list[str] = field(default_factory=list)
@@ -133,6 +134,7 @@ def compute_topk_loss(
     - distillation_losses: (bsz, seqlen/cp_size)
     - student_mass: (bsz, seqlen/cp_size)
     - teacher_mass: (bsz, seqlen/cp_size)
+
     """
     match config.strategy:
         # VeOmni uses FSDP2 internally, so its loss computation is identical to FSDP.
@@ -192,12 +194,14 @@ def distillation_ppo_loss(
         data: Micro input batch, contains
           - teacher_logprobs: (bsz, seqlen, topk)
           - teacher_ids: (bsz, seqlen, topk)
+        dp_group: Data parallel process group used for cross-rank reductions.
         student_logits: (bsz, seqlen/cp_size, vocab_size/tp_size).
         data_format: "thd" or "bshd", models not support THD format, e.g GPT-OSS, Qwen3.5
 
     Returns:
     - student_logits is not None, return the topk loss tensor (bsz, seqlen/cp_size).
     - student_logits is None, return the final policy loss scalar and metrics.
+
     """
 
     # Called as logits processor
@@ -234,6 +238,7 @@ def distillation_loss(
     Returns:
     - distillation_loss: Aggregated distillation loss scalar.
     - distillation_metrics: Dictionary of metrics.
+
     """
     assert distillation_config is not None
     loss_config: DistillationLossConfig = distillation_config.distillation_loss
@@ -303,6 +308,7 @@ def compute_forward_kl_topk(
     Returns:
     - distillation_losses: (bsz, resp_len)
     - distillation_metrics: Dictionary of metrics.
+
     """
     # topk loss has been computed in logits processor
     distillation_losses = no_padding_2_padding(model_output["distillation_losses"], data)
@@ -374,6 +380,7 @@ def compute_distillation_loss_reverse_kl_estimator(
     Returns:
     - distillation_losses: (bsz, resp_len)
     - distillation_metrics: Dictionary of metrics.
+
     """
     student_log_probs = no_padding_2_padding(model_output["log_probs"], data)
     teacher_log_probs = no_padding_2_padding(data["teacher_logprobs"], data).squeeze(-1)

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -74,6 +74,7 @@ class _VocabParallelKLDivergence(torch.autograd.Function):
           - `target_topk_*` (indices/logprobs) are in *global vocab* coordinates.
           - `vp_logits` are the *local shard* of the vocab-parallel logits on this TP rank.
           This function masks out target top-k entries that do not belong to the local shard.
+
         """
         from megatron.core.parallel_state import (
             get_tensor_model_parallel_group,
@@ -274,12 +275,14 @@ def compute_forward_kl_topk(
         student_logits: (bsz, seqlen/cp_size, vocab_size/tp_size).
         teacher_topk_log_probs: (bsz, seqlen, topk).
         teacher_topk_ids: (bsz, seqlen, topk).
+        config: DistillationConfig controlling the distillation loss behavior.
         data_format: "thd" or "bshd", models not support THD format, e.g GPT-OSS, Qwen3.5
 
     Returns:
     - distillation_losses: (bsz, seqlen/cp_size)
     - student_mass: (bsz, seqlen/cp_size)
     - teacher_mass: (bsz, seqlen/cp_size)
+
     """
     assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
 

--- a/verl/trainer/main_eval.py
+++ b/verl/trainer/main_eval.py
@@ -32,6 +32,7 @@ from verl.utils.fs import copy_to_local
 
 @ray.remote
 def process_item(config, data_source, response_lst, reward_data):
+    """Compute reward scores for a single item using the custom reward function."""
     reward_fn = get_custom_reward_fn(config)
     ground_truth = reward_data["ground_truth"]
     score_lst = [reward_fn(data_source, r, ground_truth) for r in response_lst]
@@ -40,6 +41,7 @@ def process_item(config, data_source, response_lst, reward_data):
 
 @hydra.main(config_path="config", config_name="evaluation", version_base=None)
 def main(config):
+    """Evaluate generated responses using reward model and ground truth verifier."""
     local_path = copy_to_local(config.data.path, use_shm=config.data.get("use_shm", False))
     dataset = pd.read_parquet(local_path)
     responses = dataset[config.data.response_key]

--- a/verl/trainer/main_generation_server.py
+++ b/verl/trainer/main_generation_server.py
@@ -38,6 +38,7 @@ from verl.workers.rollout.replica import get_rollout_replica_class
 
 
 async def start_server(config):
+    """Start rollout server replicas and return their handles and addresses."""
     tp_size = config.actor_rollout_ref.rollout.tensor_model_parallel_size
     num_replicas = (config.trainer.n_gpus_per_node * config.trainer.nnodes) // tp_size
     rollout_config = config.actor_rollout_ref.rollout
@@ -64,6 +65,7 @@ async def start_server(config):
 
 
 async def submit_request(server_address, **chat_complete_request):
+    """Submit a single chat completion request to the server."""
     try:
         extra_headers = chat_complete_request.pop("extra_headers", {})
         timeout = aiohttp.ClientTimeout(total=None)
@@ -80,6 +82,7 @@ async def submit_request(server_address, **chat_complete_request):
 
 
 async def generate_per_replica(server_address, model_path: str, n_samples: int, sampling_params: dict, chat_lst: list):
+    """Generate completions for a list of chats on a single replica."""
     # here we should sample n_samples for each chat_lst.
     # we use aiohttp to avoid hang in AsyncOpenAI when the number of requests is large.
 
@@ -106,6 +109,7 @@ async def generate_per_replica(server_address, model_path: str, n_samples: int, 
 async def generate(
     server_addresses: list, model_path: str, n_samples: int, sampling_params: dict, chat_numpy: np.ndarray
 ):
+    """Distribute generation across all server replicas and gather results."""
     num_replicas = len(server_addresses)
     chat_sub_array = np.array_split(chat_numpy, num_replicas)
     chat_sub_array = [chat.tolist() for chat in chat_sub_array]
@@ -121,6 +125,7 @@ async def generate(
 
 @hydra.main(config_path="config", config_name="ppo_trainer", version_base=None)
 def main(config):
+    """Run generation server with Hydra configuration."""
     ray.init(runtime_env={"env_vars": {"TOKENIZERS_PARALLELISM": "true", "NCCL_DEBUG": "WARN", "VLLM_USE_V1": "1"}})
 
     pprint(OmegaConf.to_container(config, resolve=True))  # resolve=True will eval symbol values

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -41,6 +41,7 @@ def main(config):
 
     Args:
         config: Hydra configuration dictionary containing training parameters.
+
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
     auto_set_device(config)
@@ -57,6 +58,7 @@ def run_ppo(config, task_runner_class=None) -> None:
                 for distributed PPO training including Ray initialization settings,
                 model paths, and training hyperparameters.
         task_runner_class: For recipe to change TaskRunner.
+
     """
     # Check if Ray is not initialized
     if not ray.is_initialized():
@@ -117,6 +119,7 @@ class TaskRunner:
     Attributes:
         role_worker_mapping: Dictionary mapping Role enums to Ray remote worker classes
         mapping: Dictionary mapping Role enums to resource pool IDs for GPU allocation
+
     """
 
     def __init__(self):
@@ -229,6 +232,7 @@ class TaskRunner:
         Args:
             config: Training configuration object containing all parameters needed
                    for setting up and running the PPO training process.
+
         """
         # Print the initial configuration. `resolve=True` will evaluate symbolic values.
         from pprint import pprint
@@ -323,9 +327,12 @@ def create_rl_dataset(data_paths, data_config, tokenizer, processor, is_train=Tr
         data_config: The data config.
         tokenizer (Tokenizer): The tokenizer.
         processor (Processor): The processor.
+        is_train (bool): Whether the dataset is for training. Defaults to True.
+        max_samples (int): Maximum number of samples to use, -1 means no limit. Defaults to -1.
 
     Returns:
         dataset (Dataset): The dataset.
+
     """
 
     from verl.utils.dataset.rl_dataset import get_dataset_class
@@ -354,6 +361,7 @@ def create_rl_sampler(data_config, dataset):
 
     Returns:
         sampler (Sampler): The sampler.
+
     """
     import torch
     from torch.utils.data import SequentialSampler

--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -107,6 +107,7 @@ from verl.workers.utils.padding import response_from_nested, response_to_nested
 
 
 def apply_greedy_sampling_params(params: dict[str, Any]) -> None:
+    """Apply greedy decoding parameters to the sampling configuration."""
     params["top_p"] = 1.0
     params["top_k"] = -1
     params["temperature"] = 0
@@ -196,6 +197,7 @@ class ReplayBuffer:
 
     Args:
         poll_interval (float, optional): Poll interval in seconds. Defaults to 1.0.
+
     """
 
     def __init__(self, poll_interval: float = 1.0):
@@ -237,6 +239,7 @@ class ReplayBuffer:
         Args:
             partition_id (str): Partition of transfer queue, e.g. "train" or "val".
             items (dict[str, dict]): Items to add, e.g. {"key": {"tag": "value"}}.
+
         """
         with self.lock:
             partition = self.partitions[partition_id]
@@ -251,6 +254,7 @@ class ReplayBuffer:
         Args:
             partition_id (str): Partition of transfer queue, e.g. "train" or "val".
             keys (list[str]): Keys to remove.
+
         """
         with self.lock:
             partition = self.partitions[partition_id]
@@ -269,6 +273,7 @@ class ReplayBuffer:
 
         Returns:
             KVBatchMeta: A batch of data.
+
         """
         assert (global_steps is not None or batch_size) and (not (global_steps is not None and batch_size)), (
             "Either global_steps or batch_size must be specified, but not both."
@@ -479,6 +484,7 @@ class AgentLoopManagerTQ(AgentLoopManager):
 
         Args:
             prompts (TensorDict): Input batch from train or validation dataset.
+
         """
         # mark prompts as pending in replay buffer
         global_steps = prompts["global_steps"]
@@ -505,6 +511,7 @@ class PPOTrainer:
         config: DictConfig from yaml config file.
         role_worker_mapping: dict[Role, WorkerType]
         resource_pool_manager: ResourcePoolManager
+
     """
 
     def __init__(
@@ -1587,6 +1594,7 @@ class PPOTrainer:
         metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
 
     def fit(self):
+        """Run the PPO training loop with rollout, training, and validation."""
         if self._dump_executor._shutdown:
             self._init_dump_executor()
 
@@ -1686,6 +1694,7 @@ class PPOTrainer:
         self._shutdown_dump_executor()
 
     def step(self, batch_dict: dict, metrics: dict, timing_raw: dict) -> KVBatchMeta:
+        """Execute a single training step including rollout and model updates."""
         # 1. put batch to agent loop manager
         batch_dict["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch_dict["raw_prompt"]))], dtype=object)
         if self.config.algorithm.adv_estimator == core_algos.AdvantageEstimator.REMAX:
@@ -1816,6 +1825,7 @@ class TaskRunner:
         self.resource_pool_manager = ResourcePoolManager(resource_pool_spec=resource_pool_spec, mapping=self.mapping)
 
     def run(self, config):
+        """Run the full PPO training pipeline."""
         pprint(OmegaConf.to_container(config, resolve=True))
         OmegaConf.resolve(config)
 
@@ -1846,6 +1856,7 @@ def main(config):
 
     Args:
         config: Hydra configuration dictionary containing training parameters.
+
     """
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
     auto_set_device(config)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -58,6 +58,7 @@ def register_policy_loss(name: str) -> Callable[[PolicyLossFn], PolicyLossFn]:
 
     Returns:
         function: Decorator function that registers the policy loss function.
+
     """
 
     def decorator(func: PolicyLossFn) -> PolicyLossFn:
@@ -76,6 +77,7 @@ def get_policy_loss_fn(name):
 
     Returns:
         `(callable)`: The policy loss function.
+
     """
     loss_name = name
     if loss_name not in POLICY_LOSS_REGISTRY:
@@ -143,6 +145,7 @@ def get_adv_estimator_fn(name_or_enum):
 
     Returns:
         `(callable)`: The advantage estimator function.
+
     """
     name = name_or_enum.value if isinstance(name_or_enum, Enum) else name_or_enum
     if name not in ADV_ESTIMATOR_REGISTRY:
@@ -167,6 +170,7 @@ class AdaptiveKLController:
         Args:
             current_kl (float): Current KL divergence value.
             n_steps (int): Number of steps taken.
+
         """
         target = self.target
         proportional_error = np.clip(current_kl / target - 1, -0.2, 0.2)
@@ -186,6 +190,7 @@ class FixedKLController:
         Args:
             current_kl (float): Current KL divergence value (unused).
             n_steps (int): Number of steps taken (unused).
+
         """
         pass
 
@@ -202,6 +207,7 @@ def get_kl_controller(kl_ctrl):
     Raises:
         NotImplementedError: If controller type is not supported.
         AssertionError: If adaptive controller horizon is not positive.
+
     """
     if kl_ctrl.type == "fixed":
         return FixedKLController(kl_coef=kl_ctrl.kl_coef)
@@ -229,7 +235,7 @@ def compute_gae_advantage_return(
             shape is (bs, response_length)
         response_mask: `(torch.Tensor)`
             shape is (bs, response_length). [EOS] mask. The token after [EOS] have mask zero.
-        gamma is `(float)`
+        gamma: `(float)`
             discounted factor used in RL
         lam: `(float)`
             lambda value when computing Generalized Advantage Estimation (https://arxiv.org/abs/1506.02438)
@@ -300,6 +306,7 @@ def compute_grpo_outcome_advantage(
             shape is (bs, response_length)
         Returns: `(torch.Tensor)`
             shape is (bs, response_length)
+
     """
     scores = token_level_rewards.sum(dim=-1)
 
@@ -340,10 +347,10 @@ def compute_grpo_vectorized_outcome_advantage(
     norm_adv_by_std_in_grpo: bool = True,
     config: Optional[AlgoConfig] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """
+    r"""
     Vectorized GRPO（outcome-only）:
       For each group g:
-      a_i = \\frac{r_i - \\mu_g}{\\sigma_g} (or without dividing by \\sigma_g),
+      a_i = \frac{r_i - \mu_g}{\sigma_g} (or without dividing by \sigma_g),
       then broadcast the scalar across the token dimension (multiplied by response_mask).。
     """
     with torch.no_grad():
@@ -398,6 +405,7 @@ def compute_gdpo_outcome_advantage(
         config: Algorithm configuration (optional).
         non_tensor_batch: Non-tensor batch data containing per-dimension reward scores.
         batch: Batch data containing prompts, attention_mask, etc.
+        **kwargs: Additional keyword arguments (unused).
 
     Note:
         Ref GDPO (https://arxiv.org/abs/2601.05242).
@@ -405,6 +413,7 @@ def compute_gdpo_outcome_advantage(
     Returns:
         advantages: (bs, response_length)
         returns: (bs, response_length) – same as advantages (outcome-only).
+
     """
     score_list = None
     reward_weights = None
@@ -489,11 +498,14 @@ def compute_grpo_passk_outcome_advantage(
         response_mask: (bs, response_length)
         index: (bs,) → group ID per sample
         epsilon: float for numerical stability
+        norm_adv_by_std_in_grpo: whether to normalize advantage by std within group
         config: (AlgoConfig) algorithm settings, which contains "norm_adv_by_std_in_grpo"
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: (bs, response_length)
         returns: (bs, response_length)
+
     """
     assert config is not None
     # if True, normalize advantage by std within group
@@ -550,13 +562,17 @@ def compute_reinforce_plus_plus_baseline_outcome_advantage(
             shape: (bs, response_length)
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
+        index: `(torch.Tensor)` group id per sample, used to compute the baseline
+        epsilon: (float) small constant for numerical stability
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     response_length = token_level_rewards.shape[-1]
     scores = token_level_rewards.sum(dim=-1)
@@ -601,13 +617,17 @@ def compute_rloo_outcome_advantage(
             shape: (bs, response_length)
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
+        index: `(np.ndarray)` group id per sample, used to compute the leave-one-out baseline
+        epsilon: (float) small constant for numerical stability
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     scores = token_level_rewards.sum(dim=-1)
 
@@ -653,13 +673,17 @@ def compute_opo_outcome_advantage(
             shape: (bs, response_length)
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
+        index: `(np.ndarray)` group id per sample, used to compute the length-weighted baseline
+        epsilon: (float) small constant for numerical stability
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     response_length = response_mask.sum(dim=-1)
     scores = token_level_rewards.sum(dim=-1)
@@ -704,12 +728,14 @@ def compute_reinforce_plus_plus_outcome_advantage(
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     assert config is not None
     gamma = config.gamma
@@ -750,12 +776,14 @@ def compute_remax_outcome_advantage(
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
 
     with torch.no_grad():
@@ -790,12 +818,14 @@ def compute_gpg_outcome_advantage(
         f_norm: (float)
         alpha: (float)
         config: (dict) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     scores = token_level_rewards.sum(dim=-1)
 
@@ -845,13 +875,17 @@ def compute_rloo_vectorized_outcome_advantage(
             shape: (bs, response_length)
         response_mask: `(torch.Tensor)`
             shape: (bs, response_length)
+        index: `(np.ndarray)` group id per sample, used to compute the leave-one-out baseline
+        epsilon: (float) small constant for numerical stability
         config: (AlgoConfig) algorithm config
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: `(torch.Tensor)`
             shape: (bs, response_length)
         Returns: `(torch.Tensor)`
             shape: (bs, response_length)
+
     """
     scores = token_level_rewards.sum(dim=-1)
 
@@ -905,6 +939,7 @@ def compute_optimal_token_baseline_advantage(
             that extends beyond the second-longest trajectory in the prompt group.
             Default: True
         epsilon: Small constant for numerical stability (default: 1e-8)
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: OTB advantage estimates [shape: (bs, response_length)]
@@ -913,6 +948,7 @@ def compute_optimal_token_baseline_advantage(
     Note on Rollout Importance Sampling:
         When rollout_is_weights is provided, W_t is scaled by ρ̄²(t) to minimize MSE under truncated IS:
             B_t* = Σ[G_t × ρ̄²(t) × W_t] / Σ[ρ̄²(t) × W_t]
+
     """
     with torch.no_grad():
         batch_size, seq_len = token_level_rewards.shape
@@ -1024,6 +1060,7 @@ def compute_multi_turn_optimal_token_baseline_advantage(
             that extends beyond the second-longest trajectory in the prompt group.
             Default: False
         epsilon: Small constant for numerical stability (default: 1e-8)
+        **kwargs: Additional keyword arguments (unused).
 
     Returns:
         advantages: OTB advantage estimates [shape: (bs, response_length)]
@@ -1032,6 +1069,7 @@ def compute_multi_turn_optimal_token_baseline_advantage(
     Note on Rollout Importance Sampling:
         When rollout_is_weights is provided, W_t is scaled by ρ̄²(t) to minimize MSE under truncated IS:
             B_t* = Σ[G_t × ρ̄²(t) × W_t] / Σ[ρ̄²(t) × W_t]
+
     """
     with torch.no_grad():
         # Compute returns (reward-to-go) for each timestep
@@ -1130,6 +1168,7 @@ def compute_rewards(token_level_scores, old_log_prob, ref_log_prob, kl_ratio):
 
     Returns:
         torch.Tensor: Token-level rewards with KL penalty applied.
+
     """
     kl = old_log_prob - ref_log_prob
     return token_level_scores - kl * kl_ratio
@@ -1164,6 +1203,7 @@ def agg_loss(
     Returns:
         loss: `a scalar torch.Tensor`
             aggregated loss
+
     """
     if loss_agg_mode == "token-mean":
         if batch_num_tokens is None:
@@ -1238,6 +1278,7 @@ def compute_policy_loss(
             Defaults to 3.0.
         loss_agg_mode (str, optional):
             Aggregation mode for `agg_loss`. Defaults to "token-mean".
+
     """
     assert clip_ratio_c > 1.0, (
         "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
@@ -1306,6 +1347,9 @@ def compute_policy_loss_vanilla(
             config for the actor.
         rollout_log_probs: `(torch.Tensor)`:
             log probabilities of actions under the rollout policy, shape (batch_size, response_length).
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -1399,6 +1443,9 @@ def compute_policy_loss_dppo_tv(
             config for the actor.
         rollout_log_probs: `(torch.Tensor)`:
             log probabilities of actions under the rollout policy, shape (batch_size, response_length).
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -1480,6 +1527,9 @@ def compute_policy_loss_dppo_kl(
             config for the actor.
         rollout_log_probs: `(torch.Tensor)`:
             log probabilities of actions under the rollout policy, shape (batch_size, response_length).
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -1561,6 +1611,11 @@ def compute_policy_loss_gspo(
             Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
         loss_agg_mode (str, optional):
             Aggregation mode for `agg_loss`. For GSPO, it is recommended to use "seq-mean-token-mean".
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -1637,6 +1692,11 @@ def compute_policy_loss_sapo(
             Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
         loss_agg_mode (str, optional):
             Aggregation mode for `agg_loss`. For SAPO, it is recommended to use "seq-mean-token-mean".
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -1718,6 +1778,7 @@ def compute_policy_loss_gpg(
     return:
         pg_loss: `a scalar torch.Tensor`
             policy gradient loss computed via GPG
+
     """
     assert config is not None
     pg_losses = -log_prob * advantages
@@ -1772,6 +1833,11 @@ def compute_policy_loss_clip_cov(
             Lower bound for clipping covariance. Defaults to 1.0.
         clip_cov_ub (float, optional):
             Upper bound for clipping covariance. Defaults to 5.0.
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
     assert config is not None
     assert not isinstance(config, AlgoConfig), "passing AlgoConfig not supported yet"
@@ -1868,6 +1934,11 @@ def compute_policy_loss_kl_cov(
             Ratio for selecting the top-k covariance values. Defaults to 0.0002.
         ppo_kl_coef (float, optional):
             Coefficient for the KL penalty term in the loss. Defaults to 1.
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
     assert config is not None
     assert not isinstance(config, AlgoConfig), "passing AlgoConfig not supported yet"
@@ -1944,6 +2015,11 @@ def compute_policy_loss_geo_mean(
             Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
         loss_agg_mode (str, optional):
             not used
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights (torch.Tensor, optional):
+            rollout importance-sampling correction weights, shape (batch_size, response_length).
+
     """
 
     assert config is not None
@@ -2070,6 +2146,7 @@ def compute_entropy_loss(logits, response_mask, loss_agg_mode: str = "token-mean
     Args:
         logits (torch.Tensor): shape is (bs, response_length, vocab_size)
         response_mask (torch.Tensor): shape is (bs, response_length)
+        loss_agg_mode (str): aggregation mode for the entropy loss. Defaults to "token-mean".
 
     Returns:
         entropy: a scalar torch.Tensor
@@ -2113,6 +2190,7 @@ def compute_value_loss(
             A scalar tensor containing the aggregated value-function loss.
         vf_clipfrac (float):
             Fraction of elements where the clipped loss was used.
+
     """
     vpredclipped = verl_F.clip_by_value(vpreds, values - cliprange_value, values + cliprange_value)
     vf_losses1 = (vpreds - returns) ** 2
@@ -2129,11 +2207,13 @@ def kl_penalty(logprob: torch.FloatTensor, ref_logprob: torch.FloatTensor, kl_pe
     See more description in http://joschu.net/blog/kl-approx.html
 
     Args:
-        logprob:
-        ref_logprob:
+        logprob: log-probabilities under the current policy.
+        ref_logprob: log-probabilities under the reference policy.
+        kl_penalty: name of the KL estimator to use (e.g. "kl", "k1", "k2", "k3", "k3+").
 
     Returns:
         kl_estimate
+
     """
     # Strip the optional '+' suffix so e.g. "k3+" dispatches to "k3".
     base_kl_penalty = kl_penalty[:-1] if kl_penalty.endswith("+") else kl_penalty
@@ -2157,11 +2237,13 @@ def kl_penalty_forward(logprob: torch.FloatTensor, ref_logprob: torch.FloatTenso
     See more description in http://joschu.net/blog/kl-approx.html
 
     Args:
-        logprob:
-        ref_logprob:
+        logprob: log-probabilities under the current policy.
+        ref_logprob: log-probabilities under the reference policy.
+        kl_penalty: name of the KL estimator to use (e.g. "kl", "k1", "abs", "mse", "k2", "k3").
 
     Returns:
         kl_estimate
+
     """
     if kl_penalty in ("kl", "k1"):
         return logprob - ref_logprob
@@ -2219,6 +2301,7 @@ def compute_pf_ppo_reweight_data(
 
         Raises:
             ValueError: If reweight_method is not supported.
+
         """
         if reweight_method == "pow":
             weights = torch.pow(torch.abs(scores), weight_pow)
@@ -2316,6 +2399,7 @@ def compute_policy_loss_reinforce(
         - Does NOT use PPO clipping
         - Uses log π(a|s) directly (not ratio)
         - IS weights are applied as multiplicative factor
+
     """
     assert config is not None, "ActorConfig must be provided for REINFORCE loss"
 
@@ -2404,6 +2488,7 @@ def compute_policy_loss_bypass_mode(
         Tuple of (loss, metrics):
             loss: Scalar policy loss
             metrics: Dictionary with rollout correction metrics and actor/ppo_kl
+
     """
     from verl.trainer.ppo.rollout_corr_helper import compute_rollout_correction_and_rejection_mask
 

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -45,6 +45,7 @@ def reduce_metrics(metrics: dict[str, list[Any]]) -> dict[str, Any]:
         >>> metrics = {"loss": [1.0, 2.0, 3.0], "accuracy": [0.8, 0.9, 0.7]}
         >>> reduce_metrics(metrics)
         {"loss": 2.0, "accuracy": 0.8}
+
     """
     from verl.utils.metric import reduce_metrics
 
@@ -65,6 +66,7 @@ def _compute_response_info(batch: DataProto) -> dict[str, Any]:
             - response_mask: Attention mask for the response tokens
             - prompt_length: Tensor of prompt lengths for each item in the batch
             - response_length: Tensor of response lengths for each item in the batch
+
     """
     if "prompt_length" in batch.batch and "response_length" in batch.batch:
         return dict(
@@ -109,6 +111,7 @@ def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str,
             - response_length/mean, max, min, clip_ratio: Statistics about response lengths
             - prompt_length/mean, max, min, clip_ratio: Statistics about prompt lengths
             - num_turns/mean, max, min: Statistics about the number of multi-turn conversations
+
     """
     sequence_score = batch.batch["token_level_scores"].sum(-1)
     sequence_reward = batch.batch["token_level_rewards"].sum(-1)
@@ -290,6 +293,7 @@ def compute_timing_metrics(batch: DataProto, timing_raw: dict[str, float]) -> di
         - "gen" uses only response tokens
         - Other stages ("ref", "values", "adv", "update_critic", "update_actor") use all tokens
           (prompt + response)
+
     """
     response_info = _compute_response_info(batch)
     num_prompt_tokens = torch.sum(response_info["prompt_length"]).item()
@@ -333,6 +337,7 @@ def compute_throughout_metrics(batch: DataProto, timing_raw: dict[str, float], n
     Note:
         The throughput is calculated as total_tokens / (time * n_gpus) to normalize
         across different GPU counts.
+
     """
     total_num_tokens = sum(batch.meta_info["global_token_num"])
     time = timing_raw["step"]
@@ -489,6 +494,7 @@ def bootstrap_metric(
         >>> reduce_fns = [np.mean, np.max]
         >>> bootstrap_metric(data, 3, reduce_fns)
         [(3.0, 0.5), (4.5, 0.3)]  # Example values
+
     """
     np.random.seed(seed)
     data_np = np.array(data, dtype=object)
@@ -538,6 +544,7 @@ def calc_maj_val(data: list[dict[str, Any]], vote_key: str, val_key: str) -> flo
         ... ]
         >>> calc_maj_val(data, vote_key="pred", val_key="val")
         0.9  # Returns the first "val" for the majority vote "A"
+
     """
     vote2vals = defaultdict(list)
     for d in data:
@@ -594,6 +601,7 @@ def process_validation_metrics(
         >>> infos_dict = {"score": [0.8, 0.9, 0.7], "pred": ["A", "A", "B"]}
         >>> result = process_validation_metrics(data_sources, sample_uids, infos_dict)
         >>> # result will contain statistics for each data source and variable
+
     """
     # Group metrics by data source, prompt and variable
     data_src2uid2var2vals = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))

--- a/verl/trainer/ppo/padding_utils.py
+++ b/verl/trainer/ppo/padding_utils.py
@@ -81,6 +81,7 @@ def construct_minimal_padding_template(
 
     Returns:
         A tuple of (template_sample, template_tag) ready for padding.
+
     """
     # Copy the sample template from an existing sample.
     template_sample = {}
@@ -144,6 +145,7 @@ def upsample_batch_to_divisible_size(
 
     Returns:
         The (possibly enlarged) KVBatchMeta.
+
     """
     remainder = len(batch) % batch_multiple
     if remainder == 0:

--- a/verl/trainer/ppo/prefix_grouper_utils.py
+++ b/verl/trainer/ppo/prefix_grouper_utils.py
@@ -115,6 +115,7 @@ def pg_forward(
     calculate_entropy=False,
     entropy_fn=None,
 ):
+    """Perform a forward pass through the model using PrefixGrouper."""
     logits = model(
         input_ids=concat_input_ids,
         attention_mask=attention_mask,
@@ -170,6 +171,7 @@ def forward_micro_batch_with_prefix_grouper(
 
     Returns:
         tuple: (entropy, log_probs) where entropy may be None if not calculated.
+
     """
     import verl.utils.torch_functional as verl_F
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -88,6 +88,7 @@ def apply_kl_penalty(data: DataProto, kl_ctrl: core_algos.AdaptiveKLController, 
         tuple: A tuple containing:
             - The updated data with token-level rewards adjusted by KL penalty
             - A dictionary of metrics related to the KL penalty
+
     """
     response_mask = data.batch["response_mask"]
     token_level_scores = data.batch["token_level_scores"]
@@ -126,6 +127,7 @@ def compute_response_mask(data: DataProto):
 
     Returns:
         torch.Tensor: The attention mask for the response tokens.
+
     """
     responses = data.batch["responses"]
     response_length = responses.size(1)
@@ -208,6 +210,7 @@ def compute_advantage(
 
     Returns:
         DataProto: The updated data with computed advantages and returns.
+
     """
     # Back-compatible with trainers that do not compute response mask in fit
     if "response_mask" not in data.batch.keys():
@@ -323,6 +326,7 @@ class RayPPOTrainer:
             collate_fn: Function to collate data samples into batches.
             train_sampler (Optional[Sampler], optional): Sampler for the training dataset. Defaults to None.
             device_name (str, optional): Device name for training (e.g., "cuda", "cpu"). Defaults to None.
+
         """
 
         # Store the tokenizer for text processing
@@ -523,6 +527,7 @@ class RayPPOTrainer:
             reward_extra_infos_dict (dict): Additional reward information to log
             timing_raw (dict): Timing information for profiling
             rollout_data_dir (str): Directory path to save the rollout data
+
         """
         with marked_timer("dump_rollout_generations", timing_raw, color="green"):
             inputs = self.tokenizer.batch_decode(batch.batch["prompts"], skip_special_tokens=True)
@@ -1137,6 +1142,7 @@ class RayPPOTrainer:
 
         Returns:
             The data parallel size (number of DP ranks).
+
         """
         if role not in worker_group._dispatch_info:
             dp_rank_mapping = worker_group._query_dispatch_info(role)

--- a/verl/trainer/ppo/reward.py
+++ b/verl/trainer/ppo/reward.py
@@ -65,6 +65,7 @@ def get_custom_reward_fn(config: DictConfig) -> Optional[RawRewardFn]:
         FileNotFoundError: If the specified reward function file doesn't exist.
         RuntimeError: If there's an error loading the module from file.
         AttributeError: If the specified function name isn't found in the module.
+
     """
 
     reward_fn_config = config.reward.get("custom_reward_function") or {}
@@ -119,6 +120,7 @@ def load_reward_manager(config: DictConfig, tokenizer: Any, **reward_kwargs: Any
 
     Returns:
         An instance of the specified reward manager class.
+
     """
 
     # Try to get a custom reward function based on the configuration

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -229,6 +229,7 @@ def compute_rollout_rejection_mask(
             modified_response_mask: Response mask with trust region violations masked (0=rejected),
                 shape (batch_size, seq_length).
             metrics: Dictionary of trust region metrics (all scalars).
+
     """
     if rollout_rs is None or not isinstance(rollout_rs, str):
         raise ValueError("rollout_rs must be a non-empty string (comma separated for multiple options).")
@@ -435,6 +436,7 @@ def compute_rs_metrics(
         rollout_rs_threshold: Upper threshold.
         rollout_rs_threshold_lower: Lower threshold (ignored if ``apply_lower_threshold`` is False).
         apply_lower_threshold: Whether to mask/log metrics for values below the lower threshold.
+
     """
     if not response_mask.any():
         raise ValueError("response_mask must contain at least one valid token (1).")
@@ -558,6 +560,7 @@ def compute_rollout_correction_weights(
                 - rollout_is_eff_sample_size: Effective sample size (ESS)
                 - rollout_is_seq_*: Sequence-level weight statistics
                 - rollout_is_batch_norm_factor: Normalization factor (only if batch_normalize=True)
+
     """
     # Validate input parameters
     valid_is_levels = {"token", "sequence"}
@@ -680,9 +683,12 @@ def compute_is_metrics(
             shape (batch_size, seq_length).
         rollout_is: IS weight aggregation level (matches compute_rollout_correction_weights).
         rollout_is_threshold: Upper threshold for truncated IS weights.
+        rollout_is_threshold_lower: Lower threshold for truncated IS weights.
+            Defaults to the reciprocal of ``rollout_is_threshold`` when None.
 
     Returns:
         Dictionary of IS weight metrics (all scalars).
+
     """
     if not response_mask.any():
         raise ValueError("response_mask must contain at least one valid token (1).")
@@ -825,6 +831,7 @@ def compute_rollout_correction_and_rejection_mask(
                 - IS weight statistics
                 - Rejection sampling rates
                 - Policy mismatch metrics (KL, PPL, etc.)
+
     """
     # Validate input masks
     if not response_mask.any():
@@ -928,6 +935,7 @@ def compute_offpolicy_metrics(
 
     Returns:
         Dictionary of off-policy metrics (without prefix)
+
     """
     # Validate that we have at least one valid token
     assert response_mask.any(), "Expected at least one valid token in response_mask"
@@ -1022,6 +1030,7 @@ def compute_rollout_correction_and_add_to_batch(
 
     Args:
         batch: DataProto with old_log_probs, rollout_log_probs, response_mask
+        rollout_corr_config: RolloutCorrectionConfig controlling IS weighting and rejection sampling.
 
     Returns:
         Tuple of (updated_batch, metrics):
@@ -1030,6 +1039,7 @@ def compute_rollout_correction_and_add_to_batch(
 
     Note:
         The implementation is copied from szrlee <szrlee@gmail.com>.
+
     """
     # Get new API parameters directly from config
     rollout_is = rollout_corr_config.get("rollout_is", None)
@@ -1080,6 +1090,7 @@ def compute_rollout_corr_metrics_from_logprobs(
 
     Returns:
         Dictionary of metrics with "rollout_corr/" prefix
+
     """
     # Compute off-policy diagnostic metrics
     offpolicy_metrics = compute_offpolicy_metrics(
@@ -1118,6 +1129,7 @@ def apply_bypass_mode(
 
     Note:
         The implementation is copied from szrlee <szrlee@gmail.com>.
+
     """
     from omegaconf import open_dict
 

--- a/verl/trainer/ppo/utils.py
+++ b/verl/trainer/ppo/utils.py
@@ -57,6 +57,7 @@ class Role(Enum):
 
     @classmethod
     def from_string(cls, name: str):
+        """Create a Role enum from its string representation."""
         string_mapping = {
             "actor": cls.Actor,
             "rollout": cls.Rollout,

--- a/verl/trainer/sft_trainer.py
+++ b/verl/trainer/sft_trainer.py
@@ -306,6 +306,7 @@ class SFTTrainer:
         return batch_seqlens
 
     def fit(self):
+        """Run the full SFT training loop with validation and checkpointing."""
         is_logging = self.engine.is_mp_src_rank_with_outputs() and self.engine.get_data_parallel_rank() == 0
 
         # TODO: add a unified tracking
@@ -446,6 +447,7 @@ class SFTTrainer:
 
 
 def run_sft(config):
+    """Initialize distributed process group and run the SFT trainer."""
     from verl.utils.distributed import initialize_global_process_group
 
     initialize_global_process_group()
@@ -456,6 +458,7 @@ def run_sft(config):
 
 @hydra.main(config_path="config", config_name="sft_trainer_engine", version_base=None)
 def main(config):
+    """Run SFT training with Hydra configuration."""
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
     auto_set_device(config)
     run_sft(config)

--- a/verl/trainer/sft_trainer_ray.py
+++ b/verl/trainer/sft_trainer_ray.py
@@ -245,6 +245,7 @@ class SFTTrainer:
         return batch_seqlens
 
     def fit(self):
+        """Run the full SFT training loop with validation and checkpointing."""
         tracking = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
@@ -380,6 +381,7 @@ class SFTTrainer:
 
 
 def run_sft(config):
+    """Initialize Ray and run the SFT trainer."""
     ray.init()
     trainer = SFTTrainer(config=config)
     trainer.fit()
@@ -387,6 +389,7 @@ def run_sft(config):
 
 @hydra.main(config_path="config", config_name="sft_trainer_engine", version_base=None)
 def main(config):
+    """Run SFT training with Hydra configuration."""
     # Automatically set `config.trainer.device = npu` when running on Ascend NPU.
     auto_set_device(config)
     run_sft(config)

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -151,6 +151,7 @@ class DistillationTeacherModelConfig(BaseConfig):
 
     @property
     def per_replica_world_size(self) -> int:
+        """Return the number of GPUs used by a single teacher replica."""
         return (
             self.inference.tensor_model_parallel_size
             * self.inference.data_parallel_size
@@ -159,9 +160,11 @@ class DistillationTeacherModelConfig(BaseConfig):
 
     @property
     def world_size(self) -> int:
+        """Return the total number of GPUs across all teacher replicas."""
         return self.num_replicas * self.per_replica_world_size
 
     def check_configured(self):
+        """Validate that required teacher model config fields are set."""
         if self.model_path is None:
             raise ValueError("model_path must be specified for distillation teacher model config.")
         if self.key is None:
@@ -170,6 +173,12 @@ class DistillationTeacherModelConfig(BaseConfig):
             raise ValueError("num_replicas must be specified for distillation teacher model config.")
 
     def validate_and_prepare_for_distillation(self, use_topk: bool, topk: Optional[int]) -> None:
+        """Validate context-length limits and adjust inference config for distillation.
+
+        Args:
+            use_topk: Whether top-k logprob extraction is enabled.
+            topk: Number of top logprobs to request from the teacher, if any.
+        """
         # Prompt + Response from student are fed into teacher as context
         max_model_len = self.inference.max_model_len
         student_prompt_length = self.inference.prompt_length

--- a/verl/workers/config/model.py
+++ b/verl/workers/config/model.py
@@ -244,4 +244,5 @@ class HFModelConfig(BaseConfig):
                         )
 
     def get_processor(self):
+        """Return the processor if available, otherwise fall back to the tokenizer."""
         return self.processor if self.processor is not None else self.tokenizer

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -26,6 +26,17 @@ from verl.workers.utils.padding import no_padding_2_padding
 
 
 def sft_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None):
+    """Compute the SFT loss averaged over all tokens across data parallel groups.
+
+    Args:
+        config: Actor configuration controlling the loss behavior.
+        model_output: Model forward output containing ``log_probs``.
+        data: Batch tensordict with loss masks and token-count metadata.
+        dp_group: Optional data parallel process group used for reduction.
+
+    Returns:
+        The computed scalar loss tensor along with associated metrics.
+    """
     pad_mode = tu.get_non_tensor_data(data=data, key="pad_mode", default=DatasetPadMode.NO_PADDING)
     dp_size = data["dp_size"]
     batch_num_tokens = data["batch_num_tokens"]


### PR DESCRIPTION
### What does this PR do?

Adds comprehensive Google-style docstrings to **90 files** across `verl/models/`, `verl/experimental/`, `verl/checkpoint_engine/`, `verl/single_controller/`, `verl/trainer/`, `verl/model_merger/`, `verl/tools/`, and `verl/protocol.py`, continuing the docstring standardization effort tracked in #1345.

This is the second PR in the series. The first PR (#6687) covered `verl/utils/`; this one covers all remaining modules except `verl/workers/` (which will follow in PR 3/N).

Related issue: #1345

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+docstring+1345
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

This is a documentation-only change (+1160/−9 lines); no functional code is modified, so no unit-test regressions are expected. Formatting and style were verified with the project's pre-commit hooks:

```bash
pre-commit run --all-files --show-diff-on-failure --color=always
```

### API and Usage Example

N/A — no API changes. This is a documentation-only PR.

### Design & Code Changes

All added docstrings follow the Google style convention (Args, Returns, Raises sections where applicable), consistent with the existing codebase, PR #6687, and the standard established in #1345.

<details>
<summary>Files changed by module (90 total)</summary>

| Module | Count | Key files |
|--------|-------|-----------|
| models/mcore | 10 | model_initializer.py, config_converter.py, patch.py, weight_converter.py, saver.py, model_forward_fused.py |
| models/transformers | 9 | qwen2_vl.py, glm4v.py, npu_patch.py, qwen3_vl.py, qwen3_5.py, monkey_patch.py |
| models/ top-level | 2 | registry.py, weight_loader_registry.py |
| experimental/ | 28 | agent_loop/, fully_async_policy/, reward_loop/, one_step_off_policy/, separation/, teacher_loop/ |
| checkpoint_engine/ | 6 | base.py, nixl_checkpoint_engine.py, kimi_checkpoint_engine.py, nccl/hccl/mooncake |
| single_controller/ | 4 | base/decorator.py, base/worker.py, base/worker_group.py, ray/base.py |
| trainer/ | 19 | main_ppo.py, main_ppo_sync.py, sft_trainer.py, ppo/core_algos.py, ppo/rollout_corr_helper.py, distillation/ |
| model_merger/ | 4 | base_model_merger.py, megatron_model_merger.py, fsdp_model_merger.py, __main__.py |
| tools/ | 4 | base_tool.py, schemas.py, tool_registry.py, function_tool.py |
| protocol.py | 1 | protocol.py |
| workers/ (partial) | 3 | config/distillation.py, config/model.py, utils/losses.py |

</details>

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://verl.readthedocs.io/en/latest/community/guidelines.html).
- [x] Apply pre-commit checks: `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update the documentation. — N/A (this PR *is* the documentation improvement)
- [ ] Add unit or end-to-end test(s). — N/A (no logic change, docstrings only)

### Note

This PR does not duplicate #6687 — that PR covers `verl/utils/` exclusively; this one covers all other modules except `verl/workers/`.

AI assistance (Claude) was used for drafting docstrings. All changes have been reviewed and validated by the submitter. Commit includes `Co-authored-by: Claude` attribution trailer per project guidelines.
