### PR TITLE
[fsdp] fix: re-wrap fused log_probs/entropy when `use_remove_padding=False`

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1214,10 +1214,23 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 raise NotImplementedError(f"pad_mode {pad_mode} not implemented")
 
         else:  # not using rmpad and no ulysses sp
-            response_length = tu.get_non_tensor_data(data=micro_batch, key="max_response_length", default=1024)
             if use_fused_kernels:
-                log_probs = output.log_probs[:, -response_length - 1 : -1]
-                entropy = output.entropy[:, -response_length - 1 : -1]  # (bsz, response_length)
+                if pad_mode == DatasetPadMode.NO_PADDING:
+                    # Re-wrap dense fused (bsz, seqlen) outputs as nested/jagged, as the non-fused branch does.
+                    cu_seqlens = input_ids.offsets()
+                    seq_lengths = cu_seqlens.diff()
+                    starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
+
+                    log_probs = torch.nested.narrow(output.log_probs, 1, starts, seq_lengths, layout=torch.jagged)
+                    log_probs = torch.cat([t for t in log_probs.unbind()])
+                    log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+
+                    if calculate_entropy:
+                        entropy = torch.nested.narrow(output.entropy, 1, starts, seq_lengths, layout=torch.jagged)
+                        entropy = torch.cat([t for t in entropy.unbind()])
+                        entropy = torch.nested.nested_tensor_from_jagged(entropy, cu_seqlens)
+                else:
+                    raise NotImplementedError(f"pad_mode {pad_mode} not implemented")
 
             else:
                 logits = output.logits  # (bsz, response_length, vocab_size)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1216,18 +1216,18 @@ class FSDPEngineWithLMHead(FSDPEngine):
         else:  # not using rmpad and no ulysses sp
             if use_fused_kernels:
                 if pad_mode == DatasetPadMode.NO_PADDING:
-                    # Re-wrap dense fused (bsz, seqlen) outputs as nested/jagged, as the non-fused branch does.
+                    # Re-wrap dense fused (bsz, seqlen) outputs as nested/jagged: mask out the
+                    # padding columns per sequence and pack the valid tokens to (total_nnz,).
                     cu_seqlens = input_ids.offsets()
                     seq_lengths = cu_seqlens.diff()
-                    starts = torch.zeros_like(seq_lengths, dtype=torch.int64)
+                    arange = torch.arange(output.log_probs.shape[1], device=output.log_probs.device)
+                    mask = arange < seq_lengths.unsqueeze(1)
 
-                    log_probs = torch.nested.narrow(output.log_probs, 1, starts, seq_lengths, layout=torch.jagged)
-                    log_probs = torch.cat([t for t in log_probs.unbind()])
+                    log_probs = output.log_probs[mask]
                     log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
 
                     if calculate_entropy:
-                        entropy = torch.nested.narrow(output.entropy, 1, starts, seq_lengths, layout=torch.jagged)
-                        entropy = torch.cat([t for t in entropy.unbind()])
+                        entropy = output.entropy[mask]
                         entropy = torch.nested.nested_tensor_from_jagged(entropy, cu_seqlens)
                 else:
                     raise NotImplementedError(f"pad_mode {pad_mode} not implemented")


### PR DESCRIPTION
### What does this PR do?

Related to #6780 .

Fixes a crash in the FSDP model engine (`FSDPEngineWithLMHead.prepare_model_outputs`) when `use_fused_kernels=True` is combined with `use_remove_padding=False`. The fused-kernels branch of the non-remove-padding / `NO_PADDING` path returned the fused `log_probs`/`entropy` as a **dense `(bsz, seqlen)`** slice and never re-wrapped them into the nested/jagged layout the loss path expects. The non-fused sibling branch does narrow → pack → `nested_tensor_from_jagged`, so the two paths disagreed.

The dense tensors then trip `no_padding_2_padding`'s assert (`values.shape[0]` is `bsz`, but it expects `total_nnz`):

```
File ".../verl/workers/utils/padding.py", line 131, in no_padding_2_padding
    assert sequence_offsets[-1].item() == values.shape[0]
AssertionError
```

The bug is architecture-independent — any model whose fused forward returns a dense `(bsz, seqlen)` `log_probs` hits it; it surfaced on Qwen3.5.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: 
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+fused_kernels+no_padding
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+use_remove_padding+fused
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
**End-to-end training (real model, GRPO, 1×H200):** GRPO on **Qwen3.5-0.8B**, gsm8k,
`use_remove_padding=False`, `use_fused_kernels=True`, `trainer.total_training_steps=1`.
The only change between runs is the engine file (fixed vs. unfixed).

- **Before the fix** — crashes at the first `no_padding_2_padding` on the dense fused output:
  ```
  File ".../verl/workers/utils/padding.py", line 131, in no_padding_2_padding
      assert sequence_offsets[-1].item() == values.shape[0]
  AssertionError
  ```
- **After the fix** — step 1 completes:
  ```
  step:1 - actor/pg_loss:0.0408 - actor/grad_norm:3.07 - timing_s/update_actor:28.27 - training/global_step:1
  ```

### API and Usage Example

No API/config change. The fix makes the previously-broken combination run:

```bash
#!/usr/bin/env bash
# Minimal GRPO repro for the fused-kernels + use_remove_padding=False crash.
# BEFORE the fix: crashes at no_padding_2_padding (padding.py:131).
# AFTER  the fix: step 1 completes and exits (trainer.total_training_steps=1).
# Data prep (run once): python examples/data_preprocess/gsm8k.py --local_dir "$HOME/data/gsm8k"
set -xeuo pipefail

MODEL_PATH=${MODEL_PATH:-"$HOME/Qwen3.5-0.8B/"}
TRAIN_FILE=${TRAIN_FILE:-"$HOME/gsm8k/train.parquet"}
TEST_FILE=${TEST_FILE:-"$HOME/gsm8k/test.parquet"}
NGPUS_PER_NODE=${NGPUS_PER_NODE:-1}
NNODES=${NNODES:-1}

DATA=(
    algorithm.adv_estimator=grpo
    algorithm.use_kl_in_reward=False
    data.train_files="${TRAIN_FILE}"
    data.val_files="${TEST_FILE}"
    data.train_batch_size=8
    data.max_prompt_length=512
    data.max_response_length=256
    data.filter_overlong_prompts=True
    data.truncation='error'
    data.shuffle=False
)

# >>> The two flags that trigger the bug <<<
MODEL=(
    actor_rollout_ref.model.path="${MODEL_PATH}"
    actor_rollout_ref.model.use_remove_padding=False
    actor_rollout_ref.model.use_fused_kernels=True
    actor_rollout_ref.model.enable_gradient_checkpointing=True
    # sdpa so the run doesn't require flash-attn; unrelated to the bug.
    +actor_rollout_ref.model.override_config.attn_implementation=sdpa
)

ACTOR=(
    actor_rollout_ref.actor.optim.lr=1e-6
    actor_rollout_ref.actor.strategy=fsdp2
    actor_rollout_ref.actor.ppo_mini_batch_size=8
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1
    actor_rollout_ref.actor.use_dynamic_bsz=False
    actor_rollout_ref.actor.use_kl_loss=False
    actor_rollout_ref.actor.entropy_coeff=0
    actor_rollout_ref.actor.use_torch_compile=False
    actor_rollout_ref.actor.fsdp_config.fsdp_size=${NGPUS_PER_NODE}
    actor_rollout_ref.actor.fsdp_config.param_offload=False
    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
)

ROLLOUT=(
    actor_rollout_ref.rollout.name=vllm
    actor_rollout_ref.rollout.tensor_model_parallel_size=1
    actor_rollout_ref.rollout.gpu_memory_utilization=0.4
    # Qwen3.5 is hybrid-Mamba; cap context/concurrency so the vLLM state cache
    # doesn't blow up (default max_model_len is 262144).
    actor_rollout_ref.rollout.max_model_len=2048
    actor_rollout_ref.rollout.max_num_seqs=16
    actor_rollout_ref.rollout.enable_prefix_caching=False
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1
    actor_rollout_ref.rollout.n=4
    actor_rollout_ref.rollout.enforce_eager=True
    actor_rollout_ref.rollout.free_cache_engine=True
)

TRAINER=(
    trainer.critic_warmup=0
    trainer.use_v1=True
    trainer.logger='["console"]'
    trainer.project_name=verl_fused_no_rmpad_repro
    trainer.experiment_name=fused_no_rmpad
    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
    trainer.nnodes=${NNODES}
    trainer.val_before_train=False
    trainer.save_freq=-1
    trainer.test_freq=-1
    trainer.total_epochs=1
    trainer.total_training_steps=1
)

python3 -m verl.trainer.main_ppo \
    "${DATA[@]}" "${MODEL[@]}" "${ACTOR[@]}" "${ROLLOUT[@]}" "${TRAINER[@]}" "$@"
```

Workarounds that previously avoided the crash (no longer needed): set
`use_remove_padding=True`, or `use_fused_kernels=False`.

### Design & Code Changes

- **Root cause** (`verl/workers/engine/fsdp/transformer_impl.py`): in the `else  # not using rmpad` block, the `if use_fused_kernels:` sub-branch returned `output.log_probs[:, -response_length - 1 : -1]` (dense `(bsz, seqlen)`), which the loss path cannot consume. The tail slice is also wrong for `NO_PADDING`, where sequences are right-padded and `shift_labels` is only passed under `use_remove_padding=True`.
- **Fix:** narrow the fused `log_probs`/`entropy` to the real per-sequence lengths, pack to `(total_nnz,)`, and re-wrap with `nested_tensor_from_jagged(..., cu_seqlens)`, mirroring the non-fused branch. Post-fix invariant: `model_output["log_probs"]` `.is_nested` and `.values().shape[0] == total_nnz`. Also removed the now-unused `response_length` local.
- **Files:**
  - `verl/workers/engine/fsdp/transformer_impl.py` — the fix.
  - `tests/workers/test_fused_no_padding_rewrap_on_cpu.py` — new regression test.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
