### PR TITLE
[rollout, vllm] feat: reject server-side tool parser for TITO agent rollout

### DIFF
--- a/tests/workers/config/test_rollout_config_on_cpu.py
+++ b/tests/workers/config/test_rollout_config_on_cpu.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.workers.config import AgentLoopConfig, MultiTurnConfig, RolloutConfig
+
+
+def test_vllm_multi_turn_rejects_server_side_tool_parser_args():
+    with pytest.raises(ValueError, match="client-side AgentLoop tool parsing"):
+        RolloutConfig(
+            name="vllm",
+            multi_turn=MultiTurnConfig(enable=True),
+            engine_kwargs={"vllm": {"enable_auto_tool_choice": True, "tool_call_parser": "hermes"}},
+        )
+
+
+def test_vllm_multi_turn_rejects_server_side_tool_parser_args_from_dict_config():
+    with pytest.raises(ValueError, match="client-side AgentLoop tool parsing"):
+        RolloutConfig(
+            name="vllm",
+            multi_turn={"enable": True},
+            engine_kwargs={"vllm": {"tool_parser_plugin": "custom_parser.py"}},
+        )
+
+
+def test_vllm_tool_agent_rejects_server_side_tool_parser_args():
+    with pytest.raises(ValueError, match="client-side AgentLoop tool parsing"):
+        RolloutConfig(
+            name="vllm",
+            agent=AgentLoopConfig(default_agent_loop="tool_agent"),
+            engine_kwargs={"vllm": {"tool_call_parser": "hermes"}},
+        )
+
+
+def test_vllm_function_tool_path_rejects_server_side_tool_parser_args():
+    with pytest.raises(ValueError, match="client-side AgentLoop tool parsing"):
+        RolloutConfig(
+            name="vllm",
+            multi_turn=MultiTurnConfig(function_tool_path="tools.py"),
+            engine_kwargs={"vllm": {"enable_auto_tool_choice": True}},
+        )
+
+
+def test_vllm_chat_completion_tool_parser_args_still_allowed_without_multi_turn():
+    config = RolloutConfig(
+        name="vllm",
+        multi_turn=MultiTurnConfig(enable=False),
+        engine_kwargs={"vllm": {"enable_auto_tool_choice": True, "tool_call_parser": "hermes"}},
+    )
+
+    assert config.engine_kwargs["vllm"]["tool_call_parser"] == "hermes"
+
+
+def test_vllm_multi_turn_allows_unrelated_engine_kwargs():
+    config = RolloutConfig(
+        name="vllm",
+        multi_turn=MultiTurnConfig(enable=True),
+        engine_kwargs={"vllm": {"enable_auto_tool_choice": False, "gpu_memory_utilization": 0.75}},
+    )
+
+    assert config.engine_kwargs["vllm"]["gpu_memory_utilization"] == 0.75

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -318,6 +318,30 @@ class RolloutConfig(BaseConfig):
                     f"Current rollout {self.name=} not implemented pipeline_model_parallel_size > 1 yet."
                 )
 
+        multi_turn_enabled = self.multi_turn.get("enable", False)
+        uses_agent_loop_tools = (
+            multi_turn_enabled
+            or self.agent.get("default_agent_loop", "single_turn_agent") != "single_turn_agent"
+            or self.multi_turn.get("tool_config_path") is not None
+            or self.multi_turn.get("function_tool_path") is not None
+        )
+        if self.name == "vllm" and uses_agent_loop_tools:
+            vllm_engine_kwargs = (self.engine_kwargs or {}).get("vllm", {}) or {}
+            server_side_tool_parser_args = {
+                "enable_auto_tool_choice",
+                "tool_call_parser",
+                "tool_parser_plugin",
+            }
+            configured_parser_args = sorted(
+                key for key in server_side_tool_parser_args if vllm_engine_kwargs.get(key) not in (None, False)
+            )
+            if configured_parser_args:
+                raise ValueError(
+                    "vLLM multi-turn RL rollout uses token-in-token-out generation with "
+                    "client-side AgentLoop tool parsing. Do not configure server-side vLLM "
+                    f"tool parser args in rollout.engine_kwargs.vllm: {configured_parser_args}."
+                )
+
         # Hydra passes this as dict/DictConfig; coerce to dataclass so
         # downstream .enabled etc. work. BaseConfig is frozen, hence object.__setattr__.
         if isinstance(self.disaggregation, dict):


### PR DESCRIPTION
### What does this PR do?

Follow-up to #6560. That PR proposed *exposing* server-side vLLM tool-calling
config (`enable_auto_tool_choice`, `tool_call_parser`, `tool_parser_plugin`) in
the rollout config. Per review feedback there, RL rollout uses
[token-in-token-out (TITO)](https://verl.readthedocs.io/en/latest/advance/agent_loop.html#chat-completion-vs-token-in-token-out)
generation, so tool parsing happens **client-side** in the AgentLoop and these
server-side parser args should not be passed to vLLM at all.

This PR implements that guidance as a **fail-fast guardrail**: when a vLLM
rollout enables the AgentLoop tool path (multi-turn, a non-default
`default_agent_loop`, `tool_config_path`, or `function_tool_path`), configuring
any of the server-side vLLM tool parser args in `rollout.engine_kwargs.vllm`
now raises a clear `ValueError` instead of being silently passed through to the
engine (where it is redundant/conflicting with client-side parsing).

Plain chat-completion rollouts (multi-turn disabled) are unaffected and may
still set these args.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=tool_call_parser → only #6560 (closed, opposite direction)
  - Related but **non-duplicate**: #6434 (client-side reasoning parser), #6481 (hermes tool calls on gpt-oss)
- [x] PR title formatted as `[{modules}] {type}: {description}`

### Test

Config validation is CPU-testable; no training experiment is needed (no change
to training dynamics — this only rejects an invalid config combination).

```bash
python -m pytest tests/workers/config/test_rollout_config_on_cpu.py -q
# 6 passed
```

The test file is named `*_on_cpu.py`, so it is auto-collected by
`.github/workflows/cpu_unit_tests.yml` (which runs `tests/**/test_*_on_cpu.py`
on CPU). Coverage includes:

- vLLM multi-turn rejects server-side parser args (dataclass and dict config)
- vLLM `tool_agent` rejects server-side parser args
- vLLM `function_tool_path` rejects server-side parser args
- chat-completion (multi-turn disabled) still allows the args
- unrelated `engine_kwargs.vllm` (e.g. `gpu_memory_utilization`) is untouched

### API and Usage Example

No new config fields. Behavior change only: an invalid combination now fails early.

```python
from verl.workers.config import RolloutConfig, MultiTurnConfig

# Raises ValueError: server-side tool parser args are not allowed for TITO AgentLoop rollout
RolloutConfig(
    name="vllm",
    multi_turn=MultiTurnConfig(enable=True),
    engine_kwargs={"vllm": {"enable_auto_tool_choice": True, "tool_call_parser": "hermes"}},
)

# Still allowed without multi-turn (plain chat-completion rollout)
RolloutConfig(
    name="vllm",
    multi_turn=MultiTurnConfig(enable=False),
    engine_kwargs={"vllm": {"enable_auto_tool_choice": True, "tool_call_parser": "hermes"}},
)
```

### Design & Code Changes

- `verl/workers/config/rollout.py`: in `RolloutConfig.__post_init__`, after the
  existing rollout validations, detect AgentLoop tool usage and, for the `vllm`
  backend, raise `ValueError` if any of `{enable_auto_tool_choice,
  tool_call_parser, tool_parser_plugin}` is set to a non-default value.
- `tests/workers/config/test_rollout_config_on_cpu.py`: new CPU unit tests
  covering the rejection paths and the allowed paths.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff / ruff-format / mypy pass; files unchanged by formatters).
- [ ] Add / Update the documentation. — N/A: no new config surface; this only rejects an already-invalid combination.
- [x] Add unit test(s) to the CI workflow — auto-collected by `cpu_unit_tests.yml` via the `*_on_cpu.py` suffix.
- [ ] Not related to the `recipe` submodule.
