### PR TITLE
[fsdp, trainer] fix: detach model_output and loss metrics to stop per-micro-batch graph retention in actor update

### DIFF
--- a/tests/workers/test_engine_forward_step_detach_on_cpu.py
+++ b/tests/workers/test_engine_forward_step_detach_on_cpu.py
@@ -1,0 +1,114 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression guard for verl#6698.
+
+FSDPEngineWithLMHead.forward_step used to return ``model_output`` tensors
+(log_probs/entropy) still attached to the autograd graph. forward_backward_batch
+collects these per-micro-batch outputs in ``output_lst`` until the WHOLE batch
+finishes, so the retained graph pinned, per training micro-batch, whatever the
+graph still referenced after backward — most notably the activation-checkpoint
+frame's saved block input (the embedding output, which requires grad under
+PEFT's ``enable_input_require_grads``) and its gradient buffer. On long-sequence
+LoRA runs this leaked ~0.27 GiB per micro-batch and OOM'd the actor update.
+
+This test reproduces the retention mechanism in miniature: a frozen embedding
+whose output is forced to require grad (the PEFT situation), a checkpointed
+block, and a weakref on the checkpoint-saved block input. After backward, with
+``output`` still held (as output_lst does), the saved input must be collectible
+and the returned model_output must carry no grad_fn.
+"""
+
+import gc
+import weakref
+from types import SimpleNamespace
+
+import torch
+from tensordict import TensorDict
+
+from verl.utils.device import get_device_id
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
+
+VOCAB, HIDDEN, SEQ = 16, 8, 6
+
+
+class _TinyCheckpointedLM(torch.nn.Module):
+    """Frozen embedding + checkpointed trainable block, mimicking a PEFT/LoRA
+    base model with gradient checkpointing and enable_input_require_grads."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed = torch.nn.Embedding(VOCAB, HIDDEN)
+        self.embed.weight.requires_grad_(False)  # frozen base
+        self.proj = torch.nn.Linear(HIDDEN, HIDDEN, bias=False)  # the trainable part
+        self.saved_block_input = None  # weakref to the checkpoint-saved input
+
+    def forward(self, input_ids=None, use_cache=False):
+        x = self.embed(input_ids)
+        # PEFT enable_input_require_grads: embedding output requires grad so
+        # gradients can flow into trainable params under checkpointing.
+        x.requires_grad_(True)
+        hidden = torch.utils.checkpoint.checkpoint(self.proj, x, use_reentrant=False)
+        self.saved_block_input = weakref.ref(x)
+        return SimpleNamespace(hidden=hidden)
+
+
+def _make_engine_stub():
+    """Bypass __init__; provide only what forward_step touches."""
+    eng = object.__new__(FSDPEngineWithLMHead)
+    eng._autocast_dtype = torch.float32  # skip autocast
+    eng.module = _TinyCheckpointedLM().to(get_device_id())
+    eng.prepare_model_inputs = lambda micro_batch: ({"input_ids": micro_batch["input_ids"]}, {})
+    eng.prepare_model_outputs = (
+        lambda output, output_args, micro_batch, logits_processor_func: {"log_probs": output.hidden.sum(-1)}
+    )
+    eng.get_data_parallel_group = lambda: None
+    return eng
+
+
+def _loss_fn(model_output, data, dp_group=None):
+    return model_output["log_probs"].sum(), {"dummy_metric": 1.0}
+
+
+def test_forward_step_output_carries_no_grad_fn_and_releases_graph():
+    eng = _make_engine_stub()
+    micro_batch = TensorDict(
+        {"input_ids": torch.randint(0, VOCAB, (1, SEQ))},
+        batch_size=[1],
+    )
+
+    loss, output = FSDPEngineWithLMHead.forward_step(eng, micro_batch, _loss_fn, forward_only=False)
+
+    # The live loss must still drive backward into the trainable params.
+    assert loss.grad_fn is not None
+    loss.backward()
+    assert eng.module.proj.weight.grad is not None
+
+    # Contract: nothing in the collected per-micro-batch output may keep the
+    # autograd graph alive once the loss reference is dropped.
+    for key, value in output["model_output"].items():
+        assert not (torch.is_tensor(value) and value.grad_fn is not None), (
+            f"model_output[{key!r}] still attached to the autograd graph"
+        )
+
+    saved_input = eng.module.saved_block_input
+    assert saved_input() is not None  # sanity: alive while loss exists
+    del loss
+    gc.collect()
+    # `output` is intentionally still held, like forward_backward_batch's
+    # output_lst holds it across the remaining micro-batches of the batch.
+    assert saved_input() is None, (
+        "checkpoint-saved block input (embedding output) survived backward: "
+        "the per-micro-batch output is retaining the autograd graph"
+    )
+    assert output["loss"] is not None

--- a/tests/workers/test_engine_forward_step_detach_on_cpu.py
+++ b/tests/workers/test_engine_forward_step_detach_on_cpu.py
@@ -69,9 +69,9 @@ def _make_engine_stub():
     eng._autocast_dtype = torch.float32  # skip autocast
     eng.module = _TinyCheckpointedLM().to(get_device_id())
     eng.prepare_model_inputs = lambda micro_batch: ({"input_ids": micro_batch["input_ids"]}, {})
-    eng.prepare_model_outputs = (
-        lambda output, output_args, micro_batch, logits_processor_func: {"log_probs": output.hidden.sum(-1)}
-    )
+    eng.prepare_model_outputs = lambda output, output_args, micro_batch, logits_processor_func: {
+        "log_probs": output.hidden.sum(-1)
+    }
     eng.get_data_parallel_group = lambda: None
     return eng
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1287,6 +1287,17 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 loss = torch.tensor(1.0, device=device_name)
                 metrics = {}
 
+            # Detach model outputs before they are appended to forward_backward_batch's
+            # output_lst: they are only consumed for metrics/postprocessing after backward,
+            # and keeping their grad_fn alive retains part of every micro-batch's autograd
+            # graph until the whole batch finishes. With PEFT (enable_input_require_grads)
+            # this pins the checkpointed embedding output plus its gradient buffer per
+            # micro-batch (~2 x [total_nnz, hidden] for long sequences), which accumulates
+            # across micro-batches and OOMs the actor update.
+            model_output = {
+                key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
+                for key, value in model_output.items()
+            }
             output = {
                 "model_output": model_output,
                 "loss": loss.detach().item(),

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -113,17 +113,10 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens
     # Ex: in compute_policy_loss_vanilla, pg_metrics are pg_clipfrac, ppo_kl, pg_clipfrac_lower
-    # Detach metric tensors: metrics are reporting-only, and storing tensors that still carry
-    # grad_fn (pg_loss, ppo_kl, ...) retains each micro-batch's autograd graph in
-    # forward_backward_batch's output_lst until the whole batch finishes.
-    pg_metrics = {
-        key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
-        for key, value in pg_metrics.items()
-    }
     pg_metrics = Metric.from_dict(pg_metrics, aggregation=AggregationType.MEAN)
 
     metrics.update(pg_metrics)
-    metrics["actor/pg_loss"] = Metric(value=pg_loss.detach(), aggregation=metric_aggregation)
+    metrics["actor/pg_loss"] = Metric(value=pg_loss, aggregation=metric_aggregation)
     policy_loss = pg_loss
 
     # add entropy loss
@@ -133,7 +126,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
         entropy_coeff = config.entropy_coeff
         policy_loss -= entropy_coeff * entropy_loss
-        metrics["actor/entropy_loss"] = Metric(value=entropy_loss.detach(), aggregation=metric_aggregation)
+        metrics["actor/entropy_loss"] = Metric(value=entropy_loss, aggregation=metric_aggregation)
 
     # add kl loss
     if config.use_kl_loss:
@@ -145,7 +138,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
 
         policy_loss += kl_loss * config.kl_loss_coef
-        metrics["kl_loss"] = Metric(value=kl_loss.detach(), aggregation=metric_aggregation)
+        metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
         metrics["kl_coef"] = config.kl_loss_coef
 
     return policy_loss, metrics

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -113,10 +113,17 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens
     # Ex: in compute_policy_loss_vanilla, pg_metrics are pg_clipfrac, ppo_kl, pg_clipfrac_lower
+    # Detach metric tensors: metrics are reporting-only, and storing tensors that still carry
+    # grad_fn (pg_loss, ppo_kl, ...) retains each micro-batch's autograd graph in
+    # forward_backward_batch's output_lst until the whole batch finishes.
+    pg_metrics = {
+        key: value.detach() if torch.is_tensor(value) and value.grad_fn is not None else value
+        for key, value in pg_metrics.items()
+    }
     pg_metrics = Metric.from_dict(pg_metrics, aggregation=AggregationType.MEAN)
 
     metrics.update(pg_metrics)
-    metrics["actor/pg_loss"] = Metric(value=pg_loss, aggregation=metric_aggregation)
+    metrics["actor/pg_loss"] = Metric(value=pg_loss.detach(), aggregation=metric_aggregation)
     policy_loss = pg_loss
 
     # add entropy loss
@@ -126,7 +133,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
         entropy_coeff = config.entropy_coeff
         policy_loss -= entropy_coeff * entropy_loss
-        metrics["actor/entropy_loss"] = Metric(value=entropy_loss, aggregation=metric_aggregation)
+        metrics["actor/entropy_loss"] = Metric(value=entropy_loss.detach(), aggregation=metric_aggregation)
 
     # add kl loss
     if config.use_kl_loss:
@@ -138,7 +145,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         )
 
         policy_loss += kl_loss * config.kl_loss_coef
-        metrics["kl_loss"] = Metric(value=kl_loss, aggregation=metric_aggregation)
+        metrics["kl_loss"] = Metric(value=kl_loss.detach(), aggregation=metric_aggregation)
         metrics["kl_coef"] = config.kl_loss_coef
 
     return policy_loss, metrics


### PR DESCRIPTION
### What does this PR do?

Fixes a per-micro-batch GPU memory leak in the unified engine's actor update that OOMs long-sequence LoRA runs. `FSDPEngineWithLMHead.forward_step` returns `model_output` (log_probs/entropy) still attached to the autograd graph; `forward_backward_batch` holds these per-micro-batch outputs in `output_lst` until the whole batch finishes, so the retained graph pins — per training micro-batch — the activation-checkpoint frame's saved embedding output (which requires grad under PEFT `enable_input_require_grads`) plus its gradient buffer. Full root-cause analysis with memory-history profiling in #6698. Fixes #6698.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+detach+model_output — no existing PR addresses this
- [x] Format the PR title as `[{modules}] {type}: {description}` → `[fsdp, trainer] fix: ...`

### Test

**Regression test added**: `tests/workers/test_engine_forward_step_detach_on_cpu.py` — miniature reproduction of the retention mechanism (frozen embedding + `requires_grad_` output + checkpointed block + weakref on the checkpoint-saved input). Verified red on the unfixed engine, green with the fix. CPU-only, runs in `cpu_unit_tests`.

End-to-end validation (Qwen3-8B + LoRA rank 32 GRPO, multi-turn tool-calling, 16k-token dynamic-bsz micro-batches, fsdp2 + gradient checkpointing, ~400 micro-batches/update). Per-micro-batch `torch.cuda.memory_allocated()` during the training pass:

| | mb #250 | #300 | #350 | #400 |
|---|---|---|---|---|
| before | 24.8 GiB | 37.9 GiB | ~50 GiB | 64 GiB → **OOM** |
| after | 16.2 GiB | 16.2 GiB | 16.2 GiB | 16.2 GiB ✅ |

After the fix the run reaches step 1+ with healthy metrics (grad_norm 0.015, rollout/training log-prob Pearson corr 0.993, peak allocated 31.5/79 GiB).

### API and Usage Example

No API change. The detached tensors are only consumed for metrics aggregation and postprocessing after `loss.backward()` has already run.

### Design & Code Changes

1. `verl/workers/engine/fsdp/transformer_impl.py` — `forward_step`: detach tensors in `model_output` before building the returned `output` dict (the live `loss` is still returned separately for `backward()`). Also covers the critic via `FSDPEngineWithValueHead`.
2. `tests/workers/test_engine_forward_step_detach_on_cpu.py` — regression guard (see Test above).

Note: an earlier commit on this branch also detached metric tensors in `ppo_loss`; that turned out to be redundant — `Metric.append` already does `value.detach().item()` for scalar tensors — and has been reverted, keeping the diff minimal.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): ruff clean; diff matches surrounding style.
- [x] Documentation: N/A (no user-facing behavior change).
- [x] Added regression test `tests/workers/test_engine_forward_step_detach_on_cpu.py` (CPU, runs in cpu_unit_tests).
- [x] CI requested via the Feishu group (thanks @Tianle Zhong for triggering!).