### PR TITLE
[perf] fix: correct Qwen-VL head_dim consistency and merger token count (#6903)

### DIFF
--- a/tests/utils/test_flops_counter.py
+++ b/tests/utils/test_flops_counter.py
@@ -346,24 +346,38 @@ CONFIG = {
         # mlp_N =hidden*inter*2
         # merger_N =((o+hidden*spatial_merge_size^2) * (hidden*spatial_merge_size^2))
         # deepstack_merger_N =merger_N * 3
-        # dense_N =patch_embed_N + (attn_linear_N + mlp_N) * 27 + deepstack_merger_N + merger_N
+        # The mergers downsample by spatial_merge_size**2, so they run on
+        # merger_tokens = tokens_sum // spatial_merge_size**2 (= tokens_sum // 4), not the full
+        # tokens_sum; merger FLOPs are therefore counted separately from dense_N.
+        # dense_N =patch_embed_N + (attn_linear_N + mlp_N) * 27   (mergers pulled out)
+        # merger_total_N =deepstack_merger_N + merger_N
+        # vit_dense_flops =6 * dense_N * tokens_sum + 6 * merger_total_N * (tokens_sum // 4)
         #
         # 6*(151936*4096*2
         #   + 36*(4096*(4096+1024+1024+4096) + 4096*12288*3)
         # )*(512+1024+2048)
         # + 12*(512*512+1024*1024+2048*2048)*36*4096
         # + 6 * dense_N * (512 + 1024 + 2048)
+        # + 6 * merger_total_N * ((512 + 1024 + 2048) // 4)
         # + 12 * (512**2 + 1024**2 + 2048**2) * 27 * 16 * 72
         #
         # 6*(151936*4096*2
         #   + 36*(4096*(4096+1024+1024+4096) + 4096*12288*3)
         # )*(4096+4096+4096)
         # + 12*(4096*4096+4096*4096+4096*4096)*36*4096
-        # + 6 * dense_N * (4096 + 4096 + 2048)
+        # + 6 * dense_N * (4096 + 4096 + 4096)
+        # + 6 * merger_total_N * ((4096 + 4096 + 4096) // 4)
         # + 12 * (4096**2 + 4096**2 + 4096**2) * 27 * 16 * 72
+        #
+        # The merger-token correction shifts the ViT merger term from full tokens_sum
+        # to tokens_sum//4. merger_total_N = 4 * (4096 + 1152*4) * (1152*4) = 160432128.
+        # delta = 6 * 160432128 * (tokens_sum//4 - tokens_sum):
+        #   batch0 tokens_sum=3584: 6*160432128*(896-3584)  = -2587449360384
+        #   batch1 tokens_sum=12288: 6*160432128*(3072-12288)= -8871254949888
+        # old goldens (195379819708416, 709446422495232) + delta ->
         "expected_flops_tuple": (
-            195379819708416 / 1e12,
-            709446422495232 / 1e12,
+            192792370348032 / 1e12,
+            700575167545344 / 1e12,
         ),
     },
     "qwen3_vl_moe": {
@@ -412,24 +426,34 @@ CONFIG = {
         # mlp_N =hidden*inter*2
         # merger_N =((o+hidden*spatial_merge_size^2) * (hidden*spatial_merge_size^2))
         # deepstack_merger_N =merger_N * 3
-        # dense_N =patch_embed_N + (attn_linear_N + mlp_N) * 27 + deepstack_merger_N + merger_N
+        # The mergers downsample by spatial_merge_size**2, so they run on
+        # tokens_sum // spatial_merge_size**2 (= tokens_sum // 4) tokens, counted separately.
+        # dense_N =patch_embed_N + (attn_linear_N + mlp_N) * 27   (mergers pulled out)
+        # merger_total_N =deepstack_merger_N + merger_N
+        # vit_dense_flops =6 * dense_N * tokens_sum + 6 * merger_total_N * (tokens_sum // 4)
         #
         # 6*(151936*2048*2
         #   + 48*(2048*(128*32+128*4*2+128*32)+2048*768*8*3+2048*128)
         # )*(512+1024+2048)
         # + 12*(512*512+1024*1024+2048*2048)*48*4096
         # + 6 * dense_N * (512 + 1024 + 2048)
+        # + 6 * merger_total_N * ((512 + 1024 + 2048) // 4)
         # + 12 * (512**2 + 1024**2 + 2048**2) * 27 * 16 * 72
         #
         # 6*(151936*2048*2
         #   48*(2048*(128*32+128*4*2+128*32)+2048*768*8*3+2048*128)
         # )*(4096+4096+4096)
         # + 12*(4096*4096+4096*4096+4096*4096)*48*4096
-        # + 6 * dense_N * (4096 + 4096 + 2048)
+        # + 6 * dense_N * (4096 + 4096 + 4096)
+        # + 6 * merger_total_N * ((4096 + 4096 + 4096) // 4)
         # + 12 * (4096**2 + 4096**2 + 4096**2) * 27 * 16 * 72
+        #
+        # Merger-token correction: same ViT as qwen3_vl, so same delta
+        #   batch0: -2587449360384 ; batch1: -8871254949888
+        # old goldens (92975451340800, 367622860308480) + delta ->
         "expected_flops_tuple": (
-            92975451340800 / 1e12,
-            367622860308480 / 1e12,
+            90388001980416 / 1e12,
+            358751605358592 / 1e12,
         ),
     },
 }

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -131,7 +131,7 @@ def _estimate_qwen3_vl_flops(config, tokens_sum, batch_seqlens, delta_time, **ka
     num_attention_heads = config.text_config.num_attention_heads
     intermediate_size = config.text_config.intermediate_size
 
-    head_dim = hidden_size // num_attention_heads
+    head_dim = getattr(config.text_config, "head_dim", hidden_size // num_attention_heads)
     q_size = num_attention_heads * head_dim
     k_size = num_key_value_heads * head_dim
     v_size = num_key_value_heads * head_dim
@@ -246,11 +246,20 @@ def _estimate_qwen3_vit_flop(images_seqlens, config):
         deepstack_merger_N = merger_N * len(config.deepstack_visual_indexes)
     else:
         deepstack_merger_N = 0
-    # non-attn all_layer parm
-    dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth + deepstack_merger_N + merger_N
+    # The spatial merger runs after patch merging, so it processes
+    # tokens_sum / spatial_merge_size**2 tokens, not the full tokens_sum.
+    # The deepstack mergers are the same Qwen3VLVisionPatchMerger module
+    # (hidden_size = context_dim * spatial_merge_size**2, forward does
+    # x.view(-1, hidden_size)), so they also emit tokens_sum / spatial_merge_size**2
+    # tokens and share merger_tokens with the final merger.
+    merger_tokens = tokens_sum // (spatial_merge_size**2)
+    merger_total_N = merger_N + deepstack_merger_N
+
+    # non-attn all_layer parm (excludes mergers, which run on fewer tokens)
+    dense_N = patch_embed_N + (mlp_N + attn_linear_N) * depth
 
     # non-attn all_layer & all_token fwd & bwd flops
-    dense_N_flops = 6 * dense_N * tokens_sum
+    dense_N_flops = 6 * dense_N * tokens_sum + 6 * merger_total_N * merger_tokens
 
     # In Qwen3 VL, full attention is used in all vision layers.
     full_attn_layer_num = depth


### PR DESCRIPTION
### What does this PR do?

Corrects two objective inaccuracies in the Qwen3-VL FLOPs estimators in `verl/utils/flops_counter.py`, and refreshes the affected test goldens. Addresses verl-project/verl#6903 (claims 1 and 4 only).

1. **`head_dim` sourcing (`_estimate_qwen3_vl_flops`)** — read `head_dim` from `config.text_config` via `getattr(config.text_config, "head_dim", hidden_size // num_attention_heads)`, matching the sibling estimators (`_estimate_qwen3_vl_moe_flops` and the other Qwen estimators). Qwen3-VL variants may configure a `head_dim` that differs from `hidden_size // num_attention_heads`; deriving it only from `hidden_size` under-counts attention FLOPs in that case.
2. **Merger token count (`_estimate_qwen3_vit_flop`)** — the vision patch merger and the deepstack mergers run *after* spatial merging, so their linear layers process `tokens_sum // spatial_merge_size**2` tokens, not the full `tokens_sum`. Multiplying merger parameters by the full `tokens_sum` over-counted merger FLOPs by a factor of `spatial_merge_size**2` (= 4).

Scope is deliberately limited to these two objective claims. Claims 2 (lm-head `* 2`) and 3 (`seqlen**2` attention accounting under packing) from the issue are **excluded** — they were part of upstream PR #4929, which was reverted by #4937.

### Checklist Before Starting

- [x] Search for similar PRs: [`is:pr 6903 in:body`](https://github.com/verl-project/verl/pulls?q=is%3Apr+6903+in%3Abody), [`flops_counter qwen-vl`](https://github.com/verl-project/verl/pulls?q=is%3Apr+flops_counter+qwen)
- [x] PR title format: `fix(flops_counter): ...` referencing the issue.

### Test

`torch`/`ray` are not installed in this environment, so `pytest` cannot collect `tests/utils/test_flops_counter.py` directly. The arithmetic was instead validated with a standalone torch-free replica of both estimators that:

1. reproduces the **old** goldens exactly (confirming the replica matches the pre-change code), and
2. reproduces the **new** goldens exactly (confirming the correction).

Both configs and both batches pass:

```
qwen3_vl     b0: old=195379819708416  new=192792370348032  delta=-2587449360384
qwen3_vl     b1: old=709446422495232  new=700575167545344  delta=-8871254949888
qwen3_vl_moe b0: old= 92975451340800  new= 90388001980416  delta=-2587449360384
qwen3_vl_moe b1: old=367622860308480  new=358751605358592  delta=-8871254949888
```

The delta on every case is exactly `6 * merger_total_N * (tokens_sum//4 - tokens_sum)`, i.e. only the merger term moved. The `head_dim` change produces no golden change because `head_dim == hidden_size // num_attention_heads` for the test configs. `python -m py_compile` passes on both files.

Correctness of the underlying architecture was cross-checked against the HuggingFace `transformers` Qwen3-VL source: `Qwen3VLVisionPatchMerger.hidden_size = config.hidden_size * spatial_merge_size**2` and its `forward` reshapes with `x.view(-1, self.hidden_size)`, so each merger emits `tokens_sum // spatial_merge_size**2` tokens; the deepstack mergers are the same `Qwen3VLVisionPatchMerger` module (`use_postshuffle_norm=True`), so the same `merger_tokens` applies to both.

### API and Usage Example

No API change. `estimate_flops` / `FlopsCounter` signatures are unchanged; only the internal FLOPs value for Qwen3-VL / Qwen3-VL-MoE models is corrected.

### Design & Code Changes

- `_estimate_qwen3_vl_flops`: `head_dim` now sourced via `getattr(config.text_config, "head_dim", ...)`.
- `_estimate_qwen3_vit_flop`: mergers pulled out of `dense_N` and multiplied by `merger_tokens = tokens_sum // spatial_merge_size**2`; a code comment documents why (spatial-merge downsampling, shared by the deepstack mergers).
- `tests/utils/test_flops_counter.py`: `qwen3_vl` and `qwen3_vl_moe` goldens updated with the derived deltas; derivation comments made self-contained.

The single non-obvious point is that dense layers and mergers see different token counts:

```mermaid
flowchart TD
    A["tokens_sum = sum(images_seqlens)"] --> B["dense layers (patch_embed, attn, mlp)<br/>run on full tokens_sum"]
    A --> C["mergers downsample by spatial_merge_size**2"]
    C --> D["merger_tokens = tokens_sum // spatial_merge_size**2"]
    B --> E["dense_N_flops = 6·dense_N·tokens_sum<br/>+ 6·merger_total_N·merger_tokens"]
    D --> E
```

AI assistance was used to prepare this change; the arithmetic and the architecture claims above were verified end-to-end.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting).
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). N/A — internal FLOPs-accounting fix, no user-facing docs.
- [x] Add unit or end-to-end test(s) to cover the code — existing `tests/utils/test_flops_counter.py` goldens updated to lock in the corrected values.

