### PR TITLE
[tool, rollout] feat: Adapt SkipManager on Trainer V1

### DIFF
--- a/docs/advance/skip_manager.rst
+++ b/docs/advance/skip_manager.rst
@@ -1,7 +1,7 @@
 SkipManager: Skip everything in the RL pipeline.
 ===========
 
-Last updated: 2026-05-23
+Last updated: 2026-07-08
 
 .. contents:: :local:
    :depth: 1
@@ -15,10 +15,11 @@ save **time**, **memory**, or other resources and improves **developer iteration
 debugging and experimentation.
 
 Skip behavior is centralized under the top-level Hydra key ``skip``. Modules register by **role**
-(for example ``"rollout"`` or ``"async_rollout"``) and are attached with
-``@SkipManager.annotate(role=...)``. Each role declares which integer **steps** in config are
-eligible for skip logic. **Today only rollout-related roles are implemented**; the same mechanism
-can be extended to other pipeline stages (see section 5).
+(for example ``"rollout"``, ``"rollout_tq"``, or ``"async_rollout"``) and are attached with
+@SkipManager.annotate(role=...) (or ``@SkipManager.annotate_tq(role=..., phase=...)`` for the
+V1 two-phase path). Each role declares which integer **steps** in config are eligible for skip
+logic. **Today only rollout-related roles are implemented**; the same mechanism can be extended to
+other pipeline stages (see section 6).
 
 Typical use cases
 ~~~~~~~~~~~~~~~~~
@@ -32,47 +33,48 @@ SkipManager is intended for development workflows where repeating full training 
 3. **Resource savings**: avoid recomputing or holding large tensors when bisecting bugs or tuning
    downstream logic.
 
-The built-in ``rollout`` / ``async_rollout`` modules apply this to sequence generation; other
-roles can follow the same pattern as they are added.
+The built-in ``rollout`` / ``rollout_tq`` / ``async_rollout`` modules apply this to sequence
+generation; other roles can follow the same pattern as they are added.
 
 Supported entry points today
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 28 36 36
+   :widths: 38 28 34
 
    * - Training entry
      - Skip role / config
      - Status
-   * - ``main_ppo.py`` (``RayPPOTrainer``)
+   * - ``main_ppo.py`` with trainer.use_v1=False (``RayPPOTrainer``)
      - ``skip.rollout``
      - **Supported**
-   * - ``main_ppo_sync.py`` (TransferQueue + ReplayBuffer)
-     - ``skip.rollout``
-     - **Not supported** (see section 3)
+   * - main_ppo.py with trainer.use_v1=True (V1 PPOTrainer + TransferQueue)
+     - ``skip.rollout_tq
+     - **Supported** (see section 4)
    * - ``fully_async_main`` (``FullyAsyncRollouter``)
      - ``skip.async_rollout``
      - **Supported**
 
 
-2. Shared configuration (``skip.rollout`` / ``skip.async_rollout``)
+2. Configuration (``skip.rollout`` / ``skip.rollout_tq`` / ``skip.async_rollout``)
 ---------------------------------------------------------------------
 
-Both roles use the same Hydra fields (``RolloutSkipConfig`` / ``AsyncRolloutSkipConfig`` in
-``verl/utils/skip/config.py``). Defaults live in ``verl/trainer/config/ppo_trainer.yaml`` under
-``skip.rollout`` and ``skip.async_rollout``.
+All three roles use the same Hydra field set (``RolloutSkipConfig`` /
+``RolloutTqSkipConfig`` / ``AsyncRolloutSkipConfig`` in ``verl/utils/skip/config.py``). Defaults
+live in verl/trainer/config/ppo_trainer.yaml under the respective skip.* key.
 
 Parameters
 ~~~~~~~~~~
 
 - **enable** (bool): Master switch for this role.
-- **dump_dir** (str): Root directory for cached ``DataProto`` shards (``~`` is expanded).
+- **dump_dir** (str): Root directory for cached shards (``~`` is expanded).
 - **steps** (list[int]): Steps on which skip logic is *eligible*. Outside this list, the decorated
   function always runs normally.
 
   - For ``skip.rollout``: trainer **global_steps** (via ``SkipManager.set_step``).
-  - For ``skip.async_rollout``: the feed-order index parsed from ``sample_id`` (see section 4) —
+  - For ``skip.rollout_tq: trainer **global_steps** (via ``SkipManager.set_step``).
+  - For ``skip.async_rollout``: the feed-order index parsed from ``sample_id`` (see section 5) —
     **not** trainer ``global_steps``.
 
 - **action** (``cache`` \| ``repeat``):
@@ -84,11 +86,14 @@ Parameters
 
 .. note::
 
-   Only ``cache`` and ``repeat`` are validated in config today, even though ``SkipAction`` in
-   ``verl.utils.skip.base_skip`` lists additional enum values for future modules.
+   Only cache and repeat are validated in config today, even though SkipAction in
+   verl.utils.skip.base_skip lists additional enum values for future modules.
 
-``repeat`` step selection (``RolloutSkip._find_latest_step``)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``repeat`` step selection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rollout`` / ``async_rollout`` (``RolloutSkip._find_latest_step``)
+...................................................................
 
 When ``action=repeat`` and the current step directory is missing or incomplete:
 
@@ -99,6 +104,12 @@ When ``action=repeat`` and the current step directory is missing or incomplete:
 
 ``repeat`` does **not** guarantee the cached batch matches the current prompt or trainer step—use
 it for debugging and iteration, and prefer ``cache`` when you need step-aligned replay.
+
+``rollout_tq`` (``RolloutTqSkip._resolve_load_step_v1``)
+........................................................
+
+Same fallback strategy as above, but checks the V1-format cache file (tq_batch.pt, see
+on-disk layout below) instead of gen_batch.dp.
 
 Hydra CLI examples
 ~~~~~~~~~~~~~~~~~~
@@ -111,6 +122,15 @@ Colocated PPO (``skip.rollout``):
    skip.rollout.dump_dir=/path/to/rollout_dump
    skip.rollout.steps=[1,2,3,10]
    skip.rollout.action=cache
+
+TransferQueue-based V1 trainer (``skip.rollout_tq``):
+
+.. code-block:: bash
+
+   skip.rollout_tq.enable=True
+   skip.rollout_tq.dump_dir=/path/to/rollout_dump
+   skip.rollout_tq.steps=[1,3,5]
+   skip.rollout_tq.action=cache
 
 Fully async (``skip.async_rollout``):
 
@@ -130,12 +150,15 @@ To pass a long step list from **bash** only (not valid inside static YAML):
 On-disk layout
 ~~~~~~~~~~~~~~
 
+All roles share the same project-level directory structure; only the per-step files differ.
+
 .. code-block:: text
 
    {dump_dir}/{experiment_name}_{project_name}/
        └── GBS{gbs}_N{n}_in{prompt_len}_out{response_len}/
            ├── {step}/
-           │   ├── gen_batch.dp
+           │   ├── gen_batch.dp      # rollout / async_rollout
+           │   ├── tq_batch.pt       # rollout_tq
            │   └── meta.json
            └── ...
 
@@ -145,14 +168,33 @@ On-disk layout
   size), ``actor_rollout_ref.rollout.n``, ``data.max_prompt_length``, and
   ``data.max_response_length``.
 
-Caches from colocated ``main_ppo`` (larger **GBS**) and fully async streaming (typically **GBS=1**)
-are generally **not** interchangeable unless these metadata match.
+Caches from colocated main_ppo (larger **GBS**) and fully async streaming (typically **GBS=1**)
+are generally **not** interchangeable unless these metadata match. rollout (gen_batch.dp)
+and rollout_tq (tq_batch.pt) use different file formats and are **never** interchangeable,
+even when the project metadata matches.
 
-Minimal workflow (``cache``)
+.. list-table::
+   :header-rows: 1
+   :widths: 22 18 60
+
+   * - Role
+     - Cache file
+     - Contents
+   * - rollout / async_rollout
+     - gen_batch.dp
+     - A DataProto saved via DataProto.save_to_disk — the full generate_sequences output
+       (prompts, responses, log_probs, etc.).
+   * - rollout_tq
+     - tq_batch.pt
+     - A torch.save payload containing: tensordict (all trajectory fields read from TQ via
+       tq.kv_batch_get), tags (per-trajectory tag list), keys (trajectory-level TQ keys),
+       global_steps (int). See section 4 for details.
+
+Minimal workflow (cache)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. **First run** with ``enable=True``, ``action=cache``, and ``steps`` listing the steps you care
-   about. Empty ``dump_dir`` → generation runs and writes ``gen_batch.dp`` + ``meta.json`` per step.
+   about. Empty ``dump_dir`` → generation runs and writes ``the cache file`` + ``meta.json`` per step.
 2. **Second run** with the same config and compatible trainer metadata → listed steps load from
    disk instead of regenerating.
 3. **Partial caches** (some step dirs missing): those steps regenerate on the next run; other steps
@@ -169,32 +211,218 @@ mechanism runs.
 3. Rollout quick start (``rollout`` role)
 -----------------------------------------
 
-Use ``skip.rollout`` when training with ``main_ppo.py`` / ``RayPPOTrainer`` and the standard
-``AgentLoopManager.generate_sequences`` path. Configuration fields and ``cache`` / ``repeat``
-semantics are in section 2.
+Use ``skip.rollout`` when training with main_ppo.py and trainer.use_v1=False
+(RayPPOTrainer) and the standard ``AgentLoopManager.generate_sequences`` path. Configuration
+fields and ``cache`` / ``repeat`` semantics are in section 2.
 
-**``main_ppo.py`` (supported)**
+**Wiring**
 
-- ``RayPPOTrainer.fit()`` calls ``SkipManager.init(self.config)`` and
-  ``SkipManager.set_step(self.global_steps)`` each training step.
-- ``AgentLoopManager.generate_sequences`` is decorated with
-  ``@SkipManager.annotate(role="rollout")``.
+- RayPPOTrainer.fit() calls SkipManager.init(self.config) and
+  SkipManager.set_step(self.global_steps) each training step.
+- AgentLoopManager.generate_sequences is decorated with
+  @SkipManager.annotate(role="rollout").
 
-**``main_ppo_sync.py`` (not supported yet)**
-
-``main_ppo_sync`` replaces the Agent Loop integration with ``AgentLoopManagerTQ``. The main reason
-rollout skip is not supported today is **logic coupling** in
-``AgentLoopManagerTQ.generate_sequences``: it not only drives sequence generation, but also marks
-samples in the ReplayBuffer and **writes generated data into TransferQueue (TQ)**. Skipping
-``generate_sequences`` would therefore skip both generation and the TQ handoff, which breaks the
-downstream training loop that consumes data from TQ.
-
-Decoupling “generate” from “enqueue to TQ” is non-trivial under the current design, so SkipManager
-adaptation for ``main_ppo_sync`` is **deferred** until the TransferQueue-based training path is
-further stabilized.
+The decorated function is a single entry point: it receives prompts, drives full-batch generation
+(chunk dispatch, concat, timing), and returns the complete DataProto. Skip logic wraps this
+unit as a whole — on cache-hit it returns the cached DataProto without invoking the LLM; on
+cache-miss it runs generation and dumps the result.
 
 
-4. Fully async quick start (``async_rollout`` role)
+4. Trainer V1 quick start (``rollout_tq`` role)
+---------------------------------------------------
+
+Use skip.rollout_tq when training with main_ppo.py and trainer.use_v1=True
+(V1 PPOTrainer + TransferQueue). This covers all V1 trainer modes: sync,
+colocate_async, and separate_async.
+
+.. important::
+
+   Unlike rollout (section 3), the V1 TransferQueue path does **not** have a single
+   generate_sequences entry point. Rollout is split across two methods that run at different
+   points in the training step:
+
+   - **Submit phase** — PPOTrainer._add_batch_to_generate: samples a batch from the dataloader,
+     assigns uids, and dispatches prompts to the AgentLoopManager for generation.
+   - **Sample phase** — ReplayBuffer.sample: waits for trajectories to finish, then collects
+     them from TQ into a KVBatchMeta.
+
+   A single decorator cannot cover both because the cache-hit short-circuit must happen *inside*
+   the submit phase — after uid generation (needed for key mapping) but before real rollout
+   submission (which we want to skip). The solution is SkipManager.annotate_tq, a two-phase
+   decorator selected by phase="submit" or phase="sample".
+
+Wiring
+~~~~~~
+
+- PPOTrainer.fit() calls SkipManager.init(self.config) and
+  SkipManager.set_step(self.global_steps) each training step.
+- PPOTrainer._add_batch_to_generate is decorated with
+  @SkipManager.annotate_tq(role="rollout_tq", phase="submit").
+- ReplayBuffer.sample is decorated with
+  @SkipManager.annotate_tq(role="rollout_tq", phase="sample").
+
+Method splitting
+~~~~~~~~~~~~~~~~~
+
+To give the submit-phase decorator a clean interception window, _add_batch_to_generate is
+split into two sub-methods:
+
+.. code-block:: python
+
+   @SkipManager.annotate_tq(role="rollout_tq", phase="submit")
+   def _add_batch_to_generate(self):
+       batch = self._next_train_batch()      # dataloader + uid assignment
+       self._submit_batch_to_rollout(batch)  # tag registration + generate_sequences
+
+   def _next_train_batch(self):
+       """Advance the dataloader and return a batch with fresh uids."""
+       ...
+
+   def _submit_batch_to_rollout(self, batch):
+       """Register prompt tags in TransferQueue and dispatch to AgentLoopManager."""
+       ...
+
+When skip is **disabled** or the current step is outside skip.rollout_tq.steps, the decorator
+passes through and the function body runs normally (_next_train_batch then
+_submit_batch_to_rollout).
+
+When skip is **enabled** and the step is eligible, the decorator takes over and the function body
+does not execute. Instead the decorator calls _next_train_batch itself (keeping the dataloader
+aligned even on cache-hit steps), then branches on cache availability.
+
+.. note::
+
+   If future changes add logic between _next_train_batch and _submit_batch_to_rollout
+   inside _add_batch_to_generate, that logic must also be reflected in the decorator's
+   submit-phase branch, since the decorator bypasses the function body when skip is active.
+
+Two-phase flow
+~~~~~~~~~~~~~~
+
+**Phase 1 — cache-miss** (first run, no tq_batch.pt on disk):
+
+.. code-block:: text
+
+   step()
+    |
+    +- _add_batch_to_generate()          [submit decorator: skip enabled, cache-miss]
+    |    +- _next_train_batch()           -> batch with fresh uids
+    |    +- maybe_load_and_inject()       -> False (no cache)
+    |    +- _submit_batch_to_rollout()    -> real LLM generation dispatched to TQ
+    |
+    +- replay_buffer.sample()            [sample decorator: skip enabled]
+    |    +- (original sample runs)        -> waits for trajectories, returns KVBatchMeta
+    |    +- should_save()                 -> True (no cache, partition="train")
+    |    +- prepare_data()                -> kv_batch_get all fields -> torch.save -> tq_batch.pt
+    |
+    +- (downstream: reward, advantage, actor/critic update ...)
+
+**Phase 2 — cache-hit** (subsequent run, tq_batch.pt exists):
+
+.. code-block:: text
+
+   step()
+    |
+    +- _add_batch_to_generate()          [submit decorator: skip enabled, cache-hit]
+    |    +- _next_train_batch()           -> batch with fresh uids
+    |    +- maybe_load_and_inject()       -> True -> load_dump_data()
+    |    |    +- torch.load(tq_batch.pt)  -> old keys, tags, tensordict
+    |    |    +- group old trajectories by uid prefix
+    |    |    +- map new uids -> cached groups (modulo cycling)
+    |    |    +- index_select_tensor_dict -> select/repeat trajectory rows
+    |    |    +- kv_batch_put trajectories with new keys + updated tags
+    |    |    +- kv_batch_put prompt-level keys with status="finished"
+    |    +- return (skip _submit_batch_to_rollout -- no real LLM call)
+    |
+    +- replay_buffer.sample()            [sample decorator: skip enabled]
+    |    +- (original sample runs)        -> finds finished prompts immediately, returns KVBatchMeta
+    |    +- should_save()                 -> False (cache exists)
+    |    +- (no prepare_data call)
+    |
+    +- (downstream: reward, advantage, actor/critic update ...)
+
+On-disk format: ``tq_batch.pt``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``prepare_data`` saves a ``torch.save`` payload with four keys:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Key
+     - Contents
+   * - ``tensordict``
+     - A ``TensorDict`` containing **all** trajectory fields read from TQ via
+       ``tq.kv_batch_get(keys=batch.keys)`` (no ``select_fields`` filter). Includes ``prompts``,
+       ``responses``, ``response_mask``, dataset fields (``messages``, ``datasource``, etc.), and
+       any fields written by the agent loop. ``prompts`` / ``responses`` are ``NestedTensor``
+       (jagged); the rest are regular tensors.
+   * - ``tags``
+     - ``list[dict]`` — per-trajectory tags, one per entry in ``keys``, in the same order.
+       Each tag carries ``global_steps``, ``status``, ``seq_len``, etc.
+   * - ``keys``
+     - ``list[str]`` — trajectory-level TQ keys in ``{uid}_{session_id}_{index}`` format.
+       The uid prefix is a UUID4 (no underscores), so ``key.split("_")[0]`` recovers the parent
+       prompt uid.
+   * - ``global_steps``
+     - ``int`` — the step at which the dump was created, for sanity checking.
+
+``meta.json`` records ``{"global_steps": <int>, "num_trajectories": <int>}`` and is used by
+``_check_valid_v1_step_path`` for completeness validation.
+
+Why ``kv_batch_get`` without ``select_fields``?
+...............................................
+
+``KVBatchMeta`` from ``ReplayBuffer.sample`` holds only key/tag references — the trajectory data
+body lives in TQ storage units. TQ clears keys at the end of each step (``tq.kv_clear`` in
+``PPOTrainer.fit``), so ``prepare_data`` must read the full data body **before** that cleanup.
+Reading without ``select_fields`` ensures all downstream fields (reward, log-prob, masks) are
+captured for a faithful replay.
+
+Cache-hit injection: key remapping
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``load_dump_data`` cannot reuse old keys directly — new uids were just generated by
+``_next_train_batch``. It remaps cached trajectories onto new uids:
+
+1. **Group by uid**: Parse ``old_keys`` and group trajectory indices by ``key.split("_")[0]``.
+   Each group is one prompt GRPO group (usually *n* trajectories, but may be fewer if sessions
+   failed).
+
+2. **Map new uids to groups**: For each new uid at position prompt_idx, select
+   ``groups[prompt_idx % num_cached_groups]``. If cached groups are fewer than new prompts, groups
+   cycle (modulo). If more, only the first ``num_prompts`` groups are used.
+
+3. **Fill *n* trajectories per prompt**: For each session_id in [0, n), pick
+   ``group[session_id % len(group)]``. If a group has fewer than *n* entries (partial failures),
+   trajectories cycle within the group to fill the slot.
+
+4. **Build new keys**: ``{new_uid}_{session_id}_0`` — matching the standard TQ key format.
+
+5. **Update tags**: Each trajectory tag's ``global_steps`` / ``min_global_steps`` /
+   ``max_global_steps`` are overwritten to the **current** step so ``ReplayBuffer``'s staleness
+   check (``_drop_max_off_policy_samples``) does not discard them as off-policy. The ``is_prompt``
+   flag is removed from trajectory tags (it belongs only on prompt-level keys).
+
+6. **Select tensor rows**: ``index_select_tensor_dict(data, traj_indices)`` picks (and possibly
+   duplicates) rows from the cached ``tensordict``. This handles both regular tensors and
+   NestedTensor (unbind -> select -> nested_tensor_from_tensor_list rebuild).
+
+7. **Two ``kv_batch_put`` calls**:
+
+   - **Trajectory data**: ``keys=new_keys``, ``fields=new_fields``, ``tags=new_tags`` — writes the
+     actual trajectory content into TQ storage.
+   - **Prompt-level markers**: ``keys=new_prompt_uids``, ``tags=[{"is_prompt": True, "status":
+     "finished", ...}]`` — marks each new prompt as finished so ``ReplayBuffer.sample``'s
+     ``_has_enough_samples`` passes immediately without polling.
+
+After injection, TQ holds the same structure as a normal completed rollout: ``n`` trajectory keys
+per prompt plus one prompt-level key with ``status="finished"``. ``replay_buffer.sample`` picks
+them up on the next call and returns a KVBatchMeta whose data is the injected cache.
+
+
+5. Fully async quick start (``async_rollout`` role)
 ---------------------------------------------------
 
 In :doc:`advance/fully_async`, Trainer and Rollouter run in separate processes. Rollout generation
@@ -225,7 +453,7 @@ directories is the **last segment** — Rollouter feed-order index at enqueue ti
   resolution.
 
 
-5. Design and implementation
+6. Design and implementation
 ----------------------------
 
 SkipManager API
@@ -236,11 +464,14 @@ SkipManager API
 - **``init(config)``**: Parse ``config.skip`` into ``SkipManagerConfig``, instantiate one skip module
   per registered role, and store them in ``SkipManager.skip_instances``.
 - **``set_step(step: int)``**: Set ``SkipManager.step`` for roles with ``support_online_step =
-  False`` (trainer ``global_steps`` in ``main_ppo``).
-- **``annotate(role, **kwargs)``**: Decorator factory for sync or async functions.
+  False`` (trainer ``global_steps`` in ``main_ppo`` and V1 ``PPOTrainer``).
+- **``annotate(role, **kwargs)``**: Decorator factory for sync or async functions (used by
+  ``rollout`` and ``async_rollout``).
+- **``annotate_tq(role, phase)``**: Two-phase decorator factory for the V1 TransferQueue path
+  (used by ``rollout_tq``). See section 4.
 
-Decorator flow
-~~~~~~~~~~~~~~
+Decorator flow: ``annotate`` (``rollout`` / ``async_rollout``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: text
 
@@ -261,6 +492,16 @@ Decorator flow
         ▼
    run original function → prepare_data (dump)
 
+
+Decorator flow: ``annotate`` (``rollout_tq``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. image:: https://raw.githubusercontent.com/mikequan0425/verl-community/main/SkipManager_for_trainer_v1.png
+   :align: center
+   :width: 90%
+   :alt: SkipManager_for_trainer_v1
+
+
 BaseSkip interface
 ~~~~~~~~~~~~~~~~~~
 
@@ -274,15 +515,17 @@ Each skip module subclasses ``BaseSkip`` (``verl.utils.skip.base_skip``) and reg
 Instance methods: ``is_enabled``, ``meet_precondition``, ``warp_function``, ``prepare_data``, and
 ``extract_step`` (required when ``support_online_step`` is ``True``).
 
-``RolloutSkip`` / ``AsyncRolloutSkip`` (``verl.utils.skip.rollout_skip``) implement generation
-caching for the ``rollout`` and ``async_rollout`` roles.
+``RolloutSkip`` / ``RolloutTqSkip`` / ``AsyncRolloutSkip`` (``verl.utils.skip.rollout_skip``)
+implement generation caching for the three roles. ``RolloutTqSkip`` extends ``RolloutSkip`` and
+adds V1-specific methods: ``should_save``, ``maybe_load_and_inject``, ``load_dump_data``,
+``has_v1_cache``, ``_resolve_load_step_v1``.
 
 Intercepted functions
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
-   :widths: 16 34 28 22
+   :widths: 14 36 28 22
 
    * - Role
      - Decorated function
@@ -291,7 +534,15 @@ Intercepted functions
    * - ``rollout``
      - ``AgentLoopManager.generate_sequences``
      - ``verl/experimental/agent_loop/agent_loop.py``
-     - ``SkipManager.set_step`` → trainer ``global_steps``
+     - ``SkipManager.set_step`` -> trainer ``global_steps``
+   * - ``rollout_tq``
+     - PPOTrainer._add_batch_to_generate (phase="submit")
+     - verl/trainer/ppo/v1/trainer_base.py
+     - SkipManager.set_step -> trainer global_steps
+   * - ``rollout_tq``
+     - ReplayBuffer.sample (phase="sample")
+     - verl/trainer/ppo/v1/replay_buffer.py
+     - SkipManager.set_step -> trainer ``global_steps``
    * - ``async_rollout``
      - ``FullyAsyncAgentLoopManager.generate_sequences_single``
      - ``verl/experimental/fully_async_policy/fully_async_rollouter.py``
@@ -299,6 +550,10 @@ Intercepted functions
 
 **``rollout``** wraps the full batch Agent Loop RPC (chunk dispatch, concat, timing) as one skip
 unit.
+
+**``rollout_tq``** wraps two methods with a single ``annotate_tq`` decorator, selected by
+``phase``. The submit phase intercepts *before* real generation; the sample phase intercepts
+*after* sampling to persist results.
 
 **``async_rollout``** wraps one streaming sample's ``generate_sequences_single(self, prompts,
 sample_id)`` so concurrent samples resolve step independently.
@@ -323,3 +578,6 @@ Extending with custom skip modules
 3. Add a matching field under ``SkipManagerConfig``.
 4. Attach ``@SkipManager.annotate(role="your_role_name")``. For concurrent pipelines, prefer
    ``support_online_step = True`` and pass step identity through call arguments.
+5. For split-architecture paths (like V1's submit/sample separation), use
+   @SkipManager.annotate_tq(role=..., phase=...) and split the target method so the decorator
+   can intercept between the two sub-steps.

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -1004,6 +1004,11 @@ skip:
     dump_dir: ~/.verl/rollout_dump
     steps: []
     action: cache
+  rollout_tq:
+    enable: false
+    dump_dir: ~/.verl/rollout_dump
+    steps: []
+    action: cache
   async_rollout:
     enable: false
     dump_dir: ~/.verl/rollout_dump

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -926,6 +926,11 @@ skip:
     dump_dir: ~/.verl/rollout_dump
     steps: []
     action: cache
+  rollout_tq:
+    enable: false
+    dump_dir: ~/.verl/rollout_dump
+    steps: []
+    action: cache
   async_rollout:
     enable: false
     dump_dir: ~/.verl/rollout_dump

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -942,6 +942,11 @@ skip:
     dump_dir: ~/.verl/rollout_dump
     steps: []
     action: cache
+  rollout_tq:
+    enable: false
+    dump_dir: ~/.verl/rollout_dump
+    steps: []
+    action: cache
   async_rollout:
     enable: false
     dump_dir: ~/.verl/rollout_dump

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -940,6 +940,11 @@ skip:
     dump_dir: ~/.verl/rollout_dump
     steps: []
     action: cache
+  rollout_tq:
+    enable: false
+    dump_dir: ~/.verl/rollout_dump
+    steps: []
+    action: cache
   async_rollout:
     enable: false
     dump_dir: ~/.verl/rollout_dump

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -439,7 +439,22 @@ skip:
     # Steps to skip rollout
     steps: []
 
-    # Action to take when rollout is skipped, refer to verl.utils.skip.base_skip.SkipAction
+  # Action to take when rollout is skipped, refer to verl.utils.skip.base_skip.SkipAction
+    action: cache
+
+  # configs for RolloutTqSkip (V1 TransferQueue-based trainer)
+  rollout_tq:
+
+    # Whether to enable RolloutTqSkip
+    enable: False
+
+    # Directory to save rollout data
+    dump_dir: "~/.verl/rollout_dump"
+
+    # Steps to skip rollout
+    steps: []
+
+    # Action to take when rollout is skipped (cache | repeat)
     action: cache
 
   # configs for AsyncRolloutSkip (fully async policy)

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -183,7 +183,7 @@ class ReplayBuffer:
 
         return KVBatchMeta(partition_id=batch.partition_id, keys=kept_keys, tags=kept_tags), metrics
 
-    @SkipManager.annotate_tq(role="rollout_tq")
+    @SkipManager.annotate_tq(role="rollout_tq", phase="sample")
     def sample(self, global_steps: int, partition_id: str, batch_size: int) -> KVBatchMeta:
         """Sample a batch of data from the replay buffer.
 

--- a/verl/trainer/ppo/v1/replay_buffer.py
+++ b/verl/trainer/ppo/v1/replay_buffer.py
@@ -21,6 +21,8 @@ import transfer_queue as tq
 from omegaconf import DictConfig
 from transfer_queue import KVBatchMeta
 
+from verl.utils.skip import SkipManager
+
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
@@ -181,6 +183,7 @@ class ReplayBuffer:
 
         return KVBatchMeta(partition_id=batch.partition_id, keys=kept_keys, tags=kept_tags), metrics
 
+    @SkipManager.annotate_tq(role="rollout_tq")
     def sample(self, global_steps: int, partition_id: str, batch_size: int) -> KVBatchMeta:
         """Sample a batch of data from the replay buffer.
 

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1142,8 +1142,21 @@ class PPOTrainer(ABC):
             if self.use_critic:
                 self.critic_wg.stop_profile()
 
+    @SkipManager.annotate_tq(role="rollout_tq", phase="submit")
     def _add_batch_to_generate(self):
-        """Sample a batch from dataloader and add to AgentLoopManager."""
+        """Sample a batch from dataloader and add to AgentLoopManager.
+
+        When ``rollout_tq`` skip is enabled, the decorator intercepts: it calls
+        ``_next_train_batch`` first (keeping the dataloader aligned), then either
+        injects cached data (cache-hit) or delegates to ``_submit_batch_to_rollout``
+        (cache-miss).  This body only runs when skip is disabled or the current
+        step is outside ``skip.steps``.
+        """
+        batch = self._next_train_batch()
+        self._submit_batch_to_rollout(batch)
+
+    def _next_train_batch(self):
+        """Advance the dataloader and return a batch with fresh uids."""
         try:
             if self.train_dataloader_it is None:
                 self.train_dataloader_it = iter(self.train_dataloader)
@@ -1155,17 +1168,12 @@ class PPOTrainer(ABC):
         batch_dict["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch_dict["raw_prompt"]))], dtype=object)
         batch = tu.get_tensordict(batch_dict)
         tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
+        return batch
 
-        # Skip phase two: if cached data exists, inject into TQ and skip real rollout
-        skip_inst = SkipManager.skip_instances.get("rollout_tq")
-        if skip_inst and skip_inst.maybe_load_and_inject(self.global_steps, list(batch["uid"])):
-            return
-
-        # Register each prompt (GRPO group) in TransferQueue as a tag-only status marker
+    def _submit_batch_to_rollout(self, batch):
+        """Register prompt tags in TransferQueue and dispatch to AgentLoopManager."""
         tags = [{"is_prompt": True, "status": "pending", "global_steps": self.global_steps}] * len(batch)
         tq.kv_batch_put(keys=list(batch["uid"]), partition_id="train", tags=tags)
-
-        # add batch to agent loop manager
         self.agent_loop_manager.generate_sequences(batch)
 
     def _compute_reward_colocate(self, batch: KVBatchMeta, metrics: dict | None = None) -> KVBatchMeta:

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -83,6 +83,7 @@ from verl.utils.import_utils import load_extern_type
 from verl.utils.metric import reduce_metrics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
+from verl.utils.skip import SkipManager
 from verl.utils.tracking import Tracking, ValidationGenerationsLogger
 from verl.workers.config import CriticConfig, DistillationConfig
 from verl.workers.engine_workers import ActorRolloutRefWorker, TrainingWorker, TrainingWorkerConfig
@@ -312,6 +313,9 @@ class PPOTrainer(ABC):
         """
         self.agent_loop_manager = agent_loop_manager
 
+        # initialize SkipManager for V1 rollout skip support
+        SkipManager.init(self.config)
+
         self.logger = Tracking(
             project_name=self.config.trainer.project_name,
             experiment_name=self.config.trainer.experiment_name,
@@ -340,6 +344,7 @@ class PPOTrainer(ABC):
 
         # we start from step 1
         self.global_steps += 1
+        SkipManager.set_step(self.global_steps)
         self.prev_step_profile = False
         self.curr_step_profile = (
             self.global_steps in self.config.global_profiler.steps
@@ -398,6 +403,7 @@ class PPOTrainer(ABC):
             self.logger.log(data=metrics, step=self.global_steps)
             progress_bar.update(1)
             self.global_steps += 1
+            SkipManager.set_step(self.global_steps)
             current_epoch = (self.global_steps - 1) // len(self.train_dataloader)
             if is_last_step:
                 self._shutdown_dump_executor()
@@ -450,6 +456,14 @@ class PPOTrainer(ABC):
             batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
             self.on_sample_end()
 
+            # Skip: save batch to disk when no cached data exists yet (phase one)
+            skip_inst = SkipManager.skip_instances.get("rollout_tq")
+            if skip_inst and skip_inst.should_save(self.global_steps, batch.partition_id):
+                skip_inst.prepare_data(
+                    step=self.global_steps,
+                    batch=batch,
+                    global_steps=self.global_steps,
+                )
         # 2. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
             with marked_timer("reward", timing_raw, color="yellow"):
@@ -1141,6 +1155,18 @@ class PPOTrainer(ABC):
         batch_dict["uid"] = np.array([str(uuid.uuid4()) for _ in range(len(batch_dict["raw_prompt"]))], dtype=object)
         batch = tu.get_tensordict(batch_dict)
         tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
+
+        # Skip: if V1 rollout skip is enabled and cached data exists, inject into TQ directly
+        skip_inst = SkipManager.skip_instances.get("rollout_tq")
+        if skip_inst and skip_inst.meet_precondition(self.global_steps):
+            skip_inst.load_dump_data(
+                step=self.global_steps,
+                new_prompt_uids=list(batch["uid"]),
+                n=self.config.actor_rollout_ref.rollout.n,
+                global_steps=self.global_steps,
+                partition_id="train",
+            )
+            return
 
         # Register each prompt (GRPO group) in TransferQueue as a tag-only status marker
         tags = [{"is_prompt": True, "status": "pending", "global_steps": self.global_steps}] * len(batch)

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -456,14 +456,6 @@ class PPOTrainer(ABC):
             batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
             self.on_sample_end()
 
-            # Skip: save batch to disk when no cached data exists yet (phase one)
-            skip_inst = SkipManager.skip_instances.get("rollout_tq")
-            if skip_inst and skip_inst.should_save(self.global_steps, batch.partition_id):
-                skip_inst.prepare_data(
-                    step=self.global_steps,
-                    batch=batch,
-                    global_steps=self.global_steps,
-                )
         # 2. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
             with marked_timer("reward", timing_raw, color="yellow"):

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -1156,16 +1156,9 @@ class PPOTrainer(ABC):
         batch = tu.get_tensordict(batch_dict)
         tu.assign_non_tensor_data(batch, "global_steps", self.global_steps)
 
-        # Skip: if V1 rollout skip is enabled and cached data exists, inject into TQ directly
+        # Skip phase two: if cached data exists, inject into TQ and skip real rollout
         skip_inst = SkipManager.skip_instances.get("rollout_tq")
-        if skip_inst and skip_inst.meet_precondition(self.global_steps):
-            skip_inst.load_dump_data(
-                step=self.global_steps,
-                new_prompt_uids=list(batch["uid"]),
-                n=self.config.actor_rollout_ref.rollout.n,
-                global_steps=self.global_steps,
-                partition_id="train",
-            )
+        if skip_inst and skip_inst.maybe_load_and_inject(self.global_steps, list(batch["uid"])):
             return
 
         # Register each prompt (GRPO group) in TransferQueue as a tag-only status marker

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -38,7 +38,7 @@ class PPOTrainerColocateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
-        if self.config.skip.rollout_tq.enabled:
+        if self.config.skip.rollout_tq.enable:
             return
         num_warmup_batches = self.config.trainer.v1.colocate_async.num_warmup_batches
         for _ in range(num_warmup_batches):

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -38,6 +38,8 @@ class PPOTrainerColocateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
+        if self.config.skip.rollout_tq.enabled:
+            return
         num_warmup_batches = self.config.trainer.v1.colocate_async.num_warmup_batches
         for _ in range(num_warmup_batches):
             self._add_batch_to_generate()

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -101,7 +101,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
-        if self.config.skip.rollout_tq.enabled:
+        if self.config.skip.rollout_tq.enable:
             return
         num_warmup_batches = self.config.trainer.v1.separate_async.num_warmup_batches
         for _ in range(num_warmup_batches):

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -101,6 +101,8 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         self.checkpoint_manager.update_weights(self.global_steps)
 
     def on_train_begin(self):
+        if self.config.skip.rollout_tq.enabled:
+            return
         num_warmup_batches = self.config.trainer.v1.separate_async.num_warmup_batches
         for _ in range(num_warmup_batches):
             self._add_batch_to_generate()

--- a/verl/utils/skip/__init__.py
+++ b/verl/utils/skip/__init__.py
@@ -19,4 +19,13 @@ from .config import SkipManagerConfig
 from .rollout_skip import AsyncRolloutSkip, RolloutSkip
 from .skip_manager import SkipManager
 
-__all__ = ["BaseSkip", "SkipManager", "SkipManagerConfig", "RolloutSkip", "AsyncRolloutSkip"]
+from .rollout_skip import RolloutTqSkip
+
+__all__ = [
+    "BaseSkip",
+    "SkipManager",
+    "SkipManagerConfig",
+    "RolloutSkip",
+    "RolloutTqSkip",
+    "AsyncRolloutSkip",
+]

--- a/verl/utils/skip/__init__.py
+++ b/verl/utils/skip/__init__.py
@@ -16,10 +16,8 @@ from .base_skip import BaseSkip
 from .config import SkipManagerConfig
 
 # register skip
-from .rollout_skip import AsyncRolloutSkip, RolloutSkip
+from .rollout_skip import AsyncRolloutSkip, RolloutSkip, RolloutTqSkip
 from .skip_manager import SkipManager
-
-from .rollout_skip import RolloutTqSkip
 
 __all__ = [
     "BaseSkip",

--- a/verl/utils/skip/config.py
+++ b/verl/utils/skip/config.py
@@ -52,8 +52,26 @@ class AsyncRolloutSkipConfig(BaseConfig):
 
 
 @dataclass
+class RolloutTqSkipConfig(BaseConfig):
+    """Config for V1 TransferQueue-based rollout skip behavior."""
+
+    enable: bool = False
+    dump_dir: str = "~/.verl/rollout_dump"
+    steps: list[int] = field(default_factory=list)
+    action: str = "cache"  # cache | repeat, refer to SkipAction in base_skip.py
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.enable, bool), f"`enable` must be bool, got {type(self.enable)}"
+        assert isinstance(self.dump_dir, str), f"`dump_dir` must be str, got {type(self.dump_dir)}"
+        assert isinstance(self.steps, list), f"`steps` must be list[int], got {type(self.steps)}"
+        assert all(isinstance(step, int) for step in self.steps), "`steps` must contain int only"
+        assert self.action in {"cache", "repeat"}, f"`action` must be one of cache/repeat, got {self.action}"
+
+
+@dataclass
 class SkipManagerConfig(BaseConfig):
     """Top-level config for skip modules."""
 
     rollout: RolloutSkipConfig = field(default_factory=RolloutSkipConfig)
     async_rollout: AsyncRolloutSkipConfig = field(default_factory=AsyncRolloutSkipConfig)
+    rollout_tq: RolloutTqSkipConfig = field(default_factory=RolloutTqSkipConfig)

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -165,7 +165,6 @@ class RolloutSkip(BaseSkip):
         return -1
 
 
-
 @register_skip("rollout_tq")
 class RolloutTqSkip(RolloutSkip):
     """Rollout skip for V1 TransferQueue-based trainer (``skip.rollout_tq``).
@@ -293,9 +292,7 @@ class RolloutTqSkip(RolloutSkip):
         torch.save(save_payload, step_dir / self.tq_batch_name)
 
         meta_path = step_dir / self.meta_name
-        meta_path.write_text(
-            json.dumps({"global_steps": global_steps, "num_trajectories": len(batch.keys)})
-        )
+        meta_path.write_text(json.dumps({"global_steps": global_steps, "num_trajectories": len(batch.keys)}))
         print(
             f"{self.print_mark}\033[33mDump TQ batch at step {step} "
             f"({len(batch.keys)} trajectories) to {step_dir}\033[0m",
@@ -328,8 +325,7 @@ class RolloutTqSkip(RolloutSkip):
         load_step = self._resolve_load_step_v1(step)
         if load_step == -1:
             raise FileNotFoundError(
-                f"{self.print_mark}No dump data found for step {step} "
-                f"under {self._get_project_dump_dir()}"
+                f"{self.print_mark}No dump data found for step {step} under {self._get_project_dump_dir()}"
             )
 
         step_dir = self._get_step_dump_dir(load_step)
@@ -350,8 +346,7 @@ class RolloutTqSkip(RolloutSkip):
 
         if not groups:
             raise RuntimeError(
-                f"{self.print_mark}No trajectory groups found in cached data "
-                f"({len(old_keys)} keys) at step {load_step}"
+                f"{self.print_mark}No trajectory groups found in cached data ({len(old_keys)} keys) at step {load_step}"
             )
 
         num_cached_groups = len(groups)
@@ -404,9 +399,7 @@ class RolloutTqSkip(RolloutSkip):
         )
 
         # Mark prompt-level keys as finished so ReplayBuffer can pick them up immediately
-        prompt_tags = [
-            {"is_prompt": True, "status": "finished", "global_steps": global_steps}
-        ] * len(new_prompt_uids)
+        prompt_tags = [{"is_prompt": True, "status": "finished", "global_steps": global_steps}] * len(new_prompt_uids)
         tq.kv_batch_put(
             keys=new_prompt_uids,
             partition_id=partition_id,

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -15,6 +15,7 @@ import json
 from pathlib import Path
 from typing import Callable
 
+import torch
 from omegaconf import OmegaConf
 
 from verl.protocol import DataProto
@@ -162,6 +163,245 @@ class RolloutSkip(BaseSkip):
         if larger_steps:
             return larger_steps[0]
         return -1
+
+
+
+@register_skip("rollout_tq")
+class RolloutTqSkip(RolloutSkip):
+    """Rollout skip for V1 TransferQueue-based trainer (``skip.rollout_tq``).
+
+    Unlike V0's decorator pattern, V1's split architecture (submit prompts to TQ,
+    then sample trajectories) requires direct method calls from the trainer:
+    - Phase one (no cache): trainer calls ``prepare_data`` after ``replay_buffer.sample``
+    - Phase two (cache exists): trainer calls ``load_dump_data`` in ``_add_batch_to_generate``
+    """
+
+    print_mark = "[RolloutTqSkip()] "
+    tq_batch_name = "tq_batch.pt"
+
+    def _check_valid_v1_step_path(self, path: Path) -> bool:
+        """Check whether a V1-format cached batch (``tq_batch.pt``) exists at *path*."""
+        if not path.is_dir():
+            return False
+        return (path / self.tq_batch_name).is_file() and (path / self.meta_name).is_file()
+
+    def _get_available_steps_v1(self) -> list[int]:
+        """Return sorted list of steps that have V1-format cached data."""
+        result: list[int] = []
+        project_dir = self._get_project_dump_dir()
+        if not project_dir.is_dir():
+            return result
+        for child in project_dir.iterdir():
+            if not child.is_dir():
+                continue
+            try:
+                step = int(child.name)
+            except ValueError:
+                continue
+            if not self._check_valid_v1_step_path(child):
+                continue
+            result.append(step)
+        return sorted(result)
+
+    def _resolve_load_step_v1(self, step: int) -> int:
+        """Return the actual step to load from for V1 path, or -1 if none available.
+
+        - ``cache``: exact step match
+        - ``repeat``: closest available step (prefer smaller, then larger)
+        """
+        if self._check_valid_v1_step_path(self._get_step_dump_dir(step)):
+            return step
+        if self.action == SkipAction.REPEAT:
+            available = self._get_available_steps_v1()
+            if not available:
+                return -1
+            smaller = [s for s in available if s < step]
+            if smaller:
+                return smaller[-1]
+            larger = [s for s in available if s > step]
+            if larger:
+                return larger[0]
+        return -1
+
+    def has_v1_cache(self, step: int) -> bool:
+        """V1 phase check: whether cached TQ batch data exists for *step*.
+
+        Returns True -> phase two (load from disk).
+        Returns False -> phase one (normal rollout + save).
+        """
+        return self._resolve_load_step_v1(step) != -1
+
+    def meet_precondition(self, step: int, *args, **kwargs) -> bool:
+        """Phase two: whether cached data exists and should be loaded/injected.
+
+        Overrides V0's ``meet_precondition``.  V1 does not use the decorator
+        pattern, so ``func``/``*args`` are accepted but ignored.
+        """
+        return self.is_enabled() and step in self.steps and self.has_v1_cache(step)
+
+    def should_save(self, step: int, partition_id: str = "train") -> bool:
+        """Phase one: whether the sampled batch should be saved to disk."""
+        return (
+            self.is_enabled()
+            and step in self.steps
+            and partition_id == "train"
+            and not self.has_v1_cache(step)
+        )
+
+    def prepare_data(self, step: int, batch, global_steps: int) -> None:
+        """Phase one: read full batch from TransferQueue and save to disk.
+
+        Args:
+            step: Current training step (used as dump directory name).
+            batch: :class:`transfer_queue.KVBatchMeta` from ``ReplayBuffer.sample()``.
+            global_steps: Current ``global_steps`` for metadata.
+        """
+        print(
+            f"{self.print_mark}\033[33mNo dumped data found "
+            f"from {self._get_project_dump_dir()}. "
+            f"The trainer will generate and dump the data.\033[0m",
+            flush=True,
+        )
+        import transfer_queue as tq
+
+        step_dir = self._get_step_dump_dir(step)
+        step_dir.mkdir(parents=True, exist_ok=True)
+
+        # Read all trajectory fields from TQ
+        data = tq.kv_batch_get(keys=batch.keys, partition_id=batch.partition_id)
+
+        save_payload = {
+            "tensordict": data,
+            "tags": batch.tags,
+            "keys": list(batch.keys),
+            "global_steps": global_steps,
+        }
+        torch.save(save_payload, step_dir / self.tq_batch_name)
+
+        meta_path = step_dir / self.meta_name
+        meta_path.write_text(
+            json.dumps({"global_steps": global_steps, "num_trajectories": len(batch.keys)})
+        )
+        print(
+            f"{self.print_mark}\033[33mDump TQ batch at step {step} "
+            f"({len(batch.keys)} trajectories) to {step_dir}\033[0m",
+            flush=True,
+        )
+
+    def load_dump_data(
+        self,
+        step: int,
+        new_prompt_uids: list[str],
+        n: int,
+        global_steps: int,
+        partition_id: str = "train",
+    ) -> None:
+        """Phase two: load cached data from disk and inject into TransferQueue.
+
+        Maps saved trajectories to new prompt uids in order, preserving the
+        original key structure (``{uid}_{session_id}_{index}``) and GRPO group
+        composition (each prompt gets *n* trajectories from the same original group).
+
+        Args:
+            step: Current training step.
+            new_prompt_uids: Freshly generated uids for the current batch.
+            n: Number of trajectories per prompt (``rollout.n``).
+            global_steps: Current ``global_steps``, used to override staleness tags.
+            partition_id: TQ partition (``"train"`` or ``"val"``).
+        """
+        import transfer_queue as tq
+
+        load_step = self._resolve_load_step_v1(step)
+        if load_step == -1:
+            raise FileNotFoundError(
+                f"{self.print_mark}No dump data found for step {step} "
+                f"under {self._get_project_dump_dir()}"
+            )
+
+        step_dir = self._get_step_dump_dir(load_step)
+        save_payload = torch.load(step_dir / self.tq_batch_name, weights_only=False)
+        data = save_payload["tensordict"]
+        old_keys = save_payload["keys"]
+        old_tags = save_payload["tags"]
+
+        # Group saved trajectories by parent uid.
+        # Key format: {uid}_{session_id}_{index}, uid is UUID4 (no underscores).
+        # ReplayBuffer.sample() does NOT guarantee keys are sorted by uid prefix,
+        # so we use a dict to group regardless of key ordering.
+        uid_to_indices: dict[str, list[int]] = {}
+        for idx, key in enumerate(old_keys):
+            parent_uid = key.split("_")[0]
+            uid_to_indices.setdefault(parent_uid, []).append(idx)
+        groups = list(uid_to_indices.values())
+
+        if not groups:
+            raise RuntimeError(
+                f"{self.print_mark}No trajectory groups found in cached data "
+                f"({len(old_keys)} keys) at step {load_step}"
+            )
+
+        num_cached_groups = len(groups)
+        num_prompts = len(new_prompt_uids)
+        if num_cached_groups < num_prompts:
+            print(
+                f"{self.print_mark}\033[33mCached {num_cached_groups} prompt groups but need {num_prompts} "
+                f"prompts; will cycle through available groups to fill\033[0m",
+                flush=True,
+            )
+        elif num_cached_groups > num_prompts:
+            print(
+                f"{self.print_mark}\033[33mCached {num_cached_groups} prompt groups but only need {num_prompts} "
+                f"prompts; using first {num_prompts} groups\033[0m",
+                flush=True,
+            )
+
+        # Build new keys/tags: map each new uid to a cached group.
+        # If group has fewer than *n* trajectories (some sessions failed),
+        # cycle within the group to fill *n* trajectories.
+        # If cached groups < new prompts, cycle through groups (modulo).
+        new_keys = []
+        new_tags = []
+        traj_indices: list[int] = []
+        for prompt_idx, new_uid in enumerate(new_prompt_uids):
+            group = groups[prompt_idx % num_cached_groups]
+            for session_id in range(n):
+                traj_idx = group[session_id % len(group)]
+                traj_indices.append(traj_idx)
+                new_keys.append(f"{new_uid}_{session_id}_0")
+                tag = dict(old_tags[traj_idx])
+                tag["global_steps"] = global_steps
+                tag["min_global_steps"] = global_steps
+                tag["max_global_steps"] = global_steps
+                tag.pop("is_prompt", None)
+                new_tags.append(tag)
+
+        # Select/reorder rows from the saved tensordict to match new_keys.
+        new_fields = data[torch.tensor(traj_indices, dtype=torch.long)]
+
+        # Write trajectory data to TQ
+        tq.kv_batch_put(
+            keys=new_keys,
+            fields=new_fields,
+            tags=new_tags,
+            partition_id=partition_id,
+        )
+
+        # Mark prompt-level keys as finished so ReplayBuffer can pick them up immediately
+        prompt_tags = [
+            {"is_prompt": True, "status": "finished", "global_steps": global_steps}
+        ] * len(new_prompt_uids)
+        tq.kv_batch_put(
+            keys=new_prompt_uids,
+            partition_id=partition_id,
+            tags=prompt_tags,
+        )
+
+        print(
+            f"{self.print_mark}\033[33mInjected {len(new_keys)} cached trajectories "
+            f"from step {load_step} ({len(new_prompt_uids)} prompts x {n}) "
+            f"into TQ partition '{partition_id}' at current step {step}\033[0m",
+            flush=True,
+        )
 
 
 def parse_async_rollout_sample_step(sample_id: str) -> int:

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -375,8 +375,11 @@ class RolloutTqSkip(RolloutSkip):
                 tag.pop("is_prompt", None)
                 new_tags.append(tag)
 
-        # Select/reorder rows from the saved tensordict to match new_keys.
-        new_fields = data[torch.tensor(traj_indices, dtype=torch.long)]
+        # NestedTensor (jagged prompts/responses) does not support indexing or slicing
+        # on dim=0.  Use index_select_tensor_dict which unbinds, selects, and rebuilds.
+        from verl.utils.tensordict_utils import index_select_tensor_dict
+
+        new_fields = index_select_tensor_dict(data, traj_indices)
 
         # Write trajectory data to TQ
         tq.kv_batch_put(

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -248,6 +248,29 @@ class RolloutTqSkip(RolloutSkip):
             and not self.has_v1_cache(step)
         )
 
+    def maybe_load_and_inject(self, step: int, new_prompt_uids: list[str], partition_id: str = "train") -> bool:
+        """Phase two: load cached data and inject into TransferQueue if cache exists.
+
+        Convenience wrapper that combines ``meet_precondition`` + ``load_dump_data``.
+        Returns ``True`` if cached data was injected (caller should skip real rollout),
+        ``False`` otherwise.
+
+        Args:
+            step: Current training step.
+            new_prompt_uids: Freshly generated uids for the current batch.
+            partition_id: TQ partition (``"train"`` or ``"val"``).
+        """
+        if not self.meet_precondition(step):
+            return False
+        self.load_dump_data(
+            step=step,
+            new_prompt_uids=new_prompt_uids,
+            n=self.n,
+            global_steps=step,
+            partition_id=partition_id,
+        )
+        return True
+
     def prepare_data(self, step: int, batch, global_steps: int) -> None:
         """Phase one: read full batch from TransferQueue and save to disk.
 

--- a/verl/utils/skip/rollout_skip.py
+++ b/verl/utils/skip/rollout_skip.py
@@ -232,21 +232,12 @@ class RolloutTqSkip(RolloutSkip):
         return self._resolve_load_step_v1(step) != -1
 
     def meet_precondition(self, step: int, *args, **kwargs) -> bool:
-        """Phase two: whether cached data exists and should be loaded/injected.
-
-        Overrides V0's ``meet_precondition``.  V1 does not use the decorator
-        pattern, so ``func``/``*args`` are accepted but ignored.
-        """
-        return self.is_enabled() and step in self.steps and self.has_v1_cache(step)
+        """Phase two: whether cached data exists and should be loaded/injected."""
+        return self.has_v1_cache(step)
 
     def should_save(self, step: int, partition_id: str = "train") -> bool:
         """Phase one: whether the sampled batch should be saved to disk."""
-        return (
-            self.is_enabled()
-            and step in self.steps
-            and partition_id == "train"
-            and not self.has_v1_cache(step)
-        )
+        return partition_id == "train" and not self.has_v1_cache(step)
 
     def maybe_load_and_inject(self, step: int, new_prompt_uids: list[str], partition_id: str = "train") -> bool:
         """Phase two: load cached data and inject into TransferQueue if cache exists.

--- a/verl/utils/skip/skip_manager.py
+++ b/verl/utils/skip/skip_manager.py
@@ -125,20 +125,23 @@ class SkipManager:
         return decorator
 
     @classmethod
-    def annotate_tq(cls, role: str):
-        """V1 TransferQueue-based skip decorator for the **sample** phase.
+    def annotate_tq(cls, role: str, phase: str):
+        """V1 TransferQueue-based skip decorator, unified across both phases.
 
-        Unlike V0's :meth:`annotate`, V1's split architecture separates
-        "submit prompts" (``_add_batch_to_generate``) from "sample trajectories"
-        (``ReplayBuffer.sample``).  This decorator handles the sample phase only:
-        after the original ``sample`` runs, if the skip instance says to save,
-        persist the result to disk (phase one / cache-miss).
+        V1's split architecture separates "submit prompts" (``_add_batch_to_generate``)
+        from "sample trajectories" (``ReplayBuffer.sample``).  This decorator handles
+        both, selected by *phase*:
 
-        The submit phase (phase two / cache-hit short-circuit) is handled inline
-        via ``RolloutTqSkip.maybe_load_and_inject`` because the short-circuit
-        window lies *inside* ``_add_batch_to_generate`` — after uid generation
-        but before rollout submission — and therefore cannot be a pure
-        pre-function decorator.
+        - ``phase="submit"``: decorate ``_add_batch_to_generate``.  The method must be
+          split into ``_next_train_batch`` (dataloader + uid) and ``_submit_batch_to_rollout``
+          (tag registration + generate_sequences).  The decorator always calls
+          ``_next_train_batch`` first (keeping the dataloader aligned even on cache-hit
+          steps), then checks ``meet_precondition``.  On cache-hit it injects cached data
+          into the TQ and returns; on cache-miss it calls ``_submit_batch_to_rollout``.
+
+        - ``phase="sample"``: decorate ``ReplayBuffer.sample``.  After the original
+          ``sample`` runs, if the skip instance says to save, persist the result to disk
+          (phase one / cache-miss).
         """
         def decorator(func: Callable) -> Callable:
             @functools.wraps(func)
@@ -146,10 +149,22 @@ class SkipManager:
                 skip_instance = cls.skip_instances.get(role)
                 if skip_instance is None or not skip_instance.is_enabled():
                     return func(self, *args, **kwargs)
+                step = cls.step
+                if step not in skip_instance.steps:
+                    return func(self, *args, **kwargs)
+
+                if phase == "submit":
+                    # Always prepare batch (keeps dataloader aligned on cache-hit steps)
+                    batch = self._next_train_batch()
+                    if skip_instance.maybe_load_and_inject(step, list(batch["uid"])):
+                        return
+                    self._submit_batch_to_rollout(batch)
+                    return
+
+                # phase == "sample": post-save after original sample runs
                 result = func(self, *args, **kwargs)
                 # ReplayBuffer.sample returns (batch, off_policy_metrics)
                 batch = result[0] if isinstance(result, tuple) else result
-                step = cls.step
                 if skip_instance.should_save(step, batch.partition_id):
                     skip_instance.prepare_data(step=step, batch=batch, global_steps=step)
                 return result

--- a/verl/utils/skip/skip_manager.py
+++ b/verl/utils/skip/skip_manager.py
@@ -66,8 +66,12 @@ class SkipManager:
     @classmethod
     def _should_bypass_for_validation(cls, args, kwargs) -> bool:
         prompts = cls._get_prompts_batch(args, kwargs)
+        if prompts is None and len(args) > 1:
+            return cls._should_bypass_for_validation_tensordict(args, kwargs)
         if prompts is None:
             return False
+        if hasattr(prompts, "non_tensor_data"):
+            return cls._should_bypass_for_validation_tensordict(args, kwargs)
         meta_info = getattr(prompts, "meta_info", None) or {}
         return bool(meta_info.get("validate", False))
 
@@ -119,3 +123,16 @@ class SkipManager:
             return sync_wrapper
 
         return decorator
+
+    @staticmethod
+    def _should_bypass_for_validation_tensordict(args, kwargs) -> bool:
+        """Check ``validate`` flag in TensorDict's non_tensor_data for V1 path."""
+        prompts = kwargs.get("prompts", None)
+        if prompts is None and len(args) > 1:
+            prompts = args[1]
+        if prompts is None:
+            return False
+        try:
+            return bool(getattr(prompts, "non_tensor_data", {}).get("validate", False))
+        except Exception:
+            return False

--- a/verl/utils/skip/skip_manager.py
+++ b/verl/utils/skip/skip_manager.py
@@ -143,6 +143,7 @@ class SkipManager:
           ``sample`` runs, if the skip instance says to save, persist the result to disk
           (phase one / cache-miss).
         """
+
         def decorator(func: Callable) -> Callable:
             @functools.wraps(func)
             def wrapper(self, *args, **kwargs):

--- a/verl/utils/skip/skip_manager.py
+++ b/verl/utils/skip/skip_manager.py
@@ -124,6 +124,40 @@ class SkipManager:
 
         return decorator
 
+    @classmethod
+    def annotate_tq(cls, role: str):
+        """V1 TransferQueue-based skip decorator for the **sample** phase.
+
+        Unlike V0's :meth:`annotate`, V1's split architecture separates
+        "submit prompts" (``_add_batch_to_generate``) from "sample trajectories"
+        (``ReplayBuffer.sample``).  This decorator handles the sample phase only:
+        after the original ``sample`` runs, if the skip instance says to save,
+        persist the result to disk (phase one / cache-miss).
+
+        The submit phase (phase two / cache-hit short-circuit) is handled inline
+        via ``RolloutTqSkip.maybe_load_and_inject`` because the short-circuit
+        window lies *inside* ``_add_batch_to_generate`` — after uid generation
+        but before rollout submission — and therefore cannot be a pure
+        pre-function decorator.
+        """
+        def decorator(func: Callable) -> Callable:
+            @functools.wraps(func)
+            def wrapper(self, *args, **kwargs):
+                skip_instance = cls.skip_instances.get(role)
+                if skip_instance is None or not skip_instance.is_enabled():
+                    return func(self, *args, **kwargs)
+                result = func(self, *args, **kwargs)
+                # ReplayBuffer.sample returns (batch, off_policy_metrics)
+                batch = result[0] if isinstance(result, tuple) else result
+                step = cls.step
+                if skip_instance.should_save(step, batch.partition_id):
+                    skip_instance.prepare_data(step=step, batch=batch, global_steps=step)
+                return result
+
+            return wrapper
+
+        return decorator
+
     @staticmethod
     def _should_bypass_for_validation_tensordict(args, kwargs) -> bool:
         """Check ``validate`` flag in TensorDict's non_tensor_data for V1 path."""


### PR DESCRIPTION
### What does this PR do?

Adapt SkipManager to Trainer V1, enabling rollout TQ batch caching and replay across specified training steps.

Two modes are supported:
- `cache` — dump rollout TQ batches at specified steps; later runs with matching cached data inject them directly
- `repeat` — inject cached trajectories from the nearest prior step into the current step

Verified across sync, colocated async, and separate async rollout modes.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+SkipManager
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

#### sync
1.SKIP_STEPES=[1,3,5], SKIP_ACTION=cache, no data in the target directory.

```
No dumped data found at step 1
Dump TQ batch at step 1
No dumped data found at step 3
Dump TQ batch at step 3
No dumped data found at step 5
Dump TQ batch at step 5
```

2.SKIP_STEPES=[1,3,5], SKIP_ACTION=cache, there are data from Step [1,3,5] in the target directory.
```
Injected 256 cached trajectories from step 1 at current step 1
Injected 256 cached trajectories from step 3 at current step 3
Injected 256 cached trajectories from step 5 at current step 5
```

3.SKIP_STEPES=[1,3,5], SKIP_ACTION=cache, there are data from Step [1] in the target directory.
```
Injected 256 cached trajectories from step 1 at current step 1
No dumped data found at step 3
Dump TQ batch at step 3
No dumped data found at step 5
Dump TQ batch at step 5
```

4.SKIP_STEPES=[1,3,5], SKIP_ACTION=repeat, there are data from Step [1] in the target directory.
```
Injected 256 cached trajectories from step 1 at current step 1
Injected 256 cached trajectories from step 1 at current step 3
Injected 256 cached trajectories from step 1 at current step 5
```

5.SKIP_STEPES=[1,3,5], SKIP_ACTION=repeat, no data in the target directory.
```
No dumped data found at step 1
Dump TQ batch at step 1
Injected 256 cached trajectories from step 1 at current step 3
Injected 256 cached trajectories from step 1 at current step 5
```

#### colocated async

1.SKIP_STEPES=[1,2,3], SKIP_ACTION=cache, there are data from Step [1] in the target directory.

```
Injected 256 cached trajectories from step 1 at current step 1
No dumped data found at step 2
Dump TQ batch at step 2
No dumped data found at step 3
Dump TQ batch at step 3
```

2.SKIP_STEPES=[1,2,3], SKIP_ACTION=repeat, no data in the target directory.

```
No dumped data found at step 1
Dump TQ batch at step 1
Injected 256 cached trajectories from step 1 at current step 2
Injected 256 cached trajectories from step 1 at current step 3
```

#### separate async
1.SKIP_STEPES=[1,2,3], SKIP_ACTION=cache, there are data from Step [1] in the target directory.
```
Injected 256 cached trajectories from step 1 at current step 1
No dumped data found at step 2
Dump TQ batch at step 2
No dumped data found at step 3
Dump TQ batch at step 3
```

2.SKIP_STEPES=[1,2,3], SKIP_ACTION=repeat, no data in the target directory.

```
Injected 256 cached trajectories from step 1 at current step 1
Injected 256 cached trajectories from step 1 at current step 2
Injected 256 cached trajectories from step 1 at current step 3
```

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
    skip.rollout_tq.enable=True
    skip.rollout_tq.steps=[1,2]
    skip.rollout_tq.dump_dir=$rollout_dump_path
    skip.rollout_tq.action=cache
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

<img width="2762" height="1906" alt="image" src="https://github.com/user-attachments/assets/ef511b57-44bf-4062-8773-90bcf99d426b" />

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
