### PR TITLE
[rollout] fix: fall back to sgl_kernel when sglang_kernel is absent

### DIFF
--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -84,7 +84,12 @@ def _set_envs_and_config(server_args: ServerArgs):
                 "0.1.1",
                 "Please reinstall the latest version with `pip install follow https://sgl-project.github.io/get_started/install.html#for-cuda-13`",
             )
-        except AssertionError:
+        except Exception:
+            # assert_pkg_version raises a plain Exception (not AssertionError) when the
+            # package is absent (importlib.metadata.PackageNotFoundError), and only
+            # raises AssertionError when the installed version is too low. Older sglang
+            # (e.g. 0.5.9) ships `sgl_kernel`, not `sglang_kernel`, so the first check
+            # raises a bare Exception; catch it and fall back to the legacy name.
             assert_pkg_version(
                 "sgl_kernel",
                 "0.1.1",


### PR DESCRIPTION
### What does this PR do?

`_set_envs_and_config` (sglang rollout) checks for the kernel package under the newer
`sglang_kernel` name first, then falls back to the legacy `sgl_kernel` name:

```python
try:
    assert_pkg_version("sglang_kernel", "0.1.1", ...)
except AssertionError:
    assert_pkg_version("sgl_kernel", "0.1.1", ...)
```

The fallback is gated on `except AssertionError`, but `assert_pkg_version` raises a
**plain `Exception`** (`importlib.metadata.PackageNotFoundError`) when the package is
entirely absent, and only raises `AssertionError` when the installed version is too
low. So with an older sglang (e.g. 0.5.9) that ships `sgl_kernel` but **not**
`sglang_kernel`, the first check raises a bare `Exception` that escapes the handler and
crashes before the legacy-name fallback can run:

```
Exception: sglang_kernel with minimum required version 0.1.1 is not installed
  ...assert_pkg_version (importlib.metadata.PackageNotFoundError: No package metadata
     was found for sglang_kernel)
```

This PR changes the handler to `except Exception` so the fallback actually fires.

### Behavior

- `sglang_kernel` present (sglang ≥ 0.5.12): first check passes — unchanged.
- only the installed version is too low: `AssertionError` is a subclass of `Exception`,
  so it still routes to the fallback — unchanged.
- `sglang_kernel` absent but `sgl_kernel` present (sglang 0.5.9): now correctly falls
  back instead of crashing — **fixed**.

### Not a duplicate

Searched open PRs and issues on `verl-project/verl` for `sglang_kernel` / `sgl_kernel` /
`assert_pkg_version` — no existing PR or issue addresses this fallback bug.

### Test

- Repro: a sglang-rollout GRPO run with sglang `0.5.9` (which provides `sgl_kernel`, not
  `sglang_kernel`) crashes at `_set_envs_and_config` with the `PackageNotFoundError`
  shown above, before any rollout server starts.
- With this change the `sgl_kernel` fallback runs and rollout proceeds.
- Runtime validation against a downstream sglang-0.5.9 RL pipeline is in progress; will
  update with the run result before marking ready for review.

> Note: this change was prepared with AI assistance; the author has reviewed every
> changed line and is responsible for the change.
