### PR TITLE
[model] fix: tokenizer.hf_processor: GLM-4V arm uses wrong processor class name (#6814)

### DIFF
--- a/verl/utils/tokenizer/tokenizer.py
+++ b/verl/utils/tokenizer/tokenizer.py
@@ -218,7 +218,7 @@ def hf_processor(name_or_path, **kwargs):
                 from transformers.models.qwen3_vl import Qwen3VLModel
 
                 model_class = Qwen3VLModel
-            case "Glm4vImageProcessor":
+            case "Glm4vProcessor":
                 from transformers.models.glm4v import Glm4vModel
 
                 model_class = Glm4vModel


### PR DESCRIPTION
## Motivation

Training GLM-4.1V / GLM-4V multimodal models fails in `hf_processor`, reported in #6814. This PR fixes the first error (the processor-type match); the issue's second error in `verl/models/transformers/glm4v.py` is a separate downstream concern.

## Root cause

`verl/utils/tokenizer/tokenizer.py` dispatches on `processor.__class__.__name__`:

```python
match processor.__class__.__name__:
    case "Qwen2VLProcessor":   ...
    case "Qwen2_5_VLProcessor": ...
    case "Qwen3VLProcessor":   ...
    case "Glm4vImageProcessor":          # never matches
        from transformers.models.glm4v import Glm4vModel
        model_class = Glm4vModel
```

For GLM-4.1V / GLM-4V, `AutoProcessor` returns a `Glm4vProcessor` — `Glm4vImageProcessor` is the image-processor sub-component, not the processor class. Every other arm uses the `*Processor` class name. So this arm never fires, `model_class` for `Glm4vModel` is never bound, and the GLM-4V branch falls through.

## Modifications

`verl/utils/tokenizer/tokenizer.py`: change `case "Glm4vImageProcessor":` to `case "Glm4vProcessor":` so it matches the actual processor class name, consistent with the other VL arms. The import and `model_class` assignment inside the arm are already correct.

## Duplicate-check

- Track A — the GitHub search API returned HTTP 422 for this token on this repo, so per fail-closed I enumerated all open PRs via the core API (`repos/verl-project/verl/pulls?state=open --paginate`) and grepped bodies for `6814` → no references.
- Track B — issue #6814 (state OPEN) has a single analysis comment; no "opened a PR / working on this / taking this" claim.
