### PR TITLE
[algo] feat: add CPPO (position-weighted cumulative-prefix-divergence token mask)

### DIFF
--- a/examples/cppo_trainer/README.md
+++ b/examples/cppo_trainer/README.md
@@ -132,7 +132,7 @@ CPPO adds two hyperparameters on top of the shared DPPO token-level threshold sc
 
 The prefix-average budget is calibrated per sequence from its own divergence statistics
 (Base-model warm-up):
-`delta_b^seq = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 2 * delta_b_min)`.
+`delta_b^seq = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 5 * delta_b_min)`.
 The defaults `(q, k) = (0.9, 1.0)` reproduce the paper's P90 calibration; for example
 `cppo.cppo_delta_b_q=0.95 cppo.cppo_delta_b_k=0.5` calibrates from half the 95th percentile.
 

--- a/examples/cppo_trainer/README.md
+++ b/examples/cppo_trainer/README.md
@@ -1,0 +1,177 @@
+# Cumulative Prefix-divergence Policy Optimization (CPPO)
+
+
+<div align="center">
+
+## Beyond Uniform Token-Level Trust Region in LLM Reinforcement Learning
+
+[![Paper](https://img.shields.io/badge/paper-A42C25?style=for-the-badge&logo=arxiv&logoColor=white )](https://arxiv.org/pdf/2606.10968)
+[![Project Page](https://img.shields.io/badge/Project_Page-000000?style=for-the-badge&logo=githubpages&logoColor=white)](https://hunyuan-cppo.github.io)
+[![Twitter](https://img.shields.io/badge/Twitter-%23000000.svg?style=for-the-badge&logo=twitter&logoColor=white)](https://x.com/NickZhou523786/status/2066106644736667838)
+
+</div>
+
+
+## ✨ Getting started
+
+1. Prepare the datasets by running [prepare_dapo_data.sh](https://github.com/verl-project/verl-recipe/blob/3490a22a0a3adeb7e4787fe70b1060b642efbae4/dapo/prepare_dapo_data.sh):
+
+```bash
+bash prepare_dapo_data.sh # This downloads the datasets to ${HOME}/verl/data by default
+```
+
+2. Prepare the model:
+
+```bash
+hf download Qwen/Qwen3-30B-A3B-Base --local-dir ${HOME}/verl/models/Qwen3-30B-A3B-Base
+```
+
+3. Run the script (Qwen3-30B-A3B-Base, Binary-TV):
+
+```bash
+bash examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
+```
+
+The script mirrors the DPPO example layout. Parallelism / batch follow the paper's
+Qwen3-30B-A3B-Base run: actor TP=4 / EP=8 / PP=1 / ETP=1, rollout TP=2, 8 GPUs/node,
+`train_batch_size=256`, `ppo_mini_batch_size=32` (8 gradient ministeps), `rollout.n=16`,
+1k prompt / 16k response.
+
+## 📖 Introduction
+
+🚨 **Uniform token-level trust regions are not enough for LLM RL.** CPPO is a drop-in
+mask that reallocates the divergence budget by **position** and **prefix drift**. It keeps
+the DPPO ratio-advantage surrogate and the same per-token divergence — only the masking
+decision changes (no new loss terms).
+
+<div align="left">
+  <img src="https://hunyuan-cppo.github.io/assets/readme/fig1.png" alt="CPPO vs PPO/DPPO masks" style="width: 96%; height: auto;">
+</div>
+
+**The surrogate and the masks.** PPO (and variants like GRPO) gate updates with a heuristic
+based on the probability ratio `|ρ_t − 1| ≤ ε`. DPPO replaces this with a principled
+divergence threshold `D_t ≤ δ`. CPPO goes further: it scales the threshold by a **position
+weight** `w_t` and adds a **cumulative prefix-average budget** `δ_b`, so a token is kept only
+when both `w_t·D_t ≤ δ` and the running prefix average of weighted divergence stays under
+`δ_b` (or when the update moves `π` back toward the rollout policy `μ`).
+
+🤔 **Why break "uniform thresholds"?** In autoregressive generation, early deviations
+cascade — a small policy shift at token 10 alters the conditioning for the next 10k tokens.
+Uniform constraints underestimate early-stage risk and over-restrict late-stage exploration.
+
+<div align="left">
+  <img src="https://hunyuan-cppo.github.io/assets/readme/fig2.png" alt="Position-weighted threshold" style="width: 96%; height: auto;">
+</div>
+
+CPPO ties the budget to position: early tokens (which condition the whole suffix) are
+constrained more tightly, and the threshold relaxes toward the end of the response via the
+decreasing weight `w_t ∈ [w_min, 1]`.
+
+⏳ **Pointwise evaluation ignores cumulative prefix drift.** If the history has already
+drifted far from the rollout policy, any further deviation at the current token carries high
+compounding risk. CPPO dynamically tightens the limit as off-policy drift accumulates.
+
+<div align="left">
+  <img src="https://hunyuan-cppo.github.io/assets/readme/fig3.png" alt="Cumulative prefix budget" style="width: 96%; height: auto;">
+</div>
+
+The effective threshold `c_t = min(δ, δ + δ_b·W_{t-1} − S_{t-1})` shrinks once the weighted
+prefix sum `S_{t-1}` over-spends the budget allotment `δ_b·W_{t-1}` — so a token can satisfy
+the token-level threshold yet still be masked by the prefix constraint.
+
+📉 **Theory.** Starting from a finite-horizon performance-difference identity, the paper
+proves that early-token shifts carry a remaining-horizon penalty. By tracking prefix
+deviations, CPPO provides a tighter, provably robust policy-improvement bound than uniform,
+pointwise methods.
+
+<div align="left">
+  <img src="https://hunyuan-cppo.github.io/assets/readme/theorem1.png" alt="Theorem 1" style="width: 96%; height: auto;">
+</div>
+
+🚀 **Results.** On Qwen3-30B-A3B-Base (16k rollout), CPPO reaches **54.79% Avg@16 on
+AIME 24/25/26**, delivering stronger performance while maintaining greater training stability.
+
+<div align="left">
+  <img src="https://hunyuan-cppo.github.io/assets/readme/table1.png" alt="AIME results" style="width: 96%; height: auto;">
+</div>
+
+💡 **Takeaway.** DPPO improved *how* to measure token-level shift; CPPO addresses *where* and
+*how much* shift can accumulate. For long-horizon RL, the trust-region geometry must align
+with the autoregressive prefix-to-suffix structure.
+
+> **Divergence variant.** This example implements the **Binary-TV** divergence
+> `D_t = |pi(y_t|s_t) - mu(y_t|s_t)|`, which only needs the sampled token's log-probs and is
+> therefore self-contained in `core_algos`. The paper's main experiments use a Top-K (K=20)
+> reduced-TV estimate of `D_t` (the two are comparable). The Top-K variant needs vLLM to emit
+> per-token top-K log-probs and a matching gather on the training side, which is extra plumbing
+> outside the loss; if you want it, you can wire that up in your own verl fork and feed the
+> Top-K `D_t` into the same mask.
+
+### Anchoring the divergence to the rollout policy
+
+CPPO's per-token divergence is `D_t = |pi(y_t|s_t) - mu(y_t|s_t)|`, where `mu` is the
+**rollout** policy. So the `old_log_prob` fed to the loss must be the rollout log-probs,
+not a recomputed `pi_old`. The script runs the synchronous trainer
+(`verl.trainer.main_ppo_sync`) with `algorithm.rollout_correction.bypass_mode=True`:
+in this trainer, bypass mode simply sets `old_log_probs = rollout_log_probs` and leaves
+`loss_mode` untouched, so CPPO reads `mu` directly and runs its own token mask. This
+requires `rollout.calculate_log_probs=True` (the default) and the TransferQueue backend
+(`pip install TransferQueue`).
+
+## ⚙️ Key hyperparameters
+
+CPPO adds two hyperparameters on top of the shared DPPO token-level threshold scale.
+
+| Config | Meaning | Default |
+| --- | --- | --- |
+| `actor.clip_ratio` | token-level threshold scale `delta` (same field DPPO uses) | `0.20` (MoE) / `0.15` (dense) |
+| `actor.policy_loss.cppo.cppo_w_min` | weight floor of the linear position schedule `w_t in [w_min, 1]` | `0.8` |
+| `actor.policy_loss.cppo.cppo_delta_b` | floor `delta_b_min` of the prefix-average budget | `0.02` |
+| `actor.policy_loss.cppo.cppo_delta_b_q` | quantile of `D_t` used to calibrate the budget | `0.9` |
+| `actor.policy_loss.cppo.cppo_delta_b_k` | scale applied to that quantile | `1.0` |
+
+The prefix-average budget is calibrated per sequence from its own divergence statistics
+(Base-model warm-up):
+`delta_b^seq = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 2 * delta_b_min)`.
+The defaults `(q, k) = (0.9, 1.0)` reproduce the paper's P90 calibration; for example
+`cppo.cppo_delta_b_q=0.95 cppo.cppo_delta_b_k=0.5` calibrates from half the 95th percentile.
+
+`clip_ratio` is the **divergence** threshold here (not a ratio clip); `clip_ratio_c` is the
+truncated-importance-sampling cap, kept consistent with DPPO.
+
+## 📐 Mask
+
+For a response of length `T`, with `D_t = |pi(y_t|s_t) - mu(y_t|s_t)|` (Binary-TV):
+
+```
+w_t = w_min + (1 - w_min) * (T - t) / (T - 1)       # decreasing position weight, w_t in [w_min, 1]
+Z_t = w_t * D_t
+S_t = sum_{j<=t} Z_j,   W_t = sum_{j<=t} w_j        # S_0 = W_0 = 0
+c_t = min(delta, delta + delta_b * W_{t-1} - S_{t-1})
+keep token t  iff  A_t * (rho_t - 1) <= 0   OR   Z_t <= c_t
+```
+
+The first clause always keeps update terms that move `pi` back toward `mu`; the budget
+only restricts terms that move `pi` farther from `mu`.
+
+## Citation
+
+If you find our work useful for your research, please consider citing:
+
+```bibtex
+@article{mao2026beyond,
+  title={Beyond Uniform Token-Level Trust Region in LLM Reinforcement Learning},
+  author={Mao, Renjie and Zhou, Xiangxin and Tao, Lvfang and Ding, Yixin and Shi, Yu and Lin, Yongguang and Wu, Yuheng and Zhu, Honglin and Qiu, Qian and Zhu, Wenxi},
+  journal={arXiv preprint arXiv:2606.10968},
+  year={2026}
+}
+```
+
+## 🌻 Acknowledgement
+
+We implement our reinforcement learning algorithm extending from
+[verl](https://github.com/verl-project/verl). We utilize [vLLM](https://github.com/vllm-project/vllm)
+and [sglang](https://github.com/sgl-project/sglang) for inference. Our models are trained
+primarily on the [Qwen3 family](https://huggingface.co/collections/Qwen/qwen3). Our training
+data is built from [DAPO-MATH](https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17k).
+Thanks for their great contributions!

--- a/examples/cppo_trainer/README.md
+++ b/examples/cppo_trainer/README.md
@@ -107,17 +107,6 @@ with the autoregressive prefix-to-suffix structure.
 > outside the loss; if you want it, you can wire that up in your own verl fork and feed the
 > Top-K `D_t` into the same mask.
 
-### Anchoring the divergence to the rollout policy
-
-CPPO's per-token divergence is `D_t = |pi(y_t|s_t) - mu(y_t|s_t)|`, where `mu` is the
-**rollout** policy. So the `old_log_prob` fed to the loss must be the rollout log-probs,
-not a recomputed `pi_old`. The script runs the synchronous trainer
-(`verl.trainer.main_ppo_sync`) with `algorithm.rollout_correction.bypass_mode=True`:
-in this trainer, bypass mode simply sets `old_log_probs = rollout_log_probs` and leaves
-`loss_mode` untouched, so CPPO reads `mu` directly and runs its own token mask. This
-requires `rollout.calculate_log_probs=True` (the default) and the TransferQueue backend
-(`pip install TransferQueue`).
-
 ## ⚙️ Key hyperparameters
 
 CPPO adds two hyperparameters on top of the shared DPPO token-level threshold scale.

--- a/examples/cppo_trainer/run_qwen3_1.7b_megatron.sh
+++ b/examples/cppo_trainer/run_qwen3_1.7b_megatron.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# CPPO | MoE | vLLM rollout | Megatron training | NVIDIA GPUs
+# CPPO | dense | vLLM rollout | Megatron training | NVIDIA GPUs
 # CPPO masks token-level updates with a position-weighted divergence threshold and a
 # cumulative prefix budget (paper: cppo.pdf, "Beyond Uniform Token-Level Trust Region in
 # LLM Reinforcement Learning"). Binary-TV variant.
@@ -10,14 +10,14 @@ export CUDA_DEVICE_MAX_CONNECTIONS=1
 export VLLM_USE_V1=1
 
 # ---- user-adjustable ----
-MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-30B-A3B-Base}
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-1.7B-Base}
 NNODES=${NNODES:-1}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
-# CPPO hyperparameters (paper Table 3, Qwen3-30B-A3B-Base / MoE).
+# CPPO hyperparameters (paper Table 3).
 # clip_ratio is the token-level divergence threshold scale delta:
-#   delta = 0.20 for the 30B-A3B MoE model (0.15 for dense models).
-clip_ratio=${CLIP_RATIO:-0.20}
+#   delta = 0.15 for dense models (0.20 for the 30B-A3B MoE model).
+clip_ratio=${CLIP_RATIO:-0.15}
 # Position weight floor w_t in [w_min, 1].
 cppo_w_min=${CPPO_W_MIN:-0.8}
 # Floor delta_b_min of the per-sequence dynamic prefix budget
@@ -28,30 +28,28 @@ cppo_delta_b=${CPPO_DELTA_B:-0.02}
 cppo_delta_b_q=${CPPO_DELTA_B_Q:-0.9}
 cppo_delta_b_k=${CPPO_DELTA_B_K:-1.0}
 
-train_batch_size=${TRAIN_BATCH_SIZE:-256}
+train_batch_size=${TRAIN_BATCH_SIZE:-64}
 ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-32}
 max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
-max_response_length=${MAX_RESPONSE_LENGTH:-16384}
-ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-32768}
+max_response_length=${MAX_RESPONSE_LENGTH:-8192}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-16384}
 
 actor_lr=${ACTOR_LR:-1e-6}
 entropy_coeff=${ENTROPY_COEFF:-0}
 
-actor_tp=${ACTOR_TP:-4}
+actor_tp=${ACTOR_TP:-1}
 actor_pp=${ACTOR_PP:-1}
-actor_ep=${ACTOR_EP:-8}
-actor_etp=${ACTOR_ETP:-1}
 
-rollout_tp=${ROLLOUT_TP:-2}
-rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.8}
-rollout_n=${ROLLOUT_N:-16}
+rollout_tp=${ROLLOUT_TP:-1}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.6}
+rollout_n=${ROLLOUT_N:-8}
 
 total_epochs=${TOTAL_EPOCHS:-10}
 save_freq=${SAVE_FREQ:-50}
 test_freq=${TEST_FREQ:-10}
 
-project_name=${PROJECT_NAME:-verl_cppo_qwen3_moe}
-experiment_name=${EXPERIMENT_NAME:-qwen3_30b_a3b_cppo_vllm_megatron}
+project_name=${PROJECT_NAME:-verl_cppo_qwen3_dense}
+experiment_name=${EXPERIMENT_NAME:-qwen3_1.7b_cppo_vllm_megatron}
 # ---- end user-adjustable ----
 
 train_file=${TRAIN_FILE:-$HOME/data/dapo-math-17k/train.parquet}
@@ -93,17 +91,7 @@ ACTOR=(
     actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
     actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${actor_tp}
     actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${actor_pp}
-    actor_rollout_ref.actor.megatron.expert_model_parallel_size=${actor_ep}
-    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=${actor_etp}
-    actor_rollout_ref.actor.megatron.param_offload=True
-    actor_rollout_ref.actor.megatron.grad_offload=True
-    actor_rollout_ref.actor.megatron.optimizer_offload=True
     actor_rollout_ref.actor.megatron.use_mbridge=True
-    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_router_dtype=fp32
-    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_permute_fusion=True
-    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform
-    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full
-    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1
 )
 
 ROLLOUT=(
@@ -120,8 +108,6 @@ REF=(
     actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
     actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${actor_tp}
     actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${actor_pp}
-    actor_rollout_ref.ref.megatron.expert_model_parallel_size=${actor_ep}
-    actor_rollout_ref.ref.megatron.expert_tensor_parallel_size=${actor_etp}
     actor_rollout_ref.ref.megatron.param_offload=True
     actor_rollout_ref.ref.megatron.use_mbridge=True
 )

--- a/examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
+++ b/examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# CPPO | MoE | vLLM rollout | Megatron training | NVIDIA GPUs
+# CPPO replaces DPPO's uniform per-token divergence threshold with a position-weighted
+# threshold and a cumulative prefix budget (paper: cppo.pdf, "Beyond Uniform Token-Level
+# Trust Region in LLM Reinforcement Learning"). Binary-TV variant.
+
+set -xeuo pipefail
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export VLLM_USE_V1=1
+
+# ---- user-adjustable ----
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-30B-A3B-Base}
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+# CPPO hyperparameters (paper Table 3, Qwen3-30B-A3B-Base / MoE).
+# clip_ratio is the token-level divergence threshold scale delta (same field DPPO uses):
+#   delta = 0.20 for the 30B-A3B MoE model (0.15 for dense models).
+clip_ratio=${CLIP_RATIO:-0.20}
+# Position weight floor w_t in [w_min, 1].
+cppo_w_min=${CPPO_W_MIN:-0.8}
+# Floor delta_b_min of the per-sequence dynamic prefix budget
+# delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 2*delta_b_min).
+cppo_delta_b=${CPPO_DELTA_B:-0.02}
+# Quantile and scale of the budget calibration; (0.9, 1.0) = paper P90,
+# e.g. CPPO_DELTA_B_Q=0.95 CPPO_DELTA_B_K=0.5 uses half the 95th percentile.
+cppo_delta_b_q=${CPPO_DELTA_B_Q:-0.9}
+cppo_delta_b_k=${CPPO_DELTA_B_K:-1.0}
+
+train_batch_size=${TRAIN_BATCH_SIZE:-256}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-32}
+max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
+max_response_length=${MAX_RESPONSE_LENGTH:-16384}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-32768}
+
+actor_lr=${ACTOR_LR:-1e-6}
+entropy_coeff=${ENTROPY_COEFF:-0}
+
+actor_tp=${ACTOR_TP:-4}
+actor_pp=${ACTOR_PP:-1}
+actor_ep=${ACTOR_EP:-8}
+actor_etp=${ACTOR_ETP:-1}
+
+rollout_tp=${ROLLOUT_TP:-2}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.8}
+rollout_n=${ROLLOUT_N:-16}
+
+total_epochs=${TOTAL_EPOCHS:-10}
+save_freq=${SAVE_FREQ:-50}
+test_freq=${TEST_FREQ:-10}
+
+project_name=${PROJECT_NAME:-verl_cppo_qwen3_moe}
+experiment_name=${EXPERIMENT_NAME:-qwen3_30b_a3b_cppo_vllm_megatron}
+# ---- end user-adjustable ----
+
+train_file=${TRAIN_FILE:-$HOME/data/dapo-math-17k/train.parquet}
+val_file=${VAL_FILE:-$HOME/data/aime-2024/test.parquet}
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    algorithm.norm_adv_by_std_in_grpo=False
+    # CPPO measures the divergence D_t between the rollout policy mu and the current
+    # policy pi, so old_log_probs must be the rollout log-probs (no recomputed pi_old).
+    # bypass_mode=True sets old_log_probs = rollout_log_probs; for divergence losses
+    # (cppo / dppo_tv / dppo_kl) the trainer keeps loss_mode unchanged and runs their mask.
+    algorithm.rollout_correction.bypass_mode=True
+    data.train_files="['$train_file']"
+    data.val_files="['$val_file']"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.filter_overlong_prompts=True
+    data.truncation='error'
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.use_remove_padding=True
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.policy_loss.loss_mode=cppo
+    actor_rollout_ref.actor.policy_loss.cppo.cppo_w_min=${cppo_w_min}
+    actor_rollout_ref.actor.policy_loss.cppo.cppo_delta_b=${cppo_delta_b}
+    actor_rollout_ref.actor.policy_loss.cppo.cppo_delta_b_q=${cppo_delta_b_q}
+    actor_rollout_ref.actor.policy_loss.cppo.cppo_delta_b_k=${cppo_delta_b_k}
+    actor_rollout_ref.actor.loss_agg_mode=seq-mean-token-sum-norm
+    actor_rollout_ref.actor.clip_ratio=${clip_ratio}
+    actor_rollout_ref.actor.clip_ratio_c=20.0
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_kl_loss=False
+    actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${actor_tp}
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${actor_pp}
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=${actor_ep}
+    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=${actor_etp}
+    actor_rollout_ref.actor.megatron.param_offload=True
+    actor_rollout_ref.actor.megatron.grad_offload=True
+    actor_rollout_ref.actor.megatron.optimizer_offload=True
+    actor_rollout_ref.actor.megatron.use_mbridge=True
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_router_dtype=fp32
+    +actor_rollout_ref.actor.megatron.override_transformer_config.moe_permute_fusion=True
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=${rollout_n}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+)
+
+REF=(
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${actor_tp}
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${actor_pp}
+    actor_rollout_ref.ref.megatron.expert_model_parallel_size=${actor_ep}
+    actor_rollout_ref.ref.megatron.expert_tensor_parallel_size=${actor_etp}
+    actor_rollout_ref.ref.megatron.param_offload=True
+    actor_rollout_ref.ref.megatron.use_mbridge=True
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.critic_warmup=0
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.val_before_train=False
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+)
+
+EXTRA=(
+    model_engine=megatron
+    # Synchronous TransferQueue trainer. In this trainer bypass_mode=True simply sets
+    # old_log_probs = rollout_log_probs and leaves loss_mode untouched, so CPPO reads the
+    # rollout policy mu directly and runs its own mask (no core-trainer patch needed).
+    +ray_kwargs.ray_init.runtime_env.env_vars.TRANSFER_QUEUE_ENABLE=1
+)
+
+########################### launch ###########################
+python3 -m verl.trainer.main_ppo_sync \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${REF[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@"

--- a/examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
+++ b/examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
@@ -21,7 +21,7 @@ clip_ratio=${CLIP_RATIO:-0.20}
 # Position weight floor w_t in [w_min, 1].
 cppo_w_min=${CPPO_W_MIN:-0.8}
 # Floor delta_b_min of the per-sequence dynamic prefix budget
-# delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 2*delta_b_min).
+# delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b_min, 5*delta_b_min).
 cppo_delta_b=${CPPO_DELTA_B:-0.02}
 # Quantile and scale of the budget calibration; (0.9, 1.0) = paper P90,
 # e.g. CPPO_DELTA_B_Q=0.95 CPPO_DELTA_B_K=0.5 uses half the 95th percentile.

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -99,6 +99,11 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      cppo:
+        cppo_w_min: 0.8
+        cppo_delta_b: 0.02
+        cppo_delta_b_q: 0.9
+        cppo_delta_b_k: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -69,6 +69,11 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      cppo:
+        cppo_w_min: 0.8
+        cppo_delta_b: 0.02
+        cppo_delta_b_q: 0.9
+        cppo_delta_b_k: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -78,6 +78,11 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      cppo:
+        cppo_w_min: 0.8
+        cppo_delta_b: 0.02
+        cppo_delta_b_q: 0.9
+        cppo_delta_b_k: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -83,6 +83,11 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      cppo:
+        cppo_w_min: 0.8
+        cppo_delta_b: 0.02
+        cppo_delta_b_q: 0.9
+        cppo_delta_b_k: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -75,17 +75,22 @@ policy_loss:
   # KL divergence penalty coefficient
   ppo_kl_coef: 0.1
 
-  # CPPO (cppo.pdf). Only consumed when loss_mode == "cppo". The token-level threshold
-  # delta is read from actor.clip_ratio (same convention as DPPO). These add the
-  # position weight and the cumulative prefix budget.
+  # CPPO (cppo.pdf) parameters, grouped under this section. Only consumed when
+  # loss_mode == "cppo". The token-level threshold delta is read from actor.clip_ratio
+  # (same convention as DPPO); these add the position weight and the cumulative prefix budget.
   cppo:
+
     # Weight floor of the linear position schedule w_t in [cppo_w_min, 1] (paper default 0.8)
     cppo_w_min: 0.8
+
     # Floor delta_b_min of the per-sequence dynamic budget
     # delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b, 2*delta_b) (paper Eq. 22)
     cppo_delta_b: 0.02
-    # Quantile and scale of the budget calibration; (0.9, 1.0) = paper P90, e.g. (0.95, 0.5) = half the 95th pct
+
+    # Quantile of the per-sequence divergence used to calibrate the budget (0.9 = paper P90)
     cppo_delta_b_q: 0.9
+
+    # Scale applied to that quantile; e.g. (cppo_delta_b_q, cppo_delta_b_k)=(0.95, 0.5) = half the 95th pct
     cppo_delta_b_k: 1.0
 
 # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -75,6 +75,19 @@ policy_loss:
   # KL divergence penalty coefficient
   ppo_kl_coef: 0.1
 
+  # CPPO (cppo.pdf). Only consumed when loss_mode == "cppo". The token-level threshold
+  # delta is read from actor.clip_ratio (same convention as DPPO). These add the
+  # position weight and the cumulative prefix budget.
+  cppo:
+    # Weight floor of the linear position schedule w_t in [cppo_w_min, 1] (paper default 0.8)
+    cppo_w_min: 0.8
+    # Floor delta_b_min of the per-sequence dynamic budget
+    # delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b, 2*delta_b) (paper Eq. 22)
+    cppo_delta_b: 0.02
+    # Quantile and scale of the budget calibration; (0.9, 1.0) = paper P90, e.g. (0.95, 0.5) = half the 95th pct
+    cppo_delta_b_q: 0.9
+    cppo_delta_b_k: 1.0
+
 # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
 clip_ratio_c: 3.0
 

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -84,7 +84,7 @@ policy_loss:
     cppo_w_min: 0.8
 
     # Floor delta_b_min of the per-sequence dynamic budget
-    # delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b, 2*delta_b) (paper Eq. 22)
+    # delta_b = clamp(cppo_delta_b_k * quantile(D_t, cppo_delta_b_q), delta_b, 5*delta_b) (paper Eq. 22)
     cppo_delta_b: 0.02
 
     # Quantile of the per-sequence divergence used to calibrate the budget (0.9 = paper P90)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1602,17 +1602,14 @@ def compute_policy_loss_cppo(
 
     pl = config.policy_loss
     cppo = pl.cppo
-    # delta: token-level threshold scale, shared with DPPO via clip_ratio (paper Sec. 4.1).
+    # Note: like DPPO, the token-level threshold delta is read from clip_ratio (paper Sec. 4.1).
     delta = float(config.clip_ratio)
-    # w_min: weight floor of the linear position schedule (paper default 0.8).
+    # Weight floor of the linear position schedule (paper default 0.8).
     w_min = float(cppo.get("cppo_w_min", 0.8))
-    # delta_b: floor of the per-sequence dynamic prefix-average budget delta_b_min (paper Eq. 22).
+    # Floor of the per-sequence dynamic prefix-average budget delta_b_min (paper Eq. 22).
     delta_b = float(cppo.get("cppo_delta_b", 0.02))
-    # delta_b_q: quantile of the per-sequence divergence used to calibrate the budget (Eq. 22
-    # uses the 90th percentile). delta_b_k: scale applied to that quantile. Together they give
-    #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 2 * delta_b),
-    # so e.g. (q=0.95, k=0.5) calibrates from half the 95th percentile. Defaults (0.9, 1.0)
-    # reproduce the paper's P90 calibration.
+    # Quantile and scale of the budget calibration; see Eq. 22 in the docstring. Defaults
+    # (0.9, 1.0) reproduce the paper's P90 calibration.
     delta_b_q = float(cppo.get("cppo_delta_b_q", 0.9))
     delta_b_k = float(cppo.get("cppo_delta_b_k", 1.0))
     assert 0.0 < w_min <= 1.0, f"cppo.cppo_w_min must be in (0, 1]; got {w_min}."
@@ -1621,6 +1618,7 @@ def compute_policy_loss_cppo(
     assert delta_b_k >= 0.0, f"cppo.cppo_delta_b_k must be >= 0; got {delta_b_k}."
 
     negative_approx_kl = log_prob - old_log_prob
+    # Clamp negative_approx_kl for stability
     negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
     ratio = torch.exp(negative_approx_kl)
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
@@ -1630,7 +1628,7 @@ def compute_policy_loss_cppo(
     truncated_ratio = torch.clamp(ratio, max=clip_ratio_c)
     truncated_ratio = truncated_ratio.detach()
 
-    # ── CPPO mask construction (no_grad: it is a trust-region gate, not part of the loss) ──
+    # Construct the CPPO mask under no_grad: it is a trust-region gate, not part of the loss.
     with torch.no_grad():
         response_mask_f = response_mask.float()
 
@@ -1640,7 +1638,7 @@ def compute_policy_loss_cppo(
         D_t = (prob - old_prob).abs() * response_mask_f
 
         # Position weight w_t in [w_min, 1], decreasing along the response (Eq. 9):
-        #   w_t = w_min + (1 - w_min) * (T - t) / (T - 1)  ==  1 - (1 - w_min) / (T - 1) * (t - 1)
+        #   w_t = w_min + (1 - w_min) * (T - t) / (T - 1)
         # T is the (padded) response length and t is the 1-based absolute token position. This
         # matches the reference CPPO implementation, which keys the schedule on the fixed padded
         # length rather than each sequence's valid length; responses are right-padded, so padded
@@ -1651,7 +1649,8 @@ def compute_policy_loss_cppo(
         frac = ((T_fixed - pos) / max(T_fixed - 1.0, 1.0)).clamp(0.0, 1.0)
         w_t = (w_min + (1.0 - w_min) * frac) * response_mask_f
 
-        Z_t = w_t * D_t  # weighted divergence
+        # Weighted divergence Z_t = w_t * D_t.
+        Z_t = w_t * D_t
 
         # Prefix sums with one-token right shift so the decision at t uses only the
         # preceding prefix (S_{t-1}, W_{t-1}); S_0 = W_0 = 0 (Appendix D batched form).
@@ -1662,7 +1661,6 @@ def compute_policy_loss_cppo(
 
         # Per-sequence dynamic prefix budget (Eq. 22):
         #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 2 * delta_b).
-        # delta_b_q / delta_b_k default to (0.9, 1.0) = the paper's P90 calibration.
         D_for_q = torch.where(response_mask_f.bool(), D_t, torch.full_like(D_t, float("nan")))
         q_seq = torch.nanquantile(D_for_q, q=delta_b_q, dim=-1)  # (B,)
         # Empty sequence -> NaN -> fall back to the floor.
@@ -1672,15 +1670,15 @@ def compute_policy_loss_cppo(
         # Effective threshold c_t = min(delta, delta + delta_b * W_{t-1} - S_{t-1}) (Eq. 8).
         c_t = (delta + delta_b_seq * W_prev - S_prev).clamp(max=delta)
 
-        # I_t: budget feasibility. Keep tokens moving pi back toward mu unconditionally,
-        # otherwise only if within the effective threshold (Eq. 10).
+        # Keep tokens moving pi back toward mu unconditionally, otherwise only if within
+        # the effective threshold (Eq. 10).
         feasible = Z_t <= c_t
         toward_mu = (advantages * (ratio - 1.0)) <= 0.0
         valid_mask = (toward_mu | feasible).detach().float() * response_mask_f
 
     pg_losses = -advantages * truncated_ratio * log_prob * valid_mask
 
-    # Apply rollout correction weights if provided.
+    # Apply rollout correction weights if provided
     if rollout_is_weights is not None:
         pg_losses = pg_losses * rollout_is_weights
 

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1535,6 +1535,173 @@ def compute_policy_loss_dppo_kl(
     return pg_loss, pg_metrics
 
 
+@register_policy_loss("cppo")
+def compute_policy_loss_cppo(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "token-mean",
+    config: Optional[ActorConfig] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Compute the policy objective for CPPO (Cumulative Prefix-divergence Policy Optimization).
+
+    CPPO (Binary-TV variant) keeps the DPPO token-level ratio-advantage surrogate but
+    replaces DPPO's uniform per-token threshold with a position-weighted token-level
+    threshold and a cumulative prefix budget. The only change versus DPPO is the masking
+    decision; the loss term is identical.
+
+    See "Beyond Uniform Token-Level Trust Region in LLM Reinforcement Learning" (cppo.pdf),
+    Eq. (9)-(11) and Appendix D for the batched mask construction this implements.
+
+    For a single response of length ``T`` (Algorithm 1 of the paper; ``T`` is the padded
+    response length and ``t`` the 1-based absolute token position, matching the reference
+    implementation):
+
+        D_t = |pi(y_t|s_t) - mu(y_t|s_t)|              (Binary-TV per-token divergence)
+        w_t = w_min + (1 - w_min) * (T - t) / (T - 1)  (decreasing position weight, w_t in [w_min, 1])
+        Z_t = w_t * D_t
+        S_t = sum_{j<=t} Z_j ,  W_t = sum_{j<=t} w_j    (prefix sums; S_0 = W_0 = 0)
+        c_t = min(delta, delta + delta_b * W_{t-1} - S_{t-1})   (effective threshold, Eq. 8)
+        keep token t  iff  A_t * (rho_t - 1) <= 0   OR   Z_t <= c_t      (Eq. 10)
+
+    The first clause always keeps update terms that move pi back toward mu; the budget only
+    restricts terms that move pi farther from mu.
+
+    delta (the token-level threshold scale) is read from ``config.clip_ratio`` exactly as
+    DPPO does (paper default 0.15 for dense models, 0.20 for the 30B-A3B MoE model).
+
+    The prefix-average threshold delta_b is calibrated per sequence from its own divergence
+    statistics (paper Eq. 22, Base-model warm-up calibration)::
+
+        delta_b^seq = clamp(delta_b_k * quantile(D_{1:T}, delta_b_q), delta_b_min, 2 * delta_b_min)
+
+    where ``delta_b_min`` is ``cppo.cppo_delta_b``. The quantile ``delta_b_q`` (``cppo.cppo_delta_b_q``)
+    and the scale ``delta_b_k`` (``cppo.cppo_delta_b_k``) default to ``(0.9, 1.0)``, reproducing the
+    paper's P90 calibration; e.g. ``(q=0.95, k=0.5)`` calibrates from half the 95th percentile.
+
+    Args:
+        old_log_prob (torch.Tensor):
+            Log-probabilities under the rollout policy mu, shape (batch_size, response_length).
+        log_prob (torch.Tensor):
+            Log-probabilities under the current policy pi, shape (batch_size, response_length).
+        advantages (torch.Tensor):
+            Advantage estimates for each token, shape (batch_size, response_length).
+        response_mask (torch.Tensor):
+            Mask indicating response tokens, shape (batch_size, response_length).
+        loss_agg_mode (str, optional):
+            Aggregation mode for ``agg_loss``. Defaults to "token-mean".
+        config: (verl.workers.config.ActorConfig): actor config.
+        rollout_is_weights (torch.Tensor | None):
+            Optional rollout-correction importance weights, shape (batch_size, response_length).
+    """
+
+    assert config is not None
+    assert not isinstance(config, AlgoConfig)
+
+    pl = config.policy_loss
+    cppo = pl.cppo
+    # delta: token-level threshold scale, shared with DPPO via clip_ratio (paper Sec. 4.1).
+    delta = float(config.clip_ratio)
+    # w_min: weight floor of the linear position schedule (paper default 0.8).
+    w_min = float(cppo.get("cppo_w_min", 0.8))
+    # delta_b: floor of the per-sequence dynamic prefix-average budget delta_b_min (paper Eq. 22).
+    delta_b = float(cppo.get("cppo_delta_b", 0.02))
+    # delta_b_q: quantile of the per-sequence divergence used to calibrate the budget (Eq. 22
+    # uses the 90th percentile). delta_b_k: scale applied to that quantile. Together they give
+    #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 2 * delta_b),
+    # so e.g. (q=0.95, k=0.5) calibrates from half the 95th percentile. Defaults (0.9, 1.0)
+    # reproduce the paper's P90 calibration.
+    delta_b_q = float(cppo.get("cppo_delta_b_q", 0.9))
+    delta_b_k = float(cppo.get("cppo_delta_b_k", 1.0))
+    assert 0.0 < w_min <= 1.0, f"cppo.cppo_w_min must be in (0, 1]; got {w_min}."
+    assert delta_b >= 0.0, f"cppo.cppo_delta_b must be >= 0; got {delta_b}."
+    assert 0.0 <= delta_b_q <= 1.0, f"cppo.cppo_delta_b_q must be in [0, 1]; got {delta_b_q}."
+    assert delta_b_k >= 0.0, f"cppo.cppo_delta_b_k must be >= 0; got {delta_b_k}."
+
+    negative_approx_kl = log_prob - old_log_prob
+    negative_approx_kl = torch.clamp(negative_approx_kl, min=-20.0, max=20.0)
+    ratio = torch.exp(negative_approx_kl)
+    ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
+
+    # Truncated importance sampling instead of dual-clip PPO (same idiom as DPPO).
+    clip_ratio_c = config.get("clip_ratio_c", 20.0)
+    truncated_ratio = torch.clamp(ratio, max=clip_ratio_c)
+    truncated_ratio = truncated_ratio.detach()
+
+    # ── CPPO mask construction (no_grad: it is a trust-region gate, not part of the loss) ──
+    with torch.no_grad():
+        response_mask_f = response_mask.float()
+
+        # Binary-TV per-token divergence D_t = |pi(y_t) - mu(y_t)| (same signal as DPPO-Binary-TV).
+        prob = torch.exp(log_prob)
+        old_prob = torch.exp(old_log_prob)
+        D_t = (prob - old_prob).abs() * response_mask_f
+
+        # Position weight w_t in [w_min, 1], decreasing along the response (Eq. 9):
+        #   w_t = w_min + (1 - w_min) * (T - t) / (T - 1)  ==  1 - (1 - w_min) / (T - 1) * (t - 1)
+        # T is the (padded) response length and t is the 1-based absolute token position. This
+        # matches the reference CPPO implementation, which keys the schedule on the fixed padded
+        # length rather than each sequence's valid length; responses are right-padded, so padded
+        # positions are zeroed by response_mask below.
+        bs, resp_len = response_mask_f.shape
+        T_fixed = float(resp_len)
+        pos = torch.arange(1, resp_len + 1, device=log_prob.device).unsqueeze(0).expand(bs, -1).float()
+        frac = ((T_fixed - pos) / max(T_fixed - 1.0, 1.0)).clamp(0.0, 1.0)
+        w_t = (w_min + (1.0 - w_min) * frac) * response_mask_f
+
+        Z_t = w_t * D_t  # weighted divergence
+
+        # Prefix sums with one-token right shift so the decision at t uses only the
+        # preceding prefix (S_{t-1}, W_{t-1}); S_0 = W_0 = 0 (Appendix D batched form).
+        S_cum = torch.cumsum(Z_t, dim=-1)
+        W_cum = torch.cumsum(w_t, dim=-1)
+        S_prev = torch.cat([torch.zeros_like(S_cum[:, :1]), S_cum[:, :-1]], dim=-1)
+        W_prev = torch.cat([torch.zeros_like(W_cum[:, :1]), W_cum[:, :-1]], dim=-1)
+
+        # Per-sequence dynamic prefix budget (Eq. 22):
+        #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 2 * delta_b).
+        # delta_b_q / delta_b_k default to (0.9, 1.0) = the paper's P90 calibration.
+        D_for_q = torch.where(response_mask_f.bool(), D_t, torch.full_like(D_t, float("nan")))
+        q_seq = torch.nanquantile(D_for_q, q=delta_b_q, dim=-1)  # (B,)
+        # Empty sequence -> NaN -> fall back to the floor.
+        q_seq = torch.nan_to_num(q_seq, nan=delta_b)
+        delta_b_seq = (delta_b_k * q_seq).clamp(min=delta_b, max=2.0 * delta_b).unsqueeze(-1)  # (B, 1)
+
+        # Effective threshold c_t = min(delta, delta + delta_b * W_{t-1} - S_{t-1}) (Eq. 8).
+        c_t = (delta + delta_b_seq * W_prev - S_prev).clamp(max=delta)
+
+        # I_t: budget feasibility. Keep tokens moving pi back toward mu unconditionally,
+        # otherwise only if within the effective threshold (Eq. 10).
+        feasible = Z_t <= c_t
+        toward_mu = (advantages * (ratio - 1.0)) <= 0.0
+        valid_mask = (toward_mu | feasible).detach().float() * response_mask_f
+
+    pg_losses = -advantages * truncated_ratio * log_prob * valid_mask
+
+    # Apply rollout correction weights if provided.
+    if rollout_is_weights is not None:
+        pg_losses = pg_losses * rollout_is_weights
+
+    pg_loss = agg_loss(
+        loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode, **config.global_batch_info
+    )
+
+    # Fraction of response tokens rejected by the CPPO mask (excludes the always-kept
+    # toward-mu tokens), matching DPPO's pg_clipfrac semantics.
+    rejected = (1.0 - valid_mask) * response_mask_f
+    pg_clipfrac = verl_F.masked_mean(rejected, response_mask_f)
+    pg_clipfrac_lower = verl_F.masked_mean((ratio > clip_ratio_c).float() * valid_mask, response_mask_f)
+
+    pg_metrics = {
+        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
+        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+    }
+    return pg_loss, pg_metrics
+
+
 @register_policy_loss("gspo")
 def compute_policy_loss_gspo(
     old_log_prob: torch.Tensor,

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1575,7 +1575,7 @@ def compute_policy_loss_cppo(
     The prefix-average threshold delta_b is calibrated per sequence from its own divergence
     statistics (paper Eq. 22, Base-model warm-up calibration)::
 
-        delta_b^seq = clamp(delta_b_k * quantile(D_{1:T}, delta_b_q), delta_b_min, 2 * delta_b_min)
+        delta_b^seq = clamp(delta_b_k * quantile(D_{1:T}, delta_b_q), delta_b_min, 5 * delta_b_min)
 
     where ``delta_b_min`` is ``cppo.cppo_delta_b``. The quantile ``delta_b_q`` (``cppo.cppo_delta_b_q``)
     and the scale ``delta_b_k`` (``cppo.cppo_delta_b_k``) default to ``(0.9, 1.0)``, reproducing the
@@ -1660,12 +1660,12 @@ def compute_policy_loss_cppo(
         W_prev = torch.cat([torch.zeros_like(W_cum[:, :1]), W_cum[:, :-1]], dim=-1)
 
         # Per-sequence dynamic prefix budget (Eq. 22):
-        #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 2 * delta_b).
+        #   delta_b^seq = clamp(delta_b_k * quantile(D, delta_b_q), delta_b, 5 * delta_b).
         D_for_q = torch.where(response_mask_f.bool(), D_t, torch.full_like(D_t, float("nan")))
         q_seq = torch.nanquantile(D_for_q, q=delta_b_q, dim=-1)  # (B,)
         # Empty sequence -> NaN -> fall back to the floor.
         q_seq = torch.nan_to_num(q_seq, nan=delta_b)
-        delta_b_seq = (delta_b_k * q_seq).clamp(min=delta_b, max=2.0 * delta_b).unsqueeze(-1)  # (B, 1)
+        delta_b_seq = (delta_b_k * q_seq).clamp(min=delta_b, max=5.0 * delta_b).unsqueeze(-1)  # (B, 1)
 
         # Effective threshold c_t = min(delta, delta + delta_b * W_{t-1} - S_{t-1}) (Eq. 8).
         c_t = (delta + delta_b_seq * W_prev - S_prev).clamp(max=delta)

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -90,7 +90,7 @@ class CPPOConfig(BaseConfig):
         cppo_w_min (float): Weight floor of the linear position schedule w_t in [w_min, 1] (Eq. 9;
             paper default 0.8).
         cppo_delta_b (float): Floor delta_b_min of the per-sequence dynamic prefix budget
-            delta_b = clamp(delta_b_k * quantile(D_t, delta_b_q), delta_b, 2*delta_b) (Eq. 22).
+            delta_b = clamp(delta_b_k * quantile(D_t, delta_b_q), delta_b, 5*delta_b) (Eq. 22).
         cppo_delta_b_q (float): Quantile of the budget calibration; (0.9, 1.0) is the paper's P90.
         cppo_delta_b_k (float): Scale of the budget calibration; e.g. (0.95, 0.5) uses half the 95th percentile.
     """

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -34,6 +34,7 @@ from .model import HFModelConfig
 from .optimizer import OptimizerConfig
 
 __all__ = [
+    "CPPOConfig",
     "PolicyLossConfig",
     "RouterReplayConfig",
     "ActorConfig",
@@ -76,6 +77,31 @@ class RouterReplayConfig(BaseConfig):
 
 
 @dataclass
+class CPPOConfig(BaseConfig):
+    """Configuration for CPPO (Cumulative Prefix-divergence Policy Optimization, cppo.pdf).
+
+    The inheritance from BaseConfig provides omegaconf.DictConfig-like interface for a dataclass config.
+
+    Only consumed when ``policy_loss.loss_mode == "cppo"``. The token-level threshold delta is read
+    from ``actor.clip_ratio`` (same convention as DPPO); these fields add the position weight and the
+    cumulative prefix-budget knobs.
+
+    Args:
+        cppo_w_min (float): Weight floor of the linear position schedule w_t in [w_min, 1] (Eq. 9;
+            paper default 0.8).
+        cppo_delta_b (float): Floor delta_b_min of the per-sequence dynamic prefix budget
+            delta_b = clamp(delta_b_k * quantile(D_t, delta_b_q), delta_b, 2*delta_b) (Eq. 22).
+        cppo_delta_b_q (float): Quantile of the budget calibration; (0.9, 1.0) is the paper's P90.
+        cppo_delta_b_k (float): Scale of the budget calibration; e.g. (0.95, 0.5) uses half the 95th percentile.
+    """
+
+    cppo_w_min: float = 0.8
+    cppo_delta_b: float = 0.02
+    cppo_delta_b_q: float = 0.9
+    cppo_delta_b_k: float = 1.0
+
+
+@dataclass
 class PolicyLossConfig(BaseConfig):
     """Configuration for policy loss computation.
 
@@ -88,6 +114,7 @@ class PolicyLossConfig(BaseConfig):
         clip_cov_ub (float): Upper bound for clip-cov loss.
         kl_cov_ratio (float): Ratio of tokens to be applied KL penalty for kl-cov loss.
         ppo_kl_coef (float): KL divergence penalty coefficient.
+        cppo (CPPOConfig): Configuration for the CPPO loss (only used when loss_mode == "cppo").
         rollout_correction (RolloutCorrectionConfig): Configuration for rollout correction.
     """
 
@@ -97,6 +124,7 @@ class PolicyLossConfig(BaseConfig):
     clip_cov_ub: float = 5.0
     kl_cov_ratio: float = 0.0002
     ppo_kl_coef: float = 0.1
+    cppo: CPPOConfig = field(default_factory=CPPOConfig)
     rollout_correction: RolloutCorrectionConfig = field(default_factory=RolloutCorrectionConfig)
 
 


### PR DESCRIPTION
### What does this PR do?

Adds the official implementation of **CPPO** (Cumulative Prefix-divergence Policy
Optimization), from the paper *"Beyond Uniform Token-Level Trust Region in LLM
Reinforcement Learning"* (arXiv:2606.10968).

A uniform per-token trust region is a poor fit for autoregressive generation: an early-token
deviation cascades through the entire suffix, and a pointwise threshold ignores how far the
prefix has already drifted from the rollout policy. CPPO keeps the token-level
ratio-advantage surrogate and the same per-token divergence `D_t = |π(y_t|s_t) − μ(y_t|s_t)|`,
but reallocates the divergence budget along the response via two coupled mechanisms:

1. a **position-weighted** token-level threshold (a decreasing weight `w_t ∈ [w_min, 1]`), so
   early tokens are constrained more tightly than late ones, and
2. a **cumulative prefix-average budget** `δ_b`, so the threshold tightens as off-policy
   prefix drift accumulates.

Only the masking decision changes; the surrogate objective is unchanged (no new loss terms).
This PR ships the self-contained **Binary-TV** variant of the divergence.

- Paper: https://arxiv.org/pdf/2606.10968
- Project page: https://hunyuan-cppo.github.io

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  https://github.com/volcengine/verl/pulls?q=is%3Apr+cppo
- [x] Format the PR title as `[{modules}] {type}: {description}` — `[algo] feat: add CPPO ...`.

### Test

CPPO is an algorithm/loss change that CI cannot validate, so it was validated by experiment.

Experiments on **Qwen3-30B-A3B-Base** (DAPO-Math train, AIME 24/25/26 eval, 16k rollout),
following the paper's setting (δ=0.20, w_min=0.8, δ_b=0.02, train_batch=256, rollout.n=16):

- **Avg@16** — CPPO reaches **54.79%** on AIME 24/25/26.
<img width="2180" height="1230" alt="image" src="https://github.com/user-attachments/assets/54173111-a5c7-4bce-8a3d-89ad80692fa8" />
- **Reward (train)** — reward rises smoothly without late-stage collapse.
<img width="2166" height="1229" alt="image" src="https://github.com/user-attachments/assets/ee9be9ba-9252-4e3a-abee-6aae74dad76c" />
- **Training stability** — the training–inference probability mismatch stays controlled
  throughout training (no divergence blow-up).
<img width="2205" height="1232" alt="image" src="https://github.com/user-attachments/assets/83666b1c-caa6-48f6-bf17-9ee3579dd34e" />

The mask math was additionally cross-checked offline against a scalar reference
(vectorized cumsum vs. a per-token loop) over five edge-case scenarios.

### API and Usage Example

CPPO adds two config fields on top of the shared token-level threshold scale
(`actor.clip_ratio`); no API breakage. Selected via `actor.policy_loss.loss_mode=cppo`.

```bash
# Qwen3-30B-A3B-Base, Binary-TV
bash examples/cppo_trainer/run_qwen3_30b_a3b_megatron.sh
```

```yaml
actor_rollout_ref.actor.policy_loss.loss_mode: cppo
actor_rollout_ref.actor.clip_ratio: 0.20                 # token-level divergence threshold δ
actor_rollout_ref.actor.policy_loss.cppo_w_min: 0.8      # position-weight floor, w_t ∈ [w_min, 1]
actor_rollout_ref.actor.policy_loss.cppo_delta_b: 0.02   # prefix-average budget floor δ_b
```

CPPO's divergence is measured against the **rollout** policy μ, so `old_log_probs` must be
the rollout log-probs. The example runs the synchronous trainer
(`verl.trainer.main_ppo_sync`) with `algorithm.rollout_correction.bypass_mode=True`, which
sets `old_log_probs = rollout_log_probs` and leaves `loss_mode` untouched (requires
`pip install TransferQueue`).

### Design & Code Changes

- `verl/trainer/ppo/core_algos.py` — new `@register_policy_loss("cppo")`
  `compute_policy_loss_cppo`: Binary-TV per-token divergence, position-weighted threshold,
  and a cumulative prefix budget with a per-sequence dynamic
  `δ_b = clamp(P90(D_t), δ_b, 5·δ_b)`. The mask is computed under `no_grad` (it is a
  trust-region gate); the returned metrics match the existing divergence-loss metrics
  (`pg_clipfrac` / `ppo_kl` / `pg_clipfrac_lower`).
- `verl/workers/config/actor.py` — two new `PolicyLossConfig` fields (`cppo_w_min=0.8`,
  `cppo_delta_b=0.02`); δ reuses the existing `clip_ratio` field.
- `verl/trainer/config/actor/actor.yaml` + the four `_generated_*.yaml` — config field
  declarations plus the `autogen-trainer-cfg` regeneration.
- `examples/cppo_trainer/` — `run_qwen3_30b_a3b_megatron.sh` + `README.md`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: CPPO is an algorithm/loss change; correctness is validated by the experiments above (CI has no GPU to run an RL training step), mirroring how other policy-loss variants are merged.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.