### PR TITLE
[megatron] fix: guard removed ModelType.encoder_and_decoder for Megatron-LM compatibility

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -50,6 +50,10 @@ from verl.workers.config import HFModelConfig, McoreEngineConfig
 logger = logging.getLogger(__file__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
+# `ModelType.encoder_and_decoder` was removed from Megatron-LM (NVIDIA/Megatron-LM#3836).
+# Guard references to it so verl stays compatible with both old and new Megatron-LM versions.
+_HAS_ENCODER_AND_DECODER = hasattr(ModelType, "encoder_and_decoder")
+
 
 def get_model_config(model):
     return get_attr_wrapped_model(model, "config", allow_none=False)
@@ -69,9 +73,10 @@ def get_model(
         mpu.get_pipeline_model_parallel_world_size() > 1
         and mpu.get_virtual_pipeline_model_parallel_world_size() is not None
     ):
-        assert model_type != ModelType.encoder_and_decoder, (
-            "Interleaved schedule not supported for model with both encoder and decoder"
-        )
+        if _HAS_ENCODER_AND_DECODER:
+            assert model_type != ModelType.encoder_and_decoder, (
+                "Interleaved schedule not supported for model with both encoder and decoder"
+            )
         model = []
         has_vp_stage = inspect.signature(mpu.is_pipeline_first_stage).parameters.get("vp_stage", None) is not None
         for i in range(mpu.get_virtual_pipeline_model_parallel_world_size()):
@@ -89,8 +94,9 @@ def get_model(
         post_process = mpu.is_pipeline_last_stage()
         add_encoder = True
         add_decoder = True
-        assert model_type != ModelType.encoder_and_decoder, "Model type encoder_and_decoder is not supported"
-        if model_type == ModelType.encoder_and_decoder:
+        if _HAS_ENCODER_AND_DECODER:
+            assert model_type != ModelType.encoder_and_decoder, "Model type encoder_and_decoder is not supported"
+        if _HAS_ENCODER_AND_DECODER and model_type == ModelType.encoder_and_decoder:
             if mpu.get_pipeline_model_parallel_world_size() > 1:
                 assert mpu.get_pipeline_model_parallel_split_rank() is not None, (
                     "Split rank needs to be specified for model with both encoder and decoder"


### PR DESCRIPTION
### What does this PR do?
Recent Megatron-LM removed `ModelType.encoder_and_decoder` from `megatron.core.enums`
(NVIDIA/Megatron-LM#3836). `verl/utils/megatron_utils.py::get_model()` references it in
two `assert`s and one branch, so on the latest Megatron-LM building a model raises
`AttributeError: encoder_and_decoder`. This adds a `hasattr`-based capability flag so
those references are skipped when the attribute is absent, keeping verl compatible with
both old and new Megatron-LM. verl only ever uses `encoder_or_decoder`, so when the
attribute is gone the code simply takes the existing encoder-or-decoder path.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
  -   https://github.com/verl-project/verl/pulls?q=is%3Apr+ModelType+encoder_and_decoder
- [x] Format the PR title as `[{modules}] {type}: {description}` 

### Test

Validated with a short GRPO Megatron run on GSM8K (Qwen3.5 small model, `tp=pp=cp=1`,
mbridge enabled (using megatron-bridge via `use_vanilla_mbridge=False`). This builds both the actor and the reference model through the patched
`get_model()`. With `pipeline_model_parallel_size=1` the code takes the non-interleaved
`else` branch, which is exactly where the `ModelType.encoder_and_decoder` references live:

- **Before the fix** (latest Megatron-LM): `get_model()` raises `AttributeError: encoder_and_decoder` during model build.
- **After the fix**: the guarded blocks are skipped and the run proceeds through generation,
  log-prob/ref computation, and the optimizer step without error.

```bash
train_files="['$HOME/data/gsm8k/train.parquet']"
test_files="['$HOME/data/gsm8k/test.parquet']"

python -m verl.trainer.main_ppo \
    --config-name=ppo_megatron_trainer.yaml \
    algorithm.adv_estimator=grpo \
    data.train_files="$train_files" \
    data.val_files="$test_files" \
    data.train_batch_size=8 \
    data.max_prompt_length=128 \
    data.max_response_length=128 \
    data.filter_overlong_prompts=True \
    data.truncation=error \
    actor_rollout_ref.model.path=Qwen/Qwen3-0.6B \
    actor_rollout_ref.actor.strategy=megatron \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.model.use_remove_padding=True \
    actor_rollout_ref.actor.ppo_mini_batch_size=4 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
    actor_rollout_ref.model.enable_gradient_checkpointing=True \
    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
    actor_rollout_ref.rollout.n=5 \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1 \
    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=1 \
    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=1 \
    actor_rollout_ref.actor.megatron.context_parallel_size=1 \
    actor_rollout_ref.actor.megatron.sequence_parallel=false \
    +actor_rollout_ref.actor.megatron.override_transformer_config.persist_layer_norm=false \
    actor_rollout_ref.actor.megatron.use_mbridge=True \
    actor_rollout_ref.actor.megatron.use_vanilla_mbridge=False \
    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=1 \
    actor_rollout_ref.ref.megatron.use_mbridge=True \
    actor_rollout_ref.ref.megatron.use_vanilla_mbridge=False \
    algorithm.kl_ctrl.kl_coef=0.001 \
    trainer.critic_warmup=0 \
    trainer.logger="['console']" \
    trainer.experiment_name=megatron_modeltype_compat_smoke \
    trainer.n_gpus_per_node=1 \
    trainer.nnodes=1 \
    trainer.save_freq=-1 \
    trainer.test_freq=-1 \
    trainer.total_training_steps=1
```

### API and Usage Example

N/A

### Design & Code Changes

- Add module-level `_HAS_ENCODER_AND_DECODER = hasattr(ModelType, "encoder_and_decoder")` in `verl/utils/megatron_utils.py`.
- Guard the interleaved-schedule `assert` behind `_HAS_ENCODER_AND_DECODER`.
- Guard the second `assert` and the `model_type == ModelType.encoder_and_decoder` branch behind the same flag.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
