### PR TITLE
[vllm, hardware] feat: support INT8 W8A8_DYNAMIC online quantization …

### DIFF
--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -445,7 +445,7 @@ prometheus:
   # Specify served_model_name to avoid displaying overly long model paths in Grafana
   served_model_name: ${oc.select:actor_rollout_ref.model.path,null}
 
-# type of quantization in vllm, currently support fp8 and torchao
+# type of quantization in vllm, supported values: fp8, torchao, ascend, int8-ascend
 quantization: null
 
 # extra quantization information serialized in a config file, e.g. torchao_config.json

--- a/verl/utils/fsdp_utils.py
+++ b/verl/utils/fsdp_utils.py
@@ -55,7 +55,8 @@ else:
 
 
 def init_fn(x: torch.nn.Module):
-    if torch.distributed.get_rank() != 0:
+    skip_meta = os.environ.get("VERL_LOAD_ALL_RANKS", "0") == "1"
+    if not skip_meta and torch.distributed.get_rank() != 0:
         x = x.to_empty(device=get_device_id(), recurse=False)
         get_torch_device().empty_cache()
     return x
@@ -65,7 +66,10 @@ def get_init_weight_context_manager(use_meta_tensor=True, mesh: DeviceMesh = Non
     from accelerate import init_empty_weights
 
     cpu_init_weights = lambda: torch.device("cpu")
-    if use_meta_tensor:
+    skip_meta = os.environ.get("VERL_LOAD_ALL_RANKS", "0") == "1"
+    if skip_meta:
+        init_context = cpu_init_weights
+    elif use_meta_tensor:
         if mesh is None:
             init_context = init_empty_weights if torch.distributed.get_rank() != 0 else cpu_init_weights
         else:
@@ -491,13 +495,50 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
         from verl.third_party.torch.distributed.checkpoint.state_dict import StateDictOptions, set_model_state_dict
 
     # To broadcast, it needs to be instantiated in the GPU.
-    if dist.get_rank() == 0:
+    skip_broadcast = os.environ.get("VERL_LOAD_ALL_RANKS", "0") == "1"
+    if skip_broadcast:
+        # All ranks have full weights on CPU. Manually load each FSDP2 shard
+        # to avoid HCCL collectives that fail on large tensors (CANN AICPU bug).
+        from torch.distributed.tensor import DTensor
+
+        device = get_device_id()
+        get_torch_device().empty_cache()
+        cpu_offload_flag = cpu_offload is not None
+        for name, param in model.named_parameters():
+            if name in full_state:
+                full_tensor = full_state[name]
+                if isinstance(param, DTensor):
+                    local_tensor = param.to_local()
+                    spec = param._spec
+                    chunk = full_tensor
+                    for placement, mesh_dim in zip(spec.placements, range(spec.mesh.ndim), strict=False):
+                        if isinstance(placement, Shard):
+                            num_chunks = spec.mesh.size(mesh_dim)
+                            coord = spec.mesh.get_local_rank(mesh_dim)
+                            chunks = chunk.chunk(num_chunks, dim=placement.dim)
+                            chunk = chunks[min(coord, len(chunks) - 1)]
+                    local_tensor.data.copy_(chunk.to(local_tensor.dtype).to(device))
+                else:
+                    param.data.copy_(full_tensor.to(param.dtype).to(device))
+        for name, buf in model.named_buffers():
+            if name in full_state:
+                buf.data.copy_(full_state[name].to(buf.dtype).to(device))
+            elif buf.device.type == "meta":
+                buf.data = torch.empty_like(buf, device=device)
+        if cpu_offload_flag:
+            model.to("cpu", non_blocking=True)
+            for buf in model.buffers():
+                buf.data = buf.data.to(device)
+        del full_state
+        return
+    elif dist.get_rank() == 0:
         model = model.to(device=get_device_id(), non_blocking=True)
     else:
         model = model.to_empty(device=get_device_id())
 
     cpu_offload = cpu_offload is not None
-    options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload, broadcast_from_rank0=True)
+    broadcast = not skip_broadcast
+    options = StateDictOptions(full_state_dict=True, cpu_offload=cpu_offload, broadcast_from_rank0=broadcast)
     set_model_state_dict(model, full_state, options=options)
 
     # rotary_emb is not in state_dict, so we need to broadcast it manually
@@ -505,9 +546,10 @@ def fsdp2_load_full_state_dict(model: torch.nn.Module, full_state: dict, device_
     # named_buffers() in different order on different ranks. Gemma4 has heterogeneous
     # rotary embedding buffers (256 vs 128 elements) so mismatched order = size
     # mismatch on the same broadcast collective = NCCL deadlock.
-    bufs = sorted(model.named_buffers(), key=lambda x: x[0])
-    for name, buf in bufs:
-        dist.broadcast(buf, src=0)
+    if not skip_broadcast:
+        bufs = sorted(model.named_buffers(), key=lambda x: x[0])
+        for name, buf in bufs:
+            dist.broadcast(buf, src=0)
 
     if cpu_offload:
         model.to("cpu", non_blocking=True)
@@ -1011,14 +1053,11 @@ def collect_merged_lora_params(module: nn.Module) -> OrderedDict:
 def backup_base_model_weights(module):
     """Backup base model weights to CPU with LoRA temporarily disabled.
 
-    This function temporarily disables LoRA adapters, backs up the clean base model weights
-    to CPU, then re-enables the adapters.
-
     Args:
-        module: The PEFT model with LoRA adapters
+        module: The PEFT model with LoRA adapters.
 
     Returns:
-        dict: Dictionary mapping parameter name to CPU tensor backup of base model weights
+        dict: {param_name: cpu_tensor} backup of base model weights.
     """
     from peft import PeftModel
 
@@ -1042,12 +1081,9 @@ def backup_base_model_weights(module):
 def restore_base_model_weights(module, backup):
     """Restore base model weights from CPU backup.
 
-    This function restores the base model weights from the CPU backup, effectively
-    undoing any LoRA merge operations.
-
     Args:
-        module: The PEFT model with LoRA adapters
-        backup: Dictionary mapping parameter name to CPU tensor backup of base model weights
+        module: The PEFT model with LoRA adapters.
+        backup: {param_name: cpu_tensor} from backup_base_model_weights.
     """
     with torch.no_grad():
         for name, param in module.named_parameters():
@@ -1094,39 +1130,30 @@ def merged_lora_context(actor, backup_adapters=False):
 def fsdp2_sharded_save_to_cpu(
     model: torch.nn.Module,
 ) -> tuple[dict[str, tuple[torch.Tensor, DTensorSpec]], DTensorSpec]:
-    """
-    Sharded Save: Each process only saves the local DTensor shard from its own GPU to CPU memory.
+    """Save each rank's local DTensor shard to CPU memory.
 
     Args:
-        model: FSDP2-wrapped model whose parameters are of DTensor type.
+        model: FSDP2-wrapped model whose parameters are DTensors.
 
     Returns:
-        cpu_sharded_state: Dictionary of CPU shards for the current process.
-                          Key = parameter name, Value = (CPU shard tensor, original DTensorSpec)
-        global_spec: DTensorSpec of the first parameter (used to verify global rules during loading)
+        cpu_sharded_state: {param_name: (cpu_shard, DTensorSpec | None)}
+        global_spec: DTensorSpec of the first DTensor parameter.
     """
     cpu_sharded_state = {}
-    global_spec = None  # Record global sharding rules (all parameters follow the same spec)
+    global_spec = None
 
     for param_name, param in model.named_parameters():
-        # Only process sharded parameters of DTensor type (core parameters of FSDP2)
         if not isinstance(param, DTensor):
-            # Save non-sharded parameters (e.g., running_mean of BatchNorm) as local data
             cpu_tensor = param.detach().cpu()
             cpu_sharded_state[param_name] = (cpu_tensor, None)
             continue
 
-        # Record global sharding rules (take spec of the first DTensor to ensure consistency)
         if global_spec is None:
             global_spec = param._spec
             assert hasattr(global_spec, "device_mesh"), "DTensorSpec must contain 'device_mesh' attribute"
             assert hasattr(global_spec, "placements"), "DTensorSpec must contain 'placements' attribute"
 
-        # 1. Extract local shard data from the current GPU (_local_tensor)
-        local_gpu_tensor = param._local_tensor  # Local shard attribute defined in your DTensor class
-        # 2. Move to CPU memory and detach from computation graph
-        local_cpu_tensor = local_gpu_tensor.detach().cpu()
-        # 3. Save CPU shard + original DTensorSpec (ensure sharding rules remain unchanged)
+        local_cpu_tensor = param._local_tensor.detach().cpu()
         cpu_sharded_state[param_name] = (local_cpu_tensor, param._spec)
 
     assert global_spec is not None, "No DTensor-type parameters found in the model. FSDP2 sharding may not be enabled."
@@ -1138,17 +1165,13 @@ def fsdp2_sharded_load_from_cpu(
     cpu_sharded_state: dict[str, tuple[torch.Tensor, Optional[DTensorSpec]]],
     target_spec: DTensorSpec,
 ) -> None:
-    """
-    Sharded Load: Each process only loads the CPU shard it is responsible for to the GPU,
-                  keeping sharding rules unchanged.
+    """Load each rank's CPU shard back to the corresponding GPU.
 
     Args:
-        model: FSDP2 model to be restored (must have the same structure as when saved)
-        cpu_sharded_state: Shard data read from CPU memory by the current process
-                          (from fsdp2_sharded_save_to_cpu)
-        target_spec: Global DTensorSpec from saving (used to verify sharding rule consistency)
+        model: FSDP2 model (must match the structure used during save).
+        cpu_sharded_state: Output of fsdp2_sharded_save_to_cpu.
+        target_spec: Global DTensorSpec from the save call.
     """
-    # Verify device_mesh consistency (core: ensure loaded shards map to original GPUs)
     current_device_mesh = None
     for param in model.parameters():
         if isinstance(param, DTensor):
@@ -1160,32 +1183,21 @@ def fsdp2_sharded_load_from_cpu(
     )
 
     for param_name, param in model.named_parameters():
-        # Skip parameters not in the saved state (e.g., newly added parameters)
         if param_name not in cpu_sharded_state:
             continue
 
-        # Extract CPU shard data and original Spec
         local_cpu_tensor, saved_spec = cpu_sharded_state[param_name]
 
-        # Handle different parameter types: DTensor sharded parameters vs. regular parameters
         if isinstance(param, DTensor):
-            # 1. Verify sharding rule consistency (placements must match original Spec)
             assert saved_spec is not None, f"DTensorSpec missing in saved state for parameter {param_name}"
             assert saved_spec.placements == target_spec.placements, (
                 f"Sharding strategy mismatch for parameter {param_name} (conflicts with global rules)!"
             )
 
-            # 2. Move CPU shard data to the current GPU (device of param._local_tensor)
             target_device = param._local_tensor.device
-            local_gpu_tensor = local_cpu_tensor.to(target_device)
-
-            # 3. Restore to DTensor's local shard (directly copy to _local_tensor, keep spec unchanged)
-            param._local_tensor.copy_(local_gpu_tensor)
-
+            param._local_tensor.copy_(local_cpu_tensor.to(target_device))
         else:
-            # Regular parameters: load directly to original device
             target_device = param.device
             param.data.copy_(local_cpu_tensor.to(target_device))
 
-    # Process synchronization: ensure all processes complete loading before proceeding
     dist.barrier()

--- a/verl/utils/kernel/int8_kernel.py
+++ b/verl/utils/kernel/int8_kernel.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def scaled_int8_per_channel(
+    data_hp: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize a 2D weight tensor to INT8 with per-channel (per-output-channel) scaling.
+
+    Symmetric per-channel quantization for Ascend W8A8_DYNAMIC:
+        quantized = clamp(round(data / scale), -128, 127)
+    where scale = max(abs(data_per_channel)) / 127
+
+    Args:
+        data_hp: Input high-precision tensor of shape (output_size, input_size).
+
+    Returns:
+        Tuple of (int8_data, weight_scale, weight_offset):
+            - int8_data: INT8 quantized tensor of shape (output_size, input_size)
+            - weight_scale: Per-channel scale of shape (output_size, 1), same dtype as input
+            - weight_offset: Per-channel offset of shape (output_size, 1), same dtype as input
+                            (zero for symmetric quantization)
+    """
+    assert len(data_hp.shape) == 2, f"Only 2D tensors supported, got shape {data_hp.shape}"
+
+    original_dtype = data_hp.dtype
+    data_fp32 = data_hp.float()
+
+    max_abs = data_fp32.abs().amax(dim=1, keepdim=True)
+    max_abs = torch.clamp(max_abs, min=1e-10)
+
+    scale = max_abs / 127.0
+
+    data_scaled = data_fp32 / scale
+    data_scaled = data_scaled.round().clamp(-128, 127)
+
+    int8_data = data_scaled.to(torch.int8)
+
+    weight_scale = scale.to(original_dtype)
+    weight_offset = torch.zeros_like(weight_scale)
+
+    del data_fp32, data_scaled, max_abs, scale
+
+    return int8_data, weight_scale, weight_offset

--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -201,6 +201,21 @@ if is_torch_npu_available(check_device=False):
         patch_vllm013_rotary_emb()
         FusedMoE.weight_loader = vllm_v013_weight_loader_method_wrapper(FusedMoE.weight_loader)
 
+    try:
+        from vllm_ascend.worker.worker_v1 import NPUWorker as _NPUWorker
+
+        _orig_warm_up_atb = _NPUWorker._warm_up_atb
+
+        def _safe_warm_up_atb(self):
+            try:
+                _orig_warm_up_atb(self)
+            except (AttributeError, RuntimeError):
+                pass
+
+        _NPUWorker._warm_up_atb = _safe_warm_up_atb
+    except (ImportError, RuntimeError):
+        pass
+
     VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2 = bool(int(os.getenv("VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2", "1")))
     if VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2:
         # only support vllm 0.13 and 0.11 now.
@@ -216,12 +231,19 @@ if is_torch_npu_available(check_device=False):
             )
 
         elif _VLLM_VERSION >= version.parse("0.11.0") and _VLLM_VERSION < version.parse("0.13.0"):
-            from vllm_ascend.ops.linear_op import SequenceRowParallelOp
-            from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+            try:
+                from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+                from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
-            NPUModelRunner._select_moe_comm_method = vllm_ascend_v011_select_moe_comm_method_wrapper(
-                NPUModelRunner._select_moe_comm_method
-            )
-            SequenceRowParallelOp.matmul_and_reduce = vllm_ascend_v011_matmul_and_reduce_wrapper(
-                SequenceRowParallelOp.matmul_and_reduce
-            )
+                NPUModelRunner._select_moe_comm_method = vllm_ascend_v011_select_moe_comm_method_wrapper(
+                    NPUModelRunner._select_moe_comm_method
+                )
+                SequenceRowParallelOp.matmul_and_reduce = vllm_ascend_v011_matmul_and_reduce_wrapper(
+                    SequenceRowParallelOp.matmul_and_reduce
+                )
+            except (ImportError, RuntimeError) as e:
+                import logging as _logging
+
+                _logging.getLogger(__name__).warning(
+                    "Skipping vllm_ascend v0.11 MC2 patches due to import error: %s", e
+                )

--- a/verl/utils/vllm/patch.py
+++ b/verl/utils/vllm/patch.py
@@ -21,56 +21,56 @@ try:
 
     SUPPORTED_MOE_MODELS.append(DeepseekV2ForCausalLM)
     SUPPORTED_MOE_MODELS.append(DeepseekV3ForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.mixtral import MixtralForCausalLM
 
     SUPPORTED_MOE_MODELS.append(MixtralForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.qwen2_moe import Qwen2MoeForCausalLM
 
     SUPPORTED_MOE_MODELS.append(Qwen2MoeForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.qwen3_moe import Qwen3MoeForCausalLM
 
     SUPPORTED_MOE_MODELS.append(Qwen3MoeForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.qwen3_vl_moe import Qwen3MoeLLMForCausalLM
 
     SUPPORTED_MOE_MODELS.append(Qwen3MoeLLMForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.qwen3_next import Qwen3NextForCausalLM
 
     SUPPORTED_MOE_MODELS.append(Qwen3NextForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.kimi_vl import KimiVLForConditionalGeneration
 
     SUPPORTED_MOE_MODELS.append(KimiVLForConditionalGeneration)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 try:
     from vllm.model_executor.models.qwen3_5 import Qwen3_5MoeForCausalLM
 
     SUPPORTED_MOE_MODELS.append(Qwen3_5MoeForCausalLM)
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 

--- a/verl/utils/vllm/vllm_int8_ascend_utils.py
+++ b/verl/utils/vllm/vllm_int8_ascend_utils.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+import torch
+
+from verl.utils.kernel.int8_kernel import scaled_int8_per_channel
+
+logger = logging.getLogger(__name__)
+
+
+class _W8A8DynamicQuantDescription(dict):
+    """A dict that returns 'W8A8_DYNAMIC' for quantizable layers and 'FLOAT' for others.
+
+    vllm-ascend's AscendQuantConfig expects every layer weight to appear in
+    the quant_description.  Instead of enumerating all possible layer names
+    (which depend on model architecture), we use a smart dict that infers the
+    quant type from the key name pattern when the key is not explicitly set.
+    """
+
+    _QUANT_PATTERNS = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "fc1",
+        "fc2",
+    ]
+    _SKIP_PATTERNS = [
+        "embed_tokens",
+        "lm_head",
+        "layernorm",
+        "norm",
+        "ln_",
+        "embeddings",
+        "mlp.gate.weight",
+    ]
+
+    def __missing__(self, key):
+        key_lower = key.lower()
+        for p in self._SKIP_PATTERNS:
+            if p in key_lower:
+                return "FLOAT"
+        for p in self._QUANT_PATTERNS:
+            if p in key_lower:
+                return "W8A8_DYNAMIC"
+        return "FLOAT"
+
+
+def is_int8_ascend_model(vllm_config) -> bool:
+    """Check if the model is configured for INT8 Ascend (W8A8_DYNAMIC) quantization."""
+    if os.environ.get("VERL_VLLM_INT8_ASCEND_QUANT_ENABLED", "0") == "1":
+        return True
+    quant_config = getattr(vllm_config, "quant_config", None)
+    if quant_config is None:
+        return False
+    quant_desc = getattr(quant_config, "quant_description", None)
+    if quant_desc is None:
+        return False
+    if isinstance(quant_desc, _W8A8DynamicQuantDescription):
+        return True
+    if isinstance(quant_desc, dict) and any(v == "W8A8_DYNAMIC" for v in quant_desc.values()):
+        return True
+    return False
+
+
+def load_int8_ascend_weights(weights, model, dtype=torch.bfloat16):
+    """Quantize bf16 weights to INT8 and load into the vllm model.
+
+    Ascend W8A8_DYNAMIC stores weight as (input_size, output_size) — transposed.
+    Scale/offset are 1D (output_size,).
+
+    Handles vLLM's fused parameter mapping:
+      q/k/v_proj -> qkv_proj, gate/up_proj -> gate_up_proj.
+    """
+    param_dict = dict(model.named_parameters())
+
+    qkv_mod = None
+    gate_up_mod = None
+    for n, m in model.named_modules():
+        if n.endswith(".self_attn") and qkv_mod is None:
+            qkv_mod = getattr(m, "qkv_proj", None)
+        if n.endswith(".mlp") and gate_up_mod is None:
+            gate_up_mod = getattr(m, "gate_up_proj", None)
+        if qkv_mod and gate_up_mod:
+            break
+
+    _FUSE_MAP = {}
+    if qkv_mod:
+        h = qkv_mod.num_heads * qkv_mod.head_size
+        kv = qkv_mod.num_kv_heads * qkv_mod.head_size
+        _FUSE_MAP["q_proj"] = ("qkv_proj", 0, h)
+        _FUSE_MAP["k_proj"] = ("qkv_proj", h, kv)
+        _FUSE_MAP["v_proj"] = ("qkv_proj", h + kv, kv)
+    if gate_up_mod and hasattr(gate_up_mod, "output_partition_sizes"):
+        sizes = gate_up_mod.output_partition_sizes
+        _FUSE_MAP["gate_proj"] = ("gate_up_proj", 0, sizes[0])
+        _FUSE_MAP["up_proj"] = ("gate_up_proj", sizes[0], sizes[1])
+
+    loaded_params = set()
+
+    for name, tensor in quant_weights_int8_ascend(weights, dtype=dtype):
+        parts = name.rsplit(".", 1)
+        if len(parts) != 2:
+            continue
+        prefix, attr = parts
+        proj = prefix.rsplit(".", 1)[-1]
+
+        if proj in _FUSE_MAP:
+            fused_name, offset, size = _FUSE_MAP[proj]
+            base = prefix.rsplit(".", 1)[0] if "." in prefix else ""
+            full_name = f"{base}.{fused_name}.{attr}" if base else f"{fused_name}.{attr}"
+            if full_name not in param_dict:
+                continue
+            param = param_dict[full_name]
+            loaded = tensor
+
+            if attr == "weight":
+                if loaded.ndim == 2 and param.ndim == 2:
+                    if loaded.shape[0] == size and loaded.shape[1] == param.shape[0]:
+                        param.data.narrow(1, offset, size).copy_(loaded.t().contiguous())
+                        loaded_params.add(full_name)
+                    elif loaded.shape[1] == size and loaded.shape[0] == param.shape[0]:
+                        param.data.narrow(1, offset, size).copy_(loaded)
+                        loaded_params.add(full_name)
+            else:
+                if loaded.ndim == 2:
+                    loaded = loaded.squeeze(-1)
+                if param.ndim == 1 and loaded.ndim == 1:
+                    if offset + loaded.shape[0] <= param.shape[0]:
+                        param.data.narrow(0, offset, loaded.shape[0]).copy_(loaded)
+                        loaded_params.add(full_name)
+                    elif loaded.shape == param.shape:
+                        param.data.copy_(loaded)
+                        loaded_params.add(full_name)
+        else:
+            if name not in param_dict:
+                continue
+            param = param_dict[name]
+            loaded = tensor
+            if attr == "weight" and loaded.ndim == 2 and param.ndim == 2:
+                if loaded.shape == (param.shape[1], param.shape[0]):
+                    param.data.copy_(loaded.t().contiguous())
+                    loaded_params.add(name)
+                elif loaded.shape == param.shape and loaded.shape[0] != loaded.shape[1]:
+                    param.data.copy_(loaded)
+                    loaded_params.add(name)
+                elif loaded.shape == param.shape:
+                    param.data.copy_(loaded.t().contiguous())
+                    loaded_params.add(name)
+            else:
+                if loaded.ndim == 2 and param.ndim == 1 and loaded.shape[0] == param.shape[0]:
+                    loaded = loaded.squeeze(-1)
+                if loaded.shape == param.shape:
+                    param.data.copy_(loaded)
+                    loaded_params.add(name)
+
+    return loaded_params
+
+
+INT8_ASCEND_QUANT_KWARGS = {
+    "quant_method": "ascend",
+    "default_quant_type": "W8A8_DYNAMIC",
+}
+
+
+def build_int8_ascend_quant_description(model_config) -> dict:
+    """Build a quant_model_description dict for W8A8_DYNAMIC on the fly.
+
+    vllm-ascend's AscendQuantConfig reads per-layer quant types from the
+    quant_description dict.  For online INT8 we mark every Linear weight
+    as W8A8_DYNAMIC and everything else (embed, norm, lm_head, gate) as FLOAT.
+
+    We must explicitly enumerate all layer weight names because vLLM serializes
+    the config dict to JSON when passing to subprocesses, which would lose any
+    custom __missing__ behavior from dict subclasses.
+    """
+    desc = {}
+    desc["quant_method"] = "ascend"
+
+    num_layers = getattr(model_config, "num_hidden_layers", 0)
+
+    desc["model.embed_tokens.weight"] = "FLOAT"
+    desc["model.norm.weight"] = "FLOAT"
+    desc["lm_head.weight"] = "FLOAT"
+
+    quant_proj_names = [
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    ]
+    float_names = [
+        "input_layernorm",
+        "post_attention_layernorm",
+    ]
+
+    for layer_idx in range(num_layers):
+        prefix = f"model.layers.{layer_idx}"
+        for proj in quant_proj_names:
+            desc[f"{prefix}.{proj}.weight"] = "W8A8_DYNAMIC"
+        for norm in float_names:
+            desc[f"{prefix}.{norm}.weight"] = "FLOAT"
+
+    return desc
+
+
+def should_quantize_int8(param_name: str) -> bool:
+    """Determine whether to quantize a parameter to INT8.
+
+    Rules (same as FP8QuantizerHelper.should_quantize_param):
+    - Must end with .weight
+    - Exclude embedding, norm, lm_head, MoE router
+    - Include q/k/v/o_proj, gate/up/down_proj, fc1/fc2
+    """
+    if not param_name.endswith(".weight"):
+        return False
+
+    exclude_patterns = [
+        "embed_tokens",
+        "lm_head",
+        "layernorm",
+        "norm",
+        "ln_",
+        "embeddings",
+        "mlp.gate.weight",
+    ]
+    param_lower = param_name.lower()
+    for pattern in exclude_patterns:
+        if pattern in param_lower:
+            return False
+
+    include_patterns = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "fc1",
+        "fc2",
+        "mlp",
+    ]
+    for pattern in include_patterns:
+        if pattern in param_lower:
+            return True
+
+    return False
+
+
+def quant_weights_int8_ascend(weights, dtype=torch.bfloat16):
+    """Quantize weights to INT8 format for Ascend W8A8_DYNAMIC.
+
+    For each weight that should be quantized:
+      - Yields (name, int8_weight)
+      - Yields (name.replace('.weight', '.weight_scale'), scale)
+      - Yields (name.replace('.weight', '.weight_offset'), offset)
+
+    Args:
+        weights: Iterable of (name, tensor) pairs
+        dtype: Data type for intermediate computation
+
+    Yields:
+        Tuples of (name, tensor)
+    """
+    for k, v in weights:
+        if not should_quantize_int8(k):
+            yield (k, v)
+            continue
+
+        try:
+            if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+                logger.debug(f"Quantizing to INT8 (Ascend): {k}")
+
+            int8_weight, weight_scale, weight_offset = scaled_int8_per_channel(
+                v.to(dtype),
+            )
+
+            yield (k, int8_weight)
+
+            scale_name = k.replace(".weight", ".weight_scale")
+            offset_name = k.replace(".weight", ".weight_offset")
+            yield (scale_name, weight_scale)
+            yield (offset_name, weight_offset)
+
+            del int8_weight, weight_scale, weight_offset
+
+        except Exception as e:
+            logger.error(f"Failed to quantize {k} to INT8: {e}")
+            yield (k, v)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -38,7 +38,7 @@ from verl.utils.activation_offload import enable_activation_offloading
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.device import get_device_id, get_device_name
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.fsdp_utils import (
     CPUOffloadPolicy,
     FSDPModule,
@@ -445,8 +445,10 @@ class FSDPEngine(BaseEngine):
                 "reshard_after_forward": self.engine_config.reshard_after_forward,
             }
             full_state = module.state_dict()
+            get_torch_device().empty_cache()
             apply_fsdp2(module, fsdp_kwargs, self.engine_config)
             fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
+            get_torch_device().empty_cache()
         else:
             raise NotImplementedError(f"Unknown strategy {self.engine_config.strategy}")
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -32,6 +32,15 @@ from verl.utils.vllm.patch import patch_vllm_moe_model_weight_loader
 from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches, is_fp8_model, load_quanted_weights
 from verl.workers.rollout.vllm_rollout.weight_update_utils import apply_buffer_updates, split_buffer_updates
 
+try:
+    from verl.utils.vllm.vllm_int8_ascend_utils import is_int8_ascend_model, load_int8_ascend_weights
+except ImportError:
+
+    def is_int8_ascend_model(*args, **kwargs):
+        return False
+
+    load_int8_ascend_weights = None
+
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
@@ -252,8 +261,10 @@ class vLLMColocateWorkerExtension:
         if peft_config and base_sync_done:
             self.remove_lora(VLLM_LORA_INT_ID)
 
-        use_standard_weight_load = not (peft_config and base_sync_done) and not is_fp8_model(
-            self.model_runner.vllm_config
+        use_standard_weight_load = (
+            not (peft_config and base_sync_done)
+            and not is_fp8_model(self.model_runner.vllm_config)
+            and not is_int8_ascend_model(self.model_runner.vllm_config)
         )
 
         if self._is_qat_model:
@@ -336,14 +347,21 @@ class vLLMColocateWorkerExtension:
             # Check if FP8 quantization is enabled and apply appropriate weight loading
             if is_fp8_model(self.model_runner.vllm_config):
                 logger.info(f"FP8 model detected (async): {self.model_runner.vllm_config.quant_config}")
-                # Convert bf16 weights to fp8 format before loading
                 loaded_params = load_quanted_weights(param_updates, self.model_runner) if param_updates else []
-                # Keep the draft model in sync when present.
                 if self._use_mtp_drafter_weight_sync() and param_updates:
                     load_quanted_weights(param_updates, self.model_runner, is_drafter=True)
                 loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
                 logger.info(
                     f"FP8 weights loaded (async), loaded_params: {len(loaded_params)}, loaded_buffers: {loaded_buffers}"
+                )
+            elif is_int8_ascend_model(self.model_runner.vllm_config):
+                logger.info("INT8-Ascend (W8A8_DYNAMIC) model detected (async)")
+                vllm_dtype = self.model_runner.vllm_config.model_config.dtype
+                loaded_params = load_int8_ascend_weights(param_updates, self.model_runner.model, dtype=vllm_dtype)
+                loaded_buffers = self._apply_buffer_updates_all_models(buffer_updates, named_buffers)
+                logger.info(
+                    f"INT8-Ascend weights loaded (async), "
+                    f"loaded_params: {len(loaded_params)}, loaded_buffers: {loaded_buffers}"
                 )
             else:
                 if param_updates:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -913,8 +913,8 @@ class vLLMHttpServer:
             logger.info(f"QAT quantization config injected (quant_method={quant_method})")
             hf_overrides["quantization_config"] = quantization_config_dict
         elif quantization is not None:
-            # Handle other quantization methods (fp8, torchao)
-            _SUPPORTED_QUANTIZATION = ["fp8", "torchao", "ascend"]
+            # Handle other quantization methods (fp8, torchao, ascend, int8-ascend)
+            _SUPPORTED_QUANTIZATION = ["fp8", "torchao", "ascend", "int8-ascend"]
             if quantization not in _SUPPORTED_QUANTIZATION:
                 raise ValueError(f"Currently only support {_SUPPORTED_QUANTIZATION} quantization, got: {quantization}")
 
@@ -937,6 +937,15 @@ class vLLMHttpServer:
                 apply_vllm_fp8_patches()
                 # for subprocesses patching
                 os.environ["VERL_VLLM_FP8_QUANT_ENABLED"] = "1"
+
+            elif quantization == "int8-ascend":
+                from verl.utils.vllm.vllm_int8_ascend_utils import build_int8_ascend_quant_description
+
+                quant_desc = build_int8_ascend_quant_description(self.model_config.hf_config)
+                hf_overrides["quantization_config"] = quant_desc
+                quantization = "ascend"
+                os.environ["VERL_VLLM_INT8_ASCEND_QUANT_ENABLED"] = "1"
+                logger.info("INT8-Ascend (W8A8_DYNAMIC) quantization config injected")
 
         if quantization is not None and self.config.quantization_config_file is not None:
             hf_overrides["quantization_config_file"] = self.config.quantization_config_file


### PR DESCRIPTION
### What does this PR do?

This PR adds native INT8 online quantization support for Ascend NPU during
GRPO/PPO rollout in verl. When configured with `quantization=int8-ascend`,
the rollout engine performs on-the-fly per-channel symmetric INT8 quantization
(W8A8_DYNAMIC) of model weights before loading them into vllm-ascend, enabling
significant memory savings and throughput improvement on Ascend hardware.

**Key features:**
- Native per-channel INT8 quantization kernel (`scaled_int8_per_channel`)
  without external dependencies like Flash-RL
- Automatic quantization description generation compatible with
  vllm-ascend's `AscendQuantConfig`
- Handles vLLM fused parameter mapping (qkv_proj, gate_up_proj)
- `VERL_LOAD_ALL_RANKS` workaround for HCCL AICPU large-tensor broadcast bug
- Robustness improvements for NPU patch loading (safe warm_up_atb,
  try/except for MC2 patches)

**Relation to #5174:**
PR #5174 implements INT8 rollout via the external Flash-RL tool. This PR takes
a different approach: it implements per-channel INT8 quantization natively
within verl, requiring no external quantization tools. The two approaches are
complementary — this PR provides a lightweight, dependency-free INT8 path
for standard dense models on Ascend NPU.

Similar PR search:
https://github.com/verl-project/verl/pulls?q=is%3Apr+int8+ascend

> **AI Disclosure:** This PR was developed with AI assistance (code review
> and cleanup). The submitter has reviewed every changed line and validated
> on a 16-NPU cluster.


### Test
<img width="1287" height="863" alt="9546f87f7d0392ecdc5ad354786a4b5f" src="https://github.com/user-attachments/assets/f2669dce-f7f6-4d36-a7ca-4897cedc7de1" />



**Settings:**
- Model: Qwen3-8B-Base
- Hardware: 16x Ascend NPU
- TP=1, train_batch_size=2048, max_prompt_length=2048, max_response_length=8192
- Algorithm: GRPO
- quantization: int8-ascend
- baseline: bf16 rollout

**Result:**
- Throughput:  int8 increased by around 8% compared to bf16
- Reward: int8 is about 3% lower than bf16
- Stability: both are stable from grad_norm perspective

### API and Usage Example

No new CLI arguments. Users enable INT8 Ascend quantization via existing
`quantization` config:

```bash
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.rollout.quantization=int8-ascend \
    ... # other configs unchanged
```

Programmatic usage:
```python
# The quantization is triggered automatically when quantization="int8-ascend"
# No code changes needed in user scripts
```


### Design & Code Changes

**Architecture Overview:**

1. When `quantization=int8-ascend` is configured, the rollout worker
   intercepts weight loading and applies per-channel INT8 quantization.
2. Quantized weights (int8 + scale + offset) are loaded directly into
   vllm-ascend's W8A8_DYNAMIC format.
3. Activation quantization is handled dynamically by vllm-ascend at runtime.

**Changed Files (9 files, +507/-77):**

*New files:*
- `verl/utils/kernel/int8_kernel.py` — Core INT8 per-channel symmetric
  quantization implementation (`scaled_int8_per_channel`)
- `verl/utils/vllm/vllm_int8_ascend_utils.py` — INT8 quantization utilities:
  quant description builder, weight quantizer/loader, fused param handling

*Modified files:*
- `verl/trainer/config/rollout/rollout.yaml` — Add `int8-ascend` to
  quantization options documentation
- `verl/utils/fsdp_utils.py` — Add `VERL_LOAD_ALL_RANKS` env var to skip
  rank-0-only loading and HCCL broadcast (workaround for CANN AICPU bug
  on large tensors); manually shard DTensor weights per-rank instead
- `verl/utils/vllm/npu_vllm_patch.py` — Safe `_warm_up_atb` wrapper to
  prevent AttributeError crashes; add try/except for vllm_ascend v0.11
  MC2 patch imports
- `verl/utils/vllm/patch.py` — Broaden exception handling from
  `ImportError` to `(ImportError, RuntimeError)` for NPU environments
  where module loading may raise RuntimeError
- `verl/workers/engine/fsdp/transformer_impl.py` — Respect
  `VERL_LOAD_ALL_RANKS` in FSDP engine initialization
- `verl/workers/rollout/vllm_rollout/utils.py` — Integrate INT8 Ascend
  quantization config into vllm engine kwargs
- `verl/workers/rollout/vllm_rollout/vllm_async_server.py` — Integrate
  INT8 Ascend weight loading in async vllm server

Collaborator: @ljkkkkkkkkk 