### PR TITLE
[rollout] Continuous Token Builder Core

### DIFF
--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -322,6 +322,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -288,6 +288,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -295,6 +295,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -300,6 +300,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,7 +225,7 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5, gemma4, gptoss
     model_family: auto
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,12 +225,8 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
     model_family: auto
-
-    # Optional Python module to import before creating the Continuous Token builder.
-    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
-    custom_builder_module: null
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -214,6 +214,24 @@ multi_turn:
   # - ignore_strippable: ignore strippable tokens when checking tokenization sanity
   tokenization_sanity_check_mode: strict
 
+  # Continuous Token keeps the runtime token stream across multi-turn rollout instead of
+  # reconstructing previous assistant turns from text. Disabled by default for compatibility.
+  continuous_token:
+
+    # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+    _target_: verl.workers.config.ContinuousTokenConfig
+
+    # Enable Continuous Token for multi-turn agent rollout.
+    enable: False
+
+    # Model-family specific boundary handling. auto infers from model path/tokenizer name.
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    model_family: auto
+
+    # Optional Python module to import before creating the Continuous Token builder.
+    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
+    custom_builder_module: null
+
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes
 

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -81,16 +82,24 @@ class ContinuousTokenBuilder:
         self._assert_append_only(previous_messages, updated_messages)
         appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
+        processed_messages: list[dict[str, Any]] = []
 
         for group in self._iter_append_groups(appended_messages):
             role = group[0].get("role")
             if role == "tool":
-                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+                incremental_ids.extend(
+                    self._tokenize_tool_group(
+                        group,
+                        context_messages=previous_messages + processed_messages,
+                        tools=tools,
+                    )
+                )
             elif role in {"user", "system"}:
                 # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
                 incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+            processed_messages.extend(group)
 
         incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
@@ -172,9 +181,10 @@ class ContinuousTokenBuilder:
         self,
         tool_messages: list[dict[str, Any]],
         *,
+        context_messages: list[dict[str, Any]] | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages, context_messages=context_messages)
         return self.render_delta_token_id(
             [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
             tool_messages,
@@ -225,13 +235,19 @@ class ContinuousTokenBuilder:
                     f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
                 )
 
-    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+    def _synthetic_assistant_for_tools(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
         tool_calls = []
-        for tool_message in tool_messages:
+        for index, tool_message in enumerate(tool_messages):
             tool_call = {
                 "type": "function",
                 "function": {
-                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "name": _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
                     "arguments": {},
                 },
             }
@@ -239,6 +255,33 @@ class ContinuousTokenBuilder:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
         return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GPT-OSS tool-response formatting."""
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        del tools
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
+        response_text = "".join(
+            self._format_tool_response(
+                tool_message,
+                _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
+            )
+            for index, tool_message in enumerate(tool_messages)
+        )
+        return self.tokenizer.encode(response_text, add_special_tokens=False)
+
+    @staticmethod
+    def _format_tool_response(tool_message: dict[str, Any], tool_name: str) -> str:
+        content = json.dumps(_stringify_tool_content(tool_message.get("content", "")), ensure_ascii=False)
+        return f"<|start|>functions.{tool_name} to=assistant<|channel|>commentary<|message|>{content}<|end|>"
 
 
 class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
@@ -329,6 +372,38 @@ class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Gemma4 tool-response boundary handling."""
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._tool_response_id = _require_token_id(tokenizer, "<|tool_response>")
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_token_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
+        appended_messages = updated_messages[len(previous_messages) :]
+
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if appended_messages and prefix[-1:] != [self._tool_response_id]:
+            prefix.append(self._tool_response_id)
+            inserted_token_ids.append(self._tool_response_id)
+
+        return MergeResult(
+            token_ids=prefix + appended_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
 def _require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
@@ -340,3 +415,65 @@ def _require_token_id(tokenizer: Any, token: str) -> int:
     if not isinstance(token_id, int) or token_id < 0:
         raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
     return token_id
+
+
+def _stringify_tool_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"
+        )
+    return str(content)
+
+
+def _assistant_tool_call_names(
+    messages: list[dict[str, Any]],
+) -> tuple[dict[str, str], list[str]]:
+    tool_names_by_id: dict[str, str] = {}
+    positional_tool_names: list[str] = []
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            continue
+        names: list[str] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            name = _tool_call_function_name(tool_call)
+            if name is None:
+                continue
+            names.append(name)
+            tool_call_id = tool_call.get("id")
+            if tool_call_id is not None:
+                tool_names_by_id.setdefault(str(tool_call_id), name)
+        if names and not positional_tool_names:
+            positional_tool_names = names
+    return tool_names_by_id, positional_tool_names
+
+
+def _resolve_tool_name(
+    tool_message: dict[str, Any],
+    index: int,
+    tool_names_by_id: dict[str, str],
+    positional_tool_names: list[str],
+) -> str:
+    tool_call_id = tool_message.get("tool_call_id")
+    if tool_call_id is not None and str(tool_call_id) in tool_names_by_id:
+        return tool_names_by_id[str(tool_call_id)]
+    if index < len(positional_tool_names):
+        return positional_tool_names[index]
+    if tool_message.get("name"):
+        return str(tool_message["name"])
+    return "continuous_token_tool"
+
+
+def _tool_call_function_name(tool_call: dict[str, Any]) -> str | None:
+    function = tool_call.get("function")
+    if isinstance(function, dict) and function.get("name") is not None:
+        return str(function["name"])
+    return None

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -74,12 +74,12 @@ class ContinuousTokenBuilder:
     def tokenize_incremental_messages(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        self._assert_append_only(previous_messages, next_messages)
-        appended_messages = next_messages[len(previous_messages) :]
+        self._assert_append_only(previous_messages, updated_messages)
+        appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
 
         for group in self._iter_append_groups(appended_messages):
@@ -92,18 +92,18 @@ class ContinuousTokenBuilder:
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
 
-        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
 
     def merge_tokens(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         runtime_token_ids: list[int],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> MergeResult:
-        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        appended_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
         return self._merge_token_ids(runtime_token_ids, appended_ids)
 
     def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
@@ -212,13 +212,13 @@ class ContinuousTokenBuilder:
     def _assert_append_only(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
     ) -> None:
-        if len(next_messages) < len(previous_messages):
-            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
-        if next_messages[: len(previous_messages)] != previous_messages:
+        if len(updated_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; updated_messages is shorter")
+        if updated_messages[: len(previous_messages)] != previous_messages:
             raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
-        for message in next_messages[len(previous_messages) :]:
+        for message in updated_messages[len(previous_messages) :]:
             role = message.get("role")
             if role not in self.allowed_append_roles:
                 raise ValueError(

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -1,0 +1,350 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+_SUPPORTED_APPEND_ROLES = frozenset({"tool", "user", "system"})
+_SYNTHETIC_SYSTEM_MESSAGE: dict[str, Any] = {"role": "system", "content": "continuous token synthetic system"}
+_SYNTHETIC_USER_MESSAGE: dict[str, Any] = {"role": "user", "content": "continuous token synthetic user"}
+_ASSISTANT_REASONING_CONTENT: str = "reasoning"
+MergeKind = Literal["assistant", "non_assistant"]
+
+
+@dataclass(frozen=True)
+class MergeResult:
+    """Token merge result with the token-level delta needed by callers.
+
+    ``inserted_token_ids`` are CT-created boundary tokens at the merge junction.
+    They are not model-generated tokens and therefore must not carry loss or
+    model logprobs. Generated assistant tokens are represented by
+    ``appended_token_count`` with ``kind="assistant"``.
+    """
+
+    token_ids: list[int]
+    appended_token_count: int
+    kind: MergeKind = "non_assistant"
+    inserted_token_ids: list[int] = field(default_factory=list)
+    removed_prefix_token_count: int = 0
+
+
+class ContinuousTokenBuilder:
+    """Continuous Token builder for runtime prefix reuse."""
+
+    allowed_append_roles: frozenset[str] = _SUPPORTED_APPEND_ROLES
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        *,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        allowed_append_roles: list[str] | tuple[str, ...] | set[str] | None = None,
+    ):
+        self.tokenizer = tokenizer
+        self.chat_template_kwargs = chat_template_kwargs or {}
+        if allowed_append_roles is not None:
+            allowed_roles = frozenset(allowed_append_roles)
+            unknown_roles = allowed_roles - _SUPPORTED_APPEND_ROLES
+            if unknown_roles:
+                raise ValueError(f"Unsupported Continuous Token append roles: {sorted(unknown_roles)}")
+            self.allowed_append_roles = allowed_roles
+
+    def build_initial_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self._render_tokens(messages, add_generation_prompt=True, tools=tools)
+
+    def tokenize_incremental_messages(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        self._assert_append_only(previous_messages, next_messages)
+        appended_messages = next_messages[len(previous_messages) :]
+        incremental_ids: list[int] = []
+
+        for group in self._iter_append_groups(appended_messages):
+            role = group[0].get("role")
+            if role == "tool":
+                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+            elif role in {"user", "system"}:
+                # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
+                incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
+            else:
+                raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+
+        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        return incremental_ids
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        return self._merge_token_ids(runtime_token_ids, appended_ids)
+
+    def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
+        """Append model-generated assistant tokens to the runtime token stream."""
+        merged_token_ids = list(runtime_token_ids) + list(assistant_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(assistant_token_ids),
+            kind="assistant",
+        )
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        """Merge runtime prefix tokens and appended tokens.
+
+        Model-specific builders usually override this hook for boundary handling,
+        such as inserting or trimming tokens at the prefix/appended-token junction.
+        """
+        merged_token_ids = list(runtime_token_ids) + list(appended_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+        )
+
+    def _render_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        from verl.utils.chat_template import apply_chat_template
+        from verl.utils.tokenizer import normalize_token_ids
+
+        tokenized = apply_chat_template(
+            self.tokenizer,
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            **self.chat_template_kwargs,
+        )
+        return normalize_token_ids(tokenized)
+
+    def render_delta_token_id(
+        self,
+        prefix_messages: list[dict[str, Any]],
+        appended_messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool = False,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        """Render prefix/full prompts as token IDs and return the token-level suffix."""
+        prefix_token_ids = self._render_tokens(prefix_messages, add_generation_prompt=False, tools=tools)
+        full_token_ids = self._render_tokens(
+            prefix_messages + appended_messages,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+        )
+        if full_token_ids[: len(prefix_token_ids)] != prefix_token_ids:
+            roles = [message.get("role") for message in appended_messages] or ["generation_prompt"]
+            raise ValueError(f"Continuous Token token-id suffix diff failed for roles: {roles}")
+        return full_token_ids[len(prefix_token_ids) :]
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
+            tool_messages,
+            tools=tools,
+        )
+
+    def _tokenize_single_non_tool(
+        self,
+        message: dict[str, Any],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE],
+            [message],
+            tools=tools,
+        )
+
+    def _iter_append_groups(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+        groups: list[list[dict[str, Any]]] = []
+        index = 0
+        while index < len(appended_messages):
+            role = appended_messages[index].get("role")
+            if role == "tool":
+                end = index + 1
+                while end < len(appended_messages) and appended_messages[end].get("role") == "tool":
+                    end += 1
+                groups.append(appended_messages[index:end])
+                index = end
+            else:
+                groups.append([appended_messages[index]])
+                index += 1
+        return groups
+
+    def _assert_append_only(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+    ) -> None:
+        if len(next_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
+        if next_messages[: len(previous_messages)] != previous_messages:
+            raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
+        for message in next_messages[len(previous_messages) :]:
+            role = message.get("role")
+            if role not in self.allowed_append_roles:
+                raise ValueError(
+                    f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
+                )
+
+    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+        tool_calls = []
+        for tool_message in tool_messages:
+            tool_call = {
+                "type": "function",
+                "function": {
+                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "arguments": {},
+                },
+            }
+            if tool_message.get("tool_call_id") is not None:
+                tool_call["id"] = tool_message["tool_call_id"]
+            tool_calls.append(tool_call)
+        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Qwen ChatML boundary handling.
+
+    Qwen2.5, Qwen3, and Qwen3.5 templates render ``<|im_end|>\n`` after a turn,
+    while generation may stop at ``<|im_end|>``. When the runtime prefix ends
+    there, insert the missing newline before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected Qwen newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._im_end_id = _require_token_id(tokenizer, "<|im_end|>")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._im_end_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
+    """MiniMax boundary handling.
+
+    MiniMax templates render ``[e~[\n`` after a turn, while generation may stop
+    at ``[e~[``. When the runtime prefix ends there, insert the missing newline
+    before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected MiniMax newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._eos_id = _require_token_id(tokenizer, "[e~[")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._eos_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GLM observation/user boundary handling.
+
+    ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and
+    next-message start tokens. If the runtime prefix ends with either, remove
+    that token before appending the next non-assistant segment.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._observation_id = _require_token_id(tokenizer, "<|observation|>")
+        self._user_id = _require_token_id(tokenizer, "<|user|>")
+        self._ambiguous_boundary_ids = {self._observation_id, self._user_id}
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        removed_prefix_token_count = 0
+        if prefix and prefix[-1] in self._ambiguous_boundary_ids:
+            prefix = prefix[:-1]
+            removed_prefix_token_count = 1
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            removed_prefix_token_count=removed_prefix_token_count,
+        )
+
+
+def _require_token_id(tokenizer: Any, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        raise ValueError(f"Tokenizer does not define required token {token!r}")
+    if isinstance(token_id, list):
+        if len(token_id) != 1:
+            raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")
+        token_id = token_id[0]
+    if not isinstance(token_id, int) or token_id < 0:
+        raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
+    return token_id

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -101,7 +101,9 @@ class ContinuousTokenBuilder:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
             processed_messages.extend(group)
 
-        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(
+            self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools)
+        )
         return incremental_ids
 
     def merge_tokens(
@@ -254,7 +256,12 @@ class ContinuousTokenBuilder:
             if tool_message.get("tool_call_id") is not None:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
-        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+        return {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": _ASSISTANT_REASONING_CONTENT,
+            "tool_calls": tool_calls,
+        }
 
 
 class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -271,14 +271,6 @@ class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
-class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
 class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
     """MiniMax boundary handling.
 
@@ -309,7 +301,7 @@ class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
     """GLM observation/user boundary handling.
 
     ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -21,7 +21,9 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
+    Gemma4ContinuousTokenBuilder,
     GLMContinuousTokenBuilder,
+    GptOssContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
@@ -40,6 +42,8 @@ _CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "minimaxm27": MiniMaxContinuousTokenBuilder,
     "glm47": GLMContinuousTokenBuilder,
     "glm5": GLMContinuousTokenBuilder,
+    "gemma4": Gemma4ContinuousTokenBuilder,
+    "gptoss": GptOssContinuousTokenBuilder,
 }
 
 CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
@@ -106,6 +110,12 @@ def infer_continuous_token_model_family(
         return "glm5"
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
+        marker in compact for marker in ("gemma4", "gemma4unified")
+    ):
+        return "gemma4"
+    if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
+        return "gptoss"
     if "minimaxm27" in compact:
         return "minimaxm27"
     if "minimaxm25" in compact:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Continuous Token builder registry and model-family resolution."""
+"""Continuous Token builder factory and model-family resolution."""
 
 from __future__ import annotations
 
@@ -21,115 +21,43 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
-    GLM47ContinuousTokenBuilder,
+    GLMContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
-    Qwen35ContinuousTokenBuilder,
-    Qwen3ContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
-from verl.utils.import_utils import import_external_libs
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "default": ContinuousTokenBuilder,
     "qwen": QwenContinuousTokenBuilder,
     "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": Qwen3ContinuousTokenBuilder,
-    "qwen35": Qwen35ContinuousTokenBuilder,
+    "qwen3": QwenContinuousTokenBuilder,
+    "qwen35": QwenContinuousTokenBuilder,
     "minimax": MiniMaxContinuousTokenBuilder,
-    "glm47": GLM47ContinuousTokenBuilder,
+    "minimaxm2": MiniMaxContinuousTokenBuilder,
+    "minimaxm25": MiniMaxContinuousTokenBuilder,
+    "minimaxm27": MiniMaxContinuousTokenBuilder,
+    "glm47": GLMContinuousTokenBuilder,
+    "glm5": GLMContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
-CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
-
-_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
-
-
-class ContinuousTokenBuilderRegistry:
-    """Registry for Continuous Token builder classes.
-
-    Custom builders can be registered from an imported Python module:
-
-    .. code-block:: python
-
-        @ContinuousTokenBuilderRegistry.register("deepseek")
-        class DeepseekContinuousTokenBuilder:
-            ...
-    """
-
-    _registry: dict[str, type[Any]] = {}
-
-    @classmethod
-    def register(cls, model_family: str, *, exist_ok: bool = False):
-        family = _normalize_model_family(model_family)
-        if family in _RESERVED_MODEL_FAMILIES:
-            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
-
-        def decorator(builder_cls: type[Any]) -> type[Any]:
-            if not isinstance(builder_cls, type):
-                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
-
-            existing = cls._registry.get(family)
-            if existing is not None and existing is not builder_cls and not exist_ok:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is already registered with "
-                    f"{existing}; pass exist_ok=True to replace it"
-                )
-            cls._registry[family] = builder_cls
-            return builder_cls
-
-        return decorator
-
-    @classmethod
-    def get(cls, model_family: str) -> type[Any]:
-        family = _normalize_model_family(model_family)
-        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
-            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
-            if builder_cls is None:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
-                    "but its builder class has not been implemented yet."
-                )
-            return builder_cls
-        try:
-            return cls._registry[family]
-        except KeyError as exc:
-            raise ValueError(
-                f"Unknown Continuous Token builder family {family!r}. "
-                f"Registered families: {sorted(cls._registry)}. "
-                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
-            ) from exc
-
-    @classmethod
-    def registered_families(cls) -> tuple[str, ...]:
-        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
-
-
-def register_continuous_token_builder(
-    model_family: str,
-    builder_cls: type[Any] | None = None,
-    *,
-    exist_ok: bool = False,
-):
-    """Register a Continuous Token builder class for a model family.
-
-    This wrapper supports both direct calls and decorator usage. New code should
-    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
-    """
-    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
-    if builder_cls is None:
-        return decorator
-    return decorator(builder_cls)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
 def get_continuous_token_builder_class(model_family: str) -> type[Any]:
-    return ContinuousTokenBuilderRegistry.get(model_family)
+    family = _normalize_model_family(model_family)
+    try:
+        return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token builder family {family!r}. "
+            f"Supported families: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+        ) from exc
 
 
 def list_continuous_token_builder_families() -> tuple[str, ...]:
-    return ContinuousTokenBuilderRegistry.registered_families()
+    return CONTINUOUS_TOKEN_BUILDER_FAMILIES
 
 
 def resolve_continuous_token_model_family(
@@ -139,7 +67,7 @@ def resolve_continuous_token_model_family(
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
 ) -> str:
-    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
     if family != "auto":
         logger.info("Using explicit Continuous Token builder family: %s", family)
@@ -174,17 +102,24 @@ def infer_continuous_token_model_family(
     haystack = " ".join(str(item).lower() for item in candidates if item)
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
-    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
-        marker in compact for marker in ("glm47", "glm5")
-    ):
+    if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
+        return "glm5"
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if "minimaxm27" in compact:
+        return "minimaxm27"
+    if "minimaxm25" in compact:
+        return "minimaxm25"
+    if "minimaxm2" in compact:
+        return "minimaxm2"
     if "minimax" in compact:
         return "minimax"
-    if (
-        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
-        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
-    ):
-        return "qwen"
+    if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
+        return "qwen35"
+    if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
+        return "qwen25"
+    if "qwen3" in compact:
+        return "qwen3"
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
@@ -201,11 +136,9 @@ def create_continuous_token_builder(
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
-    custom_builder_module: str | list[str] | None = None,
     **builder_kwargs: Any,
 ) -> Any:
     """Instantiate the registered builder selected by config/model metadata."""
-    import_external_libs(custom_builder_module)
     resolved_family = resolve_continuous_token_model_family(
         model_family,
         model_path=model_path,
@@ -220,7 +153,10 @@ def create_continuous_token_builder(
 def _normalize_model_family(model_family: str) -> str:
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return model_family.lower()
+    family = model_family.strip().lower()
+    if not family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return re.sub(r"[^a-z0-9]+", "", family)
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,9 +15,9 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
 import logging
 import re
+from enum import StrEnum
 from typing import Any
 
 from verl.utils.continuous_token import (

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -185,6 +185,12 @@ def infer_continuous_token_model_family(
         or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
     ):
         return "qwen"
+    logger.warning(
+        "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
+        "falling back to the default ContinuousTokenBuilder.",
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
     return "default"
 
 

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 import logging
 import re
 from typing import Any
@@ -30,26 +31,44 @@ from verl.utils.continuous_token import (
 
 logger = logging.getLogger(__name__)
 
-_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
-    "default": ContinuousTokenBuilder,
-    "qwen": QwenContinuousTokenBuilder,
-    "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": QwenContinuousTokenBuilder,
-    "qwen35": QwenContinuousTokenBuilder,
-    "minimax": MiniMaxContinuousTokenBuilder,
-    "minimaxm2": MiniMaxContinuousTokenBuilder,
-    "minimaxm25": MiniMaxContinuousTokenBuilder,
-    "minimaxm27": MiniMaxContinuousTokenBuilder,
-    "glm47": GLMContinuousTokenBuilder,
-    "glm5": GLMContinuousTokenBuilder,
-    "gemma4": Gemma4ContinuousTokenBuilder,
-    "gptoss": GptOssContinuousTokenBuilder,
+
+class ContinuousTokenModelFamily(StrEnum):
+    AUTO = "auto"
+    DEFAULT = "default"
+    QWEN = "qwen"
+    QWEN25 = "qwen25"
+    QWEN3 = "qwen3"
+    QWEN35 = "qwen35"
+    MINIMAX = "minimax"
+    MINIMAX_M2 = "minimaxm2"
+    MINIMAX_M25 = "minimaxm25"
+    MINIMAX_M27 = "minimaxm27"
+    GLM47 = "glm47"
+    GLM5 = "glm5"
+    GEMMA4 = "gemma4"
+    GPTOSS = "gptoss"
+
+
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[ContinuousTokenModelFamily, type[Any]] = {
+    ContinuousTokenModelFamily.DEFAULT: ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN25: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN3: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN35: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M2: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M25: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M27: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM47: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM5: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GEMMA4: Gemma4ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GPTOSS: GptOssContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(family.value for family in _CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
-def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+def get_continuous_token_builder_class(model_family: str | ContinuousTokenModelFamily) -> type[Any]:
     family = _normalize_model_family(model_family)
     try:
         return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
@@ -65,15 +84,15 @@ def list_continuous_token_builder_families() -> tuple[str, ...]:
 
 
 def resolve_continuous_token_model_family(
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     *,
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
-    if family != "auto":
+    if family != ContinuousTokenModelFamily.AUTO:
         logger.info("Using explicit Continuous Token builder family: %s", family)
         return family
 
@@ -96,7 +115,7 @@ def infer_continuous_token_model_family(
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Infer a built-in model family from model/tokenizer names.
 
     Unknown models intentionally fall back to ``default`` so enabling
@@ -107,42 +126,42 @@ def infer_continuous_token_model_family(
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
     if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
-        return "glm5"
+        return ContinuousTokenModelFamily.GLM5
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
-        return "glm47"
+        return ContinuousTokenModelFamily.GLM47
     if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
         marker in compact for marker in ("gemma4", "gemma4unified")
     ):
-        return "gemma4"
+        return ContinuousTokenModelFamily.GEMMA4
     if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
-        return "gptoss"
+        return ContinuousTokenModelFamily.GPTOSS
     if "minimaxm27" in compact:
-        return "minimaxm27"
+        return ContinuousTokenModelFamily.MINIMAX_M27
     if "minimaxm25" in compact:
-        return "minimaxm25"
+        return ContinuousTokenModelFamily.MINIMAX_M25
     if "minimaxm2" in compact:
-        return "minimaxm2"
+        return ContinuousTokenModelFamily.MINIMAX_M2
     if "minimax" in compact:
-        return "minimax"
+        return ContinuousTokenModelFamily.MINIMAX
     if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
-        return "qwen35"
+        return ContinuousTokenModelFamily.QWEN35
     if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
-        return "qwen25"
+        return ContinuousTokenModelFamily.QWEN25
     if "qwen3" in compact:
-        return "qwen3"
+        return ContinuousTokenModelFamily.QWEN3
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
         model_path,
         tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
     )
-    return "default"
+    return ContinuousTokenModelFamily.DEFAULT
 
 
 def create_continuous_token_builder(
     tokenizer: Any,
     *,
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
@@ -160,13 +179,22 @@ def create_continuous_token_builder(
     return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
 
 
-def _normalize_model_family(model_family: str) -> str:
+def _normalize_model_family(model_family: str | ContinuousTokenModelFamily) -> ContinuousTokenModelFamily:
+    if isinstance(model_family, ContinuousTokenModelFamily):
+        return model_family
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
     family = model_family.strip().lower()
     if not family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return re.sub(r"[^a-z0-9]+", "", family)
+    family = re.sub(r"[^a-z0-9]+", "", family)
+    try:
+        return ContinuousTokenModelFamily(family)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token model_family {model_family!r}. "
+            f"Supported families: {(ContinuousTokenModelFamily.AUTO.value, *CONTINUOUS_TOKEN_BUILDER_FAMILIES)}."
+        ) from exc
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -1,0 +1,229 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder registry and model-family resolution."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from verl.utils.continuous_token import (
+    ContinuousTokenBuilder,
+    GLM47ContinuousTokenBuilder,
+    MiniMaxContinuousTokenBuilder,
+    Qwen35ContinuousTokenBuilder,
+    Qwen3ContinuousTokenBuilder,
+    QwenContinuousTokenBuilder,
+)
+from verl.utils.import_utils import import_external_libs
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+    "default": ContinuousTokenBuilder,
+    "qwen": QwenContinuousTokenBuilder,
+    "qwen25": QwenContinuousTokenBuilder,
+    "qwen3": Qwen3ContinuousTokenBuilder,
+    "qwen35": Qwen35ContinuousTokenBuilder,
+    "minimax": MiniMaxContinuousTokenBuilder,
+    "glm47": GLM47ContinuousTokenBuilder,
+}
+
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
+
+_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
+
+
+class ContinuousTokenBuilderRegistry:
+    """Registry for Continuous Token builder classes.
+
+    Custom builders can be registered from an imported Python module:
+
+    .. code-block:: python
+
+        @ContinuousTokenBuilderRegistry.register("deepseek")
+        class DeepseekContinuousTokenBuilder:
+            ...
+    """
+
+    _registry: dict[str, type[Any]] = {}
+
+    @classmethod
+    def register(cls, model_family: str, *, exist_ok: bool = False):
+        family = _normalize_model_family(model_family)
+        if family in _RESERVED_MODEL_FAMILIES:
+            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
+
+        def decorator(builder_cls: type[Any]) -> type[Any]:
+            if not isinstance(builder_cls, type):
+                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
+
+            existing = cls._registry.get(family)
+            if existing is not None and existing is not builder_cls and not exist_ok:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is already registered with "
+                    f"{existing}; pass exist_ok=True to replace it"
+                )
+            cls._registry[family] = builder_cls
+            return builder_cls
+
+        return decorator
+
+    @classmethod
+    def get(cls, model_family: str) -> type[Any]:
+        family = _normalize_model_family(model_family)
+        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
+            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+            if builder_cls is None:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
+                    "but its builder class has not been implemented yet."
+                )
+            return builder_cls
+        try:
+            return cls._registry[family]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown Continuous Token builder family {family!r}. "
+                f"Registered families: {sorted(cls._registry)}. "
+                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+            ) from exc
+
+    @classmethod
+    def registered_families(cls) -> tuple[str, ...]:
+        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
+
+
+def register_continuous_token_builder(
+    model_family: str,
+    builder_cls: type[Any] | None = None,
+    *,
+    exist_ok: bool = False,
+):
+    """Register a Continuous Token builder class for a model family.
+
+    This wrapper supports both direct calls and decorator usage. New code should
+    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
+    """
+    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
+    if builder_cls is None:
+        return decorator
+    return decorator(builder_cls)
+
+
+def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+    return ContinuousTokenBuilderRegistry.get(model_family)
+
+
+def list_continuous_token_builder_families() -> tuple[str, ...]:
+    return ContinuousTokenBuilderRegistry.registered_families()
+
+
+def resolve_continuous_token_model_family(
+    model_family: str,
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    family = _normalize_model_family(model_family)
+    if family != "auto":
+        logger.info("Using explicit Continuous Token builder family: %s", family)
+        return family
+
+    resolved = infer_continuous_token_model_family(
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    logger.info(
+        "Resolved Continuous Token builder family from auto: %s (model_path=%r, tokenizer_name_or_path=%r)",
+        resolved,
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
+    return resolved
+
+
+def infer_continuous_token_model_family(
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Infer a built-in model family from model/tokenizer names.
+
+    Unknown models intentionally fall back to ``default`` so enabling
+    ``model_family=auto`` remains conservative.
+    """
+    candidates = [model_path, tokenizer_name_or_path, _tokenizer_name_or_path(tokenizer)]
+    haystack = " ".join(str(item).lower() for item in candidates if item)
+    compact = re.sub(r"[^a-z0-9]+", "", haystack)
+
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
+        marker in compact for marker in ("glm47", "glm5")
+    ):
+        return "glm47"
+    if "minimax" in compact:
+        return "minimax"
+    if (
+        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
+        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
+    ):
+        return "qwen"
+    return "default"
+
+
+def create_continuous_token_builder(
+    tokenizer: Any,
+    *,
+    model_family: str,
+    model_path: str | None = None,
+    tokenizer_name_or_path: str | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    custom_builder_module: str | list[str] | None = None,
+    **builder_kwargs: Any,
+) -> Any:
+    """Instantiate the registered builder selected by config/model metadata."""
+    import_external_libs(custom_builder_module)
+    resolved_family = resolve_continuous_token_model_family(
+        model_family,
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    builder_cls = get_continuous_token_builder_class(resolved_family)
+    logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
+    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+
+
+def _normalize_model_family(model_family: str) -> str:
+    if not isinstance(model_family, str) or not model_family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return model_family.lower()
+
+
+def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:
+    if tokenizer is None:
+        return None
+    name = getattr(tokenizer, "name_or_path", None)
+    if name:
+        return str(name)
+    init_kwargs = getattr(tokenizer, "init_kwargs", None)
+    if isinstance(init_kwargs, dict) and init_kwargs.get("name_or_path"):
+        return str(init_kwargs["name_or_path"])
+    return None

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,12 +18,19 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
+from verl.utils.continuous_token_wiring import (
+    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
+    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
+)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
+    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
+    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
+    "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
     "AgentLoopConfig",
@@ -45,6 +52,17 @@ class SamplingConfig(BaseConfig):
 
 
 @dataclass
+class ContinuousTokenConfig(BaseConfig):
+    enable: bool = False
+    model_family: str = "auto"
+    custom_builder_module: Optional[str] = None
+
+    def __post_init__(self):
+        if not isinstance(self.model_family, str) or not self.model_family:
+            raise ValueError("continuous_token.model_family must be a non-empty string")
+
+
+@dataclass
 class MultiTurnConfig(BaseConfig):
     _mutable_fields = {"max_assistant_turns", "max_user_turns"}
 
@@ -58,6 +76,7 @@ class MultiTurnConfig(BaseConfig):
     tool_response_truncate_side: str = "middle"
     use_inference_chat_template: bool = False
     tokenization_sanity_check_mode: str = "strict"
+    continuous_token: ContinuousTokenConfig = field(default_factory=ContinuousTokenConfig)
     format: str = "hermes"
     num_repeat_rollouts: Optional[int] = None
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,18 +18,12 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
-from verl.utils.continuous_token_wiring import (
-    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
-    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
-)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
-    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
-    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
     "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
@@ -55,7 +49,6 @@ class SamplingConfig(BaseConfig):
 class ContinuousTokenConfig(BaseConfig):
     enable: bool = False
     model_family: str = "auto"
-    custom_builder_module: Optional[str] = None
 
     def __post_init__(self):
         if not isinstance(self.model_family, str) or not self.model_family:


### PR DESCRIPTION
### What does this PR do?

This PR adds the core Continuous Token builder layer and rollout config surface. The new builder keeps a runtime token stream append-only across turns, so AgentLoop code can preserve generated assistant tokens and append tool/user/system messages without repeatedly reconstructing previous assistant text.

Continuous Token is disabled by default. Existing rollout behavior is unchanged unless `multi_turn.continuous_token.enable` is set to `True`.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes


#### Main Changes

- Adds `MergeResult` to report appended token count, assistant vs non-assistant merge kind, inserted boundary tokens, and removed prefix tokens.
- Adds `ContinuousTokenBuilder` with initial prompt rendering, append-only message validation, incremental non-assistant tokenization, assistant token appending, and token-level suffix diffing.
- Adds model-family-specific builders for known chat-template boundary behavior:
  - Qwen/Qwen2.5/Qwen3/Qwen3.5: inserts the missing newline after `<|im_end|>` before appending the next non-assistant segment.
  - MiniMax: inserts the missing newline after `[e~[` before appending the next segment.
  - GLM-4.7/GLM-5: removes ambiguous trailing `<|observation|>` or `<|user|>` when that token is both an assistant stop token and the next message boundary.
- Adds a registry and `auto` model-family resolver so built-in and custom builders can be selected from config/model metadata.
- Adds rollout config fields for enabling CT, selecting the model family, and importing a custom builder module.

#### Changed Files

- `verl/utils/continuous_token.py`
  - New core builder implementation.
  - Defines `MergeResult`, `ContinuousTokenBuilder`, Qwen, MiniMax, and GLM builders.
  - Handles tool-message grouping, synthetic context for tool responses, assistant token appends, and boundary token insert/remove metadata.

- `verl/utils/continuous_token_wiring.py`
  - New builder registry and factory.
  - Defines built-in families: `default`, `qwen`, `qwen25`, `qwen3`, `qwen35`, `minimax`, `glm47`.
  - Adds `model_family=auto` inference from model path/tokenizer name.
  - Supports custom builder registration through `custom_builder_module`.

- `verl/workers/config/rollout.py`
  - Adds `ContinuousTokenConfig`.
  - Adds `MultiTurnConfig.continuous_token`.
  - Exposes CT family option constants in `__all__`.

- `verl/trainer/config/rollout/rollout.yaml`
  - Adds the YAML config block:
    - `multi_turn.continuous_token.enable`
    - `multi_turn.continuous_token.model_family`
    - `multi_turn.continuous_token.custom_builder_module`

#### Notes

This PR only introduces the reusable CT builder/config foundation. It does not yet route AgentLoop execution through CT; that integration is added in PR 02.

#### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
