### PR TITLE
[BREAKING][ckpt] refactor: rename misleading `trainer` arg to `actor_wg`

### DIFF
--- a/tests/checkpoint_engine/test_correctness_on_gpu.py
+++ b/tests/checkpoint_engine/test_correctness_on_gpu.py
@@ -68,12 +68,12 @@ async def test_nccl_checkpoint_engine(
     # create trainer and rollout worker group
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()
@@ -127,12 +127,12 @@ async def test_nixl_checkpoint_engine(
     # create trainer and rollout worker group
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()
@@ -175,12 +175,12 @@ async def test_kimi_checkpoint_engine(
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     resource_pool.get_placement_groups(device_name=get_device_name())
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()

--- a/tests/checkpoint_engine/test_correctness_on_npu.py
+++ b/tests/checkpoint_engine/test_correctness_on_npu.py
@@ -63,12 +63,12 @@ async def test_hccl_checkpoint_engine(
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     resource_pool.get_placement_groups(device_name=get_device_name())
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()
@@ -110,12 +110,12 @@ async def test_kimi_checkpoint_engine(
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     resource_pool.get_placement_groups(device_name=get_device_name())
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()
@@ -158,12 +158,12 @@ async def test_mooncake_checkpoint_engine(
     resource_pool = RayResourcePool(process_on_nodes=[num_gpus_per_node] * num_nodes, max_colocate_count=3)
     resource_pool.get_placement_groups(device_name=get_device_name())
     trainer_pool, rollout_pool = split_resource_pool(resource_pool, [num_trainer, num_rollout])
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
     rollout, replicas = await create_rollout_worker_group(rollout_pool, model_config, rollout_config, check_allclose)
 
     # create checkpoint engine manager
-    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, trainer=trainer, replicas=replicas)
+    checkpoint_manager = CheckpointEngineManager(config=checkpoint_engine_config, actor_wg=actor_wg, replicas=replicas)
     for _ in range(3):
         await checkpoint_manager.update_weights()
         rollout.check_weights()

--- a/tests/checkpoint_engine/test_special_server_adapter.py
+++ b/tests/checkpoint_engine/test_special_server_adapter.py
@@ -195,15 +195,15 @@ async def test_server_adapter(init_config):
         init_config.actor_rollout_ref.rollout.checkpoint_engine
     )
     trainer_pool = RayResourcePool(process_on_nodes=[init_config.trainer.n_gpus_per_node], max_colocate_count=3)
-    trainer = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
-    trainer.reset()
+    actor_wg = create_trainer_worker_group(trainer_pool, model_config, checkpoint_engine_config)
+    actor_wg.reset()
 
     # 2. create standalone rollout with AgentLoopManager
     llm_server_manager = await LLMServerManager.create(config=init_config)
 
     # 3. create checkpoint engine manager
     checkpoint_manager = CheckpointEngineManager(
-        config=checkpoint_engine_config, trainer=trainer, replicas=llm_server_manager.get_replicas()
+        config=checkpoint_engine_config, actor_wg=actor_wg, replicas=llm_server_manager.get_replicas()
     )
 
     n = 4

--- a/tests/experimental/agent_loop/agent_utils.py
+++ b/tests/experimental/agent_loop/agent_utils.py
@@ -93,7 +93,7 @@ def init_agent_loop_manager(config: DictConfig) -> AgentLoopManager | RayWorkerG
     )
     checkpoint_manager = CheckpointEngineManager(
         config=omega_conf_to_dataclass(config.actor_rollout_ref.rollout.checkpoint_engine),
-        trainer=actor_rollout_wg,
+        actor_wg=actor_rollout_wg,
         replicas=llm_server_manager.get_replicas(),
     )
     checkpoint_manager.sleep_replicas()

--- a/tests/experimental/agent_loop/test_standalone_rollout.py
+++ b/tests/experimental/agent_loop/test_standalone_rollout.py
@@ -121,7 +121,7 @@ def test_hybrid_rollout_with_ep(init_config):
     agent_loop_manager = init_agent_loop_manager(init_config)
     checkpoint_manager = CheckpointEngineManager(
         config=omega_conf_to_dataclass(init_config.actor_rollout_ref.rollout.checkpoint_engine),
-        trainer=agent_loop_manager.worker_group,
+        actor_wg=agent_loop_manager.worker_group,
         replicas=agent_loop_manager.rollout_replicas,
     )
     checkpoint_manager.sleep_replicas()

--- a/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
+++ b/tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
@@ -106,7 +106,7 @@ def test_agent_reward_loop_standalone():
     # sleep rollout replicas
     checkpoint_manager = CheckpointEngineManager(
         config=omega_conf_to_dataclass(config.actor_rollout_ref.rollout.checkpoint_engine),
-        trainer=actor_rollout_wg,
+        actor_wg=actor_rollout_wg,
         replicas=llm_server_manager.get_replicas(),
     )
     checkpoint_manager.sleep_replicas()

--- a/verl/checkpoint_engine/README.md
+++ b/verl/checkpoint_engine/README.md
@@ -14,16 +14,16 @@ Checkpoint Engine is an unified abstract layer to synchronize weights between va
 
 ||Comm Library|Topology|Hardware|Performance|Elastic|Use case|
 |----|----|----|----|----|----|----|
-|naive|torch.distributed|all_gather|NVIDIA/AMD/Ascend|Very High|NA|On-policy training<br>- Trainer/rollout colocated
-|nccl|NCCL|all_gather+broadcast|NVIDIA GPU & NCCL|Very High|Low: rebuild nccl group|Off-policy training<br>- Trainer/rollout disaggregated<br>- Fixed clusters
-|hccl|HCCL|all_gather+broadcast|Ascend NPU & HCCL| High|Low: rebuild hccl group|Off-policy training<br>- Trainer/rollout disaggregated<br>- Fixed clusters
-|nixl|NIXL|all_gather+ring p2p|Various transport backends (D2D, H2H, H2D, etc)<br>- UCX<br>- UCCL<br>- Mooncacke|Medium/High|High: dynamic adjust ring topology|Off-policy training<br>- Trainer/rollout disaggregated<br>- Elastic rollout<br>- Rollout fault tolerance<br>- Heterogeneous hardware rollout
-|kimi_ckpt_engine|MOONCAKE+NCCL/HCCL|p2p+broadcast|NVIDIA/Ascend|High|Low: rebuild communication group|Off-policy training<br>- Trainer/rollout disaggregated<br>- Save checkpoint each time
-|mooncake|Mooncake Transfer Engine|all_gather+ring p2p|NVIDIA/Ascend|High|High: dynamic adjust ring topology|Off-policy training<br>- Trainer/rollout disaggregated<br>- Fixed clusters
+|naive|torch.distributed|all_gather|NVIDIA/AMD/Ascend|Very High|NA|On-policy training<br>- Actor/rollout colocated
+|nccl|NCCL|all_gather+broadcast|NVIDIA GPU & NCCL|Very High|Low: rebuild nccl group|Off-policy training<br>- Actor/rollout disaggregated<br>- Fixed clusters
+|hccl|HCCL|all_gather+broadcast|Ascend NPU & HCCL| High|Low: rebuild hccl group|Off-policy training<br>- Actor/rollout disaggregated<br>- Fixed clusters
+|nixl|NIXL|all_gather+ring p2p|Various transport backends (D2D, H2H, H2D, etc)<br>- UCX<br>- UCCL<br>- Mooncacke|Medium/High|High: dynamic adjust ring topology|Off-policy training<br>- Actor/rollout disaggregated<br>- Elastic rollout<br>- Rollout fault tolerance<br>- Heterogeneous hardware rollout
+|kimi_ckpt_engine|MOONCAKE+NCCL/HCCL|p2p+broadcast|NVIDIA/Ascend|High|Low: rebuild communication group|Off-policy training<br>- Actor/rollout disaggregated<br>- Save checkpoint each time
+|mooncake|Mooncake Transfer Engine|all_gather+ring p2p|NVIDIA/Ascend|High|High: dynamic adjust ring topology|Off-policy training<br>- Actor/rollout disaggregated<br>- Fixed clusters
 
 ##### kimi_ckpt_engine detail:
 
-In the kimi_ckpt_engine workflow, the trainer first offloads the weights to the CPU, and the rollout creates a sub communication group that includes all the cards for the rollout. Then, using Mooncake transfer engine, these weights are transmitted via P2P to a specific worker in the rollout, followed by a broadcast to all other rollout workers.
+In the kimi_ckpt_engine workflow, the actor first offloads the weights to the CPU, and the rollout creates a sub communication group that includes all the cards for the rollout. Then, using Mooncake transfer engine, these weights are transmitted via P2P to a specific worker in the rollout, followed by a broadcast to all other rollout workers.
 
 <img src="https://github.com/kip-cxj/verl/blob/cxj/doc_imgs/docs/_static/kimi_ckpt_engine.png?raw=true" alt="kimi-ckpt-engine" width="50%">
 
@@ -41,7 +41,7 @@ export HCCL_INTRA_ROCE_ENABLE=1
 ### Benchmark
 1. benchmark setup
 - model: Qwen/Qwen3-30B-A3B-Base
-- trainer: fsdp world_size=2 (since Ascend 910C has 64GB of HBM, we set world_size=4)
+- actor: fsdp world_size=2 (since Ascend 910C has 64GB of HBM, we set world_size=4)
 - rollout: num_rollout=30 (only receive weight without cuda ipc to vllm/sglang)
 ```bash
 pytest tests/checkpoint_engine/test_correctness_on_gpu.py

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -94,12 +94,12 @@ class CheckpointEngineRegistry:
 
 
 class CheckpointEngine(ABC):
-    """CheckpointEngine is an abstraction to transfer weights from trainer to rollout.
+    """CheckpointEngine is an abstraction to transfer weights from actor to rollout.
 
-    In trainer process:
-    >>> trainer = EngineRegistry.new(...) # FSDP, Megatron, VeOmini, TorchTitan, ...
+    In actor process:
+    >>> actor = EngineRegistry.new(...) # FSDP, Megatron, VeOmini, TorchTitan, ...
     >>> engine = CheckpointEngine.new(...) # NCCLCheckpointEngine, NIXLCheckpointEngine, ...
-    >>> await engine.send_weights(trainer.get_per_tensor_param())
+    >>> await engine.send_weights(actor.get_per_tensor_param())
 
     In rollout process:
     >>> engine = CheckpointEngine.new(...)
@@ -126,22 +126,22 @@ class CheckpointEngine(ABC):
     @classmethod
     @abstractmethod
     def build_topology(
-        cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]
+        cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]
     ) -> tuple[dict[str, list[Any]], dict[str, list[Any]]]:
         """Build communication topology between all workers.
 
         Args:
-            trainer_world_size: The world size of the trainer worker group.
+            actor_wg_world_size: The world size of the actor worker group.
             rollout_world_size: The world size of the rollout replica.
             metadata: A list of metadata `prepare` from all workers.
 
         Returns:
-            A tuple of two dictionaries that contains the communication topology for trainer and rollout worker group.
+            A tuple of two dictionaries that contains the communication topology for actor and rollout worker group.
             Each dict value should be a list argument equal to the world size of the worker group to dispatch to
             `init_process_group`.
 
             ```
-            world_size = rollout.world_size + trainer.world_size
+            world_size = rollout.world_size + actor_wg.world_size
             kwargs = {
                 "rank": list(range(world_size)),
                 "world_size": [world_size] * world_size,
@@ -219,13 +219,13 @@ class CheckpointEngineWithCache(CheckpointEngine):
 
 @CheckpointEngineRegistry.register("naive")
 class ColocatedCheckpointEngine(CheckpointEngine):
-    """Checkpoint engine for trainer and rollout colocated on same GPU.
+    """Checkpoint engine for actor and rollout colocated on same GPU.
 
-    In trainer process:
+    In actor process:
     >>> engine = ColocatedCheckpointEngine()
-    >>> trainer = Trainer()
+    >>> actor = Actor()
     >>> server_adapter = ServerAdapter()
-    >>> engine.send_weights(trainer.get_per_tensor_param())
+    >>> engine.send_weights(actor.get_per_tensor_param())
     >>> server_adapter.update_weights(engine.receive_weights())
     """
 
@@ -343,12 +343,12 @@ _worker_cls = ray.remote(CheckpointEngineWorker)
 
 
 class CheckpointEngineManager:
-    """Checkpoint engine manager to coordinate weight synchronization between trainer and rollout replicas.
+    """Checkpoint engine manager to coordinate weight synchronization between actor and rollout replicas.
 
     - ME: model engine, FSDP, MCore, VeOmni, export full tensor generator `get_per_tensor_param`
     - CE: checkpoint engine, NCCL, NIXL, etc
 
-    In trainer, model engine and checkpoint engine are in same process.
+    In actor, model engine and checkpoint engine are in same process.
     In rollout, checkpoint engine and rollout worker are in separate process, update weights via cuda ipc.
 
     ```
@@ -367,48 +367,48 @@ class CheckpointEngineManager:
 
     Args:
         config: The checkpoint engine config.
-        trainer: The trainer worker group.
+        actor_wg: The actor worker group (the training side that produces weights).
         replicas: The list of rollout replicas.
     """
 
     def __init__(
         self,
         config: CheckpointEngineConfig,
-        trainer: RayWorkerGroup,
+        actor_wg: RayWorkerGroup,
         replicas: list[RolloutReplica],
     ) -> None:
         self.config = config
         self.backend = config.backend
         import_external_libs(self.config.custom_backend_module or None)
         self.backend_cls = CheckpointEngineRegistry.get(config.backend)
-        self.trainer = trainer
+        self.actor_wg = actor_wg
         self.replicas = replicas
 
     def build_process_group(self, rollout: RayWorkerGroup):
-        """Build process group for trainer and rollout replicas."""
-        trainer = self.trainer
+        """Build process group for actor worker group and rollout replicas."""
+        actor_wg = self.actor_wg
 
         # 1. prepare all workers
         metadata = ray.get(
-            trainer.execute_checkpoint_engine(["prepare"] * trainer.world_size)
+            actor_wg.execute_checkpoint_engine(["prepare"] * actor_wg.world_size)
             + rollout.execute_checkpoint_engine(["prepare"] * rollout.world_size)
         )
 
         # 2. build communication topology between all workers
-        trainer_kwargs, rollout_kwargs = self.backend_cls.build_topology(
-            trainer.world_size, rollout.world_size, metadata
+        actor_wg_kwargs, rollout_kwargs = self.backend_cls.build_topology(
+            actor_wg.world_size, rollout.world_size, metadata
         )
-        for k, v in trainer_kwargs.items():
-            assert len(v) == trainer.world_size, f"trainer_kwargs[{k}] must have length of {trainer.world_size}"
+        for k, v in actor_wg_kwargs.items():
+            assert len(v) == actor_wg.world_size, f"actor_wg_kwargs[{k}] must have length of {actor_wg.world_size}"
         for k, v in rollout_kwargs.items():
             assert len(v) == rollout.world_size, f"rollout_kwargs[{k}] must have length of {rollout.world_size}"
 
-        trainer_kwargs["method"] = ["init_process_group"] * trainer.world_size
+        actor_wg_kwargs["method"] = ["init_process_group"] * actor_wg.world_size
         rollout_kwargs["method"] = ["init_process_group"] * rollout.world_size
 
         # 3. init process group between all workers
         ray.get(
-            trainer.execute_checkpoint_engine(**trainer_kwargs) + rollout.execute_checkpoint_engine(**rollout_kwargs)
+            actor_wg.execute_checkpoint_engine(**actor_wg_kwargs) + rollout.execute_checkpoint_engine(**rollout_kwargs)
         )
 
     def add_replicas(self, replicas: list[RolloutReplica]):
@@ -468,15 +468,15 @@ class CheckpointEngineManager:
 
     @auto_await
     async def update_weights(self, global_steps: int = None):
-        """Update weights from trainer to rollout replicas.
+        """Update weights from actor worker group to rollout replicas.
 
         Args:
-            global_steps: The global steps of the trainer.
+            global_steps: The global steps of the actor worker group.
         """
 
-        # 0. update weights for sync training with colocated trainer and rollout
+        # 0. update weights for sync training with colocated actor and rollout
         if self.backend == "naive":
-            ray.get(self.trainer.update_weights(global_steps=global_steps, mode=self.backend))
+            ray.get(self.actor_wg.update_weights(global_steps=global_steps, mode=self.backend))
             return
 
         # 1. abort and save all unfinished requests for partial rollout
@@ -487,7 +487,7 @@ class CheckpointEngineManager:
         for replica in self.replicas:
             workers.extend(replica.workers)
         rollout = RayWorkerGroup(worker_handles=workers, ray_cls_with_init=RayClassWithInitArgs(cls=_worker_cls))
-        trainer = self.trainer
+        actor_wg = self.actor_wg
 
         # 3. release kv_cache before weight sync (weights stay in place)
         await self.release_kv_cache_replicas()
@@ -497,13 +497,13 @@ class CheckpointEngineManager:
 
         # 5. update weights of all workers
         ray.get(
-            trainer.update_weights(global_steps=global_steps, mode=self.backend)
+            actor_wg.update_weights(global_steps=global_steps, mode=self.backend)
             + rollout.update_weights(global_steps=global_steps)
         )
 
         # 6. finalize all workers
         ray.get(
-            trainer.execute_checkpoint_engine(["finalize"] * trainer.world_size)
+            actor_wg.execute_checkpoint_engine(["finalize"] * actor_wg.world_size)
             + rollout.execute_checkpoint_engine(["finalize"] * rollout.world_size)
         )
 

--- a/verl/checkpoint_engine/hccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/hccl_checkpoint_engine.py
@@ -152,18 +152,18 @@ class HCCLCheckpointEngine(CheckpointEngine):
         torch.npu.empty_cache()
 
     @classmethod
-    def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
-        trainer_kwargs = {
-            "rank": [0] + [-1] * (trainer_world_size - 1),
-            "world_size": [rollout_world_size + 1] * trainer_world_size,
-            "master_metadata": [metadata[0]] * trainer_world_size,
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        actor_wg_kwargs = {
+            "rank": [0] + [-1] * (actor_wg_world_size - 1),
+            "world_size": [rollout_world_size + 1] * actor_wg_world_size,
+            "master_metadata": [metadata[0]] * actor_wg_world_size,
         }
         rollout_kwargs = {
             "rank": list(range(1, rollout_world_size + 1)),
             "world_size": [rollout_world_size + 1] * rollout_world_size,
             "master_metadata": [metadata[0]] * rollout_world_size,
         }
-        return trainer_kwargs, rollout_kwargs
+        return actor_wg_kwargs, rollout_kwargs
 
     def _start_zmq_server(self):
         self.ip = ray.util.get_node_ip_address().strip("[]")
@@ -199,7 +199,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
             rank (int): The rank of the current process.
             world_size (int): The total number of processes.
         """
-        # For trainer workers other than rank 0, their rank should be -1.
+        # For actor workers other than rank 0, their rank should be -1.
         if rank < 0:
             self.rank = rank
             self.world_size = world_size
@@ -239,7 +239,7 @@ class HCCLCheckpointEngine(CheckpointEngine):
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
-        # For trainer rank other than 0, consume weights without sending.
+        # For actor rank other than 0, consume weights without sending.
         if self.rank < 0:
             for name, weight in weights:
                 pass

--- a/verl/checkpoint_engine/kimi_checkpoint_engine.py
+++ b/verl/checkpoint_engine/kimi_checkpoint_engine.py
@@ -265,27 +265,27 @@ class KIMICheckpointEngine(CheckpointEngine):
             self.initialized = False
 
     @classmethod
-    def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
-        trainer_kwargs = {
-            "method": ["init_process_group"] * trainer_world_size,
-            "rank": list(range(0, trainer_world_size)),
-            "trainer_world_size": [trainer_world_size] * trainer_world_size,
-            "rollout_world_size": [rollout_world_size] * trainer_world_size,
-            "master_metadata": [metadata[0]] * trainer_world_size,
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        actor_wg_kwargs = {
+            "method": ["init_process_group"] * actor_wg_world_size,
+            "rank": list(range(0, actor_wg_world_size)),
+            "actor_wg_world_size": [actor_wg_world_size] * actor_wg_world_size,
+            "rollout_world_size": [rollout_world_size] * actor_wg_world_size,
+            "master_metadata": [metadata[0]] * actor_wg_world_size,
         }
         rollout_kwargs = {
             "method": ["init_process_group"] * rollout_world_size,
-            "rank": list(range(trainer_world_size, trainer_world_size + rollout_world_size)),
-            "trainer_world_size": [trainer_world_size] * rollout_world_size,
+            "rank": list(range(actor_wg_world_size, actor_wg_world_size + rollout_world_size)),
+            "actor_wg_world_size": [actor_wg_world_size] * rollout_world_size,
             "rollout_world_size": [rollout_world_size] * rollout_world_size,
             "master_metadata": [metadata[0]] * rollout_world_size,
         }
-        return trainer_kwargs, rollout_kwargs
+        return actor_wg_kwargs, rollout_kwargs
 
     def init_process_group(
         self,
         rank: int,
-        trainer_world_size: int,
+        actor_wg_world_size: int,
         rollout_world_size: int,
         master_metadata: MasterMetadata,
     ):
@@ -296,9 +296,9 @@ class KIMICheckpointEngine(CheckpointEngine):
             world_size (int): The total number of processes.
         """
         self.rank = rank
-        self.trainer_world_size = trainer_world_size
+        self.actor_wg_world_size = actor_wg_world_size
         self.rollout_world_size = rollout_world_size
-        self.world_size = trainer_world_size + rollout_world_size
+        self.world_size = actor_wg_world_size + rollout_world_size
 
         if not self.initialized:
             self.parameter_server = ParameterServer(
@@ -313,7 +313,7 @@ class KIMICheckpointEngine(CheckpointEngine):
             dist.use_backend(f"vllm_{get_nccl_backend()}")
             self.parameter_server.init_process_group()
 
-            self.rollout_ranks = list(range(self.trainer_world_size, self.world_size))
+            self.rollout_ranks = list(range(self.actor_wg_world_size, self.world_size))
             self.rollout_group = dist.new_group(self.rollout_ranks)
             self.initialized = True
 
@@ -335,7 +335,7 @@ class KIMICheckpointEngine(CheckpointEngine):
         start_time = time.time()
         named_tensors = {}
         for named_tensors_gpu in ckpt_get_named_tensor_buckets(
-            weights, self.bucket_size, self.trainer_world_size, self.rank, self.rollout_dtype
+            weights, self.bucket_size, self.actor_wg_world_size, self.rank, self.rollout_dtype
         ):
             with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
                 futures = [

--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -95,18 +95,18 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         return {"addr": self.hostname, "port": port}
 
     @classmethod
-    def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadatas: list[dict]):
-        trainer_kwargs = {
-            "rank": [0] + [-1] * (trainer_world_size - 1),
-            "world_size": [rollout_world_size + 1] * trainer_world_size,
-            "metadata": [metadatas[0]] * trainer_world_size,
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadatas: list[dict]):
+        actor_wg_kwargs = {
+            "rank": [0] + [-1] * (actor_wg_world_size - 1),
+            "world_size": [rollout_world_size + 1] * actor_wg_world_size,
+            "metadata": [metadatas[0]] * actor_wg_world_size,
         }
         rollout_kwargs = {
             "rank": list(range(1, rollout_world_size + 1)),
             "world_size": [rollout_world_size + 1] * rollout_world_size,
             "metadata": [metadatas[0]] * rollout_world_size,
         }
-        return trainer_kwargs, rollout_kwargs
+        return actor_wg_kwargs, rollout_kwargs
 
     def init_process_group(self, rank: int, world_size: int, metadata: dict[str, Any]):
         self.rank = rank

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -157,18 +157,18 @@ class NCCLCheckpointEngine(CheckpointEngine):
         torch.cuda.empty_cache()
 
     @classmethod
-    def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
-        trainer_kwargs = {
-            "rank": [0] + [-1] * (trainer_world_size - 1),
-            "world_size": [rollout_world_size + 1] * trainer_world_size,
-            "master_metadata": [metadata[0]] * trainer_world_size,
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        actor_wg_kwargs = {
+            "rank": [0] + [-1] * (actor_wg_world_size - 1),
+            "world_size": [rollout_world_size + 1] * actor_wg_world_size,
+            "master_metadata": [metadata[0]] * actor_wg_world_size,
         }
         rollout_kwargs = {
             "rank": list(range(1, rollout_world_size + 1)),
             "world_size": [rollout_world_size + 1] * rollout_world_size,
             "master_metadata": [metadata[0]] * rollout_world_size,
         }
-        return trainer_kwargs, rollout_kwargs
+        return actor_wg_kwargs, rollout_kwargs
 
     def _start_zmq_server(self):
         self.ip = ray.util.get_node_ip_address().strip("[]")
@@ -204,7 +204,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
             rank (int): The rank of the current process.
             world_size (int): The total number of processes.
         """
-        # For trainer workers other than rank 0, their rank should be -1.
+        # For actor workers other than rank 0, their rank should be -1.
         if rank < 0:
             self.rank = rank
             self.world_size = world_size
@@ -239,7 +239,7 @@ class NCCLCheckpointEngine(CheckpointEngine):
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
-        # For trainer rank other than 0, consume weights without sending.
+        # For actor rank other than 0, consume weights without sending.
         if self.rank < 0:
             for name, weight in weights:
                 pass

--- a/verl/checkpoint_engine/nixl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nixl_checkpoint_engine.py
@@ -286,13 +286,13 @@ class NIXLCheckpointEngine(CheckpointEngine):
         return self.agent.get_agent_metadata()
 
     @classmethod
-    def build_topology(cls, trainer_world_size: int, rollout_world_size: int, metadata: list[dict]):
-        trainer_kwargs = {
-            "method": ["init_process_group"] * trainer_world_size,
-            "rank": [0] + [-1] * (trainer_world_size - 1),
-            "world_size": [rollout_world_size + 1] * trainer_world_size,
-            "prev_agent_metadata": [None] * trainer_world_size,
-            "next_agent_metadata": [metadata[-rollout_world_size]] + [None] * (trainer_world_size - 1),
+    def build_topology(cls, actor_wg_world_size: int, rollout_world_size: int, metadata: list[dict]):
+        actor_wg_kwargs = {
+            "method": ["init_process_group"] * actor_wg_world_size,
+            "rank": [0] + [-1] * (actor_wg_world_size - 1),
+            "world_size": [rollout_world_size + 1] * actor_wg_world_size,
+            "prev_agent_metadata": [None] * actor_wg_world_size,
+            "next_agent_metadata": [metadata[-rollout_world_size]] + [None] * (actor_wg_world_size - 1),
         }
 
         rollout_kwargs = {
@@ -302,7 +302,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
             "prev_agent_metadata": [metadata[0]] + metadata[-rollout_world_size:-1],
             "next_agent_metadata": metadata[-rollout_world_size + 1 :] + [None],
         }
-        return trainer_kwargs, rollout_kwargs
+        return actor_wg_kwargs, rollout_kwargs
 
     def init_process_group(
         self, rank: int, world_size: int, prev_agent_metadata: NixlAgentMetadata, next_agent_metadata: NixlAgentMetadata
@@ -380,7 +380,7 @@ class NIXLCheckpointEngine(CheckpointEngine):
         """
         assert self.rank <= 0, "Trainer workers other than rank 0 should not send weights."
 
-        # For trainer workers other than rank 0, just consume weights and do nothing.
+        # For actor workers other than rank 0, just consume weights and do nothing.
         if self.rank < 0:
             for name, weight in weights:
                 pass

--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -169,7 +169,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         replicas = await self.rollouter.get_replicas.remote()
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
         self.checkpoint_manager = CheckpointEngineManager(
-            config=checkpoint_engine_config, trainer=self.actor_wg, replicas=replicas
+            config=checkpoint_engine_config, actor_wg=self.actor_wg, replicas=replicas
         )
         print("[FullyAsyncTrainer] Checkpoint manager initialized")
 
@@ -204,7 +204,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
 
         self.hybrid_checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
-            trainer=self.actor_rollout_wg,
+            actor_wg=self.actor_rollout_wg,
             replicas=[],  # Start empty; will be populated below
         )
 

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -125,7 +125,7 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
 
         self.checkpoint_manager = CheckpointEngineManager(
             config=omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine),
-            trainer=self.actor_rollout_wg,
+            actor_wg=self.actor_rollout_wg,
             replicas=self.llm_server_manager.get_replicas(),
         )
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -961,7 +961,7 @@ class RayPPOTrainer:
             from verl.checkpoint_engine import CheckpointEngineManager
         self.checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
-            trainer=self.actor_rollout_wg,
+            actor_wg=self.actor_rollout_wg,
             replicas=self.llm_server_manager.get_replicas(),
         )
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -246,7 +246,7 @@ class PPOTrainer(ABC):
         checkpoint_engine_config.backend = "naive"
         self.checkpoint_manager: CheckpointEngineManager = CheckpointEngineManager(
             config=checkpoint_engine_config,
-            trainer=self.actor_rollout_wg,
+            actor_wg=self.actor_rollout_wg,
             replicas=self.llm_server_manager.get_replicas(),
         )
         logger.info("checkpoint engine manager initialized")

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -73,7 +73,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
         self.standalone_checkpoint_manager = CheckpointEngineManager(
             config=checkpoint_engine_config,
-            trainer=self.actor_rollout_wg,
+            actor_wg=self.actor_rollout_wg,
             replicas=self.standalone_server_manager.get_replicas(),
         )
 


### PR DESCRIPTION
## What does this PR do?

Renames the misleadingly-named `trainer` parameter to `actor_wg` throughout the checkpoint engine.

In `CheckpointEngineManager` and the `build_topology` API, the argument named `trainer` is actually the **actor worker group** (the training-side worker group that produces and sends weights), not the PPO trainer/controller. Since the framework already uses `trainer` to refer to the top-level RL trainer elsewhere, this overloaded name is a frequent source of confusion when reading or extending the weight-synchronization path. This PR makes the name say what the object actually is.

This is a pure rename — no behavioral change.

## Changes

- `CheckpointEngineManager.__init__`: parameter `trainer` → `actor_wg`, attribute `self.trainer` → `self.actor_wg`.
- `build_process_group` / `update_weights`: local `trainer` → `actor_wg`.
- `CheckpointEngine.build_topology` (abstract + all concrete backends: nccl, nixl, mooncake, kimi, hccl): `trainer_world_size` → `actor_wg_world_size`, `trainer_kwargs` → `actor_wg_kwargs`.
- Updated all call sites that construct `CheckpointEngineManager(...)` to pass the `actor_wg=` keyword:
  - `verl/trainer/ppo/ray_trainer.py`
  - `verl/trainer/main_ppo_sync.py`
  - `verl/experimental/fully_async_policy/fully_async_trainer.py`
  - `verl/experimental/separation/ray_trainer.py`
- Updated docstrings, the checkpoint_engine `README.md`, and the affected tests under `tests/checkpoint_engine/` and `tests/experimental/`.

### Intentionally left unchanged

- The top-level `config.trainer` / `cfg.trainer` config namespace (it genuinely refers to the trainer).
- Test resource-allocation helpers such as `num_trainer`, `trainer_pool`, and `create_trainer_worker_group`, which describe the training-side resource split rather than the manager argument.
- `global_steps` docstrings that mention "trainer step/version" (that refers to the training step counter, not the worker group).

## Test

- `ruff check` and `python -m compileall` pass on all changed files.
- No logic changed; behavior is identical. Existing checkpoint engine tests cover the affected construction/usage paths.

## Checklist

- [x] Pure rename, no behavioral change
- [x] All `CheckpointEngineManager` call sites updated to the new keyword
- [x] Docstrings, README, and tests updated
- [x] Lint and compile checks pass