### PR TITLE
[trainer] fix: Update latest TorchtitanEngine

### DIFF
--- a/tests/special_e2e/run_ppo_trainer_torchtitan.sh
+++ b/tests/special_e2e/run_ppo_trainer_torchtitan.sh
@@ -1,58 +1,90 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-# Download model if not exists
+NUM_GPUS=${NUM_GPUS:-1}
+
 MODEL_ID=${MODEL_ID:-Qwen/Qwen3-0.6B}
 MODEL_PATH=${MODEL_PATH:-${HOME}/models/${MODEL_ID}}
 #huggingface-cli download "${MODEL_ID}" --local-dir "${MODEL_PATH}"
 
+TRAIN_FILES=${TRAIN_FILES:-${HOME}/data/gsm8k/train.parquet}
+VAL_FILES=${VAL_FILES:-${HOME}/data/gsm8k/test.parquet}
+
 VAL_BEFORE_TRAIN=${VAL_BEFORE_TRAIN:-False}
-NUM_GPUS=${NUM_GPUS:-1}
+
+MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-512}
+MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-256}
+
+# torchtitan parallelism
 FSDP_SIZE=${FSDP_SIZE:-1}
 TP_SIZE=${TP_SIZE:-1}
 EP_SIZE=${EP_SIZE:-1}
-VERL_EXP_NAME=${VERL_EXP_NAME:-qwen3-0.6b-function-reward-minimal-fsdp-size1}
 
-python3 -m verl.trainer.main_ppo \
-    model_engine=torchtitan \
-    algorithm.adv_estimator=grpo \
-    data.train_files=$HOME/data/gsm8k/train.parquet \
-    data.val_files=$HOME/data/gsm8k/test.parquet \
-    data.train_batch_size=256  \
-    data.max_prompt_length=512 \
-    data.max_response_length=256  \
-    data.seed=42 \
-    actor_rollout_ref.model.path="${MODEL_PATH}" \
-    actor_rollout_ref.model.use_remove_padding=True \
-    actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.actor.optim.min_lr_factor=1.0 \
-    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
-    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4  \
-    actor_rollout_ref.actor.torchtitan.data_parallel_shard_size="${FSDP_SIZE}" \
-    actor_rollout_ref.actor.torchtitan.tensor_parallel_size="${TP_SIZE}" \
-    actor_rollout_ref.actor.torchtitan.expert_parallel_size="${EP_SIZE}" \
-    actor_rollout_ref.actor.torchtitan.attn_type=flex \
-    actor_rollout_ref.actor.torchtitan.use_torch_compile=False \
-    actor_rollout_ref.actor.torchtitan.param_offload=False \
-    actor_rollout_ref.actor.torchtitan.optimizer_offload=False \
-    actor_rollout_ref.ref.torchtitan.use_torch_compile=False \
-    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
-    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
-    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
-    actor_rollout_ref.rollout.enable_chunked_prefill=False \
-    actor_rollout_ref.rollout.name=vllm \
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
-    actor_rollout_ref.rollout.free_cache_engine=True \
-    actor_rollout_ref.rollout.enforce_eager=True \
-    actor_rollout_ref.rollout.n=5 \
-    critic.optim.lr=1e-5 \
-    critic.model.path="${MODEL_PATH}" \
-    critic.ppo_micro_batch_size_per_gpu=4 \
-    algorithm.kl_ctrl.kl_coef=0.001 \
-    trainer.logger=['console','file','wandb'] \
-    trainer.project_name='verl_grpo_example_gsm8k_0217' \
-    trainer.experiment_name="${VERL_EXP_NAME}" \
-    trainer.val_before_train="${VAL_BEFORE_TRAIN}" \
-    trainer.n_gpus_per_node="${NUM_GPUS}" \
-    trainer.nnodes=1 \
-    trainer.total_training_steps=100 $@
+# torchtitan attention backend (sdpa is not a valid language-model backend):
+#   "flex"       - FlexAttention; needs torch.compile to be fast (eager is slow)
+#   "flex_flash" - FlexAttention FLASH kernel; needs flash-attn-4/CUTE, Hopper/Blackwell only
+#   "varlen"     - fast eager, flash-style; needs FA3 (flash_attn_interface)
+ATTN_TYPE=${ATTN_TYPE:-flex}
+# activation checkpointing: "selective" | "full" | "none".
+# Use "none" for spmd_backend=spmd_types with use_torch_compile=False (eager AC
+# recompute runs off the SPMD mesh context and crashes in spmd.assert_type).
+AC_MODE=${AC_MODE:-none}
+# torchtitan SPMD backend:
+#   "default"      - legacy per-parallelism sharding (no full-DTensor mesh)
+#   "full_dtensor" - all params/buffers/inputs are DTensors on a dense multi-axis mesh
+#   "spmd_types"   - spmd_types typed collectives on a dense mesh
+SPMD_BACKEND=${SPMD_BACKEND:-spmd_types}
+
+VERL_EXP_NAME=${VERL_EXP_NAME:-qwen3-0.6b-torchtitan}
+
+common_params=(
+    model_engine=torchtitan
+    algorithm.adv_estimator=grpo
+    data.train_files="${TRAIN_FILES}"
+    data.val_files="${VAL_FILES}"
+    data.train_batch_size=256
+    data.max_prompt_length=${MAX_PROMPT_LENGTH}
+    data.max_response_length=${MAX_RESPONSE_LENGTH}
+    data.seed=42
+    actor_rollout_ref.model.path="${MODEL_PATH}"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.actor.optim.lr=1e-6
+    actor_rollout_ref.actor.optim.min_lr_factor=1.0
+    actor_rollout_ref.actor.ppo_mini_batch_size=64
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4
+    actor_rollout_ref.actor.torchtitan.data_parallel_shard_size="${FSDP_SIZE}"
+    actor_rollout_ref.actor.torchtitan.tensor_parallel_size="${TP_SIZE}"
+    actor_rollout_ref.actor.torchtitan.expert_parallel_size="${EP_SIZE}"
+    actor_rollout_ref.actor.torchtitan.attn_type="${ATTN_TYPE}"
+    actor_rollout_ref.actor.torchtitan.activation_checkpoint="${AC_MODE}"
+    actor_rollout_ref.actor.torchtitan.spmd_backend="${SPMD_BACKEND}"
+    actor_rollout_ref.actor.torchtitan.use_torch_compile=False
+    actor_rollout_ref.actor.torchtitan.param_offload=False
+    actor_rollout_ref.actor.torchtitan.optimizer_offload=False
+    actor_rollout_ref.ref.torchtitan.use_torch_compile=False
+    actor_rollout_ref.ref.torchtitan.attn_type="${ATTN_TYPE}"
+    actor_rollout_ref.ref.torchtitan.activation_checkpoint="${AC_MODE}"
+    actor_rollout_ref.ref.torchtitan.spmd_backend="${SPMD_BACKEND}"
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1
+    actor_rollout_ref.rollout.enable_chunked_prefill=False
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8
+    actor_rollout_ref.rollout.free_cache_engine=True
+    actor_rollout_ref.rollout.enforce_eager=True
+    actor_rollout_ref.rollout.n=5
+    critic.optim.lr=1e-5
+    critic.model.path="${MODEL_PATH}"
+    critic.ppo_micro_batch_size_per_gpu=4
+    algorithm.kl_ctrl.kl_coef=0.001
+    trainer.logger=['console','file','wandb']
+    trainer.project_name='verl_grpo_example_gsm8k_0217'
+    trainer.experiment_name="${VERL_EXP_NAME}"
+    trainer.val_before_train="${VAL_BEFORE_TRAIN}"
+    trainer.n_gpus_per_node="${NUM_GPUS}"
+    trainer.nnodes=1
+    trainer.total_training_steps=100
+)
+
+python3 -m verl.trainer.main_ppo "${common_params[@]}" $@

--- a/tests/special_e2e/run_ppo_trainer_torchtitan.sh
+++ b/tests/special_e2e/run_ppo_trainer_torchtitan.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+# Download model if not exists
+MODEL_ID=${MODEL_ID:-Qwen/Qwen3-0.6B}
+MODEL_PATH=${MODEL_PATH:-${HOME}/models/${MODEL_ID}}
+#huggingface-cli download "${MODEL_ID}" --local-dir "${MODEL_PATH}"
+
+VAL_BEFORE_TRAIN=${VAL_BEFORE_TRAIN:-False}
+NUM_GPUS=${NUM_GPUS:-1}
+FSDP_SIZE=${FSDP_SIZE:-1}
+TP_SIZE=${TP_SIZE:-1}
+EP_SIZE=${EP_SIZE:-1}
+VERL_EXP_NAME=${VERL_EXP_NAME:-qwen3-0.6b-function-reward-minimal-fsdp-size1}
+
+python3 -m verl.trainer.main_ppo \
+    model_engine=torchtitan \
+    algorithm.adv_estimator=grpo \
+    data.train_files=$HOME/data/gsm8k/train.parquet \
+    data.val_files=$HOME/data/gsm8k/test.parquet \
+    data.train_batch_size=256  \
+    data.max_prompt_length=512 \
+    data.max_response_length=256  \
+    data.seed=42 \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.min_lr_factor=1.0 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=4  \
+    actor_rollout_ref.actor.torchtitan.data_parallel_shard_size="${FSDP_SIZE}" \
+    actor_rollout_ref.actor.torchtitan.tensor_parallel_size="${TP_SIZE}" \
+    actor_rollout_ref.actor.torchtitan.expert_parallel_size="${EP_SIZE}" \
+    actor_rollout_ref.actor.torchtitan.attn_type=flex \
+    actor_rollout_ref.actor.torchtitan.use_torch_compile=False \
+    actor_rollout_ref.actor.torchtitan.param_offload=False \
+    actor_rollout_ref.actor.torchtitan.optimizer_offload=False \
+    actor_rollout_ref.ref.torchtitan.use_torch_compile=False \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.enable_chunked_prefill=False \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.n=5 \
+    critic.optim.lr=1e-5 \
+    critic.model.path="${MODEL_PATH}" \
+    critic.ppo_micro_batch_size_per_gpu=4 \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    trainer.logger=['console','file','wandb'] \
+    trainer.project_name='verl_grpo_example_gsm8k_0217' \
+    trainer.experiment_name="${VERL_EXP_NAME}" \
+    trainer.val_before_train="${VAL_BEFORE_TRAIN}" \
+    trainer.n_gpus_per_node="${NUM_GPUS}" \
+    trainer.nnodes=1 \
+    trainer.total_training_steps=100 $@

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -42,6 +42,8 @@ actor_rollout_ref:
       pipeline_parallel_size: 1
       context_parallel_size: 1
       attn_type: flex
+      spmd_backend: spmd_types
+      activation_checkpoint: selective
       max_seq_len: null
       strategy: torchtitan
       seed: 42
@@ -178,6 +180,8 @@ actor_rollout_ref:
       pipeline_parallel_size: ${oc.select:actor_rollout_ref.actor.torchtitan.pipeline_parallel_size,1}
       context_parallel_size: ${oc.select:actor_rollout_ref.actor.torchtitan.context_parallel_size,1}
       attn_type: ${oc.select:actor_rollout_ref.actor.torchtitan.attn_type,flex}
+      spmd_backend: spmd_types
+      activation_checkpoint: selective
       max_seq_len: null
       strategy: torchtitan
       seed: ${oc.select:actor_rollout_ref.actor.torchtitan.seed,42}
@@ -506,6 +510,8 @@ critic:
     pipeline_parallel_size: 1
     context_parallel_size: 1
     attn_type: flex
+    spmd_backend: spmd_types
+    activation_checkpoint: selective
     max_seq_len: null
     strategy: torchtitan
     seed: 42

--- a/verl/trainer/config/engine/torchtitan.yaml
+++ b/verl/trainer/config/engine/torchtitan.yaml
@@ -61,6 +61,14 @@ context_parallel_size: 1
 # Attention type for torchtitan's model (e.g., "sdpa", "flex", "varlen")
 attn_type: flex
 
+# torchtitan SPMD backend: "default", "full_dtensor", or "spmd_types"
+spmd_backend: spmd_types
+
+# Activation checkpointing mode: "selective", "full", or "none".
+# Use "none" with spmd_backend=spmd_types when use_torch_compile=False (eager AC
+# recompute runs off the SPMD mesh context); compiled runs are unaffected.
+activation_checkpoint: selective
+
 # Maximum sequence length for RoPE cache. If null, defaults to torchtitan's TrainingConfig.seq_len (2048).
 max_seq_len: null
 

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -425,6 +425,13 @@ class TorchtitanEngineConfig(EngineConfig):
         context_parallel_size (int): Context parallel size, default 1
         attn_type (str): Attention type for torchtitan's model (e.g., "sdpa", "flex", "varlen"),
             default "flex"
+        spmd_backend (str): torchtitan SPMD backend, one of "default", "full_dtensor", "spmd_types",
+            default "spmd_types"
+        activation_checkpoint (str): Activation checkpointing mode, one of "selective", "full", "none".
+            Default "selective" (torchtitan's default). Use "none" under spmd_backend="spmd_types" with
+            eager: selective/full AC recompute runs on the autograd backward
+            thread where the thread-local SPMD mesh is inactive, so spmd.assert_type raises
+            "no current mesh". Compiled runs recompute in-graph and are unaffected.
         strategy (str): Strategy to use for distributed training, default "torchtitan"
         seed (int): Random seed for reproducibility.
         full_determinism (bool): If true, enable_full_determinism is called to ensure reproducible results
@@ -452,6 +459,8 @@ class TorchtitanEngineConfig(EngineConfig):
     pipeline_parallel_size: int = 1
     context_parallel_size: int = 1
     attn_type: str = "flex"
+    spmd_backend: str = "spmd_types"
+    activation_checkpoint: str = "selective"
     max_seq_len: Optional[int] = None
     strategy: str = "torchtitan"
     seed: int = 42
@@ -459,6 +468,15 @@ class TorchtitanEngineConfig(EngineConfig):
 
     def __post_init__(self):
         super().__post_init__()
+        assert self.attn_type in ["flex", "flex_flash", "varlen"], (
+            f"attn_type {self.attn_type} not supported (sdpa is not a valid language-model backend)"
+        )
+        assert self.spmd_backend in ["default", "full_dtensor", "spmd_types"], (
+            f"spmd_backend {self.spmd_backend} not supported"
+        )
+        assert self.activation_checkpoint in ["selective", "full", "none"], (
+            f"activation_checkpoint {self.activation_checkpoint} not supported"
+        )
         assert self.strategy in ["torchtitan"], f"strategy {self.strategy} not supported"
 
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -33,6 +33,7 @@ from torchtitan.components.lr_scheduler import LRSchedulersContainer
 from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed import utils as dist_utils
+from torchtitan.distributed.activation_checkpoint import FullAC, SelectiveAC
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.train import Trainer
@@ -142,6 +143,7 @@ class TorchTitanEngine(BaseEngine):
             pipeline_parallel_degree=self.engine_config.pipeline_parallel_size,
             context_parallel_degree=self.engine_config.context_parallel_size,
             expert_parallel_degree=self.engine_config.expert_parallel_size,
+            spmd_backend=self.engine_config.spmd_backend,
         )
         checkpoint = CheckpointManager.Config(
             enable=True,
@@ -158,6 +160,17 @@ class TorchTitanEngine(BaseEngine):
         else:
             training = TrainingConfig(**training_kwargs)
 
+        # Activation checkpointing mode. Note: under spmd_backend="spmd_types" with
+        # eager execution (use_torch_compile=False), selective/full AC recompute runs
+        # on the autograd backward thread where the thread-local SPMD mesh is inactive,
+        # so spmd.assert_type() raises "no current mesh". Set activation_checkpoint="none"
+        # (or enable torch.compile, which recomputes in-graph) in that configuration.
+        activation_checkpoint = {
+            "selective": SelectiveAC.Config,
+            "full": FullAC.Config,
+            "none": lambda: None,
+        }[self.engine_config.activation_checkpoint]()
+
         # Construct Torchtitan's Trainer.Config
         self.config = Trainer.Config(
             model_spec=model_spec,
@@ -168,6 +181,7 @@ class TorchTitanEngine(BaseEngine):
             checkpoint=checkpoint,
             compile=compile_config,
             training=training,
+            activation_checkpoint=activation_checkpoint,
             # Use a no-op dataloader since verl has its own data loading
             dataloader=NoOpDataLoader.Config(),
             # Provide a concrete loss so Trainer.__init__ can build it;

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -26,12 +26,11 @@ from typing import Any, Callable, Optional
 import torch
 import torch.distributed
 from tensordict import TensorDict
-from torch.distributed.checkpoint.state_dict import get_model_state_dict
 from torch.distributed.tensor import DTensor
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.loss import CrossEntropyLoss
 from torchtitan.components.lr_scheduler import LRSchedulersContainer
-from torchtitan.components.optimizer import OptimizersContainer
+from torchtitan.components.optimizer import OptimizersContainer, ParamGroupConfig
 from torchtitan.config import CompileConfig, ParallelismConfig, TrainingConfig
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.distributed.context_parallel import prepare_context_parallel_input
@@ -111,12 +110,18 @@ class TorchTitanEngine(BaseEngine):
         model_spec = model_module.model_registry(torchtitan_flavor, attn_backend=self.engine_config.attn_type)
 
         optimizer = OptimizersContainer.Config(
-            name=self.optimizer_config.name,
-            lr=self.optimizer_config.lr,
-            eps=self.optimizer_config.eps,
-            beta1=self.optimizer_config.betas[0],
-            beta2=self.optimizer_config.betas[1],
-            weight_decay=self.optimizer_config.weight_decay,
+            param_groups=[
+                ParamGroupConfig(
+                    pattern=r".*",
+                    optimizer_name=self.optimizer_config.name,
+                    optimizer_kwargs={
+                        "lr": self.optimizer_config.lr,
+                        "eps": self.optimizer_config.eps,
+                        "betas": (self.optimizer_config.betas[0], self.optimizer_config.betas[1]),
+                        "weight_decay": self.optimizer_config.weight_decay,
+                    },
+                )
+            ],
         )
 
         total_steps = self.optimizer_config.total_training_steps
@@ -485,10 +490,9 @@ class TorchTitanEngine(BaseEngine):
         for module in self.module:
             load_fsdp_model_to_gpu(module)
 
-        # Collect state dicts from all model parts
         params = {}
         for module in self.module:
-            module_params = get_model_state_dict(module)
+            module_params = module.state_dict()
             params.update(module_params)
 
         if self._is_offload_param:

--- a/verl/workers/engine/torchtitan/utils.py
+++ b/verl/workers/engine/torchtitan/utils.py
@@ -173,7 +173,9 @@ def get_attention_masks(
     attn_type: str,
 ) -> AttentionMasksType:
     match attn_type:
-        case "flex":
+        case "flex" | "flex_flash":
+            # flex_flash is FlexAttention with the FLASH kernel backend; it uses
+            # the same BlockMask as flex.
             return _get_flex_attention_masks(
                 input_batch,
                 positions,


### PR DESCRIPTION
### What does this PR do?

1. Support Titan with `spmd_types`(requires pytorch nightly >= 0624), and defaulted to `spmd_type` run instead of using `DTensor`. Note: `spmd_types` and `DTensor` speed is roughly on par, both faster than fsdp engine. See below. 
2. API-compatibility fixes so TorchTitan engine works with latest torchtitan nightly, add an e2e test script. Will set up CI using this script in a follow up PR. 

### Test on qwen3 0.6b 
```
OTEL_SDK_DISABLED=true NUM_GPUS=4 FSDP_SIZE=4  GRPC_ENABLE_FORK_SUPPORT=0 NCCL_NVLS_ENABLE=0  bash tests/special_e2e/run_ppo_trainer_fsdp.sh
```
Testing 1: Ran comparison between FSDP engine([config](https://gist.github.com/acisseJZhong/f326601da0fa9cdebc48c5844fdc84d0)) and torchtitan engine spmd_types, and default types, both running fsdp4. 
<img width="1112" height="611" alt="image" src="https://github.com/user-attachments/assets/40d01003-d614-432e-8718-f688755f2c4f" />
<img width="1112" height="613" alt="image" src="https://github.com/user-attachments/assets/96ce1558-96ac-4b84-a87f-8f06053e1a50" />
<img width="1111" height="626" alt="image" src="https://github.com/user-attachments/assets/7b6286ae-a877-44b5-8f4c-f685086e6d8f" />

======================================================================================
Testing 2: Ran comparison between FSDP engine([config](https://gist.github.com/acisseJZhong/f636681ffa6ba29be4f5a6f991093726)) and torchtitan engine(tested both `flex` and `flex_flash` attn), both running fsdp4.
<img width="1117" height="662" alt="image" src="https://github.com/user-attachments/assets/1e2a3d18-4616-4dd4-9452-ca7fdda200d9" />
<img width="1063" height="610" alt="image" src="https://github.com/user-attachments/assets/d4a4cc41-4c6d-42ab-a129-d11dc802afd3" />
<img width="1114" height="626" alt="image" src="https://github.com/user-attachments/assets/218cb751-e6f2-4dad-a3e7-b6d0709f10c4" />


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
