### PR TITLE
[rollout] fix: support SGLang FP8 ignored layers for Qwen3.x GatedDeltaNet in rollout

### DIFF
--- a/tests/utils/test_sglang_fp8_utils.py
+++ b/tests/utils/test_sglang_fp8_utils.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from types import SimpleNamespace
+
+from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper, build_sglang_fp8_quant_config
+
+
+def test_build_sglang_fp8_quant_config_preserves_defaults(monkeypatch):
+    monkeypatch.delenv("SGLANG_FP8_IGNORED_LAYERS", raising=False)
+
+    quant_config = build_sglang_fp8_quant_config()
+
+    assert quant_config == {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+    }
+
+
+def test_sglang_fp8_quant_config_merges_hf_ignored_layers(monkeypatch):
+    monkeypatch.delenv("SGLANG_FP8_IGNORED_LAYERS", raising=False)
+    hf_config = SimpleNamespace(
+        quantization_config={
+            "ignored_layers": ["model.layers.0.self_attn.q_proj"],
+            "modules_to_not_convert": ["model.layers.1.mlp.down_proj"],
+        }
+    )
+
+    quant_config = build_sglang_fp8_quant_config(hf_config)
+    helper = SGLangFP8QuantizerHelper(quant_config)
+
+    assert quant_config["ignored_layers"] == [
+        "model.layers.0.self_attn.q_proj",
+        "model.layers.1.mlp.down_proj",
+    ]
+    assert not helper.should_quantize_param("model.layers.0.self_attn.q_proj.weight")
+    assert not helper.should_quantize_param("model.layers.1.mlp.down_proj.weight")
+    assert helper.should_quantize_param("model.layers.2.mlp.down_proj.weight")
+
+
+def test_sglang_fp8_quantizer_reads_sglang_env_ignored_layers(monkeypatch):
+    monkeypatch.setenv("SGLANG_FP8_IGNORED_LAYERS", "linear_attn")
+
+    quant_config = build_sglang_fp8_quant_config()
+    helper = SGLangFP8QuantizerHelper(quant_config)
+
+    assert quant_config["ignored_layers"] == ["linear_attn"]
+    assert not helper.should_quantize_param("model.layers.0.linear_attn.in_proj_ba.weight")
+    assert not helper.should_quantize_param("model.layers.0.linear_attn.g_proj.weight")
+    assert helper.should_quantize_param("model.layers.0.mlp.experts.0.up_proj.weight")

--- a/tests/utils/test_sglang_fp8_utils.py
+++ b/tests/utils/test_sglang_fp8_utils.py
@@ -17,6 +17,14 @@ from types import SimpleNamespace
 from verl.utils.sglang.sglang_fp8_utils import SGLangFP8QuantizerHelper, build_sglang_fp8_quant_config
 
 
+class MappingLikeConfig:
+    def __init__(self, values):
+        self.values = values
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
 def test_build_sglang_fp8_quant_config_preserves_defaults(monkeypatch):
     monkeypatch.delenv("SGLANG_FP8_IGNORED_LAYERS", raising=False)
 
@@ -49,6 +57,25 @@ def test_sglang_fp8_quant_config_merges_hf_ignored_layers(monkeypatch):
     assert not helper.should_quantize_param("model.layers.0.self_attn.q_proj.weight")
     assert not helper.should_quantize_param("model.layers.1.mlp.down_proj.weight")
     assert helper.should_quantize_param("model.layers.2.mlp.down_proj.weight")
+
+
+def test_sglang_fp8_quant_config_accepts_mapping_like_config(monkeypatch):
+    monkeypatch.delenv("SGLANG_FP8_IGNORED_LAYERS", raising=False)
+    hf_config = MappingLikeConfig(
+        {
+            "quantization_config": MappingLikeConfig(
+                {
+                    "ignored_layers": ["model.layers.0.linear_attn"],
+                }
+            )
+        }
+    )
+
+    quant_config = build_sglang_fp8_quant_config(hf_config)
+    helper = SGLangFP8QuantizerHelper(quant_config)
+
+    assert quant_config["ignored_layers"] == ["model.layers.0.linear_attn"]
+    assert not helper.should_quantize_param("model.layers.0.linear_attn.in_proj_ba.weight")
 
 
 def test_sglang_fp8_quantizer_reads_sglang_env_ignored_layers(monkeypatch):

--- a/tests/utils/test_sglang_fp8_utils.py
+++ b/tests/utils/test_sglang_fp8_utils.py
@@ -78,6 +78,23 @@ def test_sglang_fp8_quant_config_accepts_mapping_like_config(monkeypatch):
     assert not helper.should_quantize_param("model.layers.0.linear_attn.in_proj_ba.weight")
 
 
+def test_sglang_fp8_quantizer_matches_regex_ignored_layers(monkeypatch):
+    monkeypatch.delenv("SGLANG_FP8_IGNORED_LAYERS", raising=False)
+    hf_config = SimpleNamespace(
+        quantization_config={
+            "ignored_layers": ["re:.*linear_attn.*"],
+        }
+    )
+
+    quant_config = build_sglang_fp8_quant_config(hf_config)
+    helper = SGLangFP8QuantizerHelper(quant_config)
+
+    assert quant_config["ignored_layers"] == ["re:.*linear_attn.*"]
+    assert not helper.should_quantize_param("model.layers.0.linear_attn.in_proj_ba.weight")
+    assert not helper.should_quantize_param("model.layers.0.linear_attn.g_proj.weight")
+    assert helper.should_quantize_param("model.layers.0.mlp.experts.0.up_proj.weight")
+
+
 def test_sglang_fp8_quantizer_reads_sglang_env_ignored_layers(monkeypatch):
     monkeypatch.setenv("SGLANG_FP8_IGNORED_LAYERS", "linear_attn")
 

--- a/verl/utils/sglang/sglang_fp8_utils.py
+++ b/verl/utils/sglang/sglang_fp8_utils.py
@@ -13,9 +13,106 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from collections.abc import Iterable
+from typing import Any
+
 from verl.utils.fp8_utils import FP8QuantizerHelper
+
+
+def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _normalize_ignored_layers(ignored_layers: Any) -> list[str]:
+    if ignored_layers is None:
+        return []
+    if isinstance(ignored_layers, str):
+        ignored_layers = ignored_layers.split(",")
+    elif not isinstance(ignored_layers, Iterable):
+        ignored_layers = [ignored_layers]
+
+    normalized = []
+    for layer in ignored_layers:
+        layer_name = str(layer).strip()
+        if layer_name:
+            normalized.append(layer_name)
+    return normalized
+
+
+def _dedupe_layers(ignored_layers: Iterable[str]) -> list[str]:
+    seen = set()
+    deduped = []
+    for layer in ignored_layers:
+        layer_lower = layer.lower()
+        if layer_lower in seen:
+            continue
+        seen.add(layer_lower)
+        deduped.append(layer)
+    return deduped
+
+
+def _get_ignored_layers_from_env() -> list[str]:
+    return _normalize_ignored_layers(os.getenv("SGLANG_FP8_IGNORED_LAYERS"))
+
+
+def get_sglang_fp8_ignored_layers(quant_config: Any = None) -> list[str]:
+    ignored_layers = []
+    ignored_layers.extend(_normalize_ignored_layers(_get_config_value(quant_config, "ignored_layers")))
+    ignored_layers.extend(_normalize_ignored_layers(_get_config_value(quant_config, "modules_to_not_convert")))
+    ignored_layers.extend(_get_ignored_layers_from_env())
+    return _dedupe_layers(ignored_layers)
+
+
+def _matches_ignored_layer(param_name: str, ignored_layer: str) -> bool:
+    ignored_layer = ignored_layer.lower().strip(".")
+    if not ignored_layer:
+        return False
+
+    name = param_name.lower().strip(".")
+    module_name = name[: -len(".weight")] if name.endswith(".weight") else name
+    for candidate in (name, module_name):
+        if candidate == ignored_layer:
+            return True
+        if candidate.startswith(f"{ignored_layer}."):
+            return True
+        if candidate.endswith(f".{ignored_layer}"):
+            return True
+        if f".{ignored_layer}." in f".{candidate}.":
+            return True
+    return False
+
+
+def build_sglang_fp8_quant_config(hf_config: Any = None, ignored_layers: Any = None) -> dict[str, Any]:
+    """Build SGLang block-wise FP8 config shared by server init and weight sync."""
+    fp8_quant_config = {
+        "activation_scheme": "dynamic",
+        "fmt": "e4m3",
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+    }
+
+    hf_quant_config = _get_config_value(hf_config, "quantization_config")
+    merged_ignored_layers = get_sglang_fp8_ignored_layers(hf_quant_config)
+    merged_ignored_layers.extend(_normalize_ignored_layers(ignored_layers))
+    merged_ignored_layers = _dedupe_layers(merged_ignored_layers)
+    if merged_ignored_layers:
+        fp8_quant_config["ignored_layers"] = merged_ignored_layers
+
+    return fp8_quant_config
 
 
 class SGLangFP8QuantizerHelper(FP8QuantizerHelper):
     def __init__(self, quant_config):
         super().__init__(quant_config)
+        self.ignored_layers = get_sglang_fp8_ignored_layers(quant_config)
+
+    def should_quantize_param(self, param_name):
+        for ignored_layer in self.ignored_layers:
+            if _matches_ignored_layer(param_name, ignored_layer):
+                return False
+        return super().should_quantize_param(param_name)

--- a/verl/utils/sglang/sglang_fp8_utils.py
+++ b/verl/utils/sglang/sglang_fp8_utils.py
@@ -23,8 +23,9 @@ from verl.utils.fp8_utils import FP8QuantizerHelper
 def _get_config_value(config: Any, key: str, default: Any = None) -> Any:
     if config is None:
         return default
-    if isinstance(config, dict):
-        return config.get(key, default)
+    get_value = getattr(config, "get", None)
+    if callable(get_value):
+        return get_value(key, default)
     return getattr(config, key, default)
 
 

--- a/verl/utils/sglang/sglang_fp8_utils.py
+++ b/verl/utils/sglang/sglang_fp8_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import os
+import re
 from collections.abc import Iterable
 from typing import Any
 
@@ -70,12 +71,19 @@ def get_sglang_fp8_ignored_layers(quant_config: Any = None) -> list[str]:
 
 
 def _matches_ignored_layer(param_name: str, ignored_layer: str) -> bool:
-    ignored_layer = ignored_layer.lower().strip(".")
+    ignored_layer = ignored_layer.strip()
     if not ignored_layer:
         return False
 
-    name = param_name.lower().strip(".")
-    module_name = name[: -len(".weight")] if name.endswith(".weight") else name
+    name = param_name.strip(".")
+    module_name = name[: -len(".weight")] if name.lower().endswith(".weight") else name
+    if ignored_layer.startswith("re:"):
+        pattern = ignored_layer[3:]
+        return any(re.match(pattern, candidate) for candidate in (name, module_name))
+
+    ignored_layer = ignored_layer.lower().strip(".")
+    name = name.lower()
+    module_name = module_name.lower()
     for candidate in (name, module_name):
         if candidate == ignored_layer:
             return True

--- a/verl/workers/rollout/sglang_rollout/async_sglang_server.py
+++ b/verl/workers/rollout/sglang_rollout/async_sglang_server.py
@@ -272,16 +272,12 @@ class SGLangHttpServer:
         quantization = self.config.get("quantization", None)
         if quantization is not None:
             if quantization == "fp8":
+                from verl.utils.sglang.sglang_fp8_utils import build_sglang_fp8_quant_config
+
                 assert version.parse(sglang.__version__) >= version.parse("0.5.5"), (
                     "sglang>=0.5.5 is required for FP8 quantization"
                 )
-                FP8_BLOCK_QUANT_KWARGS = {
-                    "activation_scheme": "dynamic",
-                    "fmt": "e4m3",
-                    "quant_method": "fp8",
-                    "weight_block_size": [128, 128],
-                }
-                fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
+                fp8_block_quant_kwargs = build_sglang_fp8_quant_config(self.model_config.hf_config)
             else:
                 raise ValueError(f"Currently only support fp8 quantization, got: {quantization}")
         infer_tp = self.config.tensor_model_parallel_size * self.config.data_parallel_size

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -119,6 +119,7 @@ class ServerAdapter(BaseRollout):
         if self.config.get("quantization", None) == "fp8":
             import sglang
             from packaging import version
+
             from verl.utils.sglang.sglang_fp8_utils import build_sglang_fp8_quant_config
 
             assert version.parse(sglang.__version__) >= version.parse("0.5.5"), (

--- a/verl/workers/rollout/sglang_rollout/sglang_rollout.py
+++ b/verl/workers/rollout/sglang_rollout/sglang_rollout.py
@@ -119,17 +119,12 @@ class ServerAdapter(BaseRollout):
         if self.config.get("quantization", None) == "fp8":
             import sglang
             from packaging import version
+            from verl.utils.sglang.sglang_fp8_utils import build_sglang_fp8_quant_config
 
             assert version.parse(sglang.__version__) >= version.parse("0.5.5"), (
                 "sglang>=0.5.5 is required for FP8 quantization"
             )
-            FP8_BLOCK_QUANT_KWARGS = {
-                "activation_scheme": "dynamic",
-                "fmt": "e4m3",
-                "quant_method": "fp8",
-                "weight_block_size": [128, 128],
-            }
-            fp8_block_quant_kwargs = dict(FP8_BLOCK_QUANT_KWARGS)
+            fp8_block_quant_kwargs = build_sglang_fp8_quant_config(self.model_config.hf_config)
             self.model_config.hf_config.quantization_config = fp8_block_quant_kwargs
         self._engine: AsyncHttpServerAdapter = None
 


### PR DESCRIPTION
## Summary

- Share SGLang rollout FP8 quantization config between server launch and weight sync.
- Preserve SGLang's `ignored_layers` / `modules_to_not_convert` rules and `SGLANG_FP8_IGNORED_LAYERS` in verl-side FP8 weight conversion.
- Support plain module/path ignored-layer entries and `re:` regex ignored-layer patterns when deciding whether verl should quantize rollout weights before `update_weights`.
- Add unit coverage for default config behavior, mapping-like quant configs, string/env ignored-layer matching, and regex ignored-layer matching.

## Motivation

SGLang 0.5.12 supports FP8 `ignored_layers`, but verl's SGLang rollout path built its FP8 config inline and the verl-side `SGLangFP8QuantizerHelper` did not honor the same ignore rules before `update_weights`.

This can break rollout FP8 for models with small projection layers, such as Qwen GatedDeltaNet `linear_attn` projections, where block-wise FP8 expects dimensions divisible by the 128x128 weight block size.

In our Qwen3.5/3.6-35B-A3B GRPO rollout, the failure was triggered by GatedDeltaNet `linear_attn.in_proj_ba`: after tensor-parallel sharding, the local projection dimension is not divisible by SGLang block-wise FP8's `weight_block_size=[128, 128]`, so verl-side FP8 conversion must apply the same ignored-layer rules before `update_weights`.

This PR supports the ignored-layer forms needed for that alignment:

- Plain module/path entries such as `linear_attn` or `model.layers.0.linear_attn`.
- Regex entries prefixed with `re:`, such as `re:.*linear_attn.*`, matching verl's existing QAT ignore-pattern convention.
- Mapping-like quantization configs, including OmegaConf-style configs that expose `.get()` without inheriting from `dict`.

With this change, users can pass ignored layers through the existing SGLang mechanisms, for example:

```bash
SGLANG_FP8_IGNORED_LAYERS=linear_attn
```

or via model quantization config entries such as:

```json
{
  "quantization_config": {
    "ignored_layers": ["re:.*linear_attn.*"]
  }
}
```

## Duplicate Check

Before opening this PR, I checked for existing open PRs with:

```bash
gh pr list --repo verl-project/verl --state open --search "SGLang FP8 ignored_layers"
gh pr list --repo verl-project/verl --state open --search "rollout fp8 ignored_layers"
gh pr list --repo verl-project/verl --state open --search "SGLang quantization_config ignored_layers"
```

No duplicate open PRs were found.

## Tests

```bash
python -m py_compile \
  verl/utils/sglang/sglang_fp8_utils.py \
  verl/workers/rollout/sglang_rollout/async_sglang_server.py \
  verl/workers/rollout/sglang_rollout/sglang_rollout.py \
  tests/utils/test_sglang_fp8_utils.py
```

Result: passed.

```bash
git diff --check
```

Result: passed.

```bash
PYTHONIOENCODING=utf-8 python tests/special_sanity/validate_structure.py \
  --allow-files tests/test_protocol_on_cpu.py tests/test_base_config_on_cpu.py tests/test_protocol_v2_on_cpu.py
```

Result: passed.

```bash
PYTHONIOENCODING=utf-8 python tests/special_sanity/check_license.py \
  --directories verl/utils/sglang verl/workers/rollout/sglang_rollout
```

Result: passed.

```bash
PYTHONIOENCODING=utf-8 python tests/special_sanity/check_device_api_usage.py --directory ./verl/utils/sglang
PYTHONIOENCODING=utf-8 python tests/special_sanity/check_device_api_usage.py --directory ./verl/workers/rollout/sglang_rollout
```

Result: passed.

Additional verification after adding `re:` support:

- Isolated smoke test for `re:.*linear_attn.*` and plain `linear_attn` ignored-layer matching: passed.

Also smoke-tested on a verl v0.7.1-based Qwen3.5/3.6-35B-A3B GRPO run with SGLang 0.5.12, rollout `quantization=fp8`, and `SGLANG_FP8_IGNORED_LAYERS=linear_attn`.

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and validated them on Qwen3.5/3.6-35B-A3B rollout FP8 training run.