### PR TITLE
[data] fix: make overlong prompt filter picklable

### DIFF
--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 import json
 import os
+import pickle
+import ssl
 from copy import deepcopy
 from pathlib import Path
 
@@ -22,6 +24,7 @@ from omegaconf import OmegaConf
 from PIL import Image
 from torch.utils.data import DataLoader
 
+import verl.utils.dataset.rl_dataset as rl_dataset_module
 from verl import DataProto
 from verl.utils import hf_processor, hf_tokenizer
 from verl.utils.dataset.rl_dataset import RLHFDataset, collate_fn
@@ -43,6 +46,88 @@ def get_gsm8k_data():
     local_path = os.path.join(local_folder, "train.parquet")
     os.makedirs(local_folder, exist_ok=True)
     return local_path
+
+
+class _FakeTokenizer:
+    name_or_path = "fake-processor"
+
+    def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=True, **kwargs):
+        assert add_generation_prompt
+        assert tokenize
+        return list(range(len(messages[0]["content"].split())))
+
+    def __call__(self, text, add_special_tokens=False, return_attention_mask=False):
+        assert not add_special_tokens
+        assert not return_attention_mask
+        return {"input_ids": list(range(len(text.split())))}
+
+
+class _FakeProcessor:
+    tokenizer = _FakeTokenizer()
+
+    def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=False, **kwargs):
+        assert add_generation_prompt
+        assert not tokenize
+        return messages[0]["content"]
+
+
+class _UnpickleableProcessor(_FakeProcessor):
+    def __init__(self):
+        self.context = ssl.create_default_context()
+
+
+def _mock_filter_dataset(processor=None, num_workers=2):
+    dataset = RLHFDataset.__new__(RLHFDataset)
+    dataset.processor = processor
+    dataset.tokenizer = None if processor is not None else _FakeTokenizer()
+    dataset.prompt_key = "prompt"
+    dataset.image_key = "images"
+    dataset.video_key = "videos"
+    dataset.audio_key = "audios"
+    dataset.image_patch_size = 14
+    dataset.config = OmegaConf.create({"trust_remote_code": False})
+    dataset.max_prompt_length = 2
+    dataset.filter_overlong_prompts = True
+    dataset.apply_chat_template_kwargs = {}
+    dataset.mm_processor_kwargs = {}
+    dataset.tool_schemas = None
+    dataset.num_workers = num_workers
+    return dataset
+
+
+def test_maybe_filter_out_long_prompts_uses_picklable_multiprocess_processor_filter(monkeypatch):
+    calls = []
+
+    def load_fake_processor(source, trust_remote_code=False, use_fast=True):
+        assert source == "fake-processor"
+        assert not trust_remote_code
+        assert use_fast
+        return _FakeProcessor()
+
+    monkeypatch.setattr(rl_dataset_module, "_load_filter_processor", load_fake_processor, raising=False)
+
+    class FakeDataFrame(list):
+        def filter(self, function, num_proc=None, desc=None, fn_kwargs=None):
+            calls.append(num_proc)
+            if num_proc is not None:
+                pickle.dumps((function, fn_kwargs))
+                assert fn_kwargs["processor_path"] == "fake-processor"
+                assert "processor" not in fn_kwargs
+            return FakeDataFrame([doc for doc in self if function(doc, **(fn_kwargs or {}))])
+
+    dataset = _mock_filter_dataset(processor=_UnpickleableProcessor(), num_workers=2)
+    dataframe = FakeDataFrame(
+        [
+            {"prompt": [{"role": "user", "content": "short"}]},
+            {"prompt": [{"role": "user", "content": "one two three"}]},
+        ]
+    )
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert calls == [2]
+    assert len(filtered) == 1
+    assert filtered[0]["prompt"][0]["content"] == "short"
 
 
 def test_rl_dataset():
@@ -133,8 +218,8 @@ def test_build_messages_accepts_video_path_or_frame_list(videos, expected_video)
 
 def test_maybe_filter_out_long_prompts_accepts_image_path(monkeypatch):
     class FakeDataFrame(list):
-        def filter(self, fn, num_proc=None, desc=None):
-            return FakeDataFrame([doc for doc in self if fn(doc)])
+        def filter(self, fn, num_proc=None, desc=None, fn_kwargs=None):
+            return FakeDataFrame([doc for doc in self if fn(doc, **(fn_kwargs or {}))])
 
     class FakeProcessor:
         def apply_chat_template(self, messages, add_generation_prompt=True, tokenize=False, **kwargs):

--- a/tests/utils/dataset/test_rl_dataset_on_cpu.py
+++ b/tests/utils/dataset/test_rl_dataset_on_cpu.py
@@ -130,6 +130,65 @@ def test_maybe_filter_out_long_prompts_uses_picklable_multiprocess_processor_fil
     assert filtered[0]["prompt"][0]["content"] == "short"
 
 
+def test_maybe_filter_out_long_prompts_disables_multiprocessing_without_processor_path():
+    calls = []
+
+    class PathlessProcessor(_UnpickleableProcessor):
+        tokenizer = type("PathlessTokenizer", (_FakeTokenizer,), {"name_or_path": None})()
+
+    class FakeDataFrame(list):
+        def filter(self, function, num_proc=None, desc=None, fn_kwargs=None):
+            calls.append(num_proc)
+            assert num_proc is None
+            assert "processor" in fn_kwargs
+            assert "processor_path" not in fn_kwargs
+            return FakeDataFrame([doc for doc in self if function(doc, **(fn_kwargs or {}))])
+
+    dataset = _mock_filter_dataset(processor=PathlessProcessor(), num_workers=2)
+    dataframe = FakeDataFrame(
+        [
+            {"prompt": [{"role": "user", "content": "short"}]},
+            {"prompt": [{"role": "user", "content": "one two three"}]},
+        ]
+    )
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert calls == [None]
+    assert len(filtered) == 1
+    assert filtered[0]["prompt"][0]["content"] == "short"
+
+
+def test_maybe_filter_out_long_prompts_disables_multiprocessing_without_tokenizer_path():
+    calls = []
+
+    class PathlessTokenizer(_FakeTokenizer):
+        name_or_path = None
+
+    class FakeDataFrame(list):
+        def filter(self, function, num_proc=None, desc=None, fn_kwargs=None):
+            calls.append(num_proc)
+            assert num_proc is None
+            assert "tokenizer" in fn_kwargs
+            assert "tokenizer_path" not in fn_kwargs
+            return FakeDataFrame([doc for doc in self if function(doc, **(fn_kwargs or {}))])
+
+    dataset = _mock_filter_dataset(num_workers=2)
+    dataset.tokenizer = PathlessTokenizer()
+    dataframe = FakeDataFrame(
+        [
+            {"prompt": [{"role": "user", "content": "short"}]},
+            {"prompt": [{"role": "user", "content": "one two three"}]},
+        ]
+    )
+
+    filtered = dataset.maybe_filter_out_long_prompts(dataframe)
+
+    assert calls == [None]
+    assert len(filtered) == 1
+    assert filtered[0]["prompt"][0]["content"] == "short"
+
+
 def test_rl_dataset():
     tokenizer = hf_tokenizer(os.path.expanduser("~/models/deepseek-ai/deepseek-coder-1.3b-instruct"))
     local_path = get_gsm8k_data()

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -477,7 +477,9 @@ class RLHFDataset(Dataset):
 
             if self.processor is not None:
                 processor_path = _get_processor_path(self.processor)
-                if use_multiprocessing and processor_path is not None:
+                if processor_path is None:
+                    use_multiprocessing = False
+                if use_multiprocessing:
                     filter_kwargs["processor_path"] = processor_path
                 else:
                     filter_kwargs["processor"] = self.processor
@@ -490,10 +492,15 @@ class RLHFDataset(Dataset):
                         "mm_processor_kwargs": dict(**self.mm_processor_kwargs),
                     }
                 )
+                if not use_multiprocessing:
+                    filter_kwargs["process_multi_modal_info_fn"] = self._process_multi_modal_info
+                    filter_kwargs["config"] = self.config
                 filter_function = _filter_prompt_length_with_processor
             else:
                 tokenizer_path = _get_tokenizer_path(self.tokenizer)
-                if use_multiprocessing and tokenizer_path is not None:
+                if tokenizer_path is None:
+                    use_multiprocessing = False
+                if use_multiprocessing:
                     filter_kwargs["tokenizer_path"] = tokenizer_path
                 else:
                     filter_kwargs["tokenizer"] = self.tokenizer
@@ -501,7 +508,7 @@ class RLHFDataset(Dataset):
 
             dataframe = dataframe.filter(
                 filter_function,
-                num_proc=self.num_workers,
+                num_proc=self.num_workers if use_multiprocessing else None,
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
                 fn_kwargs=filter_kwargs,
             )

--- a/verl/utils/dataset/rl_dataset.py
+++ b/verl/utils/dataset/rl_dataset.py
@@ -38,6 +38,274 @@ from verl.utils.tokenizer import build_multimodal_processor_inputs, normalize_to
 logger = logging.getLogger(__name__)
 
 
+_FILTER_PROCESSOR_CACHE: dict[tuple[str, bool, bool], ProcessorMixin] = {}
+_FILTER_TOKENIZER_CACHE: dict[tuple[str, bool], PreTrainedTokenizer] = {}
+
+
+def _get_processor_path(processor: ProcessorMixin) -> str | None:
+    return getattr(processor, "name_or_path", None) or getattr(
+        getattr(processor, "tokenizer", None), "name_or_path", None
+    )
+
+
+def _get_tokenizer_path(tokenizer: PreTrainedTokenizer) -> str | None:
+    return getattr(tokenizer, "name_or_path", None)
+
+
+def _load_filter_processor(source: str, trust_remote_code: bool = False, use_fast: bool = True) -> ProcessorMixin:
+    from verl.utils import hf_processor
+
+    processor = hf_processor(source, trust_remote_code=trust_remote_code, use_fast=use_fast)
+    if processor is None:
+        raise ValueError(f"Failed to create processor from {source!r} for prompt filtering")
+    return processor
+
+
+def _load_filter_tokenizer(source: str, trust_remote_code: bool = False) -> PreTrainedTokenizer:
+    from verl.utils import hf_tokenizer
+
+    return hf_tokenizer(source, trust_remote_code=trust_remote_code)
+
+
+def _get_filter_processor(source: str, trust_remote_code: bool = False, use_fast: bool = True) -> ProcessorMixin:
+    key = (source, bool(trust_remote_code), bool(use_fast))
+    if key not in _FILTER_PROCESSOR_CACHE:
+        _FILTER_PROCESSOR_CACHE[key] = _load_filter_processor(
+            source, trust_remote_code=trust_remote_code, use_fast=use_fast
+        )
+    return _FILTER_PROCESSOR_CACHE[key]
+
+
+def _get_filter_tokenizer(source: str, trust_remote_code: bool = False) -> PreTrainedTokenizer:
+    key = (source, bool(trust_remote_code))
+    if key not in _FILTER_TOKENIZER_CACHE:
+        _FILTER_TOKENIZER_CACHE[key] = _load_filter_tokenizer(source, trust_remote_code=trust_remote_code)
+    return _FILTER_TOKENIZER_CACHE[key]
+
+
+def _build_messages_for_filter(
+    example: dict,
+    *,
+    prompt_key: str,
+    image_key: str,
+    video_key: str,
+    audio_key: str,
+) -> list:
+    messages = copy.deepcopy(example[prompt_key])
+    # When concatenating multimodal datasets, get will return None for samples without a modality column.
+    images = example.get(image_key, None) or []
+    videos = example.get(video_key, None) or []
+    audios = example.get(audio_key, None) or []
+
+    image_offset, video_offset, audio_offset = 0, 0, 0
+    for message in messages:
+        if not images and not videos and not audios:
+            continue
+
+        content = message["content"]
+        if not isinstance(content, str):
+            continue
+
+        content_list = []
+        segments = re.split("(<image>|<video>|<audio>)", content)
+        segments = [item for item in segments if item != ""]
+        for segment in segments:
+            if segment == "<image>":
+                assert image_offset < len(images), f"image_offset {image_offset} >= len(images) {len(images)}"
+                image = images[image_offset]
+                if isinstance(image, Image.Image):
+                    image = image.convert("RGB")
+                    content_list.append({"type": "image", "image": image})
+                elif isinstance(image, dict):
+                    image = dict(image)
+                    if "bytes" in image:
+                        image["image"] = Image.open(BytesIO(image["bytes"]))
+                    content_list.append({"type": "image", **image})
+                elif isinstance(image, str | os.PathLike):
+                    content_list.append({"type": "image", "image": os.fspath(image)})
+                else:
+                    raise TypeError(
+                        f"image must be dict, PIL.Image, or path-like, unsupported image type: {type(image)}"
+                    )
+                image_offset += 1
+            elif segment == "<video>":
+                assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
+                video = videos[video_offset]
+                if isinstance(video, dict):
+                    content_list.append({"type": "video", **video})
+                elif isinstance(video, str | os.PathLike):
+                    content_list.append({"type": "video", "video": os.fspath(video)})
+                elif isinstance(video, list):
+                    video = [os.fspath(frame) if isinstance(frame, os.PathLike) else frame for frame in video]
+                    content_list.append({"type": "video", "video": video})
+                else:
+                    raise TypeError(f"video must be dict, list, or path-like, unsupported video type: {type(video)}")
+                video_offset += 1
+            elif segment == "<audio>":
+                assert audio_offset < len(audios), f"audio_offset {audio_offset} >= len(audios) {len(audios)}"
+                audio = audios[audio_offset]
+                if isinstance(audio, dict):
+                    payload = dict(audio)
+                    payload["type"] = "audio"
+                    if "audio" not in payload and "audio_url" not in payload:
+                        payload = {"type": "audio", "audio": audio}
+                    content_list.append(payload)
+                else:
+                    content_list.append({"type": "audio", "audio": audio})
+                audio_offset += 1
+            else:
+                content_list.append({"type": "text", "text": segment})
+        message["content"] = content_list
+
+    assert image_offset == len(images), f"image_offset {image_offset} != len(images) {len(images)}"
+    assert video_offset == len(videos), f"video_offset {video_offset} != len(videos) {len(videos)}"
+    assert audio_offset == len(audios), f"audio_offset {audio_offset} != len(audios) {len(audios)}"
+    return messages
+
+
+def _extract_audio_info_for_filter(messages: list[dict]) -> list[Any]:
+    audios = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "audio":
+                continue
+            if "audio" in item:
+                audios.append(item["audio"])
+            elif "audio_url" in item:
+                audios.append(item["audio_url"])
+            else:
+                audios.append({k: v for k, v in item.items() if k != "type"})
+    return audios or None
+
+
+def _process_multi_modal_info_for_filter(
+    messages: list[dict],
+    image_patch_size,
+) -> tuple[list[Image.Image], list[Any], list[Any]]:
+    has_visual = any(
+        isinstance(message.get("content"), list)
+        and any(isinstance(item, dict) and item.get("type") in {"image", "video"} for item in message["content"])
+        for message in messages
+    )
+    if has_visual:
+        from qwen_vl_utils import process_vision_info
+
+        images, videos = process_vision_info(messages, image_patch_size=image_patch_size, return_video_metadata=True)
+    else:
+        images, videos = None, None
+    audios = _extract_audio_info_for_filter(messages)
+    return images, videos, audios
+
+
+def _filter_prompt_length_with_processor(
+    doc: dict,
+    *,
+    max_prompt_length: int,
+    prompt_key: str,
+    image_key: str,
+    video_key: str,
+    audio_key: str,
+    image_patch_size: int,
+    apply_chat_template_kwargs: dict,
+    mm_processor_kwargs: dict,
+    tool_schemas: list[dict] | None,
+    processor_path: str | None = None,
+    processor: ProcessorMixin | None = None,
+    trust_remote_code: bool = False,
+    use_fast: bool = True,
+    process_multi_modal_info_fn=None,
+    config: DictConfig | None = None,
+) -> bool:
+    try:
+        if processor is None:
+            if processor_path is None:
+                raise ValueError("processor_path is required when processor is not provided")
+            processor = _get_filter_processor(processor_path, trust_remote_code=trust_remote_code, use_fast=use_fast)
+
+        messages = _build_messages_for_filter(
+            doc,
+            prompt_key=prompt_key,
+            image_key=image_key,
+            video_key=video_key,
+            audio_key=audio_key,
+        )
+        # pass tool schemas if available so the processor can format prompts
+        apply_kwargs = dict(**apply_chat_template_kwargs)
+        if tool_schemas is not None:
+            apply_kwargs["tools"] = tool_schemas
+
+        raw_prompt = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=False, **apply_kwargs)
+        if process_multi_modal_info_fn is None:
+            images, videos, audios = _process_multi_modal_info_for_filter(messages, image_patch_size)
+        else:
+            images, videos, audios = process_multi_modal_info_fn(messages, image_patch_size, config)
+        if images is None and videos is None and audios is None:
+            # only text prompt
+            prompt_length = len(
+                processor.tokenizer(
+                    text=raw_prompt,
+                    add_special_tokens=False,  # avoid adding special tokens
+                    return_attention_mask=False,
+                )["input_ids"]
+            )
+        else:
+            # multi-modal prompt
+            prompt_length = len(
+                build_multimodal_processor_inputs(
+                    processor,
+                    text=[raw_prompt],
+                    images=images,
+                    videos=videos,
+                    audio=audios,
+                    mm_processor_kwargs=mm_processor_kwargs,
+                )["input_ids"][0]
+            )
+        return prompt_length <= max_prompt_length
+    except Exception:
+        print("Error processing one of the samples, skipping...")
+        traceback.print_exc()
+        return False
+
+
+def _filter_prompt_length_with_tokenizer(
+    doc: dict,
+    *,
+    max_prompt_length: int,
+    prompt_key: str,
+    apply_chat_template_kwargs: dict,
+    tool_schemas: list[dict] | None,
+    tokenizer_path: str | None = None,
+    tokenizer: PreTrainedTokenizer | None = None,
+    trust_remote_code: bool = False,
+) -> bool:
+    try:
+        if tokenizer is None:
+            if tokenizer_path is None:
+                raise ValueError("tokenizer_path is required when tokenizer is not provided")
+            tokenizer = _get_filter_tokenizer(tokenizer_path, trust_remote_code=trust_remote_code)
+
+        apply_kwargs = dict(**apply_chat_template_kwargs)
+        if tool_schemas is not None:
+            apply_kwargs["tools"] = tool_schemas
+
+        # Keep explicit tokenization to avoid transformers version default changes.
+        apply_kwargs.pop("tokenize", None)
+        apply_kwargs.pop("return_dict", None)
+        apply_kwargs.pop("return_tensors", None)
+
+        tokenized_prompt = tokenizer.apply_chat_template(
+            doc[prompt_key], add_generation_prompt=True, tokenize=True, **apply_kwargs
+        )
+        return len(normalize_token_ids(tokenized_prompt)) <= max_prompt_length
+    except Exception:
+        print("Error processing one of the samples, skipping...")
+        traceback.print_exc()
+        return False
+
+
 def collate_fn(data_list: list[dict]) -> dict:
     """
     Collate a batch of sample dicts into batched tensors and arrays.
@@ -197,78 +465,45 @@ class RLHFDataset(Dataset):
     def maybe_filter_out_long_prompts(self, dataframe: datasets.Dataset = None):
         # filter out too long prompts
         if self.filter_overlong_prompts:
-            tokenizer = self.tokenizer
-            processor = self.processor
-            prompt_key = self.prompt_key
+            filter_kwargs = {
+                "max_prompt_length": self.max_prompt_length,
+                "prompt_key": self.prompt_key,
+                "apply_chat_template_kwargs": dict(**self.apply_chat_template_kwargs),
+                "tool_schemas": self.tool_schemas,
+                "trust_remote_code": self.config.get("trust_remote_code", False),
+            }
 
-            if processor is not None:
+            use_multiprocessing = self.num_workers not in (None, 0)
 
-                def doc2len(doc) -> int:
-                    try:
-                        messages = self._build_messages(doc, key=self.prompt_key)
-                        # pass tool schemas if available so the processor can format prompts
-                        apply_kwargs = dict(**self.apply_chat_template_kwargs)
-                        if self.tool_schemas is not None:
-                            apply_kwargs["tools"] = self.tool_schemas
-
-                        raw_prompt = self.processor.apply_chat_template(
-                            messages, add_generation_prompt=True, tokenize=False, **apply_kwargs
-                        )
-                        images, videos, audios = self._process_multi_modal_info(
-                            messages, self.image_patch_size, self.config
-                        )
-                        if images is None and videos is None and audios is None:
-                            # only text prompt
-                            return len(
-                                processor.tokenizer(
-                                    text=raw_prompt,
-                                    add_special_tokens=False,  # avoid adding special tokens
-                                    return_attention_mask=False,
-                                )["input_ids"]
-                            )
-                        else:
-                            # multi-modal prompt
-                            return len(
-                                build_multimodal_processor_inputs(
-                                    processor,
-                                    text=[raw_prompt],
-                                    images=images,
-                                    videos=videos,
-                                    audio=audios,
-                                    mm_processor_kwargs=self.mm_processor_kwargs,
-                                )["input_ids"][0]
-                            )
-                    except Exception:
-                        print("Error processing one of the samples, skipping...")
-                        traceback.print_exc()
-                        return self.max_prompt_length + 1
-
+            if self.processor is not None:
+                processor_path = _get_processor_path(self.processor)
+                if use_multiprocessing and processor_path is not None:
+                    filter_kwargs["processor_path"] = processor_path
+                else:
+                    filter_kwargs["processor"] = self.processor
+                filter_kwargs.update(
+                    {
+                        "image_key": self.image_key,
+                        "video_key": self.video_key,
+                        "audio_key": self.audio_key,
+                        "image_patch_size": self.image_patch_size,
+                        "mm_processor_kwargs": dict(**self.mm_processor_kwargs),
+                    }
+                )
+                filter_function = _filter_prompt_length_with_processor
             else:
-
-                def doc2len(doc) -> int:
-                    try:
-                        apply_kwargs = dict(**self.apply_chat_template_kwargs)
-                        if self.tool_schemas is not None:
-                            apply_kwargs["tools"] = self.tool_schemas
-
-                        # Keep explicit tokenization to avoid transformers version default changes.
-                        apply_kwargs.pop("tokenize", None)
-                        apply_kwargs.pop("return_dict", None)
-                        apply_kwargs.pop("return_tensors", None)
-
-                        tokenized_prompt = tokenizer.apply_chat_template(
-                            doc[prompt_key], add_generation_prompt=True, tokenize=True, **apply_kwargs
-                        )
-                        return len(normalize_token_ids(tokenized_prompt))
-                    except Exception:
-                        print("Error processing one of the samples, skipping...")
-                        traceback.print_exc()
-                        return self.max_prompt_length + 1
+                tokenizer_path = _get_tokenizer_path(self.tokenizer)
+                if use_multiprocessing and tokenizer_path is not None:
+                    filter_kwargs["tokenizer_path"] = tokenizer_path
+                else:
+                    filter_kwargs["tokenizer"] = self.tokenizer
+                filter_function = _filter_prompt_length_with_tokenizer
 
             dataframe = dataframe.filter(
-                lambda doc: doc2len(doc) <= self.max_prompt_length,
+                filter_function,
                 num_proc=self.num_workers,
                 desc=f"Filtering prompts longer than {self.max_prompt_length} tokens",
+                fn_kwargs=filter_kwargs,
             )
 
             print(f"filter dataset len: {len(dataframe)}")
@@ -310,78 +545,15 @@ class RLHFDataset(Dataset):
         Returns:
             messages: List of messages with replaced placeholder.
         """
-        messages: list = example[key]
-        # When concatenating multimodal datasets, get will return None for samples without a modality column.
-        images = example.get(self.image_key, None) or []
-        videos = example.get(self.video_key, None) or []
-        audios = example.get(self.audio_key, None) or []
-
-        image_offset, video_offset, audio_offset = 0, 0, 0
-        for message in messages:
-            if not images and not videos and not audios:
-                continue
+        if example.get(self.image_key, None) or example.get(self.video_key, None) or example.get(self.audio_key, None):
             assert self.processor is not None, "processor is needed to process multimodal data"
-
-            content = message["content"]
-            if not isinstance(content, str):
-                continue
-
-            content_list = []
-            segments = re.split("(<image>|<video>|<audio>)", content)
-            segments = [item for item in segments if item != ""]
-            for segment in segments:
-                if segment == "<image>":
-                    assert image_offset < len(images), f"image_offset {image_offset} >= len(images) {len(images)}"
-                    image = images[image_offset]
-                    if isinstance(image, Image.Image):
-                        image = image.convert("RGB")
-                        content_list.append({"type": "image", "image": image})
-                    elif isinstance(image, dict):
-                        if "bytes" in image:
-                            image["image"] = Image.open(BytesIO(image["bytes"]))
-                        content_list.append({"type": "image", **image})
-                    elif isinstance(image, str | os.PathLike):
-                        content_list.append({"type": "image", "image": os.fspath(image)})
-                    else:
-                        raise TypeError(
-                            f"image must be dict, PIL.Image, or path-like, unsupported image type: {type(image)}"
-                        )
-                    image_offset += 1
-                elif segment == "<video>":
-                    assert video_offset < len(videos), f"video_offset {video_offset} >= len(videos) {len(videos)}"
-                    video = videos[video_offset]
-                    if isinstance(video, dict):
-                        content_list.append({"type": "video", **video})
-                    elif isinstance(video, str | os.PathLike):
-                        content_list.append({"type": "video", "video": os.fspath(video)})
-                    elif isinstance(video, list):
-                        video = [os.fspath(frame) if isinstance(frame, os.PathLike) else frame for frame in video]
-                        content_list.append({"type": "video", "video": video})
-                    else:
-                        raise TypeError(
-                            f"video must be dict, list, or path-like, unsupported video type: {type(video)}"
-                        )
-                    video_offset += 1
-                elif segment == "<audio>":
-                    assert audio_offset < len(audios), f"audio_offset {audio_offset} >= len(audios) {len(audios)}"
-                    audio = audios[audio_offset]
-                    if isinstance(audio, dict):
-                        payload = dict(audio)
-                        payload["type"] = "audio"
-                        if "audio" not in payload and "audio_url" not in payload:
-                            payload = {"type": "audio", "audio": audio}
-                        content_list.append(payload)
-                    else:
-                        content_list.append({"type": "audio", "audio": audio})
-                    audio_offset += 1
-                else:
-                    content_list.append({"type": "text", "text": segment})
-            message["content"] = content_list
-
-        assert image_offset == len(images), f"image_offset {image_offset} != len(images) {len(images)}"
-        assert video_offset == len(videos), f"video_offset {video_offset} != len(videos) {len(videos)}"
-        assert audio_offset == len(audios), f"audio_offset {audio_offset} != len(audios) {len(audios)}"
-        return messages
+        return _build_messages_for_filter(
+            example,
+            prompt_key=key,
+            image_key=self.image_key,
+            video_key=self.video_key,
+            audio_key=self.audio_key,
+        )
 
     def __getitem__(self, item):
         """For rollout, apply_chat_template has been moved to AgentLoop, so we only return raw_prompt here."""

--- a/verl/utils/tokenizer/tokenizer.py
+++ b/verl/utils/tokenizer/tokenizer.py
@@ -194,6 +194,7 @@ def hf_processor(name_or_path, **kwargs):
 
     try:
         processor = AutoProcessor.from_pretrained(name_or_path, **kwargs)
+        processor.name_or_path = name_or_path
         # In newer transformers, AutoProcessor may legitimately fall back to a
         # tokenizer backend (e.g. TokenizersBackend) for text-only models.
         # Treat it as "no multimodal processor" and let callers use hf_tokenizer.


### PR DESCRIPTION
### What does this PR do?

Follow-up to #4894 and #6872.

This PR addresses the maintainer feedback to make the overlong prompt filter picklable under `Dataset.filter(..., num_proc=N)` instead of falling back to single-process filtering.

The previous implementation passed a nested `lambda`/`doc2len` closure to Hugging Face Datasets. In the multimodal path that closure captured `self` and the processor instance, so processors containing non-picklable state such as `ssl.SSLContext` could fail before multiprocessing workers processed any examples.

This change routes prompt-length filtering through module-level callables and picklable `fn_kwargs`. For multiprocessing, tokenizer/processor paths are passed to workers and loaded lazily per worker process with a small process-local cache. Single-process filtering keeps using the already-created tokenizer/processor object, and pathless tokenizer/processor fallbacks now explicitly disable multiprocessing so live objects are not sent through `num_proc` workers.

This is not duplicating an existing PR: duplicate-work checks found no open PRs for #4894 or the area keywords.

AI assistance was used to prepare this change; the submitting human should review every changed line and the test evidence before merge.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+4894+in%3Abody and https://github.com/verl-project/verl/pulls?q=is%3Apr+picklable+prompt+filter+SSLContext+filter_overlong_prompts
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
uvx pre-commit run ruff --files verl/utils/dataset/rl_dataset.py verl/utils/tokenizer/tokenizer.py tests/utils/dataset/test_rl_dataset_on_cpu.py
uvx pre-commit run ruff-format --files verl/utils/dataset/rl_dataset.py verl/utils/tokenizer/tokenizer.py tests/utils/dataset/test_rl_dataset_on_cpu.py
python -m compileall -q verl/utils/dataset/rl_dataset.py verl/utils/tokenizer/tokenizer.py tests/utils/dataset/test_rl_dataset_on_cpu.py
PYTHONPATH=. uv run --no-project --with pytest --with omegaconf --with pillow --with torch --with datasets --with transformers --with tensordict --with ray pytest tests/utils/dataset/test_rl_dataset_on_cpu.py -q -k 'picklable_multiprocess_processor_filter or disables_multiprocessing_without_processor_path or disables_multiprocessing_without_tokenizer_path or build_messages_accepts_image_path or build_messages_accepts_video_path_or_frame_list or maybe_filter_out_long_prompts_accepts_image_path'
PYTHONPATH=. uv run --no-project --with pytest --with omegaconf --with pillow --with torch --with datasets --with transformers --with tensordict --with ray --with qwen-vl-utils pytest tests/utils/test_audio_input_support_on_cpu.py -q
git diff --check
```

Also ran a local `Dataset.from_list(...).filter(num_proc=2)` smoke test with a fake processor holding `ssl.create_default_context()`. The filter completed with multiprocessing enabled and kept the expected short prompt.

### API and Usage Example

No public API change. Existing `data.filter_overlong_prompts_workers` behavior is preserved; when multiprocessing is configured, the filter callable and kwargs are now picklable instead of capturing `RLHFDataset` or processor objects.

```python
# Existing config continues to use multiprocessing filtering when the tokenizer/processor
# can be reloaded from a path.
data.filter_overlong_prompts=True
data.filter_overlong_prompts_workers=2
```

### Design & Code Changes

- Replace nested prompt-length filter closures with module-level filter callables.
- Pass filter state through `fn_kwargs` so `Dataset.filter(num_proc=...)` can pickle the callable and arguments.
- Pass tokenizer/processor paths to multiprocessing workers and lazily load them with a process-local cache.
- Preserve single-process behavior by using the already-created tokenizer/processor object when `num_proc` is disabled.
- Disable multiprocessing for pathless tokenizer/processor fallbacks so live objects are not serialized to workers.
- Expose `name_or_path` on processors created by `hf_processor()` so worker processes can reconstruct the processor.
- Add CPU regression coverage for the picklable multiprocessing processor path and both pathless processor/tokenizer fallbacks.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
  - Ran targeted `pre-commit` ruff and ruff-format hooks on the changed files listed above.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
  - Not applicable: no user-facing API or docs behavior change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: added CPU regression tests in `tests/utils/dataset/test_rl_dataset_on_cpu.py`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
  - Not applicable: no recipe submodule change.
