### PR TITLE
[fsdp, veomni] fix: wire fused top-k distillation outputs

### DIFF
--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -162,6 +162,85 @@ def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
         )
 
 
+_FUSED_DISTILLATION_KEYS = ("distillation_losses", "student_mass", "teacher_mass")
+
+
+def test_fused_topk_distillation_aux_outputs_are_required_and_emitted():
+    """Fused top-k distillation must surface VeOmni aux outputs.
+
+    If the model forward did not receive teacher_topk_ids / teacher_topk_log_probs,
+    VeOmni's fused loss will not populate fused_linear_aux; failing closed here is
+    better than silently dropping the distillation loss.
+    """
+    total_nnz = 5
+    cu_seqlens = torch.tensor([0, 2, total_nnz], dtype=torch.int64)
+    input_ids_nested = torch.nested.nested_tensor_from_jagged(torch.arange(total_nnz), offsets=cu_seqlens)
+
+    output = SimpleNamespace(
+        log_probs=torch.zeros(1, total_nnz),
+        entropy=torch.zeros(1, total_nnz),
+        fused_linear_aux=SimpleNamespace(
+            distillation_losses=(torch.arange(total_nnz, dtype=torch.float32) + 10).unsqueeze(0),
+            student_mass=(torch.arange(total_nnz, dtype=torch.float32) + 20).unsqueeze(0),
+            teacher_mass=(torch.arange(total_nnz, dtype=torch.float32) + 30).unsqueeze(0),
+        ),
+    )
+    micro_batch = TensorDict({"input_ids": input_ids_nested}, batch_size=[])
+    tu.assign_non_tensor(
+        micro_batch,
+        use_remove_padding=True,
+        pad_mode=DatasetPadMode.NO_PADDING,
+        use_fused_kernels=True,
+        calculate_entropy=False,
+        calculate_sum_pi_squared=False,
+        distillation_use_topk=True,
+    )
+
+    model_output = FSDPEngineWithLMHead.prepare_model_outputs(
+        _make_engine_stub(),
+        output=output,
+        output_args={"input_ids_rmpad_rolled": torch.arange(total_nnz), "temperature_rmpad": torch.ones(total_nnz)},
+        micro_batch=micro_batch,
+        logits_processor_func=_make_logits_processor(()),
+    )
+
+    for k in _FUSED_DISTILLATION_KEYS:
+        assert k in model_output
+        assert model_output[k].is_nested
+    torch.testing.assert_close(model_output["distillation_losses"].values(), torch.arange(total_nnz) + 10)
+
+
+def test_fused_topk_distillation_missing_aux_outputs_raises():
+    total_nnz = 3
+    cu_seqlens = torch.tensor([0, total_nnz], dtype=torch.int64)
+    input_ids_nested = torch.nested.nested_tensor_from_jagged(torch.arange(total_nnz), offsets=cu_seqlens)
+    micro_batch = TensorDict({"input_ids": input_ids_nested}, batch_size=[])
+    tu.assign_non_tensor(
+        micro_batch,
+        use_remove_padding=True,
+        pad_mode=DatasetPadMode.NO_PADDING,
+        use_fused_kernels=True,
+        calculate_entropy=False,
+        calculate_sum_pi_squared=False,
+        distillation_use_topk=True,
+    )
+    output = SimpleNamespace(
+        log_probs=torch.zeros(1, total_nnz), entropy=torch.zeros(1, total_nnz), fused_linear_aux=None
+    )
+
+    with pytest.raises(AssertionError, match="teacher_topk_ids/teacher_topk_log_probs"):
+        FSDPEngineWithLMHead.prepare_model_outputs(
+            _make_engine_stub(),
+            output=output,
+            output_args={
+                "input_ids_rmpad_rolled": torch.arange(total_nnz),
+                "temperature_rmpad": torch.ones(total_nnz),
+            },
+            micro_batch=micro_batch,
+            logits_processor_func=_make_logits_processor(()),
+        )
+
+
 def _nested_from_rows(rows):
     values = torch.tensor(rows)
     offsets = torch.tensor([0, len(rows)], dtype=torch.int64)

--- a/tests/workers/test_router_replay_engine_helpers_on_cpu.py
+++ b/tests/workers/test_router_replay_engine_helpers_on_cpu.py
@@ -37,7 +37,8 @@ multi-rank SP all-gather, end-to-end forward through the patched
 """
 
 import sys
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -108,6 +109,75 @@ def _make_engine_with_controller(
 @pytest.fixture
 def controller():
     return VeOmniRouterReplay()
+
+
+class TestVeOmniTopKDistillationInputs:
+    """Teacher top-k passthrough for VeOmni's fused distillation path."""
+
+    @staticmethod
+    def _make_engine() -> VeOmniEngineWithLMHead:
+        engine = _make_engine_with_controller(controller=None)
+        engine.use_ulysses_sp = False
+        engine.module = SimpleNamespace(config=SimpleNamespace(model_type="dummy"))
+        return engine
+
+    @staticmethod
+    def _base_prepare_outputs(total_nnz: int):
+        model_inputs = {
+            "input_ids": torch.arange(total_nnz, dtype=torch.int64).unsqueeze(0),
+            "attention_mask": None,
+            "position_ids": None,
+        }
+        output_args = {"input_ids_rmpad_rolled": torch.arange(total_nnz, dtype=torch.int64)}
+        return model_inputs, output_args
+
+    def test_prepare_model_inputs_forwards_nested_teacher_topk_and_clamp(self):
+        total_nnz, topk = 4, 2
+        offsets = torch.tensor([0, total_nnz], dtype=torch.int64)
+        teacher_ids_values = torch.arange(total_nnz * topk, dtype=torch.int64).reshape(total_nnz, topk)
+        teacher_logprobs_values = torch.randn(total_nnz, topk)
+        teacher_ids = torch.nested.nested_tensor_from_jagged(teacher_ids_values, offsets=offsets)
+        teacher_logprobs = torch.nested.nested_tensor_from_jagged(teacher_logprobs_values, offsets=offsets)
+        micro_batch = TensorDict(
+            {"teacher_ids": teacher_ids, "teacher_logprobs": teacher_logprobs},
+            batch_size=[],
+        )
+        micro_batch.set_non_tensor("use_remove_padding", True)
+        micro_batch.set_non_tensor("use_fused_kernels", True)
+        micro_batch.set_non_tensor("distillation_use_topk", True)
+        micro_batch.set_non_tensor("log_prob_min_clamp", -7.0)
+
+        with patch(
+            "verl.workers.engine.fsdp.transformer_impl.FSDPEngineWithLMHead.prepare_model_inputs",
+            return_value=self._base_prepare_outputs(total_nnz),
+        ):
+            model_inputs, _ = VeOmniEngineWithLMHead.prepare_model_inputs(self._make_engine(), micro_batch)
+
+        assert model_inputs["return_log_probs"] is True
+        assert torch.equal(model_inputs["teacher_topk_ids"], teacher_ids_values.unsqueeze(0))
+        assert torch.equal(model_inputs["teacher_topk_log_probs"], teacher_logprobs_values.unsqueeze(0))
+        assert model_inputs["log_prob_min_clamp"] == -7.0
+
+    def test_prepare_model_inputs_accepts_prermpad_teacher_topk_tensors(self):
+        total_nnz, topk = 4, 2
+        teacher_ids = torch.arange(total_nnz * topk, dtype=torch.int64).reshape(1, total_nnz, topk)
+        teacher_logprobs = torch.randn(1, total_nnz, topk)
+        micro_batch = TensorDict(
+            {"teacher_ids": teacher_ids, "teacher_logprobs": teacher_logprobs},
+            batch_size=[],
+        )
+        micro_batch.set_non_tensor("use_remove_padding", True)
+        micro_batch.set_non_tensor("use_fused_kernels", True)
+        micro_batch.set_non_tensor("distillation_use_topk", True)
+
+        with patch(
+            "verl.workers.engine.fsdp.transformer_impl.FSDPEngineWithLMHead.prepare_model_inputs",
+            return_value=self._base_prepare_outputs(total_nnz),
+        ):
+            model_inputs, _ = VeOmniEngineWithLMHead.prepare_model_inputs(self._make_engine(), micro_batch)
+
+        assert model_inputs["teacher_topk_ids"] is teacher_ids
+        assert model_inputs["teacher_topk_log_probs"] is teacher_logprobs
 
 
 # ===========================================================

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1102,14 +1102,19 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 # same model_output keys as the eager logit-processor path.
                 if distillation_use_topk:
                     aux_outputs = getattr(output, "fused_linear_aux", None)
-                    if aux_outputs is not None and aux_outputs.distillation_losses is not None:
-                        cu_seqlens = input_ids.offsets()
-                        for field_name in ("distillation_losses", "student_mass", "teacher_mass"):
-                            v = getattr(aux_outputs, field_name).squeeze(0)
-                            if self.use_ulysses_sp:
-                                pad_size = output_args["pad_size"]
-                                v = gather_outputs_and_unpad(v, gather_dim=0, unpad_dim=0, padding_size=pad_size)
-                            model_output[field_name] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
+                    assert aux_outputs is not None and aux_outputs.distillation_losses is not None, (
+                        "distillation_use_topk=True requires the model.forward to be invoked with "
+                        "teacher_topk_ids/teacher_topk_log_probs (see VeOmniEngineWithLMHead."
+                        "prepare_model_inputs) so VeOmni's chunk_topk_distill kernel populates "
+                        "fused_linear_aux.distillation_losses / student_mass / teacher_mass."
+                    )
+                    cu_seqlens = input_ids.offsets()
+                    for field_name in ("distillation_losses", "student_mass", "teacher_mass"):
+                        v = getattr(aux_outputs, field_name).squeeze(0)
+                        if self.use_ulysses_sp:
+                            pad_size = output_args["pad_size"]
+                            v = gather_outputs_and_unpad(v, gather_dim=0, unpad_dim=0, padding_size=pad_size)
+                        model_output[field_name] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
             else:
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
                 logits_rmpad.div_(temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -876,8 +876,18 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
                         "both must be provided together for fused top-K distillation."
                     )
                 # Kernel kwarg names follow veomni's chunk_topk_distill_function API.
-                teacher_topk_ids = micro_batch["teacher_ids"].values().unsqueeze(0)
-                teacher_topk_log_probs = micro_batch["teacher_logprobs"].values().unsqueeze(0)
+                teacher_ids = micro_batch["teacher_ids"]
+                teacher_logprobs = micro_batch["teacher_logprobs"]
+                if teacher_ids.is_nested:
+                    teacher_topk_ids = teacher_ids.values().unsqueeze(0)
+                    teacher_topk_log_probs = teacher_logprobs.values().unsqueeze(0)
+                else:
+                    # Tensors may already be in the rmpad [1, total_nnz, K]
+                    # layout expected by VeOmni (for example when the caller has
+                    # preprocessed the distillation batch). Avoid assuming a
+                    # NestedTensor-only representation.
+                    teacher_topk_ids = teacher_ids
+                    teacher_topk_log_probs = teacher_logprobs
                 # SP-slice along seqlen (dim=1); teacher tensors are 3D
                 # (1, total_nnz, K) so use slice_input_tensor directly —
                 # ulysses_pad_and_slice_inputs hardcodes 2D.
@@ -888,6 +898,9 @@ class VeOmniEngineWithLMHead(VeOmniEngine, FSDPEngineWithLMHead):
                     teacher_topk_log_probs = slice_input_tensor(teacher_topk_log_probs, dim=1, padding=True)
                 model_inputs["teacher_topk_ids"] = teacher_topk_ids
                 model_inputs["teacher_topk_log_probs"] = teacher_topk_log_probs
+                clamp = tu.get_non_tensor_data(data=micro_batch, key="log_prob_min_clamp", default=None)
+                if clamp is not None:
+                    model_inputs["log_prob_min_clamp"] = clamp
 
         # Router replay plumbing. Two responsibilities:
         #   (1) snapshot the ulysses pad_size for this micro-batch so


### PR DESCRIPTION
### What does this PR do?

This PR fixes the VeOmni fused-kernel path for top-k forward-KL distillation.

When `distillation_use_topk=True` with `use_fused_kernels=True`, VeOmni's patched causal LM loss can compute per-token top-k distillation auxiliary outputs through `chunk_topk_distill_function`. This PR wires the missing pieces so those outputs are correctly produced and consumed by verl:

- forwards `teacher_ids` / `teacher_logprobs` into VeOmni model forward as `teacher_topk_ids` / `teacher_topk_log_probs`;
- supports both jagged NestedTensor teacher tensors and already-rmpad teacher tensors;
- forwards optional `log_prob_min_clamp`;
- fails closed if fused top-k distillation is requested but `fused_linear_aux` does not contain the expected distillation outputs;
- adds CPU regression coverage for the fused aux-output path and VeOmni teacher top-k input passthrough.

Duplicate-work check:

- `gh pr list --repo verl-project/verl --state open --search "veomni topk distillation"` returns only this PR (`#6737`).
- `gh pr list --repo verl-project/verl --state open --search "VeOmni fused top-k distillation"` returns only this PR (`#6737`).
- `gh pr list --repo verl-project/verl --state open --search "teacher_topk_log_probs"` returns only this PR (`#6737`).

AI assistance was used to prepare this change. I reviewed the changed lines and ran the checks listed below.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+veomni+topk+distillation
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Passed:

```bash
/private/tmp/uv-cache/archive-v0/XkW9QpETjgABHVawsIv1F/ruff-0.13.2.data/scripts/ruff check \
  tests/workers/test_distillation_topk_symmetry_on_cpu.py \
  tests/workers/test_router_replay_engine_helpers_on_cpu.py \
  verl/workers/engine/fsdp/transformer_impl.py \
  verl/workers/engine/veomni/transformer_impl.py
```

```bash
/private/tmp/uv-cache/archive-v0/XkW9QpETjgABHVawsIv1F/ruff-0.13.2.data/scripts/ruff format --check \
  tests/workers/test_distillation_topk_symmetry_on_cpu.py \
  tests/workers/test_router_replay_engine_helpers_on_cpu.py \
  verl/workers/engine/fsdp/transformer_impl.py \
  verl/workers/engine/veomni/transformer_impl.py
```

```bash
PYTHONPYCACHEPREFIX=/private/tmp/verl-pycache python3 -m py_compile \
  tests/workers/test_distillation_topk_symmetry_on_cpu.py \
  tests/workers/test_router_replay_engine_helpers_on_cpu.py \
  verl/workers/engine/fsdp/transformer_impl.py \
  verl/workers/engine/veomni/transformer_impl.py
```

```bash
/Users/bytedance/Documents/VeOmni/.venv/bin/python /private/tmp/test_veomni_topk_integration.py
```

The targeted stub test passed 4 cases:

- fused distillation aux outputs are emitted as nested outputs;
- missing fused aux outputs raise a clear assertion;
- VeOmni forwards nested teacher top-k tensors and clamp config;
- VeOmni accepts already-rmpad teacher tensors.

Attempted but blocked by local environment/network:

```bash
PRE_COMMIT_HOME=/private/tmp/pre-commit-cache ./.venv/bin/pre-commit run --all-files --show-diff-on-failure --color=always
```

This failed during hook environment installation while downloading `ruff==0.12.2` with repeated `ConnectionResetError`. To partially cover this, I ran cached `ruff 0.13.2` on the changed files as shown above.

```bash
./.venv/bin/python -m pytest \
  tests/workers/test_distillation_topk_symmetry_on_cpu.py \
  tests/workers/test_router_replay_engine_helpers_on_cpu.py -q
```

This failed during collection because the ad-hoc local `.venv` lacks `ray`. Installing the full dependency set was also interrupted by network `ConnectionResetError`. The PR adds CPU regression tests that should run in the normal verl CI environment.

### API and Usage Example

No public API change.

This change affects the existing internal distillation path when the batch metadata enables:

```python
distillation_use_topk = True
use_fused_kernels = True
use_remove_padding = True
```

and the micro-batch contains:

```python
teacher_ids
teacher_logprobs
# optional:
log_prob_min_clamp
```

### Design & Code Changes

- `verl/workers/engine/veomni/transformer_impl.py`
  - Converts `teacher_ids` / `teacher_logprobs` into VeOmni kernel argument names:
    - `teacher_topk_ids`
    - `teacher_topk_log_probs`
  - Handles both jagged NestedTensor and pre-rmpad tensor layouts.
  - Preserves existing Ulysses SP slicing behavior.
  - Passes optional `log_prob_min_clamp`.

- `verl/workers/engine/fsdp/transformer_impl.py`
  - In the fused-kernel top-k distillation branch, requires `output.fused_linear_aux.distillation_losses` to exist.
  - Converts fused auxiliary outputs into nested model outputs:
    - `distillation_losses`
    - `student_mass`
    - `teacher_mass`

- Tests
  - Adds FSDP fused-output regression coverage to `tests/workers/test_distillation_topk_symmetry_on_cpu.py`.
  - Adds VeOmni teacher top-k passthrough coverage to `tests/workers/test_router_replay_engine_helpers_on_cpu.py`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Attempted, but local hook environment installation repeatedly failed while downloading `ruff==0.12.2` with `ConnectionResetError`. Changed files were checked with cached `ruff 0.13.2` and `py_compile`.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not applicable: this is an internal engine wiring fix with no public API or user-facing documentation change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: added CPU regression tests in existing worker test files; no workflow changes needed because these files are under the existing test tree.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable: this PR does not touch `recipe`.
