### PR TITLE
[rollout] feat: add optional per-wave rollout resource warmup/cleanup hooks

### DIFF
--- a/tests/experimental/agent_loop/test_rollout_resource_hooks_on_cpu.py
+++ b/tests/experimental/agent_loop/test_rollout_resource_hooks_on_cpu.py
@@ -1,0 +1,130 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for per-wave rollout resource warmup/cleanup hooks (CPU-only, no GPU/Ray)."""
+
+import asyncio
+
+import pytest
+
+from verl.experimental.agent_loop.agent_loop import (
+    _maybe_await,
+    _resolve_rollout_resource_hook,
+    _with_rollout_resource_hooks,
+)
+
+# Module-level functions so they are importable via fully-qualified name (mirrors real usage).
+
+
+def sync_hook(batch, config):
+    _CALLS.append(("sync", batch, config))
+
+
+async def async_hook(batch, config):
+    _CALLS.append(("async", batch, config))
+
+
+_CALLS: list = []
+NOT_CALLABLE = 123
+
+
+def test_maybe_await_passthrough_and_await():
+    async def _run():
+        assert await _maybe_await(5) == 5
+
+        async def coro():
+            return 7
+
+        assert await _maybe_await(coro()) == 7
+
+    asyncio.run(_run())
+
+
+def test_resolve_none_returns_none():
+    assert _resolve_rollout_resource_hook(None, "warmup") is None
+    assert _resolve_rollout_resource_hook("", "warmup") is None
+
+
+def test_resolve_valid_path_returns_callable():
+    fn = _resolve_rollout_resource_hook(f"{__name__}.sync_hook", "warmup")
+    assert fn is sync_hook
+
+
+def test_resolve_non_callable_raises():
+    with pytest.raises(TypeError):
+        _resolve_rollout_resource_hook(f"{__name__}.NOT_CALLABLE", "warmup")
+
+
+def test_hooks_run_in_order_around_impl():
+    """warmup -> impl -> cleanup, regardless of sync/async hooks."""
+    events = []
+
+    def warmup(batch, config):
+        events.append(("warmup", batch, config))
+
+    async def cleanup(batch, config):
+        events.append(("cleanup", batch, config))
+
+    async def impl():
+        events.append("impl")
+        return "result"
+
+    out = asyncio.run(_with_rollout_resource_hooks(warmup, cleanup, "BATCH", "CFG", impl))
+    assert out == "result"
+    assert events == [("warmup", "BATCH", "CFG"), "impl", ("cleanup", "BATCH", "CFG")]
+
+
+def test_no_hooks_is_noop():
+    async def impl():
+        return "ok"
+
+    out = asyncio.run(_with_rollout_resource_hooks(None, None, "B", "C", impl))
+    assert out == "ok"
+
+
+def test_cleanup_runs_even_on_impl_error():
+    cleaned = []
+
+    def cleanup(batch, config):
+        cleaned.append(True)
+
+    async def impl():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(_with_rollout_resource_hooks(None, cleanup, "B", "C", impl))
+    assert cleaned == [True]
+
+
+def test_warmup_failure_skips_impl_and_cleanup():
+    ran = {"impl": False, "cleanup": False}
+
+    def warmup(batch, config):
+        raise RuntimeError("warmup failed")
+
+    async def impl():
+        ran["impl"] = True
+
+    def cleanup(batch, config):
+        ran["cleanup"] = True
+
+    with pytest.raises(RuntimeError, match="warmup failed"):
+        asyncio.run(_with_rollout_resource_hooks(warmup, cleanup, "B", "C", impl))
+    # impl never ran (warmup raised before try); cleanup not reached either.
+    assert ran == {"impl": False, "cleanup": False}
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/experimental/agent_loop/test_rollout_resource_hooks_on_cpu.py
+++ b/tests/experimental/agent_loop/test_rollout_resource_hooks_on_cpu.py
@@ -106,7 +106,9 @@ def test_cleanup_runs_even_on_impl_error():
     assert cleaned == [True]
 
 
-def test_warmup_failure_skips_impl_and_cleanup():
+def test_warmup_failure_skips_impl_but_runs_cleanup():
+    """A partial/failed warmup must still trigger cleanup so partially-allocated resources
+    (e.g. some spawned sandboxes) are released rather than leaked; impl is skipped."""
     ran = {"impl": False, "cleanup": False}
 
     def warmup(batch, config):
@@ -120,8 +122,8 @@ def test_warmup_failure_skips_impl_and_cleanup():
 
     with pytest.raises(RuntimeError, match="warmup failed"):
         asyncio.run(_with_rollout_resource_hooks(warmup, cleanup, "B", "C", impl))
-    # impl never ran (warmup raised before try); cleanup not reached either.
-    assert ran == {"impl": False, "cleanup": False}
+    # impl never ran (warmup raised first); cleanup still runs to release partial resources.
+    assert ran == {"impl": False, "cleanup": True}
 
 
 if __name__ == "__main__":

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -510,10 +510,15 @@ async def _with_rollout_resource_hooks(warmup, cleanup, batch: DataProto, config
     (e.g. sandboxes) can be pre-spawned for the upcoming batch; ``cleanup(batch, config)``
     runs in ``finally`` so the wave's resources are released even if rollout raises. Both
     hooks are optional (``None`` skips) and may be sync or async.
+
+    ``warmup`` runs inside the ``try`` so a partial warmup (e.g. some sandboxes spawned
+    before it raised) is still followed by ``cleanup`` rather than leaking. Consequently
+    ``cleanup`` must tolerate being called after a failed or partial warmup (i.e. when only
+    some, or none, of the resources were set up).
     """
-    if warmup is not None:
-        await _maybe_await(warmup(batch, config))
     try:
+        if warmup is not None:
+            await _maybe_await(warmup(batch, config))
         return await impl()
     finally:
         if cleanup is not None:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -28,6 +28,7 @@ and is designed to be fully replaceable by other agent frameworks such as:
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import random
@@ -51,6 +52,7 @@ from verl.tools.tool_registry import load_all_tools
 from verl.trainer.distillation import is_distillation_enabled
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.dataset.rl_dataset import RLHFDataset, get_dataset_class
+from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.model import compute_position_id_with_mask
 from verl.utils.profiler import simple_timer
 from verl.utils.ray_utils import auto_await, get_event_loop
@@ -478,6 +480,46 @@ def register(agent_name: str):
     return decorator
 
 
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it is awaitable, else return it as-is.
+
+    Lets rollout-resource hooks be written as either plain or ``async`` functions.
+    """
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _resolve_rollout_resource_hook(path: Optional[str], description: str):
+    """Resolve a fully qualified function path to a callable, or ``None`` when unset.
+
+    Mirrors how custom agent loop / tool paths are loaded; the resolved object must be callable.
+    """
+    if not path:
+        return None
+    fn = load_class_from_fqn(path, description)
+    if not callable(fn):
+        raise TypeError(f"{description} '{path}' did not resolve to a callable, got {type(fn)}")
+    return fn
+
+
+async def _with_rollout_resource_hooks(warmup, cleanup, batch: DataProto, config: DictConfig, impl):
+    """Run ``impl()`` between optional per-wave warmup / cleanup hooks.
+
+    ``warmup(batch, config)`` is awaited before ``impl`` so external rollout resources
+    (e.g. sandboxes) can be pre-spawned for the upcoming batch; ``cleanup(batch, config)``
+    runs in ``finally`` so the wave's resources are released even if rollout raises. Both
+    hooks are optional (``None`` skips) and may be sync or async.
+    """
+    if warmup is not None:
+        await _maybe_await(warmup(batch, config))
+    try:
+        return await impl()
+    finally:
+        if cleanup is not None:
+            await _maybe_await(cleanup(batch, config))
+
+
 class AgentLoopWorker:
     """Agent loop worker takes a batch of messages and run each message in an agent loop.
 
@@ -535,6 +577,16 @@ class AgentLoopWorker:
             agent_loop_configs = OmegaConf.load(resolved_path)
             for agent_loop_config in agent_loop_configs:
                 _agent_loop_registry[agent_loop_config.name] = agent_loop_config
+
+        # Optional per-wave rollout resource warm-up / cleanup hooks (e.g. pre-spawn sandboxes).
+        # Resolved once per worker; called in generate_sequences (see _with_rollout_resource_hooks).
+        self._warmup_rollout_resources = _resolve_rollout_resource_hook(
+            self.rollout_config.agent.warmup_rollout_resources_path, "warmup_rollout_resources_path"
+        )
+        self._cleanup_rollout_resources = _resolve_rollout_resource_hook(
+            self.rollout_config.agent.cleanup_rollout_resources_path, "cleanup_rollout_resources_path"
+        )
+
         if self.model_config.get("custom_chat_template", None) is not None:
             if self.model_config.processor is not None:
                 self.model_config.processor.chat_template = self.model_config.custom_chat_template
@@ -559,6 +611,21 @@ class AgentLoopWorker:
         return mm_processor_kwargs
 
     async def generate_sequences(self, batch: DataProto) -> DataProto:
+        """Generate sequences for a rollout wave, wrapped by optional resource warmup/cleanup hooks.
+
+        ``warmup_rollout_resources_path`` / ``cleanup_rollout_resources_path`` (if configured) run
+        once per wave around the whole batch so external resources (e.g. sandboxes) can be
+        pre-spawned for ``len(batch)`` rollouts and released afterwards. Default = no-op.
+        """
+        return await _with_rollout_resource_hooks(
+            self._warmup_rollout_resources,
+            self._cleanup_rollout_resources,
+            batch,
+            self.config,
+            lambda: self._generate_sequences_impl(batch),
+        )
+
+    async def _generate_sequences_impl(self, batch: DataProto) -> DataProto:
         """Generate sequences from agent loop.
 
         Args:

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -344,6 +344,8 @@ actor_rollout_ref:
       num_workers: 8
       default_agent_loop: single_turn_agent
       agent_loop_config_path: null
+      warmup_rollout_resources_path: null
+      cleanup_rollout_resources_path: null
       custom_async_server:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -300,6 +300,8 @@ actor_rollout_ref:
       num_workers: 8
       default_agent_loop: single_turn_agent
       agent_loop_config_path: null
+      warmup_rollout_resources_path: null
+      cleanup_rollout_resources_path: null
       custom_async_server:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -309,6 +309,8 @@ actor_rollout_ref:
       num_workers: 8
       default_agent_loop: single_turn_agent
       agent_loop_config_path: null
+      warmup_rollout_resources_path: null
+      cleanup_rollout_resources_path: null
       custom_async_server:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -310,6 +310,8 @@ actor_rollout_ref:
       num_workers: 8
       default_agent_loop: single_turn_agent
       agent_loop_config_path: null
+      warmup_rollout_resources_path: null
+      cleanup_rollout_resources_path: null
       custom_async_server:
         _target_: verl.workers.config.CustomAsyncServerConfig
         path: null

--- a/verl/trainer/config/rollout/rollout.yaml
+++ b/verl/trainer/config/rollout/rollout.yaml
@@ -256,6 +256,14 @@ agent:
   #   max_terms: 6
   agent_loop_config_path: null
 
+  # Optional fully qualified function paths, called once per rollout wave on each AgentLoopWorker,
+  # to warm up / clean up external rollout resources (e.g. pre-spawn sandboxes for the upcoming
+  # batch). Signature: `fn(batch, config)`; may be sync or async. null disables (no behavior change).
+  #   warmup_rollout_resources_path: my_pkg.warmup.warmup_rollout_resources
+  #   cleanup_rollout_resources_path: my_pkg.warmup.cleanup_rollout_resources
+  warmup_rollout_resources_path: null
+  cleanup_rollout_resources_path: null
+
   # custom async server configs
   custom_async_server:
 

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -77,6 +77,13 @@ class AgentLoopConfig(BaseConfig):
     # Fully qualified class name for custom AgentLoopManager (e.g., "mypackage.module.MyManager").
     # Security: This class will be dynamically imported via importlib. Only use trusted class paths.
     agent_loop_manager_class: Optional[str] = None
+    # Optional fully qualified function paths called once per rollout wave on each AgentLoopWorker,
+    # to warm up / clean up external rollout resources (e.g. pre-spawn sandboxes for the upcoming
+    # batch). Signature: ``fn(batch: DataProto, config: DictConfig)``; may be sync or async.
+    # ``None`` disables the hook (default = no behavior change).
+    # Security: dynamically imported via importlib; only use trusted paths.
+    warmup_rollout_resources_path: Optional[str] = None
+    cleanup_rollout_resources_path: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
### What does this PR do?

Adds two **optional** hook points so users can warm up / clean up external rollout
resources (e.g. agent sandboxes / sidecars) **once per rollout wave**, overlapping
their cold-start cost with rollout execution instead of paying it lazily on the
critical path of each rollout.

Two new config knobs under `actor_rollout_ref.rollout.agent`:

```yaml
actor_rollout_ref:
  rollout:
    agent:
      warmup_rollout_resources_path: null   # e.g. my_pkg.warmup.warmup_rollout_resources
      cleanup_rollout_resources_path: null  # e.g. my_pkg.warmup.cleanup_rollout_resources
```

Each is a fully-qualified path to a function `fn(batch, config)` (sync or async),
resolved once per `AgentLoopWorker` via the existing `load_class_from_fqn`
(the same mechanism already used for `agent_loop_manager_class`). On every wave:

- `warmup_rollout_resources(batch, config)` runs **before** `generate_sequences`, so
  the user can pre-spawn resources for `len(batch)` rollouts (the worker's chunk =
  exactly how many this wave needs);
- `cleanup_rollout_resources(batch, config)` runs in `finally` **after** the wave, so
  resources are released even if rollout raises.

Both default to `null` → **no behavior change**.

### Why per-wave on `AgentLoopWorker.generate_sequences`?

- **Process locality**: the resource pool and its consumers (the agent loops) live in
  the `AgentLoopWorker` process; warm-up must run there. The manager level only splits
  and dispatches `worker.generate_sequences.remote(chunk)`, so hooking it would just
  fan back out to the workers.
- **Exact count**: the worker's chunk length is exactly how many resources this wave
  needs on this worker.
- **Lifetime scoping**: `start`/`finally` bounds the resources to one wave.

### What this PR intentionally does NOT include

The actual resource provider / pool / sandbox implementation is **left to the user** —
this PR only adds the framework-side hook points. A user can, for example, pre-spawn a
pool of sandboxes in `warmup_rollout_resources` and have their custom `AgentLoop` pop
from it, then drain the pool in `cleanup_rollout_resources`.

### Test

- New CPU-only unit test `tests/experimental/agent_loop/test_rollout_resource_hooks_on_cpu.py`
  covering: FQN resolution (None / valid / non-callable), sync+async hook support,
  ordering (warmup → impl → cleanup), no-op when unset, cleanup-runs-on-error, and
  warmup-failure-skips-impl. All 8 pass.
- `ruff check` / `ruff format --check` clean on changed files.
- Regenerated `_generated_*_trainer.yaml` via `scripts/generate_trainer_config.sh`.

### API and Usage Example

```python
# my_pkg/warmup.py
async def warmup_rollout_resources(batch, config):
    n = len(batch)                       # how many rollouts in this wave
    await my_pool.ensure_ready(n)        # pre-spawn N sandboxes concurrently

async def cleanup_rollout_resources(batch, config):
    await my_pool.drain()                # release the wave's resources
```