### PR TITLE
[megatron, perf] feat: pad BSHD micro-batches to mini-batch max seq_len

### DIFF
--- a/verl/models/mcore/model_forward.py
+++ b/verl/models/mcore/model_forward.py
@@ -273,6 +273,7 @@ def gptmodel_forward_model_engine(
     data_format: str = "thd",
     mtp_enable_train: bool = False,
     local_cp_size: Optional[int] = None,
+    forced_max_seqlen: Optional[int] = None,
 ):
     """Default forward pass for GPT models with optional sequence packing."""
 
@@ -384,7 +385,10 @@ def gptmodel_forward_model_engine(
         assert local_cp_size is None, "dynamic_CP is not supported for bshd format"
 
         input_ids_bshd, attention_mask_bshd, position_ids_bshd = preprocess_bshd_engine(
-            input_ids, pre_process=pre_process or (post_process and mtp_enable_train), use_fp8_padding=use_fp8_padding
+            input_ids,
+            pre_process=pre_process or (post_process and mtp_enable_train),
+            use_fp8_padding=use_fp8_padding,
+            forced_max_seqlen=forced_max_seqlen,
         )
 
         if mtp_enable_train and post_process:
@@ -401,9 +405,13 @@ def gptmodel_forward_model_engine(
                 else:
                     v = _convert_to_nested_tensor(v, input_ids_lengths)
                 logits_processor_args[k] = v
-                args[k] = preprocess_bshd_engine(v, pre_process=True, need_roll=True, use_fp8_padding=use_fp8_padding)[
-                    0
-                ]
+                args[k] = preprocess_bshd_engine(
+                    v,
+                    pre_process=True,
+                    need_roll=True,
+                    use_fp8_padding=use_fp8_padding,
+                    forced_max_seqlen=forced_max_seqlen,
+                )[0]
             model_kwargs["labels"] = args["label"].contiguous()
             model_kwargs["loss_mask"] = args["loss_mask"].contiguous()
 
@@ -414,7 +422,9 @@ def gptmodel_forward_model_engine(
 
         # For VLM model, need to pass bshd format `input_ids` and `attention_mask`.
         if vision_model:
-            input_ids_bshd, attention_mask = build_vlm_attn_mask_bshd(input_ids, batch_size, pad_token_id)
+            input_ids_bshd, attention_mask = build_vlm_attn_mask_bshd(
+                input_ids, batch_size, pad_token_id, forced_max_seqlen=forced_max_seqlen
+            )
         else:
             attention_mask = attention_mask_bshd
 
@@ -427,7 +437,11 @@ def gptmodel_forward_model_engine(
         if post_process and logits_processor is not None:
             args = {
                 k: preprocess_bshd_engine(
-                    v, pre_process=True, need_roll=(k == "label"), use_fp8_padding=use_fp8_padding
+                    v,
+                    pre_process=True,
+                    need_roll=(k == "label"),
+                    use_fp8_padding=use_fp8_padding,
+                    forced_max_seqlen=forced_max_seqlen,
                 )[0]
                 for k, v in logits_processor_args.items()
             }

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -562,7 +562,11 @@ def _build_npu_attn_mask(original_attention_mask: torch.Tensor) -> torch.Tensor:
 
 
 def preprocess_bshd_engine(
-    input_ids: torch.Tensor, pre_process: bool = True, need_roll: bool = False, use_fp8_padding: bool = False
+    input_ids: torch.Tensor,
+    pre_process: bool = True,
+    need_roll: bool = False,
+    use_fp8_padding: bool = False,
+    forced_max_seqlen: Optional[int] = None,
 ):
     """
     Preprocess bshd sequences
@@ -570,6 +574,12 @@ def preprocess_bshd_engine(
 
     The input is a jagged nested tensor with shape [batch, seq, ...]. Any
     dense dimensions after seq are preserved in the returned padded tensor.
+
+    When ``forced_max_seqlen`` is given, it overrides the per-micro-batch
+    ``seqlens_in_batch.max()`` as the raw padding target. Callers that want to
+    align tensor shapes across micro-batches (e.g. to share a cuDNN fused-attention
+    execution plan) pass the *mini-batch* global max here; any TP/CP/FP8 alignment
+    is still applied below, so this argument should be the unaligned raw max.
     """
     cp_size = mpu.get_context_parallel_world_size()
     cp_rank = mpu.get_context_parallel_rank()
@@ -577,7 +587,7 @@ def preprocess_bshd_engine(
     batch_size = input_ids.shape[0]
     dense_shape = tuple(input_ids.shape[2:])
     seqlens_in_batch = input_ids.offsets().diff()
-    max_seqlen = seqlens_in_batch.max().item()
+    max_seqlen = forced_max_seqlen if forced_max_seqlen is not None else seqlens_in_batch.max().item()
     tp_size = mpu.get_tensor_model_parallel_world_size()
     # For CP (zigzag), sequence length must be divisible by (2 * cp_size).
     # After zigzag-CP split each rank holds s/cp_size tokens, which must also be
@@ -758,9 +768,15 @@ def build_vlm_attn_mask_thd(input_ids: torch.Tensor, pad_token_id: int = None):
     return input_ids_rmpad, attention_mask
 
 
-def build_vlm_attn_mask_bshd(input_ids: torch.Tensor, batch_size: int, pad_token_id: int = None):
+def build_vlm_attn_mask_bshd(
+    input_ids: torch.Tensor, batch_size: int, pad_token_id: int = None, forced_max_seqlen: Optional[int] = None
+):
     seqlens_in_batch = input_ids.offsets().diff()
-    max_seqlen = seqlens_in_batch.max().item()
+    # When ``forced_max_seqlen`` is given, pad to the mini-batch global max (raw, unaligned)
+    # so the VLM padded tensors share the same `s_q` as the label/loss_mask produced by
+    # preprocess_bshd_engine; otherwise logits.shape[:2] != label.shape[:2]. TP/CP alignment
+    # is still applied below.
+    max_seqlen = forced_max_seqlen if forced_max_seqlen is not None else seqlens_in_batch.max().item()
 
     # For CP (zigzag), sequence length must be divisible by (2 * cp_size).
     # After zigzag-CP split each rank holds s/cp_size tokens, which must also be

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -65,7 +65,7 @@ actor_rollout_ref:
       use_mbridge: true
       vanilla_mbridge: true
       use_remove_padding: true
-      pad_bshd_to_minibatch_max: false
+      pad_bshd_to_minibatch_max: true
       use_megatron_fsdp: false
       forward_only: false
       dtype: bfloat16
@@ -252,7 +252,7 @@ actor_rollout_ref:
       use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
       vanilla_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.vanilla_mbridge,True}
       use_remove_padding: ${oc.select:actor_rollout_ref.actor.megatron.use_remove_padding,True}
-      pad_bshd_to_minibatch_max: false
+      pad_bshd_to_minibatch_max: true
       use_megatron_fsdp: false
       forward_only: true
       dtype: bfloat16
@@ -574,7 +574,7 @@ critic:
     use_mbridge: true
     vanilla_mbridge: true
     use_remove_padding: true
-    pad_bshd_to_minibatch_max: false
+    pad_bshd_to_minibatch_max: true
     use_megatron_fsdp: false
     forward_only: false
     dtype: bfloat16

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -65,6 +65,7 @@ actor_rollout_ref:
       use_mbridge: true
       vanilla_mbridge: true
       use_remove_padding: true
+      pad_bshd_to_minibatch_max: false
       use_megatron_fsdp: false
       forward_only: false
       dtype: bfloat16
@@ -251,6 +252,7 @@ actor_rollout_ref:
       use_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.use_mbridge,False}
       vanilla_mbridge: ${oc.select:actor_rollout_ref.actor.megatron.vanilla_mbridge,True}
       use_remove_padding: ${oc.select:actor_rollout_ref.actor.megatron.use_remove_padding,True}
+      pad_bshd_to_minibatch_max: false
       use_megatron_fsdp: false
       forward_only: true
       dtype: bfloat16
@@ -572,6 +574,7 @@ critic:
     use_mbridge: true
     vanilla_mbridge: true
     use_remove_padding: true
+    pad_bshd_to_minibatch_max: false
     use_megatron_fsdp: false
     forward_only: false
     dtype: bfloat16

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -103,8 +103,9 @@ vanilla_mbridge: True
 use_remove_padding: True
 
 # BSHD path only. Pad every micro-batch of a mini-batch to the mini-batch's global max sequence length instead of
-# each micro-batch's own max. Unifies padding across micro-batches to avoid repeated cuDNN compilation.
-pad_bshd_to_minibatch_max: False
+# each micro-batch's own max. Unifies padding across micro-batches to avoid repeated cuDNN compilation. Only takes
+# effect when use_remove_padding=False (BSHD); no-op on the THD path.
+pad_bshd_to_minibatch_max: True
 
 # Whether to use Megatron-FSDP (Zero-3 sharding)
 use_megatron_fsdp: False

--- a/verl/trainer/config/engine/megatron.yaml
+++ b/verl/trainer/config/engine/megatron.yaml
@@ -102,6 +102,10 @@ vanilla_mbridge: True
 # whether to use thd format (sequence packing), if not, use bshd format, padding the input_ids to the longest sequence length
 use_remove_padding: True
 
+# BSHD path only. Pad every micro-batch of a mini-batch to the mini-batch's global max sequence length instead of
+# each micro-batch's own max. Unifies padding across micro-batches to avoid repeated cuDNN compilation.
+pad_bshd_to_minibatch_max: False
+
 # Whether to use Megatron-FSDP (Zero-3 sharding)
 use_megatron_fsdp: False
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -194,6 +194,7 @@ class McoreEngineConfig(EngineConfig):
     max_seqlen_per_dp_cp_rank: Optional[int] = None
     sequence_parallel: bool = True
     use_distributed_optimizer: bool = True
+    pad_bshd_to_minibatch_max: bool = False
     use_dist_checkpointing: bool = False
     dist_checkpointing_path: Optional[str] = None
     dist_checkpointing_prefix: str = ""

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -194,7 +194,7 @@ class McoreEngineConfig(EngineConfig):
     max_seqlen_per_dp_cp_rank: Optional[int] = None
     sequence_parallel: bool = True
     use_distributed_optimizer: bool = True
-    pad_bshd_to_minibatch_max: bool = False
+    pad_bshd_to_minibatch_max: bool = True
     use_dist_checkpointing: bool = False
     dist_checkpointing_path: Optional[str] = None
     dist_checkpointing_prefix: str = ""

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -641,6 +641,16 @@ class MegatronEngine(BaseEngine):
         tu.assign_non_tensor(data, batch_num_tokens=batch_num_tokens.item())
         tu.assign_non_tensor(data, dp_size=self.get_data_parallel_size())
 
+        # BSHD path only: pad every micro-batch to the mini-batch's global max seq_len so the
+        # padded `s_q` is shared -> cuDNN plan built once per shape. Raw (unaligned)
+        # max; TP/CP/FP8 alignment is applied inside preprocess_bshd_engine.
+        pad_bshd_to_minibatch_max = self.engine_config.pad_bshd_to_minibatch_max
+        global_max_seqlen = None
+        if pad_bshd_to_minibatch_max and not self.engine_config.use_remove_padding and "input_ids" in data.keys():
+            input_ids_for_max = data["input_ids"]
+            if input_ids_for_max.is_nested:
+                global_max_seqlen = int(input_ids_for_max.offsets().diff().max().item())
+
         vpp_size = mpu.get_virtual_pipeline_model_parallel_world_size()
         if vpp_size is not None and vpp_size > 1:
             num_batches_divided_by = self.tf_config.microbatch_group_size_per_vp_stage
@@ -666,6 +676,8 @@ class MegatronEngine(BaseEngine):
 
         for micro_batch in micro_batches:
             tu.assign_non_tensor(micro_batch, num_micro_batch=n_micro_batch)
+            if global_max_seqlen is not None:
+                tu.assign_non_tensor(micro_batch, forced_max_seqlen=global_max_seqlen)
 
         forward_backward_func = get_forward_backward_func()
 
@@ -998,6 +1010,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
                 data_format=data_format,
                 mtp_enable_train=self.model_config.mtp.enable and self.model_config.mtp.enable_train,
                 local_cp_size=local_cp_size,
+                forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
             )
 
         # Router replay: record routing decisions for R2 mode
@@ -1075,6 +1088,7 @@ class MegatronEngineWithValueHead(MegatronEngineWithLMHead):
             vision_model=hasattr(self.model_config.hf_config, "vision_config"),
             pad_token_id=self.model_config.tokenizer.pad_token_id,
             data_format="thd" if self.engine_config.use_remove_padding else "bshd",
+            forced_max_seqlen=tu.get_non_tensor_data(data=batch, key="forced_max_seqlen", default=None),
         )
 
         return output, partial(postprocess_micro_batch_func, data=batch)


### PR DESCRIPTION
### What does this PR do?

In the BSHD path (`use_remove_padding=False`), each micro-batch was independently padded to its own `seqlens_in_batch.max()`, so the 32 micro-batches of a mini-batch produced 20+ different padded `s_q` shapes. Each novel shape triggers a cuDNN fused-attention **Graph Build** (~1s of synchronous CPU-side work inside the TransformerEngine `.so`, invisible to the Python profiler), and the resulting plan is cached per shape per stream.
<img width="2438" height="862" alt="image" src="https://github.com/user-attachments/assets/bcc848b7-97a9-48b7-8ee7-a08bff579b73" />
This issue was also mentioned in [NVIDIA/TransformerEngine#2033]


This PR adds an opt-in `actor_rollout_ref.actor.megatron.pad_bshd_to_minibatch_max` flag (default `false` = legacy behavior). When enabled, every micro-batch of a mini-batch is padded to the mini-batch's **global** max sequence length, so the padded `s_q` is shared across micro-batches. The cuDNN execution plan is then built once per shape instead of once per micro-batch, eliminating the repeated ~1s CPU stalls.


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - `gh pr list --repo verl-project/verl --state all --search "forced_max_seqlen"` → no results
  - `gh pr list --repo verl-project/verl --state all --search "preprocess_bshd_engine"` → only #6506 (preserves BSHD top-k trailing dims; unrelated to this change)
  - Related but distinct: #5338 (`use_length_grouped_bsz` for FSDP reduces padding *waste* via length-sorted grouping; this PR targets the Megatron BSHD path and a different cost — cuDNN plan rebuild from unequal micro-batch shapes). No overlap in code path or mechanism.
  - No existing issue describes this cuDNN plan-cache miss problem.

### Test

We benchmarked on Qwen3.5-35B-A3B (BSHD path) for 15 steps; the "Verl Fix" variant has pad_bshd_to_minibatch_max enabled. The per-stage mean timings are listed below.
Stage | Verl (s) | Verl Fix (s)
-- | -- | --
Total Step Time | 534.13 | 397.71
Gen/Rollout | 171.06 | 170.86
<mark>Old Log Prob<mark> | <mark>78.38<mark> | <mark>35.45<mark>
<mark>Actor Update<mark> | <mark>247.58<mark> | <mark>154.50<mark>
Weight Synchronization | 11.04 | 10.73
Ref Model Computation | 24.73 | 24.84

As the table shows, the Old Log Prob and Actor Update stages exhibit a substantial time reduction, primarily attributable to the elimination of repeated Graph Builds.

### API and Usage Example

New opt-in engine flag, off by default. No change to existing behavior when disabled.

```yaml
actor_rollout_ref:
  actor:
    megatron:
      use_remove_padding: False          # BSHD path
      pad_bshd_to_minibatch_max: True    # unify micro-batch seq_len within a mini-batch
```

### Design & Code Changes

The unified max is computed once per mini-batch and carried to the deep `preprocess_bshd_engine` call, where all TP/CP/FP8 alignment already lives.

- `verl/workers/config/engine.py`: add `pad_bshd_to_minibatch_max: bool = False` to `McoreEngineConfig`.
- `verl/workers/engine/megatron/transformer_impl.py`: in `forward_backward_batch`, when the flag is on and `use_remove_padding=False`, compute the mini-batch's raw (unaligned) global max seq_len from the nested `input_ids` and inject it per micro-batch via NonTensorData **after** chunking. Both `MegatronEngineWithLMHead.forward_step` and `MegatronEngineWithValueHead.forward_step` read it back and pass it to the forward fn.
- `verl/models/mcore/util.py`: `preprocess_bshd_engine` and `build_vlm_attn_mask_bshd` accept `forced_max_seqlen`; when not None it overrides `seqlens_in_batch.max()`. All TP/CP/FP8 alignment is kept as the single source inside these functions, so callers pass the **unaligned raw** max (this is also required for FP8, whose alignment depends on local `batch_size`).
- `verl/models/mcore/model_forward.py`: thread `forced_max_seqlen` through `gptmodel_forward_model_engine` to the 3 `preprocess_bshd_engine` calls (input_ids, MTP label/loss_mask, logits_processor args) and the VLM `build_vlm_attn_mask_bshd` call. The VLM fix is necessary: without it the VLM branch rebuilt `input_ids_bshd` at the per-micro-batch max (overriding forced_max), causing `logits.shape[:2] != label.shape[:2]` and tripping the logits_processor assert.
- Configs: `verl/trainer/config/engine/megatron.yaml` + regenerated `_generated_ppo_megatron_trainer.yaml` (via `scripts/generate_trainer_config.sh`).

The NonTensorData-per-micro-batch approach (vs. a staleable instance attribute) keeps the value isolated per mini-batch with no cross-batch state leakage across actor/critic/logprob passes on the same engine.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `ruff`/`autogen-trainer-cfg` verified; full `pre-commit run --all-files` to be run in a complete env.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not done yet — flag is self-documented in the engine config/yaml; will add a docs note if reviewers prefer.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Existing `tests/utils/test_megatron_bshd_preprocess.py` covers `preprocess_bshd_engine`; a focused unit test for the `forced_max_seqlen` override path will be added.
- [ ] Once your PR is ready for CI, send a message in [the \`ci-request\` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the \`verl\` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit.

---

**AI assistance disclosure**: This PR was developed with AI assistance. The submitting human has reviewed every changed line and is responsible for the change end-to-end. It is not a duplicate of an existing PR (see search links above). Local verification: `py_compile` passes, `ruff`/`autogen-trainer-cfg` pre-commit hooks verified; full Megatron-env regression tests and training comparison to be run by the submitter before requesting review.