### PR TITLE
[trainer, cfg] feat: add kl_direction (forward/reverse) to the top-k distillation loss

### DIFF
--- a/tests/workers/test_forward_kl_topk_loss_values_on_cpu.py
+++ b/tests/workers/test_forward_kl_topk_loss_values_on_cpu.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Value-level CPU tests for ``compute_forward_kl_topk`` (FSDP backend).
+
+The existing CPU coverage (``test_distillation_topk_symmetry_on_cpu``) only
+asserts the two diagnostic outputs (``overlap_count`` /
+``overlap_token_advantage``). The load-bearing outputs of the GKD-OPD loss --
+``distillation_losses`` (the objective), ``student_mass`` / ``teacher_mass``,
+the default-on ``log_prob_min_clamp`` branch, and the ``use_chunked_topk``
+path -- had no value-level assertions, so a regression in ``kl_divergence`` or
+the clamp/chunk handling would pass CI. These tests pin the loss math against
+a from-scratch reference on tiny CPU tensors.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk
+
+
+def _cfg(log_prob_min_clamp=None, use_chunked_topk=False):
+    return SimpleNamespace(
+        distillation_loss=SimpleNamespace(
+            log_prob_min_clamp=log_prob_min_clamp,
+            use_chunked_topk=use_chunked_topk,
+            chunked_topk_chunk_size=4096,
+        )
+    )
+
+
+def _nested(rows: torch.Tensor) -> torch.Tensor:
+    # compute_forward_kl_topk expects jagged nested teacher tensors and reads
+    # ``.values().unsqueeze(0)``; one batch row of (seqlen, topk) reproduces a
+    # single-sequence micro-batch.
+    return torch.nested.nested_tensor([rows], layout=torch.jagged)
+
+
+def _make_inputs(seqlen=4, vocab=10, topk=3, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    student_logits = torch.randn(1, seqlen, vocab, generator=g)
+    teacher_log_probs = torch.log_softmax(torch.randn(seqlen, vocab, generator=g), dim=-1)
+    t_lp, t_ids = torch.topk(teacher_log_probs, topk, dim=-1)
+    return student_logits, t_lp, t_ids.long()
+
+
+def _forward_kl_reference(student_logits, t_lp, t_ids, clamp=None):
+    s_at_t = torch.gather(torch.log_softmax(student_logits, dim=-1), dim=-1, index=t_ids.unsqueeze(0))
+    t_lp_b = t_lp.unsqueeze(0)
+    if clamp is not None:
+        t_lp_b, s_at_t = t_lp_b.clamp_min(clamp), s_at_t.clamp_min(clamp)
+    loss = (t_lp_b.exp() * (t_lp_b - s_at_t)).sum(dim=-1)
+    return loss, s_at_t, t_lp_b
+
+
+def test_forward_kl_topk_loss_matches_reference():
+    student_logits, t_lp, t_ids = _make_inputs()
+    out = compute_forward_kl_topk(student_logits, _nested(t_lp), _nested(t_ids), _cfg(log_prob_min_clamp=None), "thd")
+    # student_mass / teacher_mass are taken on the *unclamped* log-probs.
+    s_at_t = torch.gather(torch.log_softmax(student_logits, dim=-1), dim=-1, index=t_ids.unsqueeze(0))
+    ref_loss, _, _ = _forward_kl_reference(student_logits, t_lp, t_ids, clamp=None)
+    torch.testing.assert_close(out["distillation_losses"], ref_loss)
+    torch.testing.assert_close(out["student_mass"], s_at_t.exp().sum(dim=-1))
+    torch.testing.assert_close(out["teacher_mass"], t_lp.unsqueeze(0).exp().sum(dim=-1))
+
+
+def test_log_prob_min_clamp_branch_changes_loss():
+    # Force student log-probs far below the clamp at the teacher's top-k ids:
+    # a hard peak on id 0 drives log-prob ~ -60 at every other id.
+    seqlen, vocab, clamp = 2, 12, -10.0
+    student_logits = torch.full((1, seqlen, vocab), -30.0)
+    student_logits[..., 0] = 30.0
+    t_ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    t_lp = torch.log_softmax(torch.randn(seqlen, vocab), dim=-1).gather(dim=-1, index=t_ids)
+
+    out = compute_forward_kl_topk(
+        student_logits, _nested(t_lp), _nested(t_ids.long()), _cfg(log_prob_min_clamp=clamp), "thd"
+    )
+    ref_clamped, _, _ = _forward_kl_reference(student_logits, t_lp, t_ids, clamp=clamp)
+    ref_unclamped, _, _ = _forward_kl_reference(student_logits, t_lp, t_ids, clamp=None)
+    torch.testing.assert_close(out["distillation_losses"], ref_clamped)
+    # The clamp is on by default and materially changes the loss here.
+    assert not torch.allclose(ref_clamped, ref_unclamped)
+
+
+def test_chunked_topk_matches_default_path():
+    student_logits, t_lp, t_ids = _make_inputs(seqlen=6, vocab=16, topk=4, seed=1)
+    default = compute_forward_kl_topk(
+        student_logits, _nested(t_lp), _nested(t_ids), _cfg(use_chunked_topk=False), "thd"
+    )
+    chunked = compute_forward_kl_topk(student_logits, _nested(t_lp), _nested(t_ids), _cfg(use_chunked_topk=True), "thd")
+    assert set(chunked) == set(default)
+    for key in default:
+        torch.testing.assert_close(chunked[key], default[key])

--- a/tests/workers/test_kl_topk_direction_on_cpu.py
+++ b/tests/workers/test_kl_topk_direction_on_cpu.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU loss-math test for the ``kl_direction`` knob on the top-k distillation loss.
+
+``compute_forward_kl_topk`` historically computed only forward KL,
+``KL(teacher || student)``. The ``kl_direction`` knob adds the reverse direction,
+``KL(student || teacher)``, a loss-flexibility primitive for on-policy
+self-distillation (#6827). This pins both directions against a
+from-scratch reference on tiny CPU tensors.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk, kl_divergence
+
+
+def _nested(rows: torch.Tensor) -> torch.Tensor:
+    return torch.nested.nested_tensor([rows], layout=torch.jagged)
+
+
+def _cfg(direction: str):
+    return SimpleNamespace(
+        distillation_loss=SimpleNamespace(kl_direction=direction, log_prob_min_clamp=None, use_chunked_topk=False)
+    )
+
+
+def _inputs(seqlen=4, vocab=10, topk=3, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    student_logits = torch.randn(1, seqlen, vocab, generator=g)
+    teacher_log_probs = torch.log_softmax(torch.randn(seqlen, vocab, generator=g), dim=-1)
+    t_lp, t_ids = torch.topk(teacher_log_probs, topk, dim=-1)
+    return student_logits, t_lp, t_ids.long()
+
+
+def test_forward_keeps_current_semantics_reverse_swaps_and_they_differ():
+    student_logits, t_lp, t_ids = _inputs()
+    student_at_teacher = torch.gather(torch.log_softmax(student_logits, dim=-1), dim=-1, index=t_ids.unsqueeze(0))
+    teacher = t_lp.unsqueeze(0)
+
+    fwd = compute_forward_kl_topk(student_logits, _nested(t_lp), _nested(t_ids), _cfg("forward"), "thd")
+    rev = compute_forward_kl_topk(student_logits, _nested(t_lp), _nested(t_ids), _cfg("reverse"), "thd")
+
+    # forward == today's behavior: KL(teacher || student)
+    torch.testing.assert_close(fwd["distillation_losses"], kl_divergence(log_q=student_at_teacher, log_p=teacher))
+    # reverse == KL(student || teacher) over the teacher top-k support
+    torch.testing.assert_close(rev["distillation_losses"], kl_divergence(log_q=teacher, log_p=student_at_teacher))
+    assert not torch.allclose(fwd["distillation_losses"], rev["distillation_losses"])

--- a/verl/trainer/distillation/fsdp/losses.py
+++ b/verl/trainer/distillation/fsdp/losses.py
@@ -127,7 +127,11 @@ def compute_forward_kl_topk(
     if loss_config.log_prob_min_clamp is not None:
         student_topk_log_probs = student_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
         teacher_topk_log_probs = teacher_topk_log_probs.clamp_min(loss_config.log_prob_min_clamp)
-    distillation_losses = kl_divergence(log_q=student_topk_log_probs, log_p=teacher_topk_log_probs)
+    if getattr(loss_config, "kl_direction", "forward") == "reverse":
+        # KL(student||teacher): mode-seeking, used by short-context OPSDL.
+        distillation_losses = kl_divergence(log_q=teacher_topk_log_probs, log_p=student_topk_log_probs)
+    else:
+        distillation_losses = kl_divergence(log_q=student_topk_log_probs, log_p=teacher_topk_log_probs)
 
     # Diagnostics for tracking teacher/student top-k overlap in OPD, following
     # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016).

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -141,6 +141,8 @@ def compute_topk_loss(
 
             distillation_loss_fn = fsdp_losses.compute_forward_kl_topk
         case "megatron":
+            if distillation_config.distillation_loss.kl_direction == "reverse":
+                raise NotImplementedError("reverse kl_direction is not yet implemented for the megatron backend")
             import verl.trainer.distillation.megatron.losses as megatron_losses
 
             distillation_loss_fn = megatron_losses.compute_forward_kl_topk

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -81,6 +81,11 @@ class DistillationLossConfig(BaseConfig):
     # overhead (saved-tensor total stays constant either way).
     chunked_topk_chunk_size: int = 4096
 
+    # KL direction for ``loss_mode='forward_kl_topk'``: "forward" =
+    # KL(teacher||student) (the default); "reverse" = KL(student||teacher),
+    # used by short-context self-distillation (OPSDL). FSDP backend only.
+    kl_direction: str = "forward"
+
     use_policy_gradient: bool = True
     policy_loss_mode: str = "vanilla"
     clip_ratio: float = 0.2
@@ -102,6 +107,9 @@ class DistillationLossConfig(BaseConfig):
         from verl.trainer.distillation.losses import DistillationLossSettings, get_distillation_loss_settings
 
         self.loss_settings: DistillationLossSettings = get_distillation_loss_settings(self.loss_mode)
+
+        if self.kl_direction not in ("forward", "reverse"):
+            raise ValueError(f"kl_direction must be 'forward' or 'reverse', got {self.kl_direction!r}.")
 
         if self.policy_loss_mode != "vanilla":
             raise NotImplementedError(


### PR DESCRIPTION
### What does this PR do?

Adds a `kl_direction in {forward, reverse}` knob to `DistillationLossConfig`. `compute_forward_kl_topk` only computed forward KL (`KL(teacher||student)`); `reverse` swaps it to `KL(student||teacher)`. The existing reverse-KL path uses single-sample estimators (`k1`/`k3`/...), not the top-k support, so a top-k reverse direction was missing. Small loss-flexibility primitive for on-policy self-distillation (#6827).

Scope:
- FSDP backend honors `kl_direction`; the megatron path raises `NotImplementedError` for `reverse` (its hand-written autograd `Function` would need the gradient re-derived).
- Config validation rejects anything but `forward` / `reverse`.

### Test

`pytest tests/workers/test_kl_topk_direction_on_cpu.py` -- forward keeps today's semantics, reverse swaps, the two differ. CPU-only. Verified locally that flipping the swap fails the test, and the existing distillation CPU tests still pass.

Part of #6827.