### PR TITLE
[megatron] fix: free Transformer-Engine FP8 weight workspaces on CPU offload

### DIFF
--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -496,6 +496,35 @@ def _can_safely_resize_storage(tensor: torch.Tensor) -> bool:
     )
 
 
+def _clear_te_fp8_weight_workspaces(model_chunk):
+    """Clear cached Transformer-Engine FP8 weight workspaces on a model chunk.
+
+    When training with an FP8 param dtype (or loading a native-FP8 checkpoint),
+    Transformer-Engine ``Linear`` / ``GroupedLinear`` layers cache quantized
+    (``Float8Tensor`` / ``Float8BlockwiseQTensor``) copies of their weights in
+    ``module._fp8_workspaces`` (keyed ``weight``, ``weight0..weightN``). These
+    caches are plain tensors, not ``nn.Parameter``s or registered buffers, so the
+    parameter/buffer offloading in :func:`offload_megatron_model_to_cpu` never
+    frees them and they stay resident on the GPU -- for large MoE checkpoints this
+    can be tens of GiB per rank that defeats the offload. Transformer-Engine lazily
+    rebuilds the workspace on the next forward, so dropping it here is safe. This is
+    a no-op for bf16/fp16 models (the attribute is absent or empty).
+
+    Returns the number of cached workspace entries cleared.
+    """
+    module = getattr(model_chunk, "module", model_chunk)
+    modules_fn = getattr(module, "modules", None)
+    if modules_fn is None:
+        return 0
+    cleared = 0
+    for submodule in modules_fn():
+        workspaces = getattr(submodule, "_fp8_workspaces", None)
+        if isinstance(workspaces, dict) and workspaces:
+            cleared += len(workspaces)
+            workspaces.clear()
+    return cleared
+
+
 @torch.no_grad()
 def offload_megatron_model_to_cpu(models):
     """
@@ -575,6 +604,10 @@ def offload_megatron_model_to_cpu(models):
                     param.grad = param.grad.to("cpu")
                     if _can_safely_resize_storage(old_grad):
                         old_grad.storage().resize_(0)
+
+        # Drop Transformer-Engine FP8 weight-workspace caches, which hold quantized
+        # copies of the weights on GPU and are not covered by the parameter offload above.
+        _clear_te_fp8_weight_workspaces(model_chunk)
 
     gc.collect()
     get_torch_device().empty_cache()

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -603,7 +603,9 @@ def offload_megatron_model_to_cpu(models):
 
         # Drop Transformer-Engine FP8 weight-workspace caches, which hold quantized
         # copies of the weights on GPU and are not covered by the parameter offload above.
-        _clear_te_fp8_weight_workspaces(model_chunk)
+        cleared = _clear_te_fp8_weight_workspaces(model_chunk)
+        if cleared:
+            logger.debug("Cleared %d TE FP8 weight workspaces on offload", cleared)
 
     gc.collect()
     get_torch_device().empty_cache()

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -512,12 +512,8 @@ def _clear_te_fp8_weight_workspaces(model_chunk):
 
     Returns the number of cached workspace entries cleared.
     """
-    module = getattr(model_chunk, "module", model_chunk)
-    modules_fn = getattr(module, "modules", None)
-    if modules_fn is None:
-        return 0
     cleared = 0
-    for submodule in modules_fn():
+    for submodule in model_chunk.modules():
         workspaces = getattr(submodule, "_fp8_workspaces", None)
         if isinstance(workspaces, dict) and workspaces:
             cleared += len(workspaces)


### PR DESCRIPTION
Co-authored with @YQ-Wang.

### What does this PR do?

`offload_megatron_model_to_cpu` frees DDP buffers and walks `.parameters()`, but never clears Transformer-Engine's FP8 weight-workspace caches (`module._fp8_workspaces`). With an FP8 param dtype or a natively-FP8 checkpoint, TE `Linear` / `GroupedLinear` layers cache quantized weight copies (`Float8Tensor` / `Float8BlockwiseQTensor`) there. Those are plain tensors — not `nn.Parameter`s or registered buffers — so the offload never releases them and they stay resident on the GPU. On a large native-FP8 MoE checkpoint this is tens of GiB per rank left on the device after a "full" offload, which then collides with the rollout engine's weight reload in colocated hybrid training.

This adds `_clear_te_fp8_weight_workspaces`, called per model chunk at the end of the offload. TE rebuilds the workspace lazily on the next forward, so clearing it is safe; it is a no-op on bf16/fp16 (attribute absent) and needs no new imports or dependencies.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+fp8+workspace+offload — none found; `_fp8_workspaces` did not previously appear in the codebase.
- [x] PR title formatted as `[{modules}] {type}: {description}`.

### Test

No-op on the bf16/fp16 path and only frees an otherwise-leaked cache on FP8 paths, so correctness is unchanged. Reproducing the leak requires a GPU + Transformer-Engine + an FP8 Megatron model, so it is not coverable by CPU CI. Measured on a native-FP8 GLM-4.7-FP8 GRPO run (EP=16, 2×8 B200): per-rank allocated dropped **68.3 → 0.9 GiB** after the clear, letting the full colocated step fit where it previously OOM'd.

```
mem[pre]           alloc=68.3 GiB   (~3900 x ~0.01 GiB Float8BlockwiseQTensor cached expert weights)
cleared 2148 fp8 weight workspaces
mem[post-release]  alloc=0.9 GiB
```

### Design & Code Changes

`verl/utils/megatron_utils.py`:
- Add `_clear_te_fp8_weight_workspaces(model_chunk)` — walks the module tree and clears any non-empty `_fp8_workspaces` dict.
- Call it per `model_chunk` at the end of `offload_megatron_model_to_cpu`, before `gc.collect()` / `empty_cache()`.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (`ruff` + `ruff-format` clean on the changed file).
- [ ] Add / Update the documentation. No user-facing API/config change.
- [ ] Add unit or end-to-end test(s). Not feasible in CPU CI (needs GPU + TE + an FP8 Megatron model); the change is a no-op on non-FP8 paths.

