### PR TITLE
[fully_async, reward, docs] fix: skip reward function call when use_task_rewards=False

### DIFF
--- a/docs/algo/opd.md
+++ b/docs/algo/opd.md
@@ -297,6 +297,10 @@ distillation loss. Default: `true`.
 
 - `true`: final loss is `policy_loss + distillation_loss_coef × distill_loss`.
 - `false`: the PPO term is zeroed and only the distillation loss contributes.
+  The reward function (`_compute_score`) is **not called at all** when this is
+  `false`, so the dataset's `data_source` does not need to be registered in
+  `default_compute_score`. This is useful when training with custom datasets
+  that have no compatible reward function.
 
 Orthogonal to `use_policy_gradient` (which controls how the *distillation
 signal itself* is applied).

--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -337,6 +337,68 @@ class _FakeTokenizerCustomPad:
 
 
 @pytest.mark.asyncio
+async def test_agent_loop_postprocess_rm_scores_present_when_use_task_rewards_false():
+    """When use_task_rewards=False, reward_score must be set to 0.0 so _postprocess emits rm_scores.
+
+    Regression test for: https://github.com/verl-project/verl/pull/6870
+    """
+
+    class _DummyWorker:
+        _compute_multi_modal_inputs = AgentLoopWorker._compute_multi_modal_inputs
+        _compute_position_ids = AgentLoopWorker._compute_position_ids
+        _get_mm_processor_kwargs = AgentLoopWorker._get_mm_processor_kwargs
+        _compute_score = AgentLoopWorker._compute_score
+        _compute_teacher_logprobs = AgentLoopWorker._compute_teacher_logprobs
+        _pad_token_ids = AgentLoopWorker._pad_token_ids
+        distillation_enabled = False
+        use_task_rewards = False
+
+        def __init__(self):
+            self.tokenizer = _FakeTokenizer()
+            self.rollout_config = OmegaConf.create({"prompt_length": 4, "response_length": 4})
+            self.processor = None
+            self.mm_processor_kwargs = {}
+            self.reward_loop_worker_handles = None
+
+    output = AgentLoopOutput(
+        prompt_ids=[101, 102],
+        response_ids=[11, 12],
+        response_mask=[1, 1],
+        metrics=AgentLoopMetrics(),
+        extra_fields={},
+    )
+
+    internal = await AgentLoopWorker._agent_loop_postprocess(
+        _DummyWorker(),
+        output,
+        validate=False,
+        raw_prompt=[{"role": "user", "content": "hi"}],
+    )
+
+    # reward_score must be 0.0 (not None) so that _postprocess can build rm_scores
+    assert internal.reward_score == 0.0
+
+    postprocess_worker = type(
+        "_PostprocessWorker",
+        (),
+        {"reward_loop_worker_handles": None},
+    )()
+    merged = AgentLoopWorker._postprocess(
+        postprocess_worker,
+        inputs=[internal],
+        input_non_tensor_batch={
+            "index": np.array([0], dtype=object),
+            "agent_name": np.array(["single_turn_agent"], dtype=object),
+        },
+    )
+
+    # rm_scores must be present in the batch and be all zeros
+    assert "rm_scores" in merged.batch
+    assert merged.batch["rm_scores"].shape == merged.batch["responses"].shape
+    assert merged.batch["rm_scores"].sum().item() == 0.0
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_pad_token_ids_empty_with_non_zero_pad_id():
     """Regression test: empty token list uses tokenizer's pad_token_id (not hardcoded 0)."""
     worker = type(

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -816,6 +816,12 @@ class AgentLoopWorker:
         )
         if self.use_task_rewards:
             await self._compute_score([output], kwargs=kwargs)
+        else:
+            # When use_task_rewards=False, set reward_score to 0.0 so that
+            # rm_scores is always present in the output batch. This is required
+            # by trainers (e.g. V1 trainer) that unconditionally read rm_scores
+            # during advantage computation, even in distillation-only setups.
+            output.reward_score = 0.0
         await self._compute_teacher_logprobs(
             output,
             prompt_ids=output.prompt_ids,

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -519,6 +519,9 @@ class AgentLoopWorker:
                 config=config,
                 teacher_client=teacher_client,
             )
+            self.use_task_rewards: bool = config.distillation.distillation_loss.use_task_rewards
+        else:
+            self.use_task_rewards = True
 
         # Load tools once per worker; each trajectory just reuses self.tools.
         tool_config_path = self.rollout_config.multi_turn.tool_config_path
@@ -811,7 +814,8 @@ class AgentLoopWorker:
                 output.multi_modal_data.get("audios") if output.multi_modal_data else None
             ),
         )
-        await self._compute_score([output], kwargs=kwargs)
+        if self.use_task_rewards:
+            await self._compute_score([output], kwargs=kwargs)
         await self._compute_teacher_logprobs(
             output,
             prompt_ids=output.prompt_ids,


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in OPD training when distillation.distillation_loss.use_task_rewards=False and the dataset's data_source is not registered in `default_compute_score`.

The `use_task_rewards` flag previously only suppressed the task-reward contribution to the loss (in distillation/losses.py) but did not prevent `_compute_score` from being invoked in `agent_loop.py`. When using a custom dataset whose `data_source` is not registered in the default reward registry, this raised `NotImplementedError` and crashed training before the first step.

OPD with `use_task_rewards=False` trains entirely on the distillation loss; invoking the reward function is unnecessary and error-prone with custom datasets.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: No related pr found. https://github.com/verl-project/verl/pulls?q=is%3Apr+use_task_rewards, https://github.com/verl-project/verl/pulls?q=is%3Apr+reward+skip+distillation
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Verified under fully async OPD training with a custom QA dataset (data_source not registered in default_compute_score). Previously crashed at the first distillation step with `NotImplementedError`; now runs without invoking the reward function when `use_task_rewards=False`.

### API and Usage Example
No API change. Existing config usage:
```
distillation:
  distillation_loss:
    use_task_rewards: false   # reward function is now skipped entirely
```

### Design & Code Changes
- verl/experimental/agent_loop/agent_loop.py: reads use_task_rewards from distillation config in __init__ (defaults to True when distillation is disabled); wraps `_compute_score` call with if `self.use_task_rewards`.
- docs/algo/opd.md: clarifies that `use_task_rewards=false` skips the reward function invocation entirely, not just the loss contribution.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: 
> The fix is a single conditional guard in the agent loop. Testing requires a fully running async OPD stack (rollout server + teacher server + trainer), which is not feasible in CI. Verified by end-to-end training run with a custom dataset.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
