### PR TITLE
[worker] feat: add tinker training worker primitives

### DIFF
--- a/tests/models/test_engine.py
+++ b/tests/models/test_engine.py
@@ -24,6 +24,8 @@ import ray
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+from tensordict import TensorDict
+from torch.distributed.tensor import DTensor
 from transformers import (
     AutoConfig,
     AutoModelForCausalLM,
@@ -54,7 +56,8 @@ from verl.workers.config import (
     McoreEngineConfig,
     McoreOptimizerConfig,
 )
-from verl.workers.engine_workers import TrainingWorker, TrainingWorkerConfig
+from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
+from verl.workers.engine_workers_tinker import TinkerActorRolloutRefWorker, TinkerTrainingWorker
 from verl.workers.utils.losses import ppo_loss, sft_loss, value_loss
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
@@ -66,6 +69,17 @@ def get_test_language_model(device_count):
         model = "~/models/Qwen/Qwen2.5-0.5B"
     model = os.path.expanduser(model)
     return model
+
+
+def test_tinker_workers_expose_split_training_primitives():
+    assert issubclass(TinkerTrainingWorker, TrainingWorker)
+    assert issubclass(TinkerActorRolloutRefWorker, ActorRolloutRefWorker)
+
+    for name in ("optimizer_zero_grad", "forward_backward", "optimizer_step"):
+        assert name not in TrainingWorker.__dict__
+        assert name in TinkerTrainingWorker.__dict__
+        assert name not in ActorRolloutRefWorker.__dict__
+        assert name in TinkerActorRolloutRefWorker.__dict__
 
 
 def create_training_config(model_type, strategy, device_count, model):
@@ -508,6 +522,188 @@ def _autocast_dtype_worker(rank: int, world_size: int, rendezvous_file: str, mod
 
     dist.barrier()
     dist.destroy_process_group()
+
+
+def _local_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    if isinstance(tensor, DTensor):
+        return tensor.to_local()
+    return tensor
+
+
+def _snapshot_trainable_params(module):
+    return [_local_tensor(param).detach().float().clone() for param in module.parameters() if param.requires_grad]
+
+
+def _param_delta_norm(module, before) -> torch.Tensor:
+    device = torch.device("cuda", torch.cuda.current_device())
+    total = torch.zeros((), device=device)
+    for param, param_before in zip((p for p in module.parameters() if p.requires_grad), before, strict=True):
+        param_local = _local_tensor(param).detach().float()
+        total += (param_local - param_before.to(param_local.device)).pow(2).sum()
+    dist.all_reduce(total, op=dist.ReduceOp.SUM)
+    return total.sqrt()
+
+
+def _grad_norm(module) -> torch.Tensor:
+    device = torch.device("cuda", torch.cuda.current_device())
+    total = torch.zeros((), device=device)
+    for param in module.parameters():
+        if param.grad is None:
+            continue
+        grad = _local_tensor(param.grad).detach().float()
+        total += grad.pow(2).sum()
+    dist.all_reduce(total, op=dist.ReduceOp.SUM)
+    return total.sqrt()
+
+
+def _has_any_grad(module) -> bool:
+    any_grad = torch.tensor(
+        int(any(param.grad is not None for param in module.parameters())),
+        device=torch.device("cuda", torch.cuda.current_device()),
+    )
+    dist.all_reduce(any_grad, op=dist.ReduceOp.SUM)
+    return any_grad.item() > 0
+
+
+def _make_split_step_batch(config: HFModelConfig, engine_config: FSDPEngineConfig, world_size: int) -> TensorDict:
+    batch_size = 2
+    seq_len = 8
+    response_length = 4
+    input_ids = torch.arange(batch_size * seq_len, dtype=torch.long).reshape(batch_size, seq_len)
+    input_ids = input_ids.remainder(config.hf_config.vocab_size)
+    attention_mask = torch.ones_like(input_ids)
+    position_ids = torch.arange(seq_len, dtype=torch.long).expand(batch_size, seq_len)
+    responses = input_ids[:, -response_length:]
+    response_mask = torch.ones_like(responses)
+
+    data = DataProto.from_single_dict(
+        {
+            "input_ids": input_ids,
+            "prompts": input_ids[:, : seq_len - response_length],
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "responses": responses,
+            "response_mask": response_mask,
+            "old_log_probs": torch.zeros_like(responses, dtype=torch.float32),
+            "advantages": torch.ones_like(responses, dtype=torch.float32),
+        },
+        meta_info={"temperature": 1.0},
+    )
+    data_td = left_right_2_no_padding(data.to_tensordict())
+    tu.assign_non_tensor(
+        data_td,
+        global_batch_size=batch_size * world_size,
+        use_remove_padding=config.get("use_remove_padding", False),
+        use_dynamic_bsz=engine_config.use_dynamic_bsz,
+        max_token_len_per_gpu=engine_config.max_token_len_per_gpu,
+        micro_batch_size_per_gpu=engine_config.micro_batch_size_per_gpu,
+        use_fused_kernels=engine_config.use_fused_kernels,
+    )
+    return data_td
+
+
+def _split_training_primitives_fsdp_worker(
+    rank: int, world_size: int, rendezvous_file: str, model_path: str, strategy: str
+):
+    torch.cuda.set_device(rank)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    from verl.workers.engine import BaseEngine, EngineRegistry
+
+    model_config = HFModelConfig(
+        path=model_path,
+        load_tokenizer=False,
+        override_config={"attn_implementation": "sdpa"},
+        use_remove_padding=True,
+    )
+    engine_config = FSDPEngineConfig(
+        forward_only=False,
+        fsdp_size=world_size,
+        strategy=strategy,
+        ulysses_sequence_parallel_size=1,
+        use_remove_padding=True,
+        use_dynamic_bsz=False,
+        micro_batch_size_per_gpu=2,
+        max_token_len_per_gpu=128,
+    )
+    engine: BaseEngine = EngineRegistry.new(
+        model_type="language_model",
+        backend=engine_config.strategy,
+        model_config=model_config,
+        engine_config=engine_config,
+        optimizer_config=FSDPOptimizerConfig(lr=1e-3, lr_scheduler_type="constant"),
+        checkpoint_config=CheckpointConfig(),
+    )
+    engine.initialize()
+
+    actor_config = ActorConfig(strategy=strategy, rollout_n=1, ppo_micro_batch_size_per_gpu=-1)
+    loss_fn = partial(ppo_loss, config=actor_config)
+    before = _snapshot_trainable_params(engine.module)
+
+    with engine.train_mode(zero_grad_on_exit=False):
+        engine.optimizer_zero_grad()
+        output_1 = engine.forward_backward_batch(
+            _make_split_step_batch(model_config, engine_config, world_size),
+            loss_function=loss_fn,
+            forward_only=False,
+        )
+    if engine.is_mp_src_rank_with_outputs():
+        assert "grad_norm" not in output_1["metrics"]
+    grad_norm_1 = _grad_norm(engine.module)
+    assert grad_norm_1.item() > 0
+    assert _param_delta_norm(engine.module, before).item() == pytest.approx(0.0, abs=0.0)
+
+    with engine.train_mode(zero_grad_on_exit=False):
+        output_2 = engine.forward_backward_batch(
+            _make_split_step_batch(model_config, engine_config, world_size),
+            loss_function=loss_fn,
+            forward_only=False,
+        )
+    if engine.is_mp_src_rank_with_outputs():
+        assert "grad_norm" not in output_2["metrics"]
+    grad_norm_2 = _grad_norm(engine.module)
+    assert grad_norm_2.item() > grad_norm_1.item() * 1.5
+    assert _param_delta_norm(engine.module, before).item() == pytest.approx(0.0, abs=0.0)
+
+    with engine.train_mode(zero_grad_on_exit=True):
+        grad_norm = engine.optimizer_step()
+
+    assert grad_norm > 0
+    assert _param_delta_norm(engine.module, before).item() > 0
+    assert not _has_any_grad(engine.module)
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires at least 2 CUDA devices")
+@pytest.mark.parametrize("strategy", ["fsdp", "fsdp2"])
+def test_fsdp_engine_split_forward_backward_and_optimizer_step(strategy, tmp_path):
+    world_size = 2
+    rendezvous_file = str(tmp_path / f"rdzv_split_training_primitives_{strategy}")
+    os.makedirs(os.path.dirname(rendezvous_file), exist_ok=True)
+    model_path = create_actor_model(
+        tmp_path,
+        Qwen3Config(
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+        ),
+    )
+    mp.spawn(
+        fn=_split_training_primitives_fsdp_worker,
+        args=(world_size, rendezvous_file, model_path, strategy),
+        nprocs=world_size,
+        join=True,
+    )
 
 
 @pytest.mark.parametrize("world_size", [8])

--- a/verl/workers/engine/automodel/transformer_impl.py
+++ b/verl/workers/engine/automodel/transformer_impl.py
@@ -465,7 +465,8 @@ class AutomodelTrainModeCtx(BaseEngineCtx):
 
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, AutomodelEngine)
-        self.engine.optimizer_zero_grad()
+        if self.zero_grad_on_exit or exc_type is not None:
+            self.engine.optimizer_zero_grad()
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/verl/workers/engine/base.py
+++ b/verl/workers/engine/base.py
@@ -239,6 +239,7 @@ class BaseEngineCtx:
         self.mode = mode
         assert self.mode in ("train", "eval")
         self.disable_auto_offload = kwargs.pop("disable_auto_offload", False)
+        self.zero_grad_on_exit = kwargs.pop("zero_grad_on_exit", True)
 
     def _context_switch(self, device):
         if self.disable_auto_offload:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -916,7 +916,8 @@ class EngineTrainModeCtx(BaseEngineCtx):
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, FSDPEngine)
         set_ulysses_sequence_parallel_group(self.prev_sp_group)
-        self.engine.optimizer_zero_grad()
+        if self.zero_grad_on_exit or exc_type is not None:
+            self.engine.optimizer_zero_grad()
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -790,7 +790,8 @@ class EngineTrainModeCtx(BaseEngineCtx):
 
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, MegatronEngine)
-        self.engine.optimizer_zero_grad()
+        if self.zero_grad_on_exit or exc_type is not None:
+            self.engine.optimizer_zero_grad()
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -566,7 +566,8 @@ class EngineTrainModeCtx(BaseEngineCtx):
 
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, TorchTitanEngine)
-        self.engine.optimizer_zero_grad()
+        if self.zero_grad_on_exit or exc_type is not None:
+            self.engine.optimizer_zero_grad()
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -728,7 +728,8 @@ class EngineTrainModeCtx(BaseEngineCtx):
     def __exit__(self, exc_type, exc_value, traceback):
         assert isinstance(self.engine, VeOmniEngine)
         set_ulysses_sequence_parallel_group(self.prev_sp_group)
-        self.engine.optimizer_zero_grad()
+        if self.zero_grad_on_exit or exc_type is not None:
+            self.engine.optimizer_zero_grad()
         super().__exit__(exc_type, exc_value, traceback)
 
 

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -438,6 +438,9 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
     NOTE: ActorRolloutRefWorker no longer support spmd mode and run native server mode.
     """
 
+    actor_worker_cls = TrainingWorker
+    ref_worker_cls = TrainingWorker
+
     def __init__(
         self, config: DictConfig, role: str, distillation_config: Optional[DistillationConfig] = None, **kwargs
     ):
@@ -446,8 +449,8 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
         self.distillation_config = distillation_config
         self.distillation_enabled = is_distillation_enabled(distillation_config)
         self.role = role
-        self.actor: TrainingWorker = None
-        self.ref: TrainingWorker = None
+        self.actor: TrainingWorker | None = None
+        self.ref: TrainingWorker | None = None
         self.rollout: BaseRollout = None
         assert self.role in ["actor", "rollout", "ref", "actor_rollout", "actor_rollout_ref"]
         self._is_actor = self.role in ["actor", "actor_rollout", "actor_rollout_ref"]
@@ -534,7 +537,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
             )
             ref_training_config.engine_config.use_remove_padding = model_config.get("use_remove_padding", False)
 
-            self.ref = TrainingWorker(config=ref_training_config)
+            self.ref = self.ref_worker_cls(config=ref_training_config)
             self.ref.reset()
             self.set_dispatch_collect(mesh_name="ref", **self.ref.get_dispatch_collect())
 
@@ -582,7 +585,7 @@ class ActorRolloutRefWorker(Worker, DistProfilerExtension):
                 )
             else:
                 self.loss_fn = partial(ppo_loss, config=actor_config)
-            self.actor = TrainingWorker(config=actor_training_config)
+            self.actor = self.actor_worker_cls(config=actor_training_config)
             self.actor.reset()
             self.actor.set_loss_fn(self.loss_fn)
             self.set_dispatch_collect(mesh_name="actor", **self.actor.get_dispatch_collect())

--- a/verl/workers/engine_workers_tinker.py
+++ b/verl/workers/engine_workers_tinker.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from codetiming import Timer
+from tensordict import TensorDict
+
+from verl.single_controller.base.decorator import Dispatch, make_nd_compute_dataproto_dispatch_fn, register
+from verl.utils import tensordict_utils as tu
+from verl.utils.profiler import DistProfiler
+from verl.utils.tensordict_utils import maybe_fix_3d_position_ids
+from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker
+
+
+class TinkerTrainingWorker(TrainingWorker):
+    """
+    Training worker exposing Tinker-style split training primitives.
+
+    Unlike TrainingWorker.train_batch(), these APIs let a caller explicitly separate gradient
+    clearing, forward/backward, and optimizer stepping.
+    """
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def optimizer_zero_grad(self) -> None:
+        with self.engine.train_mode(zero_grad_on_exit=False):
+            self.engine.optimizer_zero_grad()
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"), blocking=False)
+    @DistProfiler.annotate(color="red", role="forward_backward")
+    def forward_backward(self, data: TensorDict) -> TensorDict:
+        assert self.loss_fn is not None, "loss function can't be None when calling forward_backward"
+        assert not self.engine_config.forward_only, (
+            "Can't run `forward_backward` when forward_only is in the engine config."
+        )
+        global_token_num = tu.get(data, key="global_token_num")
+        disable_auto_offload = tu.get(data, key="disable_auto_offload", default=False)
+        images_seqlens = tu.get(data, key="images_seqlens", default=None)
+
+        default_keys = dict(
+            use_remove_padding=self.model_config.get("use_remove_padding", False),
+            use_dynamic_bsz=self.engine_config.use_dynamic_bsz,
+            max_token_len_per_gpu=self.engine_config.max_token_len_per_gpu,
+            micro_batch_size_per_gpu=self.engine_config.micro_batch_size_per_gpu,
+            use_fused_kernels=self.engine_config.use_fused_kernels,
+        )
+
+        for key, val in default_keys.items():
+            if key not in data.keys():
+                tu.assign_non_tensor(data, **{key: val})
+
+        maybe_fix_3d_position_ids(data)
+
+        with (
+            self.engine.train_mode(
+                disable_auto_offload=disable_auto_offload,
+                zero_grad_on_exit=False,
+            ),
+            Timer(name="forward_backward", logger=None) as timer,
+        ):
+            output = self.engine.forward_backward_batch(data, loss_function=self.loss_fn, forward_only=False)
+        delta_time = timer.last
+
+        if self.engine.is_mp_src_rank_with_outputs():
+            output.pop("model_output")
+            final_output = self._postprocess_output(
+                output,
+                global_token_num=global_token_num,
+                delta_time=delta_time,
+                forward_only=False,
+                images_seqlens=images_seqlens,
+            ).cpu()
+        else:
+            final_output = None
+
+        return final_output
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def optimizer_step(self, update_lr_scheduler: bool = True) -> dict:
+        with self.engine.train_mode(zero_grad_on_exit=True):
+            grad_norm = self.engine.optimizer_step()
+            lr = self.engine.lr_scheduler_step() if update_lr_scheduler else None
+
+        metrics = {}
+        if grad_norm is not None and self.engine.is_mp_src_rank_with_outputs():
+            metrics["grad_norm"] = grad_norm
+        if lr is not None and self.engine.is_mp_src_rank_with_outputs():
+            metrics["lr"] = lr
+        return metrics
+
+
+class TinkerActorRolloutRefWorker(ActorRolloutRefWorker):
+    """Actor-rollout-ref worker exposing Tinker-style split training primitives for the actor."""
+
+    actor_worker_cls = TinkerTrainingWorker
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def optimizer_zero_grad(self) -> None:
+        assert "actor" in self.role, "optimizer_zero_grad only support actor role"
+        return self.actor.optimizer_zero_grad()
+
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"), blocking=False)
+    def forward_backward(self, data: TensorDict) -> TensorDict:
+        assert "actor" in self.role, "forward_backward only support actor role"
+        output = self.actor.forward_backward(data=data)
+        return output.cpu() if output is not None else None
+
+    @register(dispatch_mode=Dispatch.ONE_TO_ALL)
+    def optimizer_step(self, update_lr_scheduler: bool = True) -> dict:
+        assert "actor" in self.role, "optimizer_step only support actor role"
+        return self.actor.optimizer_step(update_lr_scheduler=update_lr_scheduler)


### PR DESCRIPTION
## Summary

This PR keeps `TrainingWorker.train_batch()` as the atomic mini-batch training API while adding an explicit worker variant for callers that need to drive the training step in smaller phases.

- Add `TinkerTrainingWorker` in `engine_workers_tinker.py`, a `TrainingWorker` subclass that exposes `optimizer_zero_grad()`, `forward_backward()`, and `optimizer_step()`.
- Add `TinkerActorRolloutRefWorker` in `engine_workers_tinker.py`, an `ActorRolloutRefWorker` subclass that routes the same split primitives to the actor worker.
- Let `ActorRolloutRefWorker` choose actor/ref worker classes through class attributes, keeping `engine_workers.py` on the regular worker path while Tinker-specific APIs live in the separate module.
- Preserve accumulated gradients after split `forward_backward()` while still clearing gradients when a train-mode context exits through an exception.

The default `TrainingWorker` and `ActorRolloutRefWorker` APIs remain unchanged, so existing callers keep the current `train_batch()` semantics:

```python
worker.train_batch(data)
```

Callers that opt into the subclass can instead do:

```python
worker.optimizer_zero_grad()
worker.forward_backward(data_1)
worker.forward_backward(data_2)
worker.optimizer_step()
```

## Tests

- `uvx ruff format --check verl/workers/engine/base.py verl/workers/engine_workers.py verl/workers/engine/fsdp/transformer_impl.py verl/workers/engine/veomni/transformer_impl.py verl/workers/engine/automodel/transformer_impl.py verl/workers/engine/megatron/transformer_impl.py verl/workers/engine/torchtitan/transformer_impl.py tests/models/test_engine.py`
- `uvx ruff check verl/workers/engine/base.py verl/workers/engine_workers.py verl/workers/engine/fsdp/transformer_impl.py verl/workers/engine/veomni/transformer_impl.py verl/workers/engine/automodel/transformer_impl.py verl/workers/engine/megatron/transformer_impl.py verl/workers/engine/torchtitan/transformer_impl.py tests/models/test_engine.py`
- `source .venv/bin/activate && python -m py_compile verl/workers/engine/base.py verl/workers/engine_workers.py verl/workers/engine/fsdp/transformer_impl.py verl/workers/engine/veomni/transformer_impl.py verl/workers/engine/automodel/transformer_impl.py verl/workers/engine/megatron/transformer_impl.py verl/workers/engine/torchtitan/transformer_impl.py tests/models/test_engine.py`

Note: local targeted pytest was not runnable because this checkout's `.venv` does not include `pytest`.
