### PR TITLE
[algo] fix: remove dead code in GPG advantage estimator

### DIFF
--- a/tests/trainer/ppo/test_gpg_advantage_on_cpu.py
+++ b/tests/trainer/ppo/test_gpg_advantage_on_cpu.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+
+from verl.trainer.ppo.core_algos import compute_gpg_outcome_advantage
+
+
+def test_gpg_singleton_group_returns_raw_score():
+    token_level_rewards = torch.tensor([[0.0, 3.0, 0.0]], dtype=torch.float32)
+    response_mask = torch.tensor([[1.0, 1.0, 1.0]], dtype=torch.float32)
+    index = np.array(["prompt-a"], dtype=object)
+
+    advantages, returns = compute_gpg_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    raw_score = token_level_rewards.sum(dim=-1, keepdim=True) * response_mask
+    torch.testing.assert_close(advantages, raw_score)
+    torch.testing.assert_close(returns, advantages)
+
+
+def test_gpg_applies_n_over_nonzero_scaling():
+    token_level_rewards = torch.tensor([[4.0], [0.0]], dtype=torch.float32)
+    response_mask = torch.ones_like(token_level_rewards)
+    index = np.array(["prompt-a", "prompt-a"], dtype=object)
+
+    advantages, _ = compute_gpg_outcome_advantage(
+        token_level_rewards=token_level_rewards,
+        response_mask=response_mask,
+        index=index,
+    )
+
+    expected = torch.tensor([[4.0], [-4.0]], dtype=torch.float32)
+    torch.testing.assert_close(advantages, expected)

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -772,7 +772,6 @@ def compute_gpg_outcome_advantage(
     index: np.ndarray,
     epsilon: float = 1e-6,
     f_norm: float = 1.0,
-    alpha: float = 1.0,
     config=None,
     **kwargs,
 ):
@@ -788,7 +787,6 @@ def compute_gpg_outcome_advantage(
             shape: (bs,)
         epsilon: (float)
         f_norm: (float)
-        alpha: (float)
         config: (dict) algorithm config
 
     Returns:
@@ -801,7 +799,6 @@ def compute_gpg_outcome_advantage(
 
     id2score = defaultdict(list)
     id2mean = {}
-    id2std = {}
 
     with torch.no_grad():
         bsz = scores.shape[0]
@@ -813,12 +810,11 @@ def compute_gpg_outcome_advantage(
 
         for idx in id2score:
             if len(id2score[idx]) == 1:
-                id2mean[idx] = torch.tensor(0.0)
-                id2std[idx] = torch.tensor(1.0)
+                # Keep singleton means device-agnostic.
+                id2mean[idx] = 0.0
             elif len(id2score[idx]) > 1:
                 scores_tensor = torch.stack(id2score[idx])
                 id2mean[idx] = torch.mean(scores_tensor)
-                id2std[idx] = torch.std(scores_tensor)
             else:
                 raise ValueError(f"no score in prompt index: {idx}")
         for i in range(bsz):


### PR DESCRIPTION
## What

Removes dead code in `compute_gpg_outcome_advantage` (`verl/trainer/ppo/core_algos.py`), addressing **Item B** of #6478, plus an adjacent device-mismatch fix.

1. **`id2std` is never read.** The function builds an `id2std` dict and populates it per group, but normalization divides centered scores by `f_norm`, not by the group std. Pure dead code.

2. **The `alpha` parameter is a no-op.** `alpha` (default `1.0`) is unconditionally overwritten by `alpha = bsz / m.clamp(min=1)` before its first use, so any caller-supplied value is silently discarded. No caller passes it (`ray_trainer.py` builds `adv_kwargs` without `alpha`, and the function keeps `**kwargs`), so removing the parameter is non-breaking.

3. **Singleton-group device mismatch.** The singleton branch set `id2mean[idx] = torch.tensor(0.0)` (always CPU), while the multi-response branch uses `torch.mean(...)` on the scores' device. On GPU this mismatches in the advantage loop. Use a plain `0.0` (device-agnostic; identical on CPU).

## Change

- Delete the `id2std` dict and the two lines that populate it.
- Remove the dead `alpha` parameter (and its docstring entry).
- Set the singleton mean to `0.0` instead of a CPU tensor.

The live local `alpha = bsz / count_nonzero(scores)` and its use in the scaling line are **kept** — that is the actual GPG scaling. Behavior is unchanged on CPU.

## Scope

Only **Item B** of #6478. **Item A** (the negative-approx-kl clamp) is handled separately in #6538 and is not touched here.

## Test

Adds `tests/trainer/ppo/test_gpg_advantage_on_cpu.py` (CPU-only, a new file to avoid conflicts with #6538/#4677 which also edit `test_core_algos_on_cpu.py`):

- `test_gpg_singleton_group_returns_raw_score` — a single non-zero-scored response gets advantage == raw masked score.
- `test_gpg_applies_n_over_nonzero_scaling` — a 2-response group (scores 4, 0) yields `alpha * (score - mean) = 2 * (score - 2)`.