### PR TITLE
[trainer] fix: gracefully finalize tracking and dataloader workers at fit() exits

### DIFF
--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -75,6 +75,7 @@ from verl.utils import hf_processor, hf_tokenizer
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path
 from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.dataloader import shutdown_dataloaders
 from verl.utils.dataset.rl_dataset import collate_fn
 from verl.utils.debug import marked_timer
 from verl.utils.debug.metrics import calculate_debug_metrics
@@ -323,6 +324,15 @@ class PPOTrainer(ABC):
             experiment_name=self.config.trainer.experiment_name,
         )
 
+        try:
+            self._fit()
+        finally:
+            # Graceful teardown on every exit (including exceptions), while the process
+            # is still healthy: stop DataLoader workers, then finalize tracking backends.
+            self._shutdown_dataloaders()
+            self.logger.finish()
+
+    def _fit(self):
         # perform validation before training
         if self.config.trainer.get("val_before_train", True):
             self.on_validate_begin()
@@ -989,6 +999,21 @@ class PPOTrainer(ABC):
             f.result()
         self._dump_futures.clear()
         self._dump_executor.shutdown(wait=True)
+
+    def _shutdown_dataloaders(self):
+        """Stop DataLoader worker processes before returning (avoids post-run SIGKILL).
+
+        With ``dataloader_num_workers > 0`` the live train iterator keeps worker
+        subprocesses alive; if they are not stopped here they are SIGKILLed at
+        interpreter/Ray teardown, surfacing a spurious post-success
+        ``RuntimeError: DataLoader worker (pid ...) is killed by signal: Killed``.
+        With torchdata's StatefulDataLoader, ``dataloader._iterator`` is the same
+        object stored in ``self.train_dataloader_it``, so this reaches the live
+        train workers as well as the (already-drained) validation workers.
+        """
+        shutdown_dataloaders(self.train_dataloader, self.val_dataloader)
+        # Drop the reference to the now shut-down iterator so it is not reused.
+        self.train_dataloader_it = None
 
     def _log_rollout_data(self, batch: KVBatchMeta, timing_raw: dict, rollout_data_dir: str):
         """Fetch rollout data from TransferQueue and dump sorted by uid."""

--- a/verl/utils/dataloader.py
+++ b/verl/utils/dataloader.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for DataLoader lifecycle management."""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def shutdown_dataloader_workers(dataloader: Any) -> bool:
+    """Best-effort shutdown for multiprocessing DataLoader iterators.
+
+    PyTorch and torchdata keep worker processes on the active iterator. There
+    is no public close API, so this helper uses the same private shutdown hook
+    that the iterator destructor calls, but does it while the trainer is still
+    in a normal execution context instead of during Python/Ray teardown.
+    """
+    iterator = getattr(dataloader, "_iterator", None)
+    if iterator is None:
+        return False
+
+    shutdown_workers = getattr(iterator, "_shutdown_workers", None)
+    try:
+        if callable(shutdown_workers):
+            shutdown_workers()
+            return True
+        return False
+    except Exception:
+        logger.warning("Failed to shut down DataLoader workers", exc_info=True)
+        return False
+    finally:
+        if getattr(dataloader, "_iterator", None) is iterator:
+            dataloader._iterator = None
+
+
+def shutdown_dataloaders(*dataloaders: Any) -> None:
+    """Shut down active worker iterators for any initialized dataloaders."""
+    for dataloader in dataloaders:
+        if dataloader is None:
+            continue
+        shutdown_dataloader_workers(dataloader)

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -185,21 +185,55 @@ class Tracking:
             if backend is None or default_backend in backend:
                 logger_instance.log(data=data, step=step)
 
+    def finish(self):
+        """Finalize the tracking backends that require explicit teardown.
+
+        Idempotent and exception-safe: this may be called explicitly at the end of
+        training and again from ``__del__`` during garbage collection; the second
+        call is a harmless no-op. A failure in one backend never propagates and
+        never prevents the other backends from finalizing, so a logger hiccup can
+        never break training. (mlflow and console are intentionally not finalized
+        here, matching the previous behavior.)
+        """
+        if getattr(self, "_finished", False):
+            return
+        self._finished = True
+        loggers = getattr(self, "logger", {})
+
+        def _safe_finish(name, fn):
+            try:
+                fn()
+            except Exception:
+                logger.warning("Failed to finish tracking backend '%s'", name, exc_info=True)
+
+        if "wandb" in loggers:
+            _safe_finish("wandb", lambda: loggers["wandb"].finish(exit_code=0))
+            # Also tear down the wandb-core service in-band, while it is still alive: this
+            # unregisters wandb's own atexit service teardown, which otherwise races the
+            # core's exit under Ray and raises BrokenPipeError at process shutdown. wandb
+            # recommends calling teardown() explicitly; its atexit hook is unreliable under
+            # multiprocessing. SystemExit is caught because teardown() calls sys.exit() when
+            # the core reports a non-zero exit code.
+            try:
+                loggers["wandb"].teardown(exit_code=0)
+            except (Exception, SystemExit):
+                logger.warning("wandb.teardown() failed", exc_info=True)
+        if "swanlab" in loggers:
+            _safe_finish("swanlab", lambda: loggers["swanlab"].finish())
+        if "vemlp_wandb" in loggers:
+            _safe_finish("vemlp_wandb", lambda: loggers["vemlp_wandb"].finish(exit_code=0))
+        if "tensorboard" in loggers:
+            _safe_finish("tensorboard", lambda: loggers["tensorboard"].finish())
+        if "clearml" in loggers:
+            _safe_finish("clearml", lambda: loggers["clearml"].finish())
+        if "trackio" in loggers:
+            _safe_finish("trackio", lambda: loggers["trackio"].finish())
+        if "file" in loggers:
+            _safe_finish("file", lambda: loggers["file"].finish())
+
     def __del__(self):
-        if "wandb" in self.logger:
-            self.logger["wandb"].finish(exit_code=0)
-        if "swanlab" in self.logger:
-            self.logger["swanlab"].finish()
-        if "vemlp_wandb" in self.logger:
-            self.logger["vemlp_wandb"].finish(exit_code=0)
-        if "tensorboard" in self.logger:
-            self.logger["tensorboard"].finish()
-        if "clearml" in self.logger:
-            self.logger["clearml"].finish()
-        if "trackio" in self.logger:
-            self.logger["trackio"].finish()
-        if "file" in self.logger:
-            self.logger["file"].finish()
+        # Fallback finalization in case finish() was not called explicitly.
+        self.finish()
 
 
 class ClearMLLogger:


### PR DESCRIPTION
### What does this PR do?

The V1 PPO trainer finalizes two end-of-run resources only via `__del__` / garbage collection, which under Ray / interpreter teardown runs too late. This PR finalizes both explicitly, in a single `try/finally` around the training loop, so cleanup runs on normal completion, `val_only`, **and** exceptions:

- **W&B dashboards show only the "System" charts.** `Tracking` finalized wandb only in `__del__`, which fires after the wandb-core service connection has already closed, so `wandb.finish()` never delivers the exit record and history/summary/exit are never flushed. Fixes #1733.
- **`RuntimeError: DataLoader worker (pid ...) is killed by signal: Killed`** printed at process exit when `data.dataloader_num_workers > 0` — the live `StatefulDataLoader` worker iterator is never shut down before `fit()` returns, so the workers are SIGKILLed during teardown. Fixes #5922; supersedes #6292 (closed for a CLA/authorship issue, not on technical merit — its helper is reused here) and, per that PR's review, covers all `fit()` exit paths.

AI assistance was used to isolate the root causes and design the fix; the submitter has reviewed and tested the change.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - [issues: `DataLoader worker killed by signal`](https://github.com/verl-project/verl/issues?q=DataLoader+worker+killed+by+signal) → #5922
  - [PRs: `dataloader worker teardown`](https://github.com/verl-project/verl/pulls?q=is%3Apr+dataloader+worker+teardown) → #6292 (closed for CLA, not merit)
  - [issues: `wandb final validation stats`](https://github.com/verl-project/verl/issues?q=wandb+log+final+validation) → #1733
  - No open PR fixes the V1 trainer's teardown.
- [x] Format the PR title as `[{modules}] {type}: {description}` → `[trainer] fix: gracefully finalize tracking and dataloader workers at fit() exits` (additive only, no `[BREAKING]`).

### Test
Not covered by CI (see Checklist Before Submitting). Validated with a minimal 2-step GRPO run (single GPU, `dataloader_num_workers=8`, wandb logging) that reproduces both symptoms:

```bash
python3 examples/data_preprocess/gsm8k.py --local_dir ~/data/gsm8k

python3 -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    data.train_files=$HOME/data/gsm8k/train.parquet \
    data.val_files=$HOME/data/gsm8k/test.parquet \
    data.train_batch_size=8 \
    data.max_prompt_length=512 \
    data.max_response_length=256 \
    data.dataloader_num_workers=8 \
    actor_rollout_ref.model.path=Qwen/Qwen2.5-0.5B-Instruct \
    actor_rollout_ref.actor.optim.lr=1e-6 \
    actor_rollout_ref.actor.ppo_mini_batch_size=8 \
    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=2 \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.n=4 \
    actor_rollout_ref.rollout.gpu_memory_utilization=0.5 \
    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=2 \
    trainer.logger='["console","wandb"]' \
    trainer.project_name=verl_teardown_repro \
    trainer.experiment_name=grpo_2step \
    trainer.n_gpus_per_node=1 \
    trainer.nnodes=1 \
    trainer.val_before_train=False \
    trainer.test_freq=-1 \
    trainer.save_freq=-1 \
    trainer.total_training_steps=2
```

- **Before:** W&B shows only System charts; the local `run-*.wandb` datastore has 0 history / 0 summary / 0 exit records; at shutdown `teardown_atexit` intermittently raises `HandleAbandonedError` / `BrokenPipeError`; and (with workers > 0) the `DataLoader worker ... killed by signal: Killed` traceback is printed.
- **After:** `training/*` metrics appear on W&B; `run-*.wandb` has `history ≥ 2`, `summary == 1`, `exit == 1`; no `teardown_atexit` traceback; no DataLoader SIGKILL traceback; exit code 0. (Re-parse the datastore offline with `wandb.sdk.internal.datastore` to confirm the record counts.)

### API and Usage Example

No CLI / config changes. One additive API: `Tracking.finish()` (idempotent, exception-safe) is now public, and `Tracking.__del__` delegates to it. The V1 trainer calls it automatically at the end of `fit()`; other callers may invoke it explicitly:

```python
tracking = Tracking(project_name, experiment_name, default_backend=["console", "wandb"])
try:
    ...  # training loop, tracking.log(...)
finally:
    tracking.finish()  # flush + finalize backends; safe to call once, a repeat call is a no-op
```

### Design & Code Changes

- `verl/utils/tracking.py`: add idempotent, exception-safe `Tracking.finish()` (per-backend `try/except`; `_finished` guard); `__del__` now delegates to it (fallback only). After `wandb.finish(exit_code=0)`, also call `wandb.teardown(exit_code=0)` **in-band** — wandb's own docs note its atexit service teardown "is not reliable in certain setups such as when using Python's `multiprocessing` module" (Ray). Doing it in-band, while the core is alive, unregisters that atexit hook and closes the service cleanly, which removes the intermittent `BrokenPipeError` / `HandleAbandonedError` at shutdown. Guarded against `SystemExit` (wandb's `teardown()` calls `sys.exit()` if the core reports a non-zero exit code).
- `verl/utils/dataloader.py` (new): `shutdown_dataloader_workers` / `shutdown_dataloaders` — best-effort, exception-safe shutdown of a DataLoader's active worker iterator (calls the iterator's `_shutdown_workers()` while still in normal control flow, then clears `_iterator`). Reused from #6292.
- `verl/trainer/ppo/v1/trainer_base.py`: extract the training body into `_fit()`; `fit()` wraps `self._fit()` in `try/finally` and, in the `finally`, calls `self._shutdown_dataloaders()` then `self.logger.finish()`. The existing `self._shutdown_dump_executor()` stays inline at the return sites (it re-raises `f.result()`, so it must not run in the `finally`, where it would mask an in-flight exception). With torchdata's `StatefulDataLoader`, `dataloader._iterator` is the same object as `self.train_dataloader_it`, so this reaches the live train workers; the validation loader is already drained by its `for`-loop.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update documentation — N/A (internal end-of-run finalization; no user-facing API or config change).
- [x] Add unit or end-to-end test(s) to the CI workflow. **If not feasible, explain why:** the change only affects end-of-run finalization *ordering*, and its symptoms (the wandb-core atexit service race and the DataLoader worker SIGKILL) surface only in a live multi-process Ray + wandb-core shutdown, which the CI unit lanes do not reproduce deterministically. Validated end-to-end via the 2-step GRPO run in the Test section.
- [x] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [x] Recipe submodule — N/A (not touched).