### PR TITLE
fix(fully_async): seed optimizer training steps before init

### DIFF
--- a/tests/experimental/fully_async_policy/test_total_training_steps_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_total_training_steps_on_cpu.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from omegaconf import OmegaConf
+
+from verl.experimental.fully_async_policy.fully_async_main import (
+    _set_fully_async_total_training_steps_before_worker_init,
+)
+
+
+def _make_config(actor_total_training_steps=-1):
+    return OmegaConf.create(
+        {
+            "rollout": {
+                "total_rollout_steps": 3200,
+            },
+            "async_training": {
+                "require_batches": 2,
+                "trigger_parameter_sync_step": 4,
+            },
+            "actor_rollout_ref": {
+                "actor": {
+                    "ppo_mini_batch_size": 100,
+                    "optim": {
+                        "total_training_steps": actor_total_training_steps,
+                    },
+                },
+            },
+        }
+    )
+
+
+def test_sets_actor_total_training_steps_before_workers_build_scheduler():
+    config = _make_config()
+
+    total_train_steps = _set_fully_async_total_training_steps_before_worker_init(config)
+
+    assert total_train_steps == 4
+    assert config.actor_rollout_ref.actor.optim.total_training_steps == 4
+
+
+def test_preserves_explicit_actor_total_training_steps():
+    config = _make_config(actor_total_training_steps=17)
+
+    total_train_steps = _set_fully_async_total_training_steps_before_worker_init(config)
+
+    assert total_train_steps == 4
+    assert config.actor_rollout_ref.actor.optim.total_training_steps == 17

--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 import hydra
 import ray
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, open_dict
 
 from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
 from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
@@ -30,6 +30,44 @@ from verl.experimental.separation.utils import create_resource_pool_manager, cre
 from verl.trainer.ppo.utils import Role
 from verl.utils.device import auto_set_device
 from verl.utils.fs import copy_to_local
+
+
+def _infer_total_train_steps_from_rollout(config):
+    total_rollout_steps = OmegaConf.select(config, "rollout.total_rollout_steps")
+    ppo_mini_batch_size = OmegaConf.select(config, "actor_rollout_ref.actor.ppo_mini_batch_size")
+    require_batches = OmegaConf.select(config, "async_training.require_batches")
+    trigger_parameter_sync_step = OmegaConf.select(config, "async_training.trigger_parameter_sync_step")
+    if (
+        total_rollout_steps is None
+        or ppo_mini_batch_size is None
+        or require_batches is None
+        or trigger_parameter_sync_step is None
+    ):
+        return None
+
+    samples_per_update = ppo_mini_batch_size * require_batches * trigger_parameter_sync_step
+    if samples_per_update <= 0:
+        return None
+    return int(total_rollout_steps / samples_per_update)
+
+
+def _set_fully_async_total_training_steps_before_worker_init(config):
+    total_train_steps = _infer_total_train_steps_from_rollout(config)
+    if total_train_steps is None:
+        return None
+
+    with open_dict(config):
+        if (
+            OmegaConf.select(config, "actor_rollout_ref.actor.optim") is not None
+            and OmegaConf.select(config, "actor_rollout_ref.actor.optim.total_training_steps") == -1
+        ):
+            config.actor_rollout_ref.actor.optim.total_training_steps = total_train_steps
+        if (
+            OmegaConf.select(config, "critic.optim") is not None
+            and OmegaConf.select(config, "critic.optim.total_training_steps") == -1
+        ):
+            config.critic.optim.total_training_steps = total_train_steps
+    return total_train_steps
 
 
 @ray.remote(num_cpus=1)
@@ -73,6 +111,9 @@ class FullyAsyncTaskRunner:
         role_worker_mapping, ray_worker_group_cls = create_role_worker_mapping(config)
         self.components["role_worker_mapping"] = role_worker_mapping
         self.components["ray_worker_group_cls"] = ray_worker_group_cls
+
+        total_train_steps = _set_fully_async_total_training_steps_before_worker_init(config)
+        print(f"[ASYNC MAIN] Pre-init total_train_steps {total_train_steps}")
 
         print("[ASYNC MAIN] Creating FullyAsyncTrainer first (needed for hybrid worker group injection)...")
         self._create_trainer(config)


### PR DESCRIPTION
Fixes #6683.

In fully async mode the trainer workers build the optimizer and LR scheduler during `init_workers()`, but total training steps were only copied from the rollouter afterwards. When `actor.optim.total_training_steps` stayed at the default `-1`, the scheduler could be built with the wrong train step count.

This seeds actor/critic optimizer `total_training_steps` from `rollout.total_rollout_steps` before trainer worker initialization, while preserving an explicitly configured optimizer value.

Validation:
- `uv run --no-project --with ruff ruff check verl/experimental/fully_async_policy/fully_async_main.py tests/experimental/fully_async_policy/test_total_training_steps_on_cpu.py`
- `uv run --no-project --with ruff ruff format --check verl/experimental/fully_async_policy/fully_async_main.py tests/experimental/fully_async_policy/test_total_training_steps_on_cpu.py`
- `git diff --check`
- helper semantic smoke with OmegaConf passed

I could not run the standard pytest command on Windows because `requirements.txt` pulls `liger-kernel` -> `triton`, and `triton` has no `win_amd64` wheel. Linux CI should cover the normal test environment.