### PR TITLE
[rollout] fix: restore turn separator dropped at multi-turn tool agent loop boundaries

### DIFF
--- a/tests/experimental/agent_loop/test_tool_call_id_on_cpu.py
+++ b/tests/experimental/agent_loop/test_tool_call_id_on_cpu.py
@@ -126,6 +126,7 @@ class TestToolCallIdOnCpu(unittest.IsolatedAsyncioTestCase):
             enable_continuous_token=False,
             tool_parser_name="qwen3_coder",
             response_length=128,
+            turn_separator=[],
             apply_chat_template=apply_chat_template,
             _call_tool=call_tool,
         )

--- a/tests/utils/test_turn_separator_on_cpu.py
+++ b/tests/utils/test_turn_separator_on_cpu.py
@@ -1,0 +1,187 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for ``initialize_turn_separator`` and the multi-turn agent-loop token boundary.
+
+These exercise the chat-template utility directly with a self-contained ChatML tokenizer, so no
+GPU, network, or model download is required. They reproduce the incremental-encoding token drop
+described in verl issue #6501 (multi-turn agent loop) and verify the separator restores parity
+with ``apply_chat_template`` of the full conversation.
+"""
+
+import re
+
+from jinja2 import Template
+
+from verl.utils.tokenizer.chat_template import initialize_system_prompt, initialize_turn_separator
+
+# Qwen-style ChatML: every turn renders as ``<|im_start|>{role}\n{content}<|im_end|>\n`` with a
+# trailing ``\n`` turn separator that generation never emits (the model stops at ``<|im_end|>``).
+_CHATML = (
+    "{% for m in messages %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+# Same structure but without the trailing per-turn separator (no ``\n`` after ``<|im_end|>``).
+_CHATML_NO_SEP = (
+    "{% for m in messages %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+# Thinking model (e.g. Qwen3): assistant turns are wrapped in ``<think></think>`` scaffolding. The
+# turn separator is still just ``\n`` -- deriving it from an assistant turn would wrongly capture
+# the scaffold, which is why the helper probes user turns instead.
+_CHATML_THINK = (
+    "{% for m in messages %}<|im_start|>{{m['role']}}\n"
+    "{% if m['role'] == 'assistant' %}<think>\n\n</think>\n\n{% endif %}"
+    "{{m['content']}}<|im_end|>\n{% endfor %}"
+    "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+)
+
+_IM_START, _IM_END, _NL = 1, 2, 3
+_SPECIALS = {"<|im_start|>": _IM_START, "<|im_end|>": _IM_END, "\n": _NL}
+
+
+class ChatMLTokenizer:
+    """Deterministic, offline tokenizer mimicking a ChatML ``apply_chat_template``."""
+
+    eos_token_id = _IM_END
+
+    def __init__(self, template: str = _CHATML):
+        self._template = Template(template)
+        self._vocab: dict[str, int] = {}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        ids: list[int] = []
+        for piece in re.split(r"(<\|im_start\|>|<\|im_end\|>|\n)", text):
+            if piece == "":
+                continue
+            if piece in _SPECIALS:
+                ids.append(_SPECIALS[piece])
+            else:
+                for word in piece.split(" "):
+                    if word:
+                        ids.append(self._vocab.setdefault(word, len(self._vocab) + 100))
+        return ids
+
+    def apply_chat_template(
+        self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs
+    ):
+        text = self._template.render(messages=messages, add_generation_prompt=add_generation_prompt)
+        return self.encode(text) if tokenize else text
+
+
+def _rollout_ids(tokenizer, system_prompt, turn_separator, turns):
+    """Reproduce ToolAgentLoop's incremental token construction.
+
+    ``turns`` is a list of ``(assistant_text, tool_content)`` pairs. Each assistant turn is the
+    model output ending at ``<|im_end|>`` (never the template's trailing separator); each tool turn
+    is rendered in isolation with the system prompt stripped, then the separator is restored.
+    """
+    user = {"role": "user", "content": "what is the weather in Paris?"}
+    ids = tokenizer.apply_chat_template([user], add_generation_prompt=True)
+    for assistant_text, tool_content in turns:
+        ids = ids + tokenizer.encode(assistant_text) + [_IM_END]
+        tool_iso = tokenizer.apply_chat_template(
+            [{"role": "tool", "content": tool_content}], add_generation_prompt=True
+        )[len(system_prompt) :]
+        ids = ids + (turn_separator + tool_iso)
+    return ids
+
+
+def _reference_ids(tokenizer, turns):
+    user = {"role": "user", "content": "what is the weather in Paris?"}
+    messages = [user]
+    for assistant_text, tool_content in turns:
+        messages.append({"role": "assistant", "content": assistant_text})
+        messages.append({"role": "tool", "content": tool_content})
+    return tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+
+
+def test_turn_separator_is_the_newline_token():
+    tok = ChatMLTokenizer()
+    assert initialize_turn_separator(tok) == [_NL]
+
+
+def test_no_separator_template_returns_empty():
+    tok = ChatMLTokenizer(_CHATML_NO_SEP)
+    assert initialize_turn_separator(tok) == []
+
+
+def test_separator_ignores_assistant_reasoning_scaffold():
+    """Regression guard for the Qwen3 ``<think>`` gotcha.
+
+    A thinking template injects ``<think></think>`` scaffolding into assistant turns. Deriving the
+    separator from an assistant probe (the original, buggy approach) captures that scaffold; the
+    helper probes user turns instead and must return just the newline separator.
+    """
+    tok = ChatMLTokenizer(_CHATML_THINK)
+
+    # The template really does inject scaffolding, so a naive assistant-turn probe is wrong: this is
+    # exactly what the first implementation computed, and it is not the separator.
+    base = tok.apply_chat_template([{"role": "user", "content": ""}], add_generation_prompt=True)
+    closed = tok.apply_chat_template(
+        [{"role": "user", "content": ""}, {"role": "assistant", "content": ""}], add_generation_prompt=False
+    )
+    assistant_probe_result = closed[len(base) :][1:]
+    assert assistant_probe_result != [_NL]
+
+    # The real helper avoids the scaffold and recovers the true separator.
+    assert initialize_turn_separator(tok) == [_NL]
+
+
+def test_incremental_encoding_matches_full_render_single_turn():
+    tok = ChatMLTokenizer()
+    system_prompt = initialize_system_prompt(tok)
+    separator = initialize_turn_separator(tok)
+    turns = [('<tool_call>\n{"name": "get_weather"}\n</tool_call>', "sunny, 25C")]
+
+    # Without the separator the incremental sequence drops one token per turn boundary.
+    buggy = _rollout_ids(tok, system_prompt, [], turns)
+    reference = _reference_ids(tok, turns)
+    assert buggy != reference
+    assert len(buggy) == len(reference) - 1
+
+    # Restoring the separator recovers exact parity with the full-conversation render.
+    fixed = _rollout_ids(tok, system_prompt, separator, turns)
+    assert fixed == reference
+
+
+def test_incremental_encoding_matches_full_render_multi_turn():
+    tok = ChatMLTokenizer()
+    system_prompt = initialize_system_prompt(tok)
+    separator = initialize_turn_separator(tok)
+    turns = [
+        ('<tool_call>\n{"name": "get_weather"}\n</tool_call>', "sunny, 25C"),
+        ('<tool_call>\n{"name": "get_time"}\n</tool_call>', "14:00"),
+        ('<tool_call>\n{"name": "get_news"}\n</tool_call>', "all quiet"),
+    ]
+    fixed = _rollout_ids(tok, system_prompt, separator, turns)
+    reference = _reference_ids(tok, turns)
+    assert fixed == reference
+    # The buggy path drops exactly one token per tool turn boundary.
+    buggy = _rollout_ids(tok, system_prompt, [], turns)
+    assert len(reference) - len(buggy) == len(turns)
+
+
+def test_separator_with_default_system_prompt_template():
+    template = (
+        "<|im_start|>system\nYou are helpful<|im_end|>\n"
+        "{% for m in messages %}<|im_start|>{{m['role']}}\n{{m['content']}}<|im_end|>\n{% endfor %}"
+        "{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}"
+    )
+    tok = ChatMLTokenizer(template)
+    system_prompt = initialize_system_prompt(tok)
+    separator = initialize_turn_separator(tok)
+    assert separator == [_NL]
+    turns = [("assistant answer", "tool result")]
+    fixed = _rollout_ids(tok, system_prompt, separator, turns)
+    assert fixed == _reference_ids(tok, turns)

--- a/tests/utils/test_turn_separator_on_cpu.py
+++ b/tests/utils/test_turn_separator_on_cpu.py
@@ -116,6 +116,47 @@ def test_no_separator_template_returns_empty():
     assert initialize_turn_separator(tok) == []
 
 
+def test_separator_with_list_valued_eos_and_multi_token_close():
+    """Guard for list-valued ``eos_token_id`` (e.g. Llama 3) with a multi-token turn close.
+
+    Each turn closes with two special tokens before the ``\\n`` separator, so the naive
+    ``suffix[1:]`` fallback would leave the second close token in the separator. Only splitting
+    after the last matching eos id recovers ``[\\n]`` -- and that split is skipped unless a
+    list-valued ``eos_token_id`` is handled, which is exactly the reviewed case.
+    """
+    end, im_end, nl = 10, 11, 12
+    specials = {"<|s|>": 9, "<|end|>": end, "<|im_end|>": im_end, "\n": nl}
+    template = Template(
+        "{% for m in messages %}<|s|>{{m['role']}}\n{{m['content']}}<|end|><|im_end|>\n{% endfor %}"
+        "{% if add_generation_prompt %}<|s|>assistant\n{% endif %}"
+    )
+
+    class MultiCloseTokenizer:
+        eos_token_id = [end, im_end]  # list rather than a single int
+
+        def __init__(self):
+            self._vocab: dict[str, int] = {}
+
+        def encode(self, text, add_special_tokens=False):
+            ids = []
+            for piece in re.split(r"(<\|s\|>|<\|end\|>|<\|im_end\|>|\n)", text):
+                if piece == "":
+                    continue
+                if piece in specials:
+                    ids.append(specials[piece])
+                else:
+                    for word in piece.split(" "):
+                        if word:
+                            ids.append(self._vocab.setdefault(word, len(self._vocab) + 100))
+            return ids
+
+        def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs):
+            text = template.render(messages=messages, add_generation_prompt=add_generation_prompt)
+            return self.encode(text) if tokenize else text
+
+    assert initialize_turn_separator(MultiCloseTokenizer()) == [nl]
+
+
 def test_separator_ignores_assistant_reasoning_scaffold():
     """Regression guard for the Qwen3 ``<think>`` gotcha.
 

--- a/tests/utils/test_turn_separator_on_cpu.py
+++ b/tests/utils/test_turn_separator_on_cpu.py
@@ -72,9 +72,7 @@ class ChatMLTokenizer:
                         ids.append(self._vocab.setdefault(word, len(self._vocab) + 100))
         return ids
 
-    def apply_chat_template(
-        self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs
-    ):
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs):
         text = self._template.render(messages=messages, add_generation_prompt=add_generation_prompt)
         return self.encode(text) if tokenize else text
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -64,7 +64,7 @@ from verl.utils.tokenizer import (
     get_processor_token_id,
     normalize_token_ids,
 )
-from verl.utils.tokenizer.chat_template import apply_chat_template, initialize_system_prompt
+from verl.utils.tokenizer.chat_template import apply_chat_template, initialize_system_prompt, initialize_turn_separator
 from verl.utils.tokenizer.continuous_token_wiring import create_continuous_token_builder
 from verl.workers.config import (
     HFModelConfig,
@@ -240,6 +240,9 @@ class AgentLoopBase(ABC):
             self.enable_continuous_token = True
             # Continuous Token doesn't use the legacy removable system prompt.
             self.system_prompt = None
+            # Continuous Token re-renders non-assistant turns from the full message list, so it does
+            # not need the incremental turn separator.
+            self.turn_separator = []
         else:
             if continuous_token_config.enable and self.processor is not None:
                 logger.warning(
@@ -247,6 +250,9 @@ class AgentLoopBase(ABC):
                 )
             processing_class = self.processor if self.processor is not None else self.tokenizer
             self.system_prompt = initialize_system_prompt(processing_class, **self.apply_chat_template_kwargs)
+            # Turn separator dropped when the model stops at the assistant close token; restored at
+            # turn boundaries in ``ToolAgentLoop._handle_processing_tools_state``.
+            self.turn_separator = initialize_turn_separator(processing_class, **self.apply_chat_template_kwargs)
         self.loop = get_event_loop()
 
     def _get_mm_processor_kwargs(self, audio_data: Optional[list[Any]] = None) -> dict[str, Any]:

--- a/verl/experimental/agent_loop/tool_agent_loop.py
+++ b/verl/experimental/agent_loop/tool_agent_loop.py
@@ -423,6 +423,12 @@ class ToolAgentLoop(AgentLoopBase):
                 videos=videos,
                 remove_system_prompt=True,
             )
+            # The model stopped at the assistant close token and never emitted the template's
+            # trailing turn separator (e.g. "\n" for Qwen); rendering this tool turn in isolation
+            # also omits it. Restore it so the incremental sequence matches apply_chat_template of
+            # the full conversation (see verl issue #6501 comment). ``turn_separator`` is [] for
+            # templates without one, so this is a no-op there.
+            response_ids = self.turn_separator + response_ids
 
         if len(agent_data.response_mask) + len(response_ids) >= self.response_length:
             return AgentState.TERMINATED

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -39,6 +39,54 @@ def initialize_system_prompt(tokenizer, **apply_chat_template_kwargs) -> list[in
     return system_prompt
 
 
+def initialize_turn_separator(tokenizer, **apply_chat_template_kwargs) -> list[int]:
+    """Tokens a chat template inserts after a message's closing token, before the next turn.
+
+    Multi-turn agent rollouts build the token sequence incrementally. The model stops at the
+    assistant close token (e.g. ``<|im_end|>``) and never emits the template's trailing
+    turn-separator (e.g. ``"\\n"``, id 198 for Qwen). Rendering the following tool/user turn in
+    isolation also omits that separator, so every turn boundary silently drops it and the rollout
+    token sequence diverges from ``apply_chat_template`` of the equivalent full conversation.
+    This returns the separator so callers can restore it at turn boundaries.
+
+    Derivation: rendering the same (user) turn with empty vs non-empty content only differs in the
+    content region, so the maximal common trailing run is exactly ``[close_token, *separator]``.
+    A user turn is used deliberately -- probing with an assistant turn would inject reasoning
+    scaffolding (e.g. Qwen3's ``<think></think>``) that is not part of the separator. The model
+    emits the close token itself (it is the stop token), so the separator is everything after it.
+
+    Returns an empty list when the template has no turn separator or an unexpected structure, so
+    callers keep their previous behavior instead of crashing.
+    """
+    empty = normalize_token_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
+        )
+    )
+    filled = normalize_token_ids(
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": "x"}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
+        )
+    )
+    # Maximal common trailing run == the message closing token(s) + inter-turn separator (identical
+    # regardless of content).
+    i = 0
+    while i < len(empty) and i < len(filled) and empty[-1 - i] == filled[-1 - i]:
+        i += 1
+    suffix = empty[len(empty) - i :]
+    if not suffix:
+        return []
+    # Split off the closing token the model already emits; the remainder is the dropped separator.
+    # A processor (VLM path) exposes ``eos_token_id`` on its wrapped tokenizer rather than itself.
+    eos_id = getattr(tokenizer, "eos_token_id", None)
+    if eos_id is None:
+        eos_id = getattr(getattr(tokenizer, "tokenizer", None), "eos_token_id", None)
+    if eos_id is not None and eos_id in suffix:
+        last_close = len(suffix) - 1 - suffix[::-1].index(eos_id)
+        return suffix[last_close + 1 :]
+    return suffix[1:]
+
+
 def extract_system_prompt_and_generation(tokenizer, **apply_chat_template_kwargs):
     token1 = normalize_token_ids(
         tokenizer.apply_chat_template(

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -77,12 +77,14 @@ def initialize_turn_separator(tokenizer, **apply_chat_template_kwargs) -> list[i
     if not suffix:
         return []
     # Split off the closing token the model already emits; the remainder is the dropped separator.
-    # A processor (VLM path) exposes ``eos_token_id`` on its wrapped tokenizer rather than itself.
+    # A processor (VLM path) exposes ``eos_token_id`` on its wrapped tokenizer rather than itself,
+    # and some tokenizers (e.g. Llama 3) expose it as a list/tuple of ids rather than a single int.
     eos_id = getattr(tokenizer, "eos_token_id", None)
     if eos_id is None:
         eos_id = getattr(getattr(tokenizer, "tokenizer", None), "eos_token_id", None)
-    if eos_id is not None and eos_id in suffix:
-        last_close = len(suffix) - 1 - suffix[::-1].index(eos_id)
+    eos_ids = {eos_id} if isinstance(eos_id, int) else set(eos_id or [])
+    last_close = max((i for i, tok_id in enumerate(suffix) if tok_id in eos_ids), default=None)
+    if last_close is not None:
         return suffix[last_close + 1 :]
     return suffix[1:]
 


### PR DESCRIPTION
### What does this PR do?

In the multi-turn tool agent loop (`ToolAgentLoop`), the token sequence is built incrementally. After the model generates an assistant turn it stops at the assistant close token (e.g. `<|im_end|>`) and never emits the chat template's trailing turn separator (`\n`, id 198 for Qwen). The following tool turn is then rendered in isolation via `apply_chat_template(add_messages, remove_system_prompt=True)`, which has no leading separator either. One separator token is therefore silently dropped at every assistant->tool boundary, so the rolled-out token sequence diverges from `apply_chat_template` of the equivalent full conversation, a train/inference token mismatch that compounds each turn.

This was diagnosed by @yyDing1 in a comment on #6501 (https://github.com/verl-project/verl/issues/6501#issuecomment-4593158066). This PR fixes the agent-loop instance, which is distinct from #6501 / #6529 (those cover the separate `initialize_system_prompt` case).

### Changes

- `verl/utils/tokenizer/chat_template.py`: add `initialize_turn_separator()`. It derives the per-turn separator generically (no hardcoded token id) by diffing empty vs non-empty **user** renders and splitting off the close token via `eos_token_id`. User turns are used deliberately: probing an assistant turn would capture reasoning scaffolding (e.g. Qwen3 `<think></think>`). `eos_token_id` is normalized to a set, so tokenizers that expose it as a list/tuple (e.g. Llama 3) are handled. Returns `[]` for templates without a separator, so it is a no-op there.
- `verl/experimental/agent_loop/agent_loop.py`: compute and cache `self.turn_separator` once in `AgentLoopBase.__init__` (empty on the continuous-token path, which re-renders from the full message list).
- `verl/experimental/agent_loop/tool_agent_loop.py`: restore the separator at the tool-turn boundary in the generic chat-template branch of `_handle_processing_tools_state`. It is prepended to `response_ids`, so the existing mask append gives it `response_mask = 0` (a context token, not trained on).
- `tests/utils/test_turn_separator_on_cpu.py`: 7 network-free CPU regression tests, including a Qwen3-style `<think>` guard and a list-valued `eos_token_id` (multi-token close) case.

### Scope and limitations

- Scoped to the generic chat-template branch. The `gpt-oss` and `gemma4` branches hand-format tool responses and are intentionally out of scope.
- Multimodal (VLM) tool rollouts: the separator is plain text and does not change image-placeholder counts, but placeholder alignment should be spot-checked on a real VLM run.
- The CPU tests validate the separator derivation and incremental-vs-full parity; they do not instantiate `ToolAgentLoop` end to end.

### Tests

Local verification (CPU only):

- Pre-commit hooks pass on the changed files: `ruff` (0.12.2) lint, `ruff-format`, `mypy` (1.17.0), `autogen-trainer-cfg` (no generated-config diff), license, docstrings, compileall.
- `pytest tests/utils/test_turn_separator_on_cpu.py`: 7/7 pass. The `<think>` guard fails against the original assistant-probe derivation, and the multi-token-close guard fails against the pre-review single-int `eos_token_id` check, so both catch their respective regressions.
- `pytest tests/experimental/agent_loop -k on_cpu`: 20 passed (includes `test_tool_call_id_on_cpu.py`, whose `_handle_processing_tools_state` mock this PR updates for the new `turn_separator` attribute).
- Full CPU suite (`tests/**/test_*_on_cpu.py`): 542 passed, 30 skipped; the remaining failures/errors are all environment-only (missing local models, GPU-only deps such as `flash_attn`/`megatron`, Windows signal-timeouts) and none touch the changed files.
- Validated against the real `Qwen/Qwen3-8B` tokenizer (tokenizer only, no GPU): reproduces the reported 54-vs-55 token drop; with the fix the incremental sequence equals `apply_chat_template` of the full conversation for single- and multi-turn.

GPU / e2e coverage is left to the project CI.

One item I could not exercise locally without a GPU/VLM: multimodal (VLM) tool rollouts. The restored separator is plain text and does not change image-placeholder counts, so alignment should be unaffected, but a reviewer spot-check on a real VLM tool rollout would be appreciated.

### Duplicate check

No open PR addresses `_handle_processing_tools_state` or the agent-loop separator drop. #6529 covers the separate `initialize_system_prompt` issue (#6500 / #6501 body).

---

**AI assistance disclosure**: This PR was developed with AI (Claude) assistance. The submitting human has reviewed every changed line and is responsible for the change end to end. It is not a duplicate of an existing PR (see duplicate check above). Verification is summarized in the Tests section: pre-commit hooks, the CPU test suite, and a real-tokenizer check all pass locally; GPU/e2e validation is left to the project CI.
