### PR TITLE
[vllm] fix: crash in start_profile/stop_profile on non-master nodes when nnodes > 1

### DIFF
--- a/tests/utils/test_server_profiler.py
+++ b/tests/utils/test_server_profiler.py
@@ -108,6 +108,7 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
 
         # Mock self object
         mock_self = MagicMock()
+        mock_self.node_rank = 0
         mock_self.profiler_controller = mock_profiler
         mock_self.engine = mock_engine
 
@@ -118,6 +119,31 @@ class TestServerProfilerFunctionality(unittest.IsolatedAsyncioTestCase):
         # Test stop_profile
         await vLLMHttpServer.stop_profile(mock_self)
         mock_engine.stop_profile.assert_called_once()
+
+    async def test_vllm_start_stop_profile_non_master_node(self):
+        try:
+            from verl.workers.rollout.vllm_rollout.vllm_async_server import vLLMHttpServer
+        except ImportError:
+            self.skipTest("vllm or dependencies not installed")
+            return
+
+        mock_profiler = MagicMock()
+        mock_profiler.check_enable.return_value = True
+        mock_profiler.check_this_rank.return_value = True
+        mock_profiler.is_discrete_mode.return_value = True
+
+        mock_engine = AsyncMock()
+
+        mock_self = MagicMock()
+        mock_self.node_rank = 1  # non-master node, should skip
+        mock_self.profiler_controller = mock_profiler
+        mock_self.engine = mock_engine
+
+        await vLLMHttpServer.start_profile(mock_self)
+        mock_engine.start_profile.assert_not_called()
+
+        await vLLMHttpServer.stop_profile(mock_self)
+        mock_engine.stop_profile.assert_not_called()
 
     async def test_sglang_start_stop_profile(self):
         try:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -684,6 +684,8 @@ class vLLMHttpServer:
             return
 
     async def start_profile(self, **kwargs):
+        if self.node_rank != 0:
+            return
         if (
             self.profiler_controller.check_enable()
             and self.profiler_controller.check_this_rank()
@@ -692,6 +694,8 @@ class vLLMHttpServer:
             await self.engine.start_profile(**kwargs)
 
     async def stop_profile(self):
+        if self.node_rank != 0:
+            return
         if (
             self.profiler_controller.check_enable()
             and self.profiler_controller.check_this_rank()


### PR DESCRIPTION
### What does this PR do?

When a replica spans multiple nodes (nnodes > 1), only node_rank==0 runs run_server() which initializes self.engine. Other nodes run run_headless() and self.engine remains None. However, start_profile() and stop_profile() are broadcast to all nodes via asyncio.gather to all replicas, causing an AttributeError on non-master nodes when accessing self.engine.start_profile().


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pull/4320
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
