### PR TITLE
[rollout] fix: disable vLLM multimodal processor cache for vLLM < v0.22.0

### DIFF
--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1015,8 +1015,11 @@ class vLLMHttpServer:
         return "vllm"
 
     def _preprocess_engine_kwargs(self, engine_kwargs: dict) -> None:
-        """Mutate engine_kwargs in-place before the CLI args dict is built. No-op by default."""
-        pass
+        """Mutate engine_kwargs in-place before the CLI args dict is built."""
+        if _VLLM_VERSION < version.parse("0.22.0"):
+            # Work around multimodal processor cache desync across pause/resume.
+            # See: https://github.com/vllm-project/vllm/pull/43001/
+            engine_kwargs.setdefault("mm_processor_cache_gb", 0)
 
     def _get_override_generation_config(self) -> dict:
         """Return the override_generation_config dict."""


### PR DESCRIPTION
### What does this PR do?
Disable vLLM's multimodal processor cache by default for vLLM older than 0.22.0 to avoid cache desync across pause/resume. Keep explicit user overrides intact. Otherwise an `AssertionError: Expected a cached item for mm_hash='...'` will be raised during verl `update_weights()` calling vllm `pause_generation(clear_cache=True)`. See https://github.com/vllm-project/vllm/pull/43001/ for details.

### Checklist Before Starting
* [x]  Search for similar PRs. Paste at least one query link here: ...
* [x]  Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  
  * `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  * If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  * `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  * If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  * Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example
> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes
> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting
Important

Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

* [x]  Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
* [x]  Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
* [ ]  Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
* [ ]  Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
* [ ]  Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
* [ ]  If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
