### PR TITLE
[fully_async] fix: check audio forwarding contract in agent loop

### DIFF
--- a/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
+++ b/tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py
@@ -19,7 +19,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/llm_server.py"
-FULLY_ASYNC_ROLLOUTER_SOURCE = REPO_ROOT / "verl/experimental/fully_async_policy/fully_async_rollouter.py"
+SINGLE_TURN_AGENT_LOOP_SOURCE = REPO_ROOT / "verl/experimental/agent_loop/single_turn_agent_loop.py"
+TOOL_AGENT_LOOP_SOURCE = REPO_ROOT / "verl/experimental/agent_loop/tool_agent_loop.py"
 VLLM_SERVER_SOURCE = REPO_ROOT / "verl/workers/rollout/vllm_rollout/vllm_async_server.py"
 
 
@@ -51,9 +52,13 @@ def test_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
 
 
 def test_fully_async_server_manager_generate_forwards_audio_and_mm_kwargs() -> None:
-    source = FULLY_ASYNC_ROLLOUTER_SOURCE.read_text(encoding="utf-8")
-    assert "audio_data=audio_data" in source
-    assert "mm_processor_kwargs=mm_processor_kwargs" in source
+    single_turn_source = SINGLE_TURN_AGENT_LOOP_SOURCE.read_text(encoding="utf-8")
+    assert "audio_data=audios" in single_turn_source
+    assert "mm_processor_kwargs=mm_processor_kwargs" in single_turn_source
+
+    tool_source = TOOL_AGENT_LOOP_SOURCE.read_text(encoding="utf-8")
+    assert "audio_data=agent_data.audio_data" in tool_source
+    assert "mm_processor_kwargs=agent_data.mm_processor_kwargs" in tool_source
 
 
 def test_vllm_generate_includes_audio_and_mm_processor_kwargs() -> None:


### PR DESCRIPTION
### What does this PR do?

Fixes the CPU audio server contract test by checking the actual agent loop call sites that forward multimodal kwargs to the fully async LLM client.

The previous assertion looked for `audio_data=audio_data` in `fully_async_rollouter.py`, but that file only wires the client into the agent loop manager. The actual forwarding happens in `single_turn_agent_loop.py` and `tool_agent_loop.py`.

AI assistance was used to prepare this change; I reviewed the changed line and ran the tests below.

### Checklist Before Starting

- [x] Search for similar PRs. Query links: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+audio_data+fully_async, https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+test_audio_server_contract_on_cpu
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `../../.venv/bin/python -m pytest -q tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py` passed (`4 passed`)
- `../../.venv/bin/ruff check tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py` passed
- `../../.venv/bin/ruff format --check tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py` passed

### API and Usage Example

No API changes.

### Design & Code Changes

- Replace the fully async contract test target from `fully_async_rollouter.py` to the actual single-turn and tool agent loop files.
- Keep the audio and `mm_processor_kwargs` forwarding assertions explicit for both default agent loop paths.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [ ] Apply pre-commit checks: not run across the whole repository; targeted ruff checks passed for the changed file.
- [ ] Add / Update documentation: not applicable; test-only fix.
- [x] Add / Update tests: this PR fixes an existing CPU unit test contract.
- [ ] Request CI in Slack/Feishu after PR creation if needed.
- [ ] Recipe submodule update: not applicable.

Duplicate-work check: I did not find an open PR for `audio_data fully_async`, `test_audio_server_contract_on_cpu`, or `FullyAsyncLLMServerClient audio`.