### PR TITLE
[rollout] Agent Loop Integration

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -307,7 +307,7 @@ class AgentLoopBase(ABC):
     async def ct_merge_non_assistant_msg(
         self,
         previous_messages: list[dict],
-        next_messages: list[dict],
+        updated_messages: list[dict],
         runtime_token_ids: list[int],
         response_mask: list[int],
         response_logprobs: Optional[list[float]] = None,
@@ -317,7 +317,7 @@ class AgentLoopBase(ABC):
             None,
             lambda: self.continuous_token_builder.merge_tokens(
                 previous_messages,
-                next_messages,
+                updated_messages,
                 runtime_token_ids,
                 tools=tools,
             ),

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -293,7 +293,7 @@ class AgentLoopBase(ABC):
 
         return multi_modal_data
 
-    async def ct_build_initial_prompt(
+    async def ct_build_initial_tokens(
         self,
         messages: list[dict],
         tools: list[dict] = None,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -297,6 +297,7 @@ class AgentLoopBase(ABC):
         messages: list[dict],
         tools: list[dict] = None,
     ) -> list[int]:
+        """Build the initial prompt token ids with Continuous Token."""
         prompt_ids = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.build_initial_tokens(messages, tools=tools),
@@ -312,6 +313,7 @@ class AgentLoopBase(ABC):
         response_logprobs: Optional[list[float]] = None,
         tools: list[dict] = None,
     ):
+        """Merge appended non-assistant messages into runtime tokens and metadata."""
         merge_result = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.merge_tokens(
@@ -334,6 +336,7 @@ class AgentLoopBase(ABC):
         response_logprobs: Optional[list[float]] = None,
         assistant_logprobs: Optional[list[float]] = None,
     ):
+        """Append assistant-generated tokens and align response metadata."""
         merge_result = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.append_assistant_tokens(
@@ -357,6 +360,7 @@ class AgentLoopBase(ABC):
         *,
         assistant_logprobs: Optional[list[float]] = None,
     ) -> tuple[list[int], Optional[list[float]]]:
+        """Align response masks and logprobs after a Continuous Token merge."""
         aligned_mask = list(response_mask)
         aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
         if aligned_logprobs is None and assistant_logprobs is not None:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -361,7 +361,7 @@ class AgentLoopBase(ABC):
         aligned_mask = list(response_mask)
         aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
         if aligned_logprobs is None and assistant_logprobs is not None:
-            aligned_logprobs = []
+            raise ValueError("response_logprobs is required when assistant_logprobs is provided")
 
         if merge_result.removed_prefix_token_count:
             aligned_mask = aligned_mask[: -merge_result.removed_prefix_token_count]

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -293,7 +293,7 @@ class AgentLoopBase(ABC):
 
         return multi_modal_data
 
-    async def build_ct_initial_prompt(
+    async def ct_build_initial_prompt(
         self,
         messages: list[dict],
         tools: list[dict] = None,
@@ -304,7 +304,7 @@ class AgentLoopBase(ABC):
         )
         return self._cap_text_prompt_length(prompt_ids)
 
-    async def merge_ct_non_assistant_msg(
+    async def ct_merge_non_assistant_msg(
         self,
         previous_messages: list[dict],
         next_messages: list[dict],
@@ -322,12 +322,12 @@ class AgentLoopBase(ABC):
                 tools=tools,
             ),
         )
-        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+        aligned_response_mask, aligned_response_logprobs = self.ct_align_response_metadata(
             merge_result, response_mask, response_logprobs
         )
         return merge_result, aligned_response_mask, aligned_response_logprobs
 
-    async def merge_ct_assistant_token(
+    async def ct_merge_assistant_token(
         self,
         runtime_token_ids: list[int],
         assistant_token_ids: list[int],
@@ -342,7 +342,7 @@ class AgentLoopBase(ABC):
                 assistant_token_ids,
             ),
         )
-        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+        aligned_response_mask, aligned_response_logprobs = self.ct_align_response_metadata(
             merge_result,
             response_mask,
             response_logprobs,
@@ -351,7 +351,7 @@ class AgentLoopBase(ABC):
         return merge_result, aligned_response_mask, aligned_response_logprobs
 
     @staticmethod
-    def _align_continuous_token_response_metadata(
+    def ct_align_response_metadata(
         merge_result: MergeResult,
         response_mask: list[int],
         response_logprobs: Optional[list[float]] = None,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -237,7 +237,6 @@ class AgentLoopBase(ABC):
                 model_path=model_config.path,
                 tokenizer_name_or_path=model_config.tokenizer_path,
                 chat_template_kwargs=self.apply_chat_template_kwargs,
-                custom_builder_module=continuous_token_config.custom_builder_module,
             )
             self.enable_continuous_token = True
             # Continuous Token doesn't use the legacy removable system prompt.

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -51,6 +51,8 @@ from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.utils.chat_template import apply_chat_template, initialize_system_prompt
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.continuous_token import MergeResult
+from verl.utils.continuous_token_wiring import create_continuous_token_builder
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
@@ -225,7 +227,24 @@ class AgentLoopBase(ABC):
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
         self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
         processing_class = self.processor if self.processor is not None else self.tokenizer
-        self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
+        self.continuous_token_builder = None
+        continuous_token_config = self.rollout_config.multi_turn.continuous_token
+        if continuous_token_config.enable and self.processor is None:
+            model_config = self.config.actor_rollout_ref.model
+            self.continuous_token_builder = create_continuous_token_builder(
+                self.tokenizer,
+                model_family=continuous_token_config.model_family,
+                model_path=model_config.path,
+                tokenizer_name_or_path=model_config.tokenizer_path,
+                chat_template_kwargs=self.apply_chat_template_kwargs,
+                custom_builder_module=continuous_token_config.custom_builder_module,
+            )
+        elif continuous_token_config.enable:
+            logger.warning("Continuous Token is enabled but processor is set; falling back to legacy multimodal path.")
+        if self.continuous_token_builder is not None:
+            self.system_prompt = []
+        else:
+            self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 
     def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
@@ -269,6 +288,120 @@ class AgentLoopBase(ABC):
                 multi_modal_data["audios"] = audios
 
         return multi_modal_data
+
+    async def build_ct_initial_prompt(
+        self,
+        messages: list[dict],
+        tools: list[dict] = None,
+    ) -> list[int]:
+        prompt_ids = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.build_initial_tokens(messages, tools=tools),
+        )
+        return self._cap_text_prompt_length(prompt_ids)
+
+    async def merge_ct_non_assistant_msg(
+        self,
+        previous_messages: list[dict],
+        next_messages: list[dict],
+        runtime_token_ids: list[int],
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        tools: list[dict] = None,
+    ):
+        merge_result = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.merge_tokens(
+                previous_messages,
+                next_messages,
+                runtime_token_ids,
+                tools=tools,
+            ),
+        )
+        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+            merge_result, response_mask, response_logprobs
+        )
+        return merge_result, aligned_response_mask, aligned_response_logprobs
+
+    async def merge_ct_assistant_token(
+        self,
+        runtime_token_ids: list[int],
+        assistant_token_ids: list[int],
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        assistant_logprobs: Optional[list[float]] = None,
+    ):
+        merge_result = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.append_assistant_tokens(
+                runtime_token_ids,
+                assistant_token_ids,
+            ),
+        )
+        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+            merge_result,
+            response_mask,
+            response_logprobs,
+            assistant_logprobs=assistant_logprobs,
+        )
+        return merge_result, aligned_response_mask, aligned_response_logprobs
+
+    @staticmethod
+    def _align_continuous_token_response_metadata(
+        merge_result: MergeResult,
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        *,
+        assistant_logprobs: Optional[list[float]] = None,
+    ) -> tuple[list[int], Optional[list[float]]]:
+        aligned_mask = list(response_mask)
+        aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
+        if aligned_logprobs is None and assistant_logprobs is not None:
+            aligned_logprobs = []
+
+        if merge_result.removed_prefix_token_count:
+            aligned_mask = aligned_mask[: -merge_result.removed_prefix_token_count]
+            if aligned_logprobs is not None:
+                aligned_logprobs = aligned_logprobs[: -merge_result.removed_prefix_token_count]
+
+        # Inserted tokens are CT-created boundary tokens, not tokens generated by the model.
+        inserted_token_count = len(merge_result.inserted_token_ids)
+        aligned_mask += [0] * inserted_token_count
+        if aligned_logprobs is not None:
+            aligned_logprobs += [0.0] * inserted_token_count
+
+        if merge_result.kind == "assistant":
+            aligned_mask += [1] * merge_result.appended_token_count
+            if aligned_logprobs is not None:
+                if assistant_logprobs is None:
+                    if merge_result.appended_token_count:
+                        raise ValueError("assistant_logprobs is required for assistant Continuous Token alignment")
+                    assistant_logprobs = []
+                if len(assistant_logprobs) != merge_result.appended_token_count:
+                    raise ValueError(
+                        "assistant_logprobs length must match appended assistant token count, "
+                        f"got {len(assistant_logprobs)} and {merge_result.appended_token_count}"
+                    )
+                aligned_logprobs += list(assistant_logprobs)
+        elif merge_result.kind == "non_assistant":
+            aligned_mask += [0] * merge_result.appended_token_count
+            if aligned_logprobs is not None:
+                aligned_logprobs += [0.0] * merge_result.appended_token_count
+        else:
+            raise ValueError(f"Unknown Continuous Token merge kind: {merge_result.kind!r}")
+
+        return aligned_mask, aligned_logprobs
+
+    def _cap_text_prompt_length(self, prompt_ids: list[int]) -> list[int]:
+        prompt_length = self.rollout_config.prompt_length
+        if len(prompt_ids) > prompt_length:
+            logger.warning(
+                "Prompt of %d tokens exceeds rollout.prompt_length=%d; left-truncating.",
+                len(prompt_ids),
+                prompt_length,
+            )
+            return prompt_ids[-prompt_length:]
+        return prompt_ids
 
     async def apply_chat_template(
         self,
@@ -349,12 +482,7 @@ class AgentLoopBase(ABC):
                     f"(e.g. ``total_pixels`` / ``max_pixels`` / fps / number of frames) or "
                     f"increase ``rollout.prompt_length``."
                 )
-            logger.warning(
-                "Prompt of %d tokens exceeds rollout.prompt_length=%d; left-truncating.",
-                len(prompt_ids),
-                prompt_length,
-            )
-            prompt_ids = prompt_ids[-prompt_length:]
+            prompt_ids = self._cap_text_prompt_length(prompt_ids)
 
         return prompt_ids
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -226,8 +226,8 @@ class AgentLoopBase(ABC):
         self.data_config = data_config.config
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
         self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
-        processing_class = self.processor if self.processor is not None else self.tokenizer
         self.continuous_token_builder = None
+        self.enable_continuous_token = False
         continuous_token_config = self.rollout_config.multi_turn.continuous_token
         if continuous_token_config.enable and self.processor is None:
             model_config = self.config.actor_rollout_ref.model
@@ -239,11 +239,15 @@ class AgentLoopBase(ABC):
                 chat_template_kwargs=self.apply_chat_template_kwargs,
                 custom_builder_module=continuous_token_config.custom_builder_module,
             )
-        elif continuous_token_config.enable:
-            logger.warning("Continuous Token is enabled but processor is set; falling back to legacy multimodal path.")
-        if self.continuous_token_builder is not None:
-            self.system_prompt = []
+            self.enable_continuous_token = True
+            # Continuous Token doesn't use the legacy removable system prompt.
+            self.system_prompt = None
         else:
+            if continuous_token_config.enable and self.processor is not None:
+                logger.warning(
+                    "Continuous Token is enabled but processor is set; falling back to legacy multimodal path."
+                )
+            processing_class = self.processor if self.processor is not None else self.tokenizer
             self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -48,7 +48,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         # 2. apply chat template and tokenize
         use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
-            prompt_ids = await self.ct_build_initial_prompt(messages)
+            prompt_ids = await self.ct_build_initial_tokens(messages)
         else:
             prompt_ids = await self.apply_chat_template(
                 messages,

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -46,7 +46,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
-        use_continuous_token = self.continuous_token_builder is not None and not multi_modal_data
+        use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
             prompt_ids = await self.build_ct_initial_prompt(messages)
         else:

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -46,13 +46,17 @@ class SingleTurnAgentLoop(AgentLoopBase):
         mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
-        prompt_ids = await self.apply_chat_template(
-            messages,
-            images=images,
-            videos=videos,
-            audios=audios,
-            mm_processor_kwargs=mm_processor_kwargs,
-        )
+        use_continuous_token = self.continuous_token_builder is not None and not multi_modal_data
+        if use_continuous_token:
+            prompt_ids = await self.build_ct_initial_prompt(messages)
+        else:
+            prompt_ids = await self.apply_chat_template(
+                messages,
+                images=images,
+                videos=videos,
+                audios=audios,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
 
         # 3. generate sequences
         metrics = {}
@@ -68,13 +72,27 @@ class SingleTurnAgentLoop(AgentLoopBase):
             )
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
-        response_mask = [1] * len(output.token_ids)
+
+        if use_continuous_token:
+            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+                prompt_ids,
+                output.token_ids,
+                [],
+                [] if output.log_probs else None,
+                assistant_logprobs=output.log_probs if output.log_probs else None,
+            )
+            response_ids = merge_result.token_ids[-len(response_mask) :] if response_mask else []
+            prompt_ids = merge_result.token_ids[: len(merge_result.token_ids) - len(response_mask)]
+        else:
+            response_ids = output.token_ids
+            response_mask = [1] * len(output.token_ids)
+            response_logprobs = output.log_probs
 
         output: AgentLoopOutput = AgentLoopOutput(
             prompt_ids=prompt_ids,
-            response_ids=output.token_ids[: self.response_length],
+            response_ids=response_ids[: self.response_length],
             response_mask=response_mask[: self.response_length],
-            response_logprobs=output.log_probs[: self.response_length] if output.log_probs else None,
+            response_logprobs=response_logprobs[: self.response_length] if response_logprobs else None,
             routed_experts=(
                 output.routed_experts[: len(prompt_ids) + self.response_length]
                 if output.routed_experts is not None

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -48,7 +48,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         # 2. apply chat template and tokenize
         use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
-            prompt_ids = await self.build_ct_initial_prompt(messages)
+            prompt_ids = await self.ct_build_initial_prompt(messages)
         else:
             prompt_ids = await self.apply_chat_template(
                 messages,
@@ -74,7 +74,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
 
         if use_continuous_token:
-            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_assistant_token(
                 prompt_ids,
                 output.token_ids,
                 [],

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -309,8 +309,10 @@ class ToolAgentLoop(AgentLoopBase):
         previous_messages = list(agent_data.messages)
 
         tasks = []
+        tool_call_names = []
         for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
+            tool_call_names.append(tool_call.name)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
@@ -339,7 +341,7 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            message["name"] = tool_call.name
+            message["name"] = tool_call_names[tool_index]
             if tool_call.tool_call_id is not None:
                 message["tool_call_id"] = tool_call.tool_call_id
 
@@ -391,7 +393,7 @@ class ToolAgentLoop(AgentLoopBase):
             return AgentState.GENERATING
         elif self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
@@ -400,11 +402,11 @@ class ToolAgentLoop(AgentLoopBase):
             # assistant tool_call message. Manually format the response tokens.
             # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
             parts = []
-            for msg in add_messages:
+            for msg, name in zip(add_messages, tool_call_names, strict=True):
                 content = msg.get("content", "")
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+                parts.append(f'<|tool_response>response:{name}{{value:<|"|>{content}<|"|>}}<tool_response|>')
             tool_response_text = "".join(parts)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -210,7 +210,7 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
         if self.enable_continuous_token:
-            prompt_ids = await self.ct_build_initial_prompt(agent_data.messages, tools=schemas)
+            prompt_ids = await self.ct_build_initial_tokens(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
                 agent_data.messages,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -341,7 +341,6 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            message["name"] = tool_call_names[tool_index]
             if tool_call.tool_call_id is not None:
                 message["tool_call_id"] = tool_call.tool_call_id
 

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -210,7 +210,7 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
         if self.enable_continuous_token:
-            prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
+            prompt_ids = await self.ct_build_initial_prompt(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
                 agent_data.messages,
@@ -263,7 +263,7 @@ class ToolAgentLoop(AgentLoopBase):
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
         if self.enable_continuous_token:
-            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_assistant_token(
                 agent_data.prompt_ids,
                 agent_data.response_ids,
                 agent_data.response_mask,
@@ -403,7 +403,7 @@ class ToolAgentLoop(AgentLoopBase):
             )
         elif self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-            merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_non_assistant_msg(
                 previous_messages,
                 agent_data.messages,
                 agent_data.prompt_ids,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -371,29 +371,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.messages.extend(add_messages)
 
-        if self.tool_parser_name == "gpt-oss":
-            logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
-            response_ids = await self.loop.run_in_executor(
-                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
-            )
-        elif self.tool_parser_name == "gemma4":
-            # Gemma4's chat template drops tool responses when passed without the preceding
-            # assistant tool_call message. Manually format the response tokens.
-            # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
-            parts = []
-            for msg in add_messages:
-                content = msg.get("content", "")
-                if isinstance(content, list):
-                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                if isinstance(content, list):
-                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
-            tool_response_text = "".join(parts)
-            response_ids = await self.loop.run_in_executor(
-                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
-            )
-        elif self.enable_continuous_token and not new_images_this_turn:
+        if self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
             merge_result, response_mask, response_logprobs = await self.ct_merge_non_assistant_msg(
                 previous_messages,
@@ -411,6 +389,26 @@ class ToolAgentLoop(AgentLoopBase):
                 agent_data.response_logprobs = response_logprobs or []
             agent_data.user_turns += 1
             return AgentState.GENERATING
+        elif self.tool_parser_name == "gpt-oss":
+            logger.info("manually format tool responses for gpt-oss")
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
+            response_ids = await self.loop.run_in_executor(
+                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
+            )
+        elif self.tool_parser_name == "gemma4":
+            # Gemma4's chat template drops tool responses when passed without the preceding
+            # assistant tool_call message. Manually format the response tokens.
+            # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
+            parts = []
+            for msg in add_messages:
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
+                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+            tool_response_text = "".join(parts)
+            response_ids = await self.loop.run_in_executor(
+                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
+            )
         else:
             # Note that we have to pass None to the images and videos if there are no new images / videos
             # to stay compatible with downstream image processing logic!

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -293,7 +293,9 @@ class ToolAgentLoop(AgentLoopBase):
         # Extract tool calls (use per-sample tools if routed)
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
-        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(
+            agent_data.response_ids, tools
+        )
         if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -209,7 +209,7 @@ class ToolAgentLoop(AgentLoopBase):
     async def _handle_pending_state(self, agent_data: AgentData, sampling_params: dict[str, Any]) -> AgentState:
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
@@ -262,7 +262,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
                 agent_data.prompt_ids,
                 agent_data.response_ids,
@@ -296,7 +296,7 @@ class ToolAgentLoop(AgentLoopBase):
         tools = [tool.tool_schema for tool in active_tools.values()]
         assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
         agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
         if agent_data.tool_calls:
@@ -401,7 +401,7 @@ class ToolAgentLoop(AgentLoopBase):
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
-        elif self.continuous_token_builder is not None and not new_images_this_turn:
+        elif self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
             merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
                 previous_messages,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -89,7 +89,6 @@ class AgentData:
 
         # Temporary state for tool calls
         self.tool_calls: list[FunctionCall] = []
-        self.tool_call_ids: list[str | None] = []
 
         self.routed_experts = None
 
@@ -295,7 +294,6 @@ class ToolAgentLoop(AgentLoopBase):
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
         assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
-        agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
         if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
@@ -311,20 +309,16 @@ class ToolAgentLoop(AgentLoopBase):
         previous_messages = list(agent_data.messages)
 
         tasks = []
-        tool_call_names = []
-        tool_call_ids = []
-        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
+        for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
-            tool_call_names.append(tool_call.name)
-            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
-            tool_call_ids.append(raw_tool_call_id)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
 
         # Process tool responses and update multi_modal_data
         # Removed: agent_data.new_images_this_turn = []
-        for tool_response, tool_reward, _ in responses:
+        for tool_index, (tool_response, tool_reward, _) in enumerate(responses):
+            tool_call = agent_data.tool_calls[tool_index]
             # Create message from tool response
             if tool_response.image or tool_response.video:
                 # Multi-modal content with structured format
@@ -345,11 +339,9 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            tool_index = len(add_messages)
-            tool_call_id = tool_call_ids[tool_index]
-            message["name"] = tool_call_names[tool_index]
-            if tool_call_id is not None:
-                message["tool_call_id"] = tool_call_id
+            message["name"] = tool_call.name
+            if tool_call.tool_call_id is not None:
+                message["tool_call_id"] = tool_call.tool_call_id
 
             add_messages.append(message)
 
@@ -381,7 +373,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         if self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
@@ -390,13 +382,13 @@ class ToolAgentLoop(AgentLoopBase):
             # assistant tool_call message. Manually format the response tokens.
             # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
             parts = []
-            for msg, name in zip(add_messages, tool_call_names, strict=True):
+            for msg in add_messages:
                 content = msg.get("content", "")
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{name}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
             tool_response_text = "".join(parts)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
@@ -450,15 +442,6 @@ class ToolAgentLoop(AgentLoopBase):
         agent_data.user_turns += 1
         return AgentState.GENERATING
 
-    def _last_parsed_tool_call_ids(self, tool_call_count: int) -> list[str | None]:
-        parsed_ids = getattr(self.tool_parser, "last_tool_call_ids", [])
-        if not isinstance(parsed_ids, list):
-            return [None] * tool_call_count
-        return [
-            parsed_ids[index] if index < len(parsed_ids) and isinstance(parsed_ids[index], str) else None
-            for index in range(tool_call_count)
-        ]
-
     def _build_assistant_message(self, content: str, agent_data: AgentData) -> dict[str, Any]:
         message: dict[str, Any] = {"role": "assistant", "content": content or ""}
         if not agent_data.tool_calls:
@@ -466,7 +449,6 @@ class ToolAgentLoop(AgentLoopBase):
 
         tool_calls = []
         for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
-            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
             function_call, has_decode_error = OpenAIFunctionCallSchema.from_openai_function_parsed_schema(
                 OpenAIFunctionParsedSchema(name=tool_call.name, arguments=tool_call.arguments)
             )
@@ -479,8 +461,8 @@ class ToolAgentLoop(AgentLoopBase):
                 "type": "function",
                 "function": function_call.model_dump(),
             }
-            if raw_tool_call_id is not None:
-                tool_call_message["id"] = raw_tool_call_id
+            if tool_call.tool_call_id is not None:
+                tool_call_message["id"] = tool_call.tool_call_id
             tool_calls.append(tool_call_message)
         message["tool_calls"] = tool_calls
         return message

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -31,7 +31,7 @@ from verl.experimental.agent_loop.agent_loop import (
 from verl.experimental.agent_loop.tool_parser import FunctionCall, ToolParser
 from verl.experimental.agent_loop.utils import build_gpt_oss_tool_response_text
 from verl.tools.function_tool import FunctionTool, normalize_function_tool_return
-from verl.tools.schemas import ToolResponse
+from verl.tools.schemas import OpenAIFunctionCallSchema, OpenAIFunctionParsedSchema, ToolResponse
 from verl.utils.profiler import simple_timer
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.workers.rollout.replica import TokenOutput
@@ -89,6 +89,7 @@ class AgentData:
 
         # Temporary state for tool calls
         self.tool_calls: list[FunctionCall] = []
+        self.tool_call_ids: list[str | None] = []
 
         self.routed_experts = None
 
@@ -208,14 +209,17 @@ class ToolAgentLoop(AgentLoopBase):
     async def _handle_pending_state(self, agent_data: AgentData, sampling_params: dict[str, Any]) -> AgentState:
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-        prompt_ids = await self.apply_chat_template(
-            agent_data.messages,
-            tools=schemas,
-            images=agent_data.image_data,
-            videos=agent_data.video_data,
-            audios=agent_data.audio_data,
-            mm_processor_kwargs=agent_data.mm_processor_kwargs,
-        )
+        if self.continuous_token_builder is not None:
+            prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
+        else:
+            prompt_ids = await self.apply_chat_template(
+                agent_data.messages,
+                tools=schemas,
+                images=agent_data.image_data,
+                videos=agent_data.video_data,
+                audios=agent_data.audio_data,
+                mm_processor_kwargs=agent_data.mm_processor_kwargs,
+            )
         agent_data.prompt_ids = prompt_ids
         return AgentState.GENERATING
 
@@ -258,10 +262,23 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
-        agent_data.prompt_ids += agent_data.response_ids
-        agent_data.response_mask += [1] * len(agent_data.response_ids)
-        if output.log_probs:
-            agent_data.response_logprobs += output.log_probs
+        if self.continuous_token_builder is not None:
+            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+                agent_data.prompt_ids,
+                agent_data.response_ids,
+                agent_data.response_mask,
+                agent_data.response_logprobs if (agent_data.response_logprobs or output.log_probs) else None,
+                assistant_logprobs=output.log_probs if output.log_probs else None,
+            )
+            agent_data.prompt_ids = merge_result.token_ids
+            agent_data.response_mask = response_mask
+            if response_logprobs is not None:
+                agent_data.response_logprobs = response_logprobs
+        else:
+            agent_data.prompt_ids += agent_data.response_ids
+            agent_data.response_mask += [1] * len(agent_data.response_ids)
+            if output.log_probs:
+                agent_data.response_logprobs += output.log_probs
 
         if output.routed_experts is not None:
             agent_data.routed_experts = output.routed_experts
@@ -277,7 +294,10 @@ class ToolAgentLoop(AgentLoopBase):
         # Extract tool calls (use per-sample tools if routed)
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
-        _, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
+        if self.continuous_token_builder is not None:
+            agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
         if agent_data.tool_calls:
             return AgentState.PROCESSING_TOOLS
@@ -288,12 +308,16 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the processing tools state: execute tool calls and prepare tool responses."""
         add_messages: list[dict[str, Any]] = []
         new_images_this_turn: list[Any] = []  # Local variable instead of agent_data attribute
+        previous_messages = list(agent_data.messages)
 
         tasks = []
         tool_call_names = []
-        for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
+        tool_call_ids = []
+        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
             tool_call_names.append(tool_call.name)
+            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
+            tool_call_ids.append(raw_tool_call_id)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
@@ -321,6 +345,11 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
+            tool_index = len(add_messages)
+            tool_call_id = tool_call_ids[tool_index]
+            message["name"] = tool_call_names[tool_index]
+            if tool_call_id is not None:
+                message["tool_call_id"] = tool_call_id
 
             add_messages.append(message)
 
@@ -372,6 +401,24 @@ class ToolAgentLoop(AgentLoopBase):
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
+        elif self.continuous_token_builder is not None and not new_images_this_turn:
+            schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
+            merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
+                previous_messages,
+                agent_data.messages,
+                agent_data.prompt_ids,
+                agent_data.response_mask,
+                agent_data.response_logprobs if agent_data.response_logprobs else None,
+                tools=schemas,
+            )
+            if len(response_mask) >= self.response_length:
+                return AgentState.TERMINATED
+            agent_data.prompt_ids = merge_result.token_ids
+            agent_data.response_mask = response_mask
+            if agent_data.response_logprobs:
+                agent_data.response_logprobs = response_logprobs or []
+            agent_data.user_turns += 1
+            return AgentState.GENERATING
         else:
             # Note that we have to pass None to the images and videos if there are no new images / videos
             # to stay compatible with downstream image processing logic!
@@ -402,6 +449,41 @@ class ToolAgentLoop(AgentLoopBase):
             agent_data.response_logprobs += [0.0] * len(response_ids)
         agent_data.user_turns += 1
         return AgentState.GENERATING
+
+    def _last_parsed_tool_call_ids(self, tool_call_count: int) -> list[str | None]:
+        parsed_ids = getattr(self.tool_parser, "last_tool_call_ids", [])
+        if not isinstance(parsed_ids, list):
+            return [None] * tool_call_count
+        return [
+            parsed_ids[index] if index < len(parsed_ids) and isinstance(parsed_ids[index], str) else None
+            for index in range(tool_call_count)
+        ]
+
+    def _build_assistant_message(self, content: str, agent_data: AgentData) -> dict[str, Any]:
+        message: dict[str, Any] = {"role": "assistant", "content": content or ""}
+        if not agent_data.tool_calls:
+            return message
+
+        tool_calls = []
+        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
+            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
+            function_call, has_decode_error = OpenAIFunctionCallSchema.from_openai_function_parsed_schema(
+                OpenAIFunctionParsedSchema(name=tool_call.name, arguments=tool_call.arguments)
+            )
+            if has_decode_error:
+                raise ValueError(
+                    f"Invalid tool call arguments for '{tool_call.name}': expected a JSON object string, "
+                    f"got {tool_call.arguments!r}"
+                )
+            tool_call_message = {
+                "type": "function",
+                "function": function_call.model_dump(),
+            }
+            if raw_tool_call_id is not None:
+                tool_call_message["id"] = raw_tool_call_id
+            tool_calls.append(tool_call_message)
+        message["tool_calls"] = tool_calls
+        return message
 
     async def _call_tool(
         self, tool_call: FunctionCall, tools_kwargs: dict[str, Any], agent_data: AgentData

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -41,6 +41,9 @@ class FunctionCall(BaseModel):
     name: str
     """The name of the function to call."""
 
+    tool_call_id: Optional[str] = None
+    """The model-emitted tool call identifier, if available."""
+
 
 class ToolParser(ABC):
     _registry: dict[str, type["ToolParser"]] = {}
@@ -549,7 +552,6 @@ class KimiToolParser(ToolParser):
 
     def __init__(self, tokenizer) -> None:
         super().__init__(tokenizer)
-        self.last_tool_call_ids: list[str] = []
         self.tool_calls_section_start_token = "<|tool_calls_section_begin|>"
         self.tool_calls_section_end_token = "<|tool_calls_section_end|>"
         self.tool_call_begin_token = "<|tool_call_begin|>"
@@ -614,17 +616,16 @@ class KimiToolParser(ToolParser):
             lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
         )
         if self.tool_calls_section_start_token not in text:
-            self.last_tool_call_ids = []
             return text, []
 
         function_calls: list[FunctionCall] = []
-        self.last_tool_call_ids = []
         for raw_name, raw_arguments in self.tool_call_regex.findall(text):
             raw_name = raw_name.strip()
             arguments = self._parse_arguments(raw_arguments)
             name = self._infer_tool_name(raw_name, arguments, tools)
-            self.last_tool_call_ids.append(raw_name)
-            function_calls.append(FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False)))
+            function_calls.append(
+                FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False), tool_call_id=raw_name)
+            )
 
         content_index = text.find(self.tool_calls_section_start_token)
         content = text[:content_index] if content_index >= 0 else text

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -580,7 +580,9 @@ class KimiToolParser(ToolParser):
         return arguments if isinstance(arguments, dict) else {}
 
     @staticmethod
-    def _infer_tool_name(raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]) -> str:
+    def _infer_tool_name(
+        raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]
+    ) -> str:
         if not tools:
             return raw_name
 

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -357,6 +357,280 @@ class Qwen3XMLToolParser(ToolParser):
             return text, []
 
 
+@ToolParser.register("glm")
+class GLMToolParser(ToolParser):
+    """Tool parser for GLM XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<tool_call>"
+        self.tool_call_end_token = "</tool_call>"
+        self.observation_token = "<|observation|>"
+        self.tool_call_regex = regex.compile(r"<tool_call>(.*?)</tool_call>", regex.DOTALL)
+        self.arg_pair_regex = regex.compile(
+            r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
+            regex.DOTALL,
+        )
+
+    @property
+    def stop_token_ids(self) -> list[int]:
+        token_id = self.tokenizer.convert_tokens_to_ids(self.observation_token)
+        if isinstance(token_id, int) and token_id >= 0:
+            return [token_id]
+        return []
+
+    @staticmethod
+    def _convert_arg_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_call(self, tool_call_text: str) -> FunctionCall:
+        first_arg_index = tool_call_text.find("<arg_key>")
+        if first_arg_index < 0:
+            name = tool_call_text.strip()
+            arguments: dict[str, Any] = {}
+        else:
+            name = tool_call_text[:first_arg_index].strip()
+            arguments = {
+                key.strip(): self._convert_arg_value(value)
+                for key, value in self.arg_pair_regex.findall(tool_call_text[first_arg_index:])
+            }
+        return FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False))
+
+    @staticmethod
+    def _strip_thinking_markers(content: str) -> str:
+        content = regex.sub(r"^\s*<think>.*?</think>", "", content, flags=regex.DOTALL)
+        content = regex.sub(r"^\s*</think>", "", content)
+        return content
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        matches = self.tool_call_regex.findall(text)
+        function_calls: list[FunctionCall] = []
+        for match in matches:
+            try:
+                function_calls.append(self._parse_tool_call(match))
+            except Exception as e:
+                logger.error(f"Failed to decode GLM tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        content = self._strip_thinking_markers(text[:content_index])
+        return content, function_calls
+
+
+@ToolParser.register("seed")
+class SeedToolParser(ToolParser):
+    """Tool parser for ByteDance Seed XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<seed:tool_call>"
+        self.tool_call_end_token = "</seed:tool_call>"
+        self.tool_call_regex = regex.compile(r"<seed:tool_call>(.*?)</seed:tool_call>", regex.DOTALL)
+        self.function_regex = regex.compile(r"<function=([^>\n]+)>\s*(.*?)</function>", regex.DOTALL)
+        self.parameter_regex = regex.compile(r"<parameter=([^>\n]+)>(.*?)</parameter>", regex.DOTALL)
+
+    @staticmethod
+    def _convert_parameter_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_call(self, tool_call_text: str) -> FunctionCall | None:
+        match = self.function_regex.search(tool_call_text)
+        if not match:
+            return None
+
+        name = match.group(1).strip()
+        body = match.group(2)
+        arguments = {
+            key.strip(): self._convert_parameter_value(value) for key, value in self.parameter_regex.findall(body)
+        }
+        return FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False))
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        for match in self.tool_call_regex.findall(text):
+            try:
+                function_call = self._parse_tool_call(match)
+                if function_call is not None:
+                    function_calls.append(function_call)
+            except Exception as e:
+                logger.error(f"Failed to decode Seed tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        return text[:content_index], function_calls
+
+
+@ToolParser.register("minimax")
+class MiniMaxToolParser(ToolParser):
+    """Tool parser for MiniMax XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<minimax:tool_call>"
+        self.tool_call_end_token = "</minimax:tool_call>"
+        self.tool_call_regex = regex.compile(r"<minimax:tool_call>(.*?)</minimax:tool_call>", regex.DOTALL)
+        self.invoke_regex = regex.compile(r'<invoke name="([^"]+)">\s*(.*?)</invoke>', regex.DOTALL)
+        self.parameter_regex = regex.compile(r'<parameter name="([^"]+)">(.*?)</parameter>', regex.DOTALL)
+
+    @staticmethod
+    def _convert_parameter_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_calls(self, tool_call_text: str) -> list[FunctionCall]:
+        function_calls: list[FunctionCall] = []
+        for name, body in self.invoke_regex.findall(tool_call_text):
+            arguments = {
+                key.strip(): self._convert_parameter_value(value) for key, value in self.parameter_regex.findall(body)
+            }
+            function_calls.append(FunctionCall(name=name.strip(), arguments=json.dumps(arguments, ensure_ascii=False)))
+        return function_calls
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        for match in self.tool_call_regex.findall(text):
+            try:
+                function_calls.extend(self._parse_tool_calls(match))
+            except Exception as e:
+                logger.error(f"Failed to decode MiniMax tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        return text[:content_index], function_calls
+
+
+@ToolParser.register("kimi")
+class KimiToolParser(ToolParser):
+    """Tool parser for Kimi K2-family special-token function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.last_tool_call_ids: list[str] = []
+        self.tool_calls_section_start_token = "<|tool_calls_section_begin|>"
+        self.tool_calls_section_end_token = "<|tool_calls_section_end|>"
+        self.tool_call_begin_token = "<|tool_call_begin|>"
+        self.tool_call_argument_begin_token = "<|tool_call_argument_begin|>"
+        self.tool_call_end_token = "<|tool_call_end|>"
+        self.im_end_token = "<|im_end|>"
+        self.tool_call_regex = regex.compile(
+            r"<\|tool_call_begin\|>(.*?)<\|tool_call_argument_begin\|>(.*?)<\|tool_call_end\|>",
+            regex.DOTALL,
+        )
+
+    @property
+    def stop_token_ids(self) -> list[int]:
+        token_id = self.tokenizer.convert_tokens_to_ids(self.im_end_token)
+        if isinstance(token_id, int) and token_id >= 0:
+            return [token_id]
+        return []
+
+    @staticmethod
+    def _parse_arguments(raw_arguments: str) -> dict[str, Any]:
+        try:
+            arguments = json.loads(raw_arguments.strip())
+        except Exception:
+            logger.warning("Kimi tool-call arguments are not valid JSON; returning an empty argument dict.")
+            return {}
+        return arguments if isinstance(arguments, dict) else {}
+
+    @staticmethod
+    def _infer_tool_name(raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]) -> str:
+        if not tools:
+            return raw_name
+
+        tool_names = [tool.function.name for tool in tools if tool.type == "function"]
+        if raw_name in tool_names:
+            return raw_name
+
+        compact_raw_name = raw_name.lower().replace("-", "_")
+        substring_matches = [name for name in tool_names if name.lower() in compact_raw_name]
+        if len(substring_matches) == 1:
+            return substring_matches[0]
+
+        argument_keys = set(arguments)
+        schema_matches = []
+        for tool in tools:
+            if tool.type != "function":
+                continue
+            required = set(tool.function.parameters.required or [])
+            if required and required.issubset(argument_keys):
+                schema_matches.append(tool.function.name)
+        if len(schema_matches) == 1:
+            return schema_matches[0]
+
+        return raw_name
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_calls_section_start_token not in text:
+            self.last_tool_call_ids = []
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        self.last_tool_call_ids = []
+        for raw_name, raw_arguments in self.tool_call_regex.findall(text):
+            raw_name = raw_name.strip()
+            arguments = self._parse_arguments(raw_arguments)
+            name = self._infer_tool_name(raw_name, arguments, tools)
+            self.last_tool_call_ids.append(raw_name)
+            function_calls.append(FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False)))
+
+        content_index = text.find(self.tool_calls_section_start_token)
+        content = text[:content_index] if content_index >= 0 else text
+        return content, function_calls
+
+
 @ToolParser.register("gemma4")
 class Gemma4ToolParser(ToolParser):
     """Tool parser for Google Gemma 4 models.

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -98,10 +98,10 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
     return message_content + "<|start|>assistant"
 
 
-def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]]) -> str:
+def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]], tool_call_names: list[str]) -> str:
     """Build gpt-oss tool response text (manual formatting + generation prompt)."""
     tool_response_texts: list[str] = []
-    for tool_msg in messages:
-        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_msg["name"])
+    for index, tool_msg in enumerate(messages):
+        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_call_names[index])
         tool_response_texts.append(formatted)
     return add_generation_prompt_for_gpt_oss("".join(tool_response_texts))

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -98,11 +98,10 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
     return message_content + "<|start|>assistant"
 
 
-def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]], tool_call_names: list[str]) -> str:
+def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]]) -> str:
     """Build gpt-oss tool response text (manual formatting + generation prompt)."""
     tool_response_texts: list[str] = []
-    for i, tool_msg in enumerate(messages):
-        actual_tool_name = tool_call_names[i]
-        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], actual_tool_name)
+    for tool_msg in messages:
+        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_msg["name"])
         tool_response_texts.append(formatted)
     return add_generation_prompt_for_gpt_oss("".join(tool_response_texts))

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -322,6 +322,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -288,6 +288,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -295,6 +295,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -300,6 +300,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,7 +225,7 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5, gemma4, gptoss
     model_family: auto
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,12 +225,8 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
     model_family: auto
-
-    # Optional Python module to import before creating the Continuous Token builder.
-    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
-    custom_builder_module: null
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -214,6 +214,24 @@ multi_turn:
   # - ignore_strippable: ignore strippable tokens when checking tokenization sanity
   tokenization_sanity_check_mode: strict
 
+  # Continuous Token keeps the runtime token stream across multi-turn rollout instead of
+  # reconstructing previous assistant turns from text. Disabled by default for compatibility.
+  continuous_token:
+
+    # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+    _target_: verl.workers.config.ContinuousTokenConfig
+
+    # Enable Continuous Token for multi-turn agent rollout.
+    enable: False
+
+    # Model-family specific boundary handling. auto infers from model path/tokenizer name.
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    model_family: auto
+
+    # Optional Python module to import before creating the Continuous Token builder.
+    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
+    custom_builder_module: null
+
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes
 

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -81,16 +82,24 @@ class ContinuousTokenBuilder:
         self._assert_append_only(previous_messages, updated_messages)
         appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
+        processed_messages: list[dict[str, Any]] = []
 
         for group in self._iter_append_groups(appended_messages):
             role = group[0].get("role")
             if role == "tool":
-                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+                incremental_ids.extend(
+                    self._tokenize_tool_group(
+                        group,
+                        context_messages=previous_messages + processed_messages,
+                        tools=tools,
+                    )
+                )
             elif role in {"user", "system"}:
                 # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
                 incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+            processed_messages.extend(group)
 
         incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
@@ -172,9 +181,10 @@ class ContinuousTokenBuilder:
         self,
         tool_messages: list[dict[str, Any]],
         *,
+        context_messages: list[dict[str, Any]] | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages, context_messages=context_messages)
         return self.render_delta_token_id(
             [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
             tool_messages,
@@ -225,13 +235,19 @@ class ContinuousTokenBuilder:
                     f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
                 )
 
-    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+    def _synthetic_assistant_for_tools(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
         tool_calls = []
-        for tool_message in tool_messages:
+        for index, tool_message in enumerate(tool_messages):
             tool_call = {
                 "type": "function",
                 "function": {
-                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "name": _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
                     "arguments": {},
                 },
             }
@@ -239,6 +255,33 @@ class ContinuousTokenBuilder:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
         return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GPT-OSS tool-response formatting."""
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        del tools
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
+        response_text = "".join(
+            self._format_tool_response(
+                tool_message,
+                _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
+            )
+            for index, tool_message in enumerate(tool_messages)
+        )
+        return self.tokenizer.encode(response_text, add_special_tokens=False)
+
+    @staticmethod
+    def _format_tool_response(tool_message: dict[str, Any], tool_name: str) -> str:
+        content = json.dumps(_stringify_tool_content(tool_message.get("content", "")), ensure_ascii=False)
+        return f"<|start|>functions.{tool_name} to=assistant<|channel|>commentary<|message|>{content}<|end|>"
 
 
 class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
@@ -329,6 +372,38 @@ class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Gemma4 tool-response boundary handling."""
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._tool_response_id = _require_token_id(tokenizer, "<|tool_response>")
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_token_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
+        appended_messages = updated_messages[len(previous_messages) :]
+
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if appended_messages and prefix[-1:] != [self._tool_response_id]:
+            prefix.append(self._tool_response_id)
+            inserted_token_ids.append(self._tool_response_id)
+
+        return MergeResult(
+            token_ids=prefix + appended_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
 def _require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
@@ -340,3 +415,65 @@ def _require_token_id(tokenizer: Any, token: str) -> int:
     if not isinstance(token_id, int) or token_id < 0:
         raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
     return token_id
+
+
+def _stringify_tool_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"
+        )
+    return str(content)
+
+
+def _assistant_tool_call_names(
+    messages: list[dict[str, Any]],
+) -> tuple[dict[str, str], list[str]]:
+    tool_names_by_id: dict[str, str] = {}
+    positional_tool_names: list[str] = []
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            continue
+        names: list[str] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            name = _tool_call_function_name(tool_call)
+            if name is None:
+                continue
+            names.append(name)
+            tool_call_id = tool_call.get("id")
+            if tool_call_id is not None:
+                tool_names_by_id.setdefault(str(tool_call_id), name)
+        if names and not positional_tool_names:
+            positional_tool_names = names
+    return tool_names_by_id, positional_tool_names
+
+
+def _resolve_tool_name(
+    tool_message: dict[str, Any],
+    index: int,
+    tool_names_by_id: dict[str, str],
+    positional_tool_names: list[str],
+) -> str:
+    tool_call_id = tool_message.get("tool_call_id")
+    if tool_call_id is not None and str(tool_call_id) in tool_names_by_id:
+        return tool_names_by_id[str(tool_call_id)]
+    if index < len(positional_tool_names):
+        return positional_tool_names[index]
+    if tool_message.get("name"):
+        return str(tool_message["name"])
+    return "continuous_token_tool"
+
+
+def _tool_call_function_name(tool_call: dict[str, Any]) -> str | None:
+    function = tool_call.get("function")
+    if isinstance(function, dict) and function.get("name") is not None:
+        return str(function["name"])
+    return None

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -74,12 +74,12 @@ class ContinuousTokenBuilder:
     def tokenize_incremental_messages(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        self._assert_append_only(previous_messages, next_messages)
-        appended_messages = next_messages[len(previous_messages) :]
+        self._assert_append_only(previous_messages, updated_messages)
+        appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
 
         for group in self._iter_append_groups(appended_messages):
@@ -92,18 +92,18 @@ class ContinuousTokenBuilder:
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
 
-        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
 
     def merge_tokens(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         runtime_token_ids: list[int],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> MergeResult:
-        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        appended_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
         return self._merge_token_ids(runtime_token_ids, appended_ids)
 
     def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
@@ -212,13 +212,13 @@ class ContinuousTokenBuilder:
     def _assert_append_only(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
     ) -> None:
-        if len(next_messages) < len(previous_messages):
-            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
-        if next_messages[: len(previous_messages)] != previous_messages:
+        if len(updated_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; updated_messages is shorter")
+        if updated_messages[: len(previous_messages)] != previous_messages:
             raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
-        for message in next_messages[len(previous_messages) :]:
+        for message in updated_messages[len(previous_messages) :]:
             role = message.get("role")
             if role not in self.allowed_append_roles:
                 raise ValueError(

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -1,0 +1,350 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+_SUPPORTED_APPEND_ROLES = frozenset({"tool", "user", "system"})
+_SYNTHETIC_SYSTEM_MESSAGE: dict[str, Any] = {"role": "system", "content": "continuous token synthetic system"}
+_SYNTHETIC_USER_MESSAGE: dict[str, Any] = {"role": "user", "content": "continuous token synthetic user"}
+_ASSISTANT_REASONING_CONTENT: str = "reasoning"
+MergeKind = Literal["assistant", "non_assistant"]
+
+
+@dataclass(frozen=True)
+class MergeResult:
+    """Token merge result with the token-level delta needed by callers.
+
+    ``inserted_token_ids`` are CT-created boundary tokens at the merge junction.
+    They are not model-generated tokens and therefore must not carry loss or
+    model logprobs. Generated assistant tokens are represented by
+    ``appended_token_count`` with ``kind="assistant"``.
+    """
+
+    token_ids: list[int]
+    appended_token_count: int
+    kind: MergeKind = "non_assistant"
+    inserted_token_ids: list[int] = field(default_factory=list)
+    removed_prefix_token_count: int = 0
+
+
+class ContinuousTokenBuilder:
+    """Continuous Token builder for runtime prefix reuse."""
+
+    allowed_append_roles: frozenset[str] = _SUPPORTED_APPEND_ROLES
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        *,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        allowed_append_roles: list[str] | tuple[str, ...] | set[str] | None = None,
+    ):
+        self.tokenizer = tokenizer
+        self.chat_template_kwargs = chat_template_kwargs or {}
+        if allowed_append_roles is not None:
+            allowed_roles = frozenset(allowed_append_roles)
+            unknown_roles = allowed_roles - _SUPPORTED_APPEND_ROLES
+            if unknown_roles:
+                raise ValueError(f"Unsupported Continuous Token append roles: {sorted(unknown_roles)}")
+            self.allowed_append_roles = allowed_roles
+
+    def build_initial_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self._render_tokens(messages, add_generation_prompt=True, tools=tools)
+
+    def tokenize_incremental_messages(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        self._assert_append_only(previous_messages, next_messages)
+        appended_messages = next_messages[len(previous_messages) :]
+        incremental_ids: list[int] = []
+
+        for group in self._iter_append_groups(appended_messages):
+            role = group[0].get("role")
+            if role == "tool":
+                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+            elif role in {"user", "system"}:
+                # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
+                incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
+            else:
+                raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+
+        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        return incremental_ids
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        return self._merge_token_ids(runtime_token_ids, appended_ids)
+
+    def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
+        """Append model-generated assistant tokens to the runtime token stream."""
+        merged_token_ids = list(runtime_token_ids) + list(assistant_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(assistant_token_ids),
+            kind="assistant",
+        )
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        """Merge runtime prefix tokens and appended tokens.
+
+        Model-specific builders usually override this hook for boundary handling,
+        such as inserting or trimming tokens at the prefix/appended-token junction.
+        """
+        merged_token_ids = list(runtime_token_ids) + list(appended_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+        )
+
+    def _render_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        from verl.utils.chat_template import apply_chat_template
+        from verl.utils.tokenizer import normalize_token_ids
+
+        tokenized = apply_chat_template(
+            self.tokenizer,
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            **self.chat_template_kwargs,
+        )
+        return normalize_token_ids(tokenized)
+
+    def render_delta_token_id(
+        self,
+        prefix_messages: list[dict[str, Any]],
+        appended_messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool = False,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        """Render prefix/full prompts as token IDs and return the token-level suffix."""
+        prefix_token_ids = self._render_tokens(prefix_messages, add_generation_prompt=False, tools=tools)
+        full_token_ids = self._render_tokens(
+            prefix_messages + appended_messages,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+        )
+        if full_token_ids[: len(prefix_token_ids)] != prefix_token_ids:
+            roles = [message.get("role") for message in appended_messages] or ["generation_prompt"]
+            raise ValueError(f"Continuous Token token-id suffix diff failed for roles: {roles}")
+        return full_token_ids[len(prefix_token_ids) :]
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
+            tool_messages,
+            tools=tools,
+        )
+
+    def _tokenize_single_non_tool(
+        self,
+        message: dict[str, Any],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE],
+            [message],
+            tools=tools,
+        )
+
+    def _iter_append_groups(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+        groups: list[list[dict[str, Any]]] = []
+        index = 0
+        while index < len(appended_messages):
+            role = appended_messages[index].get("role")
+            if role == "tool":
+                end = index + 1
+                while end < len(appended_messages) and appended_messages[end].get("role") == "tool":
+                    end += 1
+                groups.append(appended_messages[index:end])
+                index = end
+            else:
+                groups.append([appended_messages[index]])
+                index += 1
+        return groups
+
+    def _assert_append_only(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+    ) -> None:
+        if len(next_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
+        if next_messages[: len(previous_messages)] != previous_messages:
+            raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
+        for message in next_messages[len(previous_messages) :]:
+            role = message.get("role")
+            if role not in self.allowed_append_roles:
+                raise ValueError(
+                    f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
+                )
+
+    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+        tool_calls = []
+        for tool_message in tool_messages:
+            tool_call = {
+                "type": "function",
+                "function": {
+                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "arguments": {},
+                },
+            }
+            if tool_message.get("tool_call_id") is not None:
+                tool_call["id"] = tool_message["tool_call_id"]
+            tool_calls.append(tool_call)
+        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Qwen ChatML boundary handling.
+
+    Qwen2.5, Qwen3, and Qwen3.5 templates render ``<|im_end|>\n`` after a turn,
+    while generation may stop at ``<|im_end|>``. When the runtime prefix ends
+    there, insert the missing newline before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected Qwen newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._im_end_id = _require_token_id(tokenizer, "<|im_end|>")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._im_end_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
+    """MiniMax boundary handling.
+
+    MiniMax templates render ``[e~[\n`` after a turn, while generation may stop
+    at ``[e~[``. When the runtime prefix ends there, insert the missing newline
+    before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected MiniMax newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._eos_id = _require_token_id(tokenizer, "[e~[")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._eos_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GLM observation/user boundary handling.
+
+    ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and
+    next-message start tokens. If the runtime prefix ends with either, remove
+    that token before appending the next non-assistant segment.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._observation_id = _require_token_id(tokenizer, "<|observation|>")
+        self._user_id = _require_token_id(tokenizer, "<|user|>")
+        self._ambiguous_boundary_ids = {self._observation_id, self._user_id}
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        removed_prefix_token_count = 0
+        if prefix and prefix[-1] in self._ambiguous_boundary_ids:
+            prefix = prefix[:-1]
+            removed_prefix_token_count = 1
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            removed_prefix_token_count=removed_prefix_token_count,
+        )
+
+
+def _require_token_id(tokenizer: Any, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        raise ValueError(f"Tokenizer does not define required token {token!r}")
+    if isinstance(token_id, list):
+        if len(token_id) != 1:
+            raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")
+        token_id = token_id[0]
+    if not isinstance(token_id, int) or token_id < 0:
+        raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
+    return token_id

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -101,7 +101,9 @@ class ContinuousTokenBuilder:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
             processed_messages.extend(group)
 
-        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(
+            self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools)
+        )
         return incremental_ids
 
     def merge_tokens(
@@ -254,7 +256,12 @@ class ContinuousTokenBuilder:
             if tool_message.get("tool_call_id") is not None:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
-        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+        return {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": _ASSISTANT_REASONING_CONTENT,
+            "tool_calls": tool_calls,
+        }
 
 
 class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -271,14 +271,6 @@ class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
-class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
 class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
     """MiniMax boundary handling.
 
@@ -309,7 +301,7 @@ class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
     """GLM observation/user boundary handling.
 
     ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -21,7 +21,9 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
+    Gemma4ContinuousTokenBuilder,
     GLMContinuousTokenBuilder,
+    GptOssContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
@@ -40,6 +42,8 @@ _CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "minimaxm27": MiniMaxContinuousTokenBuilder,
     "glm47": GLMContinuousTokenBuilder,
     "glm5": GLMContinuousTokenBuilder,
+    "gemma4": Gemma4ContinuousTokenBuilder,
+    "gptoss": GptOssContinuousTokenBuilder,
 }
 
 CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
@@ -106,6 +110,12 @@ def infer_continuous_token_model_family(
         return "glm5"
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
+        marker in compact for marker in ("gemma4", "gemma4unified")
+    ):
+        return "gemma4"
+    if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
+        return "gptoss"
     if "minimaxm27" in compact:
         return "minimaxm27"
     if "minimaxm25" in compact:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Continuous Token builder registry and model-family resolution."""
+"""Continuous Token builder factory and model-family resolution."""
 
 from __future__ import annotations
 
@@ -21,115 +21,43 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
-    GLM47ContinuousTokenBuilder,
+    GLMContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
-    Qwen35ContinuousTokenBuilder,
-    Qwen3ContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
-from verl.utils.import_utils import import_external_libs
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "default": ContinuousTokenBuilder,
     "qwen": QwenContinuousTokenBuilder,
     "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": Qwen3ContinuousTokenBuilder,
-    "qwen35": Qwen35ContinuousTokenBuilder,
+    "qwen3": QwenContinuousTokenBuilder,
+    "qwen35": QwenContinuousTokenBuilder,
     "minimax": MiniMaxContinuousTokenBuilder,
-    "glm47": GLM47ContinuousTokenBuilder,
+    "minimaxm2": MiniMaxContinuousTokenBuilder,
+    "minimaxm25": MiniMaxContinuousTokenBuilder,
+    "minimaxm27": MiniMaxContinuousTokenBuilder,
+    "glm47": GLMContinuousTokenBuilder,
+    "glm5": GLMContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
-CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
-
-_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
-
-
-class ContinuousTokenBuilderRegistry:
-    """Registry for Continuous Token builder classes.
-
-    Custom builders can be registered from an imported Python module:
-
-    .. code-block:: python
-
-        @ContinuousTokenBuilderRegistry.register("deepseek")
-        class DeepseekContinuousTokenBuilder:
-            ...
-    """
-
-    _registry: dict[str, type[Any]] = {}
-
-    @classmethod
-    def register(cls, model_family: str, *, exist_ok: bool = False):
-        family = _normalize_model_family(model_family)
-        if family in _RESERVED_MODEL_FAMILIES:
-            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
-
-        def decorator(builder_cls: type[Any]) -> type[Any]:
-            if not isinstance(builder_cls, type):
-                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
-
-            existing = cls._registry.get(family)
-            if existing is not None and existing is not builder_cls and not exist_ok:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is already registered with "
-                    f"{existing}; pass exist_ok=True to replace it"
-                )
-            cls._registry[family] = builder_cls
-            return builder_cls
-
-        return decorator
-
-    @classmethod
-    def get(cls, model_family: str) -> type[Any]:
-        family = _normalize_model_family(model_family)
-        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
-            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
-            if builder_cls is None:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
-                    "but its builder class has not been implemented yet."
-                )
-            return builder_cls
-        try:
-            return cls._registry[family]
-        except KeyError as exc:
-            raise ValueError(
-                f"Unknown Continuous Token builder family {family!r}. "
-                f"Registered families: {sorted(cls._registry)}. "
-                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
-            ) from exc
-
-    @classmethod
-    def registered_families(cls) -> tuple[str, ...]:
-        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
-
-
-def register_continuous_token_builder(
-    model_family: str,
-    builder_cls: type[Any] | None = None,
-    *,
-    exist_ok: bool = False,
-):
-    """Register a Continuous Token builder class for a model family.
-
-    This wrapper supports both direct calls and decorator usage. New code should
-    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
-    """
-    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
-    if builder_cls is None:
-        return decorator
-    return decorator(builder_cls)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
 def get_continuous_token_builder_class(model_family: str) -> type[Any]:
-    return ContinuousTokenBuilderRegistry.get(model_family)
+    family = _normalize_model_family(model_family)
+    try:
+        return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token builder family {family!r}. "
+            f"Supported families: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+        ) from exc
 
 
 def list_continuous_token_builder_families() -> tuple[str, ...]:
-    return ContinuousTokenBuilderRegistry.registered_families()
+    return CONTINUOUS_TOKEN_BUILDER_FAMILIES
 
 
 def resolve_continuous_token_model_family(
@@ -139,7 +67,7 @@ def resolve_continuous_token_model_family(
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
 ) -> str:
-    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
     if family != "auto":
         logger.info("Using explicit Continuous Token builder family: %s", family)
@@ -174,17 +102,24 @@ def infer_continuous_token_model_family(
     haystack = " ".join(str(item).lower() for item in candidates if item)
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
-    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
-        marker in compact for marker in ("glm47", "glm5")
-    ):
+    if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
+        return "glm5"
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if "minimaxm27" in compact:
+        return "minimaxm27"
+    if "minimaxm25" in compact:
+        return "minimaxm25"
+    if "minimaxm2" in compact:
+        return "minimaxm2"
     if "minimax" in compact:
         return "minimax"
-    if (
-        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
-        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
-    ):
-        return "qwen"
+    if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
+        return "qwen35"
+    if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
+        return "qwen25"
+    if "qwen3" in compact:
+        return "qwen3"
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
@@ -201,11 +136,9 @@ def create_continuous_token_builder(
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
-    custom_builder_module: str | list[str] | None = None,
     **builder_kwargs: Any,
 ) -> Any:
     """Instantiate the registered builder selected by config/model metadata."""
-    import_external_libs(custom_builder_module)
     resolved_family = resolve_continuous_token_model_family(
         model_family,
         model_path=model_path,
@@ -220,7 +153,10 @@ def create_continuous_token_builder(
 def _normalize_model_family(model_family: str) -> str:
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return model_family.lower()
+    family = model_family.strip().lower()
+    if not family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return re.sub(r"[^a-z0-9]+", "", family)
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,9 +15,9 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
 import logging
 import re
+from enum import StrEnum
 from typing import Any
 
 from verl.utils.continuous_token import (

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -185,6 +185,12 @@ def infer_continuous_token_model_family(
         or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
     ):
         return "qwen"
+    logger.warning(
+        "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
+        "falling back to the default ContinuousTokenBuilder.",
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
     return "default"
 
 

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 import logging
 import re
 from typing import Any
@@ -30,26 +31,44 @@ from verl.utils.continuous_token import (
 
 logger = logging.getLogger(__name__)
 
-_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
-    "default": ContinuousTokenBuilder,
-    "qwen": QwenContinuousTokenBuilder,
-    "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": QwenContinuousTokenBuilder,
-    "qwen35": QwenContinuousTokenBuilder,
-    "minimax": MiniMaxContinuousTokenBuilder,
-    "minimaxm2": MiniMaxContinuousTokenBuilder,
-    "minimaxm25": MiniMaxContinuousTokenBuilder,
-    "minimaxm27": MiniMaxContinuousTokenBuilder,
-    "glm47": GLMContinuousTokenBuilder,
-    "glm5": GLMContinuousTokenBuilder,
-    "gemma4": Gemma4ContinuousTokenBuilder,
-    "gptoss": GptOssContinuousTokenBuilder,
+
+class ContinuousTokenModelFamily(StrEnum):
+    AUTO = "auto"
+    DEFAULT = "default"
+    QWEN = "qwen"
+    QWEN25 = "qwen25"
+    QWEN3 = "qwen3"
+    QWEN35 = "qwen35"
+    MINIMAX = "minimax"
+    MINIMAX_M2 = "minimaxm2"
+    MINIMAX_M25 = "minimaxm25"
+    MINIMAX_M27 = "minimaxm27"
+    GLM47 = "glm47"
+    GLM5 = "glm5"
+    GEMMA4 = "gemma4"
+    GPTOSS = "gptoss"
+
+
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[ContinuousTokenModelFamily, type[Any]] = {
+    ContinuousTokenModelFamily.DEFAULT: ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN25: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN3: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN35: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M2: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M25: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M27: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM47: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM5: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GEMMA4: Gemma4ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GPTOSS: GptOssContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(family.value for family in _CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
-def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+def get_continuous_token_builder_class(model_family: str | ContinuousTokenModelFamily) -> type[Any]:
     family = _normalize_model_family(model_family)
     try:
         return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
@@ -65,15 +84,15 @@ def list_continuous_token_builder_families() -> tuple[str, ...]:
 
 
 def resolve_continuous_token_model_family(
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     *,
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
-    if family != "auto":
+    if family != ContinuousTokenModelFamily.AUTO:
         logger.info("Using explicit Continuous Token builder family: %s", family)
         return family
 
@@ -96,7 +115,7 @@ def infer_continuous_token_model_family(
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Infer a built-in model family from model/tokenizer names.
 
     Unknown models intentionally fall back to ``default`` so enabling
@@ -107,42 +126,42 @@ def infer_continuous_token_model_family(
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
     if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
-        return "glm5"
+        return ContinuousTokenModelFamily.GLM5
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
-        return "glm47"
+        return ContinuousTokenModelFamily.GLM47
     if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
         marker in compact for marker in ("gemma4", "gemma4unified")
     ):
-        return "gemma4"
+        return ContinuousTokenModelFamily.GEMMA4
     if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
-        return "gptoss"
+        return ContinuousTokenModelFamily.GPTOSS
     if "minimaxm27" in compact:
-        return "minimaxm27"
+        return ContinuousTokenModelFamily.MINIMAX_M27
     if "minimaxm25" in compact:
-        return "minimaxm25"
+        return ContinuousTokenModelFamily.MINIMAX_M25
     if "minimaxm2" in compact:
-        return "minimaxm2"
+        return ContinuousTokenModelFamily.MINIMAX_M2
     if "minimax" in compact:
-        return "minimax"
+        return ContinuousTokenModelFamily.MINIMAX
     if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
-        return "qwen35"
+        return ContinuousTokenModelFamily.QWEN35
     if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
-        return "qwen25"
+        return ContinuousTokenModelFamily.QWEN25
     if "qwen3" in compact:
-        return "qwen3"
+        return ContinuousTokenModelFamily.QWEN3
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
         model_path,
         tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
     )
-    return "default"
+    return ContinuousTokenModelFamily.DEFAULT
 
 
 def create_continuous_token_builder(
     tokenizer: Any,
     *,
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
@@ -160,13 +179,22 @@ def create_continuous_token_builder(
     return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
 
 
-def _normalize_model_family(model_family: str) -> str:
+def _normalize_model_family(model_family: str | ContinuousTokenModelFamily) -> ContinuousTokenModelFamily:
+    if isinstance(model_family, ContinuousTokenModelFamily):
+        return model_family
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
     family = model_family.strip().lower()
     if not family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return re.sub(r"[^a-z0-9]+", "", family)
+    family = re.sub(r"[^a-z0-9]+", "", family)
+    try:
+        return ContinuousTokenModelFamily(family)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token model_family {model_family!r}. "
+            f"Supported families: {(ContinuousTokenModelFamily.AUTO.value, *CONTINUOUS_TOKEN_BUILDER_FAMILIES)}."
+        ) from exc
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -1,0 +1,229 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder registry and model-family resolution."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from verl.utils.continuous_token import (
+    ContinuousTokenBuilder,
+    GLM47ContinuousTokenBuilder,
+    MiniMaxContinuousTokenBuilder,
+    Qwen35ContinuousTokenBuilder,
+    Qwen3ContinuousTokenBuilder,
+    QwenContinuousTokenBuilder,
+)
+from verl.utils.import_utils import import_external_libs
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+    "default": ContinuousTokenBuilder,
+    "qwen": QwenContinuousTokenBuilder,
+    "qwen25": QwenContinuousTokenBuilder,
+    "qwen3": Qwen3ContinuousTokenBuilder,
+    "qwen35": Qwen35ContinuousTokenBuilder,
+    "minimax": MiniMaxContinuousTokenBuilder,
+    "glm47": GLM47ContinuousTokenBuilder,
+}
+
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
+
+_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
+
+
+class ContinuousTokenBuilderRegistry:
+    """Registry for Continuous Token builder classes.
+
+    Custom builders can be registered from an imported Python module:
+
+    .. code-block:: python
+
+        @ContinuousTokenBuilderRegistry.register("deepseek")
+        class DeepseekContinuousTokenBuilder:
+            ...
+    """
+
+    _registry: dict[str, type[Any]] = {}
+
+    @classmethod
+    def register(cls, model_family: str, *, exist_ok: bool = False):
+        family = _normalize_model_family(model_family)
+        if family in _RESERVED_MODEL_FAMILIES:
+            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
+
+        def decorator(builder_cls: type[Any]) -> type[Any]:
+            if not isinstance(builder_cls, type):
+                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
+
+            existing = cls._registry.get(family)
+            if existing is not None and existing is not builder_cls and not exist_ok:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is already registered with "
+                    f"{existing}; pass exist_ok=True to replace it"
+                )
+            cls._registry[family] = builder_cls
+            return builder_cls
+
+        return decorator
+
+    @classmethod
+    def get(cls, model_family: str) -> type[Any]:
+        family = _normalize_model_family(model_family)
+        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
+            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+            if builder_cls is None:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
+                    "but its builder class has not been implemented yet."
+                )
+            return builder_cls
+        try:
+            return cls._registry[family]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown Continuous Token builder family {family!r}. "
+                f"Registered families: {sorted(cls._registry)}. "
+                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+            ) from exc
+
+    @classmethod
+    def registered_families(cls) -> tuple[str, ...]:
+        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
+
+
+def register_continuous_token_builder(
+    model_family: str,
+    builder_cls: type[Any] | None = None,
+    *,
+    exist_ok: bool = False,
+):
+    """Register a Continuous Token builder class for a model family.
+
+    This wrapper supports both direct calls and decorator usage. New code should
+    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
+    """
+    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
+    if builder_cls is None:
+        return decorator
+    return decorator(builder_cls)
+
+
+def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+    return ContinuousTokenBuilderRegistry.get(model_family)
+
+
+def list_continuous_token_builder_families() -> tuple[str, ...]:
+    return ContinuousTokenBuilderRegistry.registered_families()
+
+
+def resolve_continuous_token_model_family(
+    model_family: str,
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    family = _normalize_model_family(model_family)
+    if family != "auto":
+        logger.info("Using explicit Continuous Token builder family: %s", family)
+        return family
+
+    resolved = infer_continuous_token_model_family(
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    logger.info(
+        "Resolved Continuous Token builder family from auto: %s (model_path=%r, tokenizer_name_or_path=%r)",
+        resolved,
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
+    return resolved
+
+
+def infer_continuous_token_model_family(
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Infer a built-in model family from model/tokenizer names.
+
+    Unknown models intentionally fall back to ``default`` so enabling
+    ``model_family=auto`` remains conservative.
+    """
+    candidates = [model_path, tokenizer_name_or_path, _tokenizer_name_or_path(tokenizer)]
+    haystack = " ".join(str(item).lower() for item in candidates if item)
+    compact = re.sub(r"[^a-z0-9]+", "", haystack)
+
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
+        marker in compact for marker in ("glm47", "glm5")
+    ):
+        return "glm47"
+    if "minimax" in compact:
+        return "minimax"
+    if (
+        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
+        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
+    ):
+        return "qwen"
+    return "default"
+
+
+def create_continuous_token_builder(
+    tokenizer: Any,
+    *,
+    model_family: str,
+    model_path: str | None = None,
+    tokenizer_name_or_path: str | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    custom_builder_module: str | list[str] | None = None,
+    **builder_kwargs: Any,
+) -> Any:
+    """Instantiate the registered builder selected by config/model metadata."""
+    import_external_libs(custom_builder_module)
+    resolved_family = resolve_continuous_token_model_family(
+        model_family,
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    builder_cls = get_continuous_token_builder_class(resolved_family)
+    logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
+    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+
+
+def _normalize_model_family(model_family: str) -> str:
+    if not isinstance(model_family, str) or not model_family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return model_family.lower()
+
+
+def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:
+    if tokenizer is None:
+        return None
+    name = getattr(tokenizer, "name_or_path", None)
+    if name:
+        return str(name)
+    init_kwargs = getattr(tokenizer, "init_kwargs", None)
+    if isinstance(init_kwargs, dict) and init_kwargs.get("name_or_path"):
+        return str(init_kwargs["name_or_path"])
+    return None

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,12 +18,19 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
+from verl.utils.continuous_token_wiring import (
+    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
+    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
+)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
+    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
+    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
+    "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
     "AgentLoopConfig",
@@ -45,6 +52,17 @@ class SamplingConfig(BaseConfig):
 
 
 @dataclass
+class ContinuousTokenConfig(BaseConfig):
+    enable: bool = False
+    model_family: str = "auto"
+    custom_builder_module: Optional[str] = None
+
+    def __post_init__(self):
+        if not isinstance(self.model_family, str) or not self.model_family:
+            raise ValueError("continuous_token.model_family must be a non-empty string")
+
+
+@dataclass
 class MultiTurnConfig(BaseConfig):
     _mutable_fields = {"max_assistant_turns", "max_user_turns"}
 
@@ -58,6 +76,7 @@ class MultiTurnConfig(BaseConfig):
     tool_response_truncate_side: str = "middle"
     use_inference_chat_template: bool = False
     tokenization_sanity_check_mode: str = "strict"
+    continuous_token: ContinuousTokenConfig = field(default_factory=ContinuousTokenConfig)
     format: str = "hermes"
     num_repeat_rollouts: Optional[int] = None
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,18 +18,12 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
-from verl.utils.continuous_token_wiring import (
-    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
-    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
-)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
-    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
-    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
     "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
@@ -55,7 +49,6 @@ class SamplingConfig(BaseConfig):
 class ContinuousTokenConfig(BaseConfig):
     enable: bool = False
     model_family: str = "auto"
-    custom_builder_module: Optional[str] = None
 
     def __post_init__(self):
         if not isinstance(self.model_family, str) or not self.model_family:


### PR DESCRIPTION
### What does this PR do?

This PR wires Continuous Token into the existing AgentLoop execution paths. When CT is enabled and the rollout is text-only, AgentLoop builds the initial prompt with the CT builder, appends generated assistant tokens directly, and merges tool/user/system messages through CT while keeping `response_mask` and rollout logprobs aligned.

Multimodal processor paths continue to use the legacy behavior.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Test will be in PR 03

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

#### Main Changes

- Creates a CT builder in `AgentLoopBase` from `multi_turn.continuous_token` config.
- Adds helper methods for CT initial prompt creation, assistant-token merge, non-assistant message merge, prompt-length capping, and response metadata alignment.
- Integrates CT into `SingleTurnAgentLoop` for text-only prompts.
- Integrates CT into `ToolAgentLoop` for tool-call rollouts:
  - Keeps assistant generated tokens in the runtime token stream.
  - Appends tool responses using CT rather than isolated per-turn template rendering.
  - Preserves assistant `tool_calls` and tool `tool_call_id`/`name` metadata in message history.
- Adds additional model-specific tool parsers needed (GLM, Seed, MiniMax, Kimi). (This is open to discussion. Inference backend like SGLang has already supported returning both token id and OpenAI compatible message that contained the parsed tool call. Maybe we don't have to implement and use tool parser in Verl if we can get parsed tool calls from inference backend directly?)

#### Changed Files

- `verl/experimental/agent_loop/agent_loop.py`
  - Instantiates `continuous_token_builder` when CT is enabled and no multimodal processor is active.
  - Adds `build_ct_initial_prompt`, `merge_ct_non_assistant_msg`, and `merge_ct_assistant_token`.
  - Adds `_align_continuous_token_response_metadata` so inserted boundary tokens get mask/logprob `0`, assistant tokens get mask `1`, and removed prefix tokens are reflected in metadata.
  - Reuses `_cap_text_prompt_length` for CT and legacy text prompts.

- `verl/experimental/agent_loop/single_turn_agent_loop.py`
  - Uses CT for text-only single-turn prompts.
  - Appends generated assistant tokens with CT and then splits the merged stream back into prompt/response for `AgentLoopOutput`.
  - Keeps masks and logprobs aligned with the CT-merged response.

- `verl/experimental/agent_loop/tool_agent_loop.py`
  - Uses CT for the initial prompt and assistant/tool-message merges.
  - Appends assistant messages with structured `tool_calls` to the message history after parsing model output.
  - Adds tool-call IDs and tool names to generated tool messages.
  - Uses parser-provided `stop_token_ids`.
  - Keeps legacy special formatting paths for `gpt-oss`, `gemma4`, and multimodal tool responses.

- `verl/experimental/agent_loop/tool_parser.py`
  - Adds `GLMToolParser`.
  - Adds `SeedToolParser`.
  - Adds `MiniMaxToolParser`.
  - Adds `KimiToolParser`, including `last_tool_call_ids`.
  - Adds stop-token behavior for GLM/Kimi-style tool-call boundaries.

#### Notes

CT remains opt-in. The integration is conservative: if CT is enabled but a multimodal processor is present, the code logs a warning and falls back to the legacy multimodal path.

This PR also contains the diff from PR01. After PR01 is merged, this branch will be rebased and will only show the diff broughput about by this PR.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
