### PR TITLE
[Draft]Support Megatron LoRA adapter export for rollout

### DIFF
--- a/tests/utils/test_megatron_lora_export_on_cpu.py
+++ b/tests/utils/test_megatron_lora_export_on_cpu.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import pytest
+import torch
+
+from verl.utils import megatron_peft_utils as peft_utils
+
+pytestmark = pytest.mark.cpu
+
+
+def test_build_peft_config_for_vllm_expands_megatron_target_modules():
+    peft_config = peft_utils.build_peft_config_for_vllm(
+        {
+            "rank": 16,
+            "alpha": 32,
+            "target_modules": ["linear_qkv", "linear_proj", "linear_fc1", "linear_fc2"],
+        }
+    )
+
+    assert peft_config["r"] == 16
+    assert peft_config["lora_alpha"] == 32
+    assert peft_config["target_modules"] == [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+    ]
+
+
+def test_gather_ep_lora_adapter_weights_passthrough_without_ep():
+    params = [
+        ("thinker.model.layers.0.self_attn.q_proj.lora_A.weight", torch.tensor([1.0])),
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight", torch.tensor([2.0])),
+    ]
+
+    result = list(peft_utils.gather_ep_lora_adapter_weights_for_vllm(iter(params)))
+
+    assert [(name, tensor.item()) for name, tensor in result] == [
+        ("thinker.model.layers.0.self_attn.q_proj.lora_A.weight", 1.0),
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight", 2.0),
+    ]
+
+
+def test_gather_ep_lora_adapter_weights_renames_local_to_global_experts(monkeypatch):
+    ep_group = object()
+    monkeypatch.setattr(peft_utils, "_get_expert_parallel_info", lambda: (2, 0, ep_group))
+
+    def fake_all_gather(tensor, ep_size, group):
+        assert ep_size == 2
+        assert group is ep_group
+        return [tensor, tensor + 100]
+
+    monkeypatch.setattr(peft_utils, "_all_gather_tensor_for_ep", fake_all_gather)
+    params = [
+        ("thinker.model.layers.0.self_attn.q_proj.lora_A.weight", torch.tensor([1.0])),
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight", torch.tensor([2.0])),
+        ("thinker.model.layers.0.mlp.experts.1.gate_proj.lora_A.weight", torch.tensor([3.0])),
+    ]
+
+    result = list(peft_utils.gather_ep_lora_adapter_weights_for_vllm(iter(params)))
+
+    assert [(name, tensor.item()) for name, tensor in result] == [
+        ("thinker.model.layers.0.self_attn.q_proj.lora_A.weight", 1.0),
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight", 2.0),
+        ("thinker.model.layers.0.mlp.experts.2.gate_proj.lora_A.weight", 102.0),
+        ("thinker.model.layers.0.mlp.experts.1.gate_proj.lora_A.weight", 3.0),
+        ("thinker.model.layers.0.mlp.experts.3.gate_proj.lora_A.weight", 103.0),
+    ]
+
+
+def test_pack_3d_moe_lora_adapter_weights_for_vllm_packs_complete_expert_groups():
+    rank = 2
+    hidden = 3
+    intermediate = 4
+    params = [("thinker.model.layers.0.self_attn.q_proj.lora_A.weight", torch.full((rank, hidden), -1.0))]
+    for expert_id in range(2):
+        shared_a = torch.full((rank, hidden), float(expert_id + 1))
+        params.extend(
+            [
+                (f"thinker.model.layers.0.mlp.experts.{expert_id}.gate_proj.lora_A.weight", shared_a),
+                (
+                    f"thinker.model.layers.0.mlp.experts.{expert_id}.gate_proj.lora_B.weight",
+                    torch.full((intermediate, rank), 10.0 + expert_id),
+                ),
+                (f"thinker.model.layers.0.mlp.experts.{expert_id}.up_proj.lora_A.weight", shared_a.clone()),
+                (
+                    f"thinker.model.layers.0.mlp.experts.{expert_id}.up_proj.lora_B.weight",
+                    torch.full((intermediate, rank), 20.0 + expert_id),
+                ),
+                (
+                    f"thinker.model.layers.0.mlp.experts.{expert_id}.down_proj.lora_A.weight",
+                    torch.full((rank, intermediate), 30.0 + expert_id),
+                ),
+                (
+                    f"thinker.model.layers.0.mlp.experts.{expert_id}.down_proj.lora_B.weight",
+                    torch.full((hidden, rank), 40.0 + expert_id),
+                ),
+            ]
+        )
+
+    result = list(peft_utils.pack_3d_moe_lora_adapter_weights_for_vllm(iter(params), model_type="qwen3_omni_moe"))
+    tensors = dict(result)
+
+    assert [name for name, _tensor in result] == [
+        "thinker.model.layers.0.self_attn.q_proj.lora_A.weight",
+        "thinker.model.layers.0.mlp.experts.base_layer.lora_A.weight",
+        "thinker.model.layers.0.mlp.experts.base_layer.lora_B.weight",
+        "thinker.model.layers.0.mlp.experts.lora_A.weight",
+        "thinker.model.layers.0.mlp.experts.lora_B.weight",
+    ]
+    assert tensors["thinker.model.layers.0.mlp.experts.base_layer.lora_A.weight"].shape == (2 * rank, hidden)
+    assert tensors["thinker.model.layers.0.mlp.experts.base_layer.lora_B.weight"].shape == (
+        2 * intermediate,
+        2 * rank,
+    )
+    assert tensors["thinker.model.layers.0.mlp.experts.lora_A.weight"].shape == (2 * rank, intermediate)
+    assert tensors["thinker.model.layers.0.mlp.experts.lora_B.weight"].shape == (hidden, 2 * rank)
+
+
+def test_pack_3d_moe_lora_adapter_weights_for_vllm_rejects_split_gate_up_lora_a():
+    params = [
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_A.weight", torch.ones(2, 3)),
+        ("thinker.model.layers.0.mlp.experts.0.gate_proj.lora_B.weight", torch.ones(4, 2)),
+        ("thinker.model.layers.0.mlp.experts.0.up_proj.lora_A.weight", torch.zeros(2, 3)),
+        ("thinker.model.layers.0.mlp.experts.0.up_proj.lora_B.weight", torch.ones(4, 2)),
+        ("thinker.model.layers.0.mlp.experts.0.down_proj.lora_A.weight", torch.ones(2, 4)),
+        ("thinker.model.layers.0.mlp.experts.0.down_proj.lora_B.weight", torch.ones(3, 2)),
+    ]
+
+    with pytest.raises(ValueError, match="different gate_proj and up_proj lora_A"):
+        list(peft_utils.pack_3d_moe_lora_adapter_weights_for_vllm(iter(params), model_type="qwen3_omni_moe"))

--- a/verl/models/mcore/bridge.py
+++ b/verl/models/mcore/bridge.py
@@ -13,13 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import torch
+from megatron.core import tensor_parallel
+
 try:
     from megatron.bridge import AutoBridge
-    from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model
+    from megatron.bridge.training.utils.train_utils import (
+        LinearForLastLayer as _BridgeLinearForLastLayer,
+        freeze_moe_router,
+        make_value_model,
+    )
 except ImportError:
     # `pip install verl[mcore]` or
     print("Megatron-Bridge package not found. Please install Megatron-Bridge with `pip install megatron-bridge`")
     raise
+
+
+class LinearForLastLayer(_BridgeLinearForLastLayer):
+    def forward(self, input_):
+        logits = torch.nn.Linear.forward(self, input_)
+        logits = logits.float()
+        if self.sequence_parallel:
+            logits = tensor_parallel.gather_from_sequence_parallel_region(
+                logits,
+                tensor_parallel_output_grad=torch.is_grad_enabled(),
+            )
+        return logits, None
+
 
 __all__ = [
     "AutoBridge",

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from collections import OrderedDict
 from typing import Optional
 
@@ -253,6 +254,14 @@ def _fused_GPTModel_forward(
     )
 
     (decoder_input, rotary_pos_emb, rotary_pos_cos, rotary_pos_sin, sequence_len_offset) = preproc_output[:5]
+    if (
+        os.environ.get("VERL_MEGATRON_LORA_RECOMPUTE_INPUT_GRAD", "1") != "0"
+        and torch.is_grad_enabled()
+        and getattr(model, "training", False)
+        and decoder_input is not None
+        and not decoder_input.requires_grad
+    ):
+        decoder_input.requires_grad_(True)
 
     # Run decoder.
     hidden_states = model.decoder(

--- a/verl/utils/megatron_peft_utils.py
+++ b/verl/utils/megatron_peft_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Utilities for PEFT (Parameter-Efficient Fine-Tuning) of Megatron in VERL."""
 
+import os
+import re
 from typing import Iterator
 
 import torch
@@ -66,6 +68,16 @@ STACKED_PARAMS = [
     ".wk.weight",
     ".weights_proj.weight",
 ]
+
+_MOE_EXPERT_LORA_RE = re.compile(
+    r"^(?P<prefix>.*\.mlp\.experts\.)(?P<expert_id>\d+)"
+    r"(?P<suffix>\.(?:gate_proj|up_proj|down_proj)\.lora_[AB]\.weight)$"
+)
+_MOE_EXPERT_LORA_3D_RE = re.compile(
+    r"^(?P<prefix>.*\.mlp\.experts\.)(?P<expert_id>\d+)\."
+    r"(?P<proj>gate_proj|up_proj|down_proj)\.lora_(?P<side>[AB])\.weight$"
+)
+_QWEN3_OMNI_3D_MOE_MODEL_TYPES = {"qwen3_omni_moe"}
 
 
 def count_adapter_parameters(model):
@@ -182,10 +194,185 @@ def add_base_layer_suffix(
         yield name, param
 
 
+def _get_expert_parallel_info() -> tuple[int, int, object | None]:
+    try:
+        from megatron.core import parallel_state
+    except Exception:
+        return 1, 0, None
+
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return 1, 0, None
+
+    try:
+        ep_size = parallel_state.get_expert_model_parallel_world_size()
+        ep_rank = parallel_state.get_expert_model_parallel_rank()
+        ep_group = parallel_state.get_expert_model_parallel_group()
+    except Exception:
+        return 1, 0, None
+
+    if ep_size is None or ep_size <= 1 or ep_group is None:
+        return 1, 0, None
+    return ep_size, ep_rank, ep_group
+
+
+def _all_gather_tensor_for_ep(tensor: torch.Tensor, ep_size: int, ep_group) -> list[torch.Tensor]:
+    src = tensor.detach().contiguous()
+    original_device = src.device
+    gather_src = src
+    if not gather_src.is_cuda and torch.cuda.is_available():
+        gather_src = gather_src.to(torch.cuda.current_device(), non_blocking=True)
+
+    gathered = [torch.empty_like(gather_src) for _ in range(ep_size)]
+    torch.distributed.all_gather(gathered, gather_src, group=ep_group)
+
+    if original_device.type == "cpu":
+        gathered = [item.cpu() for item in gathered]
+    return gathered
+
+
+def gather_ep_lora_adapter_weights_for_vllm(
+    params: Iterator[tuple[str, torch.Tensor]],
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Gather EP-local MoE LoRA tensors and rename them to global expert ids."""
+    ep_size, _ep_rank, ep_group = _get_expert_parallel_info()
+    materialized = list(params)
+    if ep_size <= 1:
+        yield from materialized
+        return
+
+    expert_ids = []
+    for name, _param in materialized:
+        match = _MOE_EXPERT_LORA_RE.match(name)
+        if match:
+            expert_ids.append(int(match.group("expert_id")))
+
+    if not expert_ids:
+        yield from materialized
+        return
+
+    enabled = os.getenv("VERL_MEGATRON_LORA_GATHER_EP_ADAPTER_WEIGHTS", "1").lower()
+    if enabled in {"0", "false", "no", "off"}:
+        yield from materialized
+        return
+
+    local_expert_count = max(expert_ids) + 1
+    debug = os.getenv("VERL_MEGATRON_LORA_GATHER_EP_ADAPTER_DEBUG", "0").lower() in {"1", "true", "yes"}
+    gathered_expert_tensors = 0
+    passthrough_tensors = 0
+
+    for name, param in materialized:
+        match = _MOE_EXPERT_LORA_RE.match(name)
+        if match is None:
+            passthrough_tensors += 1
+            yield name, param
+            continue
+
+        local_expert_id = int(match.group("expert_id"))
+        gathered = _all_gather_tensor_for_ep(param, ep_size, ep_group)
+        for gathered_ep_rank, gathered_param in enumerate(gathered):
+            global_expert_id = gathered_ep_rank * local_expert_count + local_expert_id
+            yield f"{match.group('prefix')}{global_expert_id}{match.group('suffix')}", gathered_param
+            gathered_expert_tensors += 1
+
+    if debug:
+        print(
+            "[verl.megatron_lora] gathered EP adapter tensors for vLLM: "
+            f"ep_size={ep_size} local_experts={local_expert_count} "
+            f"expert_tensors_out={gathered_expert_tensors} passthrough={passthrough_tensors}",
+            flush=True,
+        )
+
+
+def pack_3d_moe_lora_adapter_weights_for_vllm(
+    params: Iterator[tuple[str, torch.Tensor]],
+    model_type: str,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    """Pack Qwen3-Omni per-expert LoRA tensors into vLLM's 3D MoE layout."""
+    materialized = list(params)
+    enabled = os.getenv("VERL_MEGATRON_LORA_PACK_3D_MOE_ADAPTER_WEIGHTS", "1").lower()
+    if model_type not in _QWEN3_OMNI_3D_MOE_MODEL_TYPES or enabled in {"0", "false", "no", "off"}:
+        yield from materialized
+        return
+
+    grouped: dict[str, dict[int, dict[tuple[str, str], tuple[int, torch.Tensor]]]] = {}
+    for index, (name, tensor) in enumerate(materialized):
+        match = _MOE_EXPERT_LORA_3D_RE.match(name)
+        if match is None:
+            continue
+        grouped.setdefault(match.group("prefix"), {}).setdefault(int(match.group("expert_id")), {})[
+            (match.group("proj"), match.group("side"))
+        ] = (index, tensor)
+
+    required = {
+        ("gate_proj", "A"),
+        ("gate_proj", "B"),
+        ("up_proj", "A"),
+        ("up_proj", "B"),
+        ("down_proj", "A"),
+        ("down_proj", "B"),
+    }
+    replacements: dict[int, list[tuple[str, torch.Tensor]]] = {}
+    consumed_indices: set[int] = set()
+    packed_groups = 0
+    packed_tensors = 0
+
+    for prefix, experts in grouped.items():
+        if not experts or any(set(tensors) != required for tensors in experts.values()):
+            continue
+
+        expert_ids = sorted(experts)
+        first_index = min(index for tensors in experts.values() for index, _tensor in tensors.values())
+        gate_up_a = []
+        gate_up_b = []
+        down_a = []
+        down_b = []
+        for expert_id in expert_ids:
+            tensors = experts[expert_id]
+            gate_a = tensors[("gate_proj", "A")][1]
+            up_a = tensors[("up_proj", "A")][1]
+            if gate_a.shape != up_a.shape or not torch.equal(gate_a, up_a):
+                raise ValueError(
+                    "Cannot pack Qwen3-Omni 3D MoE LoRA tensors for vLLM because "
+                    f"expert {expert_id} has different gate_proj and up_proj lora_A weights."
+                )
+            gate_up_a.append(gate_a)
+            gate_up_b.append(torch.cat([tensors[("gate_proj", "B")][1], tensors[("up_proj", "B")][1]], dim=0))
+            down_a.append(tensors[("down_proj", "A")][1])
+            down_b.append(tensors[("down_proj", "B")][1])
+            consumed_indices.update(index for index, _tensor in tensors.values())
+
+        base_name = prefix.rstrip(".")
+        replacements[first_index] = [
+            (f"{base_name}.base_layer.lora_A.weight", torch.cat(gate_up_a, dim=0)),
+            (f"{base_name}.base_layer.lora_B.weight", torch.cat(gate_up_b, dim=1)),
+            (f"{base_name}.lora_A.weight", torch.cat(down_a, dim=0)),
+            (f"{base_name}.lora_B.weight", torch.cat(down_b, dim=1)),
+        ]
+        packed_groups += 1
+        packed_tensors += len(replacements[first_index])
+
+    for index, item in enumerate(materialized):
+        if index in replacements:
+            yield from replacements[index]
+        if index not in consumed_indices:
+            yield item
+
+    debug = os.getenv("VERL_MEGATRON_LORA_PACK_3D_MOE_ADAPTER_DEBUG", "0").lower() in {"1", "true", "yes"}
+    if debug:
+        print(
+            "[verl.megatron_lora] packed 3D MoE adapter tensors for vLLM: "
+            f"model_type={model_type} groups={packed_groups} "
+            f"expert_tensors_in={len(consumed_indices)} packed_tensors_out={packed_tensors}",
+            flush=True,
+        )
+
+
 __all__ = [
     "count_adapter_parameters",
     "print_adapter_info",
     "convert_megatron_to_hf_target_modules",
     "build_peft_config_for_vllm",
     "add_base_layer_suffix",
+    "gather_ep_lora_adapter_weights_for_vllm",
+    "pack_3d_moe_lora_adapter_weights_for_vllm",
 ]

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -48,7 +48,12 @@ from verl.utils.megatron.tensor_parallel import (
     vocab_parallel_log_probs_from_logits,
     vocab_parallel_sum_pi_squared,
 )
-from verl.utils.megatron_peft_utils import add_base_layer_suffix, build_peft_config_for_vllm
+from verl.utils.megatron_peft_utils import (
+    add_base_layer_suffix,
+    build_peft_config_for_vllm,
+    gather_ep_lora_adapter_weights_for_vllm,
+    pack_3d_moe_lora_adapter_weights_for_vllm,
+)
 from verl.utils.megatron_utils import (
     check_mtp_config,
     get_megatron_module_device,
@@ -729,6 +734,10 @@ class MegatronEngine(BaseEngine):
             per_tensor_param = self.bridge.export_weights(self.module)
         elif adapter_only:
             per_tensor_param = self.bridge.export_adapter_weights(self.module)
+            per_tensor_param = gather_ep_lora_adapter_weights_for_vllm(per_tensor_param)
+            per_tensor_param = pack_3d_moe_lora_adapter_weights_for_vllm(
+                per_tensor_param, model_type=self.model_config.hf_config.model_type
+            )
         else:
             per_tensor_param = (
                 self.bridge.export_hf_weights(self.module, merge_adapter_weights=False)


### PR DESCRIPTION
## Summary

Add Megatron LoRA adapter export support for Qwen3-Omni rollout sync.

## Changes

- Export adapter-only Megatron LoRA tensors for rollout engines.
- Gather EP-local MoE LoRA tensors and rewrite local expert ids to global ids.
- Pack Qwen3-Omni 3D MoE LoRA tensors into vLLM-compatible layout.
- Preserve gradients through sequence-parallel LM-head gather.
- Fix recompute + LoRA-only training by ensuring decoder inputs require grad.

## Tests

- `pytest -q tests/utils/test_megatron_lora_export_on_cpu.py`
- `python -m py_compile ...`
- `git diff --check`

related PRs
https://github.com/verl-project/verl-omni/pull/169
https://github.com/vllm-project/vllm-omni/pull/4388