### PR TITLE
[trainer] fix: Add readme and CI test for Titan Engine

### DIFF
--- a/.github/workflows/e2e_ppo_trainer_torchtitan_vllm.yml
+++ b/.github/workflows/e2e_ppo_trainer_torchtitan_vllm.yml
@@ -1,0 +1,171 @@
+# # Tests layout
+
+# Each folder under tests/ corresponds to a test category for a sub-namespace in verl. For instance:
+# - `tests/trainer` for testing functionality related to `verl/trainer`
+# - `tests/models` for testing functionality related to `verl/models`
+# - ...
+
+# There are a few folders with `special_` prefix, created for special purposes:
+# - `special_distributed`: unit tests that must run with multiple GPUs
+# - `special_e2e`: end-to-end tests with training/generation scripts
+# - `special_npu`: tests for NPUs
+# - `special_sanity`: a suite of quick sanity tests
+# - `special_standalone`: a set of test that are designed to run in dedicated environments
+
+# Accelerators for tests
+# - By default tests are run with GPU available, except for the ones under `special_npu`, and any test script whose name ends with `on_cpu.py`.
+# - For test scripts with `on_cpu.py` name suffix would be tested on CPU resources in linux environment.
+
+# # Workflow layout
+
+# All CI tests are configured by yaml files in `.github/workflows/`. Here's an overview of all test configs:
+# 1. A list of always triggered CPU sanity tests: `check-pr-title.yml`, `secrets_scan.yml`, `check-pr-title,yml`, `pre-commit.yml`, `doc.yml`
+# 2. Some heavy multi-GPU unit tests, such as `model.yml`, `vllm.yml`, `sgl.yml`
+# 3. End-to-end tests: `e2e_*.yml`
+# 4. Unit tests
+#   - `cpu_unit_tests.yml`, run pytest on all scripts with file name pattern `tests/**/test_*_on_cpu.py`
+#   - `gpu_unit_tests.yml`, run pytest on all scripts with file without the `on_cpu.py` suffix.
+#   - Since cpu/gpu unit tests by default runs all tests under `tests`, please make sure tests are manually excluded in them when
+#     - new workflow yaml is added to `.github/workflows`
+#     - new tests are added to workflow mentioned in 2.
+
+# NOTE: The TorchTitan engine requires a *nightly* PyTorch + torchtitan (the ``spmd_types`` APIs
+# are nightly-only). To avoid maintaining a dedicated Docker image, this workflow installs those
+# nightlies in-job on top of the standard CI image (see the install step). Because the image's
+# vLLM is built against a *stable* torch, the run step preloads the nightly cuBLAS to resolve the
+# resulting ``undefined symbol: cublasGemmEx`` mismatch. The pinned nightly versions need periodic
+# bumping (old nightly wheels are garbage-collected from the index). Consider running this on a
+# schedule / as non-blocking if the nightly toolchain proves flaky.
+
+name: e2e_ppo_trainer_torchtitan_vllm
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch.
+  push:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "verl/workers/engine/torchtitan/**"
+      - "verl/workers/config/engine.py"
+  pull_request:
+    branches:
+      - main
+      - v0.*
+    paths:
+      - "!docker/**"
+      # Docs
+      - "!**/*.md"
+      - "!docs/**"
+      # Entrypoints
+      - ".github/workflows/e2e_ppo_trainer_torchtitan_vllm.yml"
+      - "tests/special_e2e/run_ppo_trainer_torchtitan.sh"
+      - "verl/workers/engine/torchtitan/**"
+      - "verl/workers/config/engine.py"
+      - "examples/data_preprocess/gsm8k.py"
+      - "verl/trainer/main_ppo.py"
+      - "verl/trainer/config/ppo_trainer.yaml"
+
+# Cancel jobs on the same ref if a new one is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Declare permissions just read content.
+permissions:
+  contents: read
+
+env:
+  IMAGE: "verl-ci-cn-beijing.cr.volces.com/verlai/verl:vllm023.dev1"
+  DYNAMIC_RUNNER_ENDPOINT: "https://sd10g3clalm04ug7alq90.apigateway-cn-beijing.volceapi.com/runner"
+
+jobs:
+  setup:
+    if: github.repository_owner == 'verl-project'
+    runs-on: ubuntu-latest
+    outputs:
+      runner-label: ${{ steps.create-runner.outputs.runner-label }}
+      mlp-task-id: ${{ steps.create-runner.outputs.mlp-task-id }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: create-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "create"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-image: "${{ env.IMAGE }}"
+
+  e2e_ppo_trainer_torchtitan_vllm:
+    needs: setup
+    runs-on: ["${{ needs.setup.outputs.runner-label || 'L20x8' }}"]
+    timeout-minutes: 60 # Increase this timeout value as needed
+    env:
+      HTTPS_PROXY: ${{ secrets.PROXY_HTTPS }}
+      NO_PROXY: "localhost,127.0.0.1,hf-mirror.com"
+      HF_ENDPOINT: "https://hf-mirror.com"
+      HF_HUB_ENABLE_HF_TRANSFER: "0" # This is more stable
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Install the current repository + TorchTitan nightly stack
+        run: |
+          pip3 install -r requirements-test.txt
+          pip3 install -r requirements.txt
+          pip3 install --no-deps -e .
+          # TorchTitan's spmd_types APIs require a nightly PyTorch; the image's vLLM is built against
+          # a stable torch (ABI-incompatible -> undefined symbol: torch::Library::_def). Install a
+          # nightly-torch stack from the PyTorch index. Why these versions:
+          #   vllm        1.0.0.dev20260620 : newest nightly-torch vLLM whose API verl's rollout code
+          #                                    supports (0704+ refactored vllm.utils and dropped the
+          #                                    `FlexibleArgumentParser` import path verl relies on).
+          #   torch       2.14.0.dev20260625 : >= the spmd_types DTensor/fully_shard fix floor, and
+          #                                    ~5 days from vLLM's dev0620 build -> ABI-compatible.
+          #   torchvision 0.29.0.dev20260626 : pins torch dev0625 exactly (0-day ABI gap).
+          #   torchtitan  0.1.0.dev20260701 : provides spmd_backend; declares no torch dep.
+          # vLLM pins torch==dev0620, so install it (with deps) first, then bump torch/torchvision to
+          # the versions above with --no-deps (keeps the ABI-safe gap, preserves vLLM's dep set).
+          INDEX="https://download.pytorch.org/whl/nightly/cu130"
+          pip3 install --pre vllm==1.0.0.dev20260620+cu130 --extra-index-url "${INDEX}"
+          pip3 install --pre torchtitan==0.1.0.dev20260701+cu130 --extra-index-url "${INDEX}"
+          pip3 install --pre --no-deps \
+            torch==2.14.0.dev20260625+cu130 \
+            torchvision==0.29.0.dev20260626+cu130 \
+            --extra-index-url "${INDEX}"
+          # The image ships classic flash-attn 2 (flash_attn_2_cuda.so) built against stable torch;
+          # under nightly torch it fails to load (undefined symbol: c10::...materialize_cow_storage).
+          # vLLM's rotary-embedding path imports flash_attn unconditionally and crashes on the broken
+          # .so. Remove it so vLLM falls back to its native rotary kernel.
+          pip3 uninstall -y flash-attn
+      - name: Check final pip list
+        run: |
+          pip3 list
+      - name: Prepare GSM8K dataset21
+        run: |
+          ray stop --force
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+      - name: Running GSM8K E2E training test on 8 L20 GPUs with TorchTitan engine (FSDP_SIZE=8, spmd_types, flex, selective AC)
+        run: |
+          ray stop --force
+          # vLLM in the base image is built against stable torch; preload the nightly cuBLAS so
+          # its C extensions resolve against the nightly torch (fixes undefined symbol cublasGemmEx).
+          export LD_PRELOAD="$(python3 -c 'import glob, os, sysconfig; c = glob.glob(os.path.join(sysconfig.get_paths()["purelib"], "nvidia", "cu13", "lib", "libcublas.so.13")); print(c[0] if c else "")')"
+          NUM_GPUS=8 FSDP_SIZE=8 TOTAL_TRAIN_STEPS=2 \
+            bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
+
+  cleanup:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        setup,
+        e2e_ppo_trainer_torchtitan_vllm,
+      ]
+    if: always()
+    steps:
+      - id: destroy-runner
+        uses: volcengine/vemlp-github-runner@v1
+        with:
+          mode: "destroy"
+          faas-url: "${{ env.DYNAMIC_RUNNER_ENDPOINT }}"
+          mlp-task-id: "${{ needs.setup.outputs.mlp-task-id }}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,7 @@ verl is fast with:
    workers/model_engine
    workers/engine_workers
    workers/automodel_workers
+   workers/torchtitan_workers
    workers/sglang_worker
    workers/trtllm_worker
 

--- a/docs/workers/torchtitan_workers.rst
+++ b/docs/workers/torchtitan_workers.rst
@@ -1,0 +1,138 @@
+TorchTitan Backend
+==================
+
+Last updated: 07/06/2026.
+
+We support the `TorchTitan <https://github.com/pytorch/torchtitan>`_ backend by
+implementing the ``TorchTitanEngine`` and ``TorchTitanEngineWithLMHead`` engine
+classes. The TorchTitan backend delegates model building, parallelization
+(FSDP2 / TP / PP / CP / EP), optimizer construction and sharding, LR
+scheduling, gradient clipping, and checkpointing to TorchTitan's
+infrastructure, while using verl's training loop, data pipeline, and loss
+function.
+
+Enable it with ``model_engine=torchtitan``. The engine is registered for the
+``language_model`` model type on ``cuda`` and ``npu`` devices.
+
+**Requirements**
+
+- A recent TorchTitan **nightly** (the engine uses TorchTitan's ``Trainer``,
+  ``ParallelismConfig.spmd_backend``, and ``activation_checkpoint`` APIs).
+- A matching PyTorch **nightly** recent enough to support the ``spmd_types``
+  SPMD backend (the DTensor / ``fully_shard`` fixes it depends on).
+- Attention-backend-specific dependencies (see `Attention backend`_):
+
+  - ``flex`` — no extra dependency (torch built-in FlexAttention).
+  - ``flex_flash`` — ``flash-attn-4`` / CUTE kernels, Hopper or Blackwell only.
+  - ``varlen`` — FA3 (``flash_attn_interface``).
+
+**Pros**
+
+- FSDP2, Tensor Parallelism (TP), Pipeline Parallelism (PP), Context
+  Parallelism (CP), and Expert Parallelism (EP) out of the box.
+
+- DTensor-based SPMD backends (``full_dtensor`` / ``spmd_types``) in addition
+  to the legacy ``default`` sharding.
+
+- ``torch.compile`` support, meta-device model init, and HuggingFace
+  checkpoint loading (no manual conversion for TorchTitan-supported models).
+
+- FlexAttention backends (including the FLASH kernel on Hopper/Blackwell).
+
+**Cons**
+
+- Requires TorchTitan and PyTorch nightlies.
+
+- Model coverage is limited to model families registered in TorchTitan (e.g.
+  ``qwen3``, ``llama3``); the flavor is derived from the HuggingFace config.
+
+- ``sdpa`` is not a valid language-model attention backend (use ``flex``,
+  ``flex_flash``, or ``varlen``).
+
+
+Configuration
+-------------
+
+The TorchTitan engine is configured under ``actor_rollout_ref.<role>.torchtitan``
+(mapped from ``TorchtitanEngineConfig``). Key options:
+
+Parallelism
+^^^^^^^^^^^
+
+- ``data_parallel_shard_size`` — FSDP2 shard degree.
+- ``data_parallel_replicate_size`` — HSDP replicate degree.
+- ``tensor_parallel_size`` — TP degree.
+- ``pipeline_parallel_size`` — PP degree.
+- ``context_parallel_size`` — CP degree.
+- ``expert_parallel_size`` — EP degree (MoE models).
+
+SPMD backend
+^^^^^^^^^^^^
+
+``spmd_backend`` selects how sharding is expressed (default ``spmd_types``):
+
+- ``default`` — legacy per-parallelism sharding (no full-DTensor mesh).
+- ``full_dtensor`` — all params/buffers/inputs are DTensors on a dense
+  multi-axis mesh.
+- ``spmd_types`` — ``spmd_types`` typed collectives on a dense mesh.
+
+Attention backend
+^^^^^^^^^^^^^^^^^
+
+``attn_type`` selects the attention implementation (default ``flex``):
+
+- ``flex`` — FlexAttention; needs ``torch.compile`` to be fast (eager is slow).
+- ``flex_flash`` — FlexAttention FLASH kernel; needs ``flash-attn-4`` / CUTE,
+  Hopper/Blackwell only.
+- ``varlen`` — fast eager, flash-style; needs FA3 (``flash_attn_interface``).
+
+Activation checkpointing
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+``activation_checkpoint`` selects the AC mode (default ``selective``):
+
+- ``selective`` — TorchTitan's selective (per-op) activation checkpointing.
+- ``full`` — full activation checkpointing.
+- ``none`` — disabled.
+
+.. note::
+
+   Under ``spmd_backend=spmd_types``, TorchTitan's typed collectives require the
+   thread-local SPMD mesh to stay active across ``loss.backward()`` (activation
+   checkpointing re-runs the module forward during backward). The engine mirrors
+   TorchTitan's ``init_distributed`` by disabling autograd multithreading at
+   device-mesh init so the recompute runs on the calling thread and can access
+   the mesh. Without this (e.g. when calling backward from a non-main thread as
+   verl does under Ray), ``spmd.assert_type`` would raise
+   ``SpmdTypeError: ... no current mesh is set``.
+
+
+PPO Example
+-----------
+
+An end-to-end GRPO example on GSM8K with the TorchTitan engine is provided at
+`tests/special_e2e/run_ppo_trainer_torchtitan.sh <https://github.com/verl-project/verl/blob/main/tests/special_e2e/run_ppo_trainer_torchtitan.sh>`_.
+
+Basic: Qwen3-0.6B with FSDP2 + spmd_types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Qwen3-0.6B, pure FSDP across 4 GPUs, ``flex`` attention, ``spmd_types`` backend,
+selective activation checkpointing:
+
+.. code:: shell
+
+   NUM_GPUS=4 FSDP_SIZE=4 ATTN_TYPE=flex SPMD_BACKEND=spmd_types AC_MODE=selective \
+       bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
+
+The script exposes ``NUM_GPUS``, ``FSDP_SIZE``, ``TP_SIZE``, ``EP_SIZE``,
+``ATTN_TYPE``, ``SPMD_BACKEND``, and ``AC_MODE`` as environment variables.
+
+Adding tensor parallelism
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To mirror ``FSDP_SIZE=2 TP_SIZE=2`` on 4 GPUs:
+
+.. code:: shell
+
+   NUM_GPUS=4 FSDP_SIZE=2 TP_SIZE=2 ATTN_TYPE=flex SPMD_BACKEND=spmd_types \
+       bash tests/special_e2e/run_ppo_trainer_torchtitan.sh

--- a/docs/workers/torchtitan_workers.rst
+++ b/docs/workers/torchtitan_workers.rst
@@ -1,110 +1,102 @@
 TorchTitan Backend
 ==================
 
-Last updated: 07/06/2026.
+Last updated: 07/08/2026.
 
 We support the `TorchTitan <https://github.com/pytorch/torchtitan>`_ backend by
 implementing the ``TorchTitanEngine`` and ``TorchTitanEngineWithLMHead`` engine
 classes. The TorchTitan backend delegates model building, parallelization
-(FSDP2 / TP / PP / CP / EP), optimizer construction and sharding, LR
-scheduling, gradient clipping, and checkpointing to TorchTitan's
-infrastructure, while using verl's training loop, data pipeline, and loss
-function.
+(FSDP2 / TP / CP / EP), optimizer construction and sharding, LR scheduling,
+gradient clipping, and checkpointing to TorchTitan's infrastructure, while using
+verl's own training loop (``forward_backward_batch``), data pipeline, and loss
+function. Pipeline parallelism is not yet supported by the engine.
 
-Enable it with ``model_engine=torchtitan``. The engine is registered for the
-``language_model`` model type on ``cuda`` and ``npu`` devices.
+Enable it with ``model_engine=torchtitan``.
 
 **Requirements**
 
 - A recent TorchTitan **nightly** (the engine uses TorchTitan's ``Trainer``,
   ``ParallelismConfig.spmd_backend``, and ``activation_checkpoint`` APIs).
+  TorchTitan declares no ``torch`` dependency, so its date can float freely.
 - A matching PyTorch **nightly** recent enough to support the ``spmd_types``
-  SPMD backend (the DTensor / ``fully_shard`` fixes it depends on).
-- Attention-backend-specific dependencies (see `Attention backend`_):
+  SPMD backend (verified with ``torch>=2.14.0.dev20260625``; the DTensor /
+  ``fully_shard`` fixes it depends on landed around then).
+- **Use ABI-compatible nightly builds of the torch-compiled packages.**
+  ``torchvision`` and (with the vLLM rollout backend) ``vllm`` ship extensions
+  ABI-locked to ``torch``, so install them from the PyTorch nightly index at close
+  build dates. ``vllm`` is the binding constraint: it must be old enough for
+  verl's rollout API yet built for a nightly ``torch``. The e2e CI test uses this
+  known-good set:
+
+  .. code:: text
+
+     vllm         1.0.0.dev20260620+cu130    # newest nightly-torch vLLM verl's rollout supports
+     torch        2.14.0.dev20260625+cu130   # >= spmd_types fix floor; ABI-compatible with vLLM
+     torchvision  0.29.0.dev20260626+cu130   # pins torch dev0625 exactly (0-day ABI gap)
+     torchtitan   0.1.0.dev20260701+cu130    # no torch dep; date can float
+
+- Attention-backend-specific requirements:
 
   - ``flex`` — no extra dependency (torch built-in FlexAttention).
-  - ``flex_flash`` — ``flash-attn-4`` / CUTE kernels, Hopper or Blackwell only.
-  - ``varlen`` — FA3 (``flash_attn_interface``).
+  - ``flex_flash`` — FlexAttention FLASH kernel; Hopper/Blackwell (CUDA
+    capability >= 9.0) only.
+  - ``varlen`` — torch built-in variable-length attention; uses FA3 on Hopper
+    (SM 9.0), FA2 on older GPUs.
 
 **Pros**
 
-- FSDP2, Tensor Parallelism (TP), Pipeline Parallelism (PP), Context
-  Parallelism (CP), and Expert Parallelism (EP) out of the box.
+- N-D parallelism out of the box: FSDP2 (with HSDP replicate), Tensor
+  Parallelism (TP), Context Parallelism (CP), and Expert Parallelism (EP) for
+  MoE models — combinable in a single run.
 
-- DTensor-based SPMD backends (``full_dtensor`` / ``spmd_types``) in addition
-  to the legacy ``default`` sharding.
+- ``torch.compile`` support for higher training throughput.
 
-- ``torch.compile`` support, meta-device model init, and HuggingFace
-  checkpoint loading (no manual conversion for TorchTitan-supported models).
+- Selective or full activation checkpointing, configurable per run for
+  memory/compute tradeoffs.
 
-- FlexAttention backends (including the FLASH kernel on Hopper/Blackwell).
+- Multiple attention backends: FlexAttention (with a FLASH kernel on
+  Hopper/Blackwell) and variable-length attention.
+
+- Parameter and optimizer-state offload to CPU to fit larger models.
+
 
 **Cons**
 
-- Requires TorchTitan and PyTorch nightlies.
-
-- Model coverage is limited to model families registered in TorchTitan (e.g.
-  ``qwen3``, ``llama3``); the flavor is derived from the HuggingFace config.
-
-- ``sdpa`` is not a valid language-model attention backend (use ``flex``,
-  ``flex_flash``, or ``varlen``).
+- Pipeline parallelism is not yet supported (``pipeline_parallel_size`` is
+  accepted by the config but ``model_forward_step`` raises ``NotImplementedError``).
 
 
-Configuration
--------------
+Installation
+------------
 
-The TorchTitan engine is configured under ``actor_rollout_ref.<role>.torchtitan``
-(mapped from ``TorchtitanEngineConfig``). Key options:
+TorchTitan and its matching PyTorch build are **nightly-only** (the
+``spmd_types`` APIs are not in any stable PyPI release yet), and both come from
+the PyTorch nightly index rather than PyPI. Install them together, choosing the
+index that matches your CUDA version (``cu130`` shown here; use ``cu126`` etc.
+as appropriate):
 
-Parallelism
-^^^^^^^^^^^
+.. code:: shell
 
-- ``data_parallel_shard_size`` — FSDP2 shard degree.
-- ``data_parallel_replicate_size`` — HSDP replicate degree.
-- ``tensor_parallel_size`` — TP degree.
-- ``pipeline_parallel_size`` — PP degree.
-- ``context_parallel_size`` — CP degree.
-- ``expert_parallel_size`` — EP degree (MoE models).
+   # 1. Install matching nightly torch + torchtitan from the PyTorch nightly index
+   uv pip install --pre torch torchtitan \
+       --index-url https://download.pytorch.org/whl/nightly/cu130
 
-SPMD backend
-^^^^^^^^^^^^
+   # 2. Install verl (its other deps resolve from PyPI as usual)
+   uv pip install -e .
 
-``spmd_backend`` selects how sharding is expressed (default ``spmd_types``):
+The commands below are the recommended settings, tested in verl's e2e CI. Install
+order matters: vLLM pins an older ``torch``, so it goes first and
+``torch``/``torchvision`` are bumped afterward with ``--no-deps``:
 
-- ``default`` — legacy per-parallelism sharding (no full-DTensor mesh).
-- ``full_dtensor`` — all params/buffers/inputs are DTensors on a dense
-  multi-axis mesh.
-- ``spmd_types`` — ``spmd_types`` typed collectives on a dense mesh.
+.. code:: shell
 
-Attention backend
-^^^^^^^^^^^^^^^^^
-
-``attn_type`` selects the attention implementation (default ``flex``):
-
-- ``flex`` — FlexAttention; needs ``torch.compile`` to be fast (eager is slow).
-- ``flex_flash`` — FlexAttention FLASH kernel; needs ``flash-attn-4`` / CUTE,
-  Hopper/Blackwell only.
-- ``varlen`` — fast eager, flash-style; needs FA3 (``flash_attn_interface``).
-
-Activation checkpointing
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-``activation_checkpoint`` selects the AC mode (default ``selective``):
-
-- ``selective`` — TorchTitan's selective (per-op) activation checkpointing.
-- ``full`` — full activation checkpointing.
-- ``none`` — disabled.
-
-.. note::
-
-   Under ``spmd_backend=spmd_types``, TorchTitan's typed collectives require the
-   thread-local SPMD mesh to stay active across ``loss.backward()`` (activation
-   checkpointing re-runs the module forward during backward). The engine mirrors
-   TorchTitan's ``init_distributed`` by disabling autograd multithreading at
-   device-mesh init so the recompute runs on the calling thread and can access
-   the mesh. Without this (e.g. when calling backward from a non-main thread as
-   verl does under Ray), ``spmd.assert_type`` would raise
-   ``SpmdTypeError: ... no current mesh is set``.
+   INDEX=https://download.pytorch.org/whl/nightly/cu130
+   uv pip install --pre vllm==1.0.0.dev20260620+cu130 --extra-index-url $INDEX
+   uv pip install --pre torchtitan==0.1.0.dev20260701+cu130 --extra-index-url $INDEX
+   uv pip install --pre --no-deps \
+       torch==2.14.0.dev20260625+cu130 \
+       torchvision==0.29.0.dev20260626+cu130 \
+       --extra-index-url $INDEX
 
 
 PPO Example
@@ -116,16 +108,16 @@ An end-to-end GRPO example on GSM8K with the TorchTitan engine is provided at
 Basic: Qwen3-0.6B with FSDP2 + spmd_types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Qwen3-0.6B, pure FSDP across 4 GPUs, ``flex`` attention, ``spmd_types`` backend,
-selective activation checkpointing:
+Qwen3-0.6B, pure FSDP across 4 GPUs. ``flex`` attention, the ``spmd_types``
+backend, and selective activation checkpointing are the script defaults:
 
 .. code:: shell
 
-   NUM_GPUS=4 FSDP_SIZE=4 ATTN_TYPE=flex SPMD_BACKEND=spmd_types AC_MODE=selective \
-       bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
+   NUM_GPUS=4 FSDP_SIZE=4 bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
 
-The script exposes ``NUM_GPUS``, ``FSDP_SIZE``, ``TP_SIZE``, ``EP_SIZE``,
-``ATTN_TYPE``, ``SPMD_BACKEND``, and ``AC_MODE`` as environment variables.
+The script also exposes ``TP_SIZE``, ``EP_SIZE``, ``ATTN_TYPE``,
+``SPMD_BACKEND``, and ``AC_MODE`` as environment variables to override those
+defaults.
 
 Adding tensor parallelism
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,5 +126,4 @@ To mirror ``FSDP_SIZE=2 TP_SIZE=2`` on 4 GPUs:
 
 .. code:: shell
 
-   NUM_GPUS=4 FSDP_SIZE=2 TP_SIZE=2 ATTN_TYPE=flex SPMD_BACKEND=spmd_types \
-       bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
+   NUM_GPUS=4 FSDP_SIZE=2 TP_SIZE=2 bash tests/special_e2e/run_ppo_trainer_torchtitan.sh

--- a/tests/special_e2e/run_ppo_trainer_torchtitan.sh
+++ b/tests/special_e2e/run_ppo_trainer_torchtitan.sh
@@ -22,19 +22,20 @@ EP_SIZE=${EP_SIZE:-1}
 
 # torchtitan attention backend (sdpa is not a valid language-model backend):
 #   "flex"       - FlexAttention; needs torch.compile to be fast (eager is slow)
-#   "flex_flash" - FlexAttention FLASH kernel; needs flash-attn-4/CUTE, Hopper/Blackwell only
-#   "varlen"     - fast eager, flash-style; needs FA3 (flash_attn_interface)
+#   "flex_flash" - FlexAttention FLASH kernel; Hopper/Blackwell (CUDA capability >= 9.0) only
+#   "varlen"     - torch built-in variable-length attention; FA3 on Hopper (SM 9.0), FA2 on older GPUs
 ATTN_TYPE=${ATTN_TYPE:-flex}
 # activation checkpointing: "selective" | "full" | "none".
 # Use "none" for spmd_backend=spmd_types with use_torch_compile=False (eager AC
 # recompute runs off the SPMD mesh context and crashes in spmd.assert_type).
-AC_MODE=${AC_MODE:-none}
+AC_MODE=${AC_MODE:-selective}
 # torchtitan SPMD backend:
 #   "default"      - legacy per-parallelism sharding (no full-DTensor mesh)
 #   "full_dtensor" - all params/buffers/inputs are DTensors on a dense multi-axis mesh
 #   "spmd_types"   - spmd_types typed collectives on a dense mesh
 SPMD_BACKEND=${SPMD_BACKEND:-spmd_types}
 
+TOTAL_TRAIN_STEPS=${TOTAL_TRAIN_STEPS:-100}
 VERL_EXP_NAME=${VERL_EXP_NAME:-qwen3-0.6b-torchtitan}
 
 common_params=(
@@ -78,13 +79,13 @@ common_params=(
     critic.model.path="${MODEL_PATH}"
     critic.ppo_micro_batch_size_per_gpu=4
     algorithm.kl_ctrl.kl_coef=0.001
-    trainer.logger=['console','file','wandb']
+    trainer.logger=['console','file']
     trainer.project_name='verl_grpo_example_gsm8k_0217'
     trainer.experiment_name="${VERL_EXP_NAME}"
     trainer.val_before_train="${VAL_BEFORE_TRAIN}"
     trainer.n_gpus_per_node="${NUM_GPUS}"
     trainer.nnodes=1
-    trainer.total_training_steps=100
+    trainer.total_training_steps=${TOTAL_TRAIN_STEPS}
 )
 
 python3 -m verl.trainer.main_ppo "${common_params[@]}" $@


### PR DESCRIPTION
Add e2e CI coverage and docs for running TorchTitan engine; The CI job runs GRPO-on-GSM8K and installs the required nightly stack.

`spmd_types` is nightly-only, so CI pins a nightly torch/torchvision/vllm/torchtitan set.
PyTorch GCs nightly wheels on a ~2-month window, so these will 404 around **late Aug 2026**.
Once `spmd_types` lands in stable PyTorch + TorchTitan (with a matching vLLM), we can switch to stable pins.

## Testing
```
NUM_GPUS=8 FSDP_SIZE=8 TOTAL_TRAIN_STEPS=2 bash tests/special_e2e/run_ppo_trainer_torchtitan.sh
```
