### PR TITLE
[reward] fix: PrimeRewardManager honors reward_fn_key in __call__

### DIFF
--- a/tests/workers/reward_manager/test_prime_on_cpu.py
+++ b/tests/workers/reward_manager/test_prime_on_cpu.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU test that PrimeRewardManager honors a custom reward_fn_key."""
+
+import numpy as np
+import torch
+
+from verl import DataProto
+from verl.workers.reward_manager.prime import PrimeRewardManager
+
+
+class _DummyTokenizer:
+    def batch_decode(self, token_ids, skip_special_tokens=True):
+        return ["dummy"] * len(token_ids)
+
+
+# Must be module-level: prime scores via ProcessPoolExecutor, which pickles it.
+def _compute_score(data_source, solution_str, ground_truth, extra_info=None):
+    return 1.0
+
+
+def test_prime_reward_manager_uses_custom_reward_fn_key():
+    batch_size, prompt_len, response_len = 1, 2, 2
+    # Note the absence of a "data_source" column: the task key is "ability".
+    data = DataProto.from_single_dict(
+        {
+            "prompts": torch.zeros((batch_size, prompt_len), dtype=torch.long),
+            "responses": torch.zeros((batch_size, response_len), dtype=torch.long),
+            "attention_mask": torch.ones((batch_size, prompt_len + response_len), dtype=torch.long),
+            "ability": np.array(["math"] * batch_size, dtype=object),
+            "reward_model": np.array([{"ground_truth": "1"}] * batch_size, dtype=object),
+        }
+    )
+    manager = PrimeRewardManager(
+        tokenizer=_DummyTokenizer(),
+        num_examine=1,
+        compute_score=_compute_score,
+        reward_fn_key="ability",
+    )
+
+    reward_tensor = manager(data)
+
+    assert reward_tensor.shape == (batch_size, response_len)
+    assert reward_tensor.sum().item() == 1.0

--- a/verl/workers/reward_manager/prime.py
+++ b/verl/workers/reward_manager/prime.py
@@ -168,7 +168,7 @@ class PrimeRewardManager(AbstractRewardManager):
         response_ids = data.batch["responses"]
         valid_response_length = data.batch["attention_mask"][:, prompt_length:].sum(dim=-1)
         sequences_str = self.tokenizer.batch_decode(response_ids, skip_special_tokens=True)
-        data_sources = data.non_tensor_batch["data_source"]
+        data_sources = data.non_tensor_batch[self.reward_fn_key]
 
         scores = self.verify(data)
 


### PR DESCRIPTION
### What does this PR do?

`PrimeRewardManager.__call__` hardcodes the data-source column:

```python
data_sources = data.non_tensor_batch["data_source"]
```

while the sibling `verify()` (and every other reward manager) uses `self.reward_fn_key`. PR #975 ("fix: reward_fn_key for PRIME") converted `verify()`'s identical line to `self.reward_fn_key` but missed this duplicate in `__call__`. With a custom `reward_fn_key` and no `"data_source"` column, `__call__` raises `KeyError` at this line — before `verify()` runs.

This changes the line to `self.reward_fn_key`, mirroring `verify()`.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=prime+reward_fn_key (#975 fixed `verify()` only)
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

`tests/workers/reward_manager/test_prime_on_cpu.py` builds a `DataProto` keyed by a custom column (`ability`) with no `data_source`, instantiates `PrimeRewardManager(..., reward_fn_key="ability")`, and calls it. Fails on `main` (`KeyError: 'data_source'`), passes after the fix.

### Design & Code Changes

One-line change at `verl/workers/reward_manager/prime.py:171`, mirroring `verify()`.

### Checklist Before Submitting

- [x] Add unit test covering the change.
