### PR TITLE
[rollout] continuous token vs legacy comparision

### DIFF
--- a/tests/experimental/agent_loop/continuous_token/README.md
+++ b/tests/experimental/agent_loop/continuous_token/README.md
@@ -1,0 +1,489 @@
+# Continuous Token Agent Loop Test Results
+
+This file records the current CT-vs-legacy end-to-end tokenizer alignment
+results for the default model set used by
+`compare_agentloop_ct_vs_legacy.py`.
+
+## Test Setup
+
+Default trajectories:
+
+```text
+singleturnchat          SingleTurnAgentLoop
+multiturnsingletool     ToolAgentLoop
+multiturnmultitool      ToolAgentLoop
+```
+
+Pass criteria:
+
+```text
+Flow is complete, and CT/legacy have identical prompt_ids, response_ids,
+loss_mask, and logprobs.
+```
+
+For tool-agent cases, the deterministic server uses the tested model's own
+tokenizer and chat template to render structured assistant messages, then
+returns the token-id suffix for each assistant turn. Tool responses are produced
+by deterministic tools and are appended by the real AgentLoop state machine.
+
+## Default Models
+
+```python
+DEFAULT_MODELS = [
+    # Qwen
+    "Qwen/Qwen2.5-0.5B-Instruct",
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen2.5-72B-Instruct",
+    "Qwen/Qwen3-0.6B",
+    "Qwen/Qwen3-1.7B",
+    "Qwen/Qwen3-4B",
+    "Qwen/Qwen3-4B-Instruct-2507",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.5-0.8B",
+    # GLM
+    "zai-org/GLM-4.7",
+    "zai-org/GLM-4.7-Flash",
+    "zai-org/GLM-5",
+    "zai-org/GLM-5.1",
+    # Kimi.
+    "moonshotai/Kimi-K2-Instruct",
+    "moonshotai/Kimi-K2.5",
+    "moonshotai/Kimi-K2.6",
+    # ByteDance Seed.
+    "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    # MiniMax
+    "MiniMaxAI/MiniMax-M2",
+    "MiniMaxAI/MiniMax-M2.5",
+    "MiniMaxAI/MiniMax-M2.7",
+    # MiMo
+    "XiaomiMiMo/MiMo-7B-SFT",
+    "XiaomiMiMo/MiMo-7B-RL",
+    # Nemotron
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+]
+```
+
+DeepSeek is still WIP and is intentionally not in `DEFAULT_MODELS`. The checked
+DeepSeek tokenizer family does not expose a Jinja `chat_template` compatible
+with this `apply_chat_template`-based e2e harness. To support it, verl's
+`apply_chat_template` wrapper needs to recognize DeepSeek models and call the
+official DeepSeek `encoding` script to render/tokenize messages, instead of
+relying on `tokenizer.apply_chat_template`.
+
+## Summary
+
+```text
+default_models: 25
+default_trajectory_runs: 75
+pass: 37
+mismatch: 32
+error: 6
+```
+
+## Results
+
+```text
+Family        Models  Runs  Pass  Mismatch  Error  Notes
+Qwen          9       27    9     18        0      Single-turn passes; tool cases mismatch because legacy misses the newline after assistant EOS.
+GLM           4       12    4     8         0      Single-turn CT-vs-legacy passes; tool cases mismatch on the observation boundary. GLM-5.1 matches full template; GLM-4.7/5 have acceptable think-boundary CT-vs-full raw mismatches.
+Kimi          3       9     9     0         0      All default trajectories pass with tool_parser=kimi. CT-vs-full-template is WIP.
+Seed-OSS      1       3     3     0         0      All default trajectories pass with tool_parser=seed. CT-vs-full-template is WIP.
+MiniMax       3       9     3     0         6      Single-turn passes; tool cases are legacy-only TemplateError. CT-vs-full-template is WIP.
+MiMo          2       6     6     0         0      All default trajectories pass with Hermes parser. CT-vs-full-template is WIP.
+Nemotron      3       9     3     6         0      Single-turn passes; tool cases mismatch because legacy misses the tool-response user header. CT-vs-full-template is WIP.
+```
+
+Unless stated otherwise in a family section, the pass/mismatch/error counts are
+strict CT-vs-legacy results. CT-vs-full-template has been reviewed and
+classified for Qwen and GLM. For Kimi, Seed-OSS, MiniMax, MiMo, and Nemotron,
+CT-vs-full-template is still WIP and should not be treated as a finalized
+alignment result.
+
+## Qwen
+
+Models covered:
+
+```text
+Qwen/Qwen2.5-0.5B-Instruct
+Qwen/Qwen2.5-1.5B-Instruct
+Qwen/Qwen2.5-72B-Instruct
+Qwen/Qwen3-0.6B
+Qwen/Qwen3-1.7B
+Qwen/Qwen3-4B
+Qwen/Qwen3-4B-Instruct-2507
+Qwen/Qwen3-8B
+Qwen/Qwen3.5-0.8B
+```
+
+Result:
+
+```text
+total: 27
+pass: 9
+mismatch: 18
+error: 0
+```
+
+```text
+Model group       singleturnchat  multiturnsingletool  multiturnmultitool
+Qwen2.5           pass            mismatch             mismatch
+Qwen3             pass            mismatch             mismatch
+Qwen3.5           pass            mismatch             mismatch
+```
+
+Qwen2.5 uses `tool_parser=hermes`; Qwen3.5 uses the existing `qwen3_coder`
+parser. Qwen2.5, Qwen3, and Qwen3.5 all use the shared Qwen CT builder because
+their ChatML templates share the same boundary behavior. The tool-agent
+mismatches are expected:
+after assistant EOS, full `apply_chat_template` contains:
+
+```text
+<|im_end|>\n<|im_start|>
+```
+
+Legacy appends the next rendered turn directly after `<|im_end|>`, so it misses
+the newline boundary. CT restores that canonical newline. The inserted newline
+has `loss_mask=0` and `logprob=0.0`.
+
+The harness reports CT-vs-legacy and CT-vs-full-template separately. Each
+section uses the metric that matches what it is comparing. CT-vs-legacy is a
+strict token/metadata comparison, so a mismatch is simply a mismatch. There is
+no separate material-mismatch concept for CT-vs-legacy.
+
+CT-vs-full-template compares decoded CT text with a complete post-hoc
+`apply_chat_template` render. For that comparison, raw mismatch is an exact
+text mismatch. Material mismatch means the meaningful generated trajectory
+differs: visible assistant content, tool calls, tool responses, or non-empty
+reasoning content are different. Pure template bookkeeping differences are
+reported as acceptable mismatches and do not count as material.
+
+For CT-vs-full-template, two differences are currently acceptable.
+
+1. Final trailing newline after the last assistant EOS. Full
+   `apply_chat_template` may render:
+
+   ```text
+   ...<|im_end|>\n
+   ```
+
+   CT decodes the generated runtime stream as:
+
+   ```text
+   ...<|im_end|>
+   ```
+
+   This is not material because the model generation stops at `<|im_end|>` and
+   does not emit the template-only newline after the final EOS.
+
+2. CT-only empty Qwen3 think block at assistant tool-call turns. Per-turn
+   generation may produce:
+
+   ```text
+   <|im_start|>assistant
+   <think>
+
+   </think>
+
+   I will check Seattle first.
+   <tool_call>...</tool_call><|im_end|>
+   ```
+
+   A complete post-hoc trajectory render may suppress the empty think block and
+   produce:
+
+   ```text
+   <|im_start|>assistant
+   I will check Seattle first.
+   <tool_call>...</tool_call><|im_end|>
+   ```
+
+   This is not material because the dropped block is exactly empty and appears
+   only as Qwen3 generation-time formatting immediately after the assistant
+   header. Removing it leaves the same visible content and the same tool call.
+   A non-empty `<think>...</think>` difference is not ignored and still counts
+   as a material mismatch.
+
+Current Qwen split comparison result:
+
+```text
+CT vs legacy:
+match: 9 / 27
+mismatch: 18 / 27
+error: 0 / 27
+
+CT vs full template:
+raw mismatch: 27 / 27
+acceptable mismatch: 27 / 27
+material mismatch: 0 / 27
+```
+
+All Qwen CT-vs-full-template raw mismatches are acceptable mismatches. There
+are no material CT-vs-full-template mismatches for the current Qwen result.
+
+Qwen2.5, Qwen3-4B-Instruct-2507, Qwen3.5, and Qwen3 base single-turn cases
+only have acceptable final trailing-newline differences: 19 cases total. Qwen3
+base tool-agent cases (`Qwen3-0.6B`, `Qwen3-1.7B`, `Qwen3-4B`, `Qwen3-8B`)
+additionally have acceptable CT-only empty think blocks at assistant tool-call
+turns: 8 cases total.
+
+
+## GLM
+
+Models covered:
+
+```text
+zai-org/GLM-4.7
+zai-org/GLM-4.7-Flash
+zai-org/GLM-5
+zai-org/GLM-5.1
+```
+
+Result:
+
+```text
+total: 12
+pass: 4
+mismatch: 8
+error: 0
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+GLM          pass            mismatch             mismatch
+```
+
+GLM uses `tool_parser=glm`. 
+
+Current GLM split comparison result:
+
+```text
+CT vs legacy:
+match: 4 / 12
+mismatch: 8 / 12
+error: 0 / 12
+
+CT vs full template:
+raw mismatch: 9 / 12
+acceptable mismatch: 9 / 12
+material mismatch: 0 / 12
+```
+
+For CT-vs-legacy, the tool-case mismatch is the observation boundary. Full
+`apply_chat_template` renders:
+
+```text
+</tool_call><|observation|><tool_response>
+```
+
+Legacy keeps the assistant output's stop observation and then appends another
+observation from the rendered tool response:
+
+```text
+</tool_call><|observation|><|observation|><tool_response>
+```
+
+CT removes the ambiguous duplicate boundary and matches the full-template
+boundary. The retained CT observation boundary tokens have `loss_mask=0` and
+`logprob=0.0`.
+
+For CT-vs-full-template, GLM-5.1 matches exactly on all three trajectories.
+GLM-4.7, GLM-4.7-Flash, and GLM-5 have acceptable raw mismatches on all three
+trajectories. The mismatch is the assistant thinking boundary. The CT runtime
+stream contains the generation-time thinking opener:
+
+```text
+<|assistant|><think>Yes, move the Friday demo ...
+```
+
+The full post-hoc `apply_chat_template` render contains the corresponding
+close boundary before assistant content when the assistant message has no
+separate `reasoning_content`:
+
+```text
+<|assistant|></think>Yes, move the Friday demo ...
+```
+
+Tool-call turns show the same pattern:
+
+```text
+CT:   <|assistant|><think>I will check Seattle first ...<tool_call>...
+Full: <|assistant|></think>I will check Seattle first ...<tool_call>...
+```
+
+This is not counted as material. For these dumped cases, replacing each CT
+`<|assistant|><think>` boundary with the full-template
+`<|assistant|></think>` boundary makes the decoded CT trajectory exactly equal
+to the full post-hoc render. The visible assistant content, tool calls, and tool
+responses are unchanged; only the template boundary used to connect a
+generation-time assistant stream with a no-reasoning post-hoc assistant message
+differs.
+
+## Kimi
+
+Models covered:
+
+```text
+moonshotai/Kimi-K2-Instruct
+moonshotai/Kimi-K2.5
+moonshotai/Kimi-K2.6
+```
+
+Result:
+
+```text
+total: 9
+pass: 9
+mismatch: 0
+error: 0
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+Kimi         pass            pass                 pass
+```
+
+All pass with `tool_parser=kimi`
+
+CT-vs-full-template status: WIP. The result above is CT-vs-legacy only.
+
+## ByteDance Seed
+
+Models covered:
+
+```text
+ByteDance-Seed/Seed-OSS-36B-Instruct
+```
+
+Result:
+
+```text
+total: 3
+pass: 3
+mismatch: 0
+error: 0
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+Seed-OSS     pass            pass                 pass
+```
+
+All pass with `tool_parser=seed`. 
+
+CT-vs-full-template status: WIP. The result above is CT-vs-legacy only.
+
+## MiniMax
+
+Models covered:
+
+```text
+MiniMaxAI/MiniMax-M2
+MiniMaxAI/MiniMax-M2.5
+MiniMaxAI/MiniMax-M2.7
+```
+
+Result:
+
+```text
+total: 9
+pass: 3
+mismatch: 0
+error: 6
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+MiniMax      pass            legacy-only error    legacy-only error
+```
+
+MiniMax tool-agent cases are legacy-only errors. The MiniMax template requires
+each `role=tool` message to be preceded by an assistant message with
+`tool_calls`. Legacy renders isolated `add_messages` containing only tool
+messages, so it raises:
+
+```text
+Message has tool role, but there was no previous assistant message with a tool call!
+```
+
+CT is the correct side for tool responses because it renders the tool message
+with a synthetic assistant tool-call prefix, preserving the template context.
+
+CT-vs-full-template status: WIP. The result above is CT-vs-legacy only.
+
+## MiMo
+
+Models covered:
+
+```text
+XiaomiMiMo/MiMo-7B-SFT
+XiaomiMiMo/MiMo-7B-RL
+```
+
+Result:
+
+```text
+total: 6
+pass: 6
+mismatch: 0
+error: 0
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+MiMo         pass            pass                 pass
+```
+
+MiMo passes all default trajectories with the Hermes parser.
+
+CT-vs-full-template status: WIP. The result above is CT-vs-legacy only.
+
+## Nvidia Nemotron
+
+Models covered:
+
+```text
+nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+```
+
+Result:
+
+```text
+total: 9
+pass: 3
+mismatch: 6
+error: 0
+```
+
+```text
+Model group  singleturnchat  multiturnsingletool  multiturnmultitool
+Nemotron     pass            mismatch             mismatch
+```
+
+The tool-case mismatch is a tool-response boundary mismatch where CT is the
+correct side. Full `apply_chat_template` renders:
+
+```text
+</tool_call>
+<|im_end|>
+<|im_start|>user
+<tool_response>
+...
+```
+
+Legacy isolated tool-message rendering omits the `<|im_start|>user` header:
+
+```text
+</tool_call>
+<|im_end|><tool_response>
+...
+```
+
+CT renders tool messages with the preceding synthetic assistant tool-call
+context, so it emits the same `<|im_start|>user\n<tool_response>` boundary as
+full `apply_chat_template`. The legacy is wrong.
+
+CT-vs-full-template status: WIP. The result above is CT-vs-legacy only.

--- a/tests/experimental/agent_loop/continuous_token/compare_agentloop_ct_vs_legacy.py
+++ b/tests/experimental/agent_loop/continuous_token/compare_agentloop_ct_vs_legacy.py
@@ -27,9 +27,9 @@ This avoids hard-coding a Hermes-style raw ``<tool_call>`` string as the model
 output and lets each tokenizer render structured ``assistant.tool_calls`` in
 its own canonical format.
 
-In order to mimic the model's generation behavior, if the suffix contains EOS, 
-truncate after the final EOS token to mimic rollout stopping at EOS instead of 
-returning template whitespace that follows it. Missing EOS is allowed only for GLM; 
+In order to mimic the model's generation behavior, if the suffix contains EOS,
+truncate after the final EOS token to mimic rollout stopping at EOS instead of
+returning template whitespace that follows it. Missing EOS is allowed only for GLM;
 GLM tool-call turns append the assistant/tool boundary token ``<|observation|>``.
 
 CT and legacy are then compared by running the real
@@ -73,7 +73,6 @@ from verl.utils.chat_template import apply_chat_template
 from verl.utils.tokenizer import normalize_token_ids
 from verl.workers.rollout.replica import TokenOutput
 
-
 DEFAULT_E2E_TRAJECTORIES = ("singleturnchat", "multiturnsingletool", "multiturnmultitool")
 
 
@@ -107,7 +106,7 @@ DEFAULT_MODELS = [
     "XiaomiMiMo/MiMo-7B-RL",
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
-    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
 ]
 
 
@@ -332,7 +331,7 @@ def _tokenizer_eos_token_ids(tokenizer) -> set[int]:
         return set()
     if isinstance(eos_token_id, int):
         return {eos_token_id}
-    if isinstance(eos_token_id, (list, tuple, set)):
+    if isinstance(eos_token_id, list | tuple | set):
         return {int(token_id) for token_id in eos_token_id if token_id is not None}
     raise TypeError(f"Unsupported eos_token_id type: {type(eos_token_id)!r}")
 
@@ -361,17 +360,15 @@ def _truncate_after_final_eos(
 
     tail = token_ids[-16:]
     raise ValueError(
-        "Assistant output token-id suffix does not contain eos_token_id "
-        f"{sorted(eos_token_ids)}; tail={tail}"
+        f"Assistant output token-id suffix does not contain eos_token_id {sorted(eos_token_ids)}; tail={tail}"
     )
 
 
 def _is_glm_tokenizer(tokenizer) -> bool:
     tokenizer_name = _tokenizer_name(tokenizer).lower()
     compact_name = "".join(char for char in tokenizer_name if char.isalnum())
-    return (
-        any(marker in tokenizer_name for marker in ("glm-4.7", "glm_4.7", "glm-5", "glm_5"))
-        or any(marker in compact_name for marker in ("glm47", "glm5"))
+    return any(marker in tokenizer_name for marker in ("glm-4.7", "glm_4.7", "glm-5", "glm_5")) or any(
+        marker in compact_name for marker in ("glm47", "glm5")
     )
 
 
@@ -425,7 +422,9 @@ def _prepare_assistant_outputs(
             )
         )
         canonical_messages.append(assistant_message)
-        canonical_messages.extend(json.loads(json.dumps(message, ensure_ascii=False)) for message in step.appended_messages)
+        canonical_messages.extend(
+            json.loads(json.dumps(message, ensure_ascii=False)) for message in step.appended_messages
+        )
 
     return assistant_outputs
 
@@ -903,7 +902,9 @@ def _compare_generation_prompts(legacy: E2ERunOutput, ct: E2ERunOutput) -> dict[
     comparisons = []
     turn_count = max(len(legacy.generation_prompt_ids), len(ct.generation_prompt_ids))
     for turn_index in range(turn_count):
-        legacy_ids = legacy.generation_prompt_ids[turn_index] if turn_index < len(legacy.generation_prompt_ids) else None
+        legacy_ids = (
+            legacy.generation_prompt_ids[turn_index] if turn_index < len(legacy.generation_prompt_ids) else None
+        )
         ct_ids = ct.generation_prompt_ids[turn_index] if turn_index < len(ct.generation_prompt_ids) else None
         comparisons.append({"turn": turn_index + 1, **_compare_sequence(legacy_ids, ct_ids)})
     return {
@@ -1403,6 +1404,15 @@ def _format_ct_full_state(raw_match: Any, material_equal: Any) -> str:
     return f"raw_match={raw_match} material_mismatch={material_mismatch}"
 
 
+def _format_result_match_state(result: dict[str, Any]) -> str:
+    ct_legacy_state = _format_ct_legacy_state(result.get("ct_legacy_match"))
+    ct_full_state = _format_ct_full_state(
+        result.get("ct_full_template_match"),
+        result.get("ct_full_template_material_match"),
+    )
+    return f"ct_vs_legacy({ct_legacy_state}) ct_vs_full({ct_full_state})"
+
+
 def _format_location(location: dict[str, Any] | None) -> str:
     if not location:
         return "?:?"
@@ -1537,9 +1547,7 @@ def _run_all(args) -> list[dict[str, Any]]:
                     "model": model,
                     "trajectory": trajectory.name,
                     "loop_type": (
-                        "single_turn_agent_loop"
-                        if isinstance(trajectory, SingleTurnTrajectory)
-                        else "tool_agent_loop"
+                        "single_turn_agent_loop" if isinstance(trajectory, SingleTurnTrajectory) else "tool_agent_loop"
                     ),
                     "requested_tool_parser": args.tool_parser if isinstance(trajectory, ToolAgentTrajectory) else None,
                     "tool_parser": tool_parser if isinstance(trajectory, ToolAgentTrajectory) else None,
@@ -1552,9 +1560,7 @@ def _run_all(args) -> list[dict[str, Any]]:
                 }
                 results.append(result)
                 print(
-                    f"  ERROR {result['error_type']}: {result['error']} "
-                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
-                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    f"  ERROR {result['error_type']}: {result['error']} {_format_result_match_state(result)}",
                     flush=True,
                 )
                 _print_error_details(result)
@@ -1576,18 +1582,14 @@ def _run_all(args) -> list[dict[str, Any]]:
             status = result["status"]
             if status == "pass":
                 print(
-                    "  PASS "
-                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
-                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    f"  PASS {_format_result_match_state(result)}",
                     flush=True,
                 )
                 _print_ct_full_template_details(result)
             elif status == "mismatch":
                 comparisons = result["comparisons"]
                 print(
-                    "  MISMATCH "
-                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
-                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))}) "
+                    f"  MISMATCH {_format_result_match_state(result)} "
                     f"prompt={comparisons['prompt_ids']['equal']} "
                     f"response={comparisons['response_ids']['equal']} "
                     f"mask={comparisons['loss_mask']['equal']} "
@@ -1598,9 +1600,7 @@ def _run_all(args) -> list[dict[str, Any]]:
                 _print_mismatch_details(result)
             else:
                 print(
-                    f"  ERROR {result.get('error_type')}: {result.get('error')} "
-                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
-                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    f"  ERROR {result.get('error_type')}: {result.get('error')} {_format_result_match_state(result)}",
                     flush=True,
                 )
                 _print_error_details(result)
@@ -1669,8 +1669,7 @@ def _print_summary(results: list[dict[str, Any]]) -> None:
     ct_legacy_error_count = sum(item.get("status") == "error" for item in results)
     ct_legacy_match_count = sum(item.get("ct_legacy_match") is True for item in results)
     ct_legacy_mismatch_count = sum(
-        item.get("ct_legacy_match") is False and item.get("status") != "error"
-        for item in results
+        item.get("ct_legacy_match") is False and item.get("status") != "error" for item in results
     )
 
     ct_full_error_count = sum(

--- a/tests/experimental/agent_loop/continuous_token/compare_agentloop_ct_vs_legacy.py
+++ b/tests/experimental/agent_loop/continuous_token/compare_agentloop_ct_vs_legacy.py
@@ -1,0 +1,1738 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compare agent-loop Continuous Token (CT) and legacy token end to end.
+
+The trajectories are messages-level fixtures. The test builds a deterministic
+rollout server for each case, plus deterministic tools for ToolAgentLoop cases.
+For each assistant turn, the mock generation is obtained from the tokenizer's
+own chat template:
+
+1. render ``prefix_messages`` with ``add_generation_prompt=True``;
+2. render ``prefix_messages + [assistant_message]`` with
+   ``add_generation_prompt=False``;
+3. return the token-id suffix of the full render after the prompt render;
+
+This avoids hard-coding a Hermes-style raw ``<tool_call>`` string as the model
+output and lets each tokenizer render structured ``assistant.tool_calls`` in
+its own canonical format.
+
+In order to mimic the model's generation behavior, if the suffix contains EOS, 
+truncate after the final EOS token to mimic rollout stopping at EOS instead of 
+returning template whitespace that follows it. Missing EOS is allowed only for GLM; 
+GLM tool-call turns append the assistant/tool boundary token ``<|observation|>``.
+
+CT and legacy are then compared by running the real
+agent loop twice with the same deterministic server outputs: legacy constructs
+the loop with CT disabled, while CT constructs it with the real
+builder enabled. ToolAgentLoop cases execute hardcoded ``FunctionTool``
+instances that return the trajectory's expected tool response.
+
+The harness also decodes the full CT token stream and compares it with the
+plain text produced by applying the chat template once to the complete
+trajectory. ``--dump-sequences`` writes CT/legacy token ids, decoded text,
+loss masks/logprobs, and full-template text artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from omegaconf import OmegaConf
+from transformers import AutoTokenizer
+
+from tests.experimental.agent_loop.continuous_token.mock_trajectories import (
+    TRAJECTORY_BY_NAME,
+    MockTrajectory,
+    SingleTurnTrajectory,
+    ToolAgentTrajectory,
+    get_trajectory,
+)
+from verl.experimental.agent_loop.agent_loop import AgentLoopOutput, DictConfigWrap, ToolListWrap
+from verl.experimental.agent_loop.single_turn_agent_loop import SingleTurnAgentLoop
+from verl.experimental.agent_loop.tool_agent_loop import ToolAgentLoop
+from verl.tools.function_tool import FunctionTool
+from verl.utils.chat_template import apply_chat_template
+from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.replica import TokenOutput
+
+
+DEFAULT_E2E_TRAJECTORIES = ("singleturnchat", "multiturnsingletool", "multiturnmultitool")
+
+
+DEFAULT_MODELS = [
+    # Qwen family.
+    "Qwen/Qwen2.5-0.5B-Instruct",
+    "Qwen/Qwen2.5-1.5B-Instruct",
+    "Qwen/Qwen2.5-72B-Instruct",
+    "Qwen/Qwen3-0.6B",
+    "Qwen/Qwen3-1.7B",
+    "Qwen/Qwen3-4B",
+    "Qwen/Qwen3-4B-Instruct-2507",
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.5-0.8B",
+    # GLM family.
+    "zai-org/GLM-4.7",
+    "zai-org/GLM-4.7-Flash",
+    "zai-org/GLM-5",
+    "zai-org/GLM-5.1",
+    # Moonshot Kimi.
+    "moonshotai/Kimi-K2-Instruct",
+    "moonshotai/Kimi-K2.5",
+    "moonshotai/Kimi-K2.6",
+    # ByteDance Seed.
+    "ByteDance-Seed/Seed-OSS-36B-Instruct",
+    # MiniMax/MiMo/Memo-adjacent tokenizer families.
+    "MiniMaxAI/MiniMax-M2",
+    "MiniMaxAI/MiniMax-M2.5",
+    "MiniMaxAI/MiniMax-M2.7",
+    "XiaomiMiMo/MiMo-7B-SFT",
+    "XiaomiMiMo/MiMo-7B-RL",
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16"
+]
+
+
+@dataclass(frozen=True)
+class PreparedAssistantOutput:
+    token_ids: list[int]
+    log_probs: list[float]
+
+
+@dataclass(frozen=True)
+class E2ERunOutput:
+    prompt_ids: list[int]
+    response_ids: list[int]
+    response_mask: list[int]
+    response_logprobs: list[float] | None
+    generation_prompt_ids: list[list[int]]
+    num_turns: int
+
+
+@dataclass(frozen=True)
+class FullTemplateOutput:
+    token_ids: list[int]
+    text: str
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]] | None
+
+
+class _NoopDataset:
+    pass
+
+
+class _DeterministicServer:
+    """Deterministic replacement for rollout server generation."""
+
+    def __init__(self, assistant_outputs: list[PreparedAssistantOutput]):
+        self.assistant_outputs = list(assistant_outputs)
+        self.prompt_ids_by_call: list[list[int]] = []
+        self._next_index = 0
+
+    async def generate(self, *, prompt_ids: list[int], **kwargs) -> TokenOutput:
+        del kwargs
+        self.prompt_ids_by_call.append(list(prompt_ids))
+        if self._next_index >= len(self.assistant_outputs):
+            raise RuntimeError(
+                f"Deterministic server received unexpected generate call #{self._next_index + 1}; "
+                f"only {len(self.assistant_outputs)} assistant outputs were prepared"
+            )
+        output = self.assistant_outputs[self._next_index]
+        self._next_index += 1
+        return TokenOutput(
+            token_ids=list(output.token_ids),
+            log_probs=list(output.log_probs),
+            extra_fields={"mock_generation_turn": self._next_index},
+        )
+
+    @property
+    def num_generate_calls(self) -> int:
+        return self._next_index
+
+
+def _set_pad_token(tokenizer) -> None:
+    if getattr(tokenizer, "pad_token_id", None) is None and getattr(tokenizer, "eos_token_id", None) is not None:
+        tokenizer.pad_token_id = tokenizer.eos_token_id
+    if getattr(tokenizer, "pad_token", None) is None and getattr(tokenizer, "eos_token", None) is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+
+def _load_tokenizer(model: str, *, local_files_only: bool):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model,
+        trust_remote_code=True,
+        local_files_only=local_files_only,
+        use_fast=True,
+    )
+    _set_pad_token(tokenizer)
+    if not getattr(tokenizer, "chat_template", None):
+        raise ValueError("tokenizer has no chat_template")
+    return tokenizer
+
+
+def _render_chat_tokens(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None,
+    add_generation_prompt: bool,
+) -> list[int]:
+    tokenized = apply_chat_template(
+        tokenizer,
+        messages,
+        tools=tools,
+        add_generation_prompt=add_generation_prompt,
+        tokenize=True,
+    )
+    return normalize_token_ids(tokenized)
+
+
+def _render_chat_text(
+    tokenizer,
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None,
+    add_generation_prompt: bool,
+) -> str:
+    rendered = apply_chat_template(
+        tokenizer,
+        messages,
+        tools=tools,
+        add_generation_prompt=add_generation_prompt,
+        tokenize=False,
+    )
+    if not isinstance(rendered, str):
+        raise TypeError(f"Expected chat template text, got {type(rendered)!r}")
+    return rendered
+
+
+def _render_assistant_output_ids(
+    tokenizer,
+    prefix_messages: list[dict[str, Any]],
+    assistant_message: dict[str, Any],
+    *,
+    tools: list[dict[str, Any]] | None,
+) -> list[int]:
+    prompt_ids = _render_chat_tokens(
+        tokenizer,
+        prefix_messages,
+        tools=tools,
+        add_generation_prompt=True,
+    )
+    full_ids = _render_chat_tokens(
+        tokenizer,
+        prefix_messages + [assistant_message],
+        tools=tools,
+        add_generation_prompt=False,
+    )
+    prompt_ids = _trim_generation_think_prefix(tokenizer, prompt_ids, full_ids)
+    prompt_ids = _replace_glm_generation_think_open_with_close(tokenizer, prompt_ids, full_ids)
+    prompt_ids = _replace_nemotron_generation_think_open_with_empty_block(tokenizer, prompt_ids, full_ids)
+    if full_ids[: len(prompt_ids)] != prompt_ids:
+        raise ValueError("Assistant output token-id suffix diff failed")
+    return _truncate_after_final_eos(
+        tokenizer,
+        full_ids[len(prompt_ids) :],
+        assistant_message=assistant_message,
+    )
+
+
+def _trim_generation_think_prefix(tokenizer, prompt_ids: list[int], full_ids: list[int]) -> list[int]:
+    if full_ids[: len(prompt_ids)] == prompt_ids:
+        return prompt_ids
+    tokenizer_name = _tokenizer_name(tokenizer).lower()
+    compact_name = "".join(char for char in tokenizer_name if char.isalnum())
+    if "minimax" not in compact_name:
+        return prompt_ids
+    think_prefix_ids = tokenizer.encode("<think>\n", add_special_tokens=False)
+    if think_prefix_ids and prompt_ids[-len(think_prefix_ids) :] == think_prefix_ids:
+        trimmed_prompt_ids = prompt_ids[: -len(think_prefix_ids)]
+        if full_ids[: len(trimmed_prompt_ids)] == trimmed_prompt_ids:
+            return trimmed_prompt_ids
+    return prompt_ids
+
+
+def _replace_glm_generation_think_open_with_close(tokenizer, prompt_ids: list[int], full_ids: list[int]) -> list[int]:
+    if full_ids[: len(prompt_ids)] == prompt_ids:
+        return prompt_ids
+    tokenizer_name = _tokenizer_name(tokenizer).lower()
+    compact_name = "".join(char for char in tokenizer_name if char.isalnum())
+    if not (
+        any(marker in tokenizer_name for marker in ("glm-4.7", "glm_4.7", "glm-5", "glm_5"))
+        or any(marker in compact_name for marker in ("glm47", "glm5"))
+    ):
+        return prompt_ids
+
+    think_open_ids = tokenizer.encode("<think>", add_special_tokens=False)
+    think_close_ids = tokenizer.encode("</think>", add_special_tokens=False)
+    if not think_open_ids or not think_close_ids:
+        return prompt_ids
+    if prompt_ids[-len(think_open_ids) :] != think_open_ids:
+        return prompt_ids
+
+    replaced_prompt_ids = prompt_ids[: -len(think_open_ids)] + think_close_ids
+    if full_ids[: len(replaced_prompt_ids)] == replaced_prompt_ids:
+        return replaced_prompt_ids
+    return prompt_ids
+
+
+def _replace_nemotron_generation_think_open_with_empty_block(
+    tokenizer, prompt_ids: list[int], full_ids: list[int]
+) -> list[int]:
+    if full_ids[: len(prompt_ids)] == prompt_ids:
+        return prompt_ids
+    tokenizer_name = _tokenizer_name(tokenizer).lower()
+    if "nemotron" not in tokenizer_name:
+        return prompt_ids
+
+    think_open_ids = tokenizer.encode("<think>\n", add_special_tokens=False)
+    think_empty_block_ids = tokenizer.encode("<think></think>", add_special_tokens=False)
+    if not think_open_ids or not think_empty_block_ids:
+        return prompt_ids
+    if prompt_ids[-len(think_open_ids) :] != think_open_ids:
+        return prompt_ids
+
+    replaced_prompt_ids = prompt_ids[: -len(think_open_ids)] + think_empty_block_ids
+    if full_ids[: len(replaced_prompt_ids)] == replaced_prompt_ids:
+        return replaced_prompt_ids
+    return prompt_ids
+
+
+def _tokenizer_name(tokenizer) -> str:
+    name = getattr(tokenizer, "name_or_path", None)
+    if name:
+        return str(name)
+    init_kwargs = getattr(tokenizer, "init_kwargs", None)
+    if isinstance(init_kwargs, dict) and init_kwargs.get("name_or_path"):
+        return str(init_kwargs["name_or_path"])
+    return ""
+
+
+def _tokenizer_eos_token_ids(tokenizer) -> set[int]:
+    eos_token_id = getattr(tokenizer, "eos_token_id", None)
+    if eos_token_id is None:
+        return set()
+    if isinstance(eos_token_id, int):
+        return {eos_token_id}
+    if isinstance(eos_token_id, (list, tuple, set)):
+        return {int(token_id) for token_id in eos_token_id if token_id is not None}
+    raise TypeError(f"Unsupported eos_token_id type: {type(eos_token_id)!r}")
+
+
+def _truncate_after_final_eos(
+    tokenizer,
+    token_ids: list[int],
+    *,
+    assistant_message: dict[str, Any],
+) -> list[int]:
+    eos_token_ids = _tokenizer_eos_token_ids(tokenizer)
+    eos_token_ids.update(_kimi_assistant_end_token_ids(tokenizer))
+    if not token_ids:
+        raise ValueError("Assistant output token-id suffix is empty")
+    if eos_token_ids:
+        if token_ids[-1] in eos_token_ids:
+            return token_ids
+        for index in range(len(token_ids) - 1, -1, -1):
+            if token_ids[index] in eos_token_ids:
+                return token_ids[: index + 1]
+
+    if _is_glm_tokenizer(tokenizer):
+        if assistant_message.get("tool_calls"):
+            return token_ids + [_require_single_token_id(tokenizer, "<|observation|>")]
+        return token_ids
+
+    tail = token_ids[-16:]
+    raise ValueError(
+        "Assistant output token-id suffix does not contain eos_token_id "
+        f"{sorted(eos_token_ids)}; tail={tail}"
+    )
+
+
+def _is_glm_tokenizer(tokenizer) -> bool:
+    tokenizer_name = _tokenizer_name(tokenizer).lower()
+    compact_name = "".join(char for char in tokenizer_name if char.isalnum())
+    return (
+        any(marker in tokenizer_name for marker in ("glm-4.7", "glm_4.7", "glm-5", "glm_5"))
+        or any(marker in compact_name for marker in ("glm47", "glm5"))
+    )
+
+
+def _kimi_assistant_end_token_ids(tokenizer) -> set[int]:
+    tokenizer_name = _tokenizer_name(tokenizer).lower()
+    if "kimi" not in tokenizer_name:
+        return set()
+    token_id = tokenizer.convert_tokens_to_ids("<|im_end|>")
+    if isinstance(token_id, int) and token_id >= 0:
+        return {token_id}
+    return set()
+
+
+def _require_single_token_id(tokenizer, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        raise ValueError(f"Tokenizer does not define required token {token!r}")
+    if isinstance(token_id, list):
+        if len(token_id) != 1:
+            raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")
+        token_id = token_id[0]
+    if not isinstance(token_id, int) or token_id < 0:
+        raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
+    return token_id
+
+
+def _assistant_logprobs(turn_index: int, length: int) -> list[float]:
+    return [round(-0.01 * (turn_index + 1) - 0.0001 * ((index % 19) + 1), 7) for index in range(length)]
+
+
+def _prepare_assistant_outputs(
+    tokenizer,
+    trajectory: ToolAgentTrajectory,
+) -> list[PreparedAssistantOutput]:
+    tools = trajectory.tool_schemas()
+    canonical_messages = [json.loads(json.dumps(message, ensure_ascii=False)) for message in trajectory.raw_prompt]
+    assistant_outputs: list[PreparedAssistantOutput] = []
+
+    for turn_index, step in enumerate(trajectory.steps):
+        assistant_message = json.loads(json.dumps(step.assistant, ensure_ascii=False))
+        assistant_ids = _render_assistant_output_ids(
+            tokenizer,
+            canonical_messages,
+            assistant_message,
+            tools=tools,
+        )
+        assistant_outputs.append(
+            PreparedAssistantOutput(
+                token_ids=assistant_ids,
+                log_probs=_assistant_logprobs(turn_index, len(assistant_ids)),
+            )
+        )
+        canonical_messages.append(assistant_message)
+        canonical_messages.extend(json.loads(json.dumps(message, ensure_ascii=False)) for message in step.appended_messages)
+
+    return assistant_outputs
+
+
+def _prepare_single_turn_assistant_output(
+    tokenizer,
+    trajectory: SingleTurnTrajectory,
+) -> PreparedAssistantOutput:
+    assistant_ids = _render_assistant_output_ids(
+        tokenizer,
+        [json.loads(json.dumps(message, ensure_ascii=False)) for message in trajectory.raw_prompt],
+        {"role": "assistant", "content": trajectory.assistant_response},
+        tools=None,
+    )
+    return PreparedAssistantOutput(
+        token_ids=assistant_ids,
+        log_probs=_assistant_logprobs(0, len(assistant_ids)),
+    )
+
+
+def _make_deterministic_tools(trajectory: ToolAgentTrajectory) -> list[FunctionTool]:
+    responses_by_tool: dict[str, list[str]] = {}
+    responses_by_call: dict[tuple[str, str], list[str]] = {}
+    for step in trajectory.steps:
+        tool_calls = step.assistant.get("tool_calls") or []
+        tool_messages = []
+        for message in step.appended_messages:
+            if message.get("role") != "tool":
+                raise ValueError(
+                    f"Trajectory {trajectory.name!r} appends role={message.get('role')!r}; "
+                    "the ToolAgentLoop e2e compare currently supports tool-response trajectories only"
+                )
+            tool_messages.append(message)
+            name = message.get("name")
+            if not name:
+                raise ValueError(f"Trajectory {trajectory.name!r} has a tool message without name: {message!r}")
+            responses_by_tool.setdefault(name, []).append(str(message.get("content", "")))
+        for tool_call, tool_message in zip(tool_calls, tool_messages, strict=False):
+            function_call = tool_call.get("function") or {}
+            name = function_call.get("name")
+            if not name:
+                continue
+            arguments_key = _canonical_arguments_key(function_call.get("arguments") or {})
+            responses_by_call.setdefault((name, arguments_key), []).append(str(tool_message.get("content", "")))
+
+    deterministic_tools: list[FunctionTool] = []
+    for tool in trajectory.tools:
+        response_queue = list(responses_by_tool.get(tool.name, []))
+        responses_by_args = {
+            arguments_key: list(queue)
+            for (tool_name, arguments_key), queue in responses_by_call.items()
+            if tool_name == tool.name
+        }
+
+        def _make_tool_fn(tool_name: str, queue: list[str], by_args: dict[str, list[str]]):
+            def _tool_fn(**kwargs):
+                arguments_key = _canonical_arguments_key(kwargs)
+                if arguments_key in by_args and by_args[arguments_key]:
+                    response = by_args[arguments_key].pop(0)
+                    if response in queue:
+                        queue.remove(response)
+                    return response
+                if not queue:
+                    raise RuntimeError(f"No deterministic response left for tool {tool_name!r}")
+                return queue.pop(0)
+
+            return _tool_fn
+
+        deterministic_tools.append(
+            FunctionTool(
+                name=tool.name,
+                fn=_make_tool_fn(tool.name, response_queue, responses_by_args),
+                tool_schema=tool.tool_schema,
+            )
+        )
+    return deterministic_tools
+
+
+def _canonical_arguments_key(arguments: dict[str, Any]) -> str:
+    return json.dumps(arguments, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _continuous_token_config(enable_ct: bool) -> dict[str, Any]:
+    return {
+        "enable": enable_ct,
+        "model_family": "auto",
+        "custom_builder_module": None,
+    }
+
+
+def _make_tool_agent_config(
+    *,
+    model: str,
+    enable_ct: bool,
+    tool_parser: str,
+    trajectory: ToolAgentTrajectory,
+):
+    return OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "model": {"path": model, "tokenizer_path": model},
+                "rollout": {
+                    "prompt_length": 32768,
+                    "response_length": 32768,
+                    "multi_turn": {
+                        "format": tool_parser,
+                        "max_user_turns": trajectory.expected_num_turns + 4,
+                        "max_assistant_turns": trajectory.expected_generation_turns + 4,
+                        "max_parallel_calls": trajectory.max_parallel_calls,
+                        "max_tool_response_length": 8192,
+                        "tool_response_truncate_side": "right",
+                        "continuous_token": _continuous_token_config(enable_ct),
+                    },
+                },
+            }
+        }
+    )
+
+
+def _make_single_turn_config(*, model: str, enable_ct: bool):
+    return OmegaConf.create(
+        {
+            "actor_rollout_ref": {
+                "model": {"path": model, "tokenizer_path": model},
+                "rollout": {
+                    "prompt_length": 32768,
+                    "response_length": 32768,
+                    "multi_turn": {
+                        "continuous_token": _continuous_token_config(enable_ct),
+                    },
+                },
+            }
+        }
+    )
+
+
+def _infer_tool_parser(model: str, requested_tool_parser: str) -> str:
+    if requested_tool_parser != "auto":
+        return requested_tool_parser
+    normalized = model.lower()
+    compact = "".join(char for char in normalized if char.isalnum())
+    if any(marker in normalized for marker in ("glm-4.7", "glm_4.7", "glm-5", "glm_5")) or any(
+        marker in compact for marker in ("glm47", "glm5")
+    ):
+        return "glm"
+    if "qwen35" in compact or "qwen3coder" in compact:
+        return "qwen3_coder"
+    if "kimi" in normalized:
+        return "kimi"
+    if "bytedance-seed" in normalized or "seedoss" in compact or "seedcoder" in compact:
+        return "seed"
+    if "minimax" in compact:
+        return "minimax"
+    if "nemotron" in normalized:
+        return "qwen3_coder"
+    return "hermes"
+
+
+def _data_config():
+    return OmegaConf.create({"apply_chat_template_kwargs": {}, "mm_processor_kwargs": {}})
+
+
+async def _run_e2e_path(
+    tokenizer,
+    model: str,
+    trajectory: ToolAgentTrajectory,
+    *,
+    use_ct: bool,
+    tool_parser: str,
+) -> E2ERunOutput:
+    server = _DeterministicServer(_prepare_assistant_outputs(tokenizer, trajectory))
+    loop = ToolAgentLoop(
+        trainer_config=DictConfigWrap(
+            _make_tool_agent_config(model=model, enable_ct=use_ct, tool_parser=tool_parser, trajectory=trajectory)
+        ),
+        server_manager=server,
+        tokenizer=tokenizer,
+        processor=None,
+        dataset_cls=_NoopDataset,
+        data_config=DictConfigWrap(_data_config()),
+        tools=ToolListWrap(_make_deterministic_tools(trajectory)),
+    )
+    output: AgentLoopOutput = await loop.run(
+        sampling_params={"logprobs": True},
+        raw_prompt=[json.loads(json.dumps(message, ensure_ascii=False)) for message in trajectory.raw_prompt],
+    )
+    return E2ERunOutput(
+        prompt_ids=output.prompt_ids,
+        response_ids=output.response_ids,
+        response_mask=output.response_mask,
+        response_logprobs=output.response_logprobs,
+        generation_prompt_ids=server.prompt_ids_by_call,
+        num_turns=output.num_turns,
+    )
+
+
+async def _run_single_turn_e2e_path(
+    tokenizer,
+    model: str,
+    trajectory: SingleTurnTrajectory,
+    *,
+    use_ct: bool,
+) -> E2ERunOutput:
+    server = _DeterministicServer([_prepare_single_turn_assistant_output(tokenizer, trajectory)])
+    loop = SingleTurnAgentLoop(
+        trainer_config=DictConfigWrap(_make_single_turn_config(model=model, enable_ct=use_ct)),
+        server_manager=server,
+        tokenizer=tokenizer,
+        processor=None,
+        dataset_cls=_NoopDataset,
+        data_config=DictConfigWrap(_data_config()),
+    )
+    output: AgentLoopOutput = await loop.run(
+        sampling_params={"logprobs": True},
+        raw_prompt=[json.loads(json.dumps(message, ensure_ascii=False)) for message in trajectory.raw_prompt],
+    )
+    return E2ERunOutput(
+        prompt_ids=output.prompt_ids,
+        response_ids=output.response_ids,
+        response_mask=output.response_mask,
+        response_logprobs=output.response_logprobs,
+        generation_prompt_ids=server.prompt_ids_by_call,
+        num_turns=output.num_turns,
+    )
+
+
+def _hash_sequence(seq: list[int] | list[float] | None) -> str | None:
+    if seq is None:
+        return None
+    blob = json.dumps(seq, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _hash_text(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _first_mismatch(left: list[Any] | None, right: list[Any] | None) -> int | None:
+    if left is None or right is None:
+        return None if left is right else 0
+    for index, (left_item, right_item) in enumerate(zip(left, right, strict=False)):
+        if left_item != right_item:
+            return index
+    if len(left) != len(right):
+        return min(len(left), len(right))
+    return None
+
+
+def _compare_sequence(left: list[Any] | None, right: list[Any] | None) -> dict[str, Any]:
+    left_len = None if left is None else len(left)
+    right_len = None if right is None else len(right)
+    first_mismatch = _first_mismatch(left, right)
+    return {
+        "equal": left == right,
+        "legacy_len": left_len,
+        "ct_len": right_len,
+        "first_mismatch": first_mismatch,
+        "legacy_hash": _hash_sequence(left),
+        "ct_hash": _hash_sequence(right),
+        "legacy_value": (
+            None if first_mismatch is None or left is None or first_mismatch >= len(left) else left[first_mismatch]
+        ),
+        "ct_value": (
+            None if first_mismatch is None or right is None or first_mismatch >= len(right) else right[first_mismatch]
+        ),
+    }
+
+
+def _full_token_ids(output: E2ERunOutput) -> list[int]:
+    return list(output.prompt_ids) + list(output.response_ids)
+
+
+def _decode_token_ids(tokenizer, token_ids: list[int]) -> str:
+    return tokenizer.decode(token_ids, skip_special_tokens=False)
+
+
+def _full_messages_and_tools(trajectory: MockTrajectory) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None]:
+    if isinstance(trajectory, SingleTurnTrajectory):
+        messages = [json.loads(json.dumps(message, ensure_ascii=False)) for message in trajectory.raw_prompt]
+        messages.append({"role": "assistant", "content": trajectory.assistant_response})
+        return messages, None
+    return trajectory.full_messages(), trajectory.tool_schemas()
+
+
+def _render_full_template_output(tokenizer, trajectory: MockTrajectory) -> FullTemplateOutput:
+    messages, tools = _full_messages_and_tools(trajectory)
+    return FullTemplateOutput(
+        token_ids=_render_chat_tokens(tokenizer, messages, tools=tools, add_generation_prompt=False),
+        text=_render_chat_text(tokenizer, messages, tools=tools, add_generation_prompt=False),
+        messages=messages,
+        tools=tools,
+    )
+
+
+def _capture_full_template_output(
+    tokenizer,
+    trajectory: MockTrajectory,
+) -> tuple[FullTemplateOutput | None, dict[str, Any] | None]:
+    try:
+        return _render_full_template_output(tokenizer, trajectory), None
+    except Exception as exc:
+        return None, {"error_type": type(exc).__name__, "error": str(exc)}
+
+
+def _first_text_mismatch(left: str | None, right: str | None) -> int | None:
+    if left is None or right is None:
+        return None if left is right else 0
+    for index, (left_char, right_char) in enumerate(zip(left, right, strict=False)):
+        if left_char != right_char:
+            return index
+    if len(left) != len(right):
+        return min(len(left), len(right))
+    return None
+
+
+def _line_col(text: str | None, index: int | None) -> dict[str, int | None]:
+    if text is None or index is None:
+        return {"line": None, "column": None}
+    bounded_index = min(index, len(text))
+    line = text.count("\n", 0, bounded_index) + 1
+    last_newline = text.rfind("\n", 0, bounded_index)
+    column = bounded_index + 1 if last_newline < 0 else bounded_index - last_newline
+    return {"line": line, "column": column}
+
+
+def _text_context(text: str | None, index: int | None, *, radius: int = 96) -> dict[str, Any] | None:
+    if text is None or index is None:
+        return None
+    bounded_index = min(index, len(text))
+    start = max(0, bounded_index - radius)
+    end = min(len(text), bounded_index + radius)
+    return {"start": start, "end": end, "text": text[start:end]}
+
+
+def _compare_text(left: str | None, right: str | None, *, left_name: str, right_name: str) -> dict[str, Any]:
+    first_mismatch = _first_text_mismatch(left, right)
+    left_len = None if left is None else len(left)
+    right_len = None if right is None else len(right)
+    comparison = {
+        "equal": left == right,
+        f"{left_name}_len": left_len,
+        f"{right_name}_len": right_len,
+        "first_mismatch": first_mismatch,
+        f"{left_name}_hash": _hash_text(left),
+        f"{right_name}_hash": _hash_text(right),
+        f"{left_name}_location": _line_col(left, first_mismatch),
+        f"{right_name}_location": _line_col(right, first_mismatch),
+        f"{left_name}_char": (
+            None if left is None or first_mismatch is None or first_mismatch >= len(left) else left[first_mismatch]
+        ),
+        f"{right_name}_char": (
+            None if right is None or first_mismatch is None or first_mismatch >= len(right) else right[first_mismatch]
+        ),
+        f"{left_name}_context": _text_context(left, first_mismatch),
+        f"{right_name}_context": _text_context(right, first_mismatch),
+    }
+    return comparison
+
+
+_ASSISTANT_HEADER = "<|im_start|>assistant\n"
+_EMPTY_THINK_BLOCK = "<think>\n\n</think>\n\n"
+_GLM_GENERATION_THINK_OPEN = "<|assistant|><think>"
+_GLM_FULL_TEMPLATE_THINK_CLOSE = "<|assistant|></think>"
+
+
+def _is_skippable_ct_empty_think_block(text: str, index: int) -> bool:
+    return text.startswith(_EMPTY_THINK_BLOCK, index) and text[:index].endswith(_ASSISTANT_HEADER)
+
+
+def _ct_matches_after_dropping_empty_think_blocks(ct_text: str, target_text: str) -> tuple[bool, int]:
+    """Return whether target_text can be obtained by dropping CT-only empty think blocks."""
+    ct_index = 0
+    target_index = 0
+    dropped_blocks = 0
+    while ct_index < len(ct_text) and target_index < len(target_text):
+        if ct_text[ct_index] == target_text[target_index]:
+            ct_index += 1
+            target_index += 1
+            continue
+        if _is_skippable_ct_empty_think_block(ct_text, ct_index):
+            ct_index += len(_EMPTY_THINK_BLOCK)
+            dropped_blocks += 1
+            continue
+        return False, dropped_blocks
+
+    while ct_index < len(ct_text) and _is_skippable_ct_empty_think_block(ct_text, ct_index):
+        ct_index += len(_EMPTY_THINK_BLOCK)
+        dropped_blocks += 1
+
+    return ct_index == len(ct_text) and target_index == len(target_text) and dropped_blocks > 0, dropped_blocks
+
+
+def _replace_glm_generation_think_open_with_full_close(text: str) -> tuple[str, int]:
+    replacement_count = text.count(_GLM_GENERATION_THINK_OPEN)
+    if not replacement_count:
+        return text, 0
+    return (
+        text.replace(_GLM_GENERATION_THINK_OPEN, _GLM_FULL_TEMPLATE_THINK_CLOSE),
+        replacement_count,
+    )
+
+
+def _mark_ct_full_material_match(
+    comparison: dict[str, Any],
+    *,
+    acceptable_mismatch: bool,
+    mismatch_kinds: list[str],
+    dropped_empty_think_blocks: int = 0,
+    glm_think_boundary_replacements: int = 0,
+) -> None:
+    mismatch_kind = "+".join(mismatch_kinds) if mismatch_kinds else None
+    comparison.update(
+        {
+            "material_equal": True,
+            "acceptable_mismatch": acceptable_mismatch,
+            "mismatch_kind": mismatch_kind,
+            "mismatch_kinds": mismatch_kinds,
+        }
+    )
+    if dropped_empty_think_blocks:
+        comparison["dropped_ct_empty_think_blocks"] = dropped_empty_think_blocks
+    if glm_think_boundary_replacements:
+        comparison["glm_think_boundary_replacements"] = glm_think_boundary_replacements
+
+
+def _classify_ct_full_template_comparison(comparison: dict[str, Any], ct_text: str, full_template_text: str) -> None:
+    if comparison.get("equal"):
+        _mark_ct_full_material_match(comparison, acceptable_mismatch=False, mismatch_kinds=[])
+        return
+
+    candidate_targets = [(full_template_text, [])]
+    if full_template_text.endswith("\n"):
+        candidate_targets.append((full_template_text[:-1], ["full_template_final_trailing_newline"]))
+
+    for target_text, mismatch_kinds in candidate_targets:
+        if target_text == ct_text:
+            _mark_ct_full_material_match(
+                comparison,
+                acceptable_mismatch=True,
+                mismatch_kinds=mismatch_kinds,
+            )
+            return
+        empty_think_match, dropped_blocks = _ct_matches_after_dropping_empty_think_blocks(ct_text, target_text)
+        if empty_think_match:
+            _mark_ct_full_material_match(
+                comparison,
+                acceptable_mismatch=True,
+                mismatch_kinds=["ct_extra_empty_think_block", *mismatch_kinds],
+                dropped_empty_think_blocks=dropped_blocks,
+            )
+            return
+        normalized_ct_text, replacement_count = _replace_glm_generation_think_open_with_full_close(ct_text)
+        if replacement_count and normalized_ct_text == target_text:
+            _mark_ct_full_material_match(
+                comparison,
+                acceptable_mismatch=True,
+                mismatch_kinds=["glm_generation_think_open_vs_full_close", *mismatch_kinds],
+                glm_think_boundary_replacements=replacement_count,
+            )
+            return
+
+    comparison.update(
+        {
+            "material_equal": False,
+            "acceptable_mismatch": False,
+            "mismatch_kind": "material_text_difference",
+            "mismatch_kinds": ["material_text_difference"],
+        }
+    )
+
+
+def _compare_generation_prompts(legacy: E2ERunOutput, ct: E2ERunOutput) -> dict[str, Any]:
+    comparisons = []
+    turn_count = max(len(legacy.generation_prompt_ids), len(ct.generation_prompt_ids))
+    for turn_index in range(turn_count):
+        legacy_ids = legacy.generation_prompt_ids[turn_index] if turn_index < len(legacy.generation_prompt_ids) else None
+        ct_ids = ct.generation_prompt_ids[turn_index] if turn_index < len(ct.generation_prompt_ids) else None
+        comparisons.append({"turn": turn_index + 1, **_compare_sequence(legacy_ids, ct_ids)})
+    return {
+        "equal": all(item["equal"] for item in comparisons),
+        "turns": comparisons,
+    }
+
+
+def _summarize_output(output: E2ERunOutput) -> dict[str, Any]:
+    response_logprobs_len = None if output.response_logprobs is None else len(output.response_logprobs)
+    return {
+        "num_turns": output.num_turns,
+        "generation_turns": len(output.generation_prompt_ids),
+        "generation_prompt_lengths": [len(ids) for ids in output.generation_prompt_ids],
+        "token_len": len(_full_token_ids(output)),
+        "prompt_len": len(output.prompt_ids),
+        "response_len": len(output.response_ids),
+        "response_mask_len": len(output.response_mask),
+        "response_logprobs_len": response_logprobs_len,
+    }
+
+
+def _summarize_full_template(output: FullTemplateOutput) -> dict[str, Any]:
+    return {
+        "token_len": len(output.token_ids),
+        "text_len": len(output.text),
+        "token_hash": _hash_sequence(output.token_ids),
+        "text_hash": _hash_text(output.text),
+    }
+
+
+def _run_e2e_path_sync(
+    tokenizer,
+    model: str,
+    trajectory: ToolAgentTrajectory,
+    *,
+    use_ct: bool,
+    tool_parser: str,
+) -> E2ERunOutput:
+    return asyncio.run(
+        _run_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=use_ct,
+            tool_parser=tool_parser,
+        )
+    )
+
+
+def _run_single_turn_e2e_path_sync(
+    tokenizer,
+    model: str,
+    trajectory: SingleTurnTrajectory,
+    *,
+    use_ct: bool,
+) -> E2ERunOutput:
+    return asyncio.run(
+        _run_single_turn_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=use_ct,
+        )
+    )
+
+
+def _capture_e2e_path(
+    tokenizer,
+    model: str,
+    trajectory: ToolAgentTrajectory,
+    *,
+    use_ct: bool,
+    tool_parser: str,
+) -> tuple[E2ERunOutput | None, dict[str, Any] | None]:
+    try:
+        return (
+            _run_e2e_path_sync(
+                tokenizer,
+                model,
+                trajectory,
+                use_ct=use_ct,
+                tool_parser=tool_parser,
+            ),
+            None,
+        )
+    except Exception as exc:
+        return (
+            None,
+            {
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+def _capture_single_turn_e2e_path(
+    tokenizer,
+    model: str,
+    trajectory: SingleTurnTrajectory,
+    *,
+    use_ct: bool,
+) -> tuple[E2ERunOutput | None, dict[str, Any] | None]:
+    try:
+        return (
+            _run_single_turn_e2e_path_sync(
+                tokenizer,
+                model,
+                trajectory,
+                use_ct=use_ct,
+            ),
+            None,
+        )
+    except Exception as exc:
+        return (
+            None,
+            {
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+
+def _json_safe_path(path: Path) -> str:
+    return str(path)
+
+
+def _artifact_slug(model: str, trajectory_name: str) -> str:
+    raw = f"{model}__{trajectory_name}"
+    return "".join(char.lower() if char.isalnum() else "_" for char in raw).strip("_")
+
+
+def _output_dump_payload(tokenizer, output: E2ERunOutput) -> dict[str, Any]:
+    token_ids = _full_token_ids(output)
+    return {
+        "token_ids": token_ids,
+        "prompt_ids": output.prompt_ids,
+        "response_ids": output.response_ids,
+        "response_mask": output.response_mask,
+        "loss_mask": output.response_mask,
+        "response_logprobs": output.response_logprobs,
+        "logprobs": output.response_logprobs,
+        "generation_prompt_ids": output.generation_prompt_ids,
+        "decoded_text": _decode_token_ids(tokenizer, token_ids),
+        "decoded_prompt": _decode_token_ids(tokenizer, output.prompt_ids),
+        "decoded_response": _decode_token_ids(tokenizer, output.response_ids),
+        "summary": _summarize_output(output),
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any] | list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _dump_output_artifact(
+    *,
+    tokenizer,
+    dump_dir: Path,
+    slug: str,
+    side: str,
+    output: E2ERunOutput | None,
+    error: dict[str, Any] | None,
+) -> dict[str, str]:
+    json_path = dump_dir / f"{slug}_{side}.json"
+    artifact_paths = {f"{side}_json": _json_safe_path(json_path)}
+    if output is None:
+        _write_json(json_path, {"error": error})
+        return artifact_paths
+
+    payload = _output_dump_payload(tokenizer, output)
+    _write_json(json_path, payload)
+    decoded_path = dump_dir / f"{slug}_{side}_decoded.txt"
+    _write_text(decoded_path, payload["decoded_text"])
+    artifact_paths[f"{side}_decoded_text"] = _json_safe_path(decoded_path)
+    return artifact_paths
+
+
+def _dump_full_template_artifact(
+    *,
+    dump_dir: Path,
+    slug: str,
+    output: FullTemplateOutput | None,
+    error: dict[str, Any] | None,
+) -> dict[str, str]:
+    json_path = dump_dir / f"{slug}_full_apply_chat_template.json"
+    artifact_paths = {"full_template_json": _json_safe_path(json_path)}
+    if output is None:
+        _write_json(json_path, {"error": error})
+        return artifact_paths
+
+    payload = {
+        "token_ids": output.token_ids,
+        "text": output.text,
+        "messages": output.messages,
+        "tools": output.tools,
+        "summary": _summarize_full_template(output),
+    }
+    _write_json(json_path, payload)
+    text_path = dump_dir / f"{slug}_full_apply_chat_template.txt"
+    _write_text(text_path, output.text)
+    artifact_paths["full_template_text"] = _json_safe_path(text_path)
+
+    messages_path = dump_dir / f"{slug}_full_messages.json"
+    _write_json(messages_path, {"messages": output.messages, "tools": output.tools})
+    artifact_paths["full_messages_json"] = _json_safe_path(messages_path)
+    return artifact_paths
+
+
+def _dump_case_artifacts(
+    *,
+    tokenizer,
+    dump_dir: Path | None,
+    model: str,
+    trajectory_name: str,
+    legacy_output: E2ERunOutput | None,
+    legacy_error: dict[str, Any] | None,
+    ct_output: E2ERunOutput | None,
+    ct_error: dict[str, Any] | None,
+    full_template_output: FullTemplateOutput | None,
+    full_template_error: dict[str, Any] | None,
+) -> dict[str, str]:
+    if dump_dir is None:
+        return {}
+    slug = _artifact_slug(model, trajectory_name)
+    artifacts: dict[str, str] = {}
+    artifacts.update(
+        _dump_output_artifact(
+            tokenizer=tokenizer,
+            dump_dir=dump_dir,
+            slug=slug,
+            side="legacy",
+            output=legacy_output,
+            error=legacy_error,
+        )
+    )
+    artifacts.update(
+        _dump_output_artifact(
+            tokenizer=tokenizer,
+            dump_dir=dump_dir,
+            slug=slug,
+            side="ct",
+            output=ct_output,
+            error=ct_error,
+        )
+    )
+    artifacts.update(
+        _dump_full_template_artifact(
+            dump_dir=dump_dir,
+            slug=slug,
+            output=full_template_output,
+            error=full_template_error,
+        )
+    )
+    return artifacts
+
+
+def _ct_vs_full_template_comparison(
+    tokenizer,
+    ct_output: E2ERunOutput | None,
+    full_template_output: FullTemplateOutput | None,
+    full_template_error: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if full_template_error:
+        return {"equal": False, "material_equal": False, "error": full_template_error}
+    if ct_output is None:
+        return {
+            "equal": False,
+            "material_equal": False,
+            "error": {"error_type": "MissingCTOutput", "error": "CT output is unavailable"},
+        }
+    if full_template_output is None:
+        return {
+            "equal": False,
+            "material_equal": False,
+            "error": {"error_type": "MissingFullTemplateOutput", "error": "Full template output is unavailable"},
+        }
+    ct_text = _decode_token_ids(tokenizer, _full_token_ids(ct_output))
+    comparison = _compare_text(
+        ct_text,
+        full_template_output.text,
+        left_name="ct_text",
+        right_name="full_template_text",
+    )
+    _classify_ct_full_template_comparison(comparison, ct_text, full_template_output.text)
+    return comparison
+
+
+def run_one_case(
+    tokenizer,
+    model: str,
+    trajectory: MockTrajectory,
+    *,
+    tool_parser: str,
+    dump_dir: Path | None = None,
+) -> dict[str, Any]:
+    loop_type = "single_turn_agent_loop" if isinstance(trajectory, SingleTurnTrajectory) else "tool_agent_loop"
+    result: dict[str, Any] = {
+        "model": model,
+        "trajectory": trajectory.name,
+        "loop_type": loop_type,
+        "tool_parser": tool_parser if isinstance(trajectory, ToolAgentTrajectory) else None,
+    }
+    if isinstance(trajectory, SingleTurnTrajectory):
+        legacy_output, legacy_error = _capture_single_turn_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=False,
+        )
+        ct_output, ct_error = _capture_single_turn_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=True,
+        )
+        expected_generation_turns = 1
+    else:
+        legacy_output, legacy_error = _capture_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=False,
+            tool_parser=tool_parser,
+        )
+        ct_output, ct_error = _capture_e2e_path(
+            tokenizer,
+            model,
+            trajectory,
+            use_ct=True,
+            tool_parser=tool_parser,
+        )
+        expected_generation_turns = trajectory.expected_generation_turns
+
+    full_template_output, full_template_error = _capture_full_template_output(tokenizer, trajectory)
+    ct_vs_full_template = _ct_vs_full_template_comparison(
+        tokenizer,
+        ct_output,
+        full_template_output,
+        full_template_error,
+    )
+    artifacts = _dump_case_artifacts(
+        tokenizer=tokenizer,
+        dump_dir=dump_dir,
+        model=model,
+        trajectory_name=trajectory.name,
+        legacy_output=legacy_output,
+        legacy_error=legacy_error,
+        ct_output=ct_output,
+        ct_error=ct_error,
+        full_template_output=full_template_output,
+        full_template_error=full_template_error,
+    )
+
+    if legacy_error or ct_error:
+        result.update(
+            {
+                "status": "error",
+                "expected_flow": False,
+                "legacy_status": "error" if legacy_error else "pass",
+                "ct_status": "error" if ct_error else "pass",
+                "legacy": _summarize_output(legacy_output) if legacy_output is not None else None,
+                "ct": _summarize_output(ct_output) if ct_output is not None else None,
+                "legacy_error": legacy_error,
+                "ct_error": ct_error,
+                "error_type": (ct_error or legacy_error or {}).get("error_type"),
+                "error": (ct_error or legacy_error or {}).get("error"),
+                "expected_num_turns": trajectory.expected_num_turns,
+                "expected_generation_turns": expected_generation_turns,
+                "full_template": (
+                    _summarize_full_template(full_template_output) if full_template_output is not None else None
+                ),
+                "full_template_error": full_template_error,
+                "ct_vs_full_template": ct_vs_full_template,
+                "ct_legacy_match": False,
+                "ct_full_template_match": ct_vs_full_template.get("equal", False),
+                "ct_full_template_material_match": ct_vs_full_template.get("material_equal", False),
+                "artifacts": artifacts,
+            }
+        )
+        return result
+
+    assert legacy_output is not None
+    assert ct_output is not None
+    comparisons = {
+        "prompt_ids": _compare_sequence(legacy_output.prompt_ids, ct_output.prompt_ids),
+        "response_ids": _compare_sequence(legacy_output.response_ids, ct_output.response_ids),
+        "loss_mask": _compare_sequence(legacy_output.response_mask, ct_output.response_mask),
+        "logprobs": _compare_sequence(legacy_output.response_logprobs, ct_output.response_logprobs),
+        "generation_prompt_ids": _compare_generation_prompts(legacy_output, ct_output),
+    }
+    expected_flow = (
+        legacy_output.num_turns == trajectory.expected_num_turns
+        and ct_output.num_turns == trajectory.expected_num_turns
+        and len(legacy_output.generation_prompt_ids) == expected_generation_turns
+        and len(ct_output.generation_prompt_ids) == expected_generation_turns
+    )
+    exact_match = all(comparisons[name]["equal"] for name in ("prompt_ids", "response_ids", "loss_mask", "logprobs"))
+    ct_full_template_match = ct_vs_full_template.get("equal", False)
+    ct_full_template_material_match = ct_vs_full_template.get("material_equal", False)
+    result.update(
+        {
+            "status": "pass" if expected_flow and exact_match else "mismatch",
+            "expected_flow": expected_flow,
+            "exact_output_match": exact_match,
+            "ct_legacy_match": exact_match,
+            "ct_full_template_match": ct_full_template_match,
+            "ct_full_template_material_match": ct_full_template_material_match,
+            "legacy_status": "pass",
+            "ct_status": "pass",
+            "legacy": _summarize_output(legacy_output),
+            "ct": _summarize_output(ct_output),
+            "full_template": (
+                _summarize_full_template(full_template_output) if full_template_output is not None else None
+            ),
+            "full_template_error": full_template_error,
+            "comparisons": comparisons,
+            "ct_vs_full_template": ct_vs_full_template,
+            "expected_num_turns": trajectory.expected_num_turns,
+            "expected_generation_turns": expected_generation_turns,
+            "artifacts": artifacts,
+        }
+    )
+    return result
+
+
+def _discover_cached_models() -> list[str]:
+    hub = Path.home() / ".cache" / "huggingface" / "hub"
+    if not hub.exists():
+        return []
+    models = []
+    for path in hub.glob("models--*"):
+        if path.is_dir() and not path.name.startswith("."):
+            models.append(path.name.removeprefix("models--").replace("--", "/"))
+    return sorted(set(models))
+
+
+def _select_models(args) -> list[str]:
+    models = list(args.model or DEFAULT_MODELS)
+    if args.discover_cache:
+        models.extend(_discover_cached_models())
+    seen = set()
+    selected = []
+    for model in models:
+        if model not in seen:
+            selected.append(model)
+            seen.add(model)
+    return selected
+
+
+def _select_trajectories(args) -> list[MockTrajectory]:
+    names = args.trajectory or list(DEFAULT_E2E_TRAJECTORIES)
+    return [get_trajectory(name) for name in names]
+
+
+def _print_flow_details(result: dict[str, Any]) -> None:
+    if result.get("expected_flow"):
+        return
+    legacy = result.get("legacy") or {}
+    ct = result.get("ct") or {}
+    print(
+        "    flow: incomplete "
+        f"expected_num_turns={result.get('expected_num_turns')} "
+        f"expected_generation_turns={result.get('expected_generation_turns')} "
+        f"legacy_num_turns={legacy.get('num_turns')} "
+        f"ct_num_turns={ct.get('num_turns')} "
+        f"legacy_generation_turns={legacy.get('generation_turns')} "
+        f"ct_generation_turns={ct.get('generation_turns')}",
+        flush=True,
+    )
+
+
+def _print_sequence_mismatch(name: str, comparison: dict[str, Any]) -> None:
+    if comparison.get("equal"):
+        return
+    print(
+        f"    {name}: legacy_len={comparison.get('legacy_len')} "
+        f"ct_len={comparison.get('ct_len')} "
+        f"first_mismatch={comparison.get('first_mismatch')} "
+        f"legacy_value={comparison.get('legacy_value')} "
+        f"ct_value={comparison.get('ct_value')}",
+        flush=True,
+    )
+
+
+def _format_ct_legacy_state(match: Any) -> str:
+    return f"match={match}"
+
+
+def _format_ct_full_state(raw_match: Any, material_equal: Any) -> str:
+    material_mismatch = None if material_equal is None else not material_equal
+    return f"raw_match={raw_match} material_mismatch={material_mismatch}"
+
+
+def _format_location(location: dict[str, Any] | None) -> str:
+    if not location:
+        return "?:?"
+    return f"{location.get('line')}:{location.get('column')}"
+
+
+def _print_ct_full_template_details(result: dict[str, Any]) -> None:
+    comparison = result.get("ct_vs_full_template") or {}
+    if comparison.get("equal"):
+        return
+    error = comparison.get("error")
+    if error:
+        print(
+            f"    ct_vs_full_template: error {error.get('error_type')}: {error.get('error')}",
+            flush=True,
+        )
+        return
+    if comparison.get("acceptable_mismatch"):
+        print(
+            f"    ct_vs_full_template: acceptable mismatch "
+            f"kinds={comparison.get('mismatch_kinds') or [comparison.get('mismatch_kind')]} "
+            f"ct_text_len={comparison.get('ct_text_len')} "
+            f"full_template_text_len={comparison.get('full_template_text_len')} "
+            f"dropped_ct_empty_think_blocks={comparison.get('dropped_ct_empty_think_blocks', 0)} "
+            f"glm_think_boundary_replacements={comparison.get('glm_think_boundary_replacements', 0)}",
+            flush=True,
+        )
+        return
+    ct_context = comparison.get("ct_text_context") or {}
+    full_context = comparison.get("full_template_text_context") or {}
+    print(
+        "    ct_vs_full_template: "
+        f"ct_text_len={comparison.get('ct_text_len')} "
+        f"full_template_text_len={comparison.get('full_template_text_len')} "
+        f"first_mismatch_char={comparison.get('first_mismatch')} "
+        f"ct_location={_format_location(comparison.get('ct_text_location'))} "
+        f"full_template_location={_format_location(comparison.get('full_template_text_location'))} "
+        f"ct_char={comparison.get('ct_text_char')!r} "
+        f"full_template_char={comparison.get('full_template_text_char')!r}",
+        flush=True,
+    )
+    print(f"    ct_context: {ct_context.get('text', '')!r}", flush=True)
+    print(f"    full_template_context: {full_context.get('text', '')!r}", flush=True)
+
+
+def _print_mismatch_details(result: dict[str, Any]) -> None:
+    _print_flow_details(result)
+    comparisons = result.get("comparisons") or {}
+    for name in ("prompt_ids", "response_ids", "loss_mask", "logprobs"):
+        comparison = comparisons.get(name)
+        if comparison:
+            _print_sequence_mismatch(name, comparison)
+
+    generation_prompt_comparison = comparisons.get("generation_prompt_ids") or {}
+    for turn in generation_prompt_comparison.get("turns", []):
+        if turn.get("equal"):
+            continue
+        print(
+            f"    generation_prompt_ids turn={turn.get('turn')}: "
+            f"legacy_len={turn.get('legacy_len')} "
+            f"ct_len={turn.get('ct_len')} "
+            f"first_mismatch={turn.get('first_mismatch')} "
+            f"legacy_value={turn.get('legacy_value')} "
+            f"ct_value={turn.get('ct_value')}",
+            flush=True,
+        )
+
+    if result.get("expected_flow") is False and result.get("exact_output_match") is True:
+        print(
+            "    reason: token outputs match, but the agent loop did not complete the expected flow.",
+            flush=True,
+        )
+    elif result.get("expected_flow") is True and result.get("exact_output_match") is False:
+        print(
+            "    reason: flow completed, but CT and legacy diverged at the token/metadata positions above.",
+            flush=True,
+        )
+    _print_ct_full_template_details(result)
+
+
+def _print_error_details(result: dict[str, Any]) -> None:
+    print(
+        f"    status: legacy={result.get('legacy_status', 'error')} ct={result.get('ct_status', 'error')}",
+        flush=True,
+    )
+    printed_side_error = False
+    for side in ("legacy", "ct"):
+        error = result.get(f"{side}_error")
+        if not error:
+            continue
+        printed_side_error = True
+        print(
+            f"    {side}_error: {error.get('error_type')}: {error.get('error')}",
+            flush=True,
+        )
+    if not printed_side_error:
+        print(f"    error: {result.get('error_type')}: {result.get('error')}", flush=True)
+    _print_flow_details(result)
+    _print_ct_full_template_details(result)
+
+
+def _resolve_dump_dir(args) -> Path | None:
+    if not args.dump_sequences:
+        return None
+    if args.dump_dir:
+        return Path(args.dump_dir)
+    if args.ledger:
+        return Path(args.ledger).with_suffix("").parent / f"{Path(args.ledger).stem}_artifacts"
+    return Path("/private/tmp/verl_ct_vs_legacy_artifacts")
+
+
+def _run_all(args) -> list[dict[str, Any]]:
+    results = []
+    models = _select_models(args)
+    trajectories = _select_trajectories(args)
+    dump_dir = _resolve_dump_dir(args)
+    if dump_dir is not None:
+        dump_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Dump artifacts: {dump_dir}", flush=True)
+    total = len(models) * len(trajectories)
+    case_index = 0
+
+    for model in models:
+        tool_parser = _infer_tool_parser(model, args.tool_parser)
+        try:
+            tokenizer = _load_tokenizer(model, local_files_only=args.local_files_only)
+        except Exception as exc:
+            for trajectory in trajectories:
+                case_index += 1
+                print(f"[{case_index}/{total}] {model} :: {trajectory.name}", flush=True)
+                result = {
+                    "model": model,
+                    "trajectory": trajectory.name,
+                    "loop_type": (
+                        "single_turn_agent_loop"
+                        if isinstance(trajectory, SingleTurnTrajectory)
+                        else "tool_agent_loop"
+                    ),
+                    "requested_tool_parser": args.tool_parser if isinstance(trajectory, ToolAgentTrajectory) else None,
+                    "tool_parser": tool_parser if isinstance(trajectory, ToolAgentTrajectory) else None,
+                    "status": "error",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                    "ct_legacy_match": False,
+                    "ct_full_template_match": False,
+                    "ct_full_template_material_match": False,
+                }
+                results.append(result)
+                print(
+                    f"  ERROR {result['error_type']}: {result['error']} "
+                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
+                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    flush=True,
+                )
+                _print_error_details(result)
+            continue
+
+        for trajectory in trajectories:
+            case_index += 1
+            print(f"[{case_index}/{total}] {model} :: {trajectory.name}", flush=True)
+            result = run_one_case(
+                tokenizer,
+                model,
+                trajectory,
+                tool_parser=tool_parser,
+                dump_dir=dump_dir,
+            )
+            if isinstance(trajectory, ToolAgentTrajectory):
+                result["requested_tool_parser"] = args.tool_parser
+            results.append(result)
+            status = result["status"]
+            if status == "pass":
+                print(
+                    "  PASS "
+                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
+                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    flush=True,
+                )
+                _print_ct_full_template_details(result)
+            elif status == "mismatch":
+                comparisons = result["comparisons"]
+                print(
+                    "  MISMATCH "
+                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
+                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))}) "
+                    f"prompt={comparisons['prompt_ids']['equal']} "
+                    f"response={comparisons['response_ids']['equal']} "
+                    f"mask={comparisons['loss_mask']['equal']} "
+                    f"logprobs={comparisons['logprobs']['equal']} "
+                    f"flow={result['expected_flow']}",
+                    flush=True,
+                )
+                _print_mismatch_details(result)
+            else:
+                print(
+                    f"  ERROR {result.get('error_type')}: {result.get('error')} "
+                    f"ct_vs_legacy({_format_ct_legacy_state(result.get('ct_legacy_match'))}) "
+                    f"ct_vs_full({_format_ct_full_state(result.get('ct_full_template_match'), result.get('ct_full_template_material_match'))})",
+                    flush=True,
+                )
+                _print_error_details(result)
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", action="append", help="Model/tokenizer id to test. May be repeated.")
+    parser.add_argument(
+        "--trajectory",
+        action="append",
+        choices=sorted(TRAJECTORY_BY_NAME),
+        help=(
+            "Trajectory name to test. May be repeated. Defaults to e2e trajectories: "
+            f"{', '.join(DEFAULT_E2E_TRAJECTORIES)}."
+        ),
+    )
+    parser.add_argument(
+        "--tool-parser",
+        default="auto",
+        choices=("auto", "hermes", "qwen3_coder", "gpt-oss", "gemma4", "glm", "kimi", "seed", "minimax"),
+        help=(
+            "ToolParser format used by ToolAgentLoop. Default: auto, which resolves from model name "
+            "(for example Qwen3.5 -> qwen3_coder, GLM -> glm, Kimi -> kimi, "
+            "Seed -> seed, MiniMax -> minimax, Nemotron -> qwen3_coder, otherwise hermes)."
+        ),
+    )
+    parser.add_argument("--discover-cache", action="store_true", help="Also test all HF models found in local cache.")
+    parser.add_argument(
+        "--allow-download",
+        action="store_true",
+        help="Allow AutoTokenizer to download missing tokenizers instead of requiring local cache.",
+    )
+    parser.add_argument(
+        "--ledger",
+        help="Write the structured per-case report JSON to this path.",
+    )
+    parser.add_argument(
+        "--dump-sequences",
+        action="store_true",
+        help=(
+            "Dump CT/legacy token ids, decoded text, masks/logprobs, and the full trajectory "
+            "apply_chat_template text to artifact files."
+        ),
+    )
+    parser.add_argument(
+        "--dump-dir",
+        help=(
+            "Directory for --dump-sequences artifacts. Defaults to <ledger-stem>_artifacts next to --ledger, "
+            "or /private/tmp/verl_ct_vs_legacy_artifacts when --ledger is omitted."
+        ),
+    )
+    parser.add_argument("--fail-on-mismatch", action="store_true", help="Return non-zero when any case mismatches.")
+    args = parser.parse_args()
+    args.local_files_only = not args.allow_download
+    return args
+
+
+def _print_summary(results: list[dict[str, Any]]) -> None:
+    total = len(results)
+    pass_count = sum(item["status"] == "pass" for item in results)
+    mismatch_count = sum(item["status"] == "mismatch" for item in results)
+    error_count = sum(item["status"] == "error" for item in results)
+
+    ct_legacy_error_count = sum(item.get("status") == "error" for item in results)
+    ct_legacy_match_count = sum(item.get("ct_legacy_match") is True for item in results)
+    ct_legacy_mismatch_count = sum(
+        item.get("ct_legacy_match") is False and item.get("status") != "error"
+        for item in results
+    )
+
+    ct_full_error_count = sum(
+        bool((item.get("ct_vs_full_template") or {}).get("error"))
+        or (item.get("status") == "error" and "ct_vs_full_template" not in item)
+        for item in results
+    )
+    ct_full_match_count = sum(item.get("ct_full_template_match") is True for item in results)
+    ct_full_raw_mismatch_count = sum(
+        item.get("ct_full_template_match") is False
+        and item.get("status") != "error"
+        and not (item.get("ct_vs_full_template") or {}).get("error")
+        for item in results
+    )
+    ct_full_material_mismatch_count = sum(
+        item.get("ct_full_template_material_match") is False
+        and item.get("status") != "error"
+        and not (item.get("ct_vs_full_template") or {}).get("error")
+        for item in results
+    )
+    ct_full_acceptable_mismatch_count = sum(
+        bool((item.get("ct_vs_full_template") or {}).get("acceptable_mismatch")) for item in results
+    )
+    print(
+        f"Summary: total={total} pass={pass_count} mismatch={mismatch_count} error={error_count}",
+        flush=True,
+    )
+    print(
+        "  CT vs legacy: "
+        f"match={ct_legacy_match_count} "
+        f"mismatch={ct_legacy_mismatch_count} "
+        f"error={ct_legacy_error_count}",
+        flush=True,
+    )
+    print(
+        "  CT vs full template: "
+        f"match={ct_full_match_count} "
+        f"raw_mismatch={ct_full_raw_mismatch_count} "
+        f"acceptable_mismatch={ct_full_acceptable_mismatch_count} "
+        f"material_mismatch={ct_full_material_mismatch_count} "
+        f"error={ct_full_error_count}",
+        flush=True,
+    )
+
+
+def _write_ledger(path: str, results: list[dict[str, Any]]) -> None:
+    ledger_path = Path(path)
+    _write_json(ledger_path, results)
+    print(f"Ledger: {ledger_path}", flush=True)
+
+
+def main() -> int:
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    args = parse_args()
+    results = _run_all(args)
+    if args.ledger:
+        _write_ledger(args.ledger, results)
+    _print_summary(results)
+    if args.fail_on_mismatch and any(item["status"] != "pass" for item in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/experimental/agent_loop/continuous_token/mock_trajectories.py
+++ b/tests/experimental/agent_loop/continuous_token/mock_trajectories.py
@@ -1,0 +1,530 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structured mock trajectories for CT-vs-legacy agent-loop tokenization checks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from verl.tools.function_tool import FunctionTool
+from verl.tools.schemas import OpenAIFunctionToolSchema
+
+
+@dataclass(frozen=True)
+class TrajectoryStep:
+    """One assistant generation followed by optional environment messages."""
+
+    assistant: dict[str, Any]
+    appended_messages: tuple[dict[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class SingleTurnTrajectory:
+    """A single prompt/assistant-response trajectory for SingleTurnAgentLoop."""
+
+    name: str
+    description: str
+    raw_prompt: tuple[dict[str, Any], ...]
+    assistant_response: str
+    expected_num_turns: int = 2
+
+
+@dataclass(frozen=True)
+class ToolAgentTrajectory:
+    """A messages-level trajectory independent of any rollout server."""
+
+    name: str
+    description: str
+    raw_prompt: tuple[dict[str, Any], ...]
+    steps: tuple[TrajectoryStep, ...]
+    tools: tuple[FunctionTool, ...]
+    max_parallel_calls: int = 1
+
+    @property
+    def expected_generation_turns(self) -> int:
+        return len(self.steps)
+
+    @property
+    def expected_num_turns(self) -> int:
+        environment_turns = sum(1 for step in self.steps if step.appended_messages)
+        return 1 + self.expected_generation_turns + environment_turns
+
+    def tool_schemas(self) -> list[dict[str, Any]]:
+        return [tool.tool_schema.model_dump(exclude_unset=True, exclude_none=True) for tool in self.tools]
+
+    def full_messages(self) -> list[dict[str, Any]]:
+        messages = [dict(message) for message in self.raw_prompt]
+        for step in self.steps:
+            messages.append(_clone_message(step.assistant))
+            messages.extend(_clone_message(message) for message in step.appended_messages)
+        return messages
+
+
+MockTrajectory = SingleTurnTrajectory | ToolAgentTrajectory
+
+
+def _clone_message(message: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(message, ensure_ascii=False))
+
+
+def _schema(
+    name: str,
+    description: str,
+    properties: dict[str, dict[str, Any]],
+    required: list[str],
+) -> OpenAIFunctionToolSchema:
+    return OpenAIFunctionToolSchema.model_validate(
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                },
+            },
+        }
+    )
+
+
+def _assistant(content: str, tool_calls: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return message
+
+
+def _tool_call(call_id: str, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        },
+    }
+
+
+def _tool_message(call_id: str, name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "name": name,
+        "content": json.dumps(payload, separators=(",", ":"), ensure_ascii=False),
+    }
+
+
+def get_weather(city: str, day: str) -> dict[str, Any]:
+    """Return a deterministic weather snapshot for a city and day."""
+    table = {
+        ("Seattle", "today"): {"condition": "rain", "high_c": 12, "wind_kph": 22},
+        ("Portland", "today"): {"condition": "cloudy", "high_c": 16, "wind_kph": 11},
+        ("Denver", "tomorrow"): {"condition": "clear", "high_c": 24, "wind_kph": 18},
+        ("Boulder", "tomorrow"): {"condition": "storms", "high_c": 21, "wind_kph": 31},
+    }
+    return {"city": city, "day": day, **table.get((city, day), {"condition": "unknown", "high_c": None})}
+
+
+def estimate_travel(origin: str, destination: str, depart_window: str) -> dict[str, Any]:
+    """Estimate deterministic travel time for a simple route."""
+    route = f"{origin}->{destination}"
+    table = {
+        ("Depot A", "West Clinic", "morning"): {"minutes": 32, "risk": "low"},
+        ("Depot A", "East Clinic", "morning"): {"minutes": 51, "risk": "medium"},
+        ("Depot B", "West Clinic", "afternoon"): {"minutes": 44, "risk": "medium"},
+        ("Depot B", "East Clinic", "afternoon"): {"minutes": 28, "risk": "low"},
+    }
+    return {"route": route, "depart_window": depart_window, **table.get((origin, destination, depart_window), {})}
+
+
+def reserve_room(room: str, start_time: str, end_time: str | None = None) -> dict[str, Any]:
+    """Reserve a room if the request has a complete time range."""
+    if not end_time:
+        return {"ok": False, "error": "end_time is required", "room": room, "start_time": start_time}
+    return {"ok": True, "room": room, "start_time": start_time, "end_time": end_time, "confirmation": "room-4821"}
+
+
+def lookup_incident(incident_id: str) -> dict[str, Any]:
+    """Look up a deterministic support incident."""
+    if incident_id != "INC-1042":
+        return {"ok": False, "error": "incident_id must use the INC-#### format", "received": incident_id}
+    return {"ok": True, "incident_id": incident_id, "status": "mitigated", "owner": "edge-oncall"}
+
+
+def build_common_tools() -> tuple[FunctionTool, ...]:
+    return (
+        FunctionTool(
+            name="get_weather",
+            fn=get_weather,
+            tool_schema=_schema(
+                "get_weather",
+                "Return a deterministic weather snapshot.",
+                {
+                    "city": {"type": "string", "description": "City to check."},
+                    "day": {"type": "string", "description": "Day label such as today or tomorrow."},
+                },
+                ["city", "day"],
+            ),
+        ),
+        FunctionTool(
+            name="estimate_travel",
+            fn=estimate_travel,
+            tool_schema=_schema(
+                "estimate_travel",
+                "Estimate deterministic travel time for a route.",
+                {
+                    "origin": {"type": "string", "description": "Starting location."},
+                    "destination": {"type": "string", "description": "Destination location."},
+                    "depart_window": {"type": "string", "description": "Departure window label."},
+                },
+                ["origin", "destination", "depart_window"],
+            ),
+        ),
+        FunctionTool(
+            name="reserve_room",
+            fn=reserve_room,
+            tool_schema=_schema(
+                "reserve_room",
+                "Reserve a meeting room with an explicit time range.",
+                {
+                    "room": {"type": "string", "description": "Room name."},
+                    "start_time": {"type": "string", "description": "Local start time."},
+                    "end_time": {"type": ["string", "null"], "description": "Local end time."},
+                },
+                ["room", "start_time"],
+            ),
+        ),
+        FunctionTool(
+            name="lookup_incident",
+            fn=lookup_incident,
+            tool_schema=_schema(
+                "lookup_incident",
+                "Look up an incident status.",
+                {
+                    "incident_id": {"type": "string", "description": "Incident id in INC-#### format."},
+                },
+                ["incident_id"],
+            ),
+        ),
+    )
+
+
+TOOLS = build_common_tools()
+
+
+# system + user -> assistant
+SINGLE_TURN_CHAT = SingleTurnTrajectory(
+    name="singleturnchat",
+    description="One user request followed by one plain assistant response.",
+    raw_prompt=(
+        {"role": "system", "content": "You answer scheduling questions in one concise sentence."},
+        {"role": "user", "content": "Can I move the Friday demo to 15:30 if the room is free?"},
+    ),
+    assistant_response="Yes, move the Friday demo to 15:30 if the room remains free and notify the attendees.",
+)
+
+
+# system + user
+# -> assistant(tool_call: get_weather)
+# -> tool(get_weather)
+# -> assistant(tool_call: get_weather)
+# -> tool(get_weather)
+# -> assistant
+MULTITURN_SINGLE_TOOL = ToolAgentTrajectory(
+    name="multiturnsingletool",
+    description="Two sequential assistant tool calls, one tool response per turn, then a final answer.",
+    raw_prompt=(
+        {"role": "system", "content": "You are a concise trip-planning assistant. Use tools for live facts."},
+        {
+            "role": "user",
+            "content": "Pick a better city for an outdoor team lunch today: Seattle or Portland. Check both first.",
+        },
+    ),
+    tools=TOOLS,
+    steps=(
+        TrajectoryStep(
+            assistant=_assistant(
+                "I will check Seattle first, then compare it with Portland.",
+                [_tool_call("call_weather_seattle", "get_weather", {"city": "Seattle", "day": "today"})],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_weather_seattle",
+                    "get_weather",
+                    {"city": "Seattle", "day": "today", "condition": "rain", "high_c": 12, "wind_kph": 22},
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "Seattle looks wet, so I will check Portland before deciding.",
+                [_tool_call("call_weather_portland", "get_weather", {"city": "Portland", "day": "today"})],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_weather_portland",
+                    "get_weather",
+                    {"city": "Portland", "day": "today", "condition": "cloudy", "high_c": 16, "wind_kph": 11},
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "Choose Portland. It is cloudy rather than rainy, warmer, and less windy; keep Seattle as the indoor fallback."
+            )
+        ),
+    ),
+)
+
+
+# system + user
+# -> assistant(two parallel tool_calls: estimate_travel + get_weather)
+# -> tool(estimate_travel) + tool(get_weather)
+# -> assistant(two parallel tool_calls: estimate_travel + get_weather)
+# -> tool(estimate_travel) + tool(get_weather)
+# -> assistant
+MULTITURN_MULTI_TOOL = ToolAgentTrajectory(
+    name="multiturnmultitool",
+    description="Two assistant turns with parallel tool calls, followed by a final comparison.",
+    raw_prompt=(
+        {"role": "system", "content": "You coordinate clinic deliveries and summarize tradeoffs briefly."},
+        {
+            "role": "user",
+            "content": (
+                "Compare morning deliveries from Depot A to the West and East clinics, then compare the afternoon "
+                "Depot B options. Use weather and travel estimates before recommending a route."
+            ),
+        },
+    ),
+    tools=TOOLS,
+    max_parallel_calls=2,
+    steps=(
+        TrajectoryStep(
+            assistant=_assistant(
+                "I will check the morning route and destination weather together.",
+                [
+                    _tool_call(
+                        "call_travel_west",
+                        "estimate_travel",
+                        {"origin": "Depot A", "destination": "West Clinic", "depart_window": "morning"},
+                    ),
+                    _tool_call("call_weather_denver", "get_weather", {"city": "Denver", "day": "tomorrow"}),
+                ],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_travel_west",
+                    "estimate_travel",
+                    {"route": "Depot A->West Clinic", "depart_window": "morning", "minutes": 32, "risk": "low"},
+                ),
+                _tool_message(
+                    "call_weather_denver",
+                    "get_weather",
+                    {"city": "Denver", "day": "tomorrow", "condition": "clear", "high_c": 24, "wind_kph": 18},
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "Now I will check the afternoon alternative and the other destination weather.",
+                [
+                    _tool_call(
+                        "call_travel_east",
+                        "estimate_travel",
+                        {"origin": "Depot B", "destination": "East Clinic", "depart_window": "afternoon"},
+                    ),
+                    _tool_call("call_weather_boulder", "get_weather", {"city": "Boulder", "day": "tomorrow"}),
+                ],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_travel_east",
+                    "estimate_travel",
+                    {"route": "Depot B->East Clinic", "depart_window": "afternoon", "minutes": 28, "risk": "low"},
+                ),
+                _tool_message(
+                    "call_weather_boulder",
+                    "get_weather",
+                    {"city": "Boulder", "day": "tomorrow", "condition": "storms", "high_c": 21, "wind_kph": 31},
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "Use Depot A to West Clinic in the morning. It is slightly longer than the best afternoon estimate, "
+                "but the weather is clear and the travel risk is low; avoid the Boulder storm window."
+            )
+        ),
+    ),
+)
+
+
+# system + user
+# -> assistant(tool_call: reserve_room, invalid arguments)
+# -> user(retry instruction)
+# -> assistant(tool_call: reserve_room, corrected arguments)
+# -> tool(reserve_room)
+# -> assistant
+MULTITURN_RETRY_USER = ToolAgentTrajectory(
+    name="multiturnretryuser",
+    description="A failed tool call is followed by a user retry instruction, then the assistant retries correctly.",
+    raw_prompt=(
+        {"role": "system", "content": "You reserve rooms. If a request is incomplete, recover with one concise retry."},
+        {"role": "user", "content": "Reserve Maple Room tomorrow from 10:00 to 10:30 and confirm the booking."},
+    ),
+    tools=TOOLS,
+    steps=(
+        TrajectoryStep(
+            assistant=_assistant(
+                "I will try to reserve the room now.",
+                [_tool_call("call_room_incomplete", "reserve_room", {"room": "Maple Room", "start_time": "10:00"})],
+            ),
+            appended_messages=(
+                {
+                    "role": "user",
+                    "content": (
+                        "The room reservation tool rejected the previous call because end_time was missing. "
+                        "Retry with room=Maple Room, start_time=10:00, end_time=10:30."
+                    ),
+                },
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "I missed the end time. I will retry with the complete time range.",
+                [
+                    _tool_call(
+                        "call_room_retry",
+                        "reserve_room",
+                        {"room": "Maple Room", "start_time": "10:00", "end_time": "10:30"},
+                    )
+                ],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_room_retry",
+                    "reserve_room",
+                    {
+                        "ok": True,
+                        "room": "Maple Room",
+                        "start_time": "10:00",
+                        "end_time": "10:30",
+                        "confirmation": "room-4821",
+                    },
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant("Maple Room is reserved from 10:00 to 10:30. Confirmation: room-4821.")
+        ),
+    ),
+)
+
+
+# system + user
+# -> assistant(tool_call: lookup_incident, invalid arguments)
+# -> system(retry directive)
+# -> assistant(tool_call: lookup_incident, corrected arguments)
+# -> tool(lookup_incident)
+# -> assistant
+MULTITURN_RETRY_SYSTEM = ToolAgentTrajectory(
+    name="multiturnretrysystem",
+    description="A failed tool call is followed by a system retry directive, then the assistant retries correctly.",
+    raw_prompt=(
+        {"role": "system", "content": "You are an incident assistant. Respect system retry directives exactly."},
+        {"role": "user", "content": "Check the mitigation status for incident 1042 and summarize the owner."},
+    ),
+    tools=TOOLS,
+    steps=(
+        TrajectoryStep(
+            assistant=_assistant(
+                "I will look up the incident status.",
+                [_tool_call("call_incident_bad", "lookup_incident", {"incident_id": "1042"})],
+            ),
+            appended_messages=(
+                {
+                    "role": "system",
+                    "content": (
+                        "Tool validation failed: incident_id must use the INC-#### format. "
+                        "Retry with incident_id=INC-1042 before answering."
+                    ),
+                },
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant(
+                "I will retry with the required incident id format.",
+                [_tool_call("call_incident_retry", "lookup_incident", {"incident_id": "INC-1042"})],
+            ),
+            appended_messages=(
+                _tool_message(
+                    "call_incident_retry",
+                    "lookup_incident",
+                    {"ok": True, "incident_id": "INC-1042", "status": "mitigated", "owner": "edge-oncall"},
+                ),
+            ),
+        ),
+        TrajectoryStep(
+            assistant=_assistant("Incident INC-1042 is mitigated, and the current owner is edge-oncall.")
+        ),
+    ),
+)
+
+
+SINGLE_TURN_TRAJECTORIES: tuple[SingleTurnTrajectory, ...] = (SINGLE_TURN_CHAT,)
+
+
+TOOL_AGENT_TRAJECTORIES: tuple[ToolAgentTrajectory, ...] = (
+    MULTITURN_SINGLE_TOOL,
+    MULTITURN_MULTI_TOOL,
+    MULTITURN_RETRY_USER,
+    MULTITURN_RETRY_SYSTEM,
+)
+
+
+TRAJECTORIES: tuple[MockTrajectory, ...] = SINGLE_TURN_TRAJECTORIES + TOOL_AGENT_TRAJECTORIES
+
+
+TRAJECTORY_BY_NAME: dict[str, MockTrajectory] = {trajectory.name: trajectory for trajectory in TRAJECTORIES}
+TOOL_AGENT_TRAJECTORY_BY_NAME = {trajectory.name: trajectory for trajectory in TOOL_AGENT_TRAJECTORIES}
+
+
+def get_trajectory(name: str) -> MockTrajectory:
+    try:
+        return TRAJECTORY_BY_NAME[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown trajectory {name!r}. Choices: {sorted(TRAJECTORY_BY_NAME)}") from exc
+
+
+def select_trajectories(names: list[str] | None = None) -> list[MockTrajectory]:
+    if not names:
+        return list(TRAJECTORIES)
+    return [get_trajectory(name) for name in names]
+
+
+def get_tool_agent_trajectory(name: str) -> ToolAgentTrajectory:
+    try:
+        return TOOL_AGENT_TRAJECTORY_BY_NAME[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown tool-agent trajectory {name!r}. Choices: {sorted(TOOL_AGENT_TRAJECTORY_BY_NAME)}") from exc
+
+
+def select_tool_agent_trajectories(names: list[str] | None = None) -> list[ToolAgentTrajectory]:
+    if not names:
+        return list(TOOL_AGENT_TRAJECTORIES)
+    return [get_tool_agent_trajectory(name) for name in names]

--- a/tests/experimental/agent_loop/continuous_token/mock_trajectories.py
+++ b/tests/experimental/agent_loop/continuous_token/mock_trajectories.py
@@ -285,7 +285,8 @@ MULTITURN_SINGLE_TOOL = ToolAgentTrajectory(
         ),
         TrajectoryStep(
             assistant=_assistant(
-                "Choose Portland. It is cloudy rather than rainy, warmer, and less windy; keep Seattle as the indoor fallback."
+                "Choose Portland. It is cloudy rather than rainy, warmer, and less windy; "
+                "keep Seattle as the indoor fallback."
             )
         ),
     ),
@@ -429,9 +430,7 @@ MULTITURN_RETRY_USER = ToolAgentTrajectory(
                 ),
             ),
         ),
-        TrajectoryStep(
-            assistant=_assistant("Maple Room is reserved from 10:00 to 10:30. Confirmation: room-4821.")
-        ),
+        TrajectoryStep(assistant=_assistant("Maple Room is reserved from 10:00 to 10:30. Confirmation: room-4821.")),
     ),
 )
 
@@ -479,9 +478,7 @@ MULTITURN_RETRY_SYSTEM = ToolAgentTrajectory(
                 ),
             ),
         ),
-        TrajectoryStep(
-            assistant=_assistant("Incident INC-1042 is mitigated, and the current owner is edge-oncall.")
-        ),
+        TrajectoryStep(assistant=_assistant("Incident INC-1042 is mitigated, and the current owner is edge-oncall.")),
     ),
 )
 
@@ -521,7 +518,9 @@ def get_tool_agent_trajectory(name: str) -> ToolAgentTrajectory:
     try:
         return TOOL_AGENT_TRAJECTORY_BY_NAME[name]
     except KeyError as exc:
-        raise ValueError(f"Unknown tool-agent trajectory {name!r}. Choices: {sorted(TOOL_AGENT_TRAJECTORY_BY_NAME)}") from exc
+        raise ValueError(
+            f"Unknown tool-agent trajectory {name!r}. Choices: {sorted(TOOL_AGENT_TRAJECTORY_BY_NAME)}"
+        ) from exc
 
 
 def select_tool_agent_trajectories(names: list[str] | None = None) -> list[ToolAgentTrajectory]:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -307,7 +307,7 @@ class AgentLoopBase(ABC):
     async def ct_merge_non_assistant_msg(
         self,
         previous_messages: list[dict],
-        next_messages: list[dict],
+        updated_messages: list[dict],
         runtime_token_ids: list[int],
         response_mask: list[int],
         response_logprobs: Optional[list[float]] = None,
@@ -317,7 +317,7 @@ class AgentLoopBase(ABC):
             None,
             lambda: self.continuous_token_builder.merge_tokens(
                 previous_messages,
-                next_messages,
+                updated_messages,
                 runtime_token_ids,
                 tools=tools,
             ),

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -293,7 +293,7 @@ class AgentLoopBase(ABC):
 
         return multi_modal_data
 
-    async def ct_build_initial_prompt(
+    async def ct_build_initial_tokens(
         self,
         messages: list[dict],
         tools: list[dict] = None,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -297,6 +297,7 @@ class AgentLoopBase(ABC):
         messages: list[dict],
         tools: list[dict] = None,
     ) -> list[int]:
+        """Build the initial prompt token ids with Continuous Token."""
         prompt_ids = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.build_initial_tokens(messages, tools=tools),
@@ -312,6 +313,7 @@ class AgentLoopBase(ABC):
         response_logprobs: Optional[list[float]] = None,
         tools: list[dict] = None,
     ):
+        """Merge appended non-assistant messages into runtime tokens and metadata."""
         merge_result = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.merge_tokens(
@@ -334,6 +336,7 @@ class AgentLoopBase(ABC):
         response_logprobs: Optional[list[float]] = None,
         assistant_logprobs: Optional[list[float]] = None,
     ):
+        """Append assistant-generated tokens and align response metadata."""
         merge_result = await self.loop.run_in_executor(
             None,
             lambda: self.continuous_token_builder.append_assistant_tokens(
@@ -357,6 +360,7 @@ class AgentLoopBase(ABC):
         *,
         assistant_logprobs: Optional[list[float]] = None,
     ) -> tuple[list[int], Optional[list[float]]]:
+        """Align response masks and logprobs after a Continuous Token merge."""
         aligned_mask = list(response_mask)
         aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
         if aligned_logprobs is None and assistant_logprobs is not None:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -361,7 +361,7 @@ class AgentLoopBase(ABC):
         aligned_mask = list(response_mask)
         aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
         if aligned_logprobs is None and assistant_logprobs is not None:
-            aligned_logprobs = []
+            raise ValueError("response_logprobs is required when assistant_logprobs is provided")
 
         if merge_result.removed_prefix_token_count:
             aligned_mask = aligned_mask[: -merge_result.removed_prefix_token_count]

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -293,7 +293,7 @@ class AgentLoopBase(ABC):
 
         return multi_modal_data
 
-    async def build_ct_initial_prompt(
+    async def ct_build_initial_prompt(
         self,
         messages: list[dict],
         tools: list[dict] = None,
@@ -304,7 +304,7 @@ class AgentLoopBase(ABC):
         )
         return self._cap_text_prompt_length(prompt_ids)
 
-    async def merge_ct_non_assistant_msg(
+    async def ct_merge_non_assistant_msg(
         self,
         previous_messages: list[dict],
         next_messages: list[dict],
@@ -322,12 +322,12 @@ class AgentLoopBase(ABC):
                 tools=tools,
             ),
         )
-        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+        aligned_response_mask, aligned_response_logprobs = self.ct_align_response_metadata(
             merge_result, response_mask, response_logprobs
         )
         return merge_result, aligned_response_mask, aligned_response_logprobs
 
-    async def merge_ct_assistant_token(
+    async def ct_merge_assistant_token(
         self,
         runtime_token_ids: list[int],
         assistant_token_ids: list[int],
@@ -342,7 +342,7 @@ class AgentLoopBase(ABC):
                 assistant_token_ids,
             ),
         )
-        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+        aligned_response_mask, aligned_response_logprobs = self.ct_align_response_metadata(
             merge_result,
             response_mask,
             response_logprobs,
@@ -351,7 +351,7 @@ class AgentLoopBase(ABC):
         return merge_result, aligned_response_mask, aligned_response_logprobs
 
     @staticmethod
-    def _align_continuous_token_response_metadata(
+    def ct_align_response_metadata(
         merge_result: MergeResult,
         response_mask: list[int],
         response_logprobs: Optional[list[float]] = None,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -237,7 +237,6 @@ class AgentLoopBase(ABC):
                 model_path=model_config.path,
                 tokenizer_name_or_path=model_config.tokenizer_path,
                 chat_template_kwargs=self.apply_chat_template_kwargs,
-                custom_builder_module=continuous_token_config.custom_builder_module,
             )
             self.enable_continuous_token = True
             # Continuous Token doesn't use the legacy removable system prompt.

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -51,6 +51,8 @@ from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.utils.chat_template import apply_chat_template, initialize_system_prompt
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.continuous_token import MergeResult
+from verl.utils.continuous_token_wiring import create_continuous_token_builder
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
@@ -225,7 +227,24 @@ class AgentLoopBase(ABC):
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
         self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
         processing_class = self.processor if self.processor is not None else self.tokenizer
-        self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
+        self.continuous_token_builder = None
+        continuous_token_config = self.rollout_config.multi_turn.continuous_token
+        if continuous_token_config.enable and self.processor is None:
+            model_config = self.config.actor_rollout_ref.model
+            self.continuous_token_builder = create_continuous_token_builder(
+                self.tokenizer,
+                model_family=continuous_token_config.model_family,
+                model_path=model_config.path,
+                tokenizer_name_or_path=model_config.tokenizer_path,
+                chat_template_kwargs=self.apply_chat_template_kwargs,
+                custom_builder_module=continuous_token_config.custom_builder_module,
+            )
+        elif continuous_token_config.enable:
+            logger.warning("Continuous Token is enabled but processor is set; falling back to legacy multimodal path.")
+        if self.continuous_token_builder is not None:
+            self.system_prompt = []
+        else:
+            self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 
     def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:
@@ -269,6 +288,120 @@ class AgentLoopBase(ABC):
                 multi_modal_data["audios"] = audios
 
         return multi_modal_data
+
+    async def build_ct_initial_prompt(
+        self,
+        messages: list[dict],
+        tools: list[dict] = None,
+    ) -> list[int]:
+        prompt_ids = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.build_initial_tokens(messages, tools=tools),
+        )
+        return self._cap_text_prompt_length(prompt_ids)
+
+    async def merge_ct_non_assistant_msg(
+        self,
+        previous_messages: list[dict],
+        next_messages: list[dict],
+        runtime_token_ids: list[int],
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        tools: list[dict] = None,
+    ):
+        merge_result = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.merge_tokens(
+                previous_messages,
+                next_messages,
+                runtime_token_ids,
+                tools=tools,
+            ),
+        )
+        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+            merge_result, response_mask, response_logprobs
+        )
+        return merge_result, aligned_response_mask, aligned_response_logprobs
+
+    async def merge_ct_assistant_token(
+        self,
+        runtime_token_ids: list[int],
+        assistant_token_ids: list[int],
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        assistant_logprobs: Optional[list[float]] = None,
+    ):
+        merge_result = await self.loop.run_in_executor(
+            None,
+            lambda: self.continuous_token_builder.append_assistant_tokens(
+                runtime_token_ids,
+                assistant_token_ids,
+            ),
+        )
+        aligned_response_mask, aligned_response_logprobs = self._align_continuous_token_response_metadata(
+            merge_result,
+            response_mask,
+            response_logprobs,
+            assistant_logprobs=assistant_logprobs,
+        )
+        return merge_result, aligned_response_mask, aligned_response_logprobs
+
+    @staticmethod
+    def _align_continuous_token_response_metadata(
+        merge_result: MergeResult,
+        response_mask: list[int],
+        response_logprobs: Optional[list[float]] = None,
+        *,
+        assistant_logprobs: Optional[list[float]] = None,
+    ) -> tuple[list[int], Optional[list[float]]]:
+        aligned_mask = list(response_mask)
+        aligned_logprobs = list(response_logprobs) if response_logprobs is not None else None
+        if aligned_logprobs is None and assistant_logprobs is not None:
+            aligned_logprobs = []
+
+        if merge_result.removed_prefix_token_count:
+            aligned_mask = aligned_mask[: -merge_result.removed_prefix_token_count]
+            if aligned_logprobs is not None:
+                aligned_logprobs = aligned_logprobs[: -merge_result.removed_prefix_token_count]
+
+        # Inserted tokens are CT-created boundary tokens, not tokens generated by the model.
+        inserted_token_count = len(merge_result.inserted_token_ids)
+        aligned_mask += [0] * inserted_token_count
+        if aligned_logprobs is not None:
+            aligned_logprobs += [0.0] * inserted_token_count
+
+        if merge_result.kind == "assistant":
+            aligned_mask += [1] * merge_result.appended_token_count
+            if aligned_logprobs is not None:
+                if assistant_logprobs is None:
+                    if merge_result.appended_token_count:
+                        raise ValueError("assistant_logprobs is required for assistant Continuous Token alignment")
+                    assistant_logprobs = []
+                if len(assistant_logprobs) != merge_result.appended_token_count:
+                    raise ValueError(
+                        "assistant_logprobs length must match appended assistant token count, "
+                        f"got {len(assistant_logprobs)} and {merge_result.appended_token_count}"
+                    )
+                aligned_logprobs += list(assistant_logprobs)
+        elif merge_result.kind == "non_assistant":
+            aligned_mask += [0] * merge_result.appended_token_count
+            if aligned_logprobs is not None:
+                aligned_logprobs += [0.0] * merge_result.appended_token_count
+        else:
+            raise ValueError(f"Unknown Continuous Token merge kind: {merge_result.kind!r}")
+
+        return aligned_mask, aligned_logprobs
+
+    def _cap_text_prompt_length(self, prompt_ids: list[int]) -> list[int]:
+        prompt_length = self.rollout_config.prompt_length
+        if len(prompt_ids) > prompt_length:
+            logger.warning(
+                "Prompt of %d tokens exceeds rollout.prompt_length=%d; left-truncating.",
+                len(prompt_ids),
+                prompt_length,
+            )
+            return prompt_ids[-prompt_length:]
+        return prompt_ids
 
     async def apply_chat_template(
         self,
@@ -349,12 +482,7 @@ class AgentLoopBase(ABC):
                     f"(e.g. ``total_pixels`` / ``max_pixels`` / fps / number of frames) or "
                     f"increase ``rollout.prompt_length``."
                 )
-            logger.warning(
-                "Prompt of %d tokens exceeds rollout.prompt_length=%d; left-truncating.",
-                len(prompt_ids),
-                prompt_length,
-            )
-            prompt_ids = prompt_ids[-prompt_length:]
+            prompt_ids = self._cap_text_prompt_length(prompt_ids)
 
         return prompt_ids
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -226,8 +226,8 @@ class AgentLoopBase(ABC):
         self.data_config = data_config.config
         self.apply_chat_template_kwargs = self.data_config.get("apply_chat_template_kwargs", {})
         self.mm_processor_kwargs = self.data_config.get("mm_processor_kwargs", {})
-        processing_class = self.processor if self.processor is not None else self.tokenizer
         self.continuous_token_builder = None
+        self.enable_continuous_token = False
         continuous_token_config = self.rollout_config.multi_turn.continuous_token
         if continuous_token_config.enable and self.processor is None:
             model_config = self.config.actor_rollout_ref.model
@@ -239,11 +239,15 @@ class AgentLoopBase(ABC):
                 chat_template_kwargs=self.apply_chat_template_kwargs,
                 custom_builder_module=continuous_token_config.custom_builder_module,
             )
-        elif continuous_token_config.enable:
-            logger.warning("Continuous Token is enabled but processor is set; falling back to legacy multimodal path.")
-        if self.continuous_token_builder is not None:
-            self.system_prompt = []
+            self.enable_continuous_token = True
+            # Continuous Token doesn't use the legacy removable system prompt.
+            self.system_prompt = None
         else:
+            if continuous_token_config.enable and self.processor is not None:
+                logger.warning(
+                    "Continuous Token is enabled but processor is set; falling back to legacy multimodal path."
+                )
+            processing_class = self.processor if self.processor is not None else self.tokenizer
             self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -48,7 +48,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         # 2. apply chat template and tokenize
         use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
-            prompt_ids = await self.ct_build_initial_prompt(messages)
+            prompt_ids = await self.ct_build_initial_tokens(messages)
         else:
             prompt_ids = await self.apply_chat_template(
                 messages,

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -46,7 +46,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
-        use_continuous_token = self.continuous_token_builder is not None and not multi_modal_data
+        use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
             prompt_ids = await self.build_ct_initial_prompt(messages)
         else:

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -46,13 +46,17 @@ class SingleTurnAgentLoop(AgentLoopBase):
         mm_processor_kwargs = self._get_mm_processor_kwargs(audios)
 
         # 2. apply chat template and tokenize
-        prompt_ids = await self.apply_chat_template(
-            messages,
-            images=images,
-            videos=videos,
-            audios=audios,
-            mm_processor_kwargs=mm_processor_kwargs,
-        )
+        use_continuous_token = self.continuous_token_builder is not None and not multi_modal_data
+        if use_continuous_token:
+            prompt_ids = await self.build_ct_initial_prompt(messages)
+        else:
+            prompt_ids = await self.apply_chat_template(
+                messages,
+                images=images,
+                videos=videos,
+                audios=audios,
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
 
         # 3. generate sequences
         metrics = {}
@@ -68,13 +72,27 @@ class SingleTurnAgentLoop(AgentLoopBase):
             )
         if metrics.get("num_preempted") is None:
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
-        response_mask = [1] * len(output.token_ids)
+
+        if use_continuous_token:
+            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+                prompt_ids,
+                output.token_ids,
+                [],
+                [] if output.log_probs else None,
+                assistant_logprobs=output.log_probs if output.log_probs else None,
+            )
+            response_ids = merge_result.token_ids[-len(response_mask) :] if response_mask else []
+            prompt_ids = merge_result.token_ids[: len(merge_result.token_ids) - len(response_mask)]
+        else:
+            response_ids = output.token_ids
+            response_mask = [1] * len(output.token_ids)
+            response_logprobs = output.log_probs
 
         output: AgentLoopOutput = AgentLoopOutput(
             prompt_ids=prompt_ids,
-            response_ids=output.token_ids[: self.response_length],
+            response_ids=response_ids[: self.response_length],
             response_mask=response_mask[: self.response_length],
-            response_logprobs=output.log_probs[: self.response_length] if output.log_probs else None,
+            response_logprobs=response_logprobs[: self.response_length] if response_logprobs else None,
             routed_experts=(
                 output.routed_experts[: len(prompt_ids) + self.response_length]
                 if output.routed_experts is not None

--- a/verl/experimental/agent_loop/single_turn_agent_loop.py
+++ b/verl/experimental/agent_loop/single_turn_agent_loop.py
@@ -48,7 +48,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
         # 2. apply chat template and tokenize
         use_continuous_token = self.enable_continuous_token and not multi_modal_data
         if use_continuous_token:
-            prompt_ids = await self.build_ct_initial_prompt(messages)
+            prompt_ids = await self.ct_build_initial_prompt(messages)
         else:
             prompt_ids = await self.apply_chat_template(
                 messages,
@@ -74,7 +74,7 @@ class SingleTurnAgentLoop(AgentLoopBase):
             metrics["num_preempted"] = output.num_preempted if output.num_preempted is not None else -1
 
         if use_continuous_token:
-            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_assistant_token(
                 prompt_ids,
                 output.token_ids,
                 [],

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -309,8 +309,10 @@ class ToolAgentLoop(AgentLoopBase):
         previous_messages = list(agent_data.messages)
 
         tasks = []
+        tool_call_names = []
         for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
+            tool_call_names.append(tool_call.name)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
@@ -339,7 +341,7 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            message["name"] = tool_call.name
+            message["name"] = tool_call_names[tool_index]
             if tool_call.tool_call_id is not None:
                 message["tool_call_id"] = tool_call.tool_call_id
 
@@ -391,7 +393,7 @@ class ToolAgentLoop(AgentLoopBase):
             return AgentState.GENERATING
         elif self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
@@ -400,11 +402,11 @@ class ToolAgentLoop(AgentLoopBase):
             # assistant tool_call message. Manually format the response tokens.
             # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
             parts = []
-            for msg in add_messages:
+            for msg, name in zip(add_messages, tool_call_names, strict=True):
                 content = msg.get("content", "")
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+                parts.append(f'<|tool_response>response:{name}{{value:<|"|>{content}<|"|>}}<tool_response|>')
             tool_response_text = "".join(parts)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -210,7 +210,7 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
         if self.enable_continuous_token:
-            prompt_ids = await self.ct_build_initial_prompt(agent_data.messages, tools=schemas)
+            prompt_ids = await self.ct_build_initial_tokens(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
                 agent_data.messages,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -341,7 +341,6 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            message["name"] = tool_call_names[tool_index]
             if tool_call.tool_call_id is not None:
                 message["tool_call_id"] = tool_call.tool_call_id
 

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -210,7 +210,7 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
         if self.enable_continuous_token:
-            prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
+            prompt_ids = await self.ct_build_initial_prompt(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
                 agent_data.messages,
@@ -263,7 +263,7 @@ class ToolAgentLoop(AgentLoopBase):
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
         if self.enable_continuous_token:
-            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_assistant_token(
                 agent_data.prompt_ids,
                 agent_data.response_ids,
                 agent_data.response_mask,
@@ -403,7 +403,7 @@ class ToolAgentLoop(AgentLoopBase):
             )
         elif self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-            merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
+            merge_result, response_mask, response_logprobs = await self.ct_merge_non_assistant_msg(
                 previous_messages,
                 agent_data.messages,
                 agent_data.prompt_ids,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -371,29 +371,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.messages.extend(add_messages)
 
-        if self.tool_parser_name == "gpt-oss":
-            logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
-            response_ids = await self.loop.run_in_executor(
-                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
-            )
-        elif self.tool_parser_name == "gemma4":
-            # Gemma4's chat template drops tool responses when passed without the preceding
-            # assistant tool_call message. Manually format the response tokens.
-            # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
-            parts = []
-            for msg in add_messages:
-                content = msg.get("content", "")
-                if isinstance(content, list):
-                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                if isinstance(content, list):
-                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
-            tool_response_text = "".join(parts)
-            response_ids = await self.loop.run_in_executor(
-                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
-            )
-        elif self.enable_continuous_token and not new_images_this_turn:
+        if self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
             merge_result, response_mask, response_logprobs = await self.ct_merge_non_assistant_msg(
                 previous_messages,
@@ -411,6 +389,26 @@ class ToolAgentLoop(AgentLoopBase):
                 agent_data.response_logprobs = response_logprobs or []
             agent_data.user_turns += 1
             return AgentState.GENERATING
+        elif self.tool_parser_name == "gpt-oss":
+            logger.info("manually format tool responses for gpt-oss")
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
+            response_ids = await self.loop.run_in_executor(
+                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
+            )
+        elif self.tool_parser_name == "gemma4":
+            # Gemma4's chat template drops tool responses when passed without the preceding
+            # assistant tool_call message. Manually format the response tokens.
+            # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
+            parts = []
+            for msg in add_messages:
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
+                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+            tool_response_text = "".join(parts)
+            response_ids = await self.loop.run_in_executor(
+                None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
+            )
         else:
             # Note that we have to pass None to the images and videos if there are no new images / videos
             # to stay compatible with downstream image processing logic!

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -293,7 +293,9 @@ class ToolAgentLoop(AgentLoopBase):
         # Extract tool calls (use per-sample tools if routed)
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
-        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(
+            agent_data.response_ids, tools
+        )
         if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -209,7 +209,7 @@ class ToolAgentLoop(AgentLoopBase):
     async def _handle_pending_state(self, agent_data: AgentData, sampling_params: dict[str, Any]) -> AgentState:
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
         else:
             prompt_ids = await self.apply_chat_template(
@@ -262,7 +262,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
                 agent_data.prompt_ids,
                 agent_data.response_ids,
@@ -296,7 +296,7 @@ class ToolAgentLoop(AgentLoopBase):
         tools = [tool.tool_schema for tool in active_tools.values()]
         assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
         agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
-        if self.continuous_token_builder is not None:
+        if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
         if agent_data.tool_calls:
@@ -401,7 +401,7 @@ class ToolAgentLoop(AgentLoopBase):
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
-        elif self.continuous_token_builder is not None and not new_images_this_turn:
+        elif self.enable_continuous_token and not new_images_this_turn:
             schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
             merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
                 previous_messages,

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -89,7 +89,6 @@ class AgentData:
 
         # Temporary state for tool calls
         self.tool_calls: list[FunctionCall] = []
-        self.tool_call_ids: list[str | None] = []
 
         self.routed_experts = None
 
@@ -295,7 +294,6 @@ class ToolAgentLoop(AgentLoopBase):
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
         assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
-        agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
         if self.enable_continuous_token:
             agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
@@ -311,20 +309,16 @@ class ToolAgentLoop(AgentLoopBase):
         previous_messages = list(agent_data.messages)
 
         tasks = []
-        tool_call_names = []
-        tool_call_ids = []
-        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
+        for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
-            tool_call_names.append(tool_call.name)
-            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
-            tool_call_ids.append(raw_tool_call_id)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
 
         # Process tool responses and update multi_modal_data
         # Removed: agent_data.new_images_this_turn = []
-        for tool_response, tool_reward, _ in responses:
+        for tool_index, (tool_response, tool_reward, _) in enumerate(responses):
+            tool_call = agent_data.tool_calls[tool_index]
             # Create message from tool response
             if tool_response.image or tool_response.video:
                 # Multi-modal content with structured format
@@ -345,11 +339,9 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
-            tool_index = len(add_messages)
-            tool_call_id = tool_call_ids[tool_index]
-            message["name"] = tool_call_names[tool_index]
-            if tool_call_id is not None:
-                message["tool_call_id"] = tool_call_id
+            message["name"] = tool_call.name
+            if tool_call.tool_call_id is not None:
+                message["tool_call_id"] = tool_call.tool_call_id
 
             add_messages.append(message)
 
@@ -381,7 +373,7 @@ class ToolAgentLoop(AgentLoopBase):
 
         if self.tool_parser_name == "gpt-oss":
             logger.info("manually format tool responses for gpt-oss")
-            tool_response_text = build_gpt_oss_tool_response_text(add_messages, tool_call_names)
+            tool_response_text = build_gpt_oss_tool_response_text(add_messages)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
@@ -390,13 +382,13 @@ class ToolAgentLoop(AgentLoopBase):
             # assistant tool_call message. Manually format the response tokens.
             # Format: <|tool_response>response:func_name{value:<|"|>content<|"|>}<tool_response|>
             parts = []
-            for msg, name in zip(add_messages, tool_call_names, strict=True):
+            for msg in add_messages:
                 content = msg.get("content", "")
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
                 if isinstance(content, list):
                     content = "".join([item.get("text", "") for item in content if item.get("type") == "text"])
-                parts.append(f'<|tool_response>response:{name}{{value:<|"|>{content}<|"|>}}<tool_response|>')
+                parts.append(f'<|tool_response>response:{msg["name"]}{{value:<|"|>{content}<|"|>}}<tool_response|>')
             tool_response_text = "".join(parts)
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
@@ -450,15 +442,6 @@ class ToolAgentLoop(AgentLoopBase):
         agent_data.user_turns += 1
         return AgentState.GENERATING
 
-    def _last_parsed_tool_call_ids(self, tool_call_count: int) -> list[str | None]:
-        parsed_ids = getattr(self.tool_parser, "last_tool_call_ids", [])
-        if not isinstance(parsed_ids, list):
-            return [None] * tool_call_count
-        return [
-            parsed_ids[index] if index < len(parsed_ids) and isinstance(parsed_ids[index], str) else None
-            for index in range(tool_call_count)
-        ]
-
     def _build_assistant_message(self, content: str, agent_data: AgentData) -> dict[str, Any]:
         message: dict[str, Any] = {"role": "assistant", "content": content or ""}
         if not agent_data.tool_calls:
@@ -466,7 +449,6 @@ class ToolAgentLoop(AgentLoopBase):
 
         tool_calls = []
         for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
-            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
             function_call, has_decode_error = OpenAIFunctionCallSchema.from_openai_function_parsed_schema(
                 OpenAIFunctionParsedSchema(name=tool_call.name, arguments=tool_call.arguments)
             )
@@ -479,8 +461,8 @@ class ToolAgentLoop(AgentLoopBase):
                 "type": "function",
                 "function": function_call.model_dump(),
             }
-            if raw_tool_call_id is not None:
-                tool_call_message["id"] = raw_tool_call_id
+            if tool_call.tool_call_id is not None:
+                tool_call_message["id"] = tool_call.tool_call_id
             tool_calls.append(tool_call_message)
         message["tool_calls"] = tool_calls
         return message

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -31,7 +31,7 @@ from verl.experimental.agent_loop.agent_loop import (
 from verl.experimental.agent_loop.tool_parser import FunctionCall, ToolParser
 from verl.experimental.agent_loop.utils import build_gpt_oss_tool_response_text
 from verl.tools.function_tool import FunctionTool, normalize_function_tool_return
-from verl.tools.schemas import ToolResponse
+from verl.tools.schemas import OpenAIFunctionCallSchema, OpenAIFunctionParsedSchema, ToolResponse
 from verl.utils.profiler import simple_timer
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.workers.rollout.replica import TokenOutput
@@ -89,6 +89,7 @@ class AgentData:
 
         # Temporary state for tool calls
         self.tool_calls: list[FunctionCall] = []
+        self.tool_call_ids: list[str | None] = []
 
         self.routed_experts = None
 
@@ -208,14 +209,17 @@ class ToolAgentLoop(AgentLoopBase):
     async def _handle_pending_state(self, agent_data: AgentData, sampling_params: dict[str, Any]) -> AgentState:
         """Handle the pending state: prepare the prompt and start generation."""
         schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
-        prompt_ids = await self.apply_chat_template(
-            agent_data.messages,
-            tools=schemas,
-            images=agent_data.image_data,
-            videos=agent_data.video_data,
-            audios=agent_data.audio_data,
-            mm_processor_kwargs=agent_data.mm_processor_kwargs,
-        )
+        if self.continuous_token_builder is not None:
+            prompt_ids = await self.build_ct_initial_prompt(agent_data.messages, tools=schemas)
+        else:
+            prompt_ids = await self.apply_chat_template(
+                agent_data.messages,
+                tools=schemas,
+                images=agent_data.image_data,
+                videos=agent_data.video_data,
+                audios=agent_data.audio_data,
+                mm_processor_kwargs=agent_data.mm_processor_kwargs,
+            )
         agent_data.prompt_ids = prompt_ids
         return AgentState.GENERATING
 
@@ -258,10 +262,23 @@ class ToolAgentLoop(AgentLoopBase):
 
         agent_data.assistant_turns += 1
         agent_data.response_ids = output.token_ids
-        agent_data.prompt_ids += agent_data.response_ids
-        agent_data.response_mask += [1] * len(agent_data.response_ids)
-        if output.log_probs:
-            agent_data.response_logprobs += output.log_probs
+        if self.continuous_token_builder is not None:
+            merge_result, response_mask, response_logprobs = await self.merge_ct_assistant_token(
+                agent_data.prompt_ids,
+                agent_data.response_ids,
+                agent_data.response_mask,
+                agent_data.response_logprobs if (agent_data.response_logprobs or output.log_probs) else None,
+                assistant_logprobs=output.log_probs if output.log_probs else None,
+            )
+            agent_data.prompt_ids = merge_result.token_ids
+            agent_data.response_mask = response_mask
+            if response_logprobs is not None:
+                agent_data.response_logprobs = response_logprobs
+        else:
+            agent_data.prompt_ids += agent_data.response_ids
+            agent_data.response_mask += [1] * len(agent_data.response_ids)
+            if output.log_probs:
+                agent_data.response_logprobs += output.log_probs
 
         if output.routed_experts is not None:
             agent_data.routed_experts = output.routed_experts
@@ -277,7 +294,10 @@ class ToolAgentLoop(AgentLoopBase):
         # Extract tool calls (use per-sample tools if routed)
         active_tools = getattr(agent_data, "_active_tools", self.tools)
         tools = [tool.tool_schema for tool in active_tools.values()]
-        _, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        assistant_content, agent_data.tool_calls = await self.tool_parser.extract_tool_calls(agent_data.response_ids, tools)
+        agent_data.tool_call_ids = self._last_parsed_tool_call_ids(len(agent_data.tool_calls))
+        if self.continuous_token_builder is not None:
+            agent_data.messages.append(self._build_assistant_message(assistant_content, agent_data))
 
         if agent_data.tool_calls:
             return AgentState.PROCESSING_TOOLS
@@ -288,12 +308,16 @@ class ToolAgentLoop(AgentLoopBase):
         """Handle the processing tools state: execute tool calls and prepare tool responses."""
         add_messages: list[dict[str, Any]] = []
         new_images_this_turn: list[Any] = []  # Local variable instead of agent_data attribute
+        previous_messages = list(agent_data.messages)
 
         tasks = []
         tool_call_names = []
-        for tool_call in agent_data.tool_calls[: self.max_parallel_calls]:
+        tool_call_ids = []
+        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
             tasks.append(self._call_tool(tool_call, agent_data.tools_kwargs, agent_data))
             tool_call_names.append(tool_call.name)
+            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
+            tool_call_ids.append(raw_tool_call_id)
 
         with simple_timer("tool_calls", agent_data.metrics):
             responses = await asyncio.gather(*tasks)
@@ -321,6 +345,11 @@ class ToolAgentLoop(AgentLoopBase):
             else:
                 # Text-only content
                 message = {"role": "tool", "content": tool_response.text or ""}
+            tool_index = len(add_messages)
+            tool_call_id = tool_call_ids[tool_index]
+            message["name"] = tool_call_names[tool_index]
+            if tool_call_id is not None:
+                message["tool_call_id"] = tool_call_id
 
             add_messages.append(message)
 
@@ -372,6 +401,24 @@ class ToolAgentLoop(AgentLoopBase):
             response_ids = await self.loop.run_in_executor(
                 None, lambda: self.tokenizer.encode(tool_response_text, add_special_tokens=False)
             )
+        elif self.continuous_token_builder is not None and not new_images_this_turn:
+            schemas = getattr(agent_data, "_active_tool_schemas", self.tool_schemas)
+            merge_result, response_mask, response_logprobs = await self.merge_ct_non_assistant_msg(
+                previous_messages,
+                agent_data.messages,
+                agent_data.prompt_ids,
+                agent_data.response_mask,
+                agent_data.response_logprobs if agent_data.response_logprobs else None,
+                tools=schemas,
+            )
+            if len(response_mask) >= self.response_length:
+                return AgentState.TERMINATED
+            agent_data.prompt_ids = merge_result.token_ids
+            agent_data.response_mask = response_mask
+            if agent_data.response_logprobs:
+                agent_data.response_logprobs = response_logprobs or []
+            agent_data.user_turns += 1
+            return AgentState.GENERATING
         else:
             # Note that we have to pass None to the images and videos if there are no new images / videos
             # to stay compatible with downstream image processing logic!
@@ -402,6 +449,41 @@ class ToolAgentLoop(AgentLoopBase):
             agent_data.response_logprobs += [0.0] * len(response_ids)
         agent_data.user_turns += 1
         return AgentState.GENERATING
+
+    def _last_parsed_tool_call_ids(self, tool_call_count: int) -> list[str | None]:
+        parsed_ids = getattr(self.tool_parser, "last_tool_call_ids", [])
+        if not isinstance(parsed_ids, list):
+            return [None] * tool_call_count
+        return [
+            parsed_ids[index] if index < len(parsed_ids) and isinstance(parsed_ids[index], str) else None
+            for index in range(tool_call_count)
+        ]
+
+    def _build_assistant_message(self, content: str, agent_data: AgentData) -> dict[str, Any]:
+        message: dict[str, Any] = {"role": "assistant", "content": content or ""}
+        if not agent_data.tool_calls:
+            return message
+
+        tool_calls = []
+        for index, tool_call in enumerate(agent_data.tool_calls[: self.max_parallel_calls]):
+            raw_tool_call_id = agent_data.tool_call_ids[index] if index < len(agent_data.tool_call_ids) else None
+            function_call, has_decode_error = OpenAIFunctionCallSchema.from_openai_function_parsed_schema(
+                OpenAIFunctionParsedSchema(name=tool_call.name, arguments=tool_call.arguments)
+            )
+            if has_decode_error:
+                raise ValueError(
+                    f"Invalid tool call arguments for '{tool_call.name}': expected a JSON object string, "
+                    f"got {tool_call.arguments!r}"
+                )
+            tool_call_message = {
+                "type": "function",
+                "function": function_call.model_dump(),
+            }
+            if raw_tool_call_id is not None:
+                tool_call_message["id"] = raw_tool_call_id
+            tool_calls.append(tool_call_message)
+        message["tool_calls"] = tool_calls
+        return message
 
     async def _call_tool(
         self, tool_call: FunctionCall, tools_kwargs: dict[str, Any], agent_data: AgentData

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -41,6 +41,9 @@ class FunctionCall(BaseModel):
     name: str
     """The name of the function to call."""
 
+    tool_call_id: Optional[str] = None
+    """The model-emitted tool call identifier, if available."""
+
 
 class ToolParser(ABC):
     _registry: dict[str, type["ToolParser"]] = {}
@@ -549,7 +552,6 @@ class KimiToolParser(ToolParser):
 
     def __init__(self, tokenizer) -> None:
         super().__init__(tokenizer)
-        self.last_tool_call_ids: list[str] = []
         self.tool_calls_section_start_token = "<|tool_calls_section_begin|>"
         self.tool_calls_section_end_token = "<|tool_calls_section_end|>"
         self.tool_call_begin_token = "<|tool_call_begin|>"
@@ -614,17 +616,16 @@ class KimiToolParser(ToolParser):
             lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
         )
         if self.tool_calls_section_start_token not in text:
-            self.last_tool_call_ids = []
             return text, []
 
         function_calls: list[FunctionCall] = []
-        self.last_tool_call_ids = []
         for raw_name, raw_arguments in self.tool_call_regex.findall(text):
             raw_name = raw_name.strip()
             arguments = self._parse_arguments(raw_arguments)
             name = self._infer_tool_name(raw_name, arguments, tools)
-            self.last_tool_call_ids.append(raw_name)
-            function_calls.append(FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False)))
+            function_calls.append(
+                FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False), tool_call_id=raw_name)
+            )
 
         content_index = text.find(self.tool_calls_section_start_token)
         content = text[:content_index] if content_index >= 0 else text

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -580,7 +580,9 @@ class KimiToolParser(ToolParser):
         return arguments if isinstance(arguments, dict) else {}
 
     @staticmethod
-    def _infer_tool_name(raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]) -> str:
+    def _infer_tool_name(
+        raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]
+    ) -> str:
         if not tools:
             return raw_name
 

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -357,6 +357,280 @@ class Qwen3XMLToolParser(ToolParser):
             return text, []
 
 
+@ToolParser.register("glm")
+class GLMToolParser(ToolParser):
+    """Tool parser for GLM XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<tool_call>"
+        self.tool_call_end_token = "</tool_call>"
+        self.observation_token = "<|observation|>"
+        self.tool_call_regex = regex.compile(r"<tool_call>(.*?)</tool_call>", regex.DOTALL)
+        self.arg_pair_regex = regex.compile(
+            r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>",
+            regex.DOTALL,
+        )
+
+    @property
+    def stop_token_ids(self) -> list[int]:
+        token_id = self.tokenizer.convert_tokens_to_ids(self.observation_token)
+        if isinstance(token_id, int) and token_id >= 0:
+            return [token_id]
+        return []
+
+    @staticmethod
+    def _convert_arg_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_call(self, tool_call_text: str) -> FunctionCall:
+        first_arg_index = tool_call_text.find("<arg_key>")
+        if first_arg_index < 0:
+            name = tool_call_text.strip()
+            arguments: dict[str, Any] = {}
+        else:
+            name = tool_call_text[:first_arg_index].strip()
+            arguments = {
+                key.strip(): self._convert_arg_value(value)
+                for key, value in self.arg_pair_regex.findall(tool_call_text[first_arg_index:])
+            }
+        return FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False))
+
+    @staticmethod
+    def _strip_thinking_markers(content: str) -> str:
+        content = regex.sub(r"^\s*<think>.*?</think>", "", content, flags=regex.DOTALL)
+        content = regex.sub(r"^\s*</think>", "", content)
+        return content
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        matches = self.tool_call_regex.findall(text)
+        function_calls: list[FunctionCall] = []
+        for match in matches:
+            try:
+                function_calls.append(self._parse_tool_call(match))
+            except Exception as e:
+                logger.error(f"Failed to decode GLM tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        content = self._strip_thinking_markers(text[:content_index])
+        return content, function_calls
+
+
+@ToolParser.register("seed")
+class SeedToolParser(ToolParser):
+    """Tool parser for ByteDance Seed XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<seed:tool_call>"
+        self.tool_call_end_token = "</seed:tool_call>"
+        self.tool_call_regex = regex.compile(r"<seed:tool_call>(.*?)</seed:tool_call>", regex.DOTALL)
+        self.function_regex = regex.compile(r"<function=([^>\n]+)>\s*(.*?)</function>", regex.DOTALL)
+        self.parameter_regex = regex.compile(r"<parameter=([^>\n]+)>(.*?)</parameter>", regex.DOTALL)
+
+    @staticmethod
+    def _convert_parameter_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_call(self, tool_call_text: str) -> FunctionCall | None:
+        match = self.function_regex.search(tool_call_text)
+        if not match:
+            return None
+
+        name = match.group(1).strip()
+        body = match.group(2)
+        arguments = {
+            key.strip(): self._convert_parameter_value(value) for key, value in self.parameter_regex.findall(body)
+        }
+        return FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False))
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        for match in self.tool_call_regex.findall(text):
+            try:
+                function_call = self._parse_tool_call(match)
+                if function_call is not None:
+                    function_calls.append(function_call)
+            except Exception as e:
+                logger.error(f"Failed to decode Seed tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        return text[:content_index], function_calls
+
+
+@ToolParser.register("minimax")
+class MiniMaxToolParser(ToolParser):
+    """Tool parser for MiniMax XML-style function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.tool_call_start_token = "<minimax:tool_call>"
+        self.tool_call_end_token = "</minimax:tool_call>"
+        self.tool_call_regex = regex.compile(r"<minimax:tool_call>(.*?)</minimax:tool_call>", regex.DOTALL)
+        self.invoke_regex = regex.compile(r'<invoke name="([^"]+)">\s*(.*?)</invoke>', regex.DOTALL)
+        self.parameter_regex = regex.compile(r'<parameter name="([^"]+)">(.*?)</parameter>', regex.DOTALL)
+
+    @staticmethod
+    def _convert_parameter_value(raw_value: str) -> Any:
+        value = raw_value.strip()
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def _parse_tool_calls(self, tool_call_text: str) -> list[FunctionCall]:
+        function_calls: list[FunctionCall] = []
+        for name, body in self.invoke_regex.findall(tool_call_text):
+            arguments = {
+                key.strip(): self._convert_parameter_value(value) for key, value in self.parameter_regex.findall(body)
+            }
+            function_calls.append(FunctionCall(name=name.strip(), arguments=json.dumps(arguments, ensure_ascii=False)))
+        return function_calls
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        del tools
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_call_start_token not in text or self.tool_call_end_token not in text:
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        for match in self.tool_call_regex.findall(text):
+            try:
+                function_calls.extend(self._parse_tool_calls(match))
+            except Exception as e:
+                logger.error(f"Failed to decode MiniMax tool call: {e}")
+
+        content_index = text.find(self.tool_call_start_token)
+        return text[:content_index], function_calls
+
+
+@ToolParser.register("kimi")
+class KimiToolParser(ToolParser):
+    """Tool parser for Kimi K2-family special-token function calls."""
+
+    def __init__(self, tokenizer) -> None:
+        super().__init__(tokenizer)
+        self.last_tool_call_ids: list[str] = []
+        self.tool_calls_section_start_token = "<|tool_calls_section_begin|>"
+        self.tool_calls_section_end_token = "<|tool_calls_section_end|>"
+        self.tool_call_begin_token = "<|tool_call_begin|>"
+        self.tool_call_argument_begin_token = "<|tool_call_argument_begin|>"
+        self.tool_call_end_token = "<|tool_call_end|>"
+        self.im_end_token = "<|im_end|>"
+        self.tool_call_regex = regex.compile(
+            r"<\|tool_call_begin\|>(.*?)<\|tool_call_argument_begin\|>(.*?)<\|tool_call_end\|>",
+            regex.DOTALL,
+        )
+
+    @property
+    def stop_token_ids(self) -> list[int]:
+        token_id = self.tokenizer.convert_tokens_to_ids(self.im_end_token)
+        if isinstance(token_id, int) and token_id >= 0:
+            return [token_id]
+        return []
+
+    @staticmethod
+    def _parse_arguments(raw_arguments: str) -> dict[str, Any]:
+        try:
+            arguments = json.loads(raw_arguments.strip())
+        except Exception:
+            logger.warning("Kimi tool-call arguments are not valid JSON; returning an empty argument dict.")
+            return {}
+        return arguments if isinstance(arguments, dict) else {}
+
+    @staticmethod
+    def _infer_tool_name(raw_name: str, arguments: dict[str, Any], tools: Optional[list[OpenAIFunctionToolSchema]]) -> str:
+        if not tools:
+            return raw_name
+
+        tool_names = [tool.function.name for tool in tools if tool.type == "function"]
+        if raw_name in tool_names:
+            return raw_name
+
+        compact_raw_name = raw_name.lower().replace("-", "_")
+        substring_matches = [name for name in tool_names if name.lower() in compact_raw_name]
+        if len(substring_matches) == 1:
+            return substring_matches[0]
+
+        argument_keys = set(arguments)
+        schema_matches = []
+        for tool in tools:
+            if tool.type != "function":
+                continue
+            required = set(tool.function.parameters.required or [])
+            if required and required.issubset(argument_keys):
+                schema_matches.append(tool.function.name)
+        if len(schema_matches) == 1:
+            return schema_matches[0]
+
+        return raw_name
+
+    @rollout_trace_op
+    async def extract_tool_calls(
+        self, responses_ids: list[int], tools: list[OpenAIFunctionToolSchema] = None
+    ) -> tuple[str, list[FunctionCall]]:
+        loop = get_event_loop()
+        text = await loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.decode(responses_ids, skip_special_tokens=False),
+        )
+        if self.tool_calls_section_start_token not in text:
+            self.last_tool_call_ids = []
+            return text, []
+
+        function_calls: list[FunctionCall] = []
+        self.last_tool_call_ids = []
+        for raw_name, raw_arguments in self.tool_call_regex.findall(text):
+            raw_name = raw_name.strip()
+            arguments = self._parse_arguments(raw_arguments)
+            name = self._infer_tool_name(raw_name, arguments, tools)
+            self.last_tool_call_ids.append(raw_name)
+            function_calls.append(FunctionCall(name=name, arguments=json.dumps(arguments, ensure_ascii=False)))
+
+        content_index = text.find(self.tool_calls_section_start_token)
+        content = text[:content_index] if content_index >= 0 else text
+        return content, function_calls
+
+
 @ToolParser.register("gemma4")
 class Gemma4ToolParser(ToolParser):
     """Tool parser for Google Gemma 4 models.

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -98,10 +98,10 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
     return message_content + "<|start|>assistant"
 
 
-def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]]) -> str:
+def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]], tool_call_names: list[str]) -> str:
     """Build gpt-oss tool response text (manual formatting + generation prompt)."""
     tool_response_texts: list[str] = []
-    for tool_msg in messages:
-        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_msg["name"])
+    for index, tool_msg in enumerate(messages):
+        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_call_names[index])
         tool_response_texts.append(formatted)
     return add_generation_prompt_for_gpt_oss("".join(tool_response_texts))

--- a/verl/experimental/agent_loop/utils.py
+++ b/verl/experimental/agent_loop/utils.py
@@ -98,11 +98,10 @@ def add_generation_prompt_for_gpt_oss(message_content: str) -> str:
     return message_content + "<|start|>assistant"
 
 
-def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]], tool_call_names: list[str]) -> str:
+def build_gpt_oss_tool_response_text(messages: list[dict[str, Any]]) -> str:
     """Build gpt-oss tool response text (manual formatting + generation prompt)."""
     tool_response_texts: list[str] = []
-    for i, tool_msg in enumerate(messages):
-        actual_tool_name = tool_call_names[i]
-        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], actual_tool_name)
+    for tool_msg in messages:
+        formatted = format_gpt_oss_tool_response_manually(tool_msg["content"], tool_msg["name"])
         tool_response_texts.append(formatted)
     return add_generation_prompt_for_gpt_oss("".join(tool_response_texts))

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -322,6 +322,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -288,6 +288,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -295,6 +295,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -300,6 +300,10 @@ actor_rollout_ref:
       tool_response_truncate_side: middle
       use_inference_chat_template: false
       tokenization_sanity_check_mode: strict
+      continuous_token:
+        _target_: verl.workers.config.ContinuousTokenConfig
+        enable: false
+        model_family: auto
       format: hermes
       num_repeat_rollouts: null
     calculate_log_probs: true

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,7 +225,7 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5, gemma4, gptoss
     model_family: auto
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -225,12 +225,8 @@ multi_turn:
     enable: False
 
     # Model-family specific boundary handling. auto infers from model path/tokenizer name.
-    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, minimaxm2, minimaxm25, minimaxm27, glm47, glm5
     model_family: auto
-
-    # Optional Python module to import before creating the Continuous Token builder.
-    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
-    custom_builder_module: null
 
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -214,6 +214,24 @@ multi_turn:
   # - ignore_strippable: ignore strippable tokens when checking tokenization sanity
   tokenization_sanity_check_mode: strict
 
+  # Continuous Token keeps the runtime token stream across multi-turn rollout instead of
+  # reconstructing previous assistant turns from text. Disabled by default for compatibility.
+  continuous_token:
+
+    # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+    _target_: verl.workers.config.ContinuousTokenConfig
+
+    # Enable Continuous Token for multi-turn agent rollout.
+    enable: False
+
+    # Model-family specific boundary handling. auto infers from model path/tokenizer name.
+    # Options: auto, default, qwen, qwen25, qwen3, qwen35, minimax, glm47
+    model_family: auto
+
+    # Optional Python module to import before creating the Continuous Token builder.
+    # The module can register a custom builder via verl.utils.continuous_token_wiring.ContinuousTokenBuilderRegistry.
+    custom_builder_module: null
+
   # Format of the multi-turn rollout. Options: hermes, llama3_json, ...
   format: hermes
 

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -81,16 +82,24 @@ class ContinuousTokenBuilder:
         self._assert_append_only(previous_messages, updated_messages)
         appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
+        processed_messages: list[dict[str, Any]] = []
 
         for group in self._iter_append_groups(appended_messages):
             role = group[0].get("role")
             if role == "tool":
-                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+                incremental_ids.extend(
+                    self._tokenize_tool_group(
+                        group,
+                        context_messages=previous_messages + processed_messages,
+                        tools=tools,
+                    )
+                )
             elif role in {"user", "system"}:
                 # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
                 incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+            processed_messages.extend(group)
 
         incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
@@ -172,9 +181,10 @@ class ContinuousTokenBuilder:
         self,
         tool_messages: list[dict[str, Any]],
         *,
+        context_messages: list[dict[str, Any]] | None = None,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages, context_messages=context_messages)
         return self.render_delta_token_id(
             [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
             tool_messages,
@@ -225,13 +235,19 @@ class ContinuousTokenBuilder:
                     f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
                 )
 
-    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+    def _synthetic_assistant_for_tools(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
         tool_calls = []
-        for tool_message in tool_messages:
+        for index, tool_message in enumerate(tool_messages):
             tool_call = {
                 "type": "function",
                 "function": {
-                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "name": _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
                     "arguments": {},
                 },
             }
@@ -239,6 +255,33 @@ class ContinuousTokenBuilder:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
         return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GPT-OSS tool-response formatting."""
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        context_messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        del tools
+        tool_names_by_id, positional_tool_names = _assistant_tool_call_names(context_messages or [])
+        response_text = "".join(
+            self._format_tool_response(
+                tool_message,
+                _resolve_tool_name(tool_message, index, tool_names_by_id, positional_tool_names),
+            )
+            for index, tool_message in enumerate(tool_messages)
+        )
+        return self.tokenizer.encode(response_text, add_special_tokens=False)
+
+    @staticmethod
+    def _format_tool_response(tool_message: dict[str, Any], tool_name: str) -> str:
+        content = json.dumps(_stringify_tool_content(tool_message.get("content", "")), ensure_ascii=False)
+        return f"<|start|>functions.{tool_name} to=assistant<|channel|>commentary<|message|>{content}<|end|>"
 
 
 class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
@@ -329,6 +372,38 @@ class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
+class Gemma4ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Gemma4 tool-response boundary handling."""
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._tool_response_id = _require_token_id(tokenizer, "<|tool_response>")
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_token_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
+        appended_messages = updated_messages[len(previous_messages) :]
+
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if appended_messages and prefix[-1:] != [self._tool_response_id]:
+            prefix.append(self._tool_response_id)
+            inserted_token_ids.append(self._tool_response_id)
+
+        return MergeResult(
+            token_ids=prefix + appended_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
 def _require_token_id(tokenizer: Any, token: str) -> int:
     token_id = tokenizer.convert_tokens_to_ids(token)
     if token_id is None:
@@ -340,3 +415,65 @@ def _require_token_id(tokenizer: Any, token: str) -> int:
     if not isinstance(token_id, int) or token_id < 0:
         raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
     return token_id
+
+
+def _stringify_tool_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            item.get("text", "") for item in content if isinstance(item, dict) and item.get("type") == "text"
+        )
+    return str(content)
+
+
+def _assistant_tool_call_names(
+    messages: list[dict[str, Any]],
+) -> tuple[dict[str, str], list[str]]:
+    tool_names_by_id: dict[str, str] = {}
+    positional_tool_names: list[str] = []
+    for message in reversed(messages):
+        if message.get("role") != "assistant":
+            continue
+        tool_calls = message.get("tool_calls") or []
+        if not isinstance(tool_calls, list):
+            continue
+        names: list[str] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            name = _tool_call_function_name(tool_call)
+            if name is None:
+                continue
+            names.append(name)
+            tool_call_id = tool_call.get("id")
+            if tool_call_id is not None:
+                tool_names_by_id.setdefault(str(tool_call_id), name)
+        if names and not positional_tool_names:
+            positional_tool_names = names
+    return tool_names_by_id, positional_tool_names
+
+
+def _resolve_tool_name(
+    tool_message: dict[str, Any],
+    index: int,
+    tool_names_by_id: dict[str, str],
+    positional_tool_names: list[str],
+) -> str:
+    tool_call_id = tool_message.get("tool_call_id")
+    if tool_call_id is not None and str(tool_call_id) in tool_names_by_id:
+        return tool_names_by_id[str(tool_call_id)]
+    if index < len(positional_tool_names):
+        return positional_tool_names[index]
+    if tool_message.get("name"):
+        return str(tool_message["name"])
+    return "continuous_token_tool"
+
+
+def _tool_call_function_name(tool_call: dict[str, Any]) -> str | None:
+    function = tool_call.get("function")
+    if isinstance(function, dict) and function.get("name") is not None:
+        return str(function["name"])
+    return None

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -74,12 +74,12 @@ class ContinuousTokenBuilder:
     def tokenize_incremental_messages(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> list[int]:
-        self._assert_append_only(previous_messages, next_messages)
-        appended_messages = next_messages[len(previous_messages) :]
+        self._assert_append_only(previous_messages, updated_messages)
+        appended_messages = updated_messages[len(previous_messages) :]
         incremental_ids: list[int] = []
 
         for group in self._iter_append_groups(appended_messages):
@@ -92,18 +92,18 @@ class ContinuousTokenBuilder:
             else:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
 
-        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
         return incremental_ids
 
     def merge_tokens(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
         runtime_token_ids: list[int],
         *,
         tools: list[dict[str, Any]] | None = None,
     ) -> MergeResult:
-        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        appended_ids = self.tokenize_incremental_messages(previous_messages, updated_messages, tools=tools)
         return self._merge_token_ids(runtime_token_ids, appended_ids)
 
     def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
@@ -212,13 +212,13 @@ class ContinuousTokenBuilder:
     def _assert_append_only(
         self,
         previous_messages: list[dict[str, Any]],
-        next_messages: list[dict[str, Any]],
+        updated_messages: list[dict[str, Any]],
     ) -> None:
-        if len(next_messages) < len(previous_messages):
-            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
-        if next_messages[: len(previous_messages)] != previous_messages:
+        if len(updated_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; updated_messages is shorter")
+        if updated_messages[: len(previous_messages)] != previous_messages:
             raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
-        for message in next_messages[len(previous_messages) :]:
+        for message in updated_messages[len(previous_messages) :]:
             role = message.get("role")
             if role not in self.allowed_append_roles:
                 raise ValueError(

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -1,0 +1,350 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+_SUPPORTED_APPEND_ROLES = frozenset({"tool", "user", "system"})
+_SYNTHETIC_SYSTEM_MESSAGE: dict[str, Any] = {"role": "system", "content": "continuous token synthetic system"}
+_SYNTHETIC_USER_MESSAGE: dict[str, Any] = {"role": "user", "content": "continuous token synthetic user"}
+_ASSISTANT_REASONING_CONTENT: str = "reasoning"
+MergeKind = Literal["assistant", "non_assistant"]
+
+
+@dataclass(frozen=True)
+class MergeResult:
+    """Token merge result with the token-level delta needed by callers.
+
+    ``inserted_token_ids`` are CT-created boundary tokens at the merge junction.
+    They are not model-generated tokens and therefore must not carry loss or
+    model logprobs. Generated assistant tokens are represented by
+    ``appended_token_count`` with ``kind="assistant"``.
+    """
+
+    token_ids: list[int]
+    appended_token_count: int
+    kind: MergeKind = "non_assistant"
+    inserted_token_ids: list[int] = field(default_factory=list)
+    removed_prefix_token_count: int = 0
+
+
+class ContinuousTokenBuilder:
+    """Continuous Token builder for runtime prefix reuse."""
+
+    allowed_append_roles: frozenset[str] = _SUPPORTED_APPEND_ROLES
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        *,
+        chat_template_kwargs: dict[str, Any] | None = None,
+        allowed_append_roles: list[str] | tuple[str, ...] | set[str] | None = None,
+    ):
+        self.tokenizer = tokenizer
+        self.chat_template_kwargs = chat_template_kwargs or {}
+        if allowed_append_roles is not None:
+            allowed_roles = frozenset(allowed_append_roles)
+            unknown_roles = allowed_roles - _SUPPORTED_APPEND_ROLES
+            if unknown_roles:
+                raise ValueError(f"Unsupported Continuous Token append roles: {sorted(unknown_roles)}")
+            self.allowed_append_roles = allowed_roles
+
+    def build_initial_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self._render_tokens(messages, add_generation_prompt=True, tools=tools)
+
+    def tokenize_incremental_messages(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        self._assert_append_only(previous_messages, next_messages)
+        appended_messages = next_messages[len(previous_messages) :]
+        incremental_ids: list[int] = []
+
+        for group in self._iter_append_groups(appended_messages):
+            role = group[0].get("role")
+            if role == "tool":
+                incremental_ids.extend(self._tokenize_tool_group(group, tools=tools))
+            elif role in {"user", "system"}:
+                # System appends can represent retry/control messages; unsupported templates will fail in suffix diff.
+                incremental_ids.extend(self._tokenize_single_non_tool(group[0], tools=tools))
+            else:
+                raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
+
+        incremental_ids.extend(self.render_delta_token_id(next_messages, [], add_generation_prompt=True, tools=tools))
+        return incremental_ids
+
+    def merge_tokens(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+        runtime_token_ids: list[int],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> MergeResult:
+        appended_ids = self.tokenize_incremental_messages(previous_messages, next_messages, tools=tools)
+        return self._merge_token_ids(runtime_token_ids, appended_ids)
+
+    def append_assistant_tokens(self, runtime_token_ids: list[int], assistant_token_ids: list[int]) -> MergeResult:
+        """Append model-generated assistant tokens to the runtime token stream."""
+        merged_token_ids = list(runtime_token_ids) + list(assistant_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(assistant_token_ids),
+            kind="assistant",
+        )
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        """Merge runtime prefix tokens and appended tokens.
+
+        Model-specific builders usually override this hook for boundary handling,
+        such as inserting or trimming tokens at the prefix/appended-token junction.
+        """
+        merged_token_ids = list(runtime_token_ids) + list(appended_token_ids)
+        return MergeResult(
+            token_ids=merged_token_ids,
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+        )
+
+    def _render_tokens(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        from verl.utils.chat_template import apply_chat_template
+        from verl.utils.tokenizer import normalize_token_ids
+
+        tokenized = apply_chat_template(
+            self.tokenizer,
+            messages,
+            tokenize=True,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+            **self.chat_template_kwargs,
+        )
+        return normalize_token_ids(tokenized)
+
+    def render_delta_token_id(
+        self,
+        prefix_messages: list[dict[str, Any]],
+        appended_messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool = False,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        """Render prefix/full prompts as token IDs and return the token-level suffix."""
+        prefix_token_ids = self._render_tokens(prefix_messages, add_generation_prompt=False, tools=tools)
+        full_token_ids = self._render_tokens(
+            prefix_messages + appended_messages,
+            add_generation_prompt=add_generation_prompt,
+            tools=tools,
+        )
+        if full_token_ids[: len(prefix_token_ids)] != prefix_token_ids:
+            roles = [message.get("role") for message in appended_messages] or ["generation_prompt"]
+            raise ValueError(f"Continuous Token token-id suffix diff failed for roles: {roles}")
+        return full_token_ids[len(prefix_token_ids) :]
+
+    def _tokenize_tool_group(
+        self,
+        tool_messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        synthetic_assistant = self._synthetic_assistant_for_tools(tool_messages)
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE, synthetic_assistant],
+            tool_messages,
+            tools=tools,
+        )
+
+    def _tokenize_single_non_tool(
+        self,
+        message: dict[str, Any],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> list[int]:
+        return self.render_delta_token_id(
+            [_SYNTHETIC_SYSTEM_MESSAGE, _SYNTHETIC_USER_MESSAGE],
+            [message],
+            tools=tools,
+        )
+
+    def _iter_append_groups(self, appended_messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+        groups: list[list[dict[str, Any]]] = []
+        index = 0
+        while index < len(appended_messages):
+            role = appended_messages[index].get("role")
+            if role == "tool":
+                end = index + 1
+                while end < len(appended_messages) and appended_messages[end].get("role") == "tool":
+                    end += 1
+                groups.append(appended_messages[index:end])
+                index = end
+            else:
+                groups.append([appended_messages[index]])
+                index += 1
+        return groups
+
+    def _assert_append_only(
+        self,
+        previous_messages: list[dict[str, Any]],
+        next_messages: list[dict[str, Any]],
+    ) -> None:
+        if len(next_messages) < len(previous_messages):
+            raise ValueError("Continuous Token messages must be append-only; next_messages is shorter")
+        if next_messages[: len(previous_messages)] != previous_messages:
+            raise ValueError("Continuous Token messages must be append-only; prefix messages changed")
+        for message in next_messages[len(previous_messages) :]:
+            role = message.get("role")
+            if role not in self.allowed_append_roles:
+                raise ValueError(
+                    f"Continuous Token only supports appending roles {sorted(self.allowed_append_roles)}, got {role!r}"
+                )
+
+    def _synthetic_assistant_for_tools(self, tool_messages: list[dict[str, Any]]) -> dict[str, Any]:
+        tool_calls = []
+        for tool_message in tool_messages:
+            tool_call = {
+                "type": "function",
+                "function": {
+                    "name": tool_message.get("name") or "continuous_token_tool",
+                    "arguments": {},
+                },
+            }
+            if tool_message.get("tool_call_id") is not None:
+                tool_call["id"] = tool_message["tool_call_id"]
+            tool_calls.append(tool_call)
+        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+
+
+class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
+    """Qwen ChatML boundary handling.
+
+    Qwen2.5, Qwen3, and Qwen3.5 templates render ``<|im_end|>\n`` after a turn,
+    while generation may stop at ``<|im_end|>``. When the runtime prefix ends
+    there, insert the missing newline before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected Qwen newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._im_end_id = _require_token_id(tokenizer, "<|im_end|>")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._im_end_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
+    """Backward-compatible alias for Qwen ChatML boundary behavior."""
+
+
+class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
+    """MiniMax boundary handling.
+
+    MiniMax templates render ``[e~[\n`` after a turn, while generation may stop
+    at ``[e~[``. When the runtime prefix ends there, insert the missing newline
+    before appending non-assistant tokens.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        newline_ids = tokenizer.encode("\n", add_special_tokens=False)
+        if len(newline_ids) != 1:
+            raise ValueError(f"Expected MiniMax newline to tokenize to one token, got {newline_ids!r}")
+        self._newline_id = int(newline_ids[0])
+        self._eos_id = _require_token_id(tokenizer, "[e~[")
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        inserted_token_ids: list[int] = []
+        if prefix and prefix[-1] == self._eos_id:
+            prefix.append(self._newline_id)
+            inserted_token_ids.append(self._newline_id)
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            inserted_token_ids=inserted_token_ids,
+        )
+
+
+class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+    """GLM observation/user boundary handling.
+
+    ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and
+    next-message start tokens. If the runtime prefix ends with either, remove
+    that token before appending the next non-assistant segment.
+    """
+
+    def __init__(self, tokenizer: Any, **kwargs: Any):
+        super().__init__(tokenizer, **kwargs)
+        self._observation_id = _require_token_id(tokenizer, "<|observation|>")
+        self._user_id = _require_token_id(tokenizer, "<|user|>")
+        self._ambiguous_boundary_ids = {self._observation_id, self._user_id}
+
+    def _merge_token_ids(self, runtime_token_ids: list[int], appended_token_ids: list[int]) -> MergeResult:
+        prefix = list(runtime_token_ids)
+        removed_prefix_token_count = 0
+        if prefix and prefix[-1] in self._ambiguous_boundary_ids:
+            prefix = prefix[:-1]
+            removed_prefix_token_count = 1
+        return MergeResult(
+            token_ids=prefix + list(appended_token_ids),
+            appended_token_count=len(appended_token_ids),
+            kind="non_assistant",
+            removed_prefix_token_count=removed_prefix_token_count,
+        )
+
+
+def _require_token_id(tokenizer: Any, token: str) -> int:
+    token_id = tokenizer.convert_tokens_to_ids(token)
+    if token_id is None:
+        raise ValueError(f"Tokenizer does not define required token {token!r}")
+    if isinstance(token_id, list):
+        if len(token_id) != 1:
+            raise ValueError(f"Tokenizer returned multiple ids for required token {token!r}: {token_id!r}")
+        token_id = token_id[0]
+    if not isinstance(token_id, int) or token_id < 0:
+        raise ValueError(f"Tokenizer returned invalid id for required token {token!r}: {token_id!r}")
+    return token_id

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -101,7 +101,9 @@ class ContinuousTokenBuilder:
                 raise ValueError(f"Unsupported Continuous Token append role: {role!r}")
             processed_messages.extend(group)
 
-        incremental_ids.extend(self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools))
+        incremental_ids.extend(
+            self.render_delta_token_id(updated_messages, [], add_generation_prompt=True, tools=tools)
+        )
         return incremental_ids
 
     def merge_tokens(
@@ -254,7 +256,12 @@ class ContinuousTokenBuilder:
             if tool_message.get("tool_call_id") is not None:
                 tool_call["id"] = tool_message["tool_call_id"]
             tool_calls.append(tool_call)
-        return {"role": "assistant", "content": "", "reasoning_content": _ASSISTANT_REASONING_CONTENT, "tool_calls": tool_calls}
+        return {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": _ASSISTANT_REASONING_CONTENT,
+            "tool_calls": tool_calls,
+        }
 
 
 class GptOssContinuousTokenBuilder(ContinuousTokenBuilder):

--- a/verl/utils/continuous_token.py
+++ b/verl/utils/continuous_token.py
@@ -271,14 +271,6 @@ class QwenContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class Qwen3ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
-class Qwen35ContinuousTokenBuilder(QwenContinuousTokenBuilder):
-    """Backward-compatible alias for Qwen ChatML boundary behavior."""
-
-
 class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
     """MiniMax boundary handling.
 
@@ -309,7 +301,7 @@ class MiniMaxContinuousTokenBuilder(ContinuousTokenBuilder):
         )
 
 
-class GLM47ContinuousTokenBuilder(ContinuousTokenBuilder):
+class GLMContinuousTokenBuilder(ContinuousTokenBuilder):
     """GLM observation/user boundary handling.
 
     ``<|observation|>`` and ``<|user|>`` can be both assistant stop tokens and

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -21,7 +21,9 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
+    Gemma4ContinuousTokenBuilder,
     GLMContinuousTokenBuilder,
+    GptOssContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
@@ -40,6 +42,8 @@ _CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "minimaxm27": MiniMaxContinuousTokenBuilder,
     "glm47": GLMContinuousTokenBuilder,
     "glm5": GLMContinuousTokenBuilder,
+    "gemma4": Gemma4ContinuousTokenBuilder,
+    "gptoss": GptOssContinuousTokenBuilder,
 }
 
 CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
@@ -106,6 +110,12 @@ def infer_continuous_token_model_family(
         return "glm5"
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
+        marker in compact for marker in ("gemma4", "gemma4unified")
+    ):
+        return "gemma4"
+    if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
+        return "gptoss"
     if "minimaxm27" in compact:
         return "minimaxm27"
     if "minimaxm25" in compact:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Continuous Token builder registry and model-family resolution."""
+"""Continuous Token builder factory and model-family resolution."""
 
 from __future__ import annotations
 
@@ -21,115 +21,43 @@ from typing import Any
 
 from verl.utils.continuous_token import (
     ContinuousTokenBuilder,
-    GLM47ContinuousTokenBuilder,
+    GLMContinuousTokenBuilder,
     MiniMaxContinuousTokenBuilder,
-    Qwen35ContinuousTokenBuilder,
-    Qwen3ContinuousTokenBuilder,
     QwenContinuousTokenBuilder,
 )
-from verl.utils.import_utils import import_external_libs
 
 logger = logging.getLogger(__name__)
 
-_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
     "default": ContinuousTokenBuilder,
     "qwen": QwenContinuousTokenBuilder,
     "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": Qwen3ContinuousTokenBuilder,
-    "qwen35": Qwen35ContinuousTokenBuilder,
+    "qwen3": QwenContinuousTokenBuilder,
+    "qwen35": QwenContinuousTokenBuilder,
     "minimax": MiniMaxContinuousTokenBuilder,
-    "glm47": GLM47ContinuousTokenBuilder,
+    "minimaxm2": MiniMaxContinuousTokenBuilder,
+    "minimaxm25": MiniMaxContinuousTokenBuilder,
+    "minimaxm27": MiniMaxContinuousTokenBuilder,
+    "glm47": GLMContinuousTokenBuilder,
+    "glm5": GLMContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
-CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
-
-_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
-
-
-class ContinuousTokenBuilderRegistry:
-    """Registry for Continuous Token builder classes.
-
-    Custom builders can be registered from an imported Python module:
-
-    .. code-block:: python
-
-        @ContinuousTokenBuilderRegistry.register("deepseek")
-        class DeepseekContinuousTokenBuilder:
-            ...
-    """
-
-    _registry: dict[str, type[Any]] = {}
-
-    @classmethod
-    def register(cls, model_family: str, *, exist_ok: bool = False):
-        family = _normalize_model_family(model_family)
-        if family in _RESERVED_MODEL_FAMILIES:
-            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
-
-        def decorator(builder_cls: type[Any]) -> type[Any]:
-            if not isinstance(builder_cls, type):
-                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
-
-            existing = cls._registry.get(family)
-            if existing is not None and existing is not builder_cls and not exist_ok:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is already registered with "
-                    f"{existing}; pass exist_ok=True to replace it"
-                )
-            cls._registry[family] = builder_cls
-            return builder_cls
-
-        return decorator
-
-    @classmethod
-    def get(cls, model_family: str) -> type[Any]:
-        family = _normalize_model_family(model_family)
-        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
-            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
-            if builder_cls is None:
-                raise ValueError(
-                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
-                    "but its builder class has not been implemented yet."
-                )
-            return builder_cls
-        try:
-            return cls._registry[family]
-        except KeyError as exc:
-            raise ValueError(
-                f"Unknown Continuous Token builder family {family!r}. "
-                f"Registered families: {sorted(cls._registry)}. "
-                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
-            ) from exc
-
-    @classmethod
-    def registered_families(cls) -> tuple[str, ...]:
-        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
-
-
-def register_continuous_token_builder(
-    model_family: str,
-    builder_cls: type[Any] | None = None,
-    *,
-    exist_ok: bool = False,
-):
-    """Register a Continuous Token builder class for a model family.
-
-    This wrapper supports both direct calls and decorator usage. New code should
-    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
-    """
-    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
-    if builder_cls is None:
-        return decorator
-    return decorator(builder_cls)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
 def get_continuous_token_builder_class(model_family: str) -> type[Any]:
-    return ContinuousTokenBuilderRegistry.get(model_family)
+    family = _normalize_model_family(model_family)
+    try:
+        return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token builder family {family!r}. "
+            f"Supported families: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+        ) from exc
 
 
 def list_continuous_token_builder_families() -> tuple[str, ...]:
-    return ContinuousTokenBuilderRegistry.registered_families()
+    return CONTINUOUS_TOKEN_BUILDER_FAMILIES
 
 
 def resolve_continuous_token_model_family(
@@ -139,7 +67,7 @@ def resolve_continuous_token_model_family(
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
 ) -> str:
-    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
     if family != "auto":
         logger.info("Using explicit Continuous Token builder family: %s", family)
@@ -174,17 +102,24 @@ def infer_continuous_token_model_family(
     haystack = " ".join(str(item).lower() for item in candidates if item)
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
-    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
-        marker in compact for marker in ("glm47", "glm5")
-    ):
+    if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
+        return "glm5"
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
         return "glm47"
+    if "minimaxm27" in compact:
+        return "minimaxm27"
+    if "minimaxm25" in compact:
+        return "minimaxm25"
+    if "minimaxm2" in compact:
+        return "minimaxm2"
     if "minimax" in compact:
         return "minimax"
-    if (
-        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
-        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
-    ):
-        return "qwen"
+    if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
+        return "qwen35"
+    if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
+        return "qwen25"
+    if "qwen3" in compact:
+        return "qwen3"
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
@@ -201,11 +136,9 @@ def create_continuous_token_builder(
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
-    custom_builder_module: str | list[str] | None = None,
     **builder_kwargs: Any,
 ) -> Any:
     """Instantiate the registered builder selected by config/model metadata."""
-    import_external_libs(custom_builder_module)
     resolved_family = resolve_continuous_token_model_family(
         model_family,
         model_path=model_path,
@@ -220,7 +153,10 @@ def create_continuous_token_builder(
 def _normalize_model_family(model_family: str) -> str:
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return model_family.lower()
+    family = model_family.strip().lower()
+    if not family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return re.sub(r"[^a-z0-9]+", "", family)
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,9 +15,9 @@
 
 from __future__ import annotations
 
-from enum import StrEnum
 import logging
 import re
+from enum import StrEnum
 from typing import Any
 
 from verl.utils.continuous_token import (

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -185,6 +185,12 @@ def infer_continuous_token_model_family(
         or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
     ):
         return "qwen"
+    logger.warning(
+        "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
+        "falling back to the default ContinuousTokenBuilder.",
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
     return "default"
 
 

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 import logging
 import re
 from typing import Any
@@ -30,26 +31,44 @@ from verl.utils.continuous_token import (
 
 logger = logging.getLogger(__name__)
 
-_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any]] = {
-    "default": ContinuousTokenBuilder,
-    "qwen": QwenContinuousTokenBuilder,
-    "qwen25": QwenContinuousTokenBuilder,
-    "qwen3": QwenContinuousTokenBuilder,
-    "qwen35": QwenContinuousTokenBuilder,
-    "minimax": MiniMaxContinuousTokenBuilder,
-    "minimaxm2": MiniMaxContinuousTokenBuilder,
-    "minimaxm25": MiniMaxContinuousTokenBuilder,
-    "minimaxm27": MiniMaxContinuousTokenBuilder,
-    "glm47": GLMContinuousTokenBuilder,
-    "glm5": GLMContinuousTokenBuilder,
-    "gemma4": Gemma4ContinuousTokenBuilder,
-    "gptoss": GptOssContinuousTokenBuilder,
+
+class ContinuousTokenModelFamily(StrEnum):
+    AUTO = "auto"
+    DEFAULT = "default"
+    QWEN = "qwen"
+    QWEN25 = "qwen25"
+    QWEN3 = "qwen3"
+    QWEN35 = "qwen35"
+    MINIMAX = "minimax"
+    MINIMAX_M2 = "minimaxm2"
+    MINIMAX_M25 = "minimaxm25"
+    MINIMAX_M27 = "minimaxm27"
+    GLM47 = "glm47"
+    GLM5 = "glm5"
+    GEMMA4 = "gemma4"
+    GPTOSS = "gptoss"
+
+
+_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[ContinuousTokenModelFamily, type[Any]] = {
+    ContinuousTokenModelFamily.DEFAULT: ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN25: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN3: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.QWEN35: QwenContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M2: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M25: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.MINIMAX_M27: MiniMaxContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM47: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GLM5: GLMContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GEMMA4: Gemma4ContinuousTokenBuilder,
+    ContinuousTokenModelFamily.GPTOSS: GptOssContinuousTokenBuilder,
 }
 
-CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(family.value for family in _CONTINUOUS_TOKEN_BUILDER_REGISTRY)
 
 
-def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+def get_continuous_token_builder_class(model_family: str | ContinuousTokenModelFamily) -> type[Any]:
     family = _normalize_model_family(model_family)
     try:
         return _CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
@@ -65,15 +84,15 @@ def list_continuous_token_builder_families() -> tuple[str, ...]:
 
 
 def resolve_continuous_token_model_family(
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     *,
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Resolve ``auto`` to a concrete family, or canonicalize an explicit family."""
     family = _normalize_model_family(model_family)
-    if family != "auto":
+    if family != ContinuousTokenModelFamily.AUTO:
         logger.info("Using explicit Continuous Token builder family: %s", family)
         return family
 
@@ -96,7 +115,7 @@ def infer_continuous_token_model_family(
     model_path: str | None = None,
     tokenizer: Any | None = None,
     tokenizer_name_or_path: str | None = None,
-) -> str:
+) -> ContinuousTokenModelFamily:
     """Infer a built-in model family from model/tokenizer names.
 
     Unknown models intentionally fall back to ``default`` so enabling
@@ -107,42 +126,42 @@ def infer_continuous_token_model_family(
     compact = re.sub(r"[^a-z0-9]+", "", haystack)
 
     if any(marker in haystack for marker in ("glm-5", "glm_5")) or "glm5" in compact:
-        return "glm5"
+        return ContinuousTokenModelFamily.GLM5
     if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7")) or "glm47" in compact:
-        return "glm47"
+        return ContinuousTokenModelFamily.GLM47
     if any(marker in haystack for marker in ("gemma-4", "gemma_4")) or any(
         marker in compact for marker in ("gemma4", "gemma4unified")
     ):
-        return "gemma4"
+        return ContinuousTokenModelFamily.GEMMA4
     if any(marker in haystack for marker in ("gpt-oss", "gpt_oss")) or "gptoss" in compact:
-        return "gptoss"
+        return ContinuousTokenModelFamily.GPTOSS
     if "minimaxm27" in compact:
-        return "minimaxm27"
+        return ContinuousTokenModelFamily.MINIMAX_M27
     if "minimaxm25" in compact:
-        return "minimaxm25"
+        return ContinuousTokenModelFamily.MINIMAX_M25
     if "minimaxm2" in compact:
-        return "minimaxm2"
+        return ContinuousTokenModelFamily.MINIMAX_M2
     if "minimax" in compact:
-        return "minimax"
+        return ContinuousTokenModelFamily.MINIMAX
     if any(marker in haystack for marker in ("qwen3.5", "qwen3_5", "qwen3-5")) or "qwen35" in compact:
-        return "qwen35"
+        return ContinuousTokenModelFamily.QWEN35
     if any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5")) or "qwen25" in compact:
-        return "qwen25"
+        return ContinuousTokenModelFamily.QWEN25
     if "qwen3" in compact:
-        return "qwen3"
+        return ContinuousTokenModelFamily.QWEN3
     logger.warning(
         "No model-specific Continuous Token builder matched model_path=%r, tokenizer_name_or_path=%r; "
         "falling back to the default ContinuousTokenBuilder.",
         model_path,
         tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
     )
-    return "default"
+    return ContinuousTokenModelFamily.DEFAULT
 
 
 def create_continuous_token_builder(
     tokenizer: Any,
     *,
-    model_family: str,
+    model_family: str | ContinuousTokenModelFamily,
     model_path: str | None = None,
     tokenizer_name_or_path: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
@@ -160,13 +179,22 @@ def create_continuous_token_builder(
     return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
 
 
-def _normalize_model_family(model_family: str) -> str:
+def _normalize_model_family(model_family: str | ContinuousTokenModelFamily) -> ContinuousTokenModelFamily:
+    if isinstance(model_family, ContinuousTokenModelFamily):
+        return model_family
     if not isinstance(model_family, str) or not model_family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
     family = model_family.strip().lower()
     if not family:
         raise ValueError("Continuous Token model_family must be a non-empty string")
-    return re.sub(r"[^a-z0-9]+", "", family)
+    family = re.sub(r"[^a-z0-9]+", "", family)
+    try:
+        return ContinuousTokenModelFamily(family)
+    except ValueError as exc:
+        raise ValueError(
+            f"Unknown Continuous Token model_family {model_family!r}. "
+            f"Supported families: {(ContinuousTokenModelFamily.AUTO.value, *CONTINUOUS_TOKEN_BUILDER_FAMILIES)}."
+        ) from exc
 
 
 def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:

--- a/verl/utils/continuous_token_wiring.py
+++ b/verl/utils/continuous_token_wiring.py
@@ -1,0 +1,229 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Continuous Token builder registry and model-family resolution."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from verl.utils.continuous_token import (
+    ContinuousTokenBuilder,
+    GLM47ContinuousTokenBuilder,
+    MiniMaxContinuousTokenBuilder,
+    Qwen35ContinuousTokenBuilder,
+    Qwen3ContinuousTokenBuilder,
+    QwenContinuousTokenBuilder,
+)
+from verl.utils.import_utils import import_external_libs
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY: dict[str, type[Any] | None] = {
+    "default": ContinuousTokenBuilder,
+    "qwen": QwenContinuousTokenBuilder,
+    "qwen25": QwenContinuousTokenBuilder,
+    "qwen3": Qwen3ContinuousTokenBuilder,
+    "qwen35": Qwen35ContinuousTokenBuilder,
+    "minimax": MiniMaxContinuousTokenBuilder,
+    "glm47": GLM47ContinuousTokenBuilder,
+}
+
+CONTINUOUS_TOKEN_BUILDER_FAMILIES = tuple(_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY)
+CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS = ("auto", *CONTINUOUS_TOKEN_BUILDER_FAMILIES)
+
+_RESERVED_MODEL_FAMILIES = frozenset({"auto"})
+
+
+class ContinuousTokenBuilderRegistry:
+    """Registry for Continuous Token builder classes.
+
+    Custom builders can be registered from an imported Python module:
+
+    .. code-block:: python
+
+        @ContinuousTokenBuilderRegistry.register("deepseek")
+        class DeepseekContinuousTokenBuilder:
+            ...
+    """
+
+    _registry: dict[str, type[Any]] = {}
+
+    @classmethod
+    def register(cls, model_family: str, *, exist_ok: bool = False):
+        family = _normalize_model_family(model_family)
+        if family in _RESERVED_MODEL_FAMILIES:
+            raise ValueError(f"{family!r} is reserved and cannot be registered as a Continuous Token builder family")
+
+        def decorator(builder_cls: type[Any]) -> type[Any]:
+            if not isinstance(builder_cls, type):
+                raise TypeError(f"builder_cls must be a class, got {type(builder_cls)!r}")
+
+            existing = cls._registry.get(family)
+            if existing is not None and existing is not builder_cls and not exist_ok:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is already registered with "
+                    f"{existing}; pass exist_ok=True to replace it"
+                )
+            cls._registry[family] = builder_cls
+            return builder_cls
+
+        return decorator
+
+    @classmethod
+    def get(cls, model_family: str) -> type[Any]:
+        family = _normalize_model_family(model_family)
+        if family in _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY:
+            builder_cls = _BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY[family]
+            if builder_cls is None:
+                raise ValueError(
+                    f"Continuous Token builder family {family!r} is part of the built-in config surface, "
+                    "but its builder class has not been implemented yet."
+                )
+            return builder_cls
+        try:
+            return cls._registry[family]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown Continuous Token builder family {family!r}. "
+                f"Registered families: {sorted(cls._registry)}. "
+                f"Built-in families planned by config surface: {CONTINUOUS_TOKEN_BUILDER_FAMILIES}."
+            ) from exc
+
+    @classmethod
+    def registered_families(cls) -> tuple[str, ...]:
+        return tuple(sorted((*_BUILTIN_CONTINUOUS_TOKEN_BUILDER_REGISTRY, *cls._registry)))
+
+
+def register_continuous_token_builder(
+    model_family: str,
+    builder_cls: type[Any] | None = None,
+    *,
+    exist_ok: bool = False,
+):
+    """Register a Continuous Token builder class for a model family.
+
+    This wrapper supports both direct calls and decorator usage. New code should
+    prefer ``ContinuousTokenBuilderRegistry.register`` to match Verl registries.
+    """
+    decorator = ContinuousTokenBuilderRegistry.register(model_family, exist_ok=exist_ok)
+    if builder_cls is None:
+        return decorator
+    return decorator(builder_cls)
+
+
+def get_continuous_token_builder_class(model_family: str) -> type[Any]:
+    return ContinuousTokenBuilderRegistry.get(model_family)
+
+
+def list_continuous_token_builder_families() -> tuple[str, ...]:
+    return ContinuousTokenBuilderRegistry.registered_families()
+
+
+def resolve_continuous_token_model_family(
+    model_family: str,
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Resolve ``auto`` to a concrete family, or return an explicit family unchanged."""
+    family = _normalize_model_family(model_family)
+    if family != "auto":
+        logger.info("Using explicit Continuous Token builder family: %s", family)
+        return family
+
+    resolved = infer_continuous_token_model_family(
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    logger.info(
+        "Resolved Continuous Token builder family from auto: %s (model_path=%r, tokenizer_name_or_path=%r)",
+        resolved,
+        model_path,
+        tokenizer_name_or_path or _tokenizer_name_or_path(tokenizer),
+    )
+    return resolved
+
+
+def infer_continuous_token_model_family(
+    *,
+    model_path: str | None = None,
+    tokenizer: Any | None = None,
+    tokenizer_name_or_path: str | None = None,
+) -> str:
+    """Infer a built-in model family from model/tokenizer names.
+
+    Unknown models intentionally fall back to ``default`` so enabling
+    ``model_family=auto`` remains conservative.
+    """
+    candidates = [model_path, tokenizer_name_or_path, _tokenizer_name_or_path(tokenizer)]
+    haystack = " ".join(str(item).lower() for item in candidates if item)
+    compact = re.sub(r"[^a-z0-9]+", "", haystack)
+
+    if any(marker in haystack for marker in ("glm-4.7", "glm_4.7", "glm4.7", "glm-5", "glm_5")) or any(
+        marker in compact for marker in ("glm47", "glm5")
+    ):
+        return "glm47"
+    if "minimax" in compact:
+        return "minimax"
+    if (
+        any(marker in haystack for marker in ("qwen2.5", "qwen2_5", "qwen2-5", "qwen3.5", "qwen3_5", "qwen3-5"))
+        or any(marker in compact for marker in ("qwen25", "qwen3", "qwen35"))
+    ):
+        return "qwen"
+    return "default"
+
+
+def create_continuous_token_builder(
+    tokenizer: Any,
+    *,
+    model_family: str,
+    model_path: str | None = None,
+    tokenizer_name_or_path: str | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    custom_builder_module: str | list[str] | None = None,
+    **builder_kwargs: Any,
+) -> Any:
+    """Instantiate the registered builder selected by config/model metadata."""
+    import_external_libs(custom_builder_module)
+    resolved_family = resolve_continuous_token_model_family(
+        model_family,
+        model_path=model_path,
+        tokenizer=tokenizer,
+        tokenizer_name_or_path=tokenizer_name_or_path,
+    )
+    builder_cls = get_continuous_token_builder_class(resolved_family)
+    logger.info("Creating Continuous Token builder: family=%s class=%s", resolved_family, builder_cls)
+    return builder_cls(tokenizer, chat_template_kwargs=chat_template_kwargs, **builder_kwargs)
+
+
+def _normalize_model_family(model_family: str) -> str:
+    if not isinstance(model_family, str) or not model_family:
+        raise ValueError("Continuous Token model_family must be a non-empty string")
+    return model_family.lower()
+
+
+def _tokenizer_name_or_path(tokenizer: Any | None) -> str | None:
+    if tokenizer is None:
+        return None
+    name = getattr(tokenizer, "name_or_path", None)
+    if name:
+        return str(name)
+    init_kwargs = getattr(tokenizer, "init_kwargs", None)
+    if isinstance(init_kwargs, dict) and init_kwargs.get("name_or_path"):
+        return str(init_kwargs["name_or_path"])
+    return None

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,12 +18,19 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
+from verl.utils.continuous_token_wiring import (
+    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
+    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
+)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
+    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
+    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
+    "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
     "AgentLoopConfig",
@@ -45,6 +52,17 @@ class SamplingConfig(BaseConfig):
 
 
 @dataclass
+class ContinuousTokenConfig(BaseConfig):
+    enable: bool = False
+    model_family: str = "auto"
+    custom_builder_module: Optional[str] = None
+
+    def __post_init__(self):
+        if not isinstance(self.model_family, str) or not self.model_family:
+            raise ValueError("continuous_token.model_family must be a non-empty string")
+
+
+@dataclass
 class MultiTurnConfig(BaseConfig):
     _mutable_fields = {"max_assistant_turns", "max_user_turns"}
 
@@ -58,6 +76,7 @@ class MultiTurnConfig(BaseConfig):
     tool_response_truncate_side: str = "middle"
     use_inference_chat_template: bool = False
     tokenization_sanity_check_mode: str = "strict"
+    continuous_token: ContinuousTokenConfig = field(default_factory=ContinuousTokenConfig)
     format: str = "hermes"
     num_repeat_rollouts: Optional[int] = None
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -18,18 +18,12 @@ from typing import Optional
 from omegaconf import MISSING
 
 from verl.base_config import BaseConfig
-from verl.utils.continuous_token_wiring import (
-    CONTINUOUS_TOKEN_BUILDER_FAMILIES,
-    CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS,
-)
 from verl.utils.profiler import ProfilerConfig
 from verl.workers.config.disaggregation import DisaggregationConfig
 from verl.workers.config.model import MtpConfig
 
 __all__ = [
     "SamplingConfig",
-    "CONTINUOUS_TOKEN_BUILDER_FAMILIES",
-    "CONTINUOUS_TOKEN_MODEL_FAMILY_OPTIONS",
     "ContinuousTokenConfig",
     "MultiTurnConfig",
     "CustomAsyncServerConfig",
@@ -55,7 +49,6 @@ class SamplingConfig(BaseConfig):
 class ContinuousTokenConfig(BaseConfig):
     enable: bool = False
     model_family: str = "auto"
-    custom_builder_module: Optional[str] = None
 
     def __post_init__(self):
         if not isinstance(self.model_family, str) or not self.model_family:


### PR DESCRIPTION
### What does this PR do?

This PR adds an end-to-end comparison harness for Continuous Token vs legacy AgentLoop tokenization. It runs real `SingleTurnAgentLoop` and `ToolAgentLoop` code with deterministic model outputs/tools, then compares CT and legacy `prompt_ids`, `response_ids`, `response_mask`, and logprobs.


[WIP] It also check continuous token output with conanical apply_chat_template to full historical messages.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes
#### Overview of test result
```text
Family        Models  Runs  Pass  Mismatch  Error  Notes
Qwen          9       27    9     18        0      Single-turn passes; tool cases mismatch because legacy misses the newline after assistant EOS.
GLM           4       12    4     8         0      Single-turn CT-vs-legacy passes; tool cases mismatch on the observation boundary. GLM-5.1 matches full template; GLM-4.7/5 have acceptable think-boundary CT-vs-full raw mismatches.
Kimi          3       9     9     0         0      All default trajectories pass with tool_parser=kimi. CT-vs-full-template is WIP.
Seed-OSS      1       3     3     0         0      All default trajectories pass with tool_parser=seed. CT-vs-full-template is WIP.
MiniMax       3       9     3     0         6      Single-turn passes; tool cases are legacy-only TemplateError. CT-vs-full-template is WIP.
MiMo          2       6     6     0         0      All default trajectories pass with Hermes parser. CT-vs-full-template is WIP.
Nemotron      3       9     3     6         0      Single-turn passes; tool cases mismatch because legacy misses the tool-response user header. CT-vs-full-template is WIP.
```
#### Main Changes

- Adds structured mock trajectories for single-turn and multi-turn tool rollouts.
- Adds deterministic tools and deterministic server output generation based on each tokenizer's own chat template.
- Runs both paths:
  - Legacy AgentLoop with CT disabled.
  - Continuous Token AgentLoop with CT enabled.
- Compares token outputs, masks, logprobs, generation prompts, and full decoded CT text.
- Separately compares CT output against a full post-hoc `apply_chat_template` render and classifies acceptable raw text differences.
- Adds CLI options for selecting models, trajectories, parser format, cached/downloaded tokenizers, JSON ledger output, artifact dumps, and mismatch failures.
- Adds a README with the current default-model results.

#### Changed Files

- `tests/experimental/agent_loop/continuous_token/README.md`
  - Documents the test setup, pass criteria, default trajectories, default model list, and family-level results.
  - Records current results across Qwen, GLM, Kimi, Seed, MiniMax, MiMo, and Nemotron.
  - Explains expected CT-vs-legacy mismatches where CT matches the canonical full-template boundary and legacy misses boundary tokens.
  - Notes DeepSeek as WIP because the checked DeepSeek tokenizer family does not expose a compatible Jinja `chat_template`.

- `tests/experimental/agent_loop/continuous_token/mock_trajectories.py`
  - Adds trajectory dataclasses: `TrajectoryStep`, `SingleTurnTrajectory`, and `ToolAgentTrajectory`.
  - Adds deterministic function tools: `get_weather`, `estimate_travel`, `reserve_room`, and `lookup_incident`.
  - Adds mock trajectories:
    - `singleturnchat`
    - `multiturnsingletool`
    - `multiturnmultitool`
    - `multiturnretryuser`
    - `multiturnretrysystem`
  - Adds helpers to select trajectories and tool-agent trajectories by name.

- `tests/experimental/agent_loop/continuous_token/compare_agentloop_ct_vs_legacy.py`
  - Adds the comparison CLI.
  - Loads tokenizers, infers tool parser format, prepares assistant output suffixes from chat templates, and runs deterministic AgentLoop rollouts.
  - Compares CT and legacy outputs at token and metadata level.
  - Compares decoded CT text with full-template rendering and classifies acceptable differences such as final trailing newline, empty Qwen think block, and GLM think-boundary formatting.
  - Can write a structured ledger and sequence artifacts for debugging mismatches.


#### Notes

The harness is intentionally tokenizer/template driven. It avoids hard-coding Hermes-style tool-call strings, so each model family is tested against its own chat-template rendering behavior.

This PR also contains the diff from PR02. After PR02 is merged, this branch will be rebased and will only show the diff brought about by this PR.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
