### PR TITLE
[megatron] fix: balanced sequence split in dynamic_cp_split_batch (#6786)

### DIFF
--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -20,6 +21,7 @@ from verl import DataProto
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.model import create_random_mask
 from verl.utils.seqlen_balancing import (
+    balanced_chunk_range,
     ceildiv,
     get_reverse_idx,
     prepare_dynamic_batch,
@@ -276,3 +278,67 @@ def test_group_balanced_partitions_equal_size():
         for uid in uids_in_partition:
             uid_indices = [i for i, u in enumerate(uid_list) if u == uid]
             assert all(i in partition for i in uid_indices)
+
+
+def test_balanced_chunk_range():
+    # reporter's case: 9 items, 4 chunks -> sizes [3, 2, 2, 2], no empty chunk (issue #6786)
+    assert [balanced_chunk_range(9, 4, i) for i in range(4)] == [(0, 3), (3, 5), (5, 7), (7, 9)]
+
+    # divisible case unchanged vs the old ceil sizing: 8 items, 4 chunks -> [2, 2, 2, 2]
+    assert [balanced_chunk_range(8, 4, i) for i in range(4)] == [(0, 2), (2, 4), (4, 6), (6, 8)]
+
+    # remainder > 1: 10 items, 4 chunks -> [3, 3, 2, 2] (the first `rem` chunks get the extra item)
+    assert [balanced_chunk_range(10, 4, i) for i in range(4)] == [(0, 3), (3, 6), (6, 8), (8, 10)]
+
+    # boundary sizes: a single chunk gets everything; num_items == num_chunks -> every chunk size 1
+    assert balanced_chunk_range(9, 1, 0) == (0, 9)
+    assert [balanced_chunk_range(4, 4, i) for i in range(4)] == [(0, 1), (1, 2), (2, 3), (3, 4)]
+
+    # fewer items than chunks: graceful, only the unavoidable trailing chunks are empty
+    assert [balanced_chunk_range(2, 4, i) for i in range(4)] == [(0, 1), (1, 2), (2, 2), (2, 2)]
+
+    # empty input: no crash, every range empty
+    assert [balanced_chunk_range(0, 3, i) for i in range(3)] == [(0, 0), (0, 0), (0, 0)]
+
+    # invariants across many shapes: exact contiguous tiling, balanced sizes, no starved rank
+    for num_items in range(0, 33):
+        for num_chunks in range(1, 9):
+            ranges = [balanced_chunk_range(num_items, num_chunks, i) for i in range(num_chunks)]
+            covered = [i for start, end in ranges for i in range(start, end)]
+            assert covered == list(range(num_items))  # ordered, full coverage, no gaps or overlap
+            sizes = [end - start for start, end in ranges]
+            assert max(sizes) - min(sizes) <= 1  # balanced to within one item
+            if num_items >= num_chunks:
+                assert min(sizes) >= 1  # no rank starved (the bug in #6786)
+
+    # invalid arguments: bad num_chunks (<= 0) or out-of-range chunk_idx
+    for num_items, num_chunks, chunk_idx in [(9, 0, 0), (9, -1, 0), (9, 4, 4), (9, 4, -1)]:
+        with pytest.raises(ValueError):
+            balanced_chunk_range(num_items, num_chunks, chunk_idx)
+
+
+def test_dynamic_cp_split_distribution():
+    """Acceptance test for #6786 at the distribution level.
+
+    Mirrors how ``dynamic_cp_split_batch`` assigns sequences to ranks: each ``local_dp_rank`` takes
+    ``balanced_chunk_range(num_seqs, local_dp_size, local_dp_rank)``. (The function itself imports
+    ``megatron.core`` and runs per-rank on GPU, so the slicing logic is exercised here on CPU.)
+    """
+
+    def split_indices(num_seqs, local_dp_size):
+        return [list(range(*balanced_chunk_range(num_seqs, local_dp_size, r))) for r in range(local_dp_size)]
+
+    # reporter's scenario: 9 sequences over 4 ranks. Old ceil sizing left rank 3 empty ([3,3,3,0]);
+    # now every rank gets data.
+    per_rank = split_indices(9, 4)
+    assert per_rank == [[0, 1, 2], [3, 4], [5, 6], [7, 8]]
+    assert all(len(idx) > 0 for idx in per_rank)  # no starved rank
+
+    # for every reachable shape (num_seqs >= local_dp_size, since dynamic_cp_split_batch early-returns
+    # when num_seqs < dp_size), the ranks partition the sequences in order with no rank left empty.
+    # In-order, no-overlap partition is what lets dynamic_cp_merge_output concatenate by rank correctly.
+    for num_seqs in range(1, 33):
+        for local_dp_size in range(1, num_seqs + 1):
+            per_rank = split_indices(num_seqs, local_dp_size)
+            assert [i for idx in per_rank for i in idx] == list(range(num_seqs))
+            assert all(len(idx) > 0 for idx in per_rank)

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -44,6 +44,7 @@ from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_id, get_device_name, get_torch_device
 from verl.utils.fs import local_mkdir_safe
 from verl.utils.model import normalize_model_name
+from verl.utils.seqlen_balancing import balanced_chunk_range
 from verl.utils.torch_dtypes import PrecisionType
 from verl.workers.config import HFModelConfig, McoreEngineConfig
 
@@ -1635,9 +1636,10 @@ def dynamic_cp_split_batch(
             local_dp_rank = dp_rank // local_cp_size
             local_dp_size = dp_size // local_cp_size
             indices = list(range(len(seq_len_effective)))
-            num_seq_per_local_cp = math.ceil(len(seq_len_effective) / local_dp_size)
-            start_idx = local_dp_rank * num_seq_per_local_cp
-            end_idx = min(start_idx + num_seq_per_local_cp, len(seq_len_effective))
+            # Balanced contiguous split so trailing ranks are not starved (#6786): ceil-based sizing
+            # left e.g. 9 sequences over 4 ranks as [3, 3, 3, 0]. The split stays order-preserving so
+            # the rank-order merge in dynamic_cp_merge_output is unaffected.
+            start_idx, end_idx = balanced_chunk_range(len(seq_len_effective), local_dp_size, local_dp_rank)
             selected_indices = indices[start_idx:end_idx]
             batch = tu.index_select_tensor_dict(batch, selected_indices)
 

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -324,6 +324,37 @@ def ceildiv(a: int, b: int) -> int:
     return -(a // -b)
 
 
+def balanced_chunk_range(num_items: int, num_chunks: int, chunk_idx: int) -> tuple[int, int]:
+    """Return the contiguous ``[start, end)`` range for ``chunk_idx`` of a balanced split.
+
+    Splits ``num_items`` into ``num_chunks`` contiguous, order-preserving chunks. The first
+    ``num_items % num_chunks`` chunks get one extra item, so chunk sizes differ by at most
+    one and no chunk is empty as long as ``num_items >= num_chunks``. This avoids the starvation of
+    trailing chunks caused by ceil-based sizing (``ceil(num_items / num_chunks) * num_chunks`` can
+    exceed ``num_items``).
+
+    Args:
+        num_items: Number of items to split.
+        num_chunks: Number of chunks to split into, must be positive.
+        chunk_idx: Index of the chunk to return the range for, in ``[0, num_chunks)``.
+
+    Returns:
+        tuple[int, int]: The ``(start, end)`` half-open range for ``chunk_idx``.
+
+    Example:
+        >>> [balanced_chunk_range(9, 4, i) for i in range(4)]  # sizes [3, 2, 2, 2], no empty chunk
+        [(0, 3), (3, 5), (5, 7), (7, 9)]
+    """
+    if num_chunks <= 0:
+        raise ValueError(f"num_chunks must be positive, got {num_chunks}")
+    if not 0 <= chunk_idx < num_chunks:
+        raise ValueError(f"chunk_idx {chunk_idx} out of range [0, {num_chunks})")
+    base, remainder = divmod(num_items, num_chunks)
+    start = chunk_idx * base + min(chunk_idx, remainder)
+    end = start + base + (1 if chunk_idx < remainder else 0)
+    return start, end
+
+
 def roundup_divisible(a: int, b: int) -> int:
     """Round up a to the nearest multiple of b.
 


### PR DESCRIPTION
## Summary

`dynamic_cp_split_batch` (`verl/utils/megatron_utils.py`) splits a microbatch's sequences across `local_dp_size` ranks with ceil-based sizing:

```python
num_seq_per_local_cp = math.ceil(len(seq_len_effective) / local_dp_size)
start_idx = local_dp_rank * num_seq_per_local_cp
end_idx = min(start_idx + num_seq_per_local_cp, len(seq_len_effective))
```

When the count is not divisible, `ceil(N/k) * k` overshoots and the trailing ranks are starved. For the reported case (9 sequences, `local_dp_size = 4`) the sizes are `[3, 3, 3, 0]`, so the last rank gets an empty sub-batch (wasted compute, and an empty rank can desync the subsequent collective). Closes #6786.

## Fix

Add a small helper `balanced_chunk_range(num_items, num_chunks, chunk_idx)` to `verl/utils/seqlen_balancing.py` (next to `ceildiv` / `roundup_divisible`) that returns the contiguous `[start, end)` for a balanced split: the first `num_items % num_chunks` chunks get one extra item, so sizes differ by at most one and no chunk is empty when `num_items >= num_chunks`. `dynamic_cp_split_batch` now uses it. For 9/4 this yields `[3, 2, 2, 2]`, no empty rank.

The split stays **contiguous and order-preserving**, so the rank-order merge in `dynamic_cp_merge_output` (which `all_gather_object`s and concatenates per-rank outputs in ascending rank order, with no per-rank size assumption) is unaffected. The divisible case is byte-for-byte identical to the old behaviour.

## Why this is not a duplicate

Checked before opening: `gh issue view 6786 --comments` (no assignee, no claim), and `gh pr list --search "6786 in:body"` / `--search "dynamic_cp split batch"` both returned nothing. No existing PR addresses this.

## Tests

Added two CPU-only tests to `tests/utils/test_seqlen_balancing.py`:

- `test_balanced_chunk_range` (the helper in isolation): reporter's 9/4 case, the divisible 8/4 case, remainder > 1 (10/4), boundaries (single chunk; `num_items == num_chunks`), fewer-items-than-chunks, empty input, an invariant sweep over `num_items in [0, 32] x num_chunks in [1, 8]` (exact contiguous tiling, sizes balanced to within one, no starved rank when `num_items >= num_chunks`), and invalid-argument `ValueError`s.
- `test_dynamic_cp_split_distribution` (mirrors the call site in `dynamic_cp_split_batch`): the #6786 scenario (9 sequences over 4 ranks -> every rank gets data, vs `[3, 3, 3, 0]` before), plus a sweep over all reachable shapes asserting the per-rank slices partition the sequences in order with no overlap and no empty rank, which is what keeps `dynamic_cp_merge_output`'s rank-order concatenation correct.

Note: `dynamic_cp_split_batch` itself imports `megatron.core` and runs per-rank on GPU, so it is not directly importable in the CPU lane; the slicing logic it relies on is covered by the two tests above.

```
$ ruff check verl/utils/seqlen_balancing.py verl/utils/megatron_utils.py tests/utils/test_seqlen_balancing.py
All checks passed!
$ ruff format --check verl/utils/seqlen_balancing.py verl/utils/megatron_utils.py tests/utils/test_seqlen_balancing.py
3 files already formatted
```

I verified the helper logic directly (the hand cases plus 264 invariant combinations and the 4 error cases all pass). The pytest itself runs in the CPU CI lane: importing the `verl` package pulls torch/megatron dependencies that are not on my dev box, so I exercised the pure-Python logic standalone and rely on CI to run the committed test.

## AI assistance

This change was developed with AI assistance (Claude). I reviewed every changed line, verified the logic and the merge-compatibility myself, and can defend the change end to end. The commit carries a `Co-authored-by: Claude` trailer per `AGENTS.md`.
