### PR TITLE
[rollout, algo] fix: compute rollout_is_seq_fraction from raw weights

### DIFF
--- a/tests/trainer/ppo/test_rollout_corr.py
+++ b/tests/trainer/ppo/test_rollout_corr.py
@@ -33,6 +33,7 @@ import torch
 
 from verl.trainer.ppo.rollout_corr_helper import (
     SUPPORTED_ROLLOUT_RS_OPTIONS,
+    compute_is_metrics,
     compute_offpolicy_metrics,
     compute_rollout_correction_and_rejection_mask,
 )
@@ -410,6 +411,35 @@ def test_bool_rollout_is_threshold_is_rejected():
             rollout_is_threshold=True,
             rollout_rs=None,
         )
+
+
+def test_seq_fraction_high_uses_raw_weights():
+    """rollout_is_seq_fraction_high must be driven by the raw (pre-truncation) weights.
+
+    Truncation clamps every weight to <= rollout_is_threshold, so a per-sequence mean of
+    clamped weights can never exceed the threshold. The high fraction therefore has to come
+    from the raw per-sequence mean to remain a live diagnostic.
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    threshold = 2.0
+
+    # Sequence 0: raw mean (1.0 + 6.0) / 2 = 3.5 > threshold, but clamped mean
+    # (1.0 + 2.0) / 2 = 1.5 <= threshold. Sequence 1 stays well under the threshold.
+    raw_rollout_is_weights = torch.tensor([[1.0, 6.0], [0.9, 1.1]], device=device)
+    rollout_is_weights = raw_rollout_is_weights.clamp(max=threshold)
+    response_mask = torch.ones_like(raw_rollout_is_weights)
+    log_ratio_for_metrics = torch.log(raw_rollout_is_weights)
+
+    metrics = compute_is_metrics(
+        rollout_is_weights=rollout_is_weights,
+        raw_rollout_is_weights=raw_rollout_is_weights,
+        log_ratio_for_metrics=log_ratio_for_metrics,
+        response_mask=response_mask,
+        rollout_is="token",
+        rollout_is_threshold=threshold,
+    )
+
+    assert metrics["rollout_is_seq_fraction_high"] == pytest.approx(0.5)
 
 
 if __name__ == "__main__":

--- a/verl/trainer/ppo/rollout_corr_helper.py
+++ b/verl/trainer/ppo/rollout_corr_helper.py
@@ -769,9 +769,14 @@ def compute_is_metrics(
         seq_deviation: torch.Tensor = (seq_mean_weights - 1.0).abs()
         metrics["rollout_is_seq_max_deviation"] = seq_deviation.max().item()
 
-        # Fraction of sequences with extreme weights
-        metrics["rollout_is_seq_fraction_high"] = (seq_mean_weights > rollout_is_threshold).float().mean().item()
-        metrics["rollout_is_seq_fraction_low"] = (seq_mean_weights < rollout_is_threshold_lower).float().mean().item()
+        # Fraction of sequences with extreme weights. Use the raw (pre-truncation)
+        # per-sequence mean: every clamped weight is <= rollout_is_threshold, so a mean
+        # of clamped weights can never exceed it and the high fraction would be dead.
+        raw_seq_mean_weights: torch.Tensor = verl_F.masked_mean(raw_rollout_is_weights, response_mask, axis=-1)
+        metrics["rollout_is_seq_fraction_high"] = (raw_seq_mean_weights > rollout_is_threshold).float().mean().item()
+        metrics["rollout_is_seq_fraction_low"] = (
+            (raw_seq_mean_weights < rollout_is_threshold_lower).float().mean().item()
+        )
 
     return metrics
 


### PR DESCRIPTION
### What does this PR do?

Fixes a dead metric in `compute_is_metrics` (`verl/trainer/ppo/rollout_corr_helper.py`).

`rollout_is_seq_fraction_high` / `_low` were computed from `seq_mean_weights`, the per-sequence mean of the **clamped** `rollout_is_weights`. For TIS every weight is clamped to `max=rollout_is_threshold` (and IcePop zeroes out-of-range weights), so the per-sequence mean can never exceed `rollout_is_threshold` — making `rollout_is_seq_fraction_high` structurally `0.0`. The token-level sibling `rollout_is_ratio_fraction_high` already measures exceedance from the **raw** weights (`raw_rollout_is_weights`); the sequence-level fractions should follow the same convention.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout_is_seq_fraction (none)
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

`tests/trainer/ppo/test_rollout_corr.py::test_seq_fraction_high_uses_raw_weights` builds weights whose raw per-sequence mean exceeds the threshold while the clamped mean does not, and asserts `rollout_is_seq_fraction_high > 0`. It fails on `main` (`0.0`) and passes after the fix.

### Design & Code Changes

Compute `raw_seq_mean_weights = masked_mean(raw_rollout_is_weights, response_mask, axis=-1)` and use it for `rollout_is_seq_fraction_high` / `_low`. The descriptive sequence metrics (`seq_mean`/`seq_std`/`seq_max`/`seq_min`) are intentionally left on the clamped weights, since they describe the weights actually applied.

### Checklist Before Submitting

- [x] Add unit test covering the change.
