### PR TITLE
[hardware] feat: add ROCm/HIP platform backend (PlatformROCm)

### DIFF
--- a/tests/special_sanity/check_device_api_usage.py
+++ b/tests/special_sanity/check_device_api_usage.py
@@ -28,6 +28,7 @@ CUDA_KEYWORD_CHECK_WHITELIST = [
     "verl/utils/torch_functional.py",  # import flash_attn only on cuda
     "verl/plugin/platform/platform_base.py",  # docstring mentions torch.cuda
     "verl/plugin/platform/platform_cuda.py",  # CUDA platform implementation
+    "verl/plugin/platform/platform_rocm.py",  # ROCm platform reuses torch.cuda via hipify
     "verl/plugin/platform/platform_manager.py",  # platform auto-detection probes torch.cuda
     "verl/utils/profiler/nvtx_profile.py",  # appear in NsightSystemsProfiler
     "verl/utils/profiler/torch_profile.py",  # appear in TorchProfiler

--- a/verl/plugin/platform/platform_cuda.py
+++ b/verl/plugin/platform/platform_cuda.py
@@ -41,6 +41,10 @@ class PlatformCUDA(PlatformBase):
     def is_platform_available(self, use_smi_check=False) -> bool:
         if not hasattr(torch, "cuda"):
             return False
+        # On ROCm, torch.cuda is present too; defer to PlatformROCm so that
+        # auto-detection does not pick CUDA on AMD hardware.
+        if torch.version.hip is not None:
+            return False
         if use_smi_check:
             # In CPU-only Ray actors, torch.cuda.is_available() may return False
             # even though the cluster has GPUs. Fall back to nvidia-smi check,

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -171,3 +171,4 @@ def set_platform(platform: PlatformBase) -> None:
 # ---------------------------------------------------------------------------
 from .platform_cuda import PlatformCUDA  # noqa: E402, F401
 from .platform_npu import PlatformNPU  # noqa: E402, F401
+from .platform_rocm import PlatformROCm  # noqa: E402, F401

--- a/verl/plugin/platform/platform_rocm.py
+++ b/verl/plugin/platform/platform_rocm.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 BAAI. All rights reserved.
+"""AMD ROCm/HIP platform implementation.
+
+ROCm is largely CUDA-compatible: PyTorch on ROCm reuses the ``torch.cuda.*``
+API surface via hipify, so most of ``PlatformCUDA`` works unchanged. This class
+therefore subclasses ``PlatformCUDA`` and only overrides the parts that differ
+on ROCm, following a "CUDA base + ROCm extensions" model (always extend the
+parent via ``super()`` rather than re-implementing it).
+"""
+
+import os
+import shutil
+
+import torch
+
+from .platform_cuda import PlatformCUDA
+from .platform_manager import PlatformRegistry
+
+
+@PlatformRegistry.register(platform="amd")
+class PlatformROCm(PlatformCUDA):
+    """Platform backend for AMD ROCm/HIP GPUs (reuses PlatformCUDA where compatible)."""
+
+    @property
+    def vendor_name(self) -> str:
+        # NOTE: device_name stays 'cuda' on purpose — PyTorch ROCm exposes the
+        # device type string as "cuda" (torch.device("cuda") works via hipify).
+        return "amd"
+
+    def is_platform_available(self, use_smi_check=False) -> bool:
+        if not hasattr(torch, "cuda"):
+            return False
+        # Only ROCm (HIP) torch builds qualify as the AMD platform.
+        if torch.version.hip is None:
+            return False
+        if use_smi_check:
+            # In CPU-only Ray actors, torch.cuda.is_available() may return False
+            # even though the cluster has GPUs. Fall back to rocm-smi check,
+            # and if that's also unavailable (e.g. not on PATH), treat
+            # torch.cuda being built as sufficient evidence.
+            cmd = "rocm-smi"
+            cmd_path = shutil.which(cmd)
+            if cmd_path is None:
+                # Fallback to common absolute paths if not found in PATH
+                common_paths = [
+                    f"/usr/bin/{cmd}",
+                    f"/usr/local/bin/{cmd}",
+                    f"/opt/rocm/bin/{cmd}",
+                ]
+                for path in common_paths:
+                    if os.path.isfile(path) and os.access(path, os.X_OK):
+                        cmd_path = path
+                        break
+                if cmd_path is None:
+                    return False
+            if self.check_smi_command(cmd_path):
+                return True
+        return torch.cuda.is_available()
+
+    def rollout_env_vars(self) -> dict[str, str]:
+        # Extend CUDA's rollout env vars with ROCm-specific ones. SGLANG_USE_AITER
+        # routes SGLang's non-attention kernels (RMSNorm/RoPE/MoE/quant) through AITER.
+        # Default to "1" but honor an explicit user override (e.g. SGLANG_USE_AITER=0
+        # to fall back to vLLM kernels).
+        return {
+            **super().rollout_env_vars(),
+            "SGLANG_USE_AITER": os.environ.get("SGLANG_USE_AITER", "1"),
+        }
+
+    def ray_noset_envvars(self) -> list[str]:
+        # On ROCm, HIP_VISIBLE_DEVICES takes precedence over CUDA_VISIBLE_DEVICES,
+        # and ROCR_VISIBLE_DEVICES is also relevant, so tell Ray not to manage them.
+        return super().ray_noset_envvars() + [
+            "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
+            "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+        ]


### PR DESCRIPTION
### What does this PR do?

Add a dedicated `PlatformROCm` backend so ROCm is a first-class platform instead of silently falling back to `PlatformCUDA`. ROCm is largely CUDA-compatible (PyTorch reuses `torch.cuda.*` via hipify), so `PlatformROCm` subclasses `PlatformCUDA` and only overrides what differs, extending the parent via `super()`.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+PlatformROCm (none found).
- [x] PR title format `[hardware] feat: add ROCm/HIP platform backend (PlatformROCm)` — not a breaking change.

### Test

Validated on AMD ROCm (ROCm 7.0, 8x gfx942 / MI3xx):

- `get_platform()` resolves to `PlatformROCm` (not `PlatformCUDA`); `PlatformCUDA.is_platform_available()` returns `False` on ROCm.
- `vendor_name='amd'`, `device_name='cuda'`, `is_platform_available(use_smi_check=True)=True`.
- `rollout_env_vars()` = `{'NCCL_CUMEM_ENABLE': '0', 'SGLANG_USE_AITER': '1'}`; with `SGLANG_USE_AITER=0` exported it becomes `'0'` (override honored).
- `ray_noset_envvars()` includes CUDA + HIP + ROCR NOSET vars.
- End-to-end GRPO smoke training (Qwen3-8B, FSDP) runs with 8-GPU RCCL.

CI cannot cover this (requires ROCm hardware); validated manually.

### API and Usage Example

No API change. ROCm is auto-detected; AITER can be disabled by the user:

```bash
export SGLANG_USE_AITER=0   # fall back to vLLM RMSNorm/RoPE kernels
```

### Design & Code Changes

- **`verl/plugin/platform/platform_rocm.py` (new)** — `PlatformROCm(PlatformCUDA)`: `vendor_name="amd"` (`device_name` stays `"cuda"`); inherits `is_available` from `PlatformCUDA`; overrides `is_platform_available` (gated on `torch.version.hip`, mirroring the parent's smi-check structure but using `rocm-smi` with a `/opt/rocm/bin` lookup); `rollout_env_vars` adds a user-overridable `SGLANG_USE_AITER`; `ray_noset_envvars` adds HIP/ROCR NOSET vars.
- **`platform_cuda.py`** — `is_platform_available` returns `False` when `torch.version.hip is not None`, so auto-detection picks ROCm on AMD.
- **`platform_manager.py`** — register `PlatformROCm`.
- **`tests/special_sanity/check_device_api_usage.py`** — whitelist `platform_rocm.py` (reuses `torch.cuda` via hipify).

Notes on specific decisions:
1. **`is_platform_available` mirrors `PlatformCUDA`** — structurally aligned with the parent (HIP build check, then optional smi probe, then `torch.cuda.is_available()` fallback), only swapping `nvidia-smi` for `rocm-smi`. The leading `torch.version.hip` gate is what distinguishes ROCm from NVIDIA during auto-detection.
2. **`SGLANG_USE_AITER` in `rollout_env_vars`** — defaults to `"1"` but reads `os.environ.get(...)` so users can override.
3. **`visible_devices_envvar` stays `CUDA_VISIBLE_DEVICES`** — verl drives visibility via `CUDA_VISIBLE_DEVICES` and keeps `HIP_VISIBLE_DEVICES` unset; the HIP side is handled by `ray_noset_envvars` (preventing Ray from clearing it). Switching the primary variable to HIP would flip many read/write sites and conflict with Ray's GPU assignment.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks: all hooks pass.
- [ ] Add / Update the documentation — N/A (internal platform abstraction, no user-facing doc change).
- [x] Add unit or end-to-end test(s)... If not feasible, explain why: requires ROCm hardware; validated manually (see Test).
- [ ] Send a message in the `ci-request` channel when ready for CI.
- [x] Not related to the `recipe` submodule.
