### PR TITLE
[algo] fix: normalize critic value loss over the global mini-batch, not per micro-batch

### DIFF
--- a/tests/trainer/ppo/test_value_loss_normalization_on_cpu.py
+++ b/tests/trainer/ppo/test_value_loss_normalization_on_cpu.py
@@ -1,0 +1,251 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for critic value-loss normalization across micro-batches.
+
+The actor loss (`ppo_loss`) forwards the global batch normalization info -- ``dp_size``,
+``batch_num_tokens``, ``global_batch_size``, ``loss_scale_factor`` -- into ``agg_loss``, so its
+summed-over-micro-batch gradient equals the global-batch loss and is invariant to how the
+mini-batch is split into micro-batches. The critic loss (`value_loss` -> ``compute_value_loss`` ->
+``agg_loss``) must do the same. These tests pin that invariance for every ``loss_agg_mode``, across
+variable sequence lengths, under the ``dp_size`` FSDP gradient reduction, and for the reported
+metric; and document the per-micro-batch normalization that occurs without the global info.
+No GPU/model needed.
+"""
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import compute_value_loss
+from verl.utils.metric import AggregationType, Metric, reduce_metrics
+from verl.utils.py_functional import append_to_dict
+
+_CLIP = 0.5
+_MODES = ["token-mean", "seq-mean-token-sum", "seq-mean-token-sum-norm", "seq-mean-token-mean"]
+
+
+def _make_value_batch(batch_size, resp_len, seed=0, lengths=None):
+    g = torch.Generator().manual_seed(seed)
+    vpreds = torch.randn(batch_size, resp_len, generator=g)
+    values = torch.randn(batch_size, resp_len, generator=g)
+    returns = torch.randn(batch_size, resp_len, generator=g)
+    if lengths is None:
+        response_mask = torch.ones(batch_size, resp_len)
+    else:
+        response_mask = torch.zeros(batch_size, resp_len)
+        for i, length in enumerate(lengths):
+            response_mask[i, :length] = 1.0
+    return vpreds, values, returns, response_mask
+
+
+def _global_kwargs(mask, mode, dp_size=1):
+    """The normalization info ``value_loss`` forwards to ``compute_value_loss`` for the given mode.
+
+    ``loss_scale_factor`` stays at its default (None), which ``value_loss`` reads from
+    ``config.loss_scale_factor`` (also None by default). For "seq-mean-token-sum-norm" the None
+    scale factor falls back to the padded width, so invariance below holds because all micro-batches
+    share the same width; in the engine, differing padded widths need a constant
+    ``loss_scale_factor`` (the same requirement the actor has).
+    """
+    return {
+        "loss_agg_mode": mode,
+        "dp_size": dp_size,
+        "batch_num_tokens": int(mask.sum()),
+        "global_batch_size": mask.shape[0],
+    }
+
+
+def _accumulate(vpreds, returns, values, mask, num_micro_batches, **kwargs):
+    """Sum the per-micro-batch value losses -- what gradient accumulation feeds to the optimizer."""
+    batch_size = mask.shape[0]
+    step = batch_size // num_micro_batches
+    return sum(
+        compute_value_loss(
+            vpreds[i : i + step],
+            returns[i : i + step],
+            values[i : i + step],
+            mask[i : i + step],
+            cliprange_value=_CLIP,
+            **kwargs,
+        )[0]
+        for i in range(0, batch_size, step)
+    )
+
+
+@pytest.mark.parametrize("mode", _MODES)
+@pytest.mark.parametrize("num_micro_batches", [1, 2, 4])
+def test_value_loss_microbatch_invariant_all_modes(mode, num_micro_batches):
+    """With the global normalization forwarded, summing the per-micro-batch value losses equals the
+    whole-mini-batch value loss for every ``loss_agg_mode``, regardless of the micro-batch split."""
+    batch_size, resp_len = 8, 10
+    assert batch_size % num_micro_batches == 0
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+    kwargs = _global_kwargs(mask, mode)
+
+    whole, _ = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP, **kwargs)
+    accum = _accumulate(vpreds, returns, values, mask, num_micro_batches, **kwargs)
+
+    torch.testing.assert_close(accum, whole)
+
+
+@pytest.mark.parametrize("mode", ["token-mean", "seq-mean-token-sum", "seq-mean-token-mean"])
+@pytest.mark.parametrize("num_micro_batches", [2, 4])
+def test_value_loss_microbatch_invariant_variable_length(mode, num_micro_batches):
+    """Invariance also holds with ragged (variable-length) responses, the realistic case."""
+    batch_size, resp_len = 8, 12
+    lengths = [12, 7, 3, 11, 5, 9, 2, 6]
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len, lengths=lengths)
+    kwargs = _global_kwargs(mask, mode)
+
+    whole, _ = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP, **kwargs)
+    accum = _accumulate(vpreds, returns, values, mask, num_micro_batches, **kwargs)
+
+    torch.testing.assert_close(accum, whole)
+
+
+@pytest.mark.parametrize("dp_size", [2, 4])
+def test_value_loss_dp_size_matches_global_mean_after_fsdp_reduce(dp_size):
+    """The ``dp_size`` multiplier is correct: each rank normalizes by the global token count and
+    multiplies by ``dp_size``; FSDP mean-reduces gradients across ranks, recovering the global
+    token-mean. Models that reduction on CPU by splitting the batch into ``dp_size`` shards."""
+    batch_size, resp_len = 8, 10
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+    global_tokens = int(mask.sum())
+
+    truth, _ = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP, batch_num_tokens=global_tokens)
+
+    rank_step = batch_size // dp_size
+    rank_losses = [
+        compute_value_loss(
+            vpreds[i : i + rank_step],
+            returns[i : i + rank_step],
+            values[i : i + rank_step],
+            mask[i : i + rank_step],
+            cliprange_value=_CLIP,
+            dp_size=dp_size,
+            batch_num_tokens=global_tokens,
+        )[0]
+        for i in range(0, batch_size, rank_step)
+    ]
+    fsdp_reduced = torch.stack(rank_losses).mean()  # FSDP averages gradients across dp ranks
+
+    torch.testing.assert_close(fsdp_reduced, truth)
+
+
+def test_vf_loss_metric_sum_aggregation_reports_global_mean():
+    """The reported ``critic/vf_loss`` metric: because ``reduce_metrics`` averages plain-float
+    metrics across micro-batches, a globally-normalized (partial-sum) loss must be aggregated with
+    SUM to report the global-batch mean. Exercises the real append/reduce path ``value_loss`` uses."""
+    batch_size, resp_len, num_micro_batches = 8, 10, 4
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+    global_tokens = int(mask.sum())
+
+    whole, _ = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP, batch_num_tokens=global_tokens)
+
+    aggregated: dict = {}
+    step = batch_size // num_micro_batches
+    for i in range(0, batch_size, step):
+        vf_loss, _ = compute_value_loss(
+            vpreds[i : i + step],
+            returns[i : i + step],
+            values[i : i + step],
+            mask[i : i + step],
+            cliprange_value=_CLIP,
+            batch_num_tokens=global_tokens,
+        )
+        append_to_dict(aggregated, {"critic/vf_loss": Metric(value=vf_loss, aggregation=AggregationType.SUM)})
+
+    reduced = reduce_metrics(aggregated)
+    assert reduced["critic/vf_loss"] == pytest.approx(whole.item(), rel=1e-5)
+
+
+def test_loss_scale_factor_is_forwarded():
+    """``loss_scale_factor`` reaches ``agg_loss`` for the "seq-mean-token-sum-norm" mode: halving it
+    doubles the loss, confirming the plumbing (not just a silently-ignored kwarg)."""
+    batch_size, resp_len = 8, 10
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+    common = {"loss_agg_mode": "seq-mean-token-sum-norm", "global_batch_size": batch_size}
+
+    loss_sf10, _ = compute_value_loss(
+        vpreds, returns, values, mask, cliprange_value=_CLIP, loss_scale_factor=10, **common
+    )
+    loss_sf5, _ = compute_value_loss(
+        vpreds, returns, values, mask, cliprange_value=_CLIP, loss_scale_factor=5, **common
+    )
+
+    torch.testing.assert_close(loss_sf5, 2 * loss_sf10)
+
+
+def test_vf_clipfrac_unaffected_by_normalization():
+    """The normalization args only change the loss scalar, not the clip-fraction statistic."""
+    batch_size, resp_len = 8, 10
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+
+    _, clipfrac_local = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP)
+    _, clipfrac_global = compute_value_loss(
+        vpreds, returns, values, mask, cliprange_value=_CLIP, dp_size=4, batch_num_tokens=int(mask.sum())
+    )
+
+    torch.testing.assert_close(clipfrac_local, clipfrac_global)
+
+
+@pytest.mark.parametrize("num_micro_batches", [2, 4])
+def test_value_loss_without_global_info_is_microbatch_dependent(num_micro_batches):
+    """Pre-fix behavior / default-kwargs back-compat: without the global token count,
+    ``compute_value_loss`` normalizes by the local micro-batch token count, so the accumulated loss
+    is inflated by the micro-batch count (and would change with the micro-batch count, e.g. when
+    toggling ``use_dynamic_bsz``)."""
+    batch_size, resp_len = 8, 10
+    vpreds, values, returns, mask = _make_value_batch(batch_size, resp_len)
+
+    whole, _ = compute_value_loss(vpreds, returns, values, mask, cliprange_value=_CLIP)
+    accum = _accumulate(vpreds, returns, values, mask, num_micro_batches)
+
+    torch.testing.assert_close(accum, num_micro_batches * whole)
+    assert not torch.allclose(accum, whole)
+
+
+@pytest.mark.parametrize("device", ["cpu"] + (["cuda"] if torch.cuda.is_available() else []))
+def test_value_loss_gradient_invariant_to_microbatch_split(device):
+    """Real-autograd check on the actual gradient (not just the loss scalar): backpropagating the
+    per-micro-batch value losses accumulates into ``vpreds.grad`` exactly the whole-mini-batch
+    gradient when the global token count is forwarded -- so the critic optimizer step is invariant to
+    the micro-batch split. Runs on GPU too when one is available (a real-hardware datapoint)."""
+    batch_size, resp_len, num_micro_batches = 8, 10, 4
+    g = torch.Generator().manual_seed(0)
+    base_vpreds = torch.randn(batch_size, resp_len, dtype=torch.float64, generator=g)
+    values = torch.randn(batch_size, resp_len, dtype=torch.float64, generator=g).to(device)
+    returns = torch.randn(batch_size, resp_len, dtype=torch.float64, generator=g).to(device)
+    mask = torch.ones(batch_size, resp_len, dtype=torch.float64, device=device)
+    global_tokens = int(mask.sum())
+
+    whole_vpreds = base_vpreds.clone().to(device).requires_grad_(True)
+    whole_loss, _ = compute_value_loss(
+        whole_vpreds, returns, values, mask, cliprange_value=_CLIP, batch_num_tokens=global_tokens
+    )
+    whole_loss.backward()
+
+    accum_vpreds = base_vpreds.clone().to(device).requires_grad_(True)
+    step = batch_size // num_micro_batches
+    for i in range(0, batch_size, step):
+        loss_mb, _ = compute_value_loss(
+            accum_vpreds[i : i + step],
+            returns[i : i + step],
+            values[i : i + step],
+            mask[i : i + step],
+            cliprange_value=_CLIP,
+            batch_num_tokens=global_tokens,
+        )
+        loss_mb.backward()  # accumulates into accum_vpreds.grad, like gradient accumulation
+
+    torch.testing.assert_close(accum_vpreds.grad, whole_vpreds.grad)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -609,6 +609,7 @@ critic:
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
   cliprange_value: 0.5
   loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
+  loss_scale_factor: ${oc.select:actor_rollout_ref.actor.loss_scale_factor,null}
   checkpoint:
     _target_: verl.workers.config.McoreCheckpointConfig
     save_contents:

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -533,6 +533,7 @@ critic:
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
   cliprange_value: 0.5
   loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
+  loss_scale_factor: ${oc.select:actor_rollout_ref.actor.loss_scale_factor,null}
   checkpoint:
     _target_: verl.trainer.config.CheckpointConfig
     save_contents:

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -545,6 +545,7 @@ critic:
   data_loader_seed: 42
   cliprange_value: 0.5
   loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
+  loss_scale_factor: ${oc.select:actor_rollout_ref.actor.loss_scale_factor,null}
   checkpoint:
     _target_: verl.trainer.config.CheckpointConfig
     save_contents:

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -547,6 +547,7 @@ critic:
   data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}
   cliprange_value: 0.5
   loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
+  loss_scale_factor: ${oc.select:actor_rollout_ref.actor.loss_scale_factor,null}
   checkpoint:
     _target_: verl.trainer.config.CheckpointConfig
     save_contents:

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -63,6 +63,10 @@ cliprange_value: 0.5
 # Loss aggregation mode: "token-mean", "seq-mean-token-sum", or "seq-mean-token-mean"
 loss_agg_mode: ${oc.select:actor_rollout_ref.actor.loss_agg_mode,token-mean}
 
+# Scale factor for "seq-mean-token-sum-norm" loss aggregation mode.
+# If null, uses response_length. Set to a constant to ensure consistent normalization.
+loss_scale_factor: ${oc.select:actor_rollout_ref.actor.loss_scale_factor,null}
+
 # checkpoint configs
 checkpoint:
 

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -2088,6 +2088,10 @@ def compute_value_loss(
     response_mask: torch.Tensor,
     cliprange_value: float,
     loss_agg_mode: str = "token-mean",
+    dp_size: int = 1,
+    batch_num_tokens: Optional[int] = None,
+    global_batch_size: Optional[int] = None,
+    loss_scale_factor: Optional[int] = None,
 ):
     """
     Compute the clipped value-function loss for PPO.
@@ -2107,6 +2111,15 @@ def compute_value_loss(
             Clip range for value prediction updates.
         loss_agg_mode (str, optional):
             Aggregation mode for `agg_loss`. Defaults to "token-mean".
+        dp_size (int, optional):
+            Data parallel size, forwarded to `agg_loss` for global-batch normalization. Defaults to 1.
+        batch_num_tokens (Optional[int], optional):
+            Number of valid tokens in the global batch, forwarded to `agg_loss`. Defaults to None
+            (normalize by the local micro-batch token count).
+        global_batch_size (Optional[int], optional):
+            Global batch size, forwarded to `agg_loss` for the seq-mean modes. Defaults to None.
+        loss_scale_factor (Optional[int], optional):
+            Scale factor for the "seq-mean-token-sum-norm" mode, forwarded to `agg_loss`. Defaults to None.
 
     Returns:
         vf_loss (torch.FloatTensor):
@@ -2118,7 +2131,15 @@ def compute_value_loss(
     vf_losses1 = (vpreds - returns) ** 2
     vf_losses2 = (vpredclipped - returns) ** 2
     clipped_vf_losses = torch.max(vf_losses1, vf_losses2)
-    vf_loss = 0.5 * agg_loss(loss_mat=clipped_vf_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode)
+    vf_loss = 0.5 * agg_loss(
+        loss_mat=clipped_vf_losses,
+        loss_mask=response_mask,
+        loss_agg_mode=loss_agg_mode,
+        dp_size=dp_size,
+        batch_num_tokens=batch_num_tokens,
+        global_batch_size=global_batch_size,
+        loss_scale_factor=loss_scale_factor,
+    )
     vf_clipfrac = verl_F.masked_mean(torch.gt(vf_losses2, vf_losses1).float(), response_mask)
     return vf_loss, vf_clipfrac
 

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -64,6 +64,7 @@ class CriticConfig(BaseConfig):
         shuffle (bool): Shuffle training data across PPO epochs.
         cliprange_value (float): PPO value function clipping range.
         loss_agg_mode (str): Loss aggregation mode.
+        loss_scale_factor (Optional[int]): Scale factor for 'seq-mean-token-sum-norm' loss aggregation mode.
         checkpoint (Dict[str, Any]): Checkpoint configuration.
         profiler (Dict[str, Any]): Profiler configuration.
         enable (Optional[bool]): Whether to enable the critic.
@@ -93,6 +94,7 @@ class CriticConfig(BaseConfig):
     shuffle: bool = True
     cliprange_value: float = 0.5
     loss_agg_mode: str = "token-mean"
+    loss_scale_factor: Optional[int] = None
     ppo_micro_batch_size: Optional[int] = None
     engine: BaseConfig = field(default_factory=BaseConfig)
     optim: OptimizerConfig = field(default_factory=OptimizerConfig)

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -158,6 +158,25 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
     """
     vpreds = no_padding_2_padding(model_output["values"], data)  # (bsz, response_length)
 
+    # Normalize the value loss over the global mini-batch (dp_size / batch_num_tokens /
+    # global_batch_size) instead of the local micro-batch, so the accumulated critic gradient is
+    # invariant to how the mini-batch is split into micro-batches (as the actor's ppo_loss does).
+    dp_size = data["dp_size"]
+    batch_num_tokens = data["batch_num_tokens"]
+    global_batch_size = data["global_batch_size"]
+
+    # When the loss is normalized over the global batch, each micro-batch contributes a partial sum,
+    # so the loss metric must be aggregated with SUM to reflect the global-batch mean.
+    if (
+        dp_size > 1
+        or batch_num_tokens is not None
+        or global_batch_size is not None
+        or config.loss_scale_factor is not None
+    ):
+        metric_aggregation = AggregationType.SUM
+    else:
+        metric_aggregation = AggregationType.MEAN
+
     # select fields and convert to padded tensor
     data = data.select("values", "returns", "response_mask").to_padded_tensor()
     values = data["values"]
@@ -171,16 +190,16 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
         response_mask=response_mask,
         cliprange_value=config.cliprange_value,
         loss_agg_mode=config.loss_agg_mode,
+        dp_size=dp_size,
+        batch_num_tokens=batch_num_tokens,
+        global_batch_size=global_batch_size,
+        loss_scale_factor=config.loss_scale_factor,
     )
 
-    metrics = {}
-
-    metrics.update(
-        {
-            "critic/vf_loss": vf_loss.detach().item(),
-            "critic/vf_clipfrac": vf_clipfrac.detach().item(),
-            "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
-        }
-    )
+    metrics = {
+        "critic/vf_loss": Metric(value=vf_loss, aggregation=metric_aggregation),
+        "critic/vf_clipfrac": vf_clipfrac.detach().item(),
+        "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
+    }
 
     return vf_loss, metrics


### PR DESCRIPTION
### What does this PR do?

The critic value loss is normalized per micro-batch instead of per global mini-batch, so the accumulated critic gradient is inflated by the number of micro-batches and changes when the micro-batch count changes (for example when toggling `use_dynamic_bsz`). This effectively scales the critic learning rate by a config-dependent factor. It affects classic PPO runs with a value model (`adv_estimator=gae`, `use_critic=true`) on both the FSDP and Megatron backends.

The actor loss already handles this: `ppo_loss` forwards the global batch info (`dp_size`, `batch_num_tokens`, `global_batch_size`, `loss_scale_factor`) into `agg_loss`, so its summed-over-micro-batch gradient equals the global token-mean and is invariant to how the mini-batch is split. `value_loss` does not forward that info, so `agg_loss` falls back to the local micro-batch token count (`loss_mask.sum()`). This PR makes `value_loss` forward the same info.

The gap was introduced in the engine refactor (#4211): `ppo_loss` gained `global_batch_info` in that change while `value_loss` did not.

### Root cause

`value_loss` -> `compute_value_loss` -> `agg_loss` was called without the global normalization info. For the default `token-mean` mode, `agg_loss` then normalizes by the local micro-batch token count and multiplies by `dp_size=1`, so each micro-batch is self-normalized. Because gradient accumulation sums the per-micro-batch losses, the accumulated gradient is the sum of per-micro-batch means, i.e. about `K` times the correct global token-mean for `K` micro-batches. Reproduced with the real `agg_loss` (whole mini-batch vs. accumulation over `K` micro-batches):

```
correct global token-mean = 0.515
K=1: actor 0.515 (1.00x) | critic 0.515 (1.00x)
K=2: actor 0.515 (1.00x) | critic 1.055 (2.05x)
K=4: actor 0.515 (1.00x) | critic 2.094 (4.06x)
```

### Changes

- `verl/workers/utils/losses.py`: `value_loss` now forwards the global batch info to `compute_value_loss` directly (`dp_size`, `batch_num_tokens`, `global_batch_size` from the batch, `loss_scale_factor` from config). When global normalization is active the `critic/vf_loss` metric is aggregated with `SUM` (each micro-batch contributes a partial sum), otherwise `MEAN`, so the reported metric stays a correct global-batch mean (`reduce_metrics` averages plain-float metrics across micro-batches).
- `verl/trainer/ppo/core_algos.py`: `compute_value_loss` accepts `dp_size`, `batch_num_tokens`, `global_batch_size`, `loss_scale_factor` (defaults preserve current behavior) and forwards them to `agg_loss`.
- `verl/workers/config/critic.py`: `CriticConfig` gains `loss_scale_factor`, mirroring `ActorConfig`.
- `verl/trainer/config/critic/critic.yaml`: adds `loss_scale_factor`, inheriting from the actor via `oc.select` (same pattern as `loss_agg_mode`); the four `_generated_*.yaml` reference configs are regenerated.
- `tests/trainer/ppo/test_value_loss_normalization_on_cpu.py`: new network-free CPU regression tests (see below).

### Scope and limitations

- The `dp_size` cross-rank FSDP gradient reduction requires multiple GPUs; the CPU tests simulate it arithmetically (split the batch across shards, apply the `dp_size` multiplier, mean over shards) but do not run a real multi-GPU reduction.
- The full engine path (`value_loss` through `no_padding_2_padding` / the FSDP engine) needs flash-attn and the no-padding nested-tensor format, so it is exercised by the project's GPU tests rather than the CPU suite here.
- For the `seq-mean-token-sum-norm` mode, micro-batch invariance requires a constant `loss_scale_factor` when micro-batches are padded to different widths, the same requirement the actor already has.

### Tests

Local verification (CPU only):

- Checks pass on the changed files: `ruff` lint, `ruff-format`, `mypy` (no issues in the three changed source files), `py_compile`, and the Apache license header on the new test file. `scripts/generate_trainer_config.sh` regenerates the four reference configs with no further diff (the only change is the added critic `loss_scale_factor` line).
- `pytest tests/trainer/ppo/test_value_loss_normalization_on_cpu.py`: 26 passed. Coverage: micro-batch invariance across all four `loss_agg_mode` values, variable-length sequences, the `dp_size` FSDP mean-reduction (simulated), the `critic/vf_loss` `SUM` metric path via the real `append_to_dict`/`reduce_metrics`, `loss_scale_factor` forwarding, `vf_clipfrac` invariance, a real-autograd gradient-accumulation check, and a characterization of the pre-fix per-micro-batch inflation.
- `pytest tests/trainer/ppo/test_core_algos_on_cpu.py`: 23 passed (no regression in the existing core-algos suite).
- `pytest tests/trainer/ppo -k on_cpu --ignore=tests/trainer/ppo/v2`: 108 passed. The `tests/trainer/ppo/v2` collection error in the unfiltered run is a pre-existing Megatron import that is unavailable in the CPU environment and unrelated to this change.

The multi-GPU and full-engine coverage noted under Scope is left to the project CI.

### Duplicate check

No open PR addresses the current critic path (`verl/workers/utils/losses.py::value_loss`).

- #5767 described this issue but its diff only touched the legacy `verl/workers/actor/dp_actor.py` / `verl/workers/critic/dp_critic.py`, which were removed in the engine refactor. It was closed with the conclusion that the issue does not exist in the current path; that conclusion concerned the metric-accumulation angle and does not cover the value-loss gradient normalization, which is still present on the live path (see the reproduction above).
- #3863 addresses the same concern via a pre-refactor mechanism (`mini_batch_full_token_count`) on files that no longer exist. It is stale and superseded by the current global-batch normalization approach.

---

**AI assistance disclosure**: This PR was developed with AI assistance. The submitting human has reviewed every changed line and is responsible for the change end to end. Verification is summarized in the Tests section: the lint/type/config checks and the CPU test suite pass locally; multi-GPU and full-engine validation is left to the project CI.
