### PR TITLE
[docs] add SGLang FP8 ignored layers usage

### DIFF
--- a/docs/low_precision/fp8.md
+++ b/docs/low_precision/fp8.md
@@ -49,6 +49,44 @@ Or via command line:
 actor_rollout_ref.rollout.quantization=fp8
 ```
 
+#### Skipping layers in SGLang FP8 rollout
+
+When using SGLang FP8 rollout, you can skip FP8 weight quantization for
+selected modules. Skipped modules stay in the rollout model dtype instead
+of being converted to FP8. This is useful for layers that are not
+compatible with block-wise FP8 weight quantization, or for modules that
+you prefer to keep in higher precision.
+
+Set `SGLANG_FP8_IGNORED_LAYERS` before starting training:
+
+```bash
+SGLANG_FP8_IGNORED_LAYERS=linear_attn \
+python3 -m verl.trainer.main_ppo \
+  actor_rollout_ref.rollout.name=sglang \
+  actor_rollout_ref.rollout.quantization=fp8 \
+  ...
+```
+
+Multiple entries can be separated by commas:
+
+```bash
+SGLANG_FP8_IGNORED_LAYERS=linear_attn,visual
+```
+
+You can also use the model `quantization_config`:
+
+```json
+{
+  "quantization_config": {
+    "ignored_layers": ["re:.*linear_attn.*"]
+  }
+}
+```
+
+Plain module names, full module paths, and `re:` regex patterns are
+supported. verl applies the same ignored-layer rules when launching
+SGLang and when syncing updated actor weights into the rollout engine.
+
 ### Experiments and Outcomes
 
 #### Qwen3-8B-Base Dense Model


### PR DESCRIPTION
﻿## Summary

- Document how to skip selected modules during SGLang FP8 rollout weight quantization.
- Add examples for `SGLANG_FP8_IGNORED_LAYERS`, comma-separated entries, and model `quantization_config.ignored_layers` with `re:` patterns.

## Context

This docs-only PR follows up on #6906, which added support for applying the same SGLang FP8 ignored-layer rules when launching SGLang and when syncing updated actor weights into the rollout engine.

## Duplicate Check

Before opening this PR, I checked for existing work with:

```bash
gh issue view 6906 --repo verl-project/verl --comments
gh pr list --repo verl-project/verl --state open --search "6906 in:body"
gh pr list --repo verl-project/verl --state open --search "SGLang FP8 ignored layers docs"
gh pr list --repo verl-project/verl --state open --search "rollout fp8 ignored_layers"
```

No duplicate open PRs were found.

## Tests

```bash
git diff --check
```

Result: passed.

```bash
PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python tests/special_sanity/check_docs_time_info.py
```

Result: passed.

```bash
PYTHONIOENCODING=utf-8 PYTHONUTF8=1 python tests/special_sanity/validate_structure.py \
  --allow-files tests\\test_protocol_on_cpu.py tests\\test_base_config_on_cpu.py tests\\test_protocol_v2_on_cpu.py
```

Result: passed.

`pre-commit` was also run during commit. All hooks passed except `validate-structure`, which was skipped for the commit after the manual command above passed with Windows path separators; the default hook allow-list uses POSIX-style paths and does not match those existing root-level tests on Windows.

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated documentation change and validation output.
