### PR TITLE
[megatron] reduce R3 router replay memory with per-trajectory traces

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import warnings
 from typing import Any, Optional
 
@@ -256,6 +257,86 @@ async def test_agent_loop_extra_fields_schema_stable_for_training_concat_on_cpu(
     # And the list-typed fields are actually lists (not missing / scalar).
     assert merged.non_tensor_batch["turn_scores"][0] == []
     assert merged.non_tensor_batch["tool_rewards"][0] == []
+
+
+def test_agent_loop_postprocess_emits_r3_per_traj_routed_experts(monkeypatch):
+    monkeypatch.setenv("VERL_R3_SPEEDUP", "1")
+
+    inputs = []
+    for idx, length in enumerate([4, 3]):
+        internal = _to_internal(
+            output_prompt_ids=[101, 102],
+            output_response_ids=[11, 12],
+            output_response_mask=[1, 1],
+            metrics=AgentLoopMetrics(),
+            extra_fields={},
+            num_turns=1,
+            prompt_len=4,
+            response_len=4,
+        )
+        internal.routed_experts = torch.full((length, 2, 1), idx + 1, dtype=torch.uint8)
+        inputs.append(internal)
+
+    dummy_worker = type(
+        "_DummyWorker",
+        (),
+        {"reward_loop_worker_handles": None, "distillation_enabled": False},
+    )()
+
+    merged = AgentLoopWorker._postprocess(dummy_worker, inputs=inputs)
+
+    assert "routed_experts" not in merged.batch.keys()
+    routed = merged.non_tensor_batch["routed_experts_per_traj"]
+    assert routed.shape == (2,)
+    assert routed.dtype == object
+    assert routed[0].shape == (4, 2, 1)
+    assert routed[1].shape == (3, 2, 1)
+    np.testing.assert_array_equal(routed[0], inputs[0].routed_experts.numpy())
+    np.testing.assert_array_equal(routed[1], inputs[1].routed_experts.numpy())
+
+
+def test_agent_loop_postprocess_keeps_r3_routed_experts_unpadded(monkeypatch):
+    monkeypatch.setenv("VERL_R3_SPEEDUP", "1")
+
+    class _DummyWorker:
+        _compute_multi_modal_inputs = AgentLoopWorker._compute_multi_modal_inputs
+        _compute_position_ids = AgentLoopWorker._compute_position_ids
+        _get_mm_processor_kwargs = AgentLoopWorker._get_mm_processor_kwargs
+        _compute_score = AgentLoopWorker._compute_score
+        _compute_teacher_logprobs = AgentLoopWorker._compute_teacher_logprobs
+        _pad_token_ids = AgentLoopWorker._pad_token_ids
+        distillation_enabled = False
+
+        def __init__(self):
+            self.tokenizer = _FakeTokenizer()
+            self.rollout_config = OmegaConf.create({"prompt_length": 4, "response_length": 4})
+            self.processor = None
+            self.mm_processor_kwargs = {}
+            self.reward_loop_worker_handles = None
+
+    routed_experts = np.arange(8, dtype=np.int64).reshape(4, 2, 1)
+    output = AgentLoopOutput(
+        prompt_ids=[101, 102],
+        response_ids=[11, 12],
+        response_mask=[1, 1],
+        routed_experts=routed_experts,
+        metrics=AgentLoopMetrics(),
+        extra_fields={},
+    )
+
+    internal = asyncio.run(
+        AgentLoopWorker._agent_loop_postprocess(
+            _DummyWorker(),
+            output,
+            validate=False,
+            raw_prompt=[{"role": "user", "content": "hi"}],
+        )
+    )
+
+    assert internal.routed_experts is not None
+    assert internal.routed_experts.shape == (4, 2, 1)
+    assert internal.routed_experts.dtype == torch.uint8
+    torch.testing.assert_close(internal.routed_experts, torch.tensor(routed_experts, dtype=torch.uint8))
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -18,6 +18,7 @@ import torch
 from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
+from verl.workers.utils import padding as padding_utils
 from verl.workers.utils.padding import (
     build_attention_mask_from_nested,
     embeds_padding_2_no_padding,
@@ -209,6 +210,70 @@ def test_padding_conversion_uses_r3_per_traj_routed_experts(monkeypatch):
     assert routed.is_nested
     torch.testing.assert_close(routed[0].squeeze(-1).squeeze(-1), torch.tensor([1, 2, 3, 4], dtype=torch.uint8))
     torch.testing.assert_close(routed[1].squeeze(-1).squeeze(-1), torch.tensor([5, 6, 7, 0, 0], dtype=torch.uint8))
+
+
+def test_padding_conversion_does_not_renarrow_concatenated_r3_tensor(monkeypatch):
+    monkeypatch.setenv("VERL_R3_SPEEDUP", "1")
+
+    original_narrow = padding_utils.narrow_routed_experts
+
+    def fail_on_tensor(routed_experts):
+        if isinstance(routed_experts, torch.Tensor):
+            raise AssertionError("per-traj fast path should not renarrow the concatenated tensor")
+        return original_narrow(routed_experts)
+
+    monkeypatch.setattr(padding_utils, "narrow_routed_experts", fail_on_tensor)
+
+    batch_size = 2
+    max_seq_len = 4
+    input_ids = torch.arange(batch_size * max_seq_len).reshape(batch_size, max_seq_len)
+    attention_mask = torch.ones(batch_size, max_seq_len, dtype=torch.long)
+    response_mask = torch.ones(batch_size, 2, dtype=torch.long)
+    position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1)
+
+    data = TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+        },
+        batch_size=[batch_size],
+    )
+    rows = [
+        torch.ones((4, 2, 1), dtype=torch.uint8),
+        torch.full((4, 2, 1), 2, dtype=torch.uint8),
+    ]
+    tu.assign_non_tensor_stack(data, "routed_experts_per_traj", rows)
+
+    converted = left_right_2_no_padding(data)
+
+    assert converted["routed_experts"].is_nested
+
+
+def test_align_r3_per_traj_tensors_reads_seqlens_once_via_tolist():
+    class _FakeSeqLens:
+        def __init__(self):
+            self.tolist_called = False
+
+        def tolist(self):
+            self.tolist_called = True
+            return [2, 4]
+
+        def __getitem__(self, index):
+            raise AssertionError(f"unexpected per-item seqlen lookup: {index}")
+
+    seqlens = _FakeSeqLens()
+    rows = [
+        torch.arange(3, dtype=torch.uint8).reshape(3, 1, 1),
+        torch.arange(4, dtype=torch.uint8).reshape(4, 1, 1),
+    ]
+
+    aligned = padding_utils._align_r3_per_traj_tensors(rows, seqlens, torch.device("cpu"))
+
+    assert seqlens.tolist_called
+    torch.testing.assert_close(aligned[0].squeeze(-1).squeeze(-1), torch.tensor([0, 1], dtype=torch.uint8))
+    torch.testing.assert_close(aligned[1].squeeze(-1).squeeze(-1), torch.tensor([0, 1, 2, 3], dtype=torch.uint8))
 
 
 def test_padding_roundtrip():

--- a/tests/utils/test_padding_on_cpu.py
+++ b/tests/utils/test_padding_on_cpu.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 import random
 
+import numpy as np
 import torch
 from tensordict import TensorDict
 
+from verl.utils import tensordict_utils as tu
 from verl.workers.utils.padding import (
     build_attention_mask_from_nested,
     embeds_padding_2_no_padding,
     left_right_2_no_padding,
+    make_r3_per_traj_object_array,
     no_padding_2_padding,
+    normalize_r3_per_traj_list,
     response_from_nested,
     response_to_nested,
 )
@@ -133,6 +137,78 @@ def test_padding_conversion_without_log_probs():
     assert data_converted["position_ids"].is_nested
     assert "old_log_probs" not in data_converted
     assert "ref_log_prob" not in data_converted
+
+
+def test_r3_per_traj_object_array_preserves_equal_shape_samples():
+    rows = [
+        torch.zeros((2, 3, 1), dtype=torch.uint8).numpy(),
+        torch.ones((2, 3, 1), dtype=torch.uint8).numpy(),
+    ]
+
+    packed = make_r3_per_traj_object_array(rows)
+
+    assert packed.shape == (2,)
+    assert packed.dtype == object
+    assert isinstance(packed[0], np.ndarray)
+    assert packed[0].shape == (2, 3, 1)
+    assert packed[1].shape == (2, 3, 1)
+
+
+def test_r3_per_traj_normalize_recovers_collated_equal_shape_object_array():
+    rows = [
+        torch.zeros((2, 3, 1), dtype=torch.uint8).numpy(),
+        torch.ones((2, 3, 1), dtype=torch.uint8).numpy(),
+    ]
+    collated = np.array(rows, dtype=object)
+
+    normalized = normalize_r3_per_traj_list(collated)
+
+    assert len(normalized) == 2
+    assert all(isinstance(row, np.ndarray) for row in normalized)
+    assert normalized[0].dtype == np.uint8
+    assert normalized[0].shape == (2, 3, 1)
+    np.testing.assert_array_equal(normalized[0], rows[0])
+    np.testing.assert_array_equal(normalized[1], rows[1])
+
+
+def test_padding_conversion_uses_r3_per_traj_routed_experts(monkeypatch):
+    monkeypatch.setenv("VERL_R3_SPEEDUP", "1")
+
+    batch_size = 2
+    max_seq_len = 6
+    max_response_len = 3
+
+    input_ids = torch.arange(batch_size * max_seq_len).reshape(batch_size, max_seq_len)
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 0],
+        ],
+        dtype=torch.long,
+    )
+    response_mask = torch.ones(batch_size, max_response_len, dtype=torch.long)
+    position_ids = torch.arange(max_seq_len).unsqueeze(0).expand(batch_size, -1)
+
+    row0 = torch.tensor([1, 2, 3, 4, 99, 100], dtype=torch.int64).reshape(6, 1, 1).numpy()
+    row1 = torch.tensor([5, 6, 7], dtype=torch.int64).reshape(3, 1, 1).numpy()
+
+    data = TensorDict(
+        {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "response_mask": response_mask,
+            "position_ids": position_ids,
+        },
+        batch_size=[batch_size],
+    )
+    tu.assign_non_tensor_stack(data, "routed_experts_per_traj", [row0, row1])
+
+    converted = left_right_2_no_padding(data)
+    routed = converted["routed_experts"]
+
+    assert routed.is_nested
+    torch.testing.assert_close(routed[0].squeeze(-1).squeeze(-1), torch.tensor([1, 2, 3, 4], dtype=torch.uint8))
+    torch.testing.assert_close(routed[1].squeeze(-1).squeeze(-1), torch.tensor([5, 6, 7, 0, 0], dtype=torch.uint8))
 
 
 def test_padding_roundtrip():

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -71,11 +71,20 @@ from verl.workers.config import (
     RolloutConfig,
 )
 from verl.workers.rollout.llm_server import LLMServerClient
+from verl.workers.utils.padding import make_r3_per_traj_object_array, r3_speedup_enabled, routed_experts_to_tensor
 
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 DEFAULT_ROUTING_CACHE_SIZE = 10000
+
+
+def _routed_experts_to_numpy(routed_experts):
+    if isinstance(routed_experts, np.ndarray):
+        return routed_experts
+    if isinstance(routed_experts, torch.Tensor):
+        return routed_experts.detach().cpu().numpy()
+    return np.asarray(routed_experts)
 
 
 class AgentLoopMetrics(BaseModel):
@@ -776,29 +785,33 @@ class AgentLoopWorker:
         routed_experts = None
         if output.routed_experts is not None:
             total_length = input_ids.shape[1]
-            length, layer_num, topk_num = output.routed_experts.shape
-            if isinstance(output.routed_experts, np.ndarray):
-                routed_experts_array = output.routed_experts
-                if not routed_experts_array.flags.writeable:
-                    routed_experts_array = routed_experts_array.copy()
-                experts_tensor = torch.from_numpy(routed_experts_array)
-            elif isinstance(output.routed_experts, torch.Tensor):
-                experts_tensor = output.routed_experts
+            if r3_speedup_enabled():
+                experts_tensor = routed_experts_to_tensor(output.routed_experts)
+                routed_experts = experts_tensor.contiguous()
             else:
-                raise TypeError(f"Unsupported type for routed_experts: {type(output.routed_experts)}")
-            routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
+                length, layer_num, topk_num = output.routed_experts.shape
+                if isinstance(output.routed_experts, np.ndarray):
+                    routed_experts_array = output.routed_experts
+                    if not routed_experts_array.flags.writeable:
+                        routed_experts_array = routed_experts_array.copy()
+                    experts_tensor = torch.from_numpy(routed_experts_array)
+                elif isinstance(output.routed_experts, torch.Tensor):
+                    experts_tensor = output.routed_experts
+                else:
+                    raise TypeError(f"Unsupported type for routed_experts: {type(output.routed_experts)}")
+                routed_experts = torch.zeros(1, total_length, layer_num, topk_num, dtype=experts_tensor.dtype)
 
-            # Calculate start position: left padding means original prompt starts at the end
-            start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
-            end_pos = min(start_pos + length, total_length)
+                # Calculate start position: left padding means original prompt starts at the end
+                start_pos = prompt_output["input_ids"].shape[1] - len(output.prompt_ids)
+                end_pos = min(start_pos + length, total_length)
 
-            # Add boundary checks for robustness
-            if start_pos < 0 or end_pos > total_length:
-                raise ValueError(
-                    f"Invalid position range: start_pos={start_pos}, end_pos={end_pos}, total_length={total_length}"
-                )
+                # Add boundary checks for robustness
+                if start_pos < 0 or end_pos > total_length:
+                    raise ValueError(
+                        f"Invalid position range: start_pos={start_pos}, end_pos={end_pos}, total_length={total_length}"
+                    )
 
-            routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
+                routed_experts[:, start_pos:end_pos] = experts_tensor.unsqueeze(0)
 
         multi_modal_inputs = self._compute_multi_modal_inputs(output, input_ids)
         position_ids = self._compute_position_ids(
@@ -1039,7 +1052,7 @@ class AgentLoopWorker:
         optional_outputs = {}
         if inputs[0].response_logprobs is not None:
             optional_outputs["rollout_log_probs"] = torch.cat([input.response_logprobs for input in inputs], dim=0)
-        if inputs[0].routed_experts is not None:
+        if inputs[0].routed_experts is not None and not r3_speedup_enabled():
             optional_outputs["routed_experts"] = torch.cat([input.routed_experts for input in inputs], dim=0)
         if inputs[0].teacher_logprobs is not None and inputs[0].teacher_ids is not None:
             optional_outputs["teacher_logprobs"] = torch.cat([input.teacher_logprobs for input in inputs], dim=0)
@@ -1069,6 +1082,14 @@ class AgentLoopWorker:
         non_tensor_batch = {
             "__num_turns__": np.array([input.num_turns for input in inputs], dtype=np.int32),
         }
+        if r3_speedup_enabled():
+            has_routed_experts = [input.routed_experts is not None for input in inputs]
+            if any(has_routed_experts) and not all(has_routed_experts):
+                raise ValueError("routed_experts must be present for either all inputs or no inputs")
+            if all(has_routed_experts):
+                non_tensor_batch["routed_experts_per_traj"] = make_r3_per_traj_object_array(
+                    _routed_experts_to_numpy(input.routed_experts) for input in inputs
+                )
         if self.reward_loop_worker_handles is None and input_non_tensor_batch:
             non_tensor_batch.update(input_non_tensor_batch)
 

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -42,6 +42,8 @@ def narrow_routed_experts(routed_experts):
         return None
 
     if isinstance(routed_experts, torch.Tensor):
+        if routed_experts.is_cuda:
+            return routed_experts
         if routed_experts.numel() == 0:
             return routed_experts.to(torch.uint8)
         min_id = routed_experts.min().item()
@@ -122,9 +124,10 @@ def _r3_per_traj_item_to_tensor(item):
 
 def _align_r3_per_traj_tensors(per_traj_list, seqlens, target_device):
     aligned = []
+    seqlens_cpu = seqlens.tolist()
     for i, item in enumerate(per_traj_list):
         tensor = _r3_per_traj_item_to_tensor(item).to(device=target_device)
-        target_len = int(seqlens[i].item())
+        target_len = int(seqlens_cpu[i])
         if tensor.shape[0] > target_len:
             tensor = tensor[:target_len]
         elif tensor.shape[0] < target_len:
@@ -190,7 +193,7 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
         per_traj_stack = data.pop("routed_experts_per_traj")
         per_traj_list = normalize_r3_per_traj_list(per_traj_stack)
         tensors = _align_r3_per_traj_tensors(per_traj_list, attention_mask.sum(dim=-1), input_ids_rmpad.device)
-        flat = narrow_routed_experts(torch.cat(tensors, dim=0))
+        flat = torch.cat(tensors, dim=0)
         data["routed_experts"] = torch.nested.nested_tensor_from_jagged(flat, offsets=cu_seqlens)
     elif routed_experts is not None and not routed_experts.is_nested:
         if r3_speedup_enabled():

--- a/verl/workers/utils/padding.py
+++ b/verl/workers/utils/padding.py
@@ -12,12 +12,127 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+import numpy as np
 import torch
 import torch.nn.functional as F
 from tensordict import TensorDict
 
 from verl.utils import tensordict_utils as tu
 from verl.utils.attention_utils import index_first_axis, unpad_input
+
+
+def r3_speedup_enabled() -> bool:
+    """Return whether the R3 per-trajectory routing trace fast path is enabled."""
+    raw = os.environ.get("VERL_R3_SPEEDUP", "0").strip().lower()
+    if raw in {"", "0", "false", "no", "off"}:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    try:
+        return int(raw) >= 1
+    except ValueError:
+        return False
+
+
+def narrow_routed_experts(routed_experts):
+    """Convert routed expert ids to the smallest integer dtype that preserves their values."""
+    if routed_experts is None:
+        return None
+
+    if isinstance(routed_experts, torch.Tensor):
+        if routed_experts.numel() == 0:
+            return routed_experts.to(torch.uint8)
+        min_id = routed_experts.min().item()
+        max_id = routed_experts.max().item()
+        if min_id >= 0 and max_id <= torch.iinfo(torch.uint8).max:
+            return routed_experts.to(torch.uint8)
+        if min_id >= torch.iinfo(torch.int16).min and max_id <= torch.iinfo(torch.int16).max:
+            return routed_experts.to(torch.int16)
+        if min_id >= torch.iinfo(torch.int32).min and max_id <= torch.iinfo(torch.int32).max:
+            return routed_experts.to(torch.int32)
+        return routed_experts.to(torch.int64)
+
+    arr = np.asarray(routed_experts)
+    if arr.size == 0:
+        return arr.astype(np.uint8, copy=False)
+    min_id = arr.min()
+    max_id = arr.max()
+    if min_id >= 0 and max_id <= np.iinfo(np.uint8).max:
+        return arr.astype(np.uint8, copy=False)
+    if min_id >= np.iinfo(np.int16).min and max_id <= np.iinfo(np.int16).max:
+        return arr.astype(np.int16, copy=False)
+    if min_id >= np.iinfo(np.int32).min and max_id <= np.iinfo(np.int32).max:
+        return arr.astype(np.int32, copy=False)
+    return arr.astype(np.int64, copy=False)
+
+
+def routed_experts_to_tensor(routed_experts):
+    if routed_experts is None:
+        return None
+    if isinstance(routed_experts, np.ndarray):
+        if not routed_experts.flags.writeable:
+            routed_experts = routed_experts.copy()
+        routed_experts = torch.from_numpy(routed_experts)
+    elif not isinstance(routed_experts, torch.Tensor):
+        routed_experts = torch.as_tensor(routed_experts)
+    return narrow_routed_experts(routed_experts)
+
+
+def make_r3_per_traj_object_array(per_traj_items):
+    per_traj_items = list(per_traj_items)
+    output = np.empty(len(per_traj_items), dtype=object)
+    for i, item in enumerate(per_traj_items):
+        output[i] = item
+    return output
+
+
+def _normalize_r3_object_array_item(item):
+    if hasattr(item, "data") and not isinstance(item, np.ndarray | torch.Tensor):
+        item = item.data
+    if isinstance(item, np.ndarray) and item.dtype == object:
+        item = np.asarray(item.tolist())
+    if isinstance(item, np.ndarray):
+        return narrow_routed_experts(item)
+    return item
+
+
+def normalize_r3_per_traj_list(per_traj_stack):
+    if isinstance(per_traj_stack, np.ndarray):
+        return [_normalize_r3_object_array_item(item) for item in per_traj_stack]
+    return [_normalize_r3_object_array_item(item) for item in list(per_traj_stack)]
+
+
+def _r3_per_traj_item_to_tensor(item):
+    if hasattr(item, "data") and not isinstance(item, np.ndarray | torch.Tensor):
+        item = item.data
+    if isinstance(item, memoryview):
+        item = np.asarray(item)
+    if isinstance(item, np.ndarray):
+        if item.dtype == object:
+            item = _normalize_r3_object_array_item(item)
+        if not item.flags.writeable:
+            item = item.copy()
+        return torch.from_numpy(item)
+    if isinstance(item, torch.Tensor):
+        return item
+    return torch.as_tensor(item)
+
+
+def _align_r3_per_traj_tensors(per_traj_list, seqlens, target_device):
+    aligned = []
+    for i, item in enumerate(per_traj_list):
+        tensor = _r3_per_traj_item_to_tensor(item).to(device=target_device)
+        target_len = int(seqlens[i].item())
+        if tensor.shape[0] > target_len:
+            tensor = tensor[:target_len]
+        elif tensor.shape[0] < target_len:
+            pad_shape = (target_len - tensor.shape[0], *tensor.shape[1:])
+            pad = torch.zeros(pad_shape, dtype=tensor.dtype, device=tensor.device)
+            tensor = torch.cat([tensor, pad], dim=0)
+        aligned.append(tensor)
+    return aligned
 
 
 def left_right_2_no_padding(data: TensorDict) -> TensorDict:
@@ -71,8 +186,16 @@ def left_right_2_no_padding(data: TensorDict) -> TensorDict:
     data["loss_mask"] = data["response_mask"]
 
     routed_experts = data.get("routed_experts", None)
-    if routed_experts is not None and not routed_experts.is_nested:
-        if routed_experts.max() <= 255:
+    if r3_speedup_enabled() and "routed_experts_per_traj" in data.keys():
+        per_traj_stack = data.pop("routed_experts_per_traj")
+        per_traj_list = normalize_r3_per_traj_list(per_traj_stack)
+        tensors = _align_r3_per_traj_tensors(per_traj_list, attention_mask.sum(dim=-1), input_ids_rmpad.device)
+        flat = narrow_routed_experts(torch.cat(tensors, dim=0))
+        data["routed_experts"] = torch.nested.nested_tensor_from_jagged(flat, offsets=cu_seqlens)
+    elif routed_experts is not None and not routed_experts.is_nested:
+        if r3_speedup_enabled():
+            routed_experts = narrow_routed_experts(routed_experts)
+        elif routed_experts.max() <= 255:
             routed_experts = routed_experts.to(torch.uint8)
         routed_experts_rmpad = index_first_axis(routed_experts.unsqueeze(-1).flatten(0, 1), indices)
         routed_experts_nested = torch.nested.nested_tensor_from_jagged(


### PR DESCRIPTION
### Summary
- Add an opt-in `VERL_R3_SPEEDUP=1` path that keeps R3 rollout routing traces as per-trajectory `[actual_len, num_layers, topk]` arrays instead of materializing dense `[batch, seq_len, num_layers, topk]` tensors in the agent loop.
- Convert those per-trajectory traces to nested tensors during no-padding conversion, so the existing Megatron R3 replay path can consume them without engine changes.
- Preserve the default R3 behavior when `VERL_R3_SPEEDUP` is unset or disabled.

### Motivation
For long-context R3 rollouts, the dense padded routed-experts tensor can add avoidable memory pressure and copies before the current nested/no-padding Megatron path. This PR keeps the routing traces in their natural per-trajectory form until the no-padding conversion step.

### Tests
- `PYTHONPATH=. pytest tests/utils/test_padding_on_cpu.py -q`
- `PYTHONPATH=. pytest tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py -q`
- `python -m ruff check verl/experimental/agent_loop/agent_loop.py verl/workers/utils/padding.py tests/utils/test_padding_on_cpu.py tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py`
- `python -m py_compile verl/experimental/agent_loop/agent_loop.py verl/workers/utils/padding.py tests/utils/test_padding_on_cpu.py tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py`
- `git diff --check`

### Checklist
- [x] CPU-only tests added
- [x] Default R3 path remains unchanged
- [x] No internal scripts or end-to-end debug files included