### PR TITLE
[trainer] feat: support staleness control strategy

### DIFF
--- a/tests/trainer/ppo/v2/test_replay_buffer_on_cpu.py
+++ b/tests/trainer/ppo/v2/test_replay_buffer_on_cpu.py
@@ -11,12 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for :class:`verl.trainer.ppo.v2.replay_buffer.ReplayBuffer`.
+"""Unit tests for :class:`verl.trainer.ppo.v1.replay_buffer.ReplayBuffer`.
 
 The tests run against a real (CPU-only) TransferQueue instance. ``ReplayBuffer``
 is fully synchronous: :meth:`ReplayBuffer.sample` blocks the calling thread,
-re-polling TransferQueue every ``poll_interval`` seconds until ``batch_size``
-terminal (``finished``/``failure``) prompts are available.
+re-polling TransferQueue every ``poll_interval`` seconds until enough terminal
+(``finished``/``failure``) prompts are available, then returns a
+``(KVBatchMeta, metrics)`` tuple.
 
 To exercise the blocking consumer without deadlocking the test, the *producer*
 side -- the rollout that feeds TransferQueue -- runs in a dedicated thread (see
@@ -27,6 +28,17 @@ so the consumer never observes a terminal prompt before its trajectories exist.
 Each test uses a unique ``partition_id`` so that data written by one test never
 leaks into another (``_sync_metadata_from_transfer_queue`` lists *all*
 partitions, but ``ReplayBuffer`` tracks keys per partition).
+
+### Off-policy control
+
+``ReplayBuffer`` measures a trajectory's staleness (number of model versions it
+spans) as ``(global_steps - prompt_global_steps + 1) / parameter_sync_step`` and
+supports two strategies once a trajectory crosses ``max_off_policy_threshold``:
+
+- ``drop``: train eagerly, dropping any sampled trajectory strictly above the
+  threshold (``staleness > threshold``) and reporting drop metrics.
+- ``wait``: never drop -- block sampling while any in-flight (pending/running)
+  prompt has reached the threshold (``staleness >= threshold``).
 """
 
 import threading
@@ -58,6 +70,35 @@ def partition_id():
     return f"test-{uuid.uuid4().hex}"
 
 
+def _make_rb(
+    *,
+    max_off_policy_threshold: int = 8,
+    max_off_policy_strategy: str = "drop",
+    parameter_sync_step: int = 1,
+    poll_interval: float = POLL_INTERVAL,
+) -> ReplayBuffer:
+    """Construct a ReplayBuffer with test-friendly defaults.
+
+    Defaults (drop strategy, threshold 8, sync step 1) make the off-policy
+    filter a no-op for the generic tests that ``sample`` at ``global_steps=0``
+    over freshly produced trajectories.
+    """
+    return ReplayBuffer(
+        trainer_mode="sync",
+        trainer_config={"parameter_sync_step": parameter_sync_step},
+        max_off_policy_threshold=max_off_policy_threshold,
+        max_off_policy_strategy=max_off_policy_strategy,
+        sampler_kwargs={},
+        poll_interval=poll_interval,
+    )
+
+
+def _sample(rb: ReplayBuffer, partition_id: str, batch_size: int, global_steps: int = 0) -> KVBatchMeta:
+    """Call ``sample`` and return just the batch (dropping the metrics dict)."""
+    batch, _metrics = rb.sample(global_steps=global_steps, partition_id=partition_id, batch_size=batch_size)
+    return batch
+
+
 def _uid() -> str:
     # uid must not contain "_" because ReplayBuffer derives it via key.split("_")[0].
     return uuid.uuid4().hex
@@ -65,6 +106,20 @@ def _uid() -> str:
 
 def _trajectory_key(uid: str, session_id: int = 0, index: int = 0) -> str:
     return f"{uid}_{session_id}_{index}"
+
+
+def _set_prompt_status(partition_id: str, uid: str, status: str, global_steps: int) -> None:
+    """Transition an existing prompt to a new status (e.g. running -> finished).
+
+    Mirrors the rollout side flipping a GRPO group's status once it terminates.
+    The prompt key is rewritten in place; its trajectory values are untouched.
+    """
+    tq.kv_clear(keys=[uid], partition_id=partition_id)
+    tq.kv_put(
+        key=uid,
+        partition_id=partition_id,
+        tag={"is_prompt": True, "status": status, "global_steps": global_steps},
+    )
 
 
 @dataclass
@@ -87,6 +142,10 @@ class RolloutProducer(threading.Thread):
     consumer observes a terminal prompt, all of its trajectories are already
     present -- avoiding a producer/consumer race.
 
+    Trajectory tags carry ``global_steps`` (the dataloader dispatch step) exactly
+    like the real producer (see ``agent_loop_tq.py``); ``ReplayBuffer`` reads it
+    to decide which trajectories to drop.
+
     Uses the synchronous ``tq.kv_put`` API which is safe to call from a plain
     (non-asyncio) thread.
     """
@@ -107,7 +166,7 @@ class RolloutProducer(threading.Thread):
                         key=key,
                         partition_id=self.partition_id,
                         fields={"input_ids": torch.tensor([1, 2, 3])},
-                        tag={"is_prompt": False, "seq_len": 3},
+                        tag={"is_prompt": False, "seq_len": 3, "global_steps": spec.global_steps},
                     )
                     spec.trajectory_keys.append(key)
                 tq.kv_put(
@@ -131,17 +190,23 @@ class SampleConsumer(threading.Thread):
     """Runs the blocking ``ReplayBuffer.sample`` in a background thread so the test
     can assert that it stays blocked until the producer supplies enough data."""
 
-    def __init__(self, rb: ReplayBuffer, partition_id: str, batch_size: int):
+    def __init__(self, rb: ReplayBuffer, partition_id: str, batch_size: int, global_steps: int = 0):
         super().__init__(daemon=True)
         self.rb = rb
         self.partition_id = partition_id
         self.batch_size = batch_size
+        self.global_steps = global_steps
         self.result: KVBatchMeta | None = None
+        self.metrics: dict | None = None
         self.error: Exception | None = None
 
     def run(self) -> None:
         try:
-            self.result = self.rb.sample(self.partition_id, self.batch_size)
+            self.result, self.metrics = self.rb.sample(
+                global_steps=self.global_steps,
+                partition_id=self.partition_id,
+                batch_size=self.batch_size,
+            )
         except Exception as e:
             self.error = e
 
@@ -172,6 +237,23 @@ def _uids_of(keys: list[str]) -> set[str]:
 
 
 # --------------------------------------------------------------------------- #
+# __init__: configuration validation.
+# --------------------------------------------------------------------------- #
+
+
+def test_init_rejects_non_positive_threshold():
+    """max_off_policy_threshold must be a positive integer."""
+    with pytest.raises(AssertionError, match="max off policy threshold"):
+        _make_rb(max_off_policy_threshold=0)
+
+
+def test_init_rejects_unknown_strategy():
+    """max_off_policy_strategy must be one of {drop, wait}."""
+    with pytest.raises(AssertionError, match="max off policy strategy"):
+        _make_rb(max_off_policy_strategy="bogus")
+
+
+# --------------------------------------------------------------------------- #
 # _sync_metadata_from_transfer_queue: classification of polled metadata.
 # --------------------------------------------------------------------------- #
 
@@ -184,7 +266,7 @@ def test_sync_metadata_classifies_keys(tq_init, partition_id):
     failure = PromptSpec(uid=_uid(), status="failure", sessions=1)
     _produce(partition_id, [pending, running, finished, failure]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
         rb._sync_metadata_from_transfer_queue()
 
@@ -197,7 +279,7 @@ def test_sync_metadata_classifies_keys(tq_init, partition_id):
         expected_traj = set(running.trajectory_keys) | set(finished.trajectory_keys) | set(failure.trajectory_keys)
         assert set(rb.partitions[partition_id].keys()) == expected_traj
         for key in expected_traj:
-            assert rb.partitions[partition_id][key] == {"is_prompt": False, "seq_len": 3}
+            assert rb.partitions[partition_id][key] == {"is_prompt": False, "seq_len": 3, "global_steps": 0}
     finally:
         _clear_partition(partition_id)
 
@@ -206,7 +288,7 @@ def test_sync_metadata_unknown_status_raises(tq_init, partition_id):
     """An unrecognized prompt status is a hard error during the poll."""
     _produce(partition_id, [PromptSpec(uid=_uid(), status="bogus", sessions=0)]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
         with pytest.raises(ValueError, match="Unknown status"):
             rb._sync_metadata_from_transfer_queue()
@@ -222,13 +304,47 @@ def test_sync_metadata_records_prompt_global_steps(tq_init, partition_id):
     b = PromptSpec(uid=_uid(), status="failure", sessions=1, global_steps=3)
     _produce(partition_id, [a, b]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
         rb._sync_metadata_from_transfer_queue()
 
         assert rb.prompt_global_steps[partition_id] == {a.uid: 7, b.uid: 3}
     finally:
         _clear_partition(partition_id)
+
+
+# --------------------------------------------------------------------------- #
+# _has_enough_samples: gating logic for the two strategies (pure, no TransferQueue).
+# --------------------------------------------------------------------------- #
+
+
+def test_has_enough_samples_drop_ignores_inflight():
+    """drop gates purely on the terminal count, regardless of in-flight staleness."""
+    rb = _make_rb(max_off_policy_strategy="drop", max_off_policy_threshold=2)
+    pid = "p"
+    rb.finished_keys[pid] |= {"a", "b"}
+    # A very stale in-flight prompt must not influence the drop gate.
+    rb.running_keys[pid] |= {"c"}
+    rb.prompt_global_steps[pid]["c"] = 0
+
+    assert rb._has_enough_samples(1000, pid, batch_size=2) is True
+    assert rb._has_enough_samples(1000, pid, batch_size=3) is False
+
+
+def test_has_enough_samples_wait_blocks_on_stale_inflight():
+    """wait blocks while any in-flight prompt has reached the staleness threshold."""
+    rb = _make_rb(max_off_policy_strategy="wait", max_off_policy_threshold=2, parameter_sync_step=1)
+    pid = "p"
+    rb.finished_keys[pid] |= {"a", "b"}
+    rb.running_keys[pid] |= {"c"}
+    rb.prompt_global_steps[pid]["c"] = 0
+
+    # staleness = (g - 0 + 1) / 1; >= 2 (threshold) exactly at g == 1.
+    assert rb._has_enough_samples(global_steps=1, partition_id=pid, batch_size=2) is False
+    # g == 0 -> staleness 1 < 2 -> in-flight is fresh, terminal count suffices.
+    assert rb._has_enough_samples(global_steps=0, partition_id=pid, batch_size=2) is True
+    # wait still needs the terminal count even when nothing is stale.
+    assert rb._has_enough_samples(global_steps=0, partition_id=pid, batch_size=5) is False
 
 
 # --------------------------------------------------------------------------- #
@@ -247,9 +363,9 @@ def test_sample_returns_finished_and_failure_trajectories(tq_init, partition_id)
     _produce(partition_id, [finished, failure, running]).join_and_check()
     expected_keys = set(finished.trajectory_keys) | set(failure.trajectory_keys)
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
-        batch = rb.sample(partition_id, batch_size=2)
+        batch = _sample(rb, partition_id, batch_size=2)
 
         assert batch.partition_id == partition_id
         assert set(batch.keys) == expected_keys
@@ -274,9 +390,9 @@ def test_sample_prioritizes_smallest_global_steps(tq_init, partition_id):
     newest = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=5)
     _produce(partition_id, [newest, oldest, middle]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
-        batch = rb.sample(partition_id, batch_size=2)
+        batch = _sample(rb, partition_id, batch_size=2)
 
         # The two smallest-step prompts are picked; the newest is left behind.
         assert _uids_of(batch.keys) == {oldest.uid, middle.uid}
@@ -297,9 +413,9 @@ def test_sample_orders_by_global_steps_across_finished_and_failure(tq_init, part
     finished_new = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=9)
     _produce(partition_id, [finished_new, failure_old, finished_mid]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
-        batch = rb.sample(partition_id, batch_size=2)
+        batch = _sample(rb, partition_id, batch_size=2)
         assert _uids_of(batch.keys) == {failure_old.uid, finished_mid.uid}
     finally:
         _clear_partition(partition_id)
@@ -311,7 +427,7 @@ def test_sample_blocks_until_enough_then_unblocks(tq_init, partition_id):
     # One group ready up front -> not enough for batch_size=2.
     _produce(partition_id, [PromptSpec(uid=_uid(), status="finished", sessions=1)]).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     consumer = SampleConsumer(rb, partition_id, batch_size=2)
     try:
         consumer.start()
@@ -336,11 +452,11 @@ def test_sample_concurrent_with_streaming_producer(tq_init, partition_id):
     batch_size = 3
     specs = [PromptSpec(uid=_uid(), status="finished", sessions=2) for _ in range(batch_size)]
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     # Stream groups one-by-one with a delay; consumer blocks in sample() meanwhile.
     producer = _produce(partition_id, specs, delay=0.1)
     try:
-        batch = rb.sample(partition_id, batch_size=batch_size)
+        batch = _sample(rb, partition_id, batch_size=batch_size)
         producer.join_and_check()
 
         expected_keys = {k for spec in specs for k in spec.trajectory_keys}
@@ -359,9 +475,9 @@ def test_sync_grpo_step_returns_complete_groups(tq_init, partition_id):
     specs = [PromptSpec(uid=_uid(), status="finished", sessions=n_sessions) for _ in range(n_prompts)]
     _produce(partition_id, specs).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
-        batch = rb.sample(partition_id, batch_size=n_prompts)
+        batch = _sample(rb, partition_id, batch_size=n_prompts)
 
         # Every prompt's full GRPO group is present, nothing more, nothing less.
         assert len(batch.keys) == n_prompts * n_sessions
@@ -392,14 +508,14 @@ def test_async_overproduction_drains_in_batches_without_duplicates(tq_init, part
     _produce(partition_id, specs).join_and_check()
     all_uids = {spec.uid for spec in specs}
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
         collected_keys: list[str] = []
         consumed_uids: set[str] = set()
 
         # Drain 2 + 2 + 1 prompts across three samples.
         for bs in (batch_size, batch_size, n_prompts - 2 * batch_size):
-            batch = rb.sample(partition_id, batch_size=bs)
+            batch = _sample(rb, partition_id, batch_size=bs)
 
             sampled_uids = _uids_of(batch.keys)
             assert len(sampled_uids) == bs
@@ -427,9 +543,9 @@ def test_async_overproduction_leaves_surplus_available(tq_init, partition_id):
     specs = [PromptSpec(uid=_uid(), status="finished", sessions=1) for _ in range(n_prompts)]
     _produce(partition_id, specs).join_and_check()
 
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
-        batch = rb.sample(partition_id, batch_size=batch_size)
+        batch = _sample(rb, partition_id, batch_size=batch_size)
         sampled_uids = _uids_of(batch.keys)
         assert len(sampled_uids) == batch_size
 
@@ -447,9 +563,155 @@ def test_async_overproduction_leaves_surplus_available(tq_init, partition_id):
 def test_sample_zero_batch_size_raises_on_empty_clear(tq_init, partition_id):
     """batch_size=0 selects no prompts; clearing an empty key list is rejected by
     TransferQueue, so sample surfaces a ValueError (degenerate, documented case)."""
-    rb = ReplayBuffer(poll_interval=POLL_INTERVAL)
+    rb = _make_rb()
     try:
         with pytest.raises(ValueError, match="empty list"):
-            rb.sample(partition_id, batch_size=0)
+            _sample(rb, partition_id, batch_size=0)
+    finally:
+        _clear_partition(partition_id)
+
+
+# --------------------------------------------------------------------------- #
+# sample: off-policy "drop" strategy.
+# --------------------------------------------------------------------------- #
+
+
+def test_drop_filters_stale_trajectories_and_reports_metrics(tq_init, partition_id):
+    """drop removes sampled trajectories whose staleness strictly exceeds the
+    threshold, clears them from TransferQueue, and reports drop metrics."""
+    # staleness = (global_steps - prompt_global_steps + 1) / parameter_sync_step;
+    # drop when staleness > threshold(=2). At global_steps=5, sync=1:
+    #   stale    gs=0 -> 6 > 2 -> dropped
+    #   boundary gs=4 -> 2 not > 2 -> kept (boundary is inclusive on the keep side)
+    #   fresh    gs=5 -> 1 -> kept
+    stale = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=0)
+    boundary = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=4)
+    fresh = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=5)
+    _produce(partition_id, [stale, boundary, fresh]).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="drop", max_off_policy_threshold=2, parameter_sync_step=1)
+    try:
+        batch, metrics = rb.sample(global_steps=5, partition_id=partition_id, batch_size=3)
+
+        assert _uids_of(batch.keys) == {boundary.uid, fresh.uid}
+        assert set(batch.keys) == set(boundary.trajectory_keys) | set(fresh.trajectory_keys)
+
+        # The dropped trajectory value is removed from TransferQueue too.
+        remaining = tq.kv_list(partition_id=partition_id).get(partition_id, {})
+        assert stale.trajectory_keys[0] not in remaining
+
+        # Non-"train" partitions are reported under the "validation" prefix.
+        assert metrics["validation/off_policy/dropped_samples"] == 1
+        assert metrics["validation/off_policy/dropped_samples_staleness/mean"] == 6
+        assert metrics["validation/off_policy/dropped_samples_staleness/max"] == 6
+        assert metrics["validation/off_policy/dropped_samples_staleness/min"] == 6
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_drop_keeps_all_within_threshold_without_metrics(tq_init, partition_id):
+    """When nothing exceeds the threshold, drop keeps the full batch and emits no
+    drop metrics."""
+    specs = [PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=5) for _ in range(2)]
+    _produce(partition_id, specs).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="drop", max_off_policy_threshold=2, parameter_sync_step=1)
+    try:
+        batch, metrics = rb.sample(global_steps=5, partition_id=partition_id, batch_size=2)
+
+        assert _uids_of(batch.keys) == {spec.uid for spec in specs}
+        assert metrics == {}
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_drop_respects_parameter_sync_step(tq_init, partition_id):
+    """parameter_sync_step scales staleness: a larger sync step tolerates a wider
+    span of dataloader steps before a trajectory is dropped."""
+    # staleness = (10 - gs + 1) / 4; drop when > 2 (i.e. raw span > 8).
+    #   stale gs=0 -> 11/4 = 2.75 > 2 -> dropped
+    #   fresh gs=8 -> 3/4 = 0.75      -> kept
+    stale = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=0)
+    fresh = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=8)
+    _produce(partition_id, [stale, fresh]).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="drop", max_off_policy_threshold=2, parameter_sync_step=4)
+    try:
+        batch, metrics = rb.sample(global_steps=10, partition_id=partition_id, batch_size=2)
+
+        assert _uids_of(batch.keys) == {fresh.uid}
+        assert metrics["validation/off_policy/dropped_samples"] == 1
+    finally:
+        _clear_partition(partition_id)
+
+
+# --------------------------------------------------------------------------- #
+# sample: off-policy "wait" (dropless) strategy.
+# --------------------------------------------------------------------------- #
+
+
+def test_wait_blocks_until_stale_inflight_finishes(tq_init, partition_id):
+    """wait holds back a full batch while a stale in-flight prompt exists, then
+    proceeds (without dropping it) once it terminates."""
+    threshold, sync, g = 2, 1, 5
+    fresh = [PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=g) for _ in range(2)]
+    # In-flight prompt: staleness (5 - 0 + 1) / 1 = 6 >= 2 -> blocks sampling.
+    stale = PromptSpec(uid=_uid(), status="running", sessions=1, global_steps=0)
+    _produce(partition_id, fresh + [stale]).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="wait", max_off_policy_threshold=threshold, parameter_sync_step=sync)
+    consumer = SampleConsumer(rb, partition_id, batch_size=2, global_steps=g)
+    try:
+        consumer.start()
+
+        time.sleep(POLL_INTERVAL * 5)
+        assert consumer.is_alive(), "wait must block while a stale in-flight prompt exists"
+
+        # The stale group terminates -> no in-flight prompt at threshold -> unblock.
+        # (clear+put is not atomic, so the consumer may proceed on the two fresh
+        # groups the instant the running prompt disappears; either way it returns a
+        # full batch_size batch -- droplessness is asserted separately below.)
+        _set_prompt_status(partition_id, stale.uid, "finished", global_steps=0)
+
+        batch = consumer.result_or_raise()
+        assert len(_uids_of(batch.keys)) == 2
+    finally:
+        consumer.join(timeout=10.0)
+        _clear_partition(partition_id)
+
+
+def test_wait_keeps_stale_terminal_trajectories(tq_init, partition_id):
+    """wait is dropless: a finished-but-very-stale group that ``drop`` would
+    discard is still returned, with no drop metrics."""
+    # staleness (100 - 0 + 1) / 1 = 101, far above threshold=2; "drop" would
+    # remove it, "wait" keeps it. No in-flight prompts, so sampling never blocks.
+    stale = PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=0)
+    _produce(partition_id, [stale]).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="wait", max_off_policy_threshold=2, parameter_sync_step=1)
+    try:
+        batch, metrics = rb.sample(global_steps=100, partition_id=partition_id, batch_size=1)
+
+        assert set(batch.keys) == set(stale.trajectory_keys)
+        assert metrics == {}
+    finally:
+        _clear_partition(partition_id)
+
+
+def test_wait_does_not_block_when_inflight_is_fresh(tq_init, partition_id):
+    """wait proceeds immediately when every in-flight prompt is below threshold,
+    and never drops (no drop metrics)."""
+    threshold, sync, g = 4, 1, 3
+    finished = [PromptSpec(uid=_uid(), status="finished", sessions=1, global_steps=g) for _ in range(2)]
+    # In-flight prompt staleness (3 - 3 + 1) / 1 = 1 < 4 -> does not block.
+    inflight = PromptSpec(uid=_uid(), status="running", sessions=1, global_steps=g)
+    _produce(partition_id, finished + [inflight]).join_and_check()
+
+    rb = _make_rb(max_off_policy_strategy="wait", max_off_policy_threshold=threshold, parameter_sync_step=sync)
+    try:
+        batch, metrics = rb.sample(global_steps=g, partition_id=partition_id, batch_size=2)
+
+        assert _uids_of(batch.keys) == {spec.uid for spec in finished}
+        assert metrics == {}
     finally:
         _clear_partition(partition_id)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -908,6 +908,13 @@ trainer:
     separate_async:
       num_warmup_batches: 4
       parameter_sync_step: 4
+    sampler:
+      max_off_policy_threshold: 8
+      max_off_policy_strategy: drop
+      custom_sampler:
+        path: null
+        name: null
+      sampler_kwargs: {}
 global_profiler:
   _target_: verl.utils.profiler.ProfilerConfig
   tool: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -842,6 +842,13 @@ trainer:
     separate_async:
       num_warmup_batches: 4
       parameter_sync_step: 4
+    sampler:
+      max_off_policy_threshold: 8
+      max_off_policy_strategy: drop
+      custom_sampler:
+        path: null
+        name: null
+      sampler_kwargs: {}
 global_profiler:
   _target_: verl.utils.profiler.ProfilerConfig
   tool: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -862,6 +862,13 @@ trainer:
     separate_async:
       num_warmup_batches: 4
       parameter_sync_step: 4
+    sampler:
+      max_off_policy_threshold: 8
+      max_off_policy_strategy: drop
+      custom_sampler:
+        path: null
+        name: null
+      sampler_kwargs: {}
 global_profiler:
   _target_: verl.utils.profiler.ProfilerConfig
   tool: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -868,6 +868,13 @@ trainer:
     separate_async:
       num_warmup_batches: 4
       parameter_sync_step: 4
+    sampler:
+      max_off_policy_threshold: 8
+      max_off_policy_strategy: drop
+      custom_sampler:
+        path: null
+        name: null
+      sampler_kwargs: {}
 global_profiler:
   _target_: verl.utils.profiler.ProfilerConfig
   tool: null

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -224,6 +224,29 @@ trainer:
       # Frequency of parameter synchronization between trainer and rollout,
       parameter_sync_step: 4
 
+    # Replay buffer sampling strategy
+    sampler:
+
+      # Maximum number of model versions that trajectory can span
+      max_off_policy_threshold: 8
+
+      # How to handle trajectory that exceeds the maximum number of model versions
+      # drop: drop the trajectory
+      # wait: dropless, wait all trajectories that reach threshold to finish
+      max_off_policy_strategy: drop
+
+      # Custom sampler config
+      custom_sampler:
+
+        # Path to the custom sampler class
+        path: null
+
+        # Name of the custom sampler class
+        name: null
+
+      # Additional kwargs for the custom sampler
+      sampler_kwargs: {}
+
 # profiler configs
 global_profiler:
 

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -16,7 +16,9 @@ import os
 import time
 from collections import defaultdict
 
+import numpy as np
 import transfer_queue as tq
+from omegaconf import DictConfig
 from transfer_queue import KVBatchMeta
 
 logger = logging.getLogger(__name__)
@@ -27,7 +29,6 @@ VERL_REPLAY_BUFFER_DEBUG_INTERVAL_SECONDS = int(os.getenv("VERL_REPLAY_BUFFER_DE
 
 # TODO: Pass custom sampler to TransferQueue:
 # https://github.com/Ascend/TransferQueue/blob/main/tutorial/05_custom_sampler.py
-# TODO: make sampling strategy customizable.
 
 
 class ReplayBuffer:
@@ -61,11 +62,37 @@ class ReplayBuffer:
     Only prompt with status `finished` or `failure`, its trajectories can be sampled by replay buffer.
 
     Args:
+        trainer_mode (str): Trainer mode.
+        trainer_config (DictConfig): Trainer configuration.
+        max_off_policy_threshold (int): Maximum number of model versions that trajectory can span.
+        max_off_policy_strategy (str): How to handle trajectory that exceeds the maximum number of model versions.
+        sampler_kwargs (dict): Additional kwargs for the custom sampler.
         poll_interval (float, optional): Poll interval in seconds. Defaults to 2.0.
     """
 
-    def __init__(self, poll_interval: float = 2.0):
+    def __init__(
+        self,
+        trainer_mode: str,
+        trainer_config: DictConfig,
+        max_off_policy_threshold: int,
+        max_off_policy_strategy: str,
+        sampler_kwargs: DictConfig,
+        poll_interval: float = 2.0,
+    ):
+        self.trainer_mode = trainer_mode
+        self.trainer_config = trainer_config
+        self.max_off_policy_threshold = max_off_policy_threshold
+        self.max_off_policy_strategy = max_off_policy_strategy
+        self.sampler_kwargs = sampler_kwargs
         self.poll_interval = poll_interval
+        self.parameter_sync_step = trainer_config.get("parameter_sync_step", 1)
+
+        assert isinstance(self.max_off_policy_threshold, int) and self.max_off_policy_threshold > 0, (
+            f"Invalid max off policy threshold: {self.max_off_policy_threshold}, must be an integer greater than 0"
+        )
+        assert self.max_off_policy_strategy in ["drop", "wait"], (
+            f"Invalid max off policy strategy: {self.max_off_policy_strategy}, must be one of ['drop', 'wait']"
+        )
 
         # partition_id => {key: tag}
         self.partitions: dict[str, dict[str, dict]] = defaultdict(dict)
@@ -94,7 +121,7 @@ class ReplayBuffer:
             for key, tag in items.items():
                 if tag.get("is_prompt", False):
                     # see: [GRPO group sampling control]
-                    self.prompt_global_steps[partition_id][key] = tag.get("global_steps", 0)
+                    self.prompt_global_steps[partition_id][key] = tag["global_steps"]
                     match tag["status"]:
                         case "pending":
                             self.pending_keys[partition_id].add(key)
@@ -112,20 +139,70 @@ class ReplayBuffer:
                         partition[key] = {}
                     partition[key].update(tag)
 
-    def sample(self, partition_id: str, batch_size: int) -> KVBatchMeta:
+    def _has_enough_samples(self, global_steps: int, partition_id: str, batch_size: int) -> bool:
+        # For wait strategy, we need to wait all trajectories that reach threshold to finish
+        if self.max_off_policy_strategy == "wait":
+            for key in self.pending_keys[partition_id] | self.running_keys[partition_id]:
+                prompt_global_steps = self.prompt_global_steps[partition_id][key]
+                if (global_steps - prompt_global_steps + 1) / self.parameter_sync_step >= self.max_off_policy_threshold:
+                    return False
+
+        return len(self.finished_keys[partition_id]) + len(self.failure_keys[partition_id]) >= batch_size
+
+    def _drop_max_off_policy_samples(
+        self, global_steps: int, partition_id: str, batch: KVBatchMeta
+    ) -> tuple[KVBatchMeta, dict]:
+        if not self.max_off_policy_strategy == "drop":
+            return batch, {}
+
+        kept_keys, kept_tags = [], []
+        dropped_keys, dropped_tags = [], []
+        for key, tag in zip(batch.keys, batch.tags, strict=False):
+            prompt_global_steps = tag["global_steps"]
+            if (global_steps - prompt_global_steps + 1) / self.parameter_sync_step > self.max_off_policy_threshold:
+                dropped_keys.append(key)
+                dropped_tags.append(tag)
+            else:
+                kept_keys.append(key)
+                kept_tags.append(tag)
+
+        # Remove dropped keys from TransferQueue
+        metrics = {}
+        if len(dropped_keys) > 0:
+            # TODO: should we drop the entire GRPO group if any of its sessions exceeds the threshold?
+            tq.kv_clear(partition_id=batch.partition_id, keys=dropped_keys)
+            logger.warning(f"Dropped {len(dropped_keys)} max off policy samples from partition {batch.partition_id}")
+            dropped_global_steps = np.array([tag["global_steps"] for tag in dropped_tags])
+            trajectory_staleness = (global_steps - dropped_global_steps + 1) / self.parameter_sync_step
+            prefix = "training" if partition_id == "train" else "validation"
+            metrics[f"{prefix}/off_policy/dropped_samples"] = len(dropped_keys)
+            metrics[f"{prefix}/off_policy/dropped_samples_staleness/mean"] = trajectory_staleness.mean()
+            metrics[f"{prefix}/off_policy/dropped_samples_staleness/max"] = trajectory_staleness.max()
+            metrics[f"{prefix}/off_policy/dropped_samples_staleness/min"] = trajectory_staleness.min()
+
+        return KVBatchMeta(partition_id=batch.partition_id, keys=kept_keys, tags=kept_tags), metrics
+
+    def sample(self, global_steps: int, partition_id: str, batch_size: int) -> KVBatchMeta:
         """Sample a batch of data from the replay buffer.
 
+        NOTE: user can customize sampling strategy by setting:
+        ```bash
+        trainer.v1.sampler.custom_sampler.path = "path/to/your/sampler.py"
+        trainer.v1.sampler.custom_sampler.name = "UserCustomReplayBuffer"
+        ```
 
         Args:
+            global_steps (int): Global steps of the current training.
             partition_id (str): Partition of TransferQueue, e.g. "train" or "val".
             batch_size (int, optional): Batch size.
 
         Returns:
             KVBatchMeta: A batch of data.
+            dict: Auxiliary metrics.
         """
         last_debug_time = time.time()
         self._sync_metadata_from_transfer_queue()
-        while len(self.finished_keys[partition_id]) + len(self.failure_keys[partition_id]) < batch_size:
+        while not self._has_enough_samples(global_steps, partition_id, batch_size):
             time.sleep(self.poll_interval)
             self._sync_metadata_from_transfer_queue()
 
@@ -154,4 +231,6 @@ class ReplayBuffer:
             if uid in selected:
                 keys.append(key)
                 tags.append(tag)
-        return KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
+
+        batch = KVBatchMeta(partition_id=partition_id, keys=keys, tags=tags)
+        return self._drop_max_off_policy_samples(global_steps, partition_id, batch)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -76,6 +76,7 @@ from verl.utils.dataset.rl_dataset import collate_fn
 from verl.utils.debug import marked_timer
 from verl.utils.debug.metrics import calculate_debug_metrics
 from verl.utils.fs import copy_to_local
+from verl.utils.import_utils import load_extern_type
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
@@ -112,7 +113,29 @@ class PPOTrainer(ABC):
         if self.config.algorithm.use_kl_in_reward:
             self.kl_ctrl_in_reward = core_algos.get_kl_controller(self.config.algorithm.kl_ctrl)
 
-        self.replay_buffer = ReplayBuffer()
+        self.trainer_mode = self.config.trainer.v1.trainer_mode
+        self.parameter_sync_step = self.config.trainer.v1.get(self.trainer_mode, {}).get("parameter_sync_step", 1)
+        self.replay_buffer = self._build_replay_buffer()
+
+    def _build_replay_buffer(self) -> ReplayBuffer:
+        """Instantiate the replay buffer (or a user-provided custom sampler).
+
+        Set ``trainer.v1.sampler.custom_sampler.{path,name}`` to plug in a custom
+        ``ReplayBuffer`` subclass; otherwise the built-in implementation is used.
+        """
+        sampler_config = self.config.trainer.v1.sampler
+        custom_sampler = sampler_config.get("custom_sampler", None)
+        sampler_cls = ReplayBuffer
+        if custom_sampler is not None and custom_sampler.get("path") and custom_sampler.get("name"):
+            sampler_cls = load_extern_type(custom_sampler.path, custom_sampler.name)
+
+        return sampler_cls(
+            trainer_mode=self.trainer_mode,
+            trainer_config=self.config.trainer.v1.get(self.trainer_mode, {}),
+            max_off_policy_threshold=sampler_config.max_off_policy_threshold,
+            max_off_policy_strategy=sampler_config.max_off_policy_strategy,
+            sampler_kwargs=sampler_config.sampler_kwargs,
+        )
 
     def init(self):
         """Initialize all components of the trainer.
@@ -385,7 +408,12 @@ class PPOTrainer(ABC):
         # 2. sample batch from replay buffer
         with marked_timer("gen", timing_raw, color="red"):
             self.on_sample_begin()
-            batch = self.replay_buffer.sample(partition_id="train", batch_size=self.config.data.train_batch_size)
+            batch, off_policy_metrics = self.replay_buffer.sample(
+                global_steps=self.global_steps,
+                partition_id="train",
+                batch_size=self.config.data.train_batch_size,
+            )
+            metrics.update(off_policy_metrics)
             batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
             self.on_sample_end()
 
@@ -732,13 +760,16 @@ class PPOTrainer(ABC):
             batch = tu.get_tensordict(batch_dict)
             tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
             tu.assign_non_tensor_data(batch, "validate", True)
-            # Register each prompt (GRPO group) in TransferQueue as a tag-only status marker
-            tags = [{"is_prompt": True, "status": "pending"}] * len(batch)
+            # Register each prompt (GRPO group) in TransferQueue as a tag-only status marker.
+            # global_steps is required by ReplayBuffer's metadata sync / staleness ordering.
+            tags = [{"is_prompt": True, "status": "pending", "global_steps": self.global_steps}] * len(batch)
             tq.kv_batch_put(keys=list(batch["uid"]), partition_id="val", tags=tags)
             self.agent_loop_manager.generate_sequences(batch)
 
             # 2. sample batch from replay buffer: one prompt (GRPO group) per submitted row.
-            batch = self.replay_buffer.sample(partition_id="val", batch_size=len(batch))
+            batch, _ = self.replay_buffer.sample(
+                global_steps=self.global_steps, partition_id="val", batch_size=len(batch)
+            )
 
             # 3. [OPTIONAL] compute reward score with colocated reward model
             if self.reward_loop_manager.reward_loop_worker_handles is None:
@@ -1427,9 +1458,9 @@ class PPOTrainer(ABC):
         #     so the lag is a range: the freshest weights used give the lower bound
         #     (global_steps - max_global_steps) and the oldest weights the worst case
         #     (global_steps - min_global_steps). We log the lower bound as the primary metric.
-        trajectory_spans = max_global_steps - min_global_steps + 1
-        trajectory_staleness = (global_steps - 1) - max_global_steps
-        trajectory_staleness_worst = (global_steps - 1) - min_global_steps
+        trajectory_spans = (max_global_steps - min_global_steps + 1) / self.parameter_sync_step
+        trajectory_staleness = ((global_steps - 1) - max_global_steps) / self.parameter_sync_step
+        trajectory_staleness_worst = ((global_steps - 1) - min_global_steps) / self.parameter_sync_step
         metrics.update(
             {
                 "training/off_policy/trajectory_spans/mean": trajectory_spans.mean(),


### PR DESCRIPTION
### What does this PR do?

Follow up https://github.com/verl-project/verl/pull/6710, support two staleness control strategy:
- drop: drop the trajectory that its staleness exceeds `max_off_policy_threshold`
- wait: drop-less, wait all trajectories that its staleness reaching `max_off_policy_threshold` to finish
