### PR TITLE
[data] fix: fall back for unpickleable prompt filters

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import os
+import pickle
 from copy import deepcopy
 from pathlib import Path
 
@@ -129,6 +130,72 @@ def test_build_messages_accepts_video_path_or_frame_list(videos, expected_video)
         {"type": "text", "text": "Describe "},
         {"type": "video", "video": expected_video},
     ]
+
+
+def _mock_filter_dataset(processor=None, num_workers=2):
+    dataset = _mock_rlhf_dataset()
+    dataset.processor = processor
+    dataset.tokenizer = None if processor is not None else _FakeTokenizer()
+    dataset.filter_overlong_prompts = True
+    dataset.apply_chat_template_kwargs = {}
+    dataset.tool_schemas = None
+    dataset.image_patch_size = 14
+    dataset.config = OmegaConf.create({})
+    dataset.max_prompt_length = 2
+    dataset.mm_processor_kwargs = {}
+    dataset.num_workers = num_workers
+    return dataset
+
+
+class _FakeTokenizer:
+    def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=True, **kwargs):
+        assert add_generation_prompt
+        assert tokenize
+        return list(range(len(messages[0]["content"].split())))
+
+
+@pytest.mark.parametrize("filter_error", [TypeError("cannot pickle 'SSLContext' object"), pickle.PicklingError("boom")])
+def test_maybe_filter_out_long_prompts_falls_back_when_multiprocess_filter_is_not_pickleable(filter_error, caplog):
+    calls = []
+
+    class FakeDataFrame(list):
+        def filter(self, fn, num_proc=None, desc=None):
+            calls.append(num_proc)
+            if num_proc is not None:
+                raise filter_error
+            return FakeDataFrame([doc for doc in self if fn(doc)])
+
+    dataset = _mock_filter_dataset(num_workers=2)
+    dataframe = FakeDataFrame(
+        [
+            {"prompt": [{"role": "user", "content": "short"}]},
+            {"prompt": [{"role": "user", "content": "one two three"}]},
+        ]
+    )
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert calls == [2, None]
+    assert len(filtered) == 1
+    assert filtered[0]["prompt"][0]["content"] == "short"
+    assert "Falling back to single-process prompt filtering" in caplog.text
+
+
+def test_maybe_filter_out_long_prompts_reraises_non_serialization_filter_errors():
+    calls = []
+
+    class FakeDataFrame(list):
+        def filter(self, fn, num_proc=None, desc=None):
+            calls.append(num_proc)
+            raise TypeError("unrelated filter failure")
+
+    dataset = _mock_filter_dataset(num_workers=2)
+    dataframe = FakeDataFrame([{"prompt": [{"role": "user", "content": "short"}]}])
+
+    with pytest.raises(TypeError, match="unrelated filter failure"):
+        dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert calls == [2]
 
 
 def test_maybe_filter_out_long_prompts_accepts_image_path(monkeypatch):

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -18,6 +18,7 @@ import asyncio
 import copy
 import logging
 import os
+import pickle
 import re
 import traceback
 from collections import defaultdict
@@ -36,6 +37,10 @@ from verl.utils.import_utils import load_extern_object
 from verl.utils.tokenizer import build_multimodal_processor_inputs, normalize_token_ids
 
 logger = logging.getLogger(__name__)
+
+
+def _is_multiprocess_pickling_error(exc: Exception) -> bool:
+    return isinstance(exc, pickle.PicklingError) or "pickl" in str(exc).lower()
 
 
 def collate_fn(data_list: list[dict]) -> dict:
@@ -265,11 +270,26 @@ class RLHFDataset(Dataset):
                         traceback.print_exc()
                         return self.max_prompt_length + 1
 
-            dataframe = dataframe.filter(
-                lambda doc: doc2len(doc) <= self.max_prompt_length,
-                num_proc=self.num_workers,
-                desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
-            )
+            desc = f"Filtering prompts longer than {self.max_prompt_length} tokens"
+
+            def filter_with_num_proc(num_proc):
+                return dataframe.filter(
+                    lambda doc: doc2len(doc) <= self.max_prompt_length,
+                    num_proc=num_proc,
+                    desc=desc,
+                )
+
+            try:
+                dataframe = filter_with_num_proc(self.num_workers)
+            except (AttributeError, TypeError, pickle.PicklingError) as exc:
+                if self.num_workers is None or not _is_multiprocess_pickling_error(exc):
+                    raise
+                logger.warning(
+                    "Falling back to single-process prompt filtering because "
+                    "multiprocessing could not serialize the filter function: %s",
+                    exc,
+                )
+                dataframe = filter_with_num_proc(None)
 
             print(f"filter dataset len: {len(dataframe)}")
         return dataframe


### PR DESCRIPTION
### What does this PR do?

Fixes #4894.

`RLHFDataset.maybe_filter_out_long_prompts()` can fail during Hugging Face `Dataset.filter(..., num_proc=N)` when the prompt-length filter closure captures processor state that cannot be pickled, for example an `ssl.SSLContext`. This PR keeps the configured multiprocessing path as the first attempt, but falls back to single-process filtering when the failure is a pickling/serialization failure. Non-pickling filter errors are still re-raised.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+SSLContext+filter_overlong_prompts
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
uvx ruff format --check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py
uvx ruff check verl/utils/dataset/rl_dataset.py tests/utils/dataset/test_rl_dataset_on_cpu.py
PYTHONPATH=. uv run --no-project --with pytest --with omegaconf --with pillow --with numpy --with datasets --with transformers --with torch --with tensordict --with ray --with codetiming pytest tests/utils/dataset/test_rl_dataset_on_cpu.py -q -k 'pickleable or reraises'
```

Also ran a local Hugging Face `Dataset.from_list` smoke reproducer with a fake processor holding `ssl.create_default_context()`; the first `num_proc=2` filter attempt raised `cannot pickle 'SSLContext' object`, then fallback completed and kept the expected short prompt.

### API and Usage Example

No API change. Existing `filter_overlong_prompts_workers` behavior is preserved when multiprocessing succeeds; only pickling failures fall back to `num_proc=None` with a warning.

### Design & Code Changes

- Add a small helper to identify multiprocessing pickling failures.
- Wrap the prompt filtering call so the configured `num_proc` path is tried first.
- Fall back to single-process filtering only for pickling errors, and re-raise unrelated errors.
- Add CPU regression tests for the fallback and for non-pickling TypeError propagation.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Ran targeted ruff commands listed above instead of full pre-commit because this is a two-file data/test fix.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not applicable: no user-facing API or docs behavior change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: added CPU unit tests in `tests/utils/dataset/test_rl_dataset_on_cpu.py`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable: no recipe submodule change.
