### PR TITLE
[megatron,doc] docs: point Megatron Lite examples to verl-project/Megatron-LM

### DIFF
--- a/examples/grpo_trainer/run_deepseek_v4_megatron_lite.sh
+++ b/examples/grpo_trainer/run_deepseek_v4_megatron_lite.sh
@@ -9,7 +9,7 @@
 # mlite changes merge upstream. That checkout provides both megatron.lite and
 # the verl_mlite backend glue:
 #
-#   git clone https://github.com/ISEEKYAN/mlite
+#   git clone -b lite https://github.com/verl-project/Megatron-LM mlite
 #   pip install -e mlite/experimental/lite/examples/verl
 #
 # DeepSeek-V4 uses fused DSA kernels on Hopper and Blackwell GPUs. The critical

--- a/examples/grpo_trainer/run_kimi_k2_6_glm5_1_megatron_lite.sh
+++ b/examples/grpo_trainer/run_kimi_k2_6_glm5_1_megatron_lite.sh
@@ -9,7 +9,7 @@
 # mlite changes merge upstream. That checkout provides both megatron.lite and
 # the verl_mlite backend glue:
 #
-#   git clone https://github.com/ISEEKYAN/mlite
+#   git clone -b lite https://github.com/verl-project/Megatron-LM mlite
 #   pip install -e mlite/experimental/lite/examples/verl
 #
 # MODEL_VARIANT selects the target model. Both defaults are 256-GPU mlite runs:

--- a/examples/grpo_trainer/run_qwen3_5_35b_megatron_lite.sh
+++ b/examples/grpo_trainer/run_qwen3_5_35b_megatron_lite.sh
@@ -9,7 +9,7 @@
 # mlite changes merge upstream. That checkout provides both megatron.lite and
 # the verl_mlite backend glue:
 #
-#   git clone https://github.com/ISEEKYAN/mlite
+#   git clone -b lite https://github.com/verl-project/Megatron-LM mlite
 #   pip install -e mlite/experimental/lite/examples/verl
 #
 # Qwen3.5 uses the Megatron Lite allgather CP path. CP is intentionally kept as

--- a/examples/sft/gsm8k/run_deepseek_v4_megatron_lite.sh
+++ b/examples/sft/gsm8k/run_deepseek_v4_megatron_lite.sh
@@ -9,7 +9,7 @@
 # mlite changes merge upstream. That checkout provides both megatron.lite and
 # the verl_mlite backend glue:
 #
-#   git clone https://github.com/ISEEKYAN/mlite
+#   git clone -b lite https://github.com/verl-project/Megatron-LM mlite
 #   pip install -e mlite/experimental/lite/examples/verl
 #
 # DeepSeek-V4 uses fused DSA kernels on Hopper and Blackwell GPUs. The critical


### PR DESCRIPTION
The Megatron Lite example launchers previously instructed cloning the submitter's personal mlite repo. Point them at the official upstream home, verl-project/Megatron-LM (lite branch), into the existing 'mlite' dir so the follow-up 'pip install -e mlite/...' and MLITE_ROOT defaults stay valid.
