### PR TITLE
[reward] feat: colocated reward model for v1 sync/colocate_async trainer

### DIFF
--- a/.github/workflows/reward_model_vllm.yml
+++ b/.github/workflows/reward_model_vllm.yml
@@ -48,6 +48,7 @@ on:
       # Entrypoints
       - ".github/workflows/reward_model_vllm.yml"
       - "tests/experimental/reward_loop/**"
+      - "tests/special_e2e/run_v1_colocate_async_disrm.sh"
 
 # Cancel jobs on the same ref if a new one is triggered
 concurrency:
@@ -119,6 +120,10 @@ jobs:
       - name: Running vllm agent loop with reward model colocate tests on 8 L20 GPUs
         run: |
           ROLLOUT_NAME=vllm pytest -s -x tests/experimental/reward_loop/test_agent_reward_loop_colocate.py
+      - name: Running V1 colocate_async trainer with colocated disRM e2e on 8 L20 GPUs
+        run: |
+          ray stop --force
+          NUM_GPUS=8 ROLLOUT_NAME=vllm bash tests/special_e2e/run_v1_colocate_async_disrm.sh
 
   cleanup:
     runs-on: ubuntu-latest

--- a/tests/special_e2e/run_v1_colocate_async_disrm.sh
+++ b/tests/special_e2e/run_v1_colocate_async_disrm.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# E2E regression test for the V1 trainer (colocate_async) with a COLOCATED discriminative
+# reward model (disRM). This exercises PPOTrainer._compute_reward_colocate, which is the
+# colocated-RM path shared by all V1 trainers (sync / colocate_async / separate_async).
+#
+# Unlike run_fully_async_policy_genrm.sh (which uses a STANDALONE GenRM on its own GPUs),
+# here the reward model is colocated with the actor/rollout on the same GPUs
+# (reward.reward_model.enable_resource_pool=False). The rollout replicas are slept after
+# sampling so the reward model can reuse their GPU memory for scoring.
+#
+# GPU allocation: all GPUs are shared between training, rollout and the reward model
+# (colocate); a single node with >=2 GPUs is sufficient for the smoke test.
+
+export VERL_LOGGING_LEVEL=INFO
+export VLLM_USE_V1=1
+
+NUM_GPUS=${NUM_GPUS:-2}
+
+# Model paths (default to the conventional local cache used by other verl tests).
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/Qwen/Qwen2.5-0.5B-Instruct}
+# Discriminative reward model (sequence classification head), same family used by
+# tests/special_e2e/run_ppo_trainer_megatron.sh.
+RM_MODEL_PATH=${RM_MODEL_PATH:-${HOME}/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B}
+
+TRAIN_FILES=${TRAIN_FILES:-${HOME}/data/gsm8k/train.parquet}
+VAL_FILES=${VAL_FILES:-${HOME}/data/gsm8k/test.parquet}
+
+rollout_name=${ROLLOUT_NAME:-vllm}
+
+# Algorithm parameters
+adv_estimator=grpo
+n_resp_per_prompt=4
+
+# Keep the batch divisible by reward.num_workers (compute_rm_score chunks across workers).
+num_reward_workers=${NUM_REWARD_WORKERS:-4}
+train_prompt_bsz=${TRAIN_PROMPT_BSZ:-8}          # 8 prompts x 4 responses = 32 rows, divisible by 4 workers
+train_prompt_mini_bsz=${TRAIN_PROMPT_MINI_BSZ:-${train_prompt_bsz}}
+
+max_prompt_length=${MAX_PROMPT_LENGTH:-512}
+max_response_length=${MAX_RESPONSE_LENGTH:-512}
+
+# Reward-model rollout must fit the full chat (prompt + response + RM template overhead).
+rm_prompt_length=$(( max_prompt_length + max_response_length + 512 ))
+
+exp_name="$(basename "${MODEL_PATH,,}")-v1-colocate-async-disrm-minimal"
+
+echo "Running V1 colocate_async trainer with COLOCATED disRM"
+echo "Total GPUs: ${NUM_GPUS} (shared by training / rollout / reward model)"
+
+python3 -m verl.trainer.main_ppo \
+    trainer.use_v1=True \
+    trainer.v1.trainer_mode=colocate_async \
+    trainer.v1.colocate_async.num_warmup_batches=1 \
+    transfer_queue.enable=True \
+    data.train_files="${TRAIN_FILES}" \
+    data.val_files="${VAL_FILES}" \
+    data.prompt_key=prompt \
+    data.truncation='left' \
+    data.return_raw_chat=True \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=False \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.use_dynamic_bsz=True \
+    actor_rollout_ref.actor.fsdp_config.strategy=fsdp2 \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
+    actor_rollout_ref.rollout.name=${rollout_name} \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.rollout.prompt_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.response_length=${max_response_length} \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    reward.num_workers=${num_reward_workers} \
+    reward.reward_manager.name=dapo \
+    reward.reward_model.enable=True \
+    reward.reward_model.enable_resource_pool=False \
+    reward.reward_model.model_path="${RM_MODEL_PATH}" \
+    reward.reward_model.rollout.name=${rollout_name} \
+    reward.reward_model.rollout.tensor_model_parallel_size=1 \
+    reward.reward_model.rollout.gpu_memory_utilization=0.6 \
+    reward.reward_model.rollout.free_cache_engine=True \
+    reward.reward_model.rollout.skip_tokenizer_init=False \
+    reward.reward_model.rollout.prompt_length=${rm_prompt_length} \
+    reward.reward_model.rollout.response_length=${max_response_length} \
+    trainer.logger='["console"]' \
+    trainer.project_name='verl-test-v1-colocate-async-disrm' \
+    trainer.experiment_name="${exp_name}" \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=disable \
+    trainer.nnodes=1 \
+    trainer.n_gpus_per_node=${NUM_GPUS} \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps=1 \
+    "$@"
+
+echo "V1 colocate_async + colocated disRM E2E test completed successfully"

--- a/tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
@@ -163,6 +163,10 @@ class TestRawPromptObjectArray:
 
     @staticmethod
     def _build(raw_prompts):
+        # Mirror the production normalization in _compute_reward_colocate: the TransferQueue
+        # field may be a tensordict LinkedList (list subclass), NonTensorStack or numpy array,
+        # so it is wrapped with list(...) (not .tolist(), which only exists on numpy/tensors).
+        raw_prompts = list(raw_prompts)
         arr = np.empty(len(raw_prompts), dtype=object)
         arr[:] = raw_prompts
         return arr
@@ -201,3 +205,22 @@ class TestRawPromptObjectArray:
         assert len(chunks) == 2
         first_item = chunks[0][0]
         assert list(first_item) == [{"role": "user", "content": "0"}]
+
+    def test_list_subclass_input_like_tensordict_linkedlist(self):
+        # Regression: TransferQueue may return raw_prompt as a tensordict LinkedList,
+        # which is a `list` subclass without `.tolist()`. The production code uses
+        # list(...) to normalize it; verify that path yields a correct 1-D object array.
+        class _FakeLinkedList(list):
+            """Stand-in for tensordict.utils.LinkedList (a list subclass)."""
+
+        raw_prompts = _FakeLinkedList(
+            [
+                [{"role": "user", "content": "a"}],
+                [{"role": "user", "content": "b"}],
+            ]
+        )
+        assert not hasattr(raw_prompts, "tolist")  # the exact cause of the original crash
+        arr = self._build(raw_prompts)
+        assert arr.shape == (2,)
+        assert list(arr[0]) == [{"role": "user", "content": "a"}]
+        assert list(arr[1]) == [{"role": "user", "content": "b"}]

--- a/tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_compute_reward_colocate_on_cpu.py
@@ -1,0 +1,203 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only unit tests for the colocated reward model data plumbing in the V1 PPO trainer.
+
+These tests cover the dependency-light pieces of ``PPOTrainer._compute_reward_colocate``:
+
+- ``_lengths_to_mask``: building right-padded masks from per-row valid lengths.
+- The attention-mask layout contract expected by ``RewardManagerBase.assemble_rm_scores``
+  (i.e. ``attention_mask[:, prompt_width:].sum(dim=1)`` must equal the valid response
+  lengths, with right-padded prompts/responses).
+- Constructing a 1-D object array for ``raw_prompt`` that does not collapse equal-length
+  chat-message lists into a 2-D numpy array.
+
+The full path (TransferQueue + RewardLoopManager + GPU rollout) is exercised by the
+GPU integration test ``tests/experimental/reward_loop/test_agent_reward_loop_colocate.py``.
+"""
+
+import numpy as np
+import torch
+
+
+def _lengths_to_mask(lengths: torch.Tensor, width: int) -> torch.Tensor:
+    """Standalone copy of ``PPOTrainer._lengths_to_mask`` for unit testing.
+
+    Kept in sync with ``verl/trainer/ppo/v1/trainer_base.py``; importing the trainer
+    directly would pull in heavy runtime deps (ray, transfer_queue, vllm).
+    """
+    positions = torch.arange(width, device=lengths.device).unsqueeze(0)
+    return (positions < lengths.unsqueeze(1)).to(torch.int64)
+
+
+def _assemble_rm_scores(prompts, attention_mask, responses, scores):
+    """Replica of ``RewardManagerBase.assemble_rm_scores`` to assert the contract."""
+    prompt_length = prompts.size(1)
+    valid_response_length = attention_mask[:, prompt_length:].sum(dim=1)
+    rm_scores = torch.zeros_like(responses, dtype=torch.float32)
+    rm_scores[torch.arange(rm_scores.size(0)), valid_response_length - 1] = rm_scores.new_tensor(scores)
+    return rm_scores
+
+
+class TestLengthsToMask:
+    def test_basic_right_padding(self):
+        lengths = torch.tensor([1, 3, 2])
+        mask = _lengths_to_mask(lengths, width=4)
+        expected = torch.tensor(
+            [
+                [1, 0, 0, 0],
+                [1, 1, 1, 0],
+                [1, 1, 0, 0],
+            ],
+            dtype=torch.int64,
+        )
+        assert torch.equal(mask, expected)
+
+    def test_full_and_empty_rows(self):
+        lengths = torch.tensor([0, 4])
+        mask = _lengths_to_mask(lengths, width=4)
+        expected = torch.tensor([[0, 0, 0, 0], [1, 1, 1, 1]], dtype=torch.int64)
+        assert torch.equal(mask, expected)
+
+    def test_row_count_matches_lengths(self):
+        lengths = torch.tensor([2, 2, 2, 2, 2])
+        mask = _lengths_to_mask(lengths, width=3)
+        assert mask.shape == (5, 3)
+
+
+class TestAttentionMaskContract:
+    """The mask built by ``_compute_reward_colocate`` must satisfy assemble_rm_scores."""
+
+    def test_valid_response_length_recovered(self):
+        prompt_lengths = torch.tensor([2, 1, 3])
+        response_lengths = torch.tensor([3, 2, 1])
+        prompt_width, response_width = 4, 4
+
+        prompt_mask = _lengths_to_mask(prompt_lengths, prompt_width)
+        response_mask = _lengths_to_mask(response_lengths, response_width)
+        attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
+
+        # assemble_rm_scores slices off the prompt portion and sums the rest.
+        recovered = attention_mask[:, prompt_width:].sum(dim=1)
+        assert torch.equal(recovered, response_lengths)
+
+    def test_score_lands_on_last_valid_response_token(self):
+        prompt_lengths = torch.tensor([2, 1])
+        response_lengths = torch.tensor([3, 2])
+        prompt_width, response_width = 4, 5
+
+        prompts = torch.zeros((2, prompt_width), dtype=torch.int64)
+        responses = torch.zeros((2, response_width), dtype=torch.int64)
+        prompt_mask = _lengths_to_mask(prompt_lengths, prompt_width)
+        response_mask = _lengths_to_mask(response_lengths, response_width)
+        attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
+
+        scores = [0.5, -1.0]
+        rm_scores = _assemble_rm_scores(prompts, attention_mask, responses, scores)
+
+        # The score must be placed at index (response_length - 1) and nowhere else.
+        assert rm_scores[0, 2].item() == 0.5
+        assert rm_scores[1, 1].item() == -1.0
+        assert rm_scores.sum().item() == (0.5 - 1.0)
+        assert torch.equal(rm_scores.sum(dim=1), torch.tensor(scores))
+
+
+class TestRmScoresJaggedWriteBack:
+    """rm_scores must be written back as per-sample jagged rows (response-aligned).
+
+    The streaming reward path stores rm_scores as a jagged tensor whose per-row length
+    equals each sample's response length; ``_compute_advantage`` then calls
+    ``to_padded_tensor()`` on it. ``_compute_reward_colocate`` must produce the same layout
+    from the (bsz, response_width) tensor returned by ``assemble_rm_scores``.
+    """
+
+    @staticmethod
+    def _to_jagged(padded_rm_scores, response_lengths):
+        return torch.nested.as_nested_tensor(
+            [padded_rm_scores[i, : response_lengths[i]] for i in range(len(response_lengths))],
+            layout=torch.jagged,
+        )
+
+    def test_jagged_layout_and_lengths(self):
+        padded = torch.zeros(3, 5)
+        padded[0, 2] = 0.5
+        padded[1, 1] = -1.0
+        padded[2, 0] = 0.9
+        response_lengths = torch.tensor([3, 2, 1])
+
+        nt = self._to_jagged(padded, response_lengths)
+
+        # get_tensordict requires nested + jagged + contiguous.
+        assert nt.is_nested
+        assert nt.layout == torch.jagged
+        assert nt.is_contiguous()
+        assert nt.offsets().diff().tolist() == [3, 2, 1]
+
+    def test_padded_roundtrip_preserves_scores(self):
+        padded = torch.zeros(2, 6)
+        padded[0, 3] = 1.25
+        padded[1, 0] = -2.0
+        response_lengths = torch.tensor([4, 1])
+
+        nt = self._to_jagged(padded, response_lengths)
+        pad_back = nt.to_padded_tensor(0.0)
+
+        # Width collapses to max valid response length, scores preserved per row.
+        assert pad_back.shape == (2, 4)
+        assert torch.allclose(pad_back.sum(dim=1), torch.tensor([1.25, -2.0]))
+
+
+class TestRawPromptObjectArray:
+    """raw_prompt must remain a 1-D object array (one chat-message list per sample)."""
+
+    @staticmethod
+    def _build(raw_prompts):
+        arr = np.empty(len(raw_prompts), dtype=object)
+        arr[:] = raw_prompts
+        return arr
+
+    def test_equal_length_messages_not_collapsed(self):
+        # Two samples, each with a single-message chat of equal structure.
+        raw_prompts = [
+            [{"role": "user", "content": "a"}],
+            [{"role": "user", "content": "b"}],
+        ]
+        arr = self._build(raw_prompts)
+        assert arr.shape == (2,)
+        assert arr.dtype == object
+        # Each element is exactly one sample's message list.
+        assert list(arr[0]) == [{"role": "user", "content": "a"}]
+        assert list(arr[1]) == [{"role": "user", "content": "b"}]
+
+    def test_naive_np_array_would_collapse(self):
+        # Documents why element-wise assignment is required: np.array collapses
+        # equal-length nested lists into a 2-D array, breaking per-sample indexing.
+        raw_prompts = [
+            [{"role": "user", "content": "a"}],
+            [{"role": "user", "content": "b"}],
+        ]
+        naive = np.array(raw_prompts, dtype=object)
+        assert naive.shape == (2, 1)  # collapsed - wrong for downstream chunk/index
+
+        safe = self._build(raw_prompts)
+        assert safe.shape == (2,)  # preserved - correct
+
+    def test_chunk_and_index_roundtrip(self):
+        raw_prompts = [[{"role": "user", "content": str(i)}] for i in range(4)]
+        arr = self._build(raw_prompts)
+        # Simulate DataProto.chunk -> np.array_split along axis 0, then per-row index.
+        chunks = np.array_split(arr, 2)
+        assert len(chunks) == 2
+        first_item = chunks[0][0]
+        assert list(first_item) == [{"role": "user", "content": "0"}]

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -420,7 +420,7 @@ class PPOTrainer(ABC):
         # 3. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
             with marked_timer("reward", timing_raw, color="yellow"):
-                batch = self._compute_reward_colocate(batch)
+                batch = self._compute_reward_colocate(batch, metrics=metrics)
 
         # 4. balance batch across data parallel groups
         batch = self._balance_batch(batch, metrics=metrics)
@@ -1112,10 +1112,61 @@ class PPOTrainer(ABC):
         # add batch to agent loop manager
         self.agent_loop_manager.generate_sequences(batch)
 
-    def _compute_reward_colocate(self, batch: KVBatchMeta, metrics: dict) -> KVBatchMeta:
-        """Compute the reward with colocate reward model."""
-        # TODO: add reward model
-        raise NotImplementedError
+    def _compute_reward_colocate(self, batch: KVBatchMeta, metrics: dict | None = None) -> KVBatchMeta:
+        """Compute the reward score with a colocated reward model."""
+        assert self.reward_loop_manager is not None, "RewardLoopManager is None"
+
+        # 1. read the fields required by the reward model from TransferQueue.
+        fields = ["prompts", "responses", "raw_prompt"]
+        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id, select_fields=fields)
+
+        prompt_lengths = data["prompts"].offsets().diff()
+        response_lengths = data["responses"].offsets().diff()
+        prompts = data["prompts"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+        responses = data["responses"].to_padded_tensor(padding=self.tokenizer.pad_token_id)
+
+        # 2. rebuild the attention mask aligned with the [prompts | responses] layout.
+        prompt_mask = self._lengths_to_mask(prompt_lengths, prompts.size(1))
+        response_mask = self._lengths_to_mask(response_lengths, responses.size(1))
+        attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
+
+        raw_prompts = data["raw_prompt"].tolist()
+        raw_prompt_arr = np.empty(len(raw_prompts), dtype=object)
+        raw_prompt_arr[:] = raw_prompts
+
+        rm_input = DataProto(
+            batch=TensorDict(
+                {"prompts": prompts, "responses": responses, "attention_mask": attention_mask},
+                batch_size=len(batch),
+            ),
+            non_tensor_batch={"raw_prompt": raw_prompt_arr},
+        )
+
+        # 3. run the reward model (wakes/sleeps the reward model internally).
+        rm_output = self.reward_loop_manager.compute_rm_score(rm_input)
+
+        # 4. write rm_scores (and reward extra info) back to TransferQueue.
+        padded_rm_scores = rm_output.batch["rm_scores"]
+        rm_scores = torch.nested.as_nested_tensor(
+            [padded_rm_scores[i, : response_lengths[i]] for i in range(len(batch))],
+            layout=torch.jagged,
+        )
+        write_back = {"rm_scores": rm_scores}
+        for key in rm_output.meta_info.get("reward_extra_keys", []):
+            write_back[key] = rm_output.non_tensor_batch[key]
+        tq.kv_batch_put(
+            keys=batch.keys,
+            partition_id=batch.partition_id,
+            fields=tu.get_tensordict(write_back),
+        )
+
+        return batch
+
+    @staticmethod
+    def _lengths_to_mask(lengths: torch.Tensor, width: int) -> torch.Tensor:
+        """Build a right-padded mask of shape (len(lengths), width) from per-row valid lengths."""
+        positions = torch.arange(width, device=lengths.device).unsqueeze(0)
+        return (positions < lengths.unsqueeze(1)).to(torch.int64)
 
     def _get_required_batch_multiple(self, dp_size: int) -> int:
         """Return the global batch multiple required by downstream train steps(e.g. critics, actors)."""

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1130,7 +1130,11 @@ class PPOTrainer(ABC):
         response_mask = self._lengths_to_mask(response_lengths, responses.size(1))
         attention_mask = torch.cat([prompt_mask, response_mask], dim=1)
 
-        raw_prompts = data["raw_prompt"].tolist()
+        # `raw_prompt` is a non-tensor field; depending on the TransferQueue backend it
+        # comes back as a tensordict LinkedList (a `list` subclass), a NonTensorStack or a
+        # numpy array. `list(...)` normalizes all of them to a plain list where each element
+        # is one sample's chat-message list (whereas `.tolist()` only exists on numpy/tensors).
+        raw_prompts = list(data["raw_prompt"])
         raw_prompt_arr = np.empty(len(raw_prompts), dtype=object)
         raw_prompt_arr[:] = raw_prompts
 

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -19,6 +19,7 @@ import ray
 from omegaconf import DictConfig
 
 from verl.checkpoint_engine import CheckpointEngineManager
+from verl.trainer.ppo.utils import need_reward_model
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
@@ -54,6 +55,13 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         assert config.actor_rollout_ref.rollout.checkpoint_engine.backend != "naive", (
             "please use nccl/nixl/mooncake, etc. backend for separate async training"
         )
+
+        if need_reward_model(config):
+            assert config.reward.reward_model.enable_resource_pool, (
+                "Colocate reward model (reward.reward_model.enable_resource_pool=False) is not supported "
+                "in separate async mode, because the standalone rollout never pauses to free GPU memory. "
+                "Use standalone mode (reward.reward_model.enable_resource_pool=True) instead."
+            )
 
         super().__init__(config)
 


### PR DESCRIPTION
### What does this PR do?

Implement colocated reward model scoring (_compute_reward_colocate) for the V1 PPO trainer, enabling reward models to share GPUs with rollout in sync/colocate_async modes.

### Test

Add cpu tests and an e2e colocate_async reward model test.