### PR TITLE
[fsdp] fix: fused-kernel gradient tracking bug.

### DIFF
--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -104,9 +104,9 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
         if orig_ndim == 3:
             assert input_ids.ndim == 2, f"input_ids shape doesn't match, {hidden_states.shape} {input_ids.shape}"
             orig_batch_size = hidden_states.shape[0]
-            hidden_states_required_grad = hidden_states.requires_grad
+            hidden_states_requires_grad = hidden_states.requires_grad
             hidden_states = hidden_states.flatten(0, 1)
-            hidden_states.requires_grad = hidden_states_required_grad
+            hidden_states.requires_grad_(hidden_states_requires_grad)
             input_ids = input_ids.flatten(0, 1)
 
         T = hidden_states.shape[0]

--- a/verl/utils/experimental/torch_functional.py
+++ b/verl/utils/experimental/torch_functional.py
@@ -104,7 +104,9 @@ class FusedLinearForPPOFunction(torch.autograd.Function):
         if orig_ndim == 3:
             assert input_ids.ndim == 2, f"input_ids shape doesn't match, {hidden_states.shape} {input_ids.shape}"
             orig_batch_size = hidden_states.shape[0]
+            hidden_states_required_grad = hidden_states.requires_grad
             hidden_states = hidden_states.flatten(0, 1)
+            hidden_states.requires_grad = hidden_states_required_grad
             input_ids = input_ids.flatten(0, 1)
 
         T = hidden_states.shape[0]


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

Currently using use_liger and use_fused_kernel flags create silently corrupted result. The issue is that the .flatten(0,1) inside the fused kernels autograd forward body flips the  requires_grad flag as gradients are not tracked by default within the autograd Functions. In the backward pass, the hidden_states requires_grad is false and that returns None as the gradients. This silently breaks the backpropagation and the reward does not improve.

This PR uses the original requires_grad flag from the hidden_states without relying on the underlying behavior of .flatten(0,1).

Relevant code paths:
* https://github.com/verl-project/verl/blob/1bf9d2d76c244238e8219531c582819a6b407d47/verl/utils/experimental/torch_functional.py#L107
* https://github.com/verl-project/verl/blob/1bf9d2d76c244238e8219531c582819a6b407d47/verl/utils/experimental/torch_functional.py#L165

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

Tested offline.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
