### PR TITLE
[vllm, rollout] fix: require vLLM>=0.22.0 for Qwen3.5 router replay (R3)

### DIFF
--- a/examples/router_replay/README.md
+++ b/examples/router_replay/README.md
@@ -76,3 +76,13 @@ actor_rollout_ref.rollout.enable_rollout_routing_replay=True
 ```
 
 R3 mode requires the rollout backend to support returning router selection results. Currently, this functionality is being tested based on the vllm implementation at https://github.com/vllm-project/vllm/pull/28284 as well as bug fix at https://github.com/vllm-project/vllm/pull/33013 and SGLang implementation at https://github.com/sgl-project/sglang/commit/bed301a5acaa9577c9aa706468bdf242f6a43051.
+
+#### Requirements (vLLM backend)
+
+For **hybrid-attention MoE** models (e.g. Qwen3.5, whose Gated Delta Net linear +
+periodic full-attention layout yields more than one KV-cache group), the routed-experts
+capture path only produces a correctly-sized buffer starting from **vLLM `>= 0.22.0`**
+(`pip install -U "vllm>=0.22.0"`). On older vLLM, verl now fails fast at startup with
+an actionable error when `enable_rollout_routing_replay=True`, instead of crashing
+later inside vLLM.
+

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -369,6 +369,19 @@ class vLLMHttpServer:
             args.update(lora_args)
 
         if self.config.enable_rollout_routing_replay:
+            # R3 (Rollout Router Replay) relies on vLLM's ``enable_return_routed_experts``
+            # path (RoutedExpertsManager / RoutedExpertsCapturer), which is only correct
+            # for hybrid-attention MoE models (e.g. Qwen3.5, whose linear + full attention
+            # layout produces >1 KV-cache group) starting from vLLM 0.22.0. Earlier
+            # releases either lack the feature or under-size the routed-experts host
+            # buffer and crash with an IndexError. Fail fast with an actionable message
+            # instead of surfacing an opaque runtime error deep inside vLLM.
+            if _VLLM_VERSION < version.parse("0.22.0"):
+                raise RuntimeError(
+                    "rollout.enable_rollout_routing_replay=True requires vLLM >= 0.22.0 "
+                    f"(installed: {vllm.__version__}). Upgrade vLLM (e.g. `pip install -U "
+                    "'vllm>=0.22.0'`) or disable enable_rollout_routing_replay."
+                )
             args.update({"enable_return_routed_experts": True})
 
         server_args = ["serve", self.model_config.local_path] + build_cli_args_from_config(args)


### PR DESCRIPTION
### What does this PR do?

Rollout Router Replay in **R3** mode (`actor_rollout_ref.rollout.enable_rollout_routing_replay=True`) depends on vLLM's routed-experts capture path (`enable_return_routed_experts`). That path only produces a correctly-sized host buffer for **hybrid-attention MoE** models — e.g. Qwen3.5, whose Gated Delta Net (GDN) linear + periodic full-attention layout yields **more than one KV-cache group** — starting from **vLLM 0.22.0**. On older vLLM the buffer is under-sized and the run crashes deep inside vLLM with an opaque `IndexError` during rollout.

This PR:
- **Fails fast**: when `enable_rollout_routing_replay=True` and the installed vLLM is `< 0.22.0`, raise an actionable `RuntimeError` (telling the user to upgrade vLLM or install `verl[vllm-router-replay]`) instead of crashing later inside vLLM.
- **Adds a dedicated `vllm-router-replay` extra** (`vllm>=0.22.0` + `flash-linear-attention` for Qwen3.5 GDN) so the default `verl[vllm]` install keeps its broadly-tested version range (`vllm>=0.8.5,<=0.12.0`) for users who do **not** use router replay.

### Checklist Before Starting

- [x] Search for similar PRs. Query used (open PRs matching "router replay"):
  `https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+router+replay`
  - #6653 (preserve router replay fallback config flag), #4567 (RouterReplay/TopKRouter mismatch for qwen3vl), #4517 (routed_experts to AgentData) — none add the vLLM **version gate** for hybrid-attention MoE / Qwen3.5, so this is not a duplicate.
- [x] PR title format: `[vllm, rollout] fix: require vLLM>=0.22.0 for Qwen3.5 router replay (R3)`

### Test

- Existing behavior (R2 / router replay disabled, or vLLM already `>=0.22.0`) is unchanged — the new guard is a no-op on the supported version.
- On vLLM `< 0.22.0` with `enable_rollout_routing_replay=True`, the launcher now raises the new `RuntimeError` at startup instead of the previous mid-rollout `IndexError`.
- `python -c "import ast; ast.parse(open('setup.py').read()); ast.parse(open('verl/workers/rollout/vllm_rollout/vllm_async_server.py').read())"` — OK.
- `pip install -e .[vllm-router-replay]` resolves the new extra.

> Full R3 training on Qwen3.5-35B-A3B was validated locally on 2×8 H100; end-to-end GPU runs are not part of CI.

### API and Usage Example

```bash
# Install the router-replay extra (pins vLLM>=0.22.0 + flash-linear-attention):
pip install -e .[vllm-router-replay]

# R3 router replay now guarded on vLLM version:
python3 -m verl.trainer.main_ppo \
    actor_rollout_ref.rollout.name=vllm \
    actor_rollout_ref.rollout.enable_rollout_routing_replay=True \
    ...
```

### Design & Code Changes

- `setup.py`: new `VLLM_ROUTER_REPLAY_REQUIRES` / `vllm-router-replay` extra.
- `verl/workers/rollout/vllm_rollout/vllm_async_server.py`: runtime version gate for the R3 routed-experts path.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks to the changed files.
- [ ] Add / update documentation (N/A — behavior-preserving guard + packaging extra).
- [ ] Add CI test (not feasible: requires multi-GPU vLLM>=0.22.0 rollout of a hybrid-attention MoE model; guarded path validated manually).
- [ ] Send a message in the `ci-request` channel once ready for CI.
