### PR TITLE
[fsdp] fix: Fix Qwen3 MoE FSDP weight sync for vLLM rollout in Transformers 5

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -58,6 +58,48 @@ def _check_vllm_version_for_sleep_level():
     return vs.parse(current_version) >= vs.parse(minver)
 
 
+def _should_expand_vllm_moe_params() -> bool:
+    current_version = get_version("vllm")
+    if not current_version:
+        return False
+
+    try:
+        return vs.parse(current_version) <= vs.parse("0.24.0")
+    except vs.InvalidVersion:
+        return False
+
+
+async def _iter_vllm_compatible_moe_params(weights):
+    """Expand Transformers 5 packed MoE expert tensors to vLLM checkpoint keys.
+
+    Transformers 5 stores Qwen-style MoE experts as packed 3D parameters:
+    ``mlp.experts.gate_up_proj`` with shape
+    ``[num_experts, 2 * intermediate_size, hidden_size]`` and
+    ``mlp.experts.down_proj`` with shape
+    ``[num_experts, hidden_size, intermediate_size]``. vLLM's Qwen MoE reload
+    path still accepts the original per-expert checkpoint keys during live
+    weight sync, so stream those keys without materializing a full dict.
+    """
+    from verl.workers.rollout.utils import ensure_async_iterator
+
+    async for name, tensor in ensure_async_iterator(weights):
+        if name.endswith(".mlp.experts.gate_up_proj") and tensor.dim() == 3:
+            gate, up = tensor.chunk(2, dim=1)
+            base = name.removesuffix(".gate_up_proj")
+            for expert_id in range(tensor.size(0)):
+                yield f"{base}.{expert_id}.gate_proj.weight", gate[expert_id].contiguous()
+                yield f"{base}.{expert_id}.up_proj.weight", up[expert_id].contiguous()
+            continue
+
+        if name.endswith(".mlp.experts.down_proj") and tensor.dim() == 3:
+            base = name.removesuffix(".down_proj")
+            for expert_id in range(tensor.size(0)):
+                yield f"{base}.{expert_id}.down_proj.weight", tensor[expert_id].contiguous()
+            continue
+
+        yield name, tensor
+
+
 class ServerAdapter(BaseRollout):
     """
     vLLM server adapter used in native async mode, serve as a client to request vLLM server
@@ -185,6 +227,10 @@ class ServerAdapter(BaseRollout):
             bucket_size_mb=bucket_size_mb,
             use_shm=self.use_shm,
         )
+        if _should_expand_vllm_moe_params() and not (
+            kwargs.get("peft_config") is not None and kwargs.get("base_sync_done", False)
+        ):
+            weights = _iter_vllm_compatible_moe_params(weights)
         await sender.async_send_weights(weights)
 
         if future is not None:


### PR DESCRIPTION
### What does this PR do?

Transformers 5 stores Qwen-style MoE expert weights as packed 3D `mlp.experts.gate_up_proj` and `mlp.experts.down_proj` tensors. During live FSDP-to-vLLM rollout weight sync, those packed keys were sent directly, but vLLM's Qwen3 MoE reload path expects the original per-expert checkpoint keys like `mlp.experts.{expert_id}.gate_proj`.

Expand packed MoE expert tensors during FSDP parameter streaming so vLLM receives per-expert `gate_proj`, `up_proj`, and `down_proj` weights. Dense models and non-packed tensors continue to pass through unchanged.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+moe+transformers
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
