### PR TITLE
[ppo] feat: log rollout moe load-balance metrics

### DIFF
--- a/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import torch
+
+from verl.trainer.ppo.metric_utils import compute_rollout_moe_load_balance_metrics, infer_moe_num_experts
+
+
+def test_rollout_moe_load_balance_metrics_response_tokens_only():
+    routed_experts = torch.tensor(
+        [
+            [
+                [[0, 1], [0, 0]],
+                [[0, 1], [0, 0]],
+                [[0, 1], [2, 2]],
+                [[2, 3], [2, 2]],
+                [[0, 1], [2, 2]],
+                [[2, 3], [2, 2]],
+            ]
+        ],
+        dtype=torch.long,
+    )
+    response_mask = torch.tensor([[True, True, True, True]], dtype=torch.bool)
+
+    metrics = compute_rollout_moe_load_balance_metrics(
+        routed_experts=routed_experts,
+        response_mask=response_mask,
+        num_experts=4,
+    )
+
+    assert math.isclose(metrics["rollout/moe/max_vio/layer_0"], 0.0)
+    assert math.isclose(metrics["rollout/moe/min_vio/layer_0"], 0.0)
+    assert math.isclose(metrics["rollout/moe/avg_vio/layer_0"], 0.0)
+    assert math.isclose(metrics["rollout/moe/max_vio/layer_1"], 3.0)
+    assert math.isclose(metrics["rollout/moe/min_vio/layer_1"], -1.0)
+    assert math.isclose(metrics["rollout/moe/avg_vio/layer_1"], 1.5)
+    assert math.isclose(metrics["rollout/moe/max_vio/max"], 3.0)
+    assert math.isclose(metrics["rollout/moe/avg_vio/avg"], 0.75)
+
+
+def test_rollout_moe_load_balance_metrics_skips_invalid_inputs():
+    assert compute_rollout_moe_load_balance_metrics(None, torch.ones(1, 1), 4) == {}
+    assert compute_rollout_moe_load_balance_metrics(torch.zeros(1, 1, 1, dtype=torch.long), torch.ones(1, 1), 4) == {}
+    assert (
+        compute_rollout_moe_load_balance_metrics(torch.zeros(1, 1, 1, 1, dtype=torch.long), torch.ones(1, 1), None)
+        == {}
+    )
+
+
+def test_infer_moe_num_experts_from_nested_config():
+    assert infer_moe_num_experts({"hf_config": {"text_config": {"num_experts": 4}}}) == 4
+    assert infer_moe_num_experts({"override_config": {"model_config": {"n_routed_experts": 8}}}) == 8
+    assert infer_moe_num_experts({"num_local_experts": 2}) is None

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -282,6 +282,7 @@ actor_rollout_ref:
     skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     enable_rollout_routing_replay: false
+    moe_load_balance_metrics_interval: 0
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
       tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -273,6 +273,7 @@ actor_rollout_ref:
     skip_dump_dir: /tmp/rollout_dump
     skip_tokenizer_init: true
     enable_rollout_routing_replay: false
+    moe_load_balance_metrics_interval: 0
     profiler:
       _target_: verl.utils.profiler.ProfilerConfig
       tool: ${oc.select:global_profiler.tool,null}

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -302,6 +302,10 @@ skip_tokenizer_init: True
 # When enabled (True), the rollout will record the routing decisions.
 enable_rollout_routing_replay: False
 
+# Interval for logging rollout MoE load-balance metrics from routing replay data.
+# Set to 0 to disable.
+moe_load_balance_metrics_interval: 0
+
 
 # profile the rollout model in `generate_sequence`
 profiler:

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -15,6 +15,7 @@
 Metrics related to the PPO trainer.
 """
 
+import logging
 from collections import defaultdict
 from functools import partial
 from typing import Any, Callable
@@ -25,6 +26,8 @@ import torch
 import verl.utils.torch_functional as verl_F
 from verl import DataProto
 from verl.utils.import_utils import deprecated
+
+logger = logging.getLogger(__name__)
 
 
 @deprecated("verl.utils.metric.reduce_metrics")
@@ -76,6 +79,113 @@ def _compute_response_info(batch: DataProto) -> dict[str, Any]:
         prompt_length=prompt_length,
         response_length=response_length,
     )
+
+
+def _get_nested_attr(obj: Any, name: str) -> Any:
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def infer_moe_num_experts(model_config: Any) -> int | None:
+    """Infer the global number of routed experts from a model config-like object."""
+    candidates = [model_config]
+    hf_config = _get_nested_attr(model_config, "hf_config")
+    text_config = _get_nested_attr(model_config, "text_config")
+    override_config = _get_nested_attr(model_config, "override_config")
+    if hf_config is not None:
+        candidates.append(hf_config)
+        hf_text_config = _get_nested_attr(hf_config, "text_config")
+        if hf_text_config is not None:
+            candidates.append(hf_text_config)
+    if text_config is not None:
+        candidates.append(text_config)
+    if override_config is not None:
+        candidates.append(override_config)
+        override_model_config = _get_nested_attr(override_config, "model_config")
+        if override_model_config is not None:
+            candidates.append(override_model_config)
+        override_text_config = _get_nested_attr(override_config, "text_config")
+        if override_text_config is not None:
+            candidates.append(override_text_config)
+
+    for candidate in candidates:
+        for attr in ("num_experts", "n_routed_experts"):
+            value = _get_nested_attr(candidate, attr)
+            if value is not None:
+                return int(value)
+    return None
+
+
+def compute_rollout_moe_load_balance_metrics(
+    routed_experts: torch.Tensor | None,
+    response_mask: torch.Tensor | None,
+    num_experts: int | None,
+    prefix: str = "rollout/moe",
+) -> dict[str, Any]:
+    """Compute rollout MoE load-balance metrics from returned routed expert ids."""
+    if routed_experts is None or response_mask is None or num_experts is None or num_experts <= 0:
+        return {}
+    if routed_experts.dim() != 4:
+        logger.warning("Expected routed_experts with shape [bsz, seqlen, layers, topk], got %s", routed_experts.shape)
+        return {}
+    if response_mask.dim() != 2 or response_mask.shape[0] != routed_experts.shape[0]:
+        logger.warning(
+            "Response mask shape %s is incompatible with routed_experts %s", response_mask.shape, routed_experts.shape
+        )
+        return {}
+
+    response_len = response_mask.shape[1]
+    if routed_experts.shape[1] < response_len:
+        logger.warning(
+            "routed_experts sequence length %s is shorter than response length %s",
+            routed_experts.shape[1],
+            response_len,
+        )
+        return {}
+
+    response_routed_experts = routed_experts[:, -response_len:].detach().cpu().to(torch.long)
+    response_mask = response_mask.detach().cpu().bool()
+    selected = response_routed_experts[response_mask]
+    if selected.numel() == 0:
+        return {}
+    if selected.min() < 0 or selected.max() >= num_experts:
+        logger.warning(
+            "Skipping rollout MoE load-balance metrics because routed expert ids are outside [0, %s): min=%s max=%s",
+            num_experts,
+            selected.min().item(),
+            selected.max().item(),
+        )
+        return {}
+
+    # selected: [num_response_tokens, num_layers, topk]. Count every top-k slot
+    # without materializing a large [tokens, layers, topk, experts] one-hot tensor.
+    load_matrix = torch.stack(
+        [
+            torch.bincount(selected[:, layer_idx, :].flatten(), minlength=num_experts)
+            for layer_idx in range(selected.shape[1])
+        ]
+    ).float()
+    load_matrix = load_matrix / load_matrix.sum(dim=1, keepdim=True).clamp_min(1.0)
+    deviation = load_matrix * num_experts - 1.0
+    max_vio = deviation.max(dim=1).values
+    min_vio = deviation.min(dim=1).values
+    avg_vio = deviation.abs().mean(dim=1)
+
+    metrics: dict[str, Any] = {}
+    for i in range(load_matrix.shape[0]):
+        metrics[f"{prefix}/max_vio/layer_{i}"] = max_vio[i].detach().item()
+        metrics[f"{prefix}/min_vio/layer_{i}"] = min_vio[i].detach().item()
+        metrics[f"{prefix}/avg_vio/layer_{i}"] = avg_vio[i].detach().item()
+    metrics[f"{prefix}/max_vio/max"] = max_vio.max().detach().item()
+    metrics[f"{prefix}/max_vio/avg"] = max_vio.mean().detach().item()
+    metrics[f"{prefix}/min_vio/max"] = min_vio.max().detach().item()
+    metrics[f"{prefix}/min_vio/avg"] = min_vio.mean().detach().item()
+    metrics[f"{prefix}/avg_vio/max"] = avg_vio.max().detach().item()
+    metrics[f"{prefix}/avg_vio/avg"] = avg_vio.mean().detach().item()
+    return metrics
 
 
 def compute_data_metrics(batch: DataProto, use_critic: bool = True) -> dict[str, Any]:

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -45,9 +45,11 @@ from verl.trainer.ppo import core_algos
 from verl.trainer.ppo.core_algos import AdvantageEstimator, agg_loss
 from verl.trainer.ppo.metric_utils import (
     compute_data_metrics,
+    compute_rollout_moe_load_balance_metrics,
     compute_throughout_metrics,
     compute_timing_metrics,
     compute_variance_proxy_metrics,
+    infer_moe_num_experts,
     process_validation_metrics,
 )
 from verl.trainer.ppo.reward import compute_reward, compute_reward_async
@@ -1447,6 +1449,17 @@ class RayPPOTrainer:
 
                     if "response_mask" not in batch.batch.keys():
                         batch.batch["response_mask"] = compute_response_mask(batch)
+                    moe_lb_metrics_interval = getattr(
+                        self.config.actor_rollout_ref.rollout, "moe_load_balance_metrics_interval", 0
+                    )
+                    if moe_lb_metrics_interval > 0 and self.global_steps % moe_lb_metrics_interval == 0:
+                        metrics.update(
+                            compute_rollout_moe_load_balance_metrics(
+                                routed_experts=batch.batch.get("routed_experts", None),
+                                response_mask=batch.batch.get("response_mask", None),
+                                num_experts=infer_moe_num_experts(self.config.actor_rollout_ref.model),
+                            )
+                        )
                     # Balance the number of valid tokens across DP ranks.
                     # NOTE: This usually changes the order of data in the `batch`,
                     # which won't affect the advantage calculation (since it's based on uid),

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -233,6 +233,7 @@ class RolloutConfig(BaseConfig):
     quantization_config_file: Optional[str] = None
 
     enable_rollout_routing_replay: bool = False
+    moe_load_balance_metrics_interval: int = 0
 
     enable_sleep_mode: bool = True
 


### PR DESCRIPTION
## Summary
- add rollout MoE load-balance metrics from routed expert replay data
- report the metrics through the normal trainer metrics path under rollout/moe
- add an opt-in rollout.moe_load_balance_metrics_interval knob, defaulting to disabled

## Testing
- ruff format --check verl/trainer/ppo/metric_utils.py verl/trainer/ppo/ray_trainer.py verl/workers/config/rollout.py tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
- ruff check verl/trainer/ppo/metric_utils.py verl/trainer/ppo/ray_trainer.py verl/workers/config/rollout.py tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
- python -m py_compile verl/trainer/ppo/metric_utils.py verl/trainer/ppo/ray_trainer.py verl/workers/config/rollout.py
- PYTHONPATH=. pytest -q tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
- smoke-tested rollout/moe metric aggregation and upload through the main experiment tracker