### PR TITLE
[ckpt] fix: write HF config before bridge save to fix shard inference

### DIFF
--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -1269,6 +1269,7 @@ class MegatronCheckpointManager(BaseCheckpointManager):
         # ── 2. HF config / tokenizer (rank 0) ───────────────────────────────
         if self.should_save_hf_model:
             self._save_hf_config_and_tokenizer(local_path)
+            torch.distributed.barrier()
 
         # ── 3. Save model weights in HF format via bridge ───────────────────
         if self.should_save_hf_model:

--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -1266,16 +1266,16 @@ class MegatronCheckpointManager(BaseCheckpointManager):
             ]
         )
 
-        # ── 2. Save model weights in HF format via bridge ───────────────────
+        # ── 2. HF config / tokenizer (rank 0) ───────────────────────────────
+        if self.should_save_hf_model:
+            self._save_hf_config_and_tokenizer(local_path)
+
+        # ── 3. Save model weights in HF format via bridge ───────────────────
         if self.should_save_hf_model:
             hf_ckpt_path = get_hf_model_checkpoint_path(local_path)
             log_with_rank(f"Saving HF model checkpoint to {hf_ckpt_path} with bridge", rank=self.rank, logger=logger)
             self._save_model_as_hf_via_bridge(hf_ckpt_path)
             log_with_rank(f"Saved bridge checkpoint to {hf_ckpt_path}", rank=self.rank, logger=logger)
-
-        # ── 3. HF config / tokenizer (rank 0) ───────────────────────────────
-        if self.should_save_hf_model:
-            self._save_hf_config_and_tokenizer(local_path)
 
         # ── 4. Transformer config (rank 0, at checkpoint root) ──────────────
         if self.should_save_extra:


### PR DESCRIPTION
### What does this PR do?

Fix checkpoint-time shard inference divergence caused by HF config write ordering in the Megatron bridge path. Move `_save_hf_config_and_tokenizer` to run **before** `_save_model_as_hf_via_bridge`, so the bridge reads the correct HF config when inferring weight shards.

Fixes #6821.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: [search](https://github.com/verl-project/verl/pulls?q=is%3Apr+megatron+bridge+checkpoint+config)
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Validated on Qwen3.5-35B-A3B MoE GRPO with Megatron bridge (8xH20). Before the fix, the following parameters were missing from the saved checkpoint:
- `model.language_model.layers.{38..39}.mlp.experts.gate_up_proj`
- `model.language_model.layers.39.mlp.experts.down_proj`

After reordering the config write, all expert parameters are correctly saved.

### API and Usage Example

No API changes.

### Design & Code Changes

In `MegatronCheckpointManager._save_checkpoint()`, the step ordering is changed from:

```
2. Save model weights via bridge  (reads config)
3. Write HF config + tokenizer
```

to:

```
2. Write HF config + tokenizer
3. Save model weights via bridge  (reads config)
```

This ensures the HF `config.json` is on disk before the bridge performs shard inference, preventing the bridge from falling back to stale or missing config and dropping expert parameters.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting). (ruff/mypy passed; unrelated hooks failed due to Windows GBK encoding)
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (N/A — internal bug fix)
- [ ] Add unit or end-to-end test(s). (Requires multi-GPU Megatron bridge setup; validated manually on 8xH20 with Qwen3.5-35B-A3B)
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).