### PR TITLE
[trainer] feat: A runnable separate async trainer

### DIFF
--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -119,12 +119,14 @@ class PPOTrainerSeparateAsync(PPOTrainer):
                 self.standalone_checkpoint_manager.update_weights(self.global_steps)
 
     def switch_to_rollout(self):
+        # TODO: disable auto offload in config and offload according to the switch strategy
         self.checkpoint_manager.update_weights(self.global_steps)
         self.checkpoint_manager.resume_generation_replicas()
         self.add_replicas_to_balancer()
         self.current_mode = HybridEngineMode.ROLLOUT
 
     def switch_to_trainer(self):
+        # TODO: disable auto offload in config and offload according to the switch strategy
         self.remove_replicas_from_balancer()
         self.checkpoint_manager.abort_replicas()
         self.checkpoint_manager.sleep_replicas()
@@ -142,4 +144,5 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         ray.get(global_load_balancer.remove_servers.remote(self.llm_server_manager.server_addresses))
 
     def should_switch_to_rollout(self):
+        # TODO: Implement switch strategy by checking replay buffer and switch overhead
         return False

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -41,8 +41,6 @@ class PPOTrainerSeparateAsync(PPOTrainer):
     """
 
     def __init__(self, config: DictConfig):
-        raise NotImplementedError("separate async training is still under development")
-
         train_batch_size = config.data.train_batch_size
         ppo_mini_batch_size = config.actor_rollout_ref.actor.ppo_mini_batch_size
         assert train_batch_size == ppo_mini_batch_size, (
@@ -57,17 +55,20 @@ class PPOTrainerSeparateAsync(PPOTrainer):
             "please use nccl/nixl/mooncake, etc. backend for separate async training"
         )
 
+        super().__init__(config)
+
         # TODO: Support Decoupled PPO: https://arxiv.org/abs/2505.24298
         self.config.algorithm.rollout_correction.bypass_mode = True
-
-        super().__init__(config)
 
     def _setup(self):
         super()._setup()
 
         # initialize standalone rollout
         # TODO: make initialization parallel with super().init()
-        self.standalone_server_manager: LLMServerManager = LLMServerManager.create(config=self.config)
+        hybrid_num_replicas = len(self.llm_server_manager.rollout_replicas)
+        self.standalone_server_manager: LLMServerManager = LLMServerManager.create(
+            config=self.config, start_rank=hybrid_num_replicas
+        )
 
         # create checkpoint engine manager for trainer and standalone rollout
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
@@ -100,11 +101,6 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         if self.current_mode == HybridEngineMode.TRAINER:
             logger.info("Switching hybrid engine to rollout mode for validation")
             self.switch_to_rollout()
-
-    def on_validate_end(self):
-        if self.current_mode == HybridEngineMode.ROLLOUT:
-            logger.info("Switching hybrid engine to trainer mode for training")
-            self.switch_to_trainer()
 
     def on_sample_begin(self):
         if self.current_mode == HybridEngineMode.TRAINER and self.should_switch_to_rollout():
@@ -146,5 +142,4 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         ray.get(global_load_balancer.remove_servers.remote(self.llm_server_manager.server_addresses))
 
     def should_switch_to_rollout(self):
-        # TODO: Implement switch strategy by checking replay buffer and switch overhead
         return False

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -338,6 +338,7 @@ class LLMServerManager:
         worker_group (RayWorkerGroup): Worker group for the server replicas. If not none, init hybrid server,
             else init standalone server with a new resource pool.
         rollout_resource_pool (RayResourcePool): Resource pool for the server replicas, only needed for TensorRT-LLM.
+        start_rank (int): First ``replica_rank`` to assign.  Defaults to 0.
     """
 
     def __init__(
@@ -345,12 +346,14 @@ class LLMServerManager:
         config: DictConfig,
         worker_group: RayWorkerGroup = None,
         rollout_resource_pool: RayResourcePool = None,
+        start_rank: int = 0,
     ):
         self.config = config
         self.rollout_config = config.actor_rollout_ref.rollout
         self.model_config = config.actor_rollout_ref.model
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
+        self.start_rank = start_rank
 
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
@@ -370,16 +373,16 @@ class LLMServerManager:
         await instance._init_global_load_balancer()
         return instance
 
-    async def _initialize_llm_servers(self, start_rank: int = 0):
+    async def _initialize_llm_servers(self, start_rank: int = None):
         """Initialize the LLM server replicas.
 
         Args:
-            start_rank: First ``replica_rank`` to assign.  Defaults to 0 so that
-                existing callers are unaffected.  Subclasses (e.g.
-                ``FullyAsyncLLMServerManager``) may pass a non-zero value to avoid
-                Ray named-actor collisions when hybrid and standalone replicas
-                coexist.
+            start_rank: First ``replica_rank`` to assign.  Defaults to ``self.start_rank``
+                so standalone replicas can avoid Ray named-actor collisions with hybrid
+                replicas (which start at 0) when both coexist (e.g. separate async).
         """
+        if start_rank is None:
+            start_rank = self.start_rank
         rollout_world_size = (
             self.rollout_config.tensor_model_parallel_size
             * self.rollout_config.data_parallel_size


### PR DESCRIPTION
### What does this PR do?

See above.
Currently the colocated group never switches to rollouter, similar to the fully async implementation.
Switch and offload strategies will be introduced later.