### PR TITLE
[ckpt] fix: use separate magic_recv buffer to prevent weight corruption

### DIFF
--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -21,7 +21,11 @@ from typing import Any, AsyncGenerator, Generator
 import ray
 import torch
 from mooncake.engine import TransferEngine
-from vllm.distributed.utils import StatelessProcessGroup
+
+try:
+    from vllm.distributed.utils import StatelessProcessGroup
+except ImportError:
+    from sglang.srt.distributed.utils import StatelessProcessGroup
 
 from verl.checkpoint_engine.base import CheckpointEngine, CheckpointEngineRegistry, TensorMeta
 from verl.utils.device import get_torch_device
@@ -234,54 +238,66 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         self,
         global_steps: int | None = None,
     ) -> AsyncGenerator[tuple[str, torch.Tensor], None]:
-        """Receive weights using Mooncake TransferEngine"""
+        """Receive weights from the previous rank via RDMA.
+
+        Protocol:
+        1. Recv metadata from prev rank via TCPStore
+        2. RDMA-read data from prev rank's buffer
+        3. Forward metadata to next rank (if not last)
+        4. Yield weights to consumer
+        5. Write magic completion signal to prev rank's magic_ptr
+           (a dedicated magic_recv slot, NOT the data buffer, to avoid
+           transfer_sync_write local GPU side-effect corruption)
+        """
+        _magic = torch.tensor([0xAB, 0xDC, 0xEF, 0x88], dtype=torch.uint8, device=self.device)
+
         start_time = time.time()
         total_bytes = 0
         bufs = [self.buf[: self.bucket_size], self.buf[self.bucket_size :]]
+        magic_slots = [self.magic_recv[:4], self.magic_recv[4:]]
         idx = 0
         current = bufs[idx]
-        self.magic_buf[:4] = torch.tensor([0xAB, 0xDC, 0xEF, 0x88], dtype=torch.uint8, device=self.device)
+        self.magic_buf[:4] = _magic.clone()
 
         while True:
-            # 1 receive info from previous rank
             info = self.store.recv_obj(self.rank - 1)
             if idx >= 2 and self.rank < self.world_size - 1:
-                await self.wait_for_complete(self.magic_recv[(idx - 2) % 2 * 4 : (idx - 2) % 2 * 4 + 4])
+                await self.wait_for_complete(magic_slots[idx % 2])
 
-            ptr = info["ptr"]
-            magic_ptr = info["magic_ptr"]
+            prev_ptr = info["ptr"]
+            prev_magic_ptr = info.get("magic_ptr")
+
             ret = self.engine.transfer_sync_read(
-                self.buffer_info["session_id"],
-                current.data_ptr(),
-                ptr,
-                info["len"],
+                self.buffer_info["session_id"], current.data_ptr(), prev_ptr, info["len"],
             )
-            assert ret == 0, f"transfer_sync_read failed {ret}"
+            assert ret == 0
+
             total_bytes += info["len"]
 
-            # 2 send info to next rank
             info["ptr"] = current.data_ptr()
-            info["magic_ptr"] = self.magic_recv[idx % 2 * 4 : idx % 2 * 4 + 4].data_ptr()
+            info["magic_ptr"] = magic_slots[idx % 2].data_ptr()
             if self.rank < self.world_size - 1:
                 self.store.send_obj(info, self.rank + 1)
 
-            # 3 yield tensor from current buffer
             for name, meta in info["bucket_meta"].items():
                 dtype, shape = meta["dtype"], meta["shape"]
                 size = dtype.itemsize * shape.numel()
                 tensor = current[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
                 yield name, tensor
 
-            # 4 write magic to dedicated magic_ptr instead of data buffer ptr
-            ret = self.engine.transfer_sync_write(
-                self.buffer_info["session_id"],
-                self.magic_buf.data_ptr(),
-                magic_ptr,
-                4,
-            )
-            assert ret == 0, f"transfer_sync_write failed {ret}"
+            get_torch_device().synchronize()
 
-            # 5 swap buffer
+            if prev_magic_ptr is not None:
+                ret = self.engine.transfer_sync_write(
+                    self.buffer_info["session_id"], self.magic_buf.data_ptr(), prev_magic_ptr, 4,
+                )
+                assert ret == 0
+            else:
+                ret = self.engine.transfer_sync_write(
+                    self.buffer_info["session_id"], self.magic_buf.data_ptr(), prev_ptr, 4,
+                )
+                assert ret == 0
+
             idx += 1
             current = bufs[idx % 2]
             get_torch_device().synchronize()

--- a/verl/checkpoint_engine/mooncake_checkpoint_engine.py
+++ b/verl/checkpoint_engine/mooncake_checkpoint_engine.py
@@ -78,9 +78,12 @@ class MooncakeCheckpointEngine(CheckpointEngine):
 
         self.buf = torch.empty(2 * self.bucket_size, dtype=torch.uint8, device=self.device)
         self.magic_buf = torch.empty(4 * 1024, dtype=torch.uint8, device=self.device)
+        # Separate buffer for receiving magic completion signals (one 4-byte slot per double-buffer)
+        # This prevents the next rank's magic write from corrupting data buffer contents.
+        self.magic_recv = torch.zeros(8, dtype=torch.uint8, device=self.device)
         ret = self.engine.batch_register_memory(
-            [self.buf.data_ptr(), self.magic_buf.data_ptr()],
-            [2 * self.bucket_size, 4 * 1024],
+            [self.buf.data_ptr(), self.magic_buf.data_ptr(), self.magic_recv.data_ptr()],
+            [2 * self.bucket_size, 4 * 1024, 8],
         )
         assert ret == 0, f"batch_register_memory failed ret={ret}"
         logger.info(f"__init__ session_id={self.session_id}")
@@ -143,6 +146,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         magic = torch.tensor([0xAB, 0xDC, 0xEF, 0x88], dtype=torch.uint8, device=self.device)
         while True:
             if torch.equal(buf[:4], magic):
+                buf[:4] = 0  # reset for next use
                 break
             await asyncio.sleep(0)
 
@@ -165,6 +169,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         offset = 0
         should_wait = False
         bufs = [self.buf[: self.bucket_size], self.buf[self.bucket_size :]]
+        magic_slots = [self.magic_recv[:4], self.magic_recv[4:]]
         idx = 0
         current = bufs[idx]
 
@@ -177,6 +182,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
                 info = {
                     "bucket_meta": bucket_meta,
                     "ptr": current.data_ptr(),
+                    "magic_ptr": magic_slots[idx].data_ptr(),
                     "len": offset,
                     "is_last": False,
                 }
@@ -189,7 +195,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
                 offset = 0
 
                 if should_wait:
-                    await self.wait_for_complete(current)
+                    await self.wait_for_complete(magic_slots[idx])
                 should_wait = True
 
             assert offset + weight.nbytes <= self.bucket_size, (
@@ -209,11 +215,12 @@ class MooncakeCheckpointEngine(CheckpointEngine):
         info = {
             "bucket_meta": bucket_meta,
             "ptr": current.data_ptr(),
+            "magic_ptr": magic_slots[idx].data_ptr(),
             "len": offset,
             "is_last": True,
         }
         self.store.send_obj(info, 1)
-        await self.wait_for_complete(current)
+        await self.wait_for_complete(magic_slots[idx])
 
         time_cost = time.time() - start_time
         bandwidth = total_bytes / time_cost / (1024 * 1024 * 1024)
@@ -239,9 +246,10 @@ class MooncakeCheckpointEngine(CheckpointEngine):
             # 1 receive info from previous rank
             info = self.store.recv_obj(self.rank - 1)
             if idx >= 2 and self.rank < self.world_size - 1:
-                await self.wait_for_complete(current)
+                await self.wait_for_complete(self.magic_recv[(idx - 2) % 2 * 4 : (idx - 2) % 2 * 4 + 4])
 
             ptr = info["ptr"]
+            magic_ptr = info["magic_ptr"]
             ret = self.engine.transfer_sync_read(
                 self.buffer_info["session_id"],
                 current.data_ptr(),
@@ -253,6 +261,7 @@ class MooncakeCheckpointEngine(CheckpointEngine):
 
             # 2 send info to next rank
             info["ptr"] = current.data_ptr()
+            info["magic_ptr"] = self.magic_recv[idx % 2 * 4 : idx % 2 * 4 + 4].data_ptr()
             if self.rank < self.world_size - 1:
                 self.store.send_obj(info, self.rank + 1)
 
@@ -263,11 +272,11 @@ class MooncakeCheckpointEngine(CheckpointEngine):
                 tensor = current[meta["offset"] : meta["offset"] + size].view(dtype=dtype).view(shape)
                 yield name, tensor
 
-            # 4 write magic data to previous rank
+            # 4 write magic to dedicated magic_ptr instead of data buffer ptr
             ret = self.engine.transfer_sync_write(
                 self.buffer_info["session_id"],
                 self.magic_buf.data_ptr(),
-                ptr,
+                magic_ptr,
                 4,
             )
             assert ret == 0, f"transfer_sync_write failed {ret}"


### PR DESCRIPTION
### What does this PR do?

Fix weight corruption in `MooncakeCheckpointEngine`'s daisy-chain weight sync where the magic completion marker `[0xAB, 0xDC, 0xEF, 0x88]` overwrites the first 4 bytes of the data buffer, causing degenerate inference output (e.g. `!!!!` repeated to `max_response_length`). Introduces a dedicated `magic_recv` buffer for completion signals to isolate them from the data path.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: N/A
- [x] Format the PR title as `[ckpt] fix: use separate magic_recv buffer to prevent weight corruption in Mooncake daisy-chain sync`

### Test

This change cannot be tested by CI as it requires multi-GPU Mooncake RDMA environment. Validated by full training run:

| Metric | With bug | With fix |
|--------|----------|----------|
| `response_length/mean` | 4096 (maxed out) | 506.25 |
| `num_turns/mean` | N/A (degenerate) | 4.0 |
| Agent trajectories | `!!!!` repeated | Coherent English text |
| Checkpoint | Corrupted `embed_tokens` | Saved successfully |

### API and Usage Example

No API changes. The fix is internal to `MooncakeCheckpointEngine` — all existing config and usage remains the same.

### Design & Code Changes

**Problem:** After receiving a bucket via RDMA, the receiver writes a 4-byte magic marker to the sender's **data buffer** as a completion signal. Instrumentation shows the data buffer gets corrupted with magic bytes, and this corruption propagates through the daisy chain to downstream ranks. In Qwen3.6-27B, this overwrites `embed_tokens.weight[0:2]` with values like `-3.85e+17`, saturating all attention computations.

**Root cause mechanism** (whether `transfer_sync_write` has a local GPU side effect on intra-node RDMA, or another pathway) is still under investigation.

**Fix:** Introduce a separate RDMA-registered buffer (`magic_recv`, 8 bytes) for completion signals:

1. **`__init__`**: Add `self.magic_recv = torch.zeros(8, ...)` and register it with `batch_register_memory`
2. **`send_weights`**: Include `magic_ptr` (from `magic_slots`) in info dict; `wait_for_complete` checks `magic_slots[idx]` instead of data buffer
3. **`receive_weights`**: Extract `magic_ptr` from received info; write magic to `magic_ptr` (dedicated slot) instead of `ptr` (data buffer); forward `magic_ptr` to next rank
4. **`wait_for_complete`**: Reset magic slot to 0 after detection for reuse

Regardless of the corruption mechanism, writing to a dedicated buffer ensures any side effects only modify `magic_recv` (harmless) instead of the data buffer (fatal).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). — N/A, internal fix with no user-facing changes.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Requires multi-GPU Mooncake RDMA hardware, not feasible in CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [ ] If your PR is related to the `recipe` submodule. — N/A, no recipe changes.