### PR TITLE
[fully_async, doc] fix: ignore temperature config for teacher prompt_logprobs and warn when non-default value is set

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -668,6 +668,15 @@ rollouts on other samples.
    when the loss mode requires top-$k$ (e.g. `forward_kl_topk`); otherwise `0`
    (single-sample logprob only).
 
+   **Temperature is always forced to `1.0`** regardless of the configured value.
+   `prompt_logprobs` is computed via a forward pass over the existing (prompt + response)
+   tokens — no sampling occurs — so temperature has no effect on the result.
+   The default distillation config copies the student rollout temperature via Hydra
+   interpolation (`temperature: ${oc.select:actor_rollout_ref.rollout.temperature}`),
+   which would silently set a non-1.0 value when rollout temperature differs from 1.0
+   (e.g. 0.7). The manager ignores the configured value and always uses `temperature=1.0`,
+   logging a warning if the configured value is not 1.0.
+
 8. **Server-side load balancing.** The manager calls `client.generate(...)`,
    which acquires a backing server through the shared `GlobalRequestLoadBalancer`
    actor.

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -32,13 +32,15 @@ def _get_teacher_sampling_params(
     distillation_loss_config: DistillationLossConfig,
 ) -> dict[str, Any]:
     """Get sampling parameters for teacher model when computing log probabilities for distillation."""
-    if teacher_model_config.inference.temperature != 1.0:
-        raise NotImplementedError("vLLM does not support temperature for prompt_logprobs.")
-
+    # Temperature has no effect on prompt_logprobs: the teacher performs a forward pass over
+    # existing tokens (no sampling). Always use temperature=1.0 regardless of the config value.
+    # The default distillation.yaml copies the student rollout temperature via Hydra interpolation
+    # (temperature: ${oc.select:actor_rollout_ref.rollout.temperature}), which causes a spurious
+    # crash when rollout.temperature != 1.0.
     num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
     return {
         "max_tokens": 1,
-        "temperature": teacher_model_config.inference.temperature,
+        "temperature": 1.0,
         "prompt_logprobs": num_logprobs,
     }
 

--- a/verl/experimental/teacher_loop/teacher_manager.py
+++ b/verl/experimental/teacher_loop/teacher_manager.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import os
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -26,6 +28,9 @@ from verl.workers.config import (
 )
 from verl.workers.rollout.llm_server import LLMServerClient
 
+logger = logging.getLogger(__file__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
+
 
 def _get_teacher_sampling_params(
     teacher_model_config: DistillationTeacherModelConfig,
@@ -37,6 +42,12 @@ def _get_teacher_sampling_params(
     # The default distillation.yaml copies the student rollout temperature via Hydra interpolation
     # (temperature: ${oc.select:actor_rollout_ref.rollout.temperature}), which causes a spurious
     # crash when rollout.temperature != 1.0.
+    if teacher_model_config.inference.temperature != 1.0:
+        logger.warning(
+            "Teacher inference temperature is set to %.1f, but temperature has no effect "
+            "on prompt_logprobs (forward pass only). Using temperature=1.0.",
+            teacher_model_config.inference.temperature,
+        )
     num_logprobs = distillation_loss_config.topk if distillation_loss_config.loss_settings.use_topk else 0
     return {
         "max_tokens": 1,


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in OPD (Online Policy Distillation) training when the teacher inference temperature is set to a value other than 1.0 (e.g. via Hydra interpolation from `actor_rollout_ref.rollout.temperature`).

Temperature has no effect on `prompt_logprobs` — the teacher performs a forward pass over known tokens (no sampling). The default `distillation.yaml` copies the student rollout temperature via `${oc.select:actor_rollout_ref.rollout.temperature}`, causing a spurious crash when `rollout.temperature != 1.0`.

Previously this raised `NotImplementedError`. This PR:
1. Hardcodes `temperature=1.0` in `_get_teacher_sampling_params` (correct behavior).
2. Emits a `logger.warning` when the configured value differs from 1.0, making the override explicit rather than silent.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pull/5897, https://github.com/verl-project/verl/pull/6056
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Verified with `rollout.temperature=0.7` under fully async OPD training. Previously crashed at the first distillation step; now runs with a warning logged.

### Design & Code Changes
- `verl/experimental/teacher_loop/teacher_manager.py`: `_get_teacher_sampling_params` now always sets `temperature=1.0` and logs a warning if the config value differs.
- `docs/algo/opd.md`: documents that temperature is always forced to `1.0` for teacher prompt_logprobs, and explains the Hydra interpolation that causes non-1.0 values.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: 
> The change is a one-line guard (`temperature != 1.0` → warning) with no branching logic that alters outputs. The only testable behavior is the warning message itself, which would require mocking `LLMServerClient` and a live vLLM server to instantiate `AsyncTeacherLLMServerManager`. The three pure-Python helpers in the file (`_get_teacher_sampling_params`, `_pad_teacher_outputs`, `_resolve_teacher_key`) lack an existing test file; adding one scoped only to the warning would be disproportionate to the change. A follow-up test PR covering all three helpers together is more appropriate.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
