### PR TITLE
[fully_async] feat: Adapt vLLM 0.19+ for Ascend NPU

### DIFF
--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -18,10 +18,11 @@ import os
 import socket
 from datetime import timedelta
 from typing import Any
+
 import ray
 import torch.distributed
-from torch.distributed import ProcessGroup, Store, TCPStore
-import torch_npu
+from torch.distributed import TCPStore
+
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device, is_npu_available
 from verl.utils.net_utils import is_ipv6
 
@@ -167,8 +168,9 @@ def stateless_init_process_group(master_address, master_port, rank, world_size, 
             listen_socket = None
             listen_fd = None
 
-        from packaging import version
         import vllm
+        from packaging import version
+
         _VLLM_VERSION = version.parse(vllm.__version__)
         if _VLLM_VERSION >= version.parse("0.19.0"):
             store = create_tcp_store(

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -97,6 +97,7 @@ def initialize_global_process_group_ray(timeout_second=None, backend=None):
             init_method=os.environ.get("DIST_INIT_METHOD", None),
         )
 
+
 def create_tcp_store(
     host: str,
     port: int,
@@ -118,6 +119,7 @@ def create_tcp_store(
     except Exception:
         socket.close(listen_fd)
         raise
+
 
 def stateless_init_process_group(master_address, master_port, rank, world_size, device):
     """

--- a/verl/utils/distributed.py
+++ b/verl/utils/distributed.py
@@ -17,10 +17,11 @@ import ctypes
 import os
 import socket
 from datetime import timedelta
-
+from typing import Any
 import ray
 import torch.distributed
-
+from torch.distributed import ProcessGroup, Store, TCPStore
+import torch_npu
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device, is_npu_available
 from verl.utils.net_utils import is_ipv6
 
@@ -95,6 +96,27 @@ def initialize_global_process_group_ray(timeout_second=None, backend=None):
             init_method=os.environ.get("DIST_INIT_METHOD", None),
         )
 
+def create_tcp_store(
+    host: str,
+    port: int,
+    listen_socket: socket.socket | None = None,
+    **kwargs: Any,
+) -> TCPStore:
+    """Create a TCPStore, optionally taking ownership of ``listen_socket``."""
+    if listen_socket is None:
+        return TCPStore(host_name=host, port=port, **kwargs)
+
+    listen_fd = listen_socket.detach()
+    try:
+        return TCPStore(
+            host_name=host,
+            port=port,
+            master_listen_fd=listen_fd,
+            **kwargs,
+        )
+    except Exception:
+        socket.close(listen_fd)
+        raise
 
 def stateless_init_process_group(master_address, master_port, rank, world_size, device):
     """
@@ -126,13 +148,13 @@ def stateless_init_process_group(master_address, master_port, rank, world_size, 
         world_size: int,
         data_expiration_seconds: int = 3600,
         store_timeout: int = 300,
+        listen_socket: socket.socket | None = None,
     ) -> "StatelessProcessGroup":
         """
         This is copied from vllm/distributed/utils.py:StatelessProcessGroup.create
         Modified to support ipv6 stateless communication groups."""
         launch_server = rank == 0
-        if launch_server:
-            # listen on the specified interface (instead of 0.0.0.0)
+        if launch_server and listen_socket is None:
             if is_ipv6(master_address):
                 listen_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
             else:
@@ -145,23 +167,44 @@ def stateless_init_process_group(master_address, master_port, rank, world_size, 
             listen_socket = None
             listen_fd = None
 
-        store = TCPStore(
-            host_name=host,
-            port=port,
-            world_size=world_size,
-            is_master=launch_server,
-            timeout=timedelta(seconds=store_timeout),
-            use_libuv=False,  # for now: github.com/pytorch/pytorch/pull/150215
-            master_listen_fd=listen_fd,
-        )
+        from packaging import version
+        import vllm
+        _VLLM_VERSION = version.parse(vllm.__version__)
+        if _VLLM_VERSION >= version.parse("0.19.0"):
+            store = create_tcp_store(
+                host=host,
+                port=port,
+                listen_socket=listen_socket,
+                world_size=world_size,
+                is_master=launch_server,
+                timeout=timedelta(seconds=store_timeout),
+                use_libuv=False,
+            )
+            pg = StatelessProcessGroup(
+                rank=rank,
+                world_size=world_size,
+                store=store,
+                data_expiration_seconds=data_expiration_seconds,
+            )
+        else:
+            store = TCPStore(
+                host_name=host,
+                port=port,
+                world_size=world_size,
+                is_master=launch_server,
+                timeout=timedelta(seconds=store_timeout),
+                use_libuv=False,  # for now: github.com/pytorch/pytorch/pull/150215
+                master_listen_fd=listen_fd,
+            )
 
-        return StatelessProcessGroup(
-            rank=rank,
-            world_size=world_size,
-            store=store,
-            socket=listen_socket,
-            data_expiration_seconds=data_expiration_seconds,
-        )
+            pg = StatelessProcessGroup(
+                rank=rank,
+                world_size=world_size,
+                store=store,
+                socket=listen_socket,
+                data_expiration_seconds=data_expiration_seconds,
+            )
+        return pg
 
     pg = create_process_group(host=master_address, port=master_port, rank=rank, world_size=world_size)
 

--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -200,6 +200,12 @@ if is_torch_npu_available(check_device=False):
 
         patch_vllm013_rotary_emb()
         FusedMoE.weight_loader = vllm_v013_weight_loader_method_wrapper(FusedMoE.weight_loader)
+    elif _VLLM_VERSION >= version.parse("0.19.0"):
+        # Disable flash_attn in RotaryEmbedding (NPU) when VLLM >= 0.19
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+
+        patch_vllm013_rotary_emb()
+        FusedMoE.weight_loader = vllm_v013_weight_loader_method_wrapper(FusedMoE.weight_loader)
 
     VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2 = bool(int(os.getenv("VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2", "1")))
     if VERL_NPU_ENABLE_A2_PATCH_VLLM_ASCEND_MC2:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1011,9 +1011,12 @@ class vLLMReplica(RolloutReplica):
                 # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
                 # https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
                 "NCCL_CUMEM_ENABLE": "0",
-                "ASCEND_RT_VISIBLE_DEVICES": node_cuda_visible_devices,
                 "VLLM_ASCEND_AUTO_DETECT_QUANTIZATION": "0",
             }
+
+            if _VLLM_VERSION >= version.parse("0.20.0"):
+                env_vars["ASCEND_RT_VISIBLE_DEVICES"] = node_cuda_visible_devices
+    
             if os.environ.get("VLLM_ASCEND_TASK_QUEUE_ENABLE", None):
                 # use VLLM_ASCEND_TASK_QUEUE_ENABLE to support different TASK_QUEUE_ENABLE mode for
                 # train and rollout on Ascend NPU

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1011,6 +1011,7 @@ class vLLMReplica(RolloutReplica):
                 # https://docs.vllm.ai/en/latest/usage/troubleshooting.html?h=nccl_cumem_enable#known-issues
                 # https://github.com/vllm-project/vllm/blob/c6b0a7d3ba03ca414be1174e9bd86a97191b7090/vllm/worker/worker_base.py#L445
                 "NCCL_CUMEM_ENABLE": "0",
+                "ASCEND_RT_VISIBLE_DEVICES": node_cuda_visible_devices,
                 "VLLM_ASCEND_AUTO_DETECT_QUANTIZATION": "0",
             }
             if os.environ.get("VLLM_ASCEND_TASK_QUEUE_ENABLE", None):

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1016,7 +1016,7 @@ class vLLMReplica(RolloutReplica):
 
             if _VLLM_VERSION >= version.parse("0.20.0"):
                 env_vars["ASCEND_RT_VISIBLE_DEVICES"] = node_cuda_visible_devices
-    
+
             if os.environ.get("VLLM_ASCEND_TASK_QUEUE_ENABLE", None):
                 # use VLLM_ASCEND_TASK_QUEUE_ENABLE to support different TASK_QUEUE_ENABLE mode for
                 # train and rollout on Ascend NPU


### PR DESCRIPTION
[trainer, fully_async] Adapt vLLM 0.19+ for Ascend NPU

### What does this PR do?

This PR mainly addresses compatibility issues with vLLM 0.19.0 and later in NPU scenarios.

The main changes include:

For vLLM >= 0.19.0, continue disabling flash attention in RotaryEmbedding to avoid compatibility issues on NPU.
Wrap FusedMoE.weight_loader to keep the MoE weight loading logic compatible with newer vLLM versions.
Add a new create_tcp_store helper to create TCPStore in a unified way, with support for passing an existing listen_socket.
When listen_socket is provided, use detach() to transfer the socket file descriptor to TCPStore, and correctly close the fd on exceptions to avoid resource leaks.
Update the StatelessProcessGroup creation logic based on the vLLM version:
For vLLM >= 0.19.0: create the store through the new create_tcp_store helper.
For vLLM < 0.19.0: keep the original logic and continue passing the socket.
Add the VLLM_ASCEND_AUTO_DETECT_QUANTIZATION=0 environment variable to disable vLLM Ascend automatic quantization detection, avoiding potential misdetection or compatibility issues.

Overall, this PR improves the startup, communication, and weight-loading compatibility of verl with vLLM 0.19.0+ in Ascend NPU scenarios.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
