### PR TITLE
[rollout] fix: probe list-of-parts content in initialize_turn_separator for multimodal processors

### DIFF
--- a/tests/utils/test_turn_separator_on_cpu.py
+++ b/tests/utils/test_turn_separator_on_cpu.py
@@ -155,6 +155,39 @@ def test_separator_with_list_valued_eos_and_multi_token_close():
     assert initialize_turn_separator(MultiCloseTokenizer()) == [nl]
 
 
+class MultimodalChatMLProcessor(ChatMLTokenizer):
+    """ChatML tokenizer that rejects bare-string ``content``, like a multimodal processor.
+
+    Multimodal processors iterate ``content`` expecting a list of typed parts (``{"type": "text",
+    "text": ...}``), so a bare string is indexed as ``content["type"]`` and raises ``TypeError``.
+    This reproduces the crash the string-content probe hit on real VLM processors in CI.
+    """
+
+    def apply_chat_template(self, messages, add_generation_prompt=False, tokenize=True, tools=None, **kwargs):
+        flattened = []
+        for m in messages:
+            content = m["content"]
+            if isinstance(content, str):
+                raise TypeError("string indices must be integers, not 'str'")
+            text = "".join(part["text"] for part in content)
+            flattened.append({"role": m["role"], "content": text})
+        return super().apply_chat_template(flattened, add_generation_prompt, tokenize, tools, **kwargs)
+
+
+def test_separator_derived_when_processor_requires_list_content():
+    """Guard the multimodal path: string-content probe crashes, list-of-parts probe recovers it."""
+    proc = MultimodalChatMLProcessor()
+    # The string-content form the plain path uses really does raise on this processor.
+    try:
+        proc.apply_chat_template([{"role": "user", "content": "x"}])
+        raised = False
+    except TypeError:
+        raised = True
+    assert raised
+    # The helper falls back to list-of-parts content and still recovers the separator.
+    assert initialize_turn_separator(proc) == [_NL]
+
+
 def test_separator_ignores_assistant_reasoning_scaffold():
     """Regression guard for the Qwen3 ``<think>`` gotcha.
 

--- a/verl/utils/tokenizer/chat_template.py
+++ b/verl/utils/tokenizer/chat_template.py
@@ -58,16 +58,38 @@ def initialize_turn_separator(tokenizer, **apply_chat_template_kwargs) -> list[i
     Returns an empty list when the template has no turn separator or an unexpected structure, so
     callers keep their previous behavior instead of crashing.
     """
-    empty = normalize_token_ids(
-        tokenizer.apply_chat_template(
-            [{"role": "user", "content": ""}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
-        )
-    )
-    filled = normalize_token_ids(
-        tokenizer.apply_chat_template(
-            [{"role": "user", "content": "x"}], add_generation_prompt=False, tokenize=True, **apply_chat_template_kwargs
-        )
-    )
+    # Render two user turns that differ only in body text; the shared trailing run is the separator.
+    # A bare string ``content`` is rejected by some multimodal processors (they iterate ``content``
+    # expecting a list of typed parts), so fall back to the list-of-parts form, and return ``[]`` if
+    # neither renders. Both probes must use the same form so only the body differs.
+    empty = filled = None
+    for as_parts in (False, True):
+        if as_parts:
+            body_empty, body_filled = [{"type": "text", "text": ""}], [{"type": "text", "text": "x"}]
+        else:
+            body_empty, body_filled = "", "x"
+        try:
+            empty = normalize_token_ids(
+                tokenizer.apply_chat_template(
+                    [{"role": "user", "content": body_empty}],
+                    add_generation_prompt=False,
+                    tokenize=True,
+                    **apply_chat_template_kwargs,
+                )
+            )
+            filled = normalize_token_ids(
+                tokenizer.apply_chat_template(
+                    [{"role": "user", "content": body_filled}],
+                    add_generation_prompt=False,
+                    tokenize=True,
+                    **apply_chat_template_kwargs,
+                )
+            )
+            break
+        except Exception:
+            empty = filled = None
+    if empty is None or filled is None:
+        return []
     # Maximal common trailing run == the message closing token(s) + inter-turn separator (identical
     # regardless of content).
     i = 0


### PR DESCRIPTION
### What does this PR do?

Follow-up to #6921. `initialize_turn_separator` derives the per-turn separator by rendering a user turn with empty vs non-empty content. It probes with a bare string `content="x"`, which multimodal processors reject: they iterate `content` expecting a list of typed parts (`{"type": "text", "text": ...}`), so the string is indexed as `content["type"]` and raises `TypeError: string indices must be integers`. This crashes `AgentLoopBase.__init__` on the processor (VLM) rollout path. The empty-string probe survives (an empty string iterates to nothing), so only the non-empty probe fails.

### Fix

`initialize_turn_separator` now probes string `content` first (unchanged for plain tokenizers), and on failure retries with the list-of-parts form `[{"type": "text", "text": ...}]` that processors expect. Both probes use the same form, so only the body text differs and the separator derivation is unchanged. If neither form renders, it returns `[]` rather than propagating an exception.

`tests/utils/test_turn_separator_on_cpu.py` adds a regression test with a processor stub that rejects string content, asserting the fallback still recovers the separator.

### CI failures addressed

Three e2e checks on the #6921 merge commit failed with this `TypeError` in `initialize_turn_separator`: `e2e_ppo_trainer_veomni_vllm`, `e2e_grpo_trainer_megatron-vlm`, and `sgl`.

### Tests

Local (CPU only):

- `pytest tests/utils/test_turn_separator_on_cpu.py`: 8/8 pass, including the new regression test.
- Verified against the `Qwen/Qwen3-VL-2B-Instruct` and `Qwen/Qwen2.5-VL-3B-Instruct` processors and the plain `Qwen/Qwen3-8B` tokenizer: all return the `\n` separator (id 198) with no crash.
- `ruff check` and `ruff format --check` clean.

GPU validation for the three checks above is left to project CI.

---

**AI assistance disclosure**: This PR was developed with AI assistance. The submitting human has reviewed every changed line, is responsible for the change end to end, and verified it against the tests listed above.
