### PR TITLE
[mcore] fix: OOB IndexError in preprocess_thd_engine when FP8 …

### DIFF
--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -14,12 +14,11 @@
 """Regression coverage for verl#6492."""
 
 import importlib.util
+import pytest
 import sys
+import torch
 import types
 from pathlib import Path
-
-import pytest
-import torch
 
 import verl.utils.device as device_module
 
@@ -47,6 +46,40 @@ def _load_mcore_util_with_stubbed_megatron(monkeypatch, tp_size: int = 4):
     spec = importlib.util.spec_from_file_location("mcore_util_regression", util_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    return module
+
+
+def _load_thd_engine_util(monkeypatch, tp_size: int = 1, cp_size: int = 2, cp_rank: int = 0):
+    """Load mcore util with cp_size/cp_rank configured for preprocess_thd_engine tests.
+
+    Kept separate from _load_mcore_util_with_stubbed_megatron to avoid touching
+    the existing bshd-engine test helpers.
+    """
+    megatron = types.ModuleType("megatron")
+    core = types.ModuleType("megatron.core")
+    parallel_state = types.ModuleType("megatron.core.parallel_state")
+    packed_seq_params = types.ModuleType("megatron.core.packed_seq_params")
+
+    parallel_state.get_context_parallel_world_size = lambda: cp_size
+    parallel_state.get_context_parallel_rank = lambda: cp_rank
+    parallel_state.get_tensor_model_parallel_world_size = lambda: tp_size
+    packed_seq_params.PackedSeqParams = type("PackedSeqParams", (), {"__init__": lambda self, **kw: None})
+
+    core.parallel_state = parallel_state
+    megatron.core = core
+    monkeypatch.setitem(sys.modules, "megatron", megatron)
+    monkeypatch.setitem(sys.modules, "megatron.core", core)
+    monkeypatch.setitem(sys.modules, "megatron.core.parallel_state", parallel_state)
+    monkeypatch.setitem(sys.modules, "megatron.core.packed_seq_params", packed_seq_params)
+    monkeypatch.setattr(device_module, "is_npu_available", False)
+
+    util_path = Path(__file__).parents[2] / "verl" / "models" / "mcore" / "util.py"
+    spec = importlib.util.spec_from_file_location("mcore_util_thd", util_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # warning_once is a verl-specific logger extension; fall back to standard warning
+    if not hasattr(module.logger, "warning_once"):
+        module.logger.warning_once = module.logger.warning
     return module
 
 
@@ -125,3 +158,102 @@ def test_preprocess_bshd_engine_preserves_topk_dense_dim_on_gpu(monkeypatch):
     if not torch.cuda.is_available():
         pytest.skip("Requires CUDA")
     _check_topk_preprocess(monkeypatch, torch.device("cuda"))
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for FP8 + CP + SFT bugfix
+#
+# Root cause: when use_fp8_padding=True, seqlen_padded_i >> align_size, but the
+# old code guarded padding with `d.numel() < align_size` and filled only up to
+# `align_size` tokens.  For higher cp_ranks the first chunk slice
+# `d[half_seqlen*cp_rank : half_seqlen*(cp_rank+1)]` can reach indices beyond
+# d.shape[0], causing an IndexError.  The fix pads d to seqlen_padded_i and
+# adds bounds-safe slice helpers.
+# ---------------------------------------------------------------------------
+
+
+def _make_thd_input(seqlens: list[int]) -> torch.Tensor:
+    """Build a 1-D jagged nested tensor with token id == position index."""
+    rows = [torch.arange(s, dtype=torch.long) for s in seqlens]
+    return torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+
+def test_preprocess_thd_engine_fp8_cp_no_crash_on_cpu(monkeypatch):
+    """FP8+CP: preprocess_thd_engine must not raise IndexError for any cp_rank.
+
+    Reproduces the pre-fix OOB crash:
+      tp_size=1, cp_size=2, use_fp8_padding=True, seqlen_orig=5
+        align_size      = tp_size * cp_size * 2 = 4
+        per_seq_align   = lcm(16, 4) = 16   (from _compute_fp8_thd_align_size)
+        seqlen_padded   = 512  (16 per-seq + 496 total-align extra)
+        seqlen_per_rank = 256, half_seqlen = 128
+
+      cp_rank=1: first chunk slice = d[128:256] but d.shape[0]==5 → OOB
+        old code: `if d.numel() < align_size` (5 < 4 is False) → no pad → crash
+        new code: `if d.numel() < seqlen_padded_i` (5 < 512)   → pad to 512 → OK
+    """
+    for cp_rank in range(2):
+        mcore_util = _load_thd_engine_util(
+            monkeypatch, tp_size=1, cp_size=2, cp_rank=cp_rank
+        )
+        # seqlen=5 is intentionally much shorter than seqlen_padded to trigger the bug
+        input_ids = _make_thd_input([5])
+        ids_rmpad, _, pos_ids = mcore_util.preprocess_thd_engine(
+            input_ids, pre_process=True, need_roll=False, use_fp8_padding=True
+        )
+        assert ids_rmpad is not None
+        assert pos_ids is not None
+
+
+def test_preprocess_thd_engine_fp8_cp_correct_content_on_cpu(monkeypatch):
+    """FP8+CP: zigzag chunks must contain the correct token ids after the fix.
+
+    With tp_size=1, cp_size=2, seqlen_orig=200, use_fp8_padding=True:
+      per_seq_align = lcm(16, 4) = 16, total_align = 4*128 = 512
+      seqlen_padded = 512  (208 rounded up to 512 by total_align)
+      seqlen_per_rank = 256,  half_seqlen = 128
+
+    cp_rank=0: first chunk = tokens[0:128],   remain = tokens[384:512] (all padding)
+    cp_rank=1: first chunk = tokens[128:200] (valid) + zeros[200:256],
+               remain = tokens[256:200] → remain_len=0, all zero
+
+    Token ids equal their position index, so we assert exact values.
+    """
+    seqlen_orig = 200
+    half_seqlen = 128  # seqlen_per_rank=256 // 2
+
+    # ---- cp_rank=0 ----
+    mcore_util_r0 = _load_thd_engine_util(
+        monkeypatch, tp_size=1, cp_size=2, cp_rank=0
+    )
+    ids_r0, _, pos_r0 = mcore_util_r0.preprocess_thd_engine(
+        _make_thd_input([seqlen_orig]), pre_process=True, need_roll=False, use_fp8_padding=True
+    )
+    ids_r0 = ids_r0[0]   # [seqlen_per_rank]
+    pos_r0 = pos_r0[0]
+    # first chunk [0:128]: token ids and positions = 0..127
+    torch.testing.assert_close(ids_r0[:half_seqlen], torch.arange(0, half_seqlen, dtype=torch.long))
+    torch.testing.assert_close(pos_r0[:half_seqlen], torch.arange(0, half_seqlen, dtype=torch.long))
+    # remain chunk [128:256]: tokens[384:512] don't exist (seqlen=200), must be zero
+    assert ids_r0[half_seqlen:].sum().item() == 0, "remain chunk for cp_rank=0 should be all-zero padding"
+
+    # ---- cp_rank=1 ----
+    mcore_util_r1 = _load_thd_engine_util(
+        monkeypatch, tp_size=1, cp_size=2, cp_rank=1
+    )
+    ids_r1, _, pos_r1 = mcore_util_r1.preprocess_thd_engine(
+        _make_thd_input([seqlen_orig]), pre_process=True, need_roll=False, use_fp8_padding=True
+    )
+    ids_r1 = ids_r1[0]   # [seqlen_per_rank]
+    pos_r1 = pos_r1[0]
+    valid_in_first = seqlen_orig - half_seqlen  # 200 - 128 = 72 valid tokens
+    # first chunk: valid tokens [128:200], padding [200:256]
+    torch.testing.assert_close(
+        ids_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long)
+    )
+    torch.testing.assert_close(
+        pos_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long)
+    )
+    assert ids_r1[valid_in_first:half_seqlen].sum().item() == 0, "padding after valid first-chunk tokens"
+    # remain chunk [128:256]: remain_start=256, remain_end=min(384, 200)=200 < 256 → remain_len=0
+    assert ids_r1[half_seqlen:].sum().item() == 0, "remain chunk for cp_rank=1 should be all-zero"

--- a/tests/utils/test_megatron_bshd_preprocess.py
+++ b/tests/utils/test_megatron_bshd_preprocess.py
@@ -14,11 +14,12 @@
 """Regression coverage for verl#6492."""
 
 import importlib.util
-import pytest
 import sys
-import torch
 import types
 from pathlib import Path
+
+import pytest
+import torch
 
 import verl.utils.device as device_module
 
@@ -193,9 +194,7 @@ def test_preprocess_thd_engine_fp8_cp_no_crash_on_cpu(monkeypatch):
         new code: `if d.numel() < seqlen_padded_i` (5 < 512)   → pad to 512 → OK
     """
     for cp_rank in range(2):
-        mcore_util = _load_thd_engine_util(
-            monkeypatch, tp_size=1, cp_size=2, cp_rank=cp_rank
-        )
+        mcore_util = _load_thd_engine_util(monkeypatch, tp_size=1, cp_size=2, cp_rank=cp_rank)
         # seqlen=5 is intentionally much shorter than seqlen_padded to trigger the bug
         input_ids = _make_thd_input([5])
         ids_rmpad, _, pos_ids = mcore_util.preprocess_thd_engine(
@@ -223,13 +222,11 @@ def test_preprocess_thd_engine_fp8_cp_correct_content_on_cpu(monkeypatch):
     half_seqlen = 128  # seqlen_per_rank=256 // 2
 
     # ---- cp_rank=0 ----
-    mcore_util_r0 = _load_thd_engine_util(
-        monkeypatch, tp_size=1, cp_size=2, cp_rank=0
-    )
+    mcore_util_r0 = _load_thd_engine_util(monkeypatch, tp_size=1, cp_size=2, cp_rank=0)
     ids_r0, _, pos_r0 = mcore_util_r0.preprocess_thd_engine(
         _make_thd_input([seqlen_orig]), pre_process=True, need_roll=False, use_fp8_padding=True
     )
-    ids_r0 = ids_r0[0]   # [seqlen_per_rank]
+    ids_r0 = ids_r0[0]  # [seqlen_per_rank]
     pos_r0 = pos_r0[0]
     # first chunk [0:128]: token ids and positions = 0..127
     torch.testing.assert_close(ids_r0[:half_seqlen], torch.arange(0, half_seqlen, dtype=torch.long))
@@ -238,22 +235,16 @@ def test_preprocess_thd_engine_fp8_cp_correct_content_on_cpu(monkeypatch):
     assert ids_r0[half_seqlen:].sum().item() == 0, "remain chunk for cp_rank=0 should be all-zero padding"
 
     # ---- cp_rank=1 ----
-    mcore_util_r1 = _load_thd_engine_util(
-        monkeypatch, tp_size=1, cp_size=2, cp_rank=1
-    )
+    mcore_util_r1 = _load_thd_engine_util(monkeypatch, tp_size=1, cp_size=2, cp_rank=1)
     ids_r1, _, pos_r1 = mcore_util_r1.preprocess_thd_engine(
         _make_thd_input([seqlen_orig]), pre_process=True, need_roll=False, use_fp8_padding=True
     )
-    ids_r1 = ids_r1[0]   # [seqlen_per_rank]
+    ids_r1 = ids_r1[0]  # [seqlen_per_rank]
     pos_r1 = pos_r1[0]
     valid_in_first = seqlen_orig - half_seqlen  # 200 - 128 = 72 valid tokens
     # first chunk: valid tokens [128:200], padding [200:256]
-    torch.testing.assert_close(
-        ids_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long)
-    )
-    torch.testing.assert_close(
-        pos_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long)
-    )
+    torch.testing.assert_close(ids_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long))
+    torch.testing.assert_close(pos_r1[:valid_in_first], torch.arange(half_seqlen, seqlen_orig, dtype=torch.long))
     assert ids_r1[valid_in_first:half_seqlen].sum().item() == 0, "padding after valid first-chunk tokens"
     # remain chunk [128:256]: remain_start=256, remain_end=min(384, 200)=200 < 256 → remain_len=0
     assert ids_r1[half_seqlen:].sum().item() == 0, "remain chunk for cp_rank=1 should be all-zero"

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -446,9 +446,7 @@ def preprocess_thd_engine(
             if need_roll:
                 # Handle roll for cp_size > 1 case
                 saved_roll_dict[start_idx + half_seqlen - 1] = d[(cp_rank + 1) * half_seqlen]
-                saved_position_roll_dict[start_idx + half_seqlen - 1] = position_ids_rmpad[
-                    start_idx + half_seqlen - 1
-                ]
+                saved_position_roll_dict[start_idx + half_seqlen - 1] = position_ids_rmpad[start_idx + half_seqlen - 1]
                 if remain_len > 0:
                     if remain_end == d.shape[0]:
                         saved_roll_dict[start_idx + half_seqlen + remain_len - 1] = d[0]

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -400,42 +400,44 @@ def preprocess_thd_engine(
             seqlen = seqlen_padded_i // cp_size
             half_seqlen = seqlen // 2
             start_idx = cu_seqlens_padded_cpu[i] // cp_size
-            # split to 2 chunks
+            # Split into two zigzag CP chunks. When FP8 padding extends the logical
+            # sequence length, pad the nested tensor so chunk slicing stays in-bounds.
             d = input_ids[i]
-            # If the number of elements in `d` is smaller than the required
-            # alignment size, pad the tensor with zeros so that its total
-            # length matches `align_size`. This ensures size alignment for
-            # downstream operations (e.g., communication or memory alignment).
-            if d.numel() < align_size:
+            if d.numel() < seqlen_padded_i:
                 original_size = d.numel()
-                pad = torch.zeros(align_size - d.numel(), dtype=d.dtype, device=d.device)
+                pad = torch.zeros(seqlen_padded_i - d.numel(), dtype=d.dtype, device=d.device)
                 d = torch.cat([d, pad], dim=0)
                 logger.warning_once(
                     f"Padding tensor for context parallel alignment, original_size={original_size}, "
-                    f"align_size={align_size}"
+                    f"padded_size={seqlen_padded_i}"
                 )
 
-            input_ids_rmpad[start_idx : start_idx + half_seqlen] = d[
-                half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)
-            ]
+            first_start = half_seqlen * cp_rank
+            first_end = min(half_seqlen * (cp_rank + 1), d.shape[0])
+            first_len = max(first_end - first_start, 0)
+            if first_len > 0:
+                input_ids_rmpad[start_idx : start_idx + first_len] = d[first_start:first_end]
 
-            # Build position_ids for the first chunk
-            position_ids_rmpad[start_idx : start_idx + half_seqlen] = torch.arange(
-                half_seqlen * cp_rank, half_seqlen * (cp_rank + 1), dtype=torch.long, device=input_ids.device
-            )
+            # Build position_ids for valid tokens only; padded tokens remain zero.
+            first_pos_end = min(first_end, seqlen_orig_i)
+            first_pos_len = max(first_pos_end - first_start, 0)
+            if first_pos_len > 0:
+                position_ids_rmpad[start_idx : start_idx + first_pos_len] = torch.arange(
+                    first_start, first_pos_end, dtype=torch.long, device=input_ids.device
+                )
 
             remain_start = seqlen_padded_i - half_seqlen * (cp_rank + 1)
             remain_end = seqlen_padded_i - half_seqlen * cp_rank
             remain_end = min(remain_end, d.shape[0])
-            remain_len = remain_end - remain_start
+            remain_len = max(remain_end - remain_start, 0)
             if remain_len > 0:
                 input_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + remain_len] = d[
                     remain_start:remain_end
                 ]
                 # Build position_ids for the remaining chunk: use remain_start as base,
-                # clamped to original seqlen to avoid exceeding seqlen-1 for padded positions
+                # clamped to original seqlen to avoid exceeding seqlen-1 for padded positions.
                 pos_end = min(remain_end, seqlen_orig_i)
-                valid_pos_len = pos_end - remain_start
+                valid_pos_len = max(pos_end - remain_start, 0)
                 if valid_pos_len > 0:
                     position_ids_rmpad[start_idx + half_seqlen : start_idx + half_seqlen + valid_pos_len] = (
                         torch.arange(remain_start, pos_end, dtype=torch.long, device=input_ids.device)
@@ -444,7 +446,9 @@ def preprocess_thd_engine(
             if need_roll:
                 # Handle roll for cp_size > 1 case
                 saved_roll_dict[start_idx + half_seqlen - 1] = d[(cp_rank + 1) * half_seqlen]
-                saved_position_roll_dict[start_idx + half_seqlen - 1] = position_ids_rmpad[start_idx + half_seqlen - 1]
+                saved_position_roll_dict[start_idx + half_seqlen - 1] = position_ids_rmpad[
+                    start_idx + half_seqlen - 1
+                ]
                 if remain_len > 0:
                     if remain_end == d.shape[0]:
                         saved_roll_dict[start_idx + half_seqlen + remain_len - 1] = d[0]


### PR DESCRIPTION
### What does this PR do?

Fixes an `IndexError` (out-of-bounds tensor slice) in `preprocess_thd_engine` (`verl/models/mcore/util.py`) that occurs when **FP8 padding** and **Context Parallelism (CP > 1)** are enabled simultaneously during SFT.

**Root cause:** When `use_fp8_padding=True`, the per-sequence padded length `seqlen_padded_i` is computed by `_compute_fp8_thd_align_size` and can be much larger than `align_size` (e.g. `seqlen_padded_i=512` vs `align_size=4` for a sequence of length 5). The old guard `if d.numel() < align_size` evaluated to `False` and skipped padding entirely. For `cp_rank >= 1`, the zigzag chunk slice `d[half_seqlen * cp_rank : half_seqlen * (cp_rank + 1)]` (e.g. `d[128:256]`) then went out of bounds on a tensor of shape `(5,)`.

**Fix:** Change the padding guard to `d.numel() < seqlen_padded_i` and pad `d` to the full `seqlen_padded_i`. Replace unchecked fixed-size slices with bounds-safe helpers using `min`/`max`. Add `max(..., 0)` to `remain_len` and `valid_pos_len` to prevent negative lengths.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fp8+padding+cp
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - PR title: `[mcore] fix: out-of-bounds slice in preprocess_thd_engine with FP8 padding + CP > 1`

### Test

Two new **CPU-only** regression tests added in `tests/utils/test_megatron_bshd_preprocess.py`, no GPU required:

- `test_preprocess_thd_engine_fp8_cp_no_crash_on_cpu`: reproduces the pre-fix OOB crash with `seqlen=5`, `cp_size=2`, asserts no exception is raised for all `cp_rank` values.
- `test_preprocess_thd_engine_fp8_cp_correct_content_on_cpu`: verifies the zigzag chunk content is numerically correct for both `cp_rank=0` and `cp_rank=1` with `seqlen=200`.

Run with:

```bash
python -m pytest tests/utils/test_megatron_bshd_preprocess.py -v
```

Result: **4 passed, 1 skipped** (GPU test skipped on CPU-only machine).

### API and Usage Example

No public API changes. The fix is internal to `preprocess_thd_engine` and is transparent to callers. The behavior is only corrected for the case where `use_fp8_padding=True` and `cp_size > 1` are enabled together.

```python
# No usage change required — existing SFT configs with FP8 padding + CP > 1
# now work correctly without triggering an IndexError.
```

### Design & Code Changes

**`verl/models/mcore/util.py` — `preprocess_thd_engine`:**

- Padding guard changed from `d.numel() < align_size` to `d.numel() < seqlen_padded_i`.
- Pad target changed from `align_size` to `seqlen_padded_i`.
- First chunk copy: unconditional fixed slice replaced with bounds-checked `first_len = max(first_end - first_start, 0)`.
- `remain_len` and `valid_pos_len` now wrapped in `max(..., 0)` to defend against negative values.

**`tests/utils/test_megatron_bshd_preprocess.py`:**

- New helper `_load_thd_engine_util`, kept separate from existing `_load_mcore_util_with_stubbed_megatron` to avoid touching old tests.
- New helper `_make_thd_input` for building 1-D jagged nested tensors.
- Two new test functions covering the crash scenario and content correctness.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (bugfix, no doc change)
- [x] Add unit or end-to-end test(s) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] If your PR is related to the `recipe` submodule, update the submodule reference.