### PR TITLE
[trainer] feat: add off_policy metrics

### DIFF
--- a/tests/trainer/ppo/v2/test_replay_buffer_on_cpu.py
+++ b/tests/trainer/ppo/v2/test_replay_buffer_on_cpu.py
@@ -75,6 +75,7 @@ class PromptSpec:
     uid: str
     status: str
     sessions: int = 1
+    global_steps: int = 0
     trajectory_keys: list[str] = field(default_factory=list)
 
 
@@ -112,7 +113,7 @@ class RolloutProducer(threading.Thread):
                 tq.kv_put(
                     key=spec.uid,
                     partition_id=self.partition_id,
-                    tag={"is_prompt": True, "status": spec.status},
+                    tag={"is_prompt": True, "status": spec.status, "global_steps": spec.global_steps},
                 )
                 if self.delay:
                     time.sleep(self.delay)
@@ -215,6 +216,21 @@ def test_sync_metadata_unknown_status_raises(tq_init, partition_id):
         _clear_partition(partition_id)
 
 
+def test_sync_metadata_records_prompt_global_steps(tq_init, partition_id):
+    """The poll records each prompt's ``global_steps`` tag for staleness ordering."""
+    a = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=7)
+    b = PromptSpec(uid=_uid(), status="failure", sessions=1, global_steps=3)
+    _produce(partition_id, [a, b]).join_and_check()
+
+    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    try:
+        rb._sync_metadata_from_transfer_queue()
+
+        assert rb.prompt_global_steps[partition_id] == {a.uid: 7, b.uid: 3}
+    finally:
+        _clear_partition(partition_id)
+
+
 # --------------------------------------------------------------------------- #
 # sample: end-to-end against a real TransferQueue.
 # --------------------------------------------------------------------------- #
@@ -245,6 +261,46 @@ def test_sample_returns_finished_and_failure_trajectories(tq_init, partition_id)
         assert finished.uid not in remaining
         assert failure.uid not in remaining
         assert running.uid in remaining
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_sample_prioritizes_smallest_global_steps(tq_init, partition_id):
+    """When more prompts are ready than ``batch_size``, sample must hand out the
+    oldest ones first (smallest ``global_steps``), leaving the newer surplus."""
+    # Produced out of step order on purpose; selection must follow global_steps.
+    oldest = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=1)
+    middle = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=2)
+    newest = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=5)
+    _produce(partition_id, [newest, oldest, middle]).join_and_check()
+
+    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    try:
+        batch = rb.sample(partition_id, batch_size=2)
+
+        # The two smallest-step prompts are picked; the newest is left behind.
+        assert _uids_of(batch.keys) == {oldest.uid, middle.uid}
+
+        remaining = tq.kv_list(partition_id=partition_id).get(partition_id, {})
+        assert oldest.uid not in remaining
+        assert middle.uid not in remaining
+        assert newest.uid in remaining
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_sample_orders_by_global_steps_across_finished_and_failure(tq_init, partition_id):
+    """Ordering by ``global_steps`` spans both finished and failure prompts, not
+    just within a single status bucket."""
+    failure_old = PromptSpec(uid=_uid(), status="failure", sessions=1, global_steps=0)
+    finished_mid = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=4)
+    finished_new = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=9)
+    _produce(partition_id, [finished_new, failure_old, finished_mid]).join_and_check()
+
+    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    try:
+        batch = rb.sample(partition_id, batch_size=2)
+        assert _uids_of(batch.keys) == {failure_old.uid, finished_mid.uid}
     finally:
         _clear_partition(partition_id)
 

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -73,6 +73,8 @@ class ReplayBuffer:
         self.running_keys: dict[str, set] = defaultdict(set)
         self.finished_keys: dict[str, set] = defaultdict(set)
         self.failure_keys: dict[str, set] = defaultdict(set)
+        # partition_id => {prompt_key: global_steps}, used to prioritize older samples.
+        self.prompt_global_steps: dict[str, dict[str, int]] = defaultdict(dict)
 
     def _sync_metadata_from_transfer_queue(self):
         """Sync the metadata from TransferQueue."""
@@ -81,6 +83,7 @@ class ReplayBuffer:
         self.running_keys.clear()
         self.finished_keys.clear()
         self.failure_keys.clear()
+        self.prompt_global_steps.clear()
 
         data = tq.kv_list()
         if data is None:
@@ -91,6 +94,7 @@ class ReplayBuffer:
             for key, tag in items.items():
                 if tag.get("is_prompt", False):
                     # see: [GRPO group sampling control]
+                    self.prompt_global_steps[partition_id][key] = tag.get("global_steps", 0)
                     match tag["status"]:
                         case "pending":
                             self.pending_keys[partition_id].add(key)
@@ -137,7 +141,10 @@ class ReplayBuffer:
         # TODO: should we filter out samples with some of their sessions failed?
         finished_keys = self.finished_keys[partition_id]
         failure_keys = self.failure_keys[partition_id]
-        selected_prompt_uids = list(finished_keys.union(failure_keys))[:batch_size]
+        # Prioritize sampling the oldest prompts (smallest global_steps first) to reduce staleness.
+        prompt_global_steps = self.prompt_global_steps[partition_id]
+        sampleable_keys = sorted(finished_keys.union(failure_keys), key=lambda key: prompt_global_steps.get(key, 0))
+        selected_prompt_uids = sampleable_keys[:batch_size]
         tq.kv_clear(partition_id=partition_id, keys=selected_prompt_uids)
 
         keys, tags = [], []

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1368,8 +1368,8 @@ class PPOTrainer(ABC):
         prompt_length = data["prompts"].offsets().diff()
         response_length = data["responses"].offsets().diff()
         global_token_num = (prompt_length + response_length).tolist()
-        min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)
-        max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)
+        min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
+        max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)[non_padding_mask]
 
         # Only fetch speculative decoding stats when rollout writes them.
         spec_drafts = spec_accepts = spec_verifies = None

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -121,7 +121,7 @@ class PPOTrainer(ABC):
         2. LLMServerManager: launch and manage LLM server replicas for generation.
         3. CheckpointEngineManager: sync weights between worker group and LLM server replicas.
         4. RewardLoopManager: reward workers for rule-based reward, optional LLM server for model-based reward.
-        5. [Optional] MultiTeacherModelManager: LLM teacher servers for one-policy distillation.
+        5. [Optional] MultiTeacherModelManager: LLM teacher servers for on-policy distillation.
         """
         self._setup()
         self.on_init_end()
@@ -262,7 +262,7 @@ class PPOTrainer(ABC):
         return self.llm_server_manager.get_client()
 
     def get_teacher_client(self) -> Optional[dict[str, LLMServerClient]]:
-        """Get the One-Policy Distillation teacher server clients.
+        """Get the On-Policy Distillation teacher server clients.
 
         Returns:
             dict[str, LLMServerClient]: The teacher server clients.
@@ -1368,6 +1368,8 @@ class PPOTrainer(ABC):
         prompt_length = data["prompts"].offsets().diff()
         response_length = data["responses"].offsets().diff()
         global_token_num = (prompt_length + response_length).tolist()
+        min_global_steps = np.array([tag["min_global_steps"] for tag in batch.tags], dtype=int)
+        max_global_steps = np.array([tag["max_global_steps"] for tag in batch.tags], dtype=int)
 
         # Only fetch speculative decoding stats when rollout writes them.
         spec_drafts = spec_accepts = spec_verifies = None
@@ -1415,6 +1417,32 @@ class PPOTrainer(ABC):
         # 4. per-request speculative-decoding aggregation (same metrics async PPO logs;
         # see compute_spec_decode_metrics in verl/trainer/ppo/ray_trainer.py).
         metrics.update(compute_spec_decode_metrics(spec_drafts, spec_accepts, spec_verifies, non_padding_mask))
+
+        # 5. off-policy staleness metrics
+        #   - trajectory_spans: how many distinct model versions a single trajectory was
+        #     generated across (1 == fully generated on a single version). This captures the
+        #     within-trajectory policy inconsistency caused by partial rollout / continuation.
+        #   - trajectory_staleness: how many training steps the trajectory lags behind the
+        #     *current* policy. A trajectory spans versions [min_global_steps, max_global_steps],
+        #     so the lag is a range: the freshest weights used give the lower bound
+        #     (global_steps - max_global_steps) and the oldest weights the worst case
+        #     (global_steps - min_global_steps). We log the lower bound as the primary metric.
+        trajectory_spans = max_global_steps - min_global_steps + 1
+        trajectory_staleness = (global_steps - 1) - max_global_steps
+        trajectory_staleness_worst = (global_steps - 1) - min_global_steps
+        metrics.update(
+            {
+                "training/off_policy/trajectory_spans/mean": trajectory_spans.mean(),
+                "training/off_policy/trajectory_spans/max": trajectory_spans.max(),
+                "training/off_policy/trajectory_spans/min": trajectory_spans.min(),
+                "training/off_policy/trajectory_staleness/mean": trajectory_staleness.mean(),
+                "training/off_policy/trajectory_staleness/max": trajectory_staleness.max(),
+                "training/off_policy/trajectory_staleness/min": trajectory_staleness.min(),
+                "training/off_policy/trajectory_staleness_worst/mean": trajectory_staleness_worst.mean(),
+                "training/off_policy/trajectory_staleness_worst/max": trajectory_staleness_worst.max(),
+                "training/off_policy/trajectory_staleness_worst/min": trajectory_staleness_worst.min(),
+            }
+        )
 
 
 TRAINER_REGISTRY: dict[str, type[PPOTrainer]] = {}

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -313,9 +313,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                     break
 
             # 4. check stop reason
-            if output.stop_reason not in ("aborted", "abort") or not (
-                hasattr(self.config, "async_training") and self.config.async_training.partial_rollout
-            ):
+            if output.stop_reason not in ("aborted", "abort"):
                 break
 
             await asyncio.sleep(1)

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -217,6 +217,9 @@ class LLMServerClient:
                 **multimodal_kwargs,
                 **kwargs,
             )
+            global_steps = output.extra_fields.get("global_steps")
+            output.extra_fields.setdefault("min_global_steps", global_steps)
+            output.extra_fields.setdefault("max_global_steps", global_steps)
             return output
         finally:
             self._release_server(server_id)

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -551,6 +551,7 @@ class vLLMHttpServer:
             final_res = output
         assert final_res is not None
 
+        extra_fields = {"global_steps": self.global_steps}
         # Handle abort case: when the request is aborted by pause_generation(abort),
         # outputs may be empty. Return empty results with stop_reason="aborted"
         # instead of crashing with "IndexError: list index out of range".
@@ -560,9 +561,9 @@ class vLLMHttpServer:
                 log_probs=None,
                 routed_experts=None,
                 stop_reason="aborted",
+                extra_fields=extra_fields,
             )
 
-        extra_fields = {"global_steps": self.global_steps}
         extract_prompt_logprobs(
             output=final_res,
             num_prompt_logprobs=sampling_params.prompt_logprobs,


### PR DESCRIPTION
### What does this PR do?

1. Add `training/off_policy` metrics
2. Prioritize replay_buffer sampling by smallest `global_steps` first to reduce staleness.
3. Fix `FullyAsyncLLMServerClient` not retry on abort