### PR TITLE
[worker] feat: add per-step optimizer param overrides

### DIFF
--- a/tests/models/test_engine.py
+++ b/tests/models/test_engine.py
@@ -57,7 +57,12 @@ from verl.workers.config import (
     McoreOptimizerConfig,
 )
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
-from verl.workers.engine_workers_tinker import TinkerActorRolloutRefWorker, TinkerTrainingWorker
+from verl.workers.engine_workers_tinker import (
+    OptimStepParams,
+    TinkerActorRolloutRefWorker,
+    TinkerTrainingWorker,
+    _apply_optim_step_params,
+)
 from verl.workers.utils.losses import ppo_loss, sft_loss, value_loss
 from verl.workers.utils.padding import left_right_2_no_padding, no_padding_2_padding
 
@@ -670,10 +675,22 @@ def _split_training_primitives_fsdp_worker(
     assert grad_norm_2.item() > grad_norm_1.item() * 1.5
     assert _param_delta_norm(engine.module, before).item() == pytest.approx(0.0, abs=0.0)
 
+    optim_step_params: OptimStepParams = {
+        "lr": 5e-4,
+        "betas": (0.8, 0.9),
+        "eps": 1e-7,
+        "weight_decay": 0.02,
+    }
     with engine.train_mode(zero_grad_on_exit=True):
+        _apply_optim_step_params(engine.optimizer, optim_step_params)
         grad_norm = engine.optimizer_step()
 
     assert grad_norm > 0
+    for param_group in engine.optimizer.param_groups:
+        assert param_group["lr"] == pytest.approx(optim_step_params["lr"])
+        assert param_group["betas"] == pytest.approx(optim_step_params["betas"])
+        assert param_group["eps"] == pytest.approx(optim_step_params["eps"])
+        assert param_group["weight_decay"] == pytest.approx(optim_step_params["weight_decay"])
     assert _param_delta_norm(engine.module, before).item() > 0
     assert not _has_any_grad(engine.module)
 

--- a/verl/workers/engine_workers_tinker.py
+++ b/verl/workers/engine_workers_tinker.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import TypedDict
+
 from codetiming import Timer
 from tensordict import TensorDict
 
@@ -19,6 +21,90 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.profiler import DistProfiler
 from verl.utils.tensordict_utils import maybe_fix_3d_position_ids
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker
+
+
+class OptimStepParams(TypedDict, total=False):
+    """Runtime param-group override for Tinker-style optimizer steps.
+
+    This payload is only consumed by ``TinkerTrainingWorker.optimizer_step``. It is
+    not part of the generic engine API, does not participate in optimizer
+    construction, and does not configure LR scheduler behavior. Tinker callers
+    that own scheduling should pass the resulting optimizer values here.
+
+    The current implementation applies each provided key to all optimizer param
+    groups before one explicit optimizer step. For VeOmni MultiOptimizer, the
+    Tinker worker flattens the wrapped optimizers' param groups and applies the
+    same global override. Optimizer-specific or group-specific overrides require a
+    different payload shape.
+    """
+
+    lr: float
+    eps: float
+    betas: tuple[float, float]
+    weight_decay: float
+
+
+def _iter_optimizer_param_groups(optimizer):
+    """Return a flat list of param groups, including VeOmni MultiOptimizer children."""
+    if getattr(optimizer, "_is_multi_optimizer", False):
+        optimizers = optimizer.optimizers_dict.values()
+    else:
+        optimizers = [optimizer]
+
+    param_groups = []
+    for opt in optimizers:
+        opt_param_groups = getattr(opt, "param_groups", None)
+        if opt_param_groups is None:
+            raise NotImplementedError(
+                f"{type(opt).__name__} does not expose param_groups for per-step optimizer params"
+            )
+        param_groups.extend(opt_param_groups)
+    return param_groups
+
+
+def _apply_optim_step_params(optimizer, optim_step_params: OptimStepParams | None) -> None:
+    """Apply a Tinker step-time override to every optimizer param group.
+
+    The override is intentionally global: every provided key must exist with the
+    same value type on all param groups. This keeps mixed optimizers such as
+    VeOmni Muon+AdamW fail-fast for optimizer-specific keys like ``betas`` while
+    still allowing shared keys such as ``lr``.
+    """
+    if optim_step_params is None:
+        return
+
+    if hasattr(optim_step_params, "to_dict"):
+        optim_step_params = optim_step_params.to_dict()
+    if not isinstance(optim_step_params, dict):
+        raise TypeError(f"optim_step_params must be a dict, got {type(optim_step_params)}")
+
+    normalized_params = {key: value for key, value in optim_step_params.items() if value is not None}
+    if not normalized_params:
+        return
+
+    param_groups = _iter_optimizer_param_groups(optimizer)
+    if not param_groups:
+        raise ValueError(f"{type(optimizer).__name__} does not have param_groups")
+
+    for key, value in normalized_params.items():
+        if key not in param_groups[0]:
+            raise ValueError(f"{type(optimizer).__name__} does not support optim_step_params key: {key!r}")
+
+        expected_type = type(param_groups[0][key])
+        if not isinstance(value, expected_type):
+            raise TypeError(
+                f"optim_step_params type mismatch for {type(optimizer).__name__}: "
+                f"{key!r} got {type(value).__name__}, expected {expected_type.__name__}"
+            )
+
+        for param_group in param_groups:
+            if key not in param_group:
+                raise ValueError(f"{type(optimizer).__name__} has inconsistent param_group key: {key!r}")
+            if not isinstance(param_group[key], expected_type):
+                raise TypeError(f"{type(optimizer).__name__} has inconsistent param_group type for {key!r}")
+
+    for param_group in param_groups:
+        param_group.update(normalized_params)
 
 
 class TinkerTrainingWorker(TrainingWorker):
@@ -84,16 +170,15 @@ class TinkerTrainingWorker(TrainingWorker):
         return final_output
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def optimizer_step(self, update_lr_scheduler: bool = True) -> dict:
+    def optimizer_step(self, optim_step_params: OptimStepParams | None = None) -> dict:
+        """Run one Tinker optimizer step with an optional global param-group override."""
         with self.engine.train_mode(zero_grad_on_exit=True):
+            _apply_optim_step_params(self.engine.optimizer, optim_step_params)
             grad_norm = self.engine.optimizer_step()
-            lr = self.engine.lr_scheduler_step() if update_lr_scheduler else None
 
         metrics = {}
         if grad_norm is not None and self.engine.is_mp_src_rank_with_outputs():
             metrics["grad_norm"] = grad_norm
-        if lr is not None and self.engine.is_mp_src_rank_with_outputs():
-            metrics["lr"] = lr
         return metrics
 
 
@@ -107,13 +192,13 @@ class TinkerActorRolloutRefWorker(ActorRolloutRefWorker):
         assert "actor" in self.role, "optimizer_zero_grad only support actor role"
         return self.actor.optimizer_zero_grad()
 
-    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="train"), blocking=False)
+    @register(dispatch_mode=make_nd_compute_dataproto_dispatch_fn(mesh_name="actor"), blocking=False)
     def forward_backward(self, data: TensorDict) -> TensorDict:
         assert "actor" in self.role, "forward_backward only support actor role"
         output = self.actor.forward_backward(data=data)
         return output.cpu() if output is not None else None
 
     @register(dispatch_mode=Dispatch.ONE_TO_ALL)
-    def optimizer_step(self, update_lr_scheduler: bool = True) -> dict:
+    def optimizer_step(self, optim_step_params: OptimStepParams | None = None) -> dict:
         assert "actor" in self.role, "optimizer_step only support actor role"
-        return self.actor.optimizer_step(update_lr_scheduler=update_lr_scheduler)
+        return self.actor.optimizer_step(optim_step_params=optim_step_params)


### PR DESCRIPTION
## Summary

This PR extends the Tinker-style worker primitives from #6717 with optional optimizer step parameters for callers that drive optimizer stepping explicitly.

- Add `OptimStepParams`, a lightweight Tinker-worker-local runtime payload for optimizer param-group values such as `lr`, `betas`, `eps`, and `weight_decay`.
- Keep the params scoped to `TinkerTrainingWorker.optimizer_step()` rather than the generic engine API, so regular `TrainingWorker.train_batch()` and backend `optimizer_step()` implementations remain unchanged.
- Apply params directly to optimizer param groups immediately before the explicit optimizer step, with runtime key/type checks against the actual optimizer param groups.
- Flatten VeOmni `MultiOptimizer` child optimizer param groups for global params while failing fast for optimizer-specific or group-specific keys.
- Leave LR scheduler ownership to the caller on the Tinker worker path; callers can pass scheduled optimizer values through `optim_step_params`.
- Fix `TinkerActorRolloutRefWorker.forward_backward()` to dispatch on the `actor` mesh at the composite worker layer.

The default training path remains unchanged:

```python
worker.train_batch(data)
```

Callers using the Tinker worker can optionally pass optimizer step params for an explicit step:

```python
worker.optimizer_zero_grad()
worker.forward_backward(data_1)
worker.forward_backward(data_2)
worker.optimizer_step(optim_step_params={"lr": 5e-4})
```

## Tests

- `uvx ruff format --check tests/models/test_engine.py verl/workers/engine_workers_tinker.py`
- `uvx ruff check tests/models/test_engine.py verl/workers/engine_workers_tinker.py`
- `source .venv/bin/activate && python -m py_compile tests/models/test_engine.py verl/workers/engine_workers_tinker.py`

Note: local targeted pytest was not runnable because this checkout's `.venv` does not include `pytest`.