### PR TITLE
[doc] fix: stop sidebar from scrolling in sync with main content

### DIFF
--- a/docs/_static/js/resizable-sidebar.js
+++ b/docs/_static/js/resizable-sidebar.js
@@ -129,6 +129,18 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
+// the sidebar will be scrolled when the cursor is hovered over it
+document.addEventListener('DOMContentLoaded', function() {
+    const nav = window.SphinxRtdTheme && window.SphinxRtdTheme.Navigation;
+
+    if (!nav) return;
+
+    nav.onScroll = function() {
+        this.winScroll = false;
+        this.winPosition = this.win.scrollTop();
+    };
+});
+
 // Fix navigation issues - Using MutationObserver for reliable initialization
 document.addEventListener('DOMContentLoaded', function() {
     let navigationFixed = false;


### PR DESCRIPTION
### What does this PR do?

In the current documentation layout, scrolling within the main content area also causes the sidebar menu to scroll up or down. With this code change, the sidebar menu will scroll only when the user hovers the cursor over the sidebar itself.