### PR TITLE
[rollout, trainer, cfg] feat: privileged-context teacher scoring for OPSD

### DIFF
--- a/tests/workers/test_distillation_config_opsd_on_cpu.py
+++ b/tests/workers/test_distillation_config_opsd_on_cpu.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the OPSD fields on ``DistillationConfig``."""
+
+from verl.workers.config.distillation import DistillationConfig
+
+
+def test_opsd_defaults_are_off_and_backward_compatible():
+    c = DistillationConfig()
+    assert c.self_distillation is False
+    assert c.privileged_solution_key == "ground_truth"
+    # markers default to newline-wrapped text so the solution is set off from the prompt
+    assert c.privileged_prefix.strip() and c.privileged_suffix.strip()
+
+
+def test_opsd_fields_settable_without_enabling_distillation():
+    # enabled=False short-circuits teacher-pool validation, so OPSD fields can be
+    # exercised standalone.
+    c = DistillationConfig(self_distillation=True, privileged_solution_key="solution")
+    assert c.self_distillation is True
+    assert c.privileged_solution_key == "solution"

--- a/tests/workers/test_distillation_config_opsd_on_cpu.py
+++ b/tests/workers/test_distillation_config_opsd_on_cpu.py
@@ -29,3 +29,42 @@ def test_self_distillation_requires_enabled():
 
     with pytest.raises(ValueError):
         DistillationConfig(self_distillation=True)  # enabled defaults to False
+
+
+def test_privileged_mode_defaults_to_append():
+    c = DistillationConfig()
+    assert c.privileged_mode == "append"
+    assert c.privileged_problem_key == "extra_info.problem"
+    assert c.privileged_enable_thinking is True
+
+
+def test_privileged_mode_rejects_unknown_value():
+    import pytest
+
+    with pytest.raises(ValueError, match="privileged_mode"):
+        DistillationConfig(self_distillation=True, privileged_mode="banana")
+
+
+def test_chat_turn_requires_problem_key():
+    import pytest
+
+    with pytest.raises(ValueError, match="privileged_problem_key"):
+        DistillationConfig(self_distillation=True, privileged_mode="chat_turn", privileged_problem_key="")
+
+
+def test_chat_turn_template_must_have_placeholders():
+    import pytest
+
+    with pytest.raises(ValueError, match="placeholders"):
+        DistillationConfig(
+            self_distillation=True, privileged_mode="chat_turn", privileged_user_template="no placeholders here"
+        )
+
+
+def test_chat_turn_valid_fields_pass_field_checks():
+    import pytest
+
+    # With valid chat_turn fields the first failure is the enabled gate, proving
+    # the mode/problem-key/template checks all passed.
+    with pytest.raises(ValueError, match="enabled"):
+        DistillationConfig(self_distillation=True, privileged_mode="chat_turn")

--- a/tests/workers/test_distillation_config_opsd_on_cpu.py
+++ b/tests/workers/test_distillation_config_opsd_on_cpu.py
@@ -19,14 +19,13 @@ from verl.workers.config.distillation import DistillationConfig
 def test_opsd_defaults_are_off_and_backward_compatible():
     c = DistillationConfig()
     assert c.self_distillation is False
-    assert c.privileged_solution_key == "ground_truth"
+    assert c.privileged_solution_key == "reward_model.ground_truth"
     # markers default to newline-wrapped text so the solution is set off from the prompt
     assert c.privileged_prefix.strip() and c.privileged_suffix.strip()
 
 
-def test_opsd_fields_settable_without_enabling_distillation():
-    # enabled=False short-circuits teacher-pool validation, so OPSD fields can be
-    # exercised standalone.
-    c = DistillationConfig(self_distillation=True, privileged_solution_key="solution")
-    assert c.self_distillation is True
-    assert c.privileged_solution_key == "solution"
+def test_self_distillation_requires_enabled():
+    import pytest
+
+    with pytest.raises(ValueError):
+        DistillationConfig(self_distillation=True)  # enabled defaults to False

--- a/tests/workers/test_opsd_privileged_context_on_cpu.py
+++ b/tests/workers/test_opsd_privileged_context_on_cpu.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the OPSD privileged-context helpers.
+
+These pin the two pure token-surgery ops that distinguish on-policy
+self-distillation (OPSD) from plain OPD: building the teacher's privileged input
+(problem + ground-truth solution + student response) and realigning the teacher's
+per-token scores back onto the student's ``prompt + response`` positions.
+"""
+
+import torch
+
+from verl.trainer.distillation.privileged_context import (
+    build_privileged_sequence,
+    slice_privileged_teacher_to_student,
+)
+
+
+def test_build_privileged_sequence_layout():
+    seq = build_privileged_sequence(
+        prompt_ids=[1, 2],
+        response_ids=[9, 10],
+        solution_ids=[5, 6, 7],
+        prefix_ids=[100],
+        suffix_ids=[200, 201],
+    )
+    assert seq == [1, 2, 100, 5, 6, 7, 200, 201, 9, 10]
+    # the response is the suffix, exactly as in a plain prompt+response teacher input
+    assert seq[-2:] == [9, 10]
+
+
+def test_build_privileged_sequence_empty_markers():
+    assert build_privileged_sequence([1], [9], [5], [], []) == [1, 5, 9]
+
+
+def test_slice_privileged_teacher_keeps_response_pads_prompt():
+    priv_len, k = 10, 2
+    teacher_ids = torch.arange(priv_len * k).reshape(priv_len, k)
+    teacher_logprobs = torch.randn(priv_len, k)
+
+    ids, logprobs = slice_privileged_teacher_to_student(
+        teacher_ids, teacher_logprobs, student_prompt_length=2, response_length=2, pad_token_id=0
+    )
+
+    # aligned to student prompt(2) + response(2)
+    assert ids.shape == (4, k) and logprobs.shape == (4, k)
+    # response rows == the teacher's last response_length rows (privileged scores)
+    assert torch.equal(ids[-2:], teacher_ids[-2:])
+    assert torch.equal(logprobs[-2:], teacher_logprobs[-2:])
+    # prompt rows are padded / zeroed (the response mask drops them downstream)
+    assert torch.all(ids[:2] == 0)
+    assert torch.all(logprobs[:2] == 0.0)
+
+
+def test_slice_preserves_dtype_and_pad_value():
+    teacher_ids = torch.arange(6).reshape(3, 2).long()
+    teacher_logprobs = torch.randn(3, 2, dtype=torch.float32)
+
+    ids, logprobs = slice_privileged_teacher_to_student(
+        teacher_ids, teacher_logprobs, student_prompt_length=1, response_length=2, pad_token_id=7
+    )
+
+    assert ids.dtype == torch.long and logprobs.dtype == torch.float32
+    assert ids[0, 0].item() == 7

--- a/tests/workers/test_opsd_privileged_context_on_cpu.py
+++ b/tests/workers/test_opsd_privileged_context_on_cpu.py
@@ -75,7 +75,9 @@ def test_build_privileged_sequence_insert_before_marker():
 
 
 def test_build_privileged_sequence_insert_marker_not_found_falls_back():
-    seq = build_privileged_sequence([1, 2], [9], [5], [100], [200], insert_before_token_ids=[42])
+    seq = build_privileged_sequence(
+        [1, 2], [9], [5], [100], [200], insert_before_token_ids=[42]
+    )
     assert seq == [1, 2, 100, 5, 200, 9]  # append fallback
 
 
@@ -128,4 +130,31 @@ def test_slice_preserves_dtype_and_pad_value():
 
 def test_slice_negative_response_length_raises():
     with pytest.raises(ValueError):
-        slice_privileged_teacher_to_student(torch.arange(6).reshape(3, 2), torch.randn(3, 2), 1, -1, 0)
+        slice_privileged_teacher_to_student(
+            torch.arange(6).reshape(3, 2), torch.randn(3, 2), 1, -1, 0
+        )
+
+
+def test_privileged_slice_aligns_response_rows_after_padding():
+    """End-to-end alignment: after the privileged slice + the same left/right pad
+    that ``_pad_teacher_outputs`` applies, response token ``j`` lands at absolute
+    row ``prompt_width + j`` -- the privileged teacher's score for that token. The
+    pad is replicated inline (``F.pad``) so we don't import the heavy
+    teacher_manager package."""
+    import torch.nn.functional as F
+
+    prompt_len, block_len, resp_len, k = 3, 4, 2, 2
+    prompt_width, response_width = 5, 4  # batch widths (>= the per-sample lengths)
+    n = prompt_len + block_len + resp_len  # teacher scores prompt + block + response
+    teacher_ids = torch.arange(n * k).reshape(n, k)
+    teacher_logprobs = torch.randn(n, k)
+
+    ids, _ = slice_privileged_teacher_to_student(
+        teacher_ids, teacher_logprobs, prompt_len, resp_len, pad_token_id=0
+    )
+    # _pad_teacher_outputs: left-pad the prompt region, right-pad the response region
+    padded = F.pad(ids, (0, 0, prompt_width - prompt_len, response_width - resp_len), value=0)
+    assert padded.shape[0] == prompt_width + response_width
+    for j in range(resp_len):
+        # absolute row prompt_width+j == the teacher's privileged score for response token j
+        assert torch.equal(padded[prompt_width + j], teacher_ids[prompt_len + block_len + j])

--- a/tests/workers/test_opsd_privileged_context_on_cpu.py
+++ b/tests/workers/test_opsd_privileged_context_on_cpu.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 
 from verl.trainer.distillation.privileged_context import (
+    build_privileged_chat_turn,
     build_privileged_sequence,
     resolve_privileged_solution,
     slice_privileged_teacher_to_student,
@@ -158,3 +159,53 @@ def test_privileged_slice_aligns_response_rows_after_padding():
     for j in range(resp_len):
         # absolute row prompt_width+j == the teacher's privileged score for response token j
         assert torch.equal(padded[prompt_width + j], teacher_ids[prompt_len + block_len + j])
+
+
+class _FakeChatTokenizer:
+    """Minimal stand-in exposing apply_chat_template: [BOS=1] + per-char ids +
+    assistant opener [7] when add_generation_prompt, recording call kwargs."""
+
+    def __init__(self):
+        self.last_kwargs = None
+
+    def apply_chat_template(self, messages, tokenize, add_generation_prompt, **kwargs):
+        self.last_kwargs = kwargs
+        assert tokenize and add_generation_prompt
+        assert messages[0]["role"] == "user"
+        ids = [1] + [ord(c) % 100 + 10 for c in messages[0]["content"]]
+        return ids + [7]
+
+
+def test_build_privileged_chat_turn_places_solution_in_user_turn():
+    tok = _FakeChatTokenizer()
+    seq = build_privileged_chat_turn(
+        tok,
+        problem="P",
+        solution="S",
+        response_ids=[9, 10],
+        user_template="q:{problem} a:{solution}",
+        chat_template_kwargs={"enable_thinking": True},
+    )
+    # templated prompt = BOS + content + assistant opener, then the response
+    expected_prompt = [1] + [ord(c) % 100 + 10 for c in "q:P a:S"] + [7]
+    assert seq == expected_prompt + [9, 10]
+    assert tok.last_kwargs == {"enable_thinking": True}
+
+
+def test_build_privileged_chat_turn_literal_braces_are_safe():
+    # {problem}/{solution} are replaced literally; \boxed{} etc. must survive
+    tok = _FakeChatTokenizer()
+    template = "solve {problem} using {solution}; answer in \\boxed{}"
+    seq = build_privileged_chat_turn(tok, "x+1=2", "x=1", [], template)
+    text = "solve x+1=2 using x=1; answer in \\boxed{}"
+    assert seq == [1] + [ord(c) % 100 + 10 for c in text] + [7]
+
+
+def test_reference_user_template_has_placeholders_and_reference_markers():
+    from verl.trainer.distillation.privileged_context import REFERENCE_USER_TEMPLATE
+
+    assert "{problem}" in REFERENCE_USER_TEMPLATE
+    assert "{solution}" in REFERENCE_USER_TEMPLATE
+    # anchors of the reference implementation's wording
+    assert "=== Reference Solution Begin ===" in REFERENCE_USER_TEMPLATE
+    assert REFERENCE_USER_TEMPLATE.endswith("\\boxed{}.")

--- a/tests/workers/test_opsd_privileged_context_on_cpu.py
+++ b/tests/workers/test_opsd_privileged_context_on_cpu.py
@@ -11,20 +11,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""CPU tests for the OPSD privileged-context helpers.
+"""CPU tests for the OPSD privileged-context helpers."""
 
-These pin the two pure token-surgery ops that distinguish on-policy
-self-distillation (OPSD) from plain OPD: building the teacher's privileged input
-(problem + ground-truth solution + student response) and realigning the teacher's
-per-token scores back onto the student's ``prompt + response`` positions.
-"""
-
+import numpy as np
+import pytest
 import torch
 
 from verl.trainer.distillation.privileged_context import (
     build_privileged_sequence,
+    resolve_privileged_solution,
     slice_privileged_teacher_to_student,
 )
+
+
+def test_resolve_privileged_solution_nested_dotted_key():
+    sk = {"reward_model": {"ground_truth": "72"}}
+    assert resolve_privileged_solution(sk, "reward_model.ground_truth") == "72"
+    # flat key still works
+    assert resolve_privileged_solution({"sol": "x"}, "sol") == "x"
+
+
+def test_resolve_privileged_solution_missing_returns_none():
+    assert resolve_privileged_solution({"a": 1}, "reward_model.ground_truth") is None
+    assert resolve_privileged_solution(None, "x") is None
+    assert resolve_privileged_solution({"g": ""}, "g") is None
+
+
+def test_resolve_privileged_solution_normalizes_scalar_array_list():
+    assert resolve_privileged_solution({"g": np.array("72")}, "g") == "72"  # 0-d -> item
+    assert resolve_privileged_solution({"g": np.array(["x"])}, "g") == "x"  # 1-elem array
+    assert resolve_privileged_solution({"g": ["a", "b"]}, "g") == "a\nb"  # list -> joined
 
 
 def test_build_privileged_sequence_layout():
@@ -44,6 +60,25 @@ def test_build_privileged_sequence_empty_markers():
     assert build_privileged_sequence([1], [9], [5], [], []) == [1, 5, 9]
 
 
+def test_build_privileged_sequence_insert_before_marker():
+    # marker = [8] (e.g. an assistant-turn opener); solution block goes before its
+    # last occurrence, the response after the original prompt tail.
+    seq = build_privileged_sequence(
+        prompt_ids=[1, 8, 2, 8],
+        response_ids=[9],
+        solution_ids=[5],
+        prefix_ids=[100],
+        suffix_ids=[200],
+        insert_before_token_ids=[8],
+    )
+    assert seq == [1, 8, 2, 100, 5, 200, 8, 9]
+
+
+def test_build_privileged_sequence_insert_marker_not_found_falls_back():
+    seq = build_privileged_sequence([1, 2], [9], [5], [100], [200], insert_before_token_ids=[42])
+    assert seq == [1, 2, 100, 5, 200, 9]  # append fallback
+
+
 def test_slice_privileged_teacher_keeps_response_pads_prompt():
     priv_len, k = 10, 2
     teacher_ids = torch.arange(priv_len * k).reshape(priv_len, k)
@@ -53,23 +88,44 @@ def test_slice_privileged_teacher_keeps_response_pads_prompt():
         teacher_ids, teacher_logprobs, student_prompt_length=2, response_length=2, pad_token_id=0
     )
 
-    # aligned to student prompt(2) + response(2)
     assert ids.shape == (4, k) and logprobs.shape == (4, k)
-    # response rows == the teacher's last response_length rows (privileged scores)
     assert torch.equal(ids[-2:], teacher_ids[-2:])
     assert torch.equal(logprobs[-2:], teacher_logprobs[-2:])
-    # prompt rows are padded / zeroed (the response mask drops them downstream)
     assert torch.all(ids[:2] == 0)
     assert torch.all(logprobs[:2] == 0.0)
+
+
+def test_slice_response_length_zero_is_empty_not_whole_tensor():
+    # regression: teacher_ids[-0:] would return the whole tensor; an empty
+    # response must yield only the padded prompt rows.
+    teacher_ids = torch.arange(12).reshape(6, 2)
+    teacher_logprobs = torch.randn(6, 2)
+    ids, logprobs = slice_privileged_teacher_to_student(
+        teacher_ids, teacher_logprobs, student_prompt_length=3, response_length=0, pad_token_id=0
+    )
+    assert ids.shape == (3, 2) and logprobs.shape == (3, 2)
+    assert torch.all(ids == 0)
+
+
+def test_slice_pad_token_id_none_falls_back_to_zero():
+    teacher_ids = torch.arange(6).reshape(3, 2)
+    teacher_logprobs = torch.randn(3, 2)
+    ids, _ = slice_privileged_teacher_to_student(
+        teacher_ids, teacher_logprobs, student_prompt_length=1, response_length=2, pad_token_id=None
+    )
+    assert ids[0, 0].item() == 0
 
 
 def test_slice_preserves_dtype_and_pad_value():
     teacher_ids = torch.arange(6).reshape(3, 2).long()
     teacher_logprobs = torch.randn(3, 2, dtype=torch.float32)
-
     ids, logprobs = slice_privileged_teacher_to_student(
         teacher_ids, teacher_logprobs, student_prompt_length=1, response_length=2, pad_token_id=7
     )
-
     assert ids.dtype == torch.long and logprobs.dtype == torch.float32
     assert ids[0, 0].item() == 7
+
+
+def test_slice_negative_response_length_raises():
+    with pytest.raises(ValueError):
+        slice_privileged_teacher_to_student(torch.arange(6).reshape(3, 2), torch.randn(3, 2), 1, -1, 0)

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -49,6 +49,10 @@ from verl.experimental.agent_loop.utils import resolve_config_path
 from verl.protocol import DataProto
 from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
+from verl.trainer.distillation.privileged_context import (
+    build_privileged_sequence,
+    slice_privileged_teacher_to_student,
+)
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
 from verl.utils.model import compute_position_id_with_mask
@@ -521,6 +525,17 @@ class AgentLoopWorker:
             from verl.experimental.teacher_loop.teacher_manager import AsyncTeacherLLMServerManager
 
             self.teacher_key: str = config.distillation.teacher_key
+            self.self_distillation: bool = config.distillation.self_distillation
+            self.privileged_solution_key: str = config.distillation.privileged_solution_key
+            self._privileged_prefix_ids: list[int] = []
+            self._privileged_suffix_ids: list[int] = []
+            if self.self_distillation:
+                self._privileged_prefix_ids = self.tokenizer.encode(
+                    config.distillation.privileged_prefix, add_special_tokens=False
+                )
+                self._privileged_suffix_ids = self.tokenizer.encode(
+                    config.distillation.privileged_suffix, add_special_tokens=False
+                )
             self.teacher_server_manager = AsyncTeacherLLMServerManager(
                 config=config,
                 teacher_client=teacher_client,
@@ -1014,17 +1029,35 @@ class AgentLoopWorker:
         """Compute teacher logprobs for single sample."""
         if self.distillation_enabled and not validate:
             routing_key = None
+            solution_ids = None
             if sample_kwargs is not None:
                 routing_value = sample_kwargs.get(self.teacher_key)
                 if routing_value is not None:
                     # Non-tensor batch values arrive as 0-d numpy objects / arrays; normalize to Python.
                     routing_key = routing_value.item() if hasattr(routing_value, "item") else routing_value
+                if self.self_distillation:
+                    solution = sample_kwargs.get(self.privileged_solution_key)
+                    if solution is not None:
+                        solution = solution.item() if hasattr(solution, "item") else solution
+                        solution_ids = self.tokenizer.encode(str(solution), add_special_tokens=False)
+            if solution_ids is not None:
+                # OPSD: the teacher conditions on the privileged ground-truth solution.
+                sequence_ids = build_privileged_sequence(
+                    prompt_ids, response_ids, solution_ids, self._privileged_prefix_ids, self._privileged_suffix_ids
+                )
+            else:
+                sequence_ids = prompt_ids + response_ids
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(
-                sequence_ids=prompt_ids + response_ids,
+                sequence_ids=sequence_ids,
                 multi_modal_data=output.multi_modal_data,
                 mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,
             )
+            if solution_ids is not None:
+                # Realign the teacher's privileged-context scores onto the student's positions.
+                teacher_ids, teacher_logprobs = slice_privileged_teacher_to_student(
+                    teacher_ids, teacher_logprobs, len(prompt_ids), len(response_ids), self.tokenizer.pad_token_id
+                )
             output.extra_fields["teacher_ids"] = teacher_ids
             output.extra_fields["teacher_logprobs"] = teacher_logprobs
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -50,6 +50,8 @@ from verl.protocol import DataProto
 from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.distillation.privileged_context import (
+    REFERENCE_USER_TEMPLATE,
+    build_privileged_chat_turn,
     build_privileged_sequence,
     resolve_privileged_solution,
     slice_privileged_teacher_to_student,
@@ -528,20 +530,31 @@ class AgentLoopWorker:
             self.teacher_key: str = config.distillation.teacher_key
             self.self_distillation: bool = config.distillation.self_distillation
             self.privileged_solution_key: str = config.distillation.privileged_solution_key
+            self.privileged_mode: str = config.distillation.privileged_mode
+            self.privileged_problem_key: str = config.distillation.privileged_problem_key
             self._privileged_prefix_ids: list[int] = []
             self._privileged_suffix_ids: list[int] = []
             self._privileged_insert_before_ids: Optional[list[int]] = None
+            self._privileged_user_template: str = REFERENCE_USER_TEMPLATE
+            self._privileged_chat_kwargs: dict[str, Any] = {}
             if self.self_distillation:
-                self._privileged_prefix_ids = self.tokenizer.encode(
-                    config.distillation.privileged_prefix, add_special_tokens=False
-                )
-                self._privileged_suffix_ids = self.tokenizer.encode(
-                    config.distillation.privileged_suffix, add_special_tokens=False
-                )
-                if config.distillation.privileged_insert_before:
-                    self._privileged_insert_before_ids = self.tokenizer.encode(
-                        config.distillation.privileged_insert_before, add_special_tokens=False
+                if self.privileged_mode == "chat_turn":
+                    if config.distillation.privileged_user_template:
+                        self._privileged_user_template = config.distillation.privileged_user_template
+                    self._privileged_chat_kwargs = {
+                        "enable_thinking": config.distillation.privileged_enable_thinking
+                    }
+                else:
+                    self._privileged_prefix_ids = self.tokenizer.encode(
+                        config.distillation.privileged_prefix, add_special_tokens=False
                     )
+                    self._privileged_suffix_ids = self.tokenizer.encode(
+                        config.distillation.privileged_suffix, add_special_tokens=False
+                    )
+                    if config.distillation.privileged_insert_before:
+                        self._privileged_insert_before_ids = self.tokenizer.encode(
+                            config.distillation.privileged_insert_before, add_special_tokens=False
+                        )
             self.teacher_server_manager = AsyncTeacherLLMServerManager(
                 config=config,
                 teacher_client=teacher_client,
@@ -1048,15 +1061,31 @@ class AgentLoopWorker:
                         f"'{self.privileged_solution_key}'; verl's ground truth is usually at "
                         f"'reward_model.ground_truth'."
                     )
-                solution_ids = self.tokenizer.encode(solution, add_special_tokens=False)
-                sequence_ids = build_privileged_sequence(
-                    prompt_ids,
-                    response_ids,
-                    solution_ids,
-                    self._privileged_prefix_ids,
-                    self._privileged_suffix_ids,
-                    self._privileged_insert_before_ids,
-                )
+                if self.privileged_mode == "chat_turn":
+                    problem = resolve_privileged_solution(sample_kwargs, self.privileged_problem_key)
+                    if not problem:
+                        raise ValueError(
+                            f"privileged_mode='chat_turn' needs the raw problem text at "
+                            f"'{self.privileged_problem_key}' but nothing resolved there."
+                        )
+                    sequence_ids = build_privileged_chat_turn(
+                        self.tokenizer,
+                        problem,
+                        solution,
+                        response_ids,
+                        self._privileged_user_template,
+                        self._privileged_chat_kwargs,
+                    )
+                else:
+                    solution_ids = self.tokenizer.encode(solution, add_special_tokens=False)
+                    sequence_ids = build_privileged_sequence(
+                        prompt_ids,
+                        response_ids,
+                        solution_ids,
+                        self._privileged_prefix_ids,
+                        self._privileged_suffix_ids,
+                        self._privileged_insert_before_ids,
+                    )
             else:
                 sequence_ids = prompt_ids + response_ids
             teacher_ids, teacher_logprobs = await self.teacher_server_manager.compute_teacher_logprobs_single(

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -1035,7 +1035,6 @@ class AgentLoopWorker:
         """Compute teacher logprobs for single sample."""
         if self.distillation_enabled and not validate:
             routing_key = None
-            solution_ids = None
             if sample_kwargs is not None:
                 routing_value = sample_kwargs.get(self.teacher_key)
                 if routing_value is not None:
@@ -1050,8 +1049,6 @@ class AgentLoopWorker:
                         f"'reward_model.ground_truth'."
                     )
                 solution_ids = self.tokenizer.encode(solution, add_special_tokens=False)
-            if solution_ids is not None:
-                # OPSD: the teacher conditions on the privileged ground-truth solution.
                 sequence_ids = build_privileged_sequence(
                     prompt_ids,
                     response_ids,
@@ -1068,7 +1065,7 @@ class AgentLoopWorker:
                 mm_processor_kwargs=output.mm_processor_kwargs,
                 routing_key=routing_key,
             )
-            if solution_ids is not None:
+            if self.self_distillation:
                 # Realign the teacher's privileged-context scores onto the student's positions.
                 teacher_ids, teacher_logprobs = slice_privileged_teacher_to_student(
                     teacher_ids, teacher_logprobs, len(prompt_ids), len(response_ids), self.tokenizer.pad_token_id

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -51,6 +51,7 @@ from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.trainer.distillation.privileged_context import (
     build_privileged_sequence,
+    resolve_privileged_solution,
     slice_privileged_teacher_to_student,
 )
 from verl.utils.config import omega_conf_to_dataclass
@@ -529,6 +530,7 @@ class AgentLoopWorker:
             self.privileged_solution_key: str = config.distillation.privileged_solution_key
             self._privileged_prefix_ids: list[int] = []
             self._privileged_suffix_ids: list[int] = []
+            self._privileged_insert_before_ids: Optional[list[int]] = None
             if self.self_distillation:
                 self._privileged_prefix_ids = self.tokenizer.encode(
                     config.distillation.privileged_prefix, add_special_tokens=False
@@ -536,6 +538,10 @@ class AgentLoopWorker:
                 self._privileged_suffix_ids = self.tokenizer.encode(
                     config.distillation.privileged_suffix, add_special_tokens=False
                 )
+                if config.distillation.privileged_insert_before:
+                    self._privileged_insert_before_ids = self.tokenizer.encode(
+                        config.distillation.privileged_insert_before, add_special_tokens=False
+                    )
             self.teacher_server_manager = AsyncTeacherLLMServerManager(
                 config=config,
                 teacher_client=teacher_client,
@@ -1035,15 +1041,24 @@ class AgentLoopWorker:
                 if routing_value is not None:
                     # Non-tensor batch values arrive as 0-d numpy objects / arrays; normalize to Python.
                     routing_key = routing_value.item() if hasattr(routing_value, "item") else routing_value
-                if self.self_distillation:
-                    solution = sample_kwargs.get(self.privileged_solution_key)
-                    if solution is not None:
-                        solution = solution.item() if hasattr(solution, "item") else solution
-                        solution_ids = self.tokenizer.encode(str(solution), add_special_tokens=False)
+            if self.self_distillation:
+                solution = resolve_privileged_solution(sample_kwargs, self.privileged_solution_key)
+                if not solution:
+                    raise ValueError(
+                        f"self_distillation is enabled but no privileged solution resolved at "
+                        f"'{self.privileged_solution_key}'; verl's ground truth is usually at "
+                        f"'reward_model.ground_truth'."
+                    )
+                solution_ids = self.tokenizer.encode(solution, add_special_tokens=False)
             if solution_ids is not None:
                 # OPSD: the teacher conditions on the privileged ground-truth solution.
                 sequence_ids = build_privileged_sequence(
-                    prompt_ids, response_ids, solution_ids, self._privileged_prefix_ids, self._privileged_suffix_ids
+                    prompt_ids,
+                    response_ids,
+                    solution_ids,
+                    self._privileged_prefix_ids,
+                    self._privileged_suffix_ids,
+                    self._privileged_insert_before_ids,
                 )
             else:
                 sequence_ids = prompt_ids + response_ids

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -124,6 +124,13 @@ class AsyncTeacherLLMServerManager:
         teacher_key = self._resolve_teacher_key(routing_key)
         teacher_model_config = self.teacher_model_configs[teacher_key]
         client = self.teacher_client[teacher_key]
+        max_model_len = teacher_model_config.inference.max_model_len
+        if max_model_len is not None and len(sequence_ids) + 1 > max_model_len:
+            raise ValueError(
+                f"Teacher input ({len(sequence_ids)} tokens, +1 to score) exceeds the teacher's "
+                f"max_model_len ({max_model_len}); with OPSD privileged context this usually means "
+                f"the reference solution is too long -- raise max_model_len or shorten the solution."
+            )
         teacher_output = await client.generate(
             request_id=uuid4().hex,
             prompt_ids=sequence_ids,

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -128,8 +128,7 @@ class AsyncTeacherLLMServerManager:
         if max_model_len is not None and len(sequence_ids) + 1 > max_model_len:
             raise ValueError(
                 f"Teacher input ({len(sequence_ids)} tokens, +1 to score) exceeds the teacher's "
-                f"max_model_len ({max_model_len}); with OPSD privileged context this usually means "
-                f"the reference solution is too long -- raise max_model_len or shorten the solution."
+                f"max_model_len ({max_model_len}); raise the teacher's max_model_len or shorten the input."
             )
         teacher_output = await client.generate(
             request_id=uuid4().hex,

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -912,7 +912,7 @@ distillation:
   privileged_suffix: '
 
 
-    Now evaluate the response:
+    Using this as a reference, derive the answer yourself. Think step by step.
 
     '
   privileged_insert_before: ''

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -901,6 +901,14 @@ distillation:
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
+  self_distillation: false
+  privileged_solution_key: ground_truth
+  privileged_prefix: '
+
+    Reference solution: '
+  privileged_suffix: '
+
+    Now evaluate the response: '
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -902,13 +902,20 @@ distillation:
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
   self_distillation: false
-  privileged_solution_key: ground_truth
+  privileged_solution_key: reward_model.ground_truth
   privileged_prefix: '
 
-    Reference solution: '
+
+    Reference solution:
+
+    '
   privileged_suffix: '
 
-    Now evaluate the response: '
+
+    Now evaluate the response:
+
+    '
+  privileged_insert_before: ''
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -916,6 +916,10 @@ distillation:
 
     '
   privileged_insert_before: ''
+  privileged_mode: append
+  privileged_problem_key: extra_info.problem
+  privileged_user_template: ''
+  privileged_enable_thinking: true
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -824,13 +824,20 @@ distillation:
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
   self_distillation: false
-  privileged_solution_key: ground_truth
+  privileged_solution_key: reward_model.ground_truth
   privileged_prefix: '
 
-    Reference solution: '
+
+    Reference solution:
+
+    '
   privileged_suffix: '
 
-    Now evaluate the response: '
+
+    Now evaluate the response:
+
+    '
+  privileged_insert_before: ''
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -838,6 +838,10 @@ distillation:
 
     '
   privileged_insert_before: ''
+  privileged_mode: append
+  privileged_problem_key: extra_info.problem
+  privileged_user_template: ''
+  privileged_enable_thinking: true
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -834,7 +834,7 @@ distillation:
   privileged_suffix: '
 
 
-    Now evaluate the response:
+    Using this as a reference, derive the answer yourself. Think step by step.
 
     '
   privileged_insert_before: ''

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -823,6 +823,14 @@ distillation:
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
+  self_distillation: false
+  privileged_solution_key: ground_truth
+  privileged_prefix: '
+
+    Reference solution: '
+  privileged_suffix: '
+
+    Now evaluate the response: '
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -854,6 +854,10 @@ distillation:
 
     '
   privileged_insert_before: ''
+  privileged_mode: append
+  privileged_problem_key: extra_info.problem
+  privileged_user_template: ''
+  privileged_enable_thinking: true
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -850,7 +850,7 @@ distillation:
   privileged_suffix: '
 
 
-    Now evaluate the response:
+    Using this as a reference, derive the answer yourself. Think step by step.
 
     '
   privileged_insert_before: ''

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -839,6 +839,14 @@ distillation:
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
+  self_distillation: false
+  privileged_solution_key: ground_truth
+  privileged_prefix: '
+
+    Reference solution: '
+  privileged_suffix: '
+
+    Now evaluate the response: '
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -840,13 +840,20 @@ distillation:
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
   self_distillation: false
-  privileged_solution_key: ground_truth
+  privileged_solution_key: reward_model.ground_truth
   privileged_prefix: '
 
-    Reference solution: '
+
+    Reference solution:
+
+    '
   privileged_suffix: '
 
-    Now evaluate the response: '
+
+    Now evaluate the response:
+
+    '
+  privileged_insert_before: ''
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -838,13 +838,20 @@ distillation:
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
   self_distillation: false
-  privileged_solution_key: ground_truth
+  privileged_solution_key: reward_model.ground_truth
   privileged_prefix: '
 
-    Reference solution: '
+
+    Reference solution:
+
+    '
   privileged_suffix: '
 
-    Now evaluate the response: '
+
+    Now evaluate the response:
+
+    '
+  privileged_insert_before: ''
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -848,7 +848,7 @@ distillation:
   privileged_suffix: '
 
 
-    Now evaluate the response:
+    Using this as a reference, derive the answer yourself. Think step by step.
 
     '
   privileged_insert_before: ''

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -852,6 +852,10 @@ distillation:
 
     '
   privileged_insert_before: ''
+  privileged_mode: append
+  privileged_problem_key: extra_info.problem
+  privileged_user_template: ''
+  privileged_enable_thinking: true
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -837,6 +837,14 @@ distillation:
         response_length: ${oc.select:actor_rollout_ref.rollout.response_length}
         temperature: ${oc.select:actor_rollout_ref.rollout.temperature}
   teacher_key: data_source
+  self_distillation: false
+  privileged_solution_key: ground_truth
+  privileged_prefix: '
+
+    Reference solution: '
+  privileged_suffix: '
+
+    Now evaluate the response: '
 trainer:
   balance_batch: true
   total_epochs: 30

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -126,3 +126,15 @@ privileged_suffix: "\n\nUsing this as a reference, derive the answer yourself. T
 # Optional: insert the solution before the last occurrence of this marker text in
 # the prompt (e.g. the assistant-turn opener) instead of appending. Empty = append.
 privileged_insert_before: ""
+# How the teacher input is built. "append": splice prefix+solution+suffix into the
+# student's templated prompt (fields above). "chat_turn": rebuild the teacher user
+# message from the raw (problem, solution) pair via the chat template, matching the
+# OPSD reference implementation token-for-token.
+privileged_mode: append
+# chat_turn only: non-tensor batch field with the raw (untemplated) problem text.
+privileged_problem_key: extra_info.problem
+# chat_turn only: teacher user-message template with literal {problem}/{solution}
+# placeholders. Empty = the reference implementation's wording.
+privileged_user_template: ""
+# chat_turn only: enable_thinking kwarg for the teacher chat template (Qwen3).
+privileged_enable_thinking: true

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -117,14 +117,12 @@ teacher_key: data_source
 # single teacher at the student checkpoint (teacher_model.model_path == student
 # path) to make it a frozen self-teacher.
 self_distillation: false
-# Non-tensor batch field holding the ground-truth solution text.
-privileged_solution_key: ground_truth
+# Non-tensor batch field holding the ground-truth solution. verl stores it nested
+# at reward_model.ground_truth; a dotted key reaches into the nested dict.
+privileged_solution_key: reward_model.ground_truth
 # Marker text wrapping the privileged solution in the teacher input.
-privileged_prefix: "
-
-Reference solution:
-"
-privileged_suffix: "
-
-Now evaluate the response:
-"
+privileged_prefix: "\n\nReference solution:\n"
+privileged_suffix: "\n\nNow evaluate the response:\n"
+# Optional: insert the solution before the last occurrence of this marker text in
+# the prompt (e.g. the assistant-turn opener) instead of appending. Empty = append.
+privileged_insert_before: ""

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -111,3 +111,20 @@ teacher_models:
 
 # Key to route examples to the appropriate teacher model in multi-teacher setups. Should correspond to a field in the data proto, e.g., task.
 teacher_key: data_source
+
+# On-Policy Self-Distillation (OPSD): the teacher conditions on the ground-truth
+# solution (privileged context) while the student sees only the problem. Point a
+# single teacher at the student checkpoint (teacher_model.model_path == student
+# path) to make it a frozen self-teacher.
+self_distillation: false
+# Non-tensor batch field holding the ground-truth solution text.
+privileged_solution_key: ground_truth
+# Marker text wrapping the privileged solution in the teacher input.
+privileged_prefix: "
+
+Reference solution:
+"
+privileged_suffix: "
+
+Now evaluate the response:
+"

--- a/verl/trainer/config/distillation/distillation.yaml
+++ b/verl/trainer/config/distillation/distillation.yaml
@@ -122,7 +122,7 @@ self_distillation: false
 privileged_solution_key: reward_model.ground_truth
 # Marker text wrapping the privileged solution in the teacher input.
 privileged_prefix: "\n\nReference solution:\n"
-privileged_suffix: "\n\nNow evaluate the response:\n"
+privileged_suffix: "\n\nUsing this as a reference, derive the answer yourself. Think step by step.\n"
 # Optional: insert the solution before the last occurrence of this marker text in
 # the prompt (e.g. the assistant-turn opener) instead of appending. Empty = append.
 privileged_insert_before: ""

--- a/verl/trainer/distillation/privileged_context.py
+++ b/verl/trainer/distillation/privileged_context.py
@@ -24,6 +24,23 @@ so the rest of verl's on-policy-distillation pipeline is reused unchanged.
 
 import torch
 
+# The teacher user-message wording of the OPSD reference implementation
+# (siyan-zhao/OPSD, ``SelfDistillationDataCollator``), reproduced verbatim so a
+# ``chat_turn`` teacher matches it token-for-token. ``{problem}`` and
+# ``{solution}`` are literal placeholders (replaced, not ``str.format``-ed, so
+# things like ``\boxed{}`` in templates or solutions need no escaping).
+REFERENCE_USER_TEMPLATE = (
+    "Problem: {problem}\n\n"
+    "Here is a reference solution to this problem:\n"
+    "=== Reference Solution Begin ===\n{solution}\n=== Reference Solution End ===\n"
+    "\n\nAfter reading the reference solution above, make sure you truly understand "
+    "the reasoning behind each step — do not copy or paraphrase it. Now, using your "
+    "own words and independent reasoning, derive the same final answer to the problem above. "
+    "Think step by step, explore different approaches, and don't be afraid to backtrack "
+    "or reconsider if something doesn't work out:\n"
+    "\nPlease reason step by step, and put your final answer within \\boxed{}."
+)
+
 
 def resolve_privileged_solution(sample_kwargs: dict | None, key: str) -> str | None:
     """Resolve the ground-truth solution from a (possibly nested) sample field.
@@ -100,6 +117,49 @@ def build_privileged_sequence(
                 return prompt_ids[:i] + block + prompt_ids[i:] + response_ids
         # marker not found -> fall through to the default append
     return prompt_ids + block + response_ids
+
+
+def build_privileged_chat_turn(
+    tokenizer,
+    problem: str,
+    solution: str,
+    response_ids: list[int],
+    user_template: str = REFERENCE_USER_TEMPLATE,
+    chat_template_kwargs: dict | None = None,
+) -> list[int]:
+    """Build the OPSD teacher input as a proper chat turn (reference-impl style).
+
+    Instead of splicing the solution into the student's already-templated prompt
+    (``build_privileged_sequence``), rebuild the teacher's user message from the
+    raw ``(problem, solution)`` pair and run it through the chat template with
+    ``add_generation_prompt=True`` -- the privileged solution then lives inside
+    the *user* turn, exactly as in the OPSD reference implementation, and the
+    student's on-policy response follows the assistant-turn opener.
+
+    ``{problem}`` / ``{solution}`` in ``user_template`` are replaced literally
+    (no ``str.format``), so braces elsewhere in the template or solution are safe.
+
+    Args:
+        tokenizer: a tokenizer exposing ``apply_chat_template``.
+        problem: the raw problem statement (not the templated prompt).
+        solution: the ground-truth solution text.
+        response_ids: the student's on-policy response token ids.
+        user_template: teacher user-message template with literal ``{problem}``
+            and ``{solution}`` placeholders.
+        chat_template_kwargs: extra kwargs for ``apply_chat_template`` (e.g.
+            ``{"enable_thinking": True}`` for Qwen3 templates).
+
+    Returns:
+        The teacher input token ids: templated teacher prompt + response.
+    """
+    user_message = user_template.replace("{problem}", problem).replace("{solution}", solution)
+    prompt_ids = tokenizer.apply_chat_template(
+        [{"role": "user", "content": user_message}],
+        tokenize=True,
+        add_generation_prompt=True,
+        **(chat_template_kwargs or {}),
+    )
+    return list(prompt_ids) + list(response_ids)
 
 
 def slice_privileged_teacher_to_student(

--- a/verl/trainer/distillation/privileged_context.py
+++ b/verl/trainer/distillation/privileged_context.py
@@ -25,35 +25,81 @@ so the rest of verl's on-policy-distillation pipeline is reused unchanged.
 import torch
 
 
+def resolve_privileged_solution(sample_kwargs: dict | None, key: str) -> str | None:
+    """Resolve the ground-truth solution from a (possibly nested) sample field.
+
+    ``key`` may be dotted (e.g. ``"reward_model.ground_truth"``) to reach into
+    nested dicts -- verl stores the ground truth at
+    ``non_tensor_batch["reward_model"]["ground_truth"]``, not at a top-level key,
+    so a flat ``.get(key)`` silently misses it and OPSD degrades to plain OPD.
+
+    Normalizes numpy 0-d scalars (``.item()``), arrays/lists (joined with
+    newlines), and dicts to a stripped string. Returns ``None`` if the field is
+    absent or resolves to an empty string.
+    """
+    if sample_kwargs is None:
+        return None
+    cur = sample_kwargs
+    for part in key.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    if hasattr(cur, "item") and getattr(cur, "size", 1) == 1:
+        cur = cur.item()
+    elif hasattr(cur, "tolist"):
+        cur = cur.tolist()
+    if isinstance(cur, list | tuple):
+        cur = "\n".join(str(x) for x in cur) if len(cur) else None
+    if cur is None:
+        return None
+    solution = str(cur).strip()
+    return solution or None
+
+
 def build_privileged_sequence(
     prompt_ids: list[int],
     response_ids: list[int],
     solution_ids: list[int],
     prefix_ids: list[int],
     suffix_ids: list[int],
+    insert_before_token_ids: list[int] | None = None,
 ) -> list[int]:
     """Build the OPSD teacher's input token sequence.
 
-    Layout: ``prompt + prefix + solution + suffix + response``. The teacher sees
-    the ground-truth solution (wrapped in ``prefix`` / ``suffix`` marker tokens)
-    spliced between the problem and the student's response; the student never
-    sees it. The response is the suffix of the sequence, exactly as in the plain
-    ``prompt + response`` teacher input, so the teacher's scores for the response
-    tokens remain well defined.
+    Default layout: ``prompt + prefix + solution + suffix + response`` -- the
+    privileged solution (wrapped in ``prefix`` / ``suffix`` markers) is appended
+    to the student prompt, and the response is the suffix exactly as in the plain
+    ``prompt + response`` teacher input.
+
+    ``prompt_ids`` is the post-``apply_chat_template`` prompt, so it ends with the
+    template's assistant-turn opener. Appending the solution after it puts the
+    solution inside the assistant turn. If a template needs the solution placed
+    *before* a specific marker (e.g. the assistant-turn opener), pass
+    ``insert_before_token_ids``: the solution block is then inserted before the
+    **last** occurrence of that sub-sequence in ``prompt_ids``. If the marker is
+    not found, this falls back to the default append.
 
     Args:
         prompt_ids: the student's prompt (problem) token ids.
         response_ids: the student's on-policy response token ids.
         solution_ids: the ground-truth solution token ids.
-        prefix_ids: marker tokens placed before the solution (e.g. a
-            "reference solution begin" tag). May be empty.
-        suffix_ids: marker tokens placed after the solution (e.g. an "end" tag
-            plus a transition prompt). May be empty.
+        prefix_ids: marker tokens placed before the solution. May be empty.
+        suffix_ids: marker tokens placed after the solution. May be empty.
+        insert_before_token_ids: if provided and found, insert the solution block
+            before the last occurrence of this sub-sequence in ``prompt_ids``.
 
     Returns:
         The concatenated teacher input token ids.
     """
-    return prompt_ids + prefix_ids + solution_ids + suffix_ids + response_ids
+    block = prefix_ids + solution_ids + suffix_ids
+    if insert_before_token_ids:
+        m = len(insert_before_token_ids)
+        for i in range(len(prompt_ids) - m, -1, -1):
+            if prompt_ids[i : i + m] == insert_before_token_ids:
+                return prompt_ids[:i] + block + prompt_ids[i:] + response_ids
+        # marker not found -> fall through to the default append
+    return prompt_ids + block + response_ids
 
 
 def slice_privileged_teacher_to_student(
@@ -61,36 +107,44 @@ def slice_privileged_teacher_to_student(
     teacher_logprobs: torch.Tensor,
     student_prompt_length: int,
     response_length: int,
-    pad_token_id: int,
+    pad_token_id: int | None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Realign privileged-context teacher outputs onto the student's positions.
 
-    The teacher's top-k outputs are computed over the privileged sequence
-    (``prompt + prefix + solution + suffix + response``) and are 1:1 aligned to
-    it. Only the final ``response_length`` rows -- the teacher's per-token scores
-    for the response tokens under the privileged context -- are distillation
-    targets. This keeps those rows and pads the ``student_prompt_length`` prompt
-    rows (the downstream response mask zeroes the prompt region out anyway), so
-    the returned tensors are aligned to the student's ``prompt + response`` and
-    feed the existing padding / loss path unchanged.
+    The teacher's top-k outputs are computed over the privileged sequence and are
+    1:1 aligned to it. Only the final ``response_length`` rows -- the teacher's
+    per-token scores for the response tokens under the privileged context -- are
+    distillation targets. This keeps those rows and pads the
+    ``student_prompt_length`` prompt rows (the downstream response mask zeroes the
+    prompt region out anyway), so the returned tensors are aligned to the
+    student's ``prompt + response`` and feed the existing padding / loss path
+    unchanged.
 
     Args:
         teacher_ids: ``(privileged_len + response_length, k)`` teacher top-k ids.
         teacher_logprobs: ``(privileged_len + response_length, k)`` teacher
             top-k log-probs.
         student_prompt_length: length of the student's (non-privileged) prompt.
-        response_length: number of response tokens.
-        pad_token_id: id used to fill the padded prompt rows.
+        response_length: number of response tokens (may be 0).
+        pad_token_id: id used to fill the padded prompt rows; ``None`` falls back
+            to ``0`` (these rows are masked out downstream, so the value is inert).
 
     Returns:
         ``(ids, logprobs)``, each ``(student_prompt_length + response_length, k)``
         and aligned to the student's ``prompt + response`` sequence.
     """
+    if response_length < 0:
+        raise ValueError(f"response_length must be non-negative, got {response_length}")
+    if pad_token_id is None:
+        pad_token_id = 0
     k = teacher_ids.shape[-1]
-    response_ids = teacher_ids[-response_length:]
-    response_logprobs = teacher_logprobs[-response_length:]
+    # Index from an explicit start: ``teacher_ids[-0:]`` would return the whole
+    # tensor, so a 0-length response must slice from the end, not from ``-0``.
+    start = teacher_ids.shape[0] - response_length
+    response_ids = teacher_ids[start:]
+    response_logprobs = teacher_logprobs[start:]
     prompt_ids = torch.full(
-        (student_prompt_length, k), pad_token_id, dtype=response_ids.dtype, device=response_ids.device
+        (student_prompt_length, k), int(pad_token_id), dtype=response_ids.dtype, device=response_ids.device
     )
     prompt_logprobs = torch.zeros(
         (student_prompt_length, k), dtype=response_logprobs.dtype, device=response_logprobs.device

--- a/verl/trainer/distillation/privileged_context.py
+++ b/verl/trainer/distillation/privileged_context.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Privileged-context helpers for On-Policy Self-Distillation (OPSD).
+
+In OPSD the teacher and student share weights but see different contexts: the
+student sees only the problem, while the teacher additionally sees the
+ground-truth solution. The teacher does not generate -- it scores the student's
+own on-policy response conditioned on the privileged solution. These two pure
+helpers build the teacher's privileged input sequence and realign the teacher's
+per-token top-k outputs back onto the student's ``prompt + response`` positions,
+so the rest of verl's on-policy-distillation pipeline is reused unchanged.
+"""
+
+import torch
+
+
+def build_privileged_sequence(
+    prompt_ids: list[int],
+    response_ids: list[int],
+    solution_ids: list[int],
+    prefix_ids: list[int],
+    suffix_ids: list[int],
+) -> list[int]:
+    """Build the OPSD teacher's input token sequence.
+
+    Layout: ``prompt + prefix + solution + suffix + response``. The teacher sees
+    the ground-truth solution (wrapped in ``prefix`` / ``suffix`` marker tokens)
+    spliced between the problem and the student's response; the student never
+    sees it. The response is the suffix of the sequence, exactly as in the plain
+    ``prompt + response`` teacher input, so the teacher's scores for the response
+    tokens remain well defined.
+
+    Args:
+        prompt_ids: the student's prompt (problem) token ids.
+        response_ids: the student's on-policy response token ids.
+        solution_ids: the ground-truth solution token ids.
+        prefix_ids: marker tokens placed before the solution (e.g. a
+            "reference solution begin" tag). May be empty.
+        suffix_ids: marker tokens placed after the solution (e.g. an "end" tag
+            plus a transition prompt). May be empty.
+
+    Returns:
+        The concatenated teacher input token ids.
+    """
+    return prompt_ids + prefix_ids + solution_ids + suffix_ids + response_ids
+
+
+def slice_privileged_teacher_to_student(
+    teacher_ids: torch.Tensor,
+    teacher_logprobs: torch.Tensor,
+    student_prompt_length: int,
+    response_length: int,
+    pad_token_id: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Realign privileged-context teacher outputs onto the student's positions.
+
+    The teacher's top-k outputs are computed over the privileged sequence
+    (``prompt + prefix + solution + suffix + response``) and are 1:1 aligned to
+    it. Only the final ``response_length`` rows -- the teacher's per-token scores
+    for the response tokens under the privileged context -- are distillation
+    targets. This keeps those rows and pads the ``student_prompt_length`` prompt
+    rows (the downstream response mask zeroes the prompt region out anyway), so
+    the returned tensors are aligned to the student's ``prompt + response`` and
+    feed the existing padding / loss path unchanged.
+
+    Args:
+        teacher_ids: ``(privileged_len + response_length, k)`` teacher top-k ids.
+        teacher_logprobs: ``(privileged_len + response_length, k)`` teacher
+            top-k log-probs.
+        student_prompt_length: length of the student's (non-privileged) prompt.
+        response_length: number of response tokens.
+        pad_token_id: id used to fill the padded prompt rows.
+
+    Returns:
+        ``(ids, logprobs)``, each ``(student_prompt_length + response_length, k)``
+        and aligned to the student's ``prompt + response`` sequence.
+    """
+    k = teacher_ids.shape[-1]
+    response_ids = teacher_ids[-response_length:]
+    response_logprobs = teacher_logprobs[-response_length:]
+    prompt_ids = torch.full(
+        (student_prompt_length, k), pad_token_id, dtype=response_ids.dtype, device=response_ids.device
+    )
+    prompt_logprobs = torch.zeros(
+        (student_prompt_length, k), dtype=response_logprobs.dtype, device=response_logprobs.device
+    )
+    ids = torch.cat([prompt_ids, response_ids], dim=0)
+    logprobs = torch.cat([prompt_logprobs, response_logprobs], dim=0)
+    return ids, logprobs

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -270,13 +270,22 @@ class DistillationConfig(BaseConfig):
     # (teacher.model_path == student path) to make it a frozen self-teacher.
     self_distillation: bool = False
     # Non-tensor batch field holding the ground-truth solution text.
-    privileged_solution_key: str = "ground_truth"
+    privileged_solution_key: str = "reward_model.ground_truth"
     # Marker text wrapping the privileged solution in the teacher's input.
     privileged_prefix: str = "\n\nReference solution:\n"
     privileged_suffix: str = "\n\nNow evaluate the response:\n"
+    # Optional: insert the privileged solution before the last occurrence of this
+    # marker text in the prompt (e.g. the assistant-turn opener) instead of appending
+    # it. Empty = append after the prompt.
+    privileged_insert_before: str = ""
     distillation_loss: DistillationLossConfig = field(default_factory=DistillationLossConfig)
 
     def __post_init__(self):
+        if self.self_distillation:
+            if not self.enabled:
+                raise ValueError("self_distillation requires distillation.enabled=True.")
+            if not self.privileged_solution_key:
+                raise ValueError("self_distillation requires a non-empty privileged_solution_key.")
         if not self.enabled:
             return
 

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -264,6 +264,16 @@ class DistillationConfig(BaseConfig):
     nnodes: int = 0
     teacher_models: dict[str, DistillationTeacherModelConfig] = field(default_factory=dict)
     teacher_key: str = "data_source"
+    # On-Policy Self-Distillation (OPSD): the teacher shares the student's weights but
+    # additionally conditions on the ground-truth solution (privileged context); the
+    # student sees only the problem. Point a single teacher at the student checkpoint
+    # (teacher.model_path == student path) to make it a frozen self-teacher.
+    self_distillation: bool = False
+    # Non-tensor batch field holding the ground-truth solution text.
+    privileged_solution_key: str = "ground_truth"
+    # Marker text wrapping the privileged solution in the teacher's input.
+    privileged_prefix: str = "\n\nReference solution:\n"
+    privileged_suffix: str = "\n\nNow evaluate the response:\n"
     distillation_loss: DistillationLossConfig = field(default_factory=DistillationLossConfig)
 
     def __post_init__(self):

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -283,10 +283,37 @@ class DistillationConfig(BaseConfig):
     # marker text in the prompt (e.g. the assistant-turn opener) instead of appending
     # it. Empty = append after the prompt.
     privileged_insert_before: str = ""
+    # How the teacher input is built. "append": splice prefix+solution+suffix into
+    # the student's templated prompt (token-level, fields above). "chat_turn":
+    # rebuild the teacher user message from the raw (problem, solution) pair via
+    # the chat template, matching the OPSD reference implementation -- required to
+    # reproduce the paper's runs token-for-token.
+    privileged_mode: str = "append"
+    # chat_turn only: non-tensor batch field with the raw problem statement
+    # (dotted). The dataset must carry the untemplated problem text.
+    privileged_problem_key: str = "extra_info.problem"
+    # chat_turn only: teacher user-message template with literal {problem} and
+    # {solution} placeholders. Empty = the reference implementation's wording
+    # (verl.trainer.distillation.privileged_context.REFERENCE_USER_TEMPLATE).
+    privileged_user_template: str = ""
+    # chat_turn only: value of the chat template's enable_thinking kwarg for the
+    # teacher prompt (the reference implementation defaults teacher_thinking=True).
+    privileged_enable_thinking: bool = True
     distillation_loss: DistillationLossConfig = field(default_factory=DistillationLossConfig)
 
     def __post_init__(self):
         if self.self_distillation:
+            if self.privileged_mode not in ("append", "chat_turn"):
+                raise ValueError(f"privileged_mode must be 'append' or 'chat_turn', got {self.privileged_mode!r}.")
+            if self.privileged_mode == "chat_turn":
+                if not self.privileged_problem_key:
+                    raise ValueError("privileged_mode='chat_turn' requires a non-empty privileged_problem_key.")
+                if self.privileged_user_template and not (
+                    "{problem}" in self.privileged_user_template and "{solution}" in self.privileged_user_template
+                ):
+                    raise ValueError(
+                        "privileged_user_template must contain the literal {problem} and {solution} placeholders."
+                    )
             if not self.enabled:
                 raise ValueError("self_distillation requires distillation.enabled=True.")
             if not self.privileged_solution_key:

--- a/verl/workers/config/distillation.py
+++ b/verl/workers/config/distillation.py
@@ -267,13 +267,18 @@ class DistillationConfig(BaseConfig):
     # On-Policy Self-Distillation (OPSD): the teacher shares the student's weights but
     # additionally conditions on the ground-truth solution (privileged context); the
     # student sees only the problem. Point a single teacher at the student checkpoint
-    # (teacher.model_path == student path) to make it a frozen self-teacher.
+    # (teacher.model_path == student path) to make it a frozen self-teacher. OPSD is
+    # a supervised signal: pair with distillation_loss.use_policy_gradient=False and
+    # use_task_rewards=False.
     self_distillation: bool = False
-    # Non-tensor batch field holding the ground-truth solution text.
+    # Non-tensor batch field with the privileged solution; dotted to reach nested
+    # dicts (verl stores ground truth at reward_model.ground_truth). NOTE: on some
+    # datasets (e.g. gsm8k) ground_truth is only the final answer -- point this at
+    # the full worked solution (e.g. extra_info.answer) for a stronger signal.
     privileged_solution_key: str = "reward_model.ground_truth"
     # Marker text wrapping the privileged solution in the teacher's input.
     privileged_prefix: str = "\n\nReference solution:\n"
-    privileged_suffix: str = "\n\nNow evaluate the response:\n"
+    privileged_suffix: str = "\n\nUsing this as a reference, derive the answer yourself. Think step by step.\n"
     # Optional: insert the privileged solution before the last occurrence of this
     # marker text in the prompt (e.g. the assistant-turn opener) instead of appending
     # it. Empty = append after the prompt.


### PR DESCRIPTION
### What does this PR do?

The first piece of On-Policy Self-Distillation (OPSD, #6827): the teacher conditions on the ground-truth solution (privileged context) while the student sees only the problem, and scores the student's own on-policy rollout. This is the half plain OPD lacks -- verl's OPD teacher sees only `prompt + response`.

- `verl/trainer/distillation/privileged_context.py` -- two pure helpers: `build_privileged_sequence` (splice the GT solution, wrapped in marker tokens, into the teacher input) and `slice_privileged_teacher_to_student` (realign the teacher's per-token response scores back onto the student's `prompt + response` positions). CPU-tested.
- `DistillationConfig` -- `self_distillation`, `privileged_solution_key`, `privileged_prefix`, `privileged_suffix`.
- `agent_loop._compute_teacher_logprobs` -- when `self_distillation` is on, build the privileged teacher sequence and slice the scores back; otherwise the path is unchanged (`prompt + response`).

### Route

Reuses the existing external-teacher path with `teacher.model_path == student model_path`, i.e. a frozen self-teacher (the student's init checkpoint) scoring the rollout with privileged context. The whole OPD data + loss pipeline is reused unchanged -- only the teacher's input sequence and the realignment are new. The dynamic / EMA self-teacher (a second in-engine forward) is a separate, GPU-gated follow-up.

### Test

`pytest tests/workers/test_opsd_privileged_context_on_cpu.py tests/workers/test_distillation_config_opsd_on_cpu.py` -- splice layout + slice-back shapes/dtype + the config fields. CPU-only. The end-to-end GPU run (teacher = student checkpoint, top-k overlap rises, convergence) is the remaining validation, hence draft.

Part of #6827.