### PR TITLE
[model] feat: support Gemma4 multimodal models in RL (GRPO)

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -804,7 +804,8 @@ class AgentLoopWorker:
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
     ) -> torch.Tensor:
         """Compute position ids for multi-modal inputs."""
-        if self.processor is None:
+        # text-only OR non-M-RoPE multimodal (e.g. Gemma4) -> standard 1D positions
+        if self.processor is None or not hasattr(self.processor, "get_rope_index"):
             return compute_position_id_with_mask(attention_mask)  # (1, seq_len)
 
         multi_modal_kwargs = {

--- a/verl/utils/model.py
+++ b/verl/utils/model.py
@@ -56,7 +56,7 @@ from verl.utils.transformers_compat import get_auto_model_for_vision2seq
 
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
-_VARLEN_MULTI_MODAL_KEYS = {"input_features", "feature_attention_mask"}
+_VARLEN_MULTI_MODAL_KEYS = {"input_features", "feature_attention_mask", "mm_token_type_ids"}
 
 
 class LambdaLayer(nn.Module):

--- a/verl/utils/tokenizer.py
+++ b/verl/utils/tokenizer.py
@@ -224,6 +224,10 @@ def hf_processor(name_or_path, **kwargs):
                 model_class = Glm4vModel
             case "MllamaProcessor":
                 pass  # MllamaProcessor and MllamaModel doesn't have get_rope_index property
+            case "Gemma4Processor":
+                # Gemma4 uses standard 1D RoPE -> no get_rope_index to bind. Disable its strict
+                # per-image-token check (which Qwen's processor lacks).
+                processor.validate_inputs = lambda *args, **kwargs: None
             case _:
                 raise ValueError(f"Unsupported processor type: {processor.__class__.__name__}")
 


### PR DESCRIPTION
## [model] feat: support Gemma4 multimodal models in RL

---
What does this PR do?

Adds support for Gemma4 multimodal models in RL (GRPO/PPO). verl's VLM plumbing assumed Qwen-VL-shaped processors — M-RoPE position ids, image_grid_thw, and strict per-image-token validation — so Gemma4 failed during rollout post-processing and the FSDP forward. The fixes are capability-detected (keyed on processor capabilities, not model name), so existing Qwen-VL / GLM-4V paths are unchanged. Addresses #6341 (complements #6030, which added Gemma4 FSDP SFT).

Checklist Before Starting

- [x] Search for similar PRs/Issues: (related: #6341, #6030)

## Test

New-model support — not coverable by CI without a multimodal GPU run. Validated end-to-end by experiment:

- Setup: google/gemma-4-E2B-it, GRPO, FSDP (actor/ref) + vLLM rollout, attn_implementation=sdpa, use_remove_padding=False, on H200.
- Result: trains stably; reward and eval metrics increase over training. <attach training-curve screenshot / before-after eval numbers>
- Existing Qwen-VL path re-verified unaffected (the new branches are never taken for Qwen — see below).

<img width="519" height="281" alt="image" src="https://github.com/user-attachments/assets/ba74d72f-2e01-41b2-8feb-41f3f0b6af37" />
<img width="534" height="290" alt="image" src="https://github.com/user-attachments/assets/023ad1b9-3b60-431d-968a-e10e77598a49" />


### API and Usage Example

No API changes (no new CLI args, config keys, or function signatures). Gemma4 just works once selected. Because Gemma4's global (full-attention) layers use head_dim=512 (FlashAttention-2/3 cap at 256), use SDPA:

actor_rollout_ref.model.path=google/gemma-4-E2B-it \
+actor_rollout_ref.model.override_config.attn_implementation=sdpa \
actor_rollout_ref.model.use_remove_padding=False

Design & Code Changes

verl hoists the model's internal multimodal prep (position ids, processor features) out of forward into its own rollout/forward glue, written to Qwen-VL's shape. This PR makes that glue handle non-Qwen VLMs (Gemma4) via capability checks. Three changes:

- verl/utils/tokenizer.py (hf_processor): add a Gemma4Processor case. Gemma uses standard 1D RoPE (no get_rope_index to bind), and its processor strictly validates one image placeholder per image — which rejects the placeholder-stripped text verl reconstructs at rollout. Disable that check for Gemma4 only; image features are still produced (image processing processor() is unconditional and runs after validate_inputs).
- verl/experimental/agent_loop/agent_loop.py (_compute_position_ids): fall back to mask-based 1D positions when the processor has no get_rope_index. Gemma encodes image structure in the attention mask (mm_token_type_ids) and the vision tower, not in M-RoPE positions. Qwen has get_rope_index, so its branch is unchanged.
- verl/utils/model.py (extract_multi_modal_inputs): add mm_token_type_ids to _VARLEN_MULTI_MODAL_KEYS so the per-sample, variable-length token-type mask is pad-batched instead of torch.cat (which fails on differing sequence lengths). Qwen consumes mm_token_type_ids into M-RoPE positions earlier, so it never reaches this path.

Fixes target the granular functions (not the _agent_loop_postprocess orchestrator), so they also cover the new AgentLoopWorkerTQ from #6710, which overrides the orchestrator but calls these inherited functions.

### Checklist

- [x] Read the Contribute Guide.
- [x] pre-commit run passes (ruff/mypy/etc.). (Local check-naming-conventions flags a "veRL" substring inside .venv/.../ray — a dependency, not this change; clean in CI.)
- [x] Tests: new multimodal model support requires GPU + a gated checkpoint, so not added to CI; validated by the experiment above. <explain / link CI if you add a small unit test>
- [x] Not a recipe submodule change.
- [x] Minimal changes 0 agent slope ;)
