### PR TITLE
[fsdp, megatron, trainer] fix: enhance mem footprint for forward_kl_topk OPD

### DIFF
--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -80,9 +80,12 @@ def _make_logits_processor(keys):
 
 
 @pytest.mark.parametrize("use_remove_padding", [True, False])
-def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
+@pytest.mark.parametrize("distillation_only", [False, True])
+def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding, distillation_only):
     """distillation_use_topk=True must populate distillation outputs into
-    model_output regardless of use_remove_padding. See verl#6293."""
+    model_output regardless of use_remove_padding. See verl#6293.
+
+    When distillation_only=True, log_probs must be omitted (supervised top-k path)."""
     bsz = 2
     seq_lengths_list = [3, 2]
     seq_lengths = torch.tensor(seq_lengths_list, dtype=torch.int64)
@@ -125,6 +128,7 @@ def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
         calculate_entropy=False,
         calculate_sum_pi_squared=False,
         distillation_use_topk=True,
+        distillation_only=distillation_only,
         max_response_length=max(seq_lengths_list),
     )
 
@@ -146,9 +150,15 @@ def test_distillation_outputs_emitted_in_both_padding_modes(use_remove_padding):
             logits_processor_func=_make_logits_processor(_DISTILLATION_KEYS),
         )
 
-    assert "log_probs" in model_output, (
-        f"log_probs missing (use_remove_padding={use_remove_padding}); keys: {list(model_output.keys())}"
-    )
+    if distillation_only:
+        assert "log_probs" not in model_output, (
+            f"log_probs should be omitted when distillation_only=True "
+            f"(use_remove_padding={use_remove_padding}); keys: {list(model_output.keys())}"
+        )
+    else:
+        assert "log_probs" in model_output, (
+            f"log_probs missing (use_remove_padding={use_remove_padding}); keys: {list(model_output.keys())}"
+        )
 
     for k in _DISTILLATION_KEYS:
         assert k in model_output, (

--- a/tests/workers/test_megatron_distillation_only_on_cpu.py
+++ b/tests/workers/test_megatron_distillation_only_on_cpu.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for Megatron supervised top-k distillation (distillation_only) path.
+
+``MegatronEngineWithLMHead._lm_head_logits_processor`` must propagate distillation
+outputs from ``logits_processor_func`` and omit ``log_probs`` when
+``distillation_only=True``.
+
+``vocab_parallel_log_probs_from_logits`` is patched out: it requires Megatron TP
+groups and cannot run on CPU in CI. The contract under test is call-skipping and
+key propagation, not numerical log-prob correctness.
+"""
+
+import os
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.workers.engine.megatron.transformer_impl import MegatronEngineWithLMHead
+
+_VOCAB_SIZE = 8
+_DISTILLATION_KEYS = ("distillation_losses", "student_mass", "teacher_mass")
+
+
+def _make_engine_stub():
+    eng = object.__new__(MegatronEngineWithLMHead)
+    eng.engine_config = SimpleNamespace(
+        entropy_from_logits_with_chunking=False,
+        entropy_from_logits_chunk_size=1024,
+    )
+    return eng
+
+
+def _make_logits_processor(keys):
+    def _proc(student_logits, data, data_format):
+        n = student_logits.shape[1]
+        return {k: torch.full((1, n), float(i + 1)) for i, k in enumerate(keys)}
+
+    return _proc
+
+
+def _run_logits_processor(eng, *, distillation_use_topk, distillation_only):
+    total_nnz = 5 if distillation_use_topk else 4
+    logits = torch.randn(1, total_nnz, _VOCAB_SIZE)
+    label = torch.randint(0, _VOCAB_SIZE, (1, total_nnz))
+    temperature = torch.ones(1, total_nnz)
+    batch = TensorDict({}, batch_size=[])
+
+    with patch(
+        "verl.workers.engine.megatron.transformer_impl.vocab_parallel_log_probs_from_logits",
+        return_value=torch.zeros(1, total_nnz),
+    ) as mock_log_probs:
+        ret = eng._lm_head_logits_processor(
+            logits.clone(),
+            label,
+            temperature.clone(),
+            calculate_sum_pi_squared=False,
+            calculate_entropy=False,
+            distillation_use_topk=distillation_use_topk,
+            distillation_only=distillation_only,
+            logits_processor_func=_make_logits_processor(_DISTILLATION_KEYS),
+            batch=batch,
+            data_format="thd",
+        )
+
+    return mock_log_probs, ret, total_nnz
+
+
+@pytest.mark.parametrize("distillation_only", [False, True])
+def test_megatron_logits_processor_distillation_only_skips_log_probs(distillation_only):
+    eng = _make_engine_stub()
+    mock_log_probs, ret, total_nnz = _run_logits_processor(
+        eng, distillation_use_topk=True, distillation_only=distillation_only
+    )
+
+    if distillation_only:
+        mock_log_probs.assert_not_called()
+        assert "log_probs" not in ret
+    else:
+        mock_log_probs.assert_called_once()
+        assert "log_probs" in ret
+
+    for k in _DISTILLATION_KEYS:
+        assert k in ret, f"Missing distillation key {k!r}; got {list(ret.keys())}"
+        assert ret[k].shape == (1, total_nnz), f"{k} shape {ret[k].shape}"
+
+
+def test_megatron_logits_processor_without_topk_always_computes_log_probs():
+    """When distillation_use_topk=False, log_probs are always computed.
+
+    distillation_only is only set by the trainer when use_topk=True, so we do not
+    parametrize distillation_only=True here (that combo cannot occur in production).
+    """
+    eng = _make_engine_stub()
+    mock_log_probs, ret, _ = _run_logits_processor(eng, distillation_use_topk=False, distillation_only=False)
+
+    mock_log_probs.assert_called_once()
+    assert "log_probs" in ret
+    for k in _DISTILLATION_KEYS:
+        assert k not in ret

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -207,9 +207,14 @@ def distillation_ppo_loss(
     # Called as final policy loss
     distillation_loss_config = distillation_config.distillation_loss
     distill_loss, distill_metrics = distillation_loss(config, distillation_config, model_output, data)
-    policy_loss, policy_metrics = ppo_loss(config, model_output, data, dp_group)
-    if not distillation_loss_config.use_task_rewards:
+    if not distillation_loss_config.use_task_rewards and not distillation_loss_config.use_policy_gradient:
+        # no need to compute policy loss
         policy_loss = 0.0
+        policy_metrics = {}
+    else:
+        policy_loss, policy_metrics = ppo_loss(config, model_output, data, dp_group)
+        if not distillation_loss_config.use_task_rewards:
+            policy_loss = 0.0
 
     # Combine distillation with policy loss
     policy_metrics.update(distill_metrics)

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1304,6 +1304,14 @@ class RayPPOTrainer:
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
+        if is_distillation_enabled(self.config.get("distillation")):
+            distillation_loss_cfg = self.distillation_config.distillation_loss
+            distillation_only = (
+                distillation_use_topk
+                and not distillation_loss_cfg.use_task_rewards
+                and not distillation_loss_cfg.use_policy_gradient
+            )
         ppo_mini_batch_size = self.config.actor_rollout_ref.actor.ppo_mini_batch_size
         ppo_mini_batch_size = ppo_mini_batch_size * self.config.actor_rollout_ref.rollout.n
         ppo_epochs = self.config.actor_rollout_ref.actor.ppo_epochs
@@ -1313,6 +1321,7 @@ class RayPPOTrainer:
             batch_td,
             calculate_entropy=calculate_entropy,
             distillation_use_topk=distillation_use_topk,
+            distillation_only=distillation_only,
             global_batch_size=ppo_mini_batch_size,
             mini_batch_size=ppo_mini_batch_size,
             epochs=ppo_epochs,

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1430,9 +1430,18 @@ class PPOTrainer(ABC):
             if is_distillation_enabled(self.config.get("distillation"))
             else False
         )
+        distillation_only = False  # distillation_only flag means we can skip policy loss and reduce mem footprint
+        if is_distillation_enabled(self.config.get("distillation")):
+            distillation_loss_cfg = self.distillation_config.distillation_loss
+            distillation_only = (
+                distillation_use_topk
+                and not distillation_loss_cfg.use_task_rewards
+                and not distillation_loss_cfg.use_policy_gradient
+            )
         extra_info = {
             "calculate_entropy": calculate_entropy,
             "distillation_use_topk": distillation_use_topk,
+            "distillation_only": distillation_only,
             "global_batch_size": ppo_mini_batch_size,
             "mini_batch_size": ppo_mini_batch_size,
             "epochs": self.config.actor_rollout_ref.actor.ppo_epochs,

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1139,18 +1139,10 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 logits_rmpad.div_(temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))
 
                 log_probs = None
-                if not distillation_only:
-                    # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
-                    inplace_backward = True
-                    if calculate_entropy:
-                        inplace_backward = False
-                    log_probs = logprobs_from_logits(
-                        logits=logits_rmpad,
-                        labels=input_ids_rmpad_rolled,
-                        inplace_backward=inplace_backward,
-                    )
 
-                # compute entropy
+                if calculate_sum_pi_squared:
+                    sum_pi_squared_rmpad = verl_F.calculate_sum_pi_squared_from_logits(logits_rmpad)
+
                 if calculate_entropy:
                     if not self.engine_config.entropy_checkpointing:
                         if self.engine_config.entropy_from_logits_with_chunking:
@@ -1165,28 +1157,30 @@ class FSDPEngineWithLMHead(FSDPEngine):
                             self.compute_entropy_from_logits, logits_rmpad
                         )
 
-                # compute sum_pi_squared (Σπ²) for optimal-baseline advantage estimators
-                if calculate_sum_pi_squared:
-                    sum_pi_squared_rmpad = verl_F.calculate_sum_pi_squared_from_logits(logits_rmpad)
-
                 # logits_processor_func return tensors with shape (1, total_nnz/sp_size)
                 if distillation_use_topk:
                     outputs = logits_processor_func(student_logits=logits_rmpad.unsqueeze(0), data=micro_batch)
                     cu_seqlens = input_ids.offsets()
                     for k, v in outputs.items():
                         v = v.squeeze(0)
-                        if distillation_only:
-                            assert v.shape == (logits_rmpad.shape[0],), (
-                                f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
-                            )
-                        else:
-                            assert v.shape == log_probs.shape, (
-                                f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
-                            )
+                        assert v.shape == (logits_rmpad.shape[0],), (
+                            f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
+                        )
                         if self.use_ulysses_sp:
                             pad_size = output_args["pad_size"]
                             v = gather_outputs_and_unpad(v, gather_dim=0, unpad_dim=0, padding_size=pad_size)
                         model_output[k] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
+
+                if not distillation_only:
+                    # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
+                    inplace_backward = True
+                    if calculate_entropy:
+                        inplace_backward = False
+                    log_probs = logprobs_from_logits(
+                        logits=logits_rmpad,
+                        labels=input_ids_rmpad_rolled,
+                        inplace_backward=inplace_backward,
+                    )
 
             # gather log_prob if sp > 1
             if self.use_ulysses_sp:
@@ -1270,9 +1264,6 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
                     logits_rmpad = torch.cat([t for t in logits.unbind()])
                     input_ids_rmpad_rolled = output_args["input_ids_rmpad_rolled"]
-                    log_probs = None
-                    if not distillation_only:
-                        log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
 
                     # Mirror the use_remove_padding=True branch (see verl#6293).
                     # No Ulysses SP gather here: this branch is the no-SP path
@@ -1283,15 +1274,14 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         outputs = logits_processor_func(student_logits=logits_rmpad.unsqueeze(0), data=micro_batch)
                         for k, v in outputs.items():
                             v = v.squeeze(0)
-                            if distillation_only:
-                                assert v.shape == (logits_rmpad.shape[0],), (
-                                    f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
-                                )
-                            else:
-                                assert v.shape == log_probs.shape, (
-                                    f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
-                                )
+                            assert v.shape == (logits_rmpad.shape[0],), (
+                                f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
+                            )
                             model_output[k] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
+
+                    log_probs = None
+                    if not distillation_only:
+                        log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
 
                     # (bsz, j1), for each sample, length of each sample: [real_prompt_length + real_response_length]
                     if not distillation_only:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1097,6 +1097,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
             data=micro_batch, key="calculate_sum_pi_squared", default=False
         )
         distillation_use_topk = tu.get_non_tensor_data(data=micro_batch, key="distillation_use_topk", default=False)
+        distillation_only = tu.get_non_tensor_data(data=micro_batch, key="distillation_only", default=False)
 
         if calculate_sum_pi_squared and use_fused_kernels:
             raise NotImplementedError(
@@ -1114,8 +1115,10 @@ class FSDPEngineWithLMHead(FSDPEngine):
 
             if use_fused_kernels:
                 # temperature is singleton
-                log_probs = output.log_probs.squeeze(0)  # (total_nnz,)
-                entropy_rmpad = output.entropy.squeeze(0)  # (total_nnz,)
+                log_probs = None
+                if not distillation_only:
+                    log_probs = output.log_probs.squeeze(0)  # (total_nnz,)
+                entropy_rmpad = output.entropy.squeeze(0) if calculate_entropy else None  # (total_nnz,)
 
                 # When the fused kernel also computed top-K distillation
                 # (veomni's chunk_topk_distill path), extract the per-token
@@ -1135,15 +1138,17 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 logits_rmpad = output.logits.squeeze(0)  # (total_nnz, vocab_size)
                 logits_rmpad.div_(temperature_rmpad.clamp(min=1e-8).unsqueeze(-1).to(logits_rmpad.dtype))
 
-                # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
-                inplace_backward = True
-                if calculate_entropy:
-                    inplace_backward = False
-                log_probs = logprobs_from_logits(
-                    logits=logits_rmpad,
-                    labels=input_ids_rmpad_rolled,
-                    inplace_backward=inplace_backward,
-                )
+                log_probs = None
+                if not distillation_only:
+                    # if use_sp: ((total_nnz / sp) + pad) ; if not use_sp: (batch, seqlen)
+                    inplace_backward = True
+                    if calculate_entropy:
+                        inplace_backward = False
+                    log_probs = logprobs_from_logits(
+                        logits=logits_rmpad,
+                        labels=input_ids_rmpad_rolled,
+                        inplace_backward=inplace_backward,
+                    )
 
                 # compute entropy
                 if calculate_entropy:
@@ -1170,7 +1175,14 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     cu_seqlens = input_ids.offsets()
                     for k, v in outputs.items():
                         v = v.squeeze(0)
-                        assert v.shape == log_probs.shape, f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
+                        if distillation_only:
+                            assert v.shape == (logits_rmpad.shape[0],), (
+                                f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
+                            )
+                        else:
+                            assert v.shape == log_probs.shape, (
+                                f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
+                            )
                         if self.use_ulysses_sp:
                             pad_size = output_args["pad_size"]
                             v = gather_outputs_and_unpad(v, gather_dim=0, unpad_dim=0, padding_size=pad_size)
@@ -1181,12 +1193,13 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 pad_size = output_args["pad_size"]
 
                 # gather and unpad for the ulysses sp
-                log_probs = gather_outputs_and_unpad(
-                    log_probs,
-                    gather_dim=0,
-                    unpad_dim=0,
-                    padding_size=pad_size,
-                )
+                if not distillation_only:
+                    log_probs = gather_outputs_and_unpad(
+                        log_probs,
+                        gather_dim=0,
+                        unpad_dim=0,
+                        padding_size=pad_size,
+                    )
                 if calculate_entropy:
                     entropy_rmpad = gather_outputs_and_unpad(
                         entropy_rmpad,
@@ -1205,7 +1218,8 @@ class FSDPEngineWithLMHead(FSDPEngine):
             if pad_mode == DatasetPadMode.NO_PADDING:
                 cu_seqlens = input_ids.offsets()
                 # (bsz, j1), for each sample, is the length of each sample: [real_prompt length + real_response length]
-                log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+                if not distillation_only:
+                    log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
                 if calculate_entropy:
                     entropy = torch.nested.nested_tensor_from_jagged(entropy_rmpad, cu_seqlens)
                 if calculate_sum_pi_squared:
@@ -1223,8 +1237,10 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     arange = torch.arange(output.log_probs.shape[1], device=output.log_probs.device)
                     mask = arange < seq_lengths.unsqueeze(1)
 
-                    log_probs = output.log_probs[mask]
-                    log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+                    log_probs = None
+                    if not distillation_only:
+                        log_probs = output.log_probs[mask]
+                        log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
 
                     if calculate_entropy:
                         entropy = output.entropy[mask]
@@ -1254,7 +1270,9 @@ class FSDPEngineWithLMHead(FSDPEngine):
                     logits = torch.nested.narrow(logits, 1, starts, seq_lengths, layout=torch.jagged)
                     logits_rmpad = torch.cat([t for t in logits.unbind()])
                     input_ids_rmpad_rolled = output_args["input_ids_rmpad_rolled"]
-                    log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
+                    log_probs = None
+                    if not distillation_only:
+                        log_probs = logprobs_from_logits(logits=logits_rmpad, labels=input_ids_rmpad_rolled)
 
                     # Mirror the use_remove_padding=True branch (see verl#6293).
                     # No Ulysses SP gather here: this branch is the no-SP path
@@ -1265,13 +1283,19 @@ class FSDPEngineWithLMHead(FSDPEngine):
                         outputs = logits_processor_func(student_logits=logits_rmpad.unsqueeze(0), data=micro_batch)
                         for k, v in outputs.items():
                             v = v.squeeze(0)
-                            assert v.shape == log_probs.shape, (
-                                f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
-                            )
+                            if distillation_only:
+                                assert v.shape == (logits_rmpad.shape[0],), (
+                                    f"logits_rmpad len: {logits_rmpad.shape[0]}, {k} shape: {v.shape}"
+                                )
+                            else:
+                                assert v.shape == log_probs.shape, (
+                                    f"log_probs shape: {log_probs.shape}, {k} shape: {v.shape}"
+                                )
                             model_output[k] = torch.nested.nested_tensor_from_jagged(v, cu_seqlens)
 
                     # (bsz, j1), for each sample, length of each sample: [real_prompt_length + real_response_length]
-                    log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
+                    if not distillation_only:
+                        log_probs = torch.nested.nested_tensor_from_jagged(log_probs, cu_seqlens)
                     if calculate_entropy:
                         entropy = torch.nested.narrow(entropy, 1, starts, seq_lengths, layout=torch.jagged)
                         entropy_rmpad = torch.cat([t for t in entropy.unbind()])
@@ -1285,7 +1309,8 @@ class FSDPEngineWithLMHead(FSDPEngine):
                 else:
                     raise NotImplementedError(f"pad_mode {pad_mode} not implemented")
 
-        model_output["log_probs"] = log_probs
+        if not distillation_only:
+            model_output["log_probs"] = log_probs
         if calculate_entropy:
             model_output["entropy"] = entropy
         if calculate_sum_pi_squared:

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -33,7 +33,7 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.megatron_checkpoint_manager import MegatronCheckpointManager
 from verl.utils.dataset.dataset_utils import DatasetPadMode
 from verl.utils.debug import log_gpu_memory_usage
-from verl.utils.device import get_device_id, get_device_name
+from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.megatron.pipeline_parallel import make_batch_generator
 from verl.utils.megatron.router_replay_patch import RouterReplay, RouterReplayAction, apply_router_replay_patch
 from verl.utils.megatron.router_replay_utils import (
@@ -511,6 +511,10 @@ class MegatronEngine(BaseEngine):
         Returns:
             grad_norm (float): The norm of the gradients before clipping or update.
         """
+        # forward_kl_topk leaves large fp32 vocab tensors until backward ends;
+        # free cached blocks before grad-norm all_reduce to reduce OOM on tight VRAM.
+        if getattr(self, "_distillation_use_topk_active", False):
+            get_torch_device().empty_cache()
         update_successful, grad_norm, num_zeros_in_grad = self.optimizer.step()
 
         if update_successful:
@@ -631,6 +635,7 @@ class MegatronEngine(BaseEngine):
             offload_megatron_optimizer(self.optimizer)
 
     def forward_backward_batch(self, data: TensorDict, loss_function: Callable, forward_only=False) -> Any:
+        self._distillation_use_topk_active = tu.get_non_tensor_data(data, key="distillation_use_topk", default=False)
         tu.assign_non_tensor(data, sp_size=self.engine_config.context_parallel_size)
 
         # compute num_tokens in global batch for loss normalization
@@ -841,6 +846,58 @@ class MegatronEngineWithLMHead(MegatronEngine):
     def prepare_model_outputs(self, output: dict, data: TensorDict):
         return output
 
+    def _lm_head_logits_processor(
+        self,
+        logits,
+        label,
+        temperature,
+        *,
+        calculate_sum_pi_squared: bool,
+        calculate_entropy: bool,
+        distillation_use_topk: bool,
+        distillation_only: bool,
+        logits_processor_func: Callable,
+        batch: TensorDict,
+        data_format: str,
+    ):
+        assert logits.shape[:2] == label.shape[:2]
+        # avoid non-positive temperature such as padding
+        temperature[temperature <= 0] = 1e-8
+        assert torch.all(temperature > 0).item(), f"temperature tensor must be positive. Got {temperature}"
+        logits.div_(temperature.unsqueeze(dim=-1).to(logits.dtype))
+        ret = {}
+        # sum_pi_squared is non-destructive — must run before vocab_parallel_entropy.
+        if calculate_sum_pi_squared:
+            ret["sum_pi_squared"] = vocab_parallel_sum_pi_squared(logits)
+        if calculate_entropy:
+            logits_bak = logits.clone()
+            # # disable the hint until the fused_kernel is optimized for triton>=3.3
+            # if torch.distributed.get_rank() == 0:
+            #     logger.warning_once(
+            #         "For memory-efficient computation, enable fused kernels via "
+            #         "`actor_rollout_ref.model.use_fused_kernels=True`. "
+            #         "The current `clone()` operation ensures correctness but increases memory usage."
+            #     )
+            if self.engine_config.entropy_from_logits_with_chunking:
+                entropy = vocab_parallel_entropy_with_chunking(
+                    logits,
+                    chunk_size=self.engine_config.entropy_from_logits_chunk_size,
+                )
+            else:
+                entropy = vocab_parallel_entropy(logits)
+
+            ret["entropy"] = entropy
+        else:
+            logits_bak = logits
+
+        # logits_processor_func return tensors with shape (1, total_nnz/cp_size)
+        if distillation_use_topk:
+            ret.update(logits_processor_func(student_logits=logits_bak, data=batch, data_format=data_format))
+        if not distillation_only:
+            ret["log_probs"] = vocab_parallel_log_probs_from_logits(logits_bak, label)
+
+        return ret
+
     def forward_step(
         self, batch_iter: Iterator[TensorDict], model, logits_processor_func, postprocess_micro_batch_func
     ):
@@ -862,6 +919,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
         calculate_entropy = tu.get_non_tensor_data(batch, key="calculate_entropy", default=False)
         calculate_sum_pi_squared = tu.get_non_tensor_data(batch, key="calculate_sum_pi_squared", default=False)
         distillation_use_topk = tu.get_non_tensor_data(batch, key="distillation_use_topk", default=False)
+        distillation_only = tu.get_non_tensor_data(batch, key="distillation_only", default=False)
 
         if calculate_sum_pi_squared and use_fused_kernels:
             raise NotImplementedError(
@@ -939,43 +997,16 @@ class MegatronEngineWithLMHead(MegatronEngine):
             forward_fn = get_mcore_engine_forward_fn(self.model_config.hf_config)
             data_format = "thd" if self.engine_config.use_remove_padding else "bshd"
 
-            def logits_processor(logits, label, temperature):
-                assert logits.shape[:2] == label.shape[:2]
-                # avoid non-positive temperature such as padding
-                temperature[temperature <= 0] = 1e-8
-                assert torch.all(temperature > 0).item(), f"temperature tensor must be positive. Got {temperature}"
-                logits.div_(temperature.unsqueeze(dim=-1).to(logits.dtype))
-                ret = {}
-                # sum_pi_squared is non-destructive — must run before vocab_parallel_entropy.
-                if calculate_sum_pi_squared:
-                    ret["sum_pi_squared"] = vocab_parallel_sum_pi_squared(logits)
-                if calculate_entropy:
-                    logits_bak = logits.clone()
-                    # # disable the hint until the fused_kernel is optimized for triton>=3.3
-                    # if torch.distributed.get_rank() == 0:
-                    #     logger.warning_once(
-                    #         "For memory-efficient computation, enable fused kernels via "
-                    #         "`actor_rollout_ref.model.use_fused_kernels=True`. "
-                    #         "The current `clone()` operation ensures correctness but increases memory usage."
-                    #     )
-                    if self.engine_config.entropy_from_logits_with_chunking:
-                        entropy = vocab_parallel_entropy_with_chunking(
-                            logits,
-                            chunk_size=self.engine_config.entropy_from_logits_chunk_size,
-                        )
-                    else:
-                        entropy = vocab_parallel_entropy(logits)
-
-                    ret["entropy"] = entropy
-                else:
-                    logits_bak = logits
-
-                # logits_processor_func return tensors with shape (1, total_nnz/cp_size)
-                if distillation_use_topk:
-                    ret.update(logits_processor_func(student_logits=logits_bak, data=batch, data_format=data_format))
-                log_probs = vocab_parallel_log_probs_from_logits(logits_bak, label)
-                ret["log_probs"] = log_probs
-                return ret
+            logits_processor = partial(
+                self._lm_head_logits_processor,
+                calculate_sum_pi_squared=calculate_sum_pi_squared,
+                calculate_entropy=calculate_entropy,
+                distillation_use_topk=distillation_use_topk,
+                distillation_only=distillation_only,
+                logits_processor_func=logits_processor_func,
+                batch=batch,
+                data_format=data_format,
+            )
 
             response_attention_mask = None
             if attention_mask is not None and not loss_mask.is_nested:


### PR DESCRIPTION
### What does this PR do?

Reduce VRAM and compute for OPD (forward_kl_topk + use_policy_gradient=False + use_task_rewards=False) by skipping redundant full-vocab log_probs and PPO-loss work when only the top-k distillation loss is needed.

Introduces a distillation_only flag (set in the trainer, consumed by actor engines) and scopes empty_cache() on Megatron to top-k distillation steps.

Target config: distillation.distillation_loss.loss_mode=forward_kl_topk with supervised distillation

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

pytest tests/workers/test_megatron_distillation_only_on_cpu.py -q
pytest tests/workers/test_distillation_topk_symmetry_on_cpu.py -q

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
