### PR TITLE
[fsdp, trainer] fix: detach model_output and loss metrics to stop per-micro-batch graph retention in actor update

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1287,6 +1287,17 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 loss = torch.tensor(1.0, device=device_name)
                 metrics = {}
 
+            # Detach model outputs before they are appended to forward_backward_batch's
+            # output_lst: they are only consumed for metrics/postprocessing after backward,
+            # and keeping their grad_fn alive retains part of every micro-batch's autograd
+            # graph until the whole batch finishes. With PEFT (enable_input_require_grads)
+            # this pins the checkpointed embedding output plus its gradient buffer per
+            # micro-batch (~2 x [total_nnz, hidden] for long sequences), which accumulates
+            # across micro-batches and OOMs the actor update.
+            model_output = {
+                key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
+                for key, value in model_output.items()
+            }
             output = {
                 "model_output": model_output,
                 "loss": loss.detach().item(),

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -113,10 +113,17 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens
     # Ex: in compute_policy_loss_vanilla, pg_metrics are pg_clipfrac, ppo_kl, pg_clipfrac_lower
+    # Detach metric tensors: metrics are reporting-only, and storing tensors that still carry
+    # grad_fn (pg_loss, ppo_kl, ...) retains each micro-batch's autograd graph in
+    # forward_backward_batch's output_lst until the whole batch finishes.
+    pg_metrics = {
+        key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
+        for key, value in pg_metrics.items()
+    }
     pg_metrics = Metric.from_dict(pg_metrics, aggregation=AggregationType.MEAN)
 
     metrics.update(pg_metrics)
-    metrics["actor/pg_loss"] = Metric(value=pg_loss, aggregation=metric_aggregation)
+    metrics["actor/pg_loss"] = Metric(value=pg_loss.detach(), aggregation=metric_aggregation)
     policy_loss = pg_loss
 
     # add entropy loss
@@ -126,7 +133,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
         entropy_coeff = config.entropy_coeff
         policy_loss -= entropy_coeff * entropy_loss
-        metrics["actor/entropy_loss"] = Metric(value=entropy_loss, aggregation=metric_aggregation)
+        metrics["actor/entropy_loss"] = Metric(value=entropy_loss.detach(), aggregation=metric_aggregation)
 
     # add kl loss
     if config.use_kl_loss:
@@ -138,7 +145,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
 
         policy_loss += kl_loss * config.kl_loss_coef
-        metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
+        metrics["kl_loss"] = Metric(value=kl_loss.detach(), aggregation=metric_aggregation)
         metrics["kl_coef"] = config.kl_loss_coef
 
     return policy_loss, metrics


### PR DESCRIPTION
### What does this PR do?

Fixes a per-micro-batch GPU memory leak in the unified engine's actor update. Fixes #6696.

`FSDPEngineWithLMHead.forward_step` returns `model_output` whose tensors (`log_probs`, `entropy`) still carry `grad_fn`; `forward_backward_batch` collects them in `output_lst` until the whole batch finishes, so part of every training micro-batch's autograd graph stays alive after `loss.backward()`. With PEFT/LoRA (`enable_input_require_grads()`) the retained graph pins the checkpointed **embedding output** plus its **gradient buffer** per micro-batch (2 x ~139 MiB at 16k packed tokens), accumulating ~0.27 GiB per training micro-batch — an actor update with ~150 training micro-batches leaks ~40 GiB and OOMs an 80GB GPU. `ppo_loss` additionally stores live loss tensors (`pg_loss`, `entropy_loss`, `kl_loss`, `pg_metrics` such as `ppo_kl`) in the metrics dict, anchoring the same graphs.

This PR detaches at both collection points. These tensors are only consumed for metrics/postprocessing *after* backward, so the change is behavior-neutral.

### Test

Profiled with `torch.cuda.memory._record_memory_history` + snapshots on Qwen3-8B LoRA (rank 32) GRPO, multi-turn tool-calling, 16k-token dynamic-bsz micro-batches, fsdp2, gradient checkpointing (see #6696 for the full analysis):

| allocated during training pass | mb #250 | #300 | #350 | #400 |
|---|---|---|---|---|
| before | 24.8 GiB | 37.9 GiB | ~50 GiB | 64 GiB → OOM |
| after | 16.2 GiB | 16.2 GiB | 16.2 GiB | 16.2 GiB |

End-to-end training (fully_async disaggregated, also exercised via the shared engine path used by `main_ppo`) proceeds normally after the fix; no-grad recompute passes are unaffected.

### Checklist

- [x] Root cause analysis included in #6696
- [x] Behavior-neutral: only detaches tensors consumed post-backward for reporting
- [ ] New regression test (happy to add one if maintainers can point at the preferred place to assert no graph retention across micro-batches)
