### PR TITLE
[megatron] feat: migrate fused logprob/entropy from GPTModel.forward monkey-patch to Megatron output_processor hook

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_megatron_vllm_2.yml
+++ b/.github/workflows/e2e_ppo_trainer_megatron_vllm_2.yml
@@ -135,15 +135,38 @@ jobs:
       - name: Prepare GSM8K dataset
         run: |
           python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
-      - name: Running GSM8K E2E training tests with 3D parallelism on 8 L20 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
+      - name: Running GSM8K E2E training tests with fused kernels and 3D parallelism on 8 L20 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
         run: |
           ray stop --force
+          log_file="${RUNNER_TEMP}/fused-kernel-e2e.log"
+          set +e
           ADV_ESTIMATOR=grpo USE_DUMMY_MODEL=True DUMMY_MODEL_CONFIG_PATH=tests/special_e2e/ppo_trainer/expert_parallel/qwen2moe_minimal.json \
           PPO_MAX_TOKEN_LEN=1024 FWD_MAX_TOKEN_LEN=1024 \
           MAX_PROMPT_LENGTH=512 MAX_RESPONSE_LENGTH=512 \
           MODEL_ID=Qwen/Qwen3-30B-A3B-Instruct-2507 USE_MBRIDGE=True VANILLA_MBRIDGE=False VALUE_VANILLA_MBRIDGE=False \
+          USE_FUSED_KERNELS=True USE_REMOVE_PADDING=True \
           COMMON_PP=2 COMMON_VPP=null COMMON_CP=1 COMMON_TP=4 COMMON_EP=4 COMMON_ETP=1 INFER_TP=8 \
-          USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 bash tests/special_e2e/run_ppo_trainer_megatron.sh
+          USE_DIST_CKPT=False ALL_OFFLOAD=True SKIP_SAVE_HF_MODEL=1 bash tests/special_e2e/run_ppo_trainer_megatron.sh \
+            2>&1 | tee "${log_file}"
+          statuses=("${PIPESTATUS[@]}")
+          set -e
+
+          if (( statuses[1] != 0 )); then
+            echo "::error::Failed to capture the complete fused-kernel E2E log."
+            exit "${statuses[1]}"
+          fi
+
+          grep_status=0
+          grep -Fq "Falling back to non-fused" "${log_file}" || grep_status=$?
+          if (( grep_status == 0 )); then
+            echo "::error::Fused-kernel E2E fell back to the non-fused path."
+            exit 1
+          elif (( grep_status != 1 )); then
+            echo "::error::Failed to inspect the fused-kernel E2E log."
+            exit "${grep_status}"
+          fi
+
+          exit "${statuses[0]}"
       - name: Running GSM8K E2E training tests with 3D parallelism with FP8 rollout on 8 L20 GPUs with Megatron-Bridge (Qwen3-30B-A3B-Instruct-2507)
         run: |
           ray stop --force

--- a/.github/workflows/model.yml
+++ b/.github/workflows/model.yml
@@ -183,6 +183,7 @@ jobs:
         run: |
           ray stop --force
           pytest -s -x tests/models/test_engine.py
+          pytest -s -x tests/models/test_model_forward_fused.py
 
   cleanup:
     runs-on: ubuntu-latest

--- a/tests/models/test_model_forward_fused.py
+++ b/tests/models/test_model_forward_fused.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+from megatron.core.distributed.distributed_data_parallel import DistributedDataParallel
+from megatron.core.models.gpt.gpt_model import GPTModel
+from megatron.core.transformer.module import Float16Module
+
+from verl.models.mcore import model_forward_fused as mff
+
+
+def _new_uninitialized_model(model_cls=GPTModel):
+    model = object.__new__(model_cls)
+    torch.nn.Module.__init__(model)
+    return model
+
+
+def test_mcore_gpt_forward_has_native_output_processor_contract():
+    parameters = inspect.signature(GPTModel.forward).parameters
+    assert {"output_processor", "output_processor_context"}.issubset(parameters)
+
+
+def test_native_hook_selection_preserves_forward_and_is_idempotent(monkeypatch):
+    model = _new_uninitialized_model()
+    original_forward = model.forward.__func__
+    signature_calls = 0
+    original_signature = inspect.signature
+
+    def counted_signature(callable_):
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(callable_)
+
+    monkeypatch.setattr(mff.inspect, "signature", counted_signature)
+
+    mff.patch_fused_forward(model)
+    mff.patch_fused_forward(model)
+    mff.unpatch_fused_forward(model)
+    mff.unpatch_fused_forward(model)
+    mff.patch_fused_forward(model)
+
+    assert signature_calls == 1
+    assert getattr(model, mff._FUSED_FORWARD_MODE_ATTR) == mff._HOOK_MODE
+    assert model.forward.__func__ is original_forward
+    assert not hasattr(model, "forward_backup")
+
+
+def test_legacy_fallback_patch_and_unpatch_are_idempotent():
+    class LegacyGPTModel(GPTModel):
+        def forward(self, input_ids=None):
+            return input_ids
+
+    model = _new_uninitialized_model(LegacyGPTModel)
+    original_forward = model.forward.__func__
+
+    mff.patch_fused_forward(model)
+    backup = model.forward_backup
+    mff.patch_fused_forward(model)
+
+    assert getattr(model, mff._FUSED_FORWARD_MODE_ATTR) == mff._LEGACY_MODE
+    assert model.forward.__func__ is mff._fused_GPTModel_forward
+    assert model.forward_backup is backup
+
+    mff.unpatch_fused_forward(model)
+    mff.unpatch_fused_forward(model)
+    assert model.forward.__func__ is original_forward
+    assert not hasattr(model, "forward_backup")
+
+    mff.patch_fused_forward(model)
+    assert model.forward.__func__ is mff._fused_GPTModel_forward
+    mff.unpatch_fused_forward(model)
+    assert model.forward.__func__ is original_forward
+
+
+def test_engine_hook_context_and_current_thd_arguments(monkeypatch):
+    input_ids = torch.tensor([[1, 2, 3]])
+    labels = torch.tensor([[2, 3, 4]])
+    preprocess_calls = []
+
+    def fake_preprocess(value, **kwargs):
+        preprocess_calls.append(kwargs)
+        return value, "packed", None
+
+    monkeypatch.setattr(mff, "preprocess_thd_engine", fake_preprocess)
+
+    class Model:
+        pre_process = True
+        post_process = False
+        config = SimpleNamespace(
+            fp8="hybrid",
+            csa_window_size=64,
+            experimental_attention_variant="dsv4_hybrid",
+        )
+
+        def __init__(self, mode):
+            setattr(self, mff._FUSED_FORWARD_MODE_ATTR, mode)
+            self.calls = []
+
+        def __call__(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(log_probs=torch.tensor([1.0]), entropy=torch.tensor([2.0]))
+
+    hook_model = Model(mff._HOOK_MODE)
+    output = mff.fused_forward_model_engine()(hook_model, input_ids, labels, {}, 0.7, True, 0, "dualpipev")
+
+    hook_kwargs = hook_model.calls[-1]
+    assert output.log_probs.tolist() == [1.0]
+    assert "temperature" not in hook_kwargs
+    assert hook_kwargs["output_processor"] is mff.fused_output_processor
+    assert hook_kwargs["output_processor_context"].temperature == pytest.approx(0.7)
+    assert preprocess_calls == [
+        {"pre_process": True, "use_fp8_padding": True, "min_local_rows": 64, "cp_layout": "dualpipev"},
+        {
+            "pre_process": True,
+            "need_roll": True,
+            "use_fp8_padding": True,
+            "min_local_rows": 64,
+            "cp_layout": "dualpipev",
+        },
+    ]
+
+    legacy_model = Model(mff._LEGACY_MODE)
+    mff.fused_forward_model_engine()(legacy_model, input_ids, labels, {}, 0.5, True, 0)
+    legacy_kwargs = legacy_model.calls[-1]
+    assert legacy_kwargs["temperature"] == pytest.approx(0.5)
+    assert "output_processor" not in legacy_kwargs
+    assert "output_processor_context" not in legacy_kwargs
+
+
+class _OutputLayer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(4, 3))
+
+
+class _Decoder(torch.nn.Module):
+    def forward(self, *, hidden_states, **_kwargs):
+        return hidden_states
+
+
+def test_megatron_bridge_wrapper_chain_reaches_native_hook(monkeypatch):
+    """Exercise the Float16Module -> DDP stack built by Megatron Bridge."""
+    model = _new_uninitialized_model()
+    model.config = SimpleNamespace(
+        fine_grained_activation_offloading=False,
+        moe_paged_stash=False,
+        mtp_num_layers=0,
+        use_mup=False,
+        sequence_parallel=False,
+    )
+    model.share_embeddings_and_output_weights = False
+    model.mtp_process = False
+    model.post_process = True
+    model.output_layer = _OutputLayer()
+    model.decoder = _Decoder()
+    model.pg_collection = SimpleNamespace(tp=None, cp=None)
+    hidden_states = torch.ones(2, 1, 3)
+
+    def preprocess(_self, **_kwargs):
+        return hidden_states, None, None, None, None, None
+
+    model._preprocess = MethodType(preprocess, model)
+
+    mixed_precision_wrapper = object.__new__(Float16Module)
+    torch.nn.Module.__init__(mixed_precision_wrapper)
+    mixed_precision_wrapper.module = model
+    mixed_precision_wrapper.pg_collection = SimpleNamespace(pp=SimpleNamespace(rank=lambda: 0, size=lambda: 1))
+    mixed_precision_wrapper.vp_stage = None
+    mixed_precision_wrapper.vp_size = None
+    mixed_precision_wrapper.float16_convertor = lambda value: value
+
+    ddp_wrapper = object.__new__(DistributedDataParallel)
+    torch.nn.Module.__init__(ddp_wrapper)
+    ddp_wrapper.module = mixed_precision_wrapper
+
+    seen = {}
+
+    def fake_linear_cross_entropy(hidden, weight, labels, temperature, reduction, group):
+        seen.update(
+            hidden=hidden,
+            weight=weight,
+            labels=labels,
+            temperature=temperature,
+            reduction=reduction,
+            group=group,
+        )
+        return torch.ones(2), torch.ones(2) * 2
+
+    monkeypatch.setattr(mff, "linear_cross_entropy", fake_linear_cross_entropy)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: None)
+
+    original_forward = model.forward.__func__
+    mff.patch_fused_forward(ddp_wrapper)
+    output = ddp_wrapper(
+        input_ids=torch.tensor([[1, 2]]),
+        position_ids=torch.tensor([[0, 1]]),
+        attention_mask=None,
+        labels=torch.tensor([1, 2]),
+        output_processor=mff.fused_output_processor,
+        output_processor_context=mff.FusedOutputProcessorContext(temperature=0.7),
+        fp32_output=False,
+    )
+
+    assert model.forward.__func__ is original_forward
+    assert not hasattr(model, "forward_backup")
+    assert output.log_probs.tolist() == [1.0, 1.0]
+    assert output.entropy.tolist() == [2.0, 2.0]
+    assert seen["temperature"] == pytest.approx(0.7)
+    assert seen["weight"] is model.output_layer.weight
+
+
+def test_output_processor_preserves_config_logger_payload(monkeypatch):
+    input_ids = object()
+    position_ids = object()
+    attention_mask = object()
+    decoder_input = object()
+    log_probs = torch.tensor([1.0])
+    entropy = torch.tensor([2.0])
+    config = SimpleNamespace(sequence_parallel=False)
+    logged = {}
+
+    def fake_linear_cross_entropy(*_args, **_kwargs):
+        return log_probs, entropy
+
+    def fake_log_config_to_disk(config_arg, payload, prefix):
+        logged.update(config=config_arg, payload=payload, prefix=prefix)
+
+    monkeypatch.setattr(mff, "linear_cross_entropy", fake_linear_cross_entropy)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: None)
+    monkeypatch.setattr(mff, "has_config_logger_enabled", lambda config_arg: config_arg is config)
+    monkeypatch.setattr(mff, "log_config_to_disk", fake_log_config_to_disk)
+
+    mff.fused_output_processor(
+        hidden_states=torch.tensor([[1.0]]),
+        output_layer=SimpleNamespace(weight=torch.tensor([[1.0]])),
+        output_weight=None,
+        labels=torch.tensor([0]),
+        context=mff.FusedOutputProcessorContext(temperature=1.0),
+        config=config,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        attention_mask=attention_mask,
+        decoder_input=decoder_input,
+    )
+
+    assert list(logged["payload"]) == [
+        "input_ids",
+        "position_ids",
+        "attention_mask",
+        "decoder_input",
+        "logprobs",
+        "entropy",
+    ]
+    assert logged["payload"]["input_ids"] is input_ids
+    assert logged["payload"]["position_ids"] is position_ids
+    assert logged["payload"]["attention_mask"] is attention_mask
+    assert logged["payload"]["decoder_input"] is decoder_input
+    assert logged["payload"]["logprobs"] is log_probs
+    assert logged["payload"]["entropy"] is entropy
+    assert logged["config"] is config
+    assert logged["prefix"] == "input_and_logits"
+
+
+@pytest.mark.parametrize(
+    ("sequence_parallel", "use_tied_weight"),
+    [(True, True), (False, False)],
+)
+def test_output_processor_gathers_before_kernel_and_resolves_weight(monkeypatch, sequence_parallel, use_tied_weight):
+    hidden_states = torch.tensor([[1.0]])
+    gathered_hidden_states = torch.tensor([[3.0]])
+    tied_weight = torch.tensor([[5.0]])
+    output_layer_weight = torch.tensor([[7.0]])
+    labels = torch.tensor([0])
+    events = []
+    seen = {}
+
+    def fake_gather(value):
+        events.append("gather")
+        assert value is hidden_states
+        return gathered_hidden_states
+
+    def fake_linear_cross_entropy(hidden, weight, labels_arg, temperature, reduction, group):
+        events.append("linear_cross_entropy")
+        seen.update(hidden=hidden, weight=weight, labels=labels_arg, temperature=temperature)
+        return torch.tensor([11.0]), torch.tensor([13.0])
+
+    monkeypatch.setattr(mff, "gather_from_sequence_parallel_region", fake_gather)
+    monkeypatch.setattr(mff, "linear_cross_entropy", fake_linear_cross_entropy)
+    monkeypatch.setattr(mff.parallel_state, "get_tensor_model_parallel_group", lambda: None)
+
+    output_weight = tied_weight if use_tied_weight else None
+    output = mff.fused_output_processor(
+        hidden_states=hidden_states,
+        output_layer=SimpleNamespace(weight=output_layer_weight),
+        output_weight=output_weight,
+        labels=labels,
+        context=mff.FusedOutputProcessorContext(temperature=0.9),
+        config=SimpleNamespace(sequence_parallel=sequence_parallel),
+    )
+
+    expected_hidden = gathered_hidden_states if sequence_parallel else hidden_states
+    expected_weight = tied_weight if use_tied_weight else output_layer_weight
+    assert events == (["gather"] if sequence_parallel else []) + ["linear_cross_entropy"]
+    assert seen["hidden"] is expected_hidden
+    assert seen["weight"] is expected_weight
+    assert seen["labels"] is labels
+    assert seen["temperature"] == pytest.approx(0.9)
+    assert output.log_probs.tolist() == [11.0]
+    assert output.entropy.tolist() == [13.0]

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Optional
 
 import megatron.core as mcore
@@ -36,6 +38,92 @@ from verl.utils.model import CausalLMOutputForPPO
 
 from .util import postprocess_packed_seqs_for_dict_output, postprocess_thd_engine
 
+_FUSED_FORWARD_MODE_ATTR = "_verl_fused_forward_mode"
+_HOOK_MODE = "hook"
+_LEGACY_MODE = "legacy"
+
+
+def _supports_output_processor_hook(patching_model: torch.nn.Module) -> bool:
+    parameters = inspect.signature(patching_model.forward).parameters
+    return {"output_processor", "output_processor_context"}.issubset(parameters)
+
+
+def _resolve_fused_forward_mode(patching_model: torch.nn.Module) -> str:
+    return _HOOK_MODE if _supports_output_processor_hook(patching_model) else _LEGACY_MODE
+
+
+def _get_fused_forward_mode(model: torch.nn.Module) -> str:
+    model = unwrap_model(model)
+    mode = getattr(model, _FUSED_FORWARD_MODE_ATTR, None)
+    if mode is None and hasattr(model, "language_model"):
+        mode = getattr(model.language_model, _FUSED_FORWARD_MODE_ATTR, None)
+    return mode if mode in (_HOOK_MODE, _LEGACY_MODE) else _LEGACY_MODE
+
+
+def _use_output_processor_hook(model: torch.nn.Module) -> bool:
+    return _get_fused_forward_mode(model) == _HOOK_MODE
+
+
+@dataclass
+class FusedOutputProcessorContext:
+    """Context passed through Megatron's native output-processor hook."""
+
+    temperature: float
+
+
+def fused_output_processor(
+    *,
+    hidden_states,
+    output_layer,
+    output_weight,
+    labels,
+    context,
+    config,
+    **_ignored,
+):
+    """Compute fused log probabilities and entropy at Megatron's postprocess boundary."""
+    output = CausalLMOutputForPPO(
+        loss=None,
+        logits=None,
+        past_key_values=None,
+        hidden_states=hidden_states,
+        attentions=None,
+    )
+
+    if config.sequence_parallel:
+        hidden_states = gather_from_sequence_parallel_region(hidden_states)
+
+    # Megatron passes the shared embedding as output_weight for tied models. For
+    # untied models the weight lives on output_layer.
+    weight = output_weight if output_weight is not None else output_layer.weight
+
+    temperature = context.temperature
+    logprobs, entropy = linear_cross_entropy(
+        hidden_states,
+        weight,
+        labels,
+        temperature,
+        "none",
+        parallel_state.get_tensor_model_parallel_group(),
+    )
+
+    if has_config_logger_enabled(config):
+        payload = OrderedDict(
+            {
+                "input_ids": _ignored.get("input_ids"),
+                "position_ids": _ignored.get("position_ids"),
+                "attention_mask": _ignored.get("attention_mask"),
+                "decoder_input": _ignored.get("decoder_input"),
+                "logprobs": logprobs,
+                "entropy": entropy,
+            }
+        )
+        log_config_to_disk(config, payload, prefix="input_and_logits")
+
+    output.entropy = entropy
+    output.log_probs = logprobs
+    return output
+
 
 def _get_patching_model(model: torch.nn.Module):
     model = unwrap_model(model)
@@ -50,19 +138,33 @@ def _get_patching_model(model: torch.nn.Module):
 
 
 def patch_fused_forward(model: torch.nn.Module):
+    model = _get_patching_model(model)
+    if model is None:
+        return
+
+    mode = getattr(model, _FUSED_FORWARD_MODE_ATTR, None)
+    if mode is None:
+        mode = _resolve_fused_forward_mode(model)
+        setattr(model, _FUSED_FORWARD_MODE_ATTR, mode)
+
+    if mode == _HOOK_MODE:
+        return
+
     assert version.parse(mcore.__version__) >= version.parse("0.13.0"), (
         "Fused forward patching requires mecore >= 0.13.0"
     )
-    model = _get_patching_model(model)
-    if model is not None:
+    if not hasattr(model, "forward_backup"):
         model.forward_backup = model.forward
         model.forward = _fused_GPTModel_forward.__get__(model, model.__class__)
 
 
 def unpatch_fused_forward(model: torch.nn.Module):
     model = _get_patching_model(model)
-    if model is not None:
+    if model is None or _get_fused_forward_mode(model) == _HOOK_MODE:
+        return
+    if hasattr(model, "forward_backup"):
         model.forward = model.forward_backup
+        delattr(model, "forward_backup")
 
 
 def fused_forward_model_gen(vision_model: bool = False):
@@ -117,7 +219,15 @@ def fused_forward_model_gen(vision_model: bool = False):
             input_args["input_ids"] = input_ids
             input_args["attention_mask"] = attention_mask
 
-        output_orig: CausalLMOutputForPPO = model(**input_args)
+        if _use_output_processor_hook(model):
+            input_args.pop("temperature", None)
+            output_orig: CausalLMOutputForPPO = model(
+                **input_args,
+                output_processor=fused_output_processor,
+                output_processor_context=FusedOutputProcessorContext(temperature=temperature),
+            )
+        else:
+            output_orig: CausalLMOutputForPPO = model(**input_args)
 
         if post_process:
             # output_orig is in type of CausalLMOutputForPPO
@@ -195,15 +305,22 @@ def fused_forward_model_engine(vision_model: bool = False):
             cp_layout=cp_layout,
         )
         labels_rmpad = labels_rmpad.contiguous()
-        output_orig: CausalLMOutputForPPO = model(
+        forward_kwargs = dict(
             input_ids=input_ids_rmpad,
             attention_mask=attention_mask,
             position_ids=None,
             packed_seq_params=packed_seq_params,
             labels=labels_rmpad,
-            temperature=temperature,
             **model_kwargs,
         )
+        if _use_output_processor_hook(model):
+            output_orig: CausalLMOutputForPPO = model(
+                **forward_kwargs,
+                output_processor=fused_output_processor,
+                output_processor_context=FusedOutputProcessorContext(temperature=temperature),
+            )
+        else:
+            output_orig: CausalLMOutputForPPO = model(temperature=temperature, **forward_kwargs)
 
         if not post_process:
             return output_orig

--- a/verl/models/mcore/model_forward_fused.py
+++ b/verl/models/mcore/model_forward_fused.py
@@ -44,6 +44,15 @@ _LEGACY_MODE = "legacy"
 
 
 def _supports_output_processor_hook(patching_model: torch.nn.Module) -> bool:
+    """Check whether the model supports Megatron's native output-processor hook.
+
+    The ``output_processor`` / ``output_processor_context`` contract was
+    introduced in Megatron Core 0.18.0. Models without this contract fall back
+    to the legacy ``forward`` monkey patch.
+
+    TODO: Remove this check and the legacy patch once all supported Megatron
+    stacks require Megatron Core 0.18.0 or newer.
+    """
     parameters = inspect.signature(patching_model.forward).parameters
     return {"output_processor", "output_processor_context"}.issubset(parameters)
 


### PR DESCRIPTION
### What does this PR do?

`verl/models/mcore/model_forward_fused.py` currently replaces the entire `GPTModel.forward` with `_fused_GPTModel_forward` so the training loop can pass `temperature` into Megatron's `_postprocess` boundary, where `linear_cross_entropy` computes fused log-probabilities and entropy.

Megatron-Core 0.18 includes a native `output_processor` / `output_processor_context` extension point at exactly that boundary, introduced by [NVIDIA/Megatron-LM#4686](https://github.com/NVIDIA/Megatron-LM/pull/4686) for [NVIDIA/Megatron-LM#4590](https://github.com/NVIDIA/Megatron-LM/issues/4590). This PR uses that contract to avoid replacing `GPTModel.forward` on the current Megatron stack: `temperature` travels through `output_processor_context`, and a callback runs the fused log-probability and entropy kernel at the postprocess hook.

This revision is rebased onto current `main` after [verl-project/verl#7101](https://github.com/verl-project/verl/pull/7101), which upgraded the model CI stack to Megatron-Core `core_v0.18.0`.

Compared with the first revision of this PR, the `VERL_FUSED_USE_OP_HOOK` environment switch has been removed. The native path is now selected automatically when the bound GPT model exposes both hook parameters. For still-supported older models without the complete hook contract, the existing legacy forward patch is selected automatically.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+output_processor+fused
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[megatron] feat: migrate fused logprob/entropy from GPTModel.forward monkey-patch to Megatron output_processor hook`
- [x] No duplicate open PR implementing the same verl-side migration was found.

### Test

#### Fresh validation on the final post-#7101 revision

```text
pytest -s -x tests/models/test_model_forward_fused.py
8 passed

pytest -s -x tests/utils/test_megatron_bshd_preprocess.py
10 passed

pytest -s -x tests/workers/test_megatron_value_head_cp_layout_on_cpu.py
1 passed
```

The focused tests cover:

- native capability detection and one-time signature inspection;
- native and legacy patch/unpatch idempotence;
- native mode preserving `GPTModel.forward` identity and not creating `forward_backup`;
- automatic legacy fallback when either hook parameter is unavailable;
- `temperature` propagation through `output_processor_context`;
- the real Megatron Bridge wrapper chain;
- tied and untied output-weight resolution;
- sequence-parallel gather before `linear_cross_entropy`;
- current FP8-padding, `min_local_rows`, `cp_layout`, and THD arguments;
- config-logger payload preservation.

The wrapper-contract test exercises:

```text
Float16Module
-> DistributedDataParallel
-> GPTModel.forward
-> _postprocess
-> output_processor
```

The contract was checked against Megatron-Core `core_v0.18.0` and Megatron Bridge `r0.5.0`. Both wrappers propagate the hook keyword arguments, the callback is invoked using `context=`, native `GPTModel.forward` retains its original identity, and no `forward_backup` is created.

Additional final-revision gates:

- changed-files pre-commit: passed;
- Python compile checks: passed;
- `git diff upstream/main...HEAD --check`: clean;
- format-patch reconstruction: passed;
- bundle and artifact SHA256 verification: passed.

#### Earlier numerical and live integration validation

The following numerical A/B and live integration results were completed on an earlier revision of this PR before the final post-#7101 rebase. They were not rerun in full on the final revision. The subsequent refactor removed the selection environment variable and retained the callback's fused computation; the fresh tests above cover the final native/fallback selection and wrapper behavior.

Environment used for the earlier same-batch numerical validation:

```text
Megatron-Core: 0.18.0+97f3bce88
PyTorch: 2.9.1+cu128
Transformer Engine: 2.10
flash-attn: 2.8.3
dtype: bf16
```

| Scenario | Coverage | Result |
| --- | --- | --- |
| Synthetic same-batch A/B | TP=1/2, tied and untied embeddings, both output-weight branches, sequence-parallel gather | `log_probs` / `entropy` `max_abs=0` |
| Real model-build regression | Manual wrapping versus the real `get_model` build chain | Bit-identical |
| Real training-shape batch | Variable-length padding, THD `padding_causal`, GRPO advantages, including the covered `pg_loss` path | `max_abs=0` |
| Environment with vLLM installed | Dependency-contamination regression | Bit-identical |
| Live Megatron engine path | GSM8K tokens, nested/THD inputs, TP=2 and TP=1, `fused_forward_model_engine` | `log_probs` / `entropy` `max_abs=0` |

Forward memory usage was also measured as identical between the hook and legacy paths (`Δ=0`).

A separate earlier 5-step smoke used a dense Qwen2.5-0.5B model on 4×A100 with:

- Megatron engine TP=2 and PP=1;
- `use_fused_kernels=True`;
- full parameter, gradient, and optimizer offload;
- vLLM rollout and GRPO on GSM8K;
- rollout-to-actor weight resharding;
- fused log-probability and entropy computation;
- optimizer updates;
- distributed checkpoint save at step 4.

Both the native-hook and legacy-patch runs completed all five steps without NaN or infinity. Actor/rollout probability correlation remained approximately `0.9996` per step.

The two runs used independently sampled rollout trajectories, so their per-step metrics are not treated as a numerical equivalence comparison. Exact numerical equivalence is provided by the identical-weight, identical-batch A/B results above. Checkpoint reload/resume was not independently exercised.

#### Rebased local limitations

`tests/models/test_engine.py` was attempted on the final revision. One test passed, but the remaining FSDP case could not complete because the local fixture `/root/models/Qwen/Qwen2.5-0.5B` was unavailable. This is a missing local fixture and is not reported as a product test result.

The official post-#7101 image was unavailable locally. The following therefore still require project CI:

- `verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm024.dev2`;
- TP >= 2 with `use_fused_kernels=True`;
- confirmation that the native callback executes;
- finite forward, log-probability, and entropy outputs;
- at least one optimizer update.

The final local validation does not claim FP8 numerical execution, pipeline parallelism, MTP, or checkpoint reload/resume coverage.

### API and Usage Example

No public API, CLI, environment variable, or configuration surface is added or changed. Existing users continue to enable fused kernels in the same way:

```yaml
actor_rollout_ref:
  model:
    use_fused_kernels: true
```

When the bound GPT model exposes both `output_processor` and `output_processor_context`, verl uses the native hook automatically. Otherwise, it uses the existing legacy patch.

The `VERL_FUSED_USE_OP_HOOK` environment variable present in the first, unmerged revision of this PR has been removed. It was never part of a verl release, so no released user-facing interface is being removed.

### Design & Code Changes

The native path is selected only when the bound GPT model exposes both `output_processor` and `output_processor_context`.

On that path:

- `GPTModel.forward` remains unchanged and no `forward_backup` is created.
- `temperature` is removed from the native GPT arguments and passed only through `output_processor_context`.
- The callback accepts Megatron's `context=` keyword. Megatron's `_postprocess` invokes the callback with `context=output_processor_context`, while the `GPTModel.forward` call uses `output_processor_context=...`.
- Tied embeddings use `output_weight`.
- Untied embeddings use `output_layer.weight`.
- Sequence-parallel hidden states are gathered before `linear_cross_entropy`.
- Config-logger inputs and fused log-probability/entropy outputs are preserved.

Capability is resolved once during model construction through signature inspection rather than a version-string comparison. Runtime forwards do not repeat the inspection. Wrapper unwrapping reaches the underlying GPT model before capability detection.

If either hook parameter is absent, model construction selects the existing legacy forward patch. Patch and unpatch operations remain idempotent on both paths.

The rebase preserves current-main handling of `cp_layout`, `min_local_rows`, FP8 padding arguments, THD preprocessing, decoder tuple outputs, vision inputs, and `moe_n_hash_layers`.

Migrating `model_forward_1f1b_overlap.py` to Megatron's schedule-plan hook is intentionally outside this PR and should be handled as a separate follow-up.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting). An earlier all-files run passed, and changed-file checks passed again after the final rebase.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs): no documentation update is required because this revision adds no released user-facing API, CLI, environment variable, or configuration behavior.
- [x] Add unit or end-to-end tests to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows): the focused test was added to the existing `model_engine` workflow. Official-image TP>=2 and optimizer-update coverage require the maintainer-approved CI run.
- [ ] Send a message in the [`ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in the verl Slack workspace. If Slack is inaccessible, use the linked Feishu group from the contribution template.
- [x] This PR is not related to the `recipe` submodule.

AI assistance disclosure: OpenAI Codex assisted with implementation and test execution; I reviewed the resulting changes and outputs before submission.