### PR TITLE
[trainer] fix: use FullyAsyncLLMServerClient for async trainer

### DIFF
--- a/tests/checkpoint_engine/test_special_server_adapter.py
+++ b/tests/checkpoint_engine/test_special_server_adapter.py
@@ -21,14 +21,13 @@ from transformers import PreTrainedTokenizer
 
 from tests.checkpoint_engine.test_utils import create_trainer_worker_group
 from verl.checkpoint_engine import CheckpointEngineManager
-from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncLLMServerClient
 from verl.single_controller.ray import (
     RayResourcePool,
 )
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.tokenizer import normalize_token_ids
 from verl.workers.config import CheckpointEngineConfig, HFModelConfig
-from verl.workers.rollout.llm_server import LLMServerClient, LLMServerManager
+from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerClient, LLMServerManager
 
 
 @pytest.fixture

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -17,7 +17,6 @@ import logging
 import os
 import time
 from pprint import pformat
-from typing import Any, Optional
 
 import numpy as np
 import ray
@@ -39,120 +38,16 @@ from verl.trainer.ppo.utils import (
     create_rl_sampler,
     need_reward_model,
 )
-from verl.utils import normalize_token_ids
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.profiler import marked_timer
-from verl.utils.rollout_trace import rollout_trace_op
 from verl.utils.skip import SkipManager
 from verl.utils.tracking import ValidationGenerationsLogger
-from verl.workers.rollout.llm_server import LLMServerClient, LLMServerManager
-from verl.workers.rollout.replica import RolloutReplica, TokenOutput
+from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerManager
+from verl.workers.rollout.replica import RolloutReplica
 from verl.workers.rollout.utils import update_prometheus_config
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
-
-
-class FullyAsyncLLMServerClient(LLMServerClient):
-    """FullyLLMServerClient supports resume generation on partial rollout, making rollout interruption
-    invisible to the AgentLoop.
-    """
-
-    @rollout_trace_op
-    async def generate(
-        self,
-        request_id,
-        *,
-        prompt_ids: list[int],
-        sampling_params: dict[str, Any],
-        image_data: Optional[list[Any]] = None,
-        video_data: Optional[list[Any]] = None,
-        audio_data: Optional[list[Any]] = None,
-        mm_processor_kwargs: Optional[dict[str, Any]] = None,
-    ) -> TokenOutput:
-        """Generate tokens from prompt ids.
-
-        Args:
-            request_id (str): request id for sticky session.
-            prompt_ids (List[int]): List of prompt token ids.
-            sampling_params (Dict[str, Any]): Sampling parameters for the chat completion.
-            image_data (Optional[List[Any]]): Image data for the chat completion.
-            video_data (Optional[List[Any]]): Video data for the chat completion.
-            audio_data (Optional[List[Any]]): Audio data for the chat completion.
-            mm_processor_kwargs (Optional[Dict[str, Any]]): Multimodal processor kwargs.
-
-        Returns:
-            TokenOutput: token output
-        """
-        prompt_ids = normalize_token_ids(prompt_ids)
-
-        limit_key = None
-        if "max_tokens" in sampling_params:
-            limit_key = "max_tokens"
-        elif "max_new_tokens" in sampling_params:
-            limit_key = "max_new_tokens"
-        original_max_tokens = sampling_params.get(limit_key) if limit_key else None
-
-        final_output = TokenOutput(
-            token_ids=[],
-            log_probs=[],
-            num_preempted=0,
-        )
-        min_global_steps, max_global_steps = None, None
-
-        while True:
-            # 1. generate tokens
-            output = await super().generate(
-                request_id=request_id,
-                prompt_ids=prompt_ids + final_output.token_ids,
-                sampling_params=sampling_params,
-                image_data=image_data,
-                video_data=video_data,
-                audio_data=audio_data,
-                mm_processor_kwargs=mm_processor_kwargs,
-            )
-
-            # 2. merge output into final_output
-            final_output.token_ids.extend(output.token_ids)
-            if output.log_probs is not None:
-                final_output.log_probs.extend(output.log_probs)
-            # On partial rollout resume the model version may differ, so keep
-            # existing routing and only append routing for newly generated tokens.
-            if output.routed_experts is not None and len(output.token_ids) > 0:
-                if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
-                else:
-                    final_output.routed_experts = torch.cat(
-                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids) :]],
-                        dim=0,
-                    )
-            if output.num_preempted is not None:
-                final_output.num_preempted += output.num_preempted
-            final_output.stop_reason = output.stop_reason
-
-            # update model weights version
-            global_steps = output.extra_fields.get("global_steps", None)
-            if min_global_steps is None:
-                min_global_steps = global_steps
-            max_global_steps = global_steps
-
-            # 3. update max_new_tokens
-            if original_max_tokens is not None:
-                sampling_params[limit_key] = original_max_tokens - len(final_output.token_ids)
-                if len(final_output.token_ids) >= original_max_tokens:
-                    final_output.stop_reason = "length"
-                    break
-
-            # 4. check stop reason
-            if output.stop_reason not in ("aborted", "abort") or not self.config.async_training.partial_rollout:
-                break
-
-            await asyncio.sleep(1)
-
-        final_output.extra_fields["global_steps"] = global_steps
-        final_output.extra_fields["min_global_steps"] = min_global_steps
-        final_output.extra_fields["max_global_steps"] = max_global_steps
-        return final_output
 
 
 class FullyAsyncLLMServerManager(LLMServerManager):

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -16,6 +16,7 @@ import os
 
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.debug import marked_timer
+from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -27,6 +28,10 @@ class PPOTrainerColocateAsync(PPOTrainer):
     1. Trainer and rollout are colocated.
     2. Partial rollout is enabled.
     """
+
+    def get_llm_client(self):
+        """Get the LLM server client for rollout generation."""
+        return self.llm_server_manager.get_client(client_cls=FullyAsyncLLMServerClient)
 
     def on_init_end(self):
         # update weights after loading checkpoint

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -22,7 +22,7 @@ from verl.checkpoint_engine import CheckpointEngineManager
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
-from verl.workers.rollout.llm_server import LLMServerManager
+from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerManager
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -83,7 +83,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
 
     def get_llm_client(self):
         # get server client from standalone rollout
-        return self.standalone_server_manager.get_client()
+        return self.standalone_server_manager.get_client(client_cls=FullyAsyncLLMServerClient)
 
     def on_init_end(self):
         # update weights after loading checkpoint

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -313,7 +313,9 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                     break
 
             # 4. check stop reason
-            if output.stop_reason not in ("aborted", "abort") or not self.config.async_training.partial_rollout:
+            if output.stop_reason not in ("aborted", "abort") or not (
+                hasattr(self.config, "async_training") and self.config.async_training.partial_rollout
+            ):
                 break
 
             await asyncio.sleep(1)

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -25,10 +25,12 @@ from typing import Any, Optional
 from uuid import uuid4
 
 import ray
+import torch
 from cachetools import LRUCache
 from omegaconf import DictConfig
 
 from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
+from verl.utils import normalize_token_ids
 from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
@@ -218,6 +220,108 @@ class LLMServerClient:
             return output
         finally:
             self._release_server(server_id)
+
+
+class FullyAsyncLLMServerClient(LLMServerClient):
+    """FullyLLMServerClient supports resume generation on partial rollout, making rollout interruption
+    invisible to the AgentLoop.
+    """
+
+    @rollout_trace_op
+    async def generate(
+        self,
+        request_id,
+        *,
+        prompt_ids: list[int],
+        sampling_params: dict[str, Any],
+        image_data: Optional[list[Any]] = None,
+        video_data: Optional[list[Any]] = None,
+        audio_data: Optional[list[Any]] = None,
+        mm_processor_kwargs: Optional[dict[str, Any]] = None,
+    ) -> TokenOutput:
+        """Generate tokens from prompt ids.
+
+        Args:
+            request_id (str): request id for sticky session.
+            prompt_ids (List[int]): List of prompt token ids.
+            sampling_params (Dict[str, Any]): Sampling parameters for the chat completion.
+            image_data (Optional[List[Any]]): Image data for the chat completion.
+            video_data (Optional[List[Any]]): Video data for the chat completion.
+            audio_data (Optional[List[Any]]): Audio data for the chat completion.
+            mm_processor_kwargs (Optional[Dict[str, Any]]): Multimodal processor kwargs.
+
+        Returns:
+            TokenOutput: token output
+        """
+        prompt_ids = normalize_token_ids(prompt_ids)
+
+        limit_key = None
+        if "max_tokens" in sampling_params:
+            limit_key = "max_tokens"
+        elif "max_new_tokens" in sampling_params:
+            limit_key = "max_new_tokens"
+        original_max_tokens = sampling_params.get(limit_key) if limit_key else None
+
+        final_output = TokenOutput(
+            token_ids=[],
+            log_probs=[],
+            num_preempted=0,
+        )
+        min_global_steps, max_global_steps = None, None
+
+        while True:
+            # 1. generate tokens
+            output = await super().generate(
+                request_id=request_id,
+                prompt_ids=prompt_ids + final_output.token_ids,
+                sampling_params=sampling_params,
+                image_data=image_data,
+                video_data=video_data,
+                audio_data=audio_data,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
+
+            # 2. merge output into final_output
+            final_output.token_ids.extend(output.token_ids)
+            if output.log_probs is not None:
+                final_output.log_probs.extend(output.log_probs)
+            # On partial rollout resume the model version may differ, so keep
+            # existing routing and only append routing for newly generated tokens.
+            if output.routed_experts is not None and len(output.token_ids) > 0:
+                if final_output.routed_experts is None:
+                    final_output.routed_experts = output.routed_experts
+                else:
+                    final_output.routed_experts = torch.cat(
+                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids) :]],
+                        dim=0,
+                    )
+            if output.num_preempted is not None:
+                final_output.num_preempted += output.num_preempted
+            final_output.stop_reason = output.stop_reason
+
+            # update model weights version
+            global_steps = output.extra_fields.get("global_steps", None)
+            if min_global_steps is None:
+                min_global_steps = global_steps
+            max_global_steps = global_steps
+
+            # 3. update max_new_tokens
+            if original_max_tokens is not None:
+                sampling_params[limit_key] = original_max_tokens - len(final_output.token_ids)
+                if len(final_output.token_ids) >= original_max_tokens:
+                    final_output.stop_reason = "length"
+                    break
+
+            # 4. check stop reason
+            if output.stop_reason not in ("aborted", "abort") or not self.config.async_training.partial_rollout:
+                break
+
+            await asyncio.sleep(1)
+
+        final_output.extra_fields["global_steps"] = global_steps
+        final_output.extra_fields["min_global_steps"] = min_global_steps
+        final_output.extra_fields["max_global_steps"] = max_global_steps
+        return final_output
 
 
 class LLMServerManager:


### PR DESCRIPTION
### What does this PR do?

Follow up https://github.com/verl-project/verl/pull/6710, use `FullyAsyncLLMServerClient` for async trainer colocate_async/separate_async to automatically resume on abort.
