### PR TITLE
[fully_async] fix: introduce accumulated_idle_time to record the actual rollouter idle time

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -400,6 +400,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
         self.global_steps = 1
         self.idle_start_time = time.time()
         self.step_start_time = time.time()
+        self.accumulated_idle_time = 0.0
 
         # Concurrency control
         # Modified by self.pause() or self._should_pause_generation()
@@ -475,12 +476,13 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             self.staleness_samples = len(self.active_tasks) + await self.message_queue_client.get_queue_size()
             timing_raw = {}
             rollout_version_time = max(time.time() - self.step_start_time, 1e-6)
+            # Sum all fully-drained idle periods already recorded in this version period,
+            # plus any currently-open idle period (rollouter idle right now at reset time).
+            total_idle_time = self.accumulated_idle_time
             if self.idle_start_time > self.step_start_time:
-                rollout_active_time = self.idle_start_time - self.step_start_time
-                idle_ratio = 1 - rollout_active_time / rollout_version_time
-            else:
-                rollout_active_time = rollout_version_time
-                idle_ratio = 0
+                total_idle_time += time.time() - self.idle_start_time
+            idle_ratio = min(total_idle_time / rollout_version_time, 1.0)
+            rollout_active_time = rollout_version_time - total_idle_time
             timing_raw["fully_async/rollouter/active_time"] = rollout_active_time
             timing_raw["fully_async/rollouter/version_time"] = rollout_version_time
             timing_raw["fully_async/rollouter/idle_ratio"] = idle_ratio
@@ -491,6 +493,7 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                 f"idle_ratio: {timing_raw['fully_async/rollouter/idle_ratio']:.4f}"
             )
             self.step_start_time = time.time()
+            self.accumulated_idle_time = 0.0
 
         return timing_raw
 
@@ -787,6 +790,13 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
                     if not resume_future.done():
                         self.idle_start_time = time.time()
                         await resume_future
+                        # We were truly idle (all tasks drained, resume arrived late).
+                        # Accumulate this idle period so reset_staleness can account for
+                        # multiple pause/idle cycles within a single version period.
+                        async with self.lock:
+                            if self.idle_start_time > self.step_start_time:
+                                self.accumulated_idle_time += time.time() - self.idle_start_time
+                            self.idle_start_time = 0  # consumed into accumulated_idle_time
                 finally:
                     if not resume_future.done():
                         resume_future.cancel()


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Fix fully async rollouter idle ratio measurement issue:https://github.com/verl-project/verl/issues/6693

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully_async+idle
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
