### PR TITLE
[fsdp] fix: handle missing chunked top-k config

### DIFF
--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -109,13 +109,14 @@ def compute_forward_kl_topk(
     # F.log_softmax path OOMs. See ``DistillationLossConfig.use_chunked_topk``
     # for trade-offs and benchmark numbers.
     loss_config: DistillationLossConfig = config.distillation_loss
-    if loss_config.use_chunked_topk:
+    use_chunked_topk = getattr(loss_config, "use_chunked_topk", False)
+    if use_chunked_topk:
         # log_softmax is monotonic, so topk(logits) == topk(log_softmax(logits)).
         student_topk_ids = torch.topk(student_logits, k=teacher_topk_ids.shape[-1], dim=-1).indices
         student_topk_log_probs = _chunked_topk_log_probs(
             student_logits,
             teacher_topk_ids,
-            chunk_size=loss_config.chunked_topk_chunk_size,
+            chunk_size=getattr(loss_config, "chunked_topk_chunk_size", 4096),
         )
     else:
         student_log_probs = F.log_softmax(student_logits, dim=-1)


### PR DESCRIPTION
## Summary

- Preserve backward compatibility for lightweight distillation loss configs that do not define `use_chunked_topk`.
- Default missing `chunked_topk_chunk_size` to the existing 4096 value when the chunked path is enabled.

## Root Cause

PR #6593 added optional chunked top-k configuration fields, but `compute_forward_kl_topk` accessed them directly. Existing CPU tests use a `SimpleNamespace` distillation config with only `log_prob_min_clamp`, so the default path raised `AttributeError` before it could fall back to the non-chunked implementation.

## Validation

- `/root/modelchef/.venv/bin/pytest tests/workers/test_distillation_topk_symmetry_on_cpu.py -q`
- `/root/modelchef/.venv/bin/pytest tests/workers/test_chunked_topk_log_probs_on_cpu.py -q`
- `/root/modelchef/.venv/bin/ruff check verl/trainer/distillation/fsdp/losses.py`
