### PR TITLE
[rollout] fix: Adjust cuda graph capture sizes config logic for vLLM >= 0.11.1 compatibility

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -219,7 +219,7 @@ class vLLMHttpServer:
         engine_kwargs = {key: val for key, val in engine_kwargs.items() if val is not None}
         if self.config.get("limit_images", None):  # support for multi-image data
             engine_kwargs["limit_mm_per_prompt"] = {"image": self.config.get("limit_images")}
-        if self.config.cudagraph_capture_sizes:
+        if self.config.cudagraph_capture_sizes and _VLLM_VERSION <= version.parse("0.11.0"):
             engine_kwargs["cuda_graph_sizes"] = self.config.cudagraph_capture_sizes
 
         self._preprocess_engine_kwargs(engine_kwargs)
@@ -251,6 +251,8 @@ class vLLMHttpServer:
                 dcp_size,
             )
             compilation_config["cudagraph_mode"] = "PIECEWISE"
+        if self.config.cudagraph_capture_sizes and _VLLM_VERSION > version.parse("0.11.0"):
+            compilation_config["cudagraph_capture_sizes"] = self.config.cudagraph_capture_sizes
 
         compilation_config = json.dumps(compilation_config)
         args = {


### PR DESCRIPTION
Update the judgment condition of `cuda_graph_capture_sizes` in vLLMHttpServer to adapt to breaking config changes introduced in vLLM 0.11.1+. Starting from vLLM 0.11.1, the `cuda_graph_sizes` argument can no longer be passed directly via server startup commands; instead, `cudagraph_capture_sizes` must be configured inside `compilation_config`. This modification avoids runtime errors on new vLLM releases while keeping backward compatibility with older version deployments.

### What does this PR do?

vLLM versions >= 0.11.1 have changed the configuration method for CUDA graph capture sizes:
1. Legacy approach (<=0.11.0): Pass `cuda_graph_sizes` directly as a startup argument to vLLM server commands
2. New approach (>=0.11.1): Configure `cudagraph_capture_sizes` within the compilation_config structure instead of top-level CLI args


This commit adjusts the version judgment branch for setting CUDA graph capture sizes in vLLMHttpServer.
It switches to the new compilation_config internal parameter for vLLM >= 0.11.1, eliminating parameter unrecognized errors on newer vLLM releases, and retains the original top-level argument logic to maintain compatibility with existing low-version runtime configurations.


Here is the link of [vllm0.11.1](https://docs.vllm.ai/en/v0.11.1/cli/serve/) and there is no args named `cuda_graph_sizes`.