### PR TITLE
[megatron] fix: support FP8 padding for BSHD actor forward

### DIFF
--- a/tests/models/test_mcore_bshd_fp8_padding.py
+++ b/tests/models/test_mcore_bshd_fp8_padding.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import torch
+
+from verl.models.mcore.util import postprocess_bshd, preprocess_bshd
+
+
+def test_preprocess_bshd_fp8_padding_aligns_local_tokens_and_roundtrips():
+    input_ids = torch.tensor(
+        [
+            [10, 11, 12, 0, 0],
+            [20, 21, 22, 23, 24],
+            [30, 31, 0, 0, 0],
+        ],
+        dtype=torch.long,
+    )
+    attention_mask = torch.tensor(
+        [
+            [True, True, True, False, False],
+            [True, True, True, True, True],
+            [True, True, False, False, False],
+        ]
+    )
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.long).unsqueeze(0).expand_as(input_ids)
+
+    with (
+        patch("verl.models.mcore.util.mpu.get_context_parallel_world_size", return_value=1),
+        patch("verl.models.mcore.util.mpu.get_tensor_model_parallel_world_size", return_value=2),
+    ):
+        input_ids_bshd, attention_mask_bshd, position_ids_bshd = preprocess_bshd(
+            input_ids,
+            attention_mask,
+            position_ids,
+            sequence_parallel=True,
+            pre_process=True,
+            use_fp8_padding=True,
+        )
+
+    assert input_ids_bshd.shape == (3, 256)
+    assert position_ids_bshd.shape == (3, 256)
+    assert attention_mask_bshd.shape == (3, 256)
+    assert (input_ids_bshd.shape[0] * input_ids_bshd.shape[1] // 2) % 128 == 0
+
+    restored = postprocess_bshd(input_ids_bshd, attention_mask_bshd, attention_mask, input_ids.shape[1])
+    torch.testing.assert_close(restored, input_ids)

--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -131,8 +131,6 @@ def model_forward_gen(vision_model: bool = False):
             When using the bshd format, we have to add paddings to the input_ids to meet the longest sequence length, 
             so it is recommended to disable dynamic batch size and set batch size to 1
             """
-            assert fp8 is None, "fp8 is not supported for bshd format yet"
-
             batch_size, sequence_length = attention_mask.shape[:2]
             position_ids_for_preprocess = (
                 torch.arange(sequence_length, device=input_ids.device).unsqueeze(0).expand(batch_size, -1)
@@ -146,6 +144,7 @@ def model_forward_gen(vision_model: bool = False):
                 position_ids_for_preprocess,
                 sequence_parallel=sp,
                 pre_process=pre_process_for_bshd,
+                use_fp8_padding=use_fp8_padding,
             )
             output_orig = model(
                 input_ids=new_input_ids,
@@ -156,7 +155,12 @@ def model_forward_gen(vision_model: bool = False):
             if post_process and logits_processor is not None:
                 args = {
                     k: preprocess_bshd(
-                        v, attention_mask, position_ids_for_preprocess, sequence_parallel=sp, pre_process=True
+                        v,
+                        attention_mask,
+                        position_ids_for_preprocess,
+                        sequence_parallel=sp,
+                        pre_process=True,
+                        use_fp8_padding=use_fp8_padding,
                     )[0]
                     for k, v in logits_processor_args.items()
                 }

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -41,6 +41,16 @@ def _compute_fp8_thd_align_size(align_size: int) -> tuple[int, int]:
     return math.lcm(16, align_size), align_size * 128
 
 
+def _align_bshd_max_seqlen_for_fp8(
+    max_seqlen: int, batch_size: int, align_size: int, tp_size: int, cp_size: int
+) -> int:
+    """Align BSHD max sequence length for TransformerEngine FP8 block quantization."""
+    fp8_total_align = 128 * tp_size * cp_size
+    fp8_seq_align = fp8_total_align // math.gcd(batch_size, fp8_total_align)
+    fp8_seq_align = math.lcm(fp8_seq_align, align_size)
+    return ((max_seqlen + fp8_seq_align - 1) // fp8_seq_align) * fp8_seq_align
+
+
 def preprocess_packed_seqs(
     input_ids: torch.Tensor, attention_mask: torch.Tensor, pre_process: bool = True, use_fp8_padding: bool = False
 ) -> tuple[torch.Tensor, PackedSeqParams]:
@@ -199,6 +209,7 @@ def preprocess_bshd(
     position_ids: torch.Tensor,
     sequence_parallel: bool = False,
     pre_process: bool = True,
+    use_fp8_padding: bool = False,
 ):
     """
     Remove left padding from input_ids, attention_mask and position_ids
@@ -212,10 +223,13 @@ def preprocess_bshd(
     shape = list(input_ids.shape)  # batch_size, seq_len,...
     seq_lens = attention_mask.sum(dim=1)
     seq_len = seq_lens.max().item()
+    tp_size = mpu.get_tensor_model_parallel_world_size()
     if sequence_parallel:
-        sp_world_size = mpu.get_tensor_model_parallel_world_size()
-        pad_size = (sp_world_size - seq_len % sp_world_size) % sp_world_size
+        pad_size = (tp_size - seq_len % tp_size) % tp_size
         seq_len = seq_len + pad_size
+    if use_fp8_padding:
+        align_size = tp_size * cp_size * 2 if cp_size > 1 else tp_size
+        seq_len = _align_bshd_max_seqlen_for_fp8(seq_len, batch_size, align_size, tp_size, cp_size)
     shape[1] = seq_len
     if pre_process:
         new_input_ids = torch.zeros(dtype=input_ids.dtype, device=input_ids.device, size=shape)
@@ -593,12 +607,7 @@ def preprocess_bshd_engine(
         # We need:
         # 1) max_seqlen aligned for SP/CP splitting.
         # 2) batch_size * max_seqlen % (128 * tp_size * cp_size) == 0.
-        # Compute the required alignment for max_seqlen:
-        fp8_total_align = 128 * tp_size * cp_size
-        fp8_seq_align = fp8_total_align // math.gcd(batch_size, fp8_total_align)
-        # Also ensure SP and CP split alignment.
-        fp8_seq_align = math.lcm(fp8_seq_align, align_size)
-        max_seqlen = ((max_seqlen + fp8_seq_align - 1) // fp8_seq_align) * fp8_seq_align
+        max_seqlen = _align_bshd_max_seqlen_for_fp8(max_seqlen, batch_size, align_size, tp_size, cp_size)
 
     local_max_seqlen = max_seqlen // cp_size if cp_size > 1 else max_seqlen
     attention_mask = torch.zeros(batch_size, local_max_seqlen, dtype=torch.bool, device=input_ids.device)


### PR DESCRIPTION
## What

This is the main-branch companion to #6884, requested by maintainers so the BSHD FP8 actor update fix is available on main as well as release/v0.7.1.

It removes the hard BSHD FP8 assertion in the Megatron actor forward path, propagates `use_fp8_padding` into regular BSHD preprocessing for the input and logits processor arguments, and aligns BSHD padded sequence length so TransformerEngine FP8 block quantization sees a local token count divisible by 128. The main branch already had equivalent alignment logic in `preprocess_bshd_engine`; this patch factors that into a helper and reuses it for regular BSHD too.

## Why

With `data_format=bshd` and `fp8=hybrid`/`e4m3`, actor update currently fails before forward with:

```text
AssertionError: fp8 is not supported for bshd format yet
```

Removing the assertion alone is not enough: the padded BSHD shape must also satisfy TE FP8 block quantization alignment.

## Duplicate-work check

Per `AGENTS.md`, I checked for overlapping work before opening this PR:

- `gh issue view 5508 --repo verl-project/verl --comments`
- `gh pr list --repo verl-project/verl --state open --search "5508 in:body" --limit 20`
- `gh pr list --repo verl-project/verl --state open --search "bshd fp8" --limit 20`
- `gh pr list --repo verl-project/verl --state open --search "actor fp8 padding" --limit 20`
- `gh pr list --repo verl-project/verl --state open --search '"fp8 is not supported for bshd format yet"' --limit 20`

The only same-scope result is #6884, which targets `release/v0.7.1`. #6703 appears in some keyword searches but fixes a THD/CP OOB issue and is not a duplicate of this BSHD actor-padding fix.

## Tests

- `git diff --check` passed
- `python -m py_compile tests/models/test_mcore_bshd_fp8_padding.py verl/models/mcore/util.py verl/models/mcore/model_forward.py` passed using the local bundled Python
- `python -m pytest tests/models/test_mcore_bshd_fp8_padding.py -q` could not run locally because this Windows helper environment does not have `pytest` installed
- A direct execution attempt of the test function could not run locally because this helper environment does not have `torch` installed

AI assistance was used to prepare this patch; human review done before marking ready for review.
