### PR TITLE
[rollout] fix: skip redundant clone in get_named_tensor_buckets to avoid OOM during SGLang weight sync

### DIFF
--- a/tests/workers/rollout/test_sglang_rollout_sharding_manager.py
+++ b/tests/workers/rollout/test_sglang_rollout_sharding_manager.py
@@ -16,7 +16,7 @@
 import pytest
 import torch
 
-from verl.workers.rollout.sglang_rollout.utils import get_named_tensor_buckets
+from verl.workers.rollout.sglang_rollout.utils import _compact_for_bucket, get_named_tensor_buckets
 
 _TENSOR_1MB = torch.zeros(512, 512)
 _BYTES_1MB = 1 << 20
@@ -56,3 +56,45 @@ async def test_get_named_tensor_buckets(named_tensors, bucket_size_mb, gt_groups
         assert len(group) == len(gt_group)
         for (name, _), (gt_name) in zip(group, gt_group, strict=True):
             assert name == gt_name
+
+
+def test_compact_for_bucket_skips_clone_for_owned_contiguous_tensor():
+    # A freshly-allocated contiguous tensor owns tight storage (the DTensor.full_tensor() case).
+    # It must be returned as-is so bucketing does not transiently double its peak memory.
+    tensor = torch.randn(128, 64)
+    assert _compact_for_bucket(tensor) is tensor
+
+
+def test_compact_for_bucket_clones_view_into_larger_buffer():
+    # A contiguous view that spans only part of a larger backing buffer must be compacted,
+    # otherwise the whole buffer stays resident / gets shipped.
+    base = torch.randn(256, 64)
+    view = base[:128]
+    assert view.is_contiguous()
+    out = _compact_for_bucket(view)
+    assert out is not view
+    assert out.untyped_storage().nbytes() == out.numel() * out.element_size()
+    assert torch.equal(out, view)
+
+
+def test_compact_for_bucket_clones_non_contiguous_tensor():
+    tensor = torch.randn(64, 128).t()
+    assert not tensor.is_contiguous()
+    out = _compact_for_bucket(tensor)
+    assert out is not tensor
+    assert out.data_ptr() != tensor.data_ptr()  # cloned into its own fresh storage
+    assert torch.equal(out, tensor)
+
+
+@pytest.mark.asyncio
+async def test_get_named_tensor_buckets_preserves_values():
+    # The conditional clone must not change the data that ends up in the buckets.
+    named_tensors = [("a", torch.randn(64, 64)), ("b", torch.randn(64, 64)), ("c", torch.randn(64, 64))]
+    expected = {name: tensor.clone() for name, tensor in named_tensors}
+    flat = {}
+    async for group in get_named_tensor_buckets(iter(named_tensors), 0.5 * _BYTES_1MB):
+        for name, tensor in group:
+            flat[name] = tensor
+    assert set(flat) == set(expected)
+    for name, tensor in expected.items():
+        assert torch.equal(flat[name], tensor)

--- a/verl/workers/rollout/sglang_rollout/utils.py
+++ b/verl/workers/rollout/sglang_rollout/utils.py
@@ -71,6 +71,24 @@ def broadcast_pyobj(
         return data
 
 
+def _compact_for_bucket(tensor: torch.Tensor) -> torch.Tensor:
+    """Return a tensor safe to retain in a weight-sync bucket without pinning extra memory.
+
+    ``get_named_tensor_buckets`` keeps every tensor alive until its bucket is flushed. A tensor
+    that is a *view* into a larger backing buffer would therefore keep that whole buffer resident
+    (and ship the whole buffer downstream), so such views must be compacted with ``clone()``.
+
+    However the weights synced here come from ``DTensor.full_tensor()`` (a fresh all-gather) and
+    already own tight, contiguous storage. Cloning those allocates a second full-size buffer and
+    transiently doubles the tensor's footprint -- which OOMs on multi-GiB fused MoE weights
+    (e.g. ``[num_experts, ...]`` ``gate_up_proj``/``qkv``) while the actor params and rollout
+    weights are both already resident. Skip the clone when the tensor already owns its storage.
+    """
+    if tensor.is_contiguous() and tensor.untyped_storage().nbytes() == tensor.numel() * tensor.element_size():
+        return tensor
+    return tensor.clone()
+
+
 async def get_named_tensor_buckets(
     iterable: Iterator[tuple[str, torch.Tensor]], bucket_bytes: int
 ) -> Iterator[list[tuple[str, torch.Tensor]]]:
@@ -101,10 +119,10 @@ async def get_named_tensor_buckets(
         if current_size + tensor_size > bucket_bytes:
             if current_bucket:
                 yield current_bucket
-            current_bucket = [(name, tensor.clone())]
+            current_bucket = [(name, _compact_for_bucket(tensor))]
             current_size = tensor_size
         else:
-            current_bucket.append((name, tensor.clone()))
+            current_bucket.append((name, _compact_for_bucket(tensor)))
             current_size += tensor_size
 
     if current_bucket:


### PR DESCRIPTION
### What does this PR do?

`get_named_tensor_buckets` (`verl/workers/rollout/sglang_rollout/utils.py`) unconditionally `clone()`d every tensor before bucketing it for the SGLang actor→rollout weight sync. The clone is only needed to **compact a tensor that is a view into a larger backing buffer** (so the buffer can be released and we don't ship it whole). A tensor that already owns tight, contiguous storage — the `DTensor.full_tensor()` all-gather case — is cloned for nothing, which transiently doubles its footprint and OOMs on multi-GiB fused MoE weights (`gate_up_proj`/`qkv`) while the actor params and the rollout weights are both resident.

This clones only when the tensor is non-contiguous or backed by larger storage:

```python
if tensor.is_contiguous() and tensor.untyped_storage().nbytes() == tensor.numel() * tensor.element_size():
    return tensor          # already owns tight storage; cloning would only double peak memory
return tensor.clone()
```

Fixes #6733.

### Why this is not a duplicate

Checked the #6733 timeline and searched open PRs touching `get_named_tensor_buckets` / the sglang bucket clone — none in flight (#5599 and #5514 match on keywords but are unrelated Megatron LoRA/atropos work).

### Safety analysis (this *removes* a clone, so worth spelling out)

The two weight sources feeding this function:

- **FSDP** (`get_per_tensor_param` → `DTensor.full_tensor()`): each param is a fresh all-gather allocation that owns tight contiguous storage and is kept alive by the bucket. Skipping the clone is safe and is exactly the OOM case reported.
- **Megatron** (`per_tensor_generator`): the large fused weights (MoE experts, qkv/gate_up) are **slices of a `full_tensor`** → `storage > footprint` → still cloned by the predicate (no behavior change). The remaining tight tensors come from per-iteration-fresh `torch.empty_like` all-gather buffers, or from the live (frozen-during-sync) model param on the src PP rank — neither is reused before the bucket is `await`ed, so skipping the clone is safe.

I don't have a multi-GPU Megatron cluster to run end-to-end, so a maintainer sanity-check that no rollout/checkpoint path feeds a *reused, tight-storage* buffer into this function would be appreciated.

### Test

Added to `tests/workers/rollout/test_sglang_rollout_sharding_manager.py`:
- `test_compact_for_bucket_skips_clone_for_owned_contiguous_tensor` — tight tensor returned as-is (same `data_ptr`, no extra allocation).
- `test_compact_for_bucket_clones_view_into_larger_buffer` — a slice of a larger tensor is compacted; values preserved.
- `test_compact_for_bucket_clones_non_contiguous_tensor` — non-contiguous tensor cloned into its own storage; values preserved.
- `test_get_named_tensor_buckets_preserves_values` — bucketing still preserves all names/values.

Verified the logic on CPU (torch only, no GPU):

```
PASS  owned-contiguous tight tensor -> returned as-is (no clone, no extra alloc)
PASS  contiguous view into larger buffer -> cloned+compacted, values equal
PASS  non-contiguous tensor -> cloned, values equal
PASS  bucketing preserves all names and values
```

The GPU OOM repro itself needs the full actor+SGLang RL stack, which is best left to verl's GPU CI.

### AI assistance

This change was developed with AI assistance (Claude). I reviewed every line, did the safety analysis above, and ran the CPU tests myself.
