### PR TITLE
[vllm, rollout] fix: handle non-contiguous weights in bucketed transfer

### DIFF
--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -58,6 +58,24 @@ def _generate_weights(weight_specs, seed):
     return weights
 
 
+def test_weight_to_bytes_accepts_strided_tensor():
+    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import _weight_to_bytes
+
+    base = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
+    weight = base[:, 0, :]
+
+    assert not weight.is_contiguous()
+    with pytest.raises(RuntimeError):
+        weight.view(-1).view(torch.uint8)
+
+    byte_view = _weight_to_bytes(weight)
+    recovered = byte_view.view(dtype=weight.dtype).view(weight.shape)
+
+    assert byte_view.dtype == torch.uint8
+    assert byte_view.numel() == weight.nbytes
+    assert torch.equal(recovered, weight)
+
+
 # ---------------------------------------------------------------------------
 # Process entry points (must be module-level for pickling with spawn)
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_bucketed_weight_transfer.py
+++ b/tests/utils/test_bucketed_weight_transfer.py
@@ -58,21 +58,64 @@ def _generate_weights(weight_specs, seed):
     return weights
 
 
-def test_weight_to_bytes_accepts_strided_tensor():
-    from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import _weight_to_bytes
+class _FakeSocket:
+    def __init__(self):
+        self.messages = []
+
+    def send_pyobj(self, message):
+        self.messages.append(message)
+
+    def recv(self):
+        return b""
+
+
+class _FakeTorchDevice:
+    def synchronize(self):
+        pass
+
+
+def test_sender_accepts_strided_tensor(monkeypatch):
+    from verl.workers.rollout.vllm_rollout import bucketed_weight_transfer
 
     base = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)
     weight = base[:, 0, :]
+    buffer = torch.empty(weight.nbytes, dtype=torch.uint8)
+    socket = _FakeSocket()
+    sender = bucketed_weight_transfer.BucketedWeightSender(
+        zmq_handle="ipc:///tmp/test-bwt-unused.sock",
+        bucket_size_mb=1,
+        use_shm=True,
+    )
 
     assert not weight.is_contiguous()
     with pytest.raises(RuntimeError):
         weight.view(-1).view(torch.uint8)
 
-    byte_view = _weight_to_bytes(weight)
-    recovered = byte_view.view(dtype=weight.dtype).view(weight.shape)
+    monkeypatch.setattr(sender, "_init_socket", lambda: setattr(sender, "socket", socket))
+    monkeypatch.setattr(sender, "_init_buffer", lambda: setattr(sender, "buffer", buffer))
+    monkeypatch.setattr(sender, "_cleanup", lambda: None)
+    monkeypatch.setattr(bucketed_weight_transfer, "get_torch_device", lambda: _FakeTorchDevice())
 
-    assert byte_view.dtype == torch.uint8
-    assert byte_view.numel() == weight.nbytes
+    asyncio.run(sender.async_send_weights(iter([("strided", weight)])))
+
+    recovered = buffer.view(dtype=weight.dtype).view(weight.shape)
+
+    assert socket.messages == [
+        {
+            "bucket_meta": {
+                "strided": {
+                    "name": "strided",
+                    "shape": weight.shape,
+                    "dtype": weight.dtype,
+                    "offset": 0,
+                    "handle": None,
+                }
+            },
+            "is_last": True,
+        }
+    ]
+    assert buffer.dtype == torch.uint8
+    assert buffer.numel() == weight.nbytes
     assert torch.equal(recovered, weight)
 
 

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -71,6 +71,11 @@ def rebuild_shared_memory(name: str, size: int, dtype=torch.uint8):
     return tensor, shm
 
 
+def _weight_to_bytes(weight: torch.Tensor) -> torch.Tensor:
+    """Return a contiguous uint8 view of a weight tensor's logical values."""
+    return weight.contiguous().view(-1).view(torch.uint8)
+
+
 class BucketedWeightSender:
     """
     Send model weights via bucketed IPC transfer over ZMQ.
@@ -148,7 +153,7 @@ class BucketedWeightSender:
                     "offset": offset,
                     "handle": None,
                 }
-                self.buffer[offset : offset + weight.nbytes].copy_(weight.view(-1).view(torch.uint8), non_blocking=True)
+                self.buffer[offset : offset + weight.nbytes].copy_(_weight_to_bytes(weight), non_blocking=True)
                 offset += weight.nbytes
 
             # send the last bucket

--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -71,11 +71,6 @@ def rebuild_shared_memory(name: str, size: int, dtype=torch.uint8):
     return tensor, shm
 
 
-def _weight_to_bytes(weight: torch.Tensor) -> torch.Tensor:
-    """Return a contiguous uint8 view of a weight tensor's logical values."""
-    return weight.contiguous().view(-1).view(torch.uint8)
-
-
 class BucketedWeightSender:
     """
     Send model weights via bucketed IPC transfer over ZMQ.
@@ -153,7 +148,9 @@ class BucketedWeightSender:
                     "offset": offset,
                     "handle": None,
                 }
-                self.buffer[offset : offset + weight.nbytes].copy_(_weight_to_bytes(weight), non_blocking=True)
+                self.buffer[offset : offset + weight.nbytes].view(dtype=weight.dtype).view(weight.shape).copy_(
+                    weight, non_blocking=True
+                )
                 offset += weight.nbytes
 
             # send the last bucket


### PR DESCRIPTION
### What does this PR do?

Fixes vLLM rollout weight updates when the actor exports a valid but non-contiguous tensor. The bucketed weight sender previously packed weights with `weight.view(-1).view(torch.uint8)`, which crashes for strided tensors with:

```text
RuntimeError: view size is not compatible with input tensor's size and stride
```

This PR adds a small byte-packing helper that first compacts the tensor with `.contiguous()` before reinterpreting it as `torch.uint8`. This keeps the common contiguous path cheap while allowing exporters such as Megatron-Bridge to return strided tensor views.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: 
   - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+bucketed_weight_transfer
   - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+non-contiguous+tensor+update_weights
   - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+view+size+is+not+compatible+input+tensor+stride
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- Added a unit test for it. 
- Tested with the latest megatron-bridge v0.5.0, and verified it is working.

### API and Usage Example

No API or user-facing usage changes.

### Design & Code Changes

- Added a helper who calls `weight.contiguous().view(-1).view(torch.uint8)` so valid strided/non-contiguous tensors can be serialized into the contiguous bucket buffer.
 
### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ x Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
