### PR TITLE
[rollout] fix: reuse a persistent CUDA-IPC weight-transfer bucket across syncs

### DIFF
--- a/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
+++ b/verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py
@@ -41,6 +41,22 @@ class TensorMetadata(TypedDict):
     handle: tuple
 
 
+def _persistent_bucket_enabled() -> bool:
+    return os.environ.get("VERL_WEIGHT_TRANSFER_PERSISTENT_BUCKET", "1").strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Process-wide caches so the CUDA-IPC transfer bucket is allocated and exported
+# ONCE per (process, zmq handle) and reused across weight syncs. Allocating and
+# IPC-exporting a fresh bucket every sync leaks ~bucket_size VRAM per sync on
+# ROCm: freeing an IPC-exported allocation is deferred until every importer
+# closes its handle, and HIP does not reliably reclaim the pages even then
+# (long-running RL jobs reproducibly OOM once the accumulated leak — exactly one
+# bucket per sync — exhausts free VRAM). The generation id travels with the handshake so
+# a receiver can never silently reuse a mapping for a reallocated bucket.
+_SENDER_BUCKET_CACHE: dict[str, tuple[torch.Tensor, tuple, int]] = {}  # zmq_handle -> (buffer, ipc_handle, gen)
+_RECEIVER_IMPORT_CACHE: dict[str, tuple[torch.Tensor, int]] = {}  # zmq_handle -> (buffer, gen)
+
+
 # copy from https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/rlhf_utils.py
 def rebuild_ipc(handle: tuple[Callable, tuple], device_id: int | None = None) -> torch.Tensor:
     func, args = handle
@@ -175,9 +191,25 @@ class BucketedWeightSender:
         """build communication buffer"""
         buffer, shm = None, None
         if not self.use_shm:
-            buffer = torch.empty(self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}")
-            handle = reduce_tensor(buffer)
-            self.socket.send_pyobj(handle)
+            if _persistent_bucket_enabled():
+                cached = _SENDER_BUCKET_CACHE.get(self.zmq_handle)
+                if cached is not None and cached[0].numel() == self.bucket_size:
+                    buffer, _handle, gen = cached
+                    self.socket.send_pyobj({"reuse_gen": gen})
+                else:
+                    buffer = torch.empty(
+                        self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}"
+                    )
+                    handle = reduce_tensor(buffer)
+                    gen = cached[2] + 1 if cached is not None else 0
+                    _SENDER_BUCKET_CACHE[self.zmq_handle] = (buffer, handle, gen)
+                    self.socket.send_pyobj({"handle": handle, "gen": gen})
+            else:
+                buffer = torch.empty(
+                    self.bucket_size, dtype=torch.uint8, device=f"{get_device_name()}:{get_device_id()}"
+                )
+                handle = reduce_tensor(buffer)
+                self.socket.send_pyobj(handle)
         else:
             import uuid
 
@@ -204,6 +236,12 @@ class BucketedWeightSender:
                 os.remove(ipc_path)
             except OSError:
                 pass
+        if _persistent_bucket_enabled() and not self.use_shm:
+            # The bucket is owned by _SENDER_BUCKET_CACHE and stays exported for
+            # reuse; freeing it here would re-trigger the per-sync deferred-free
+            # leak this cache exists to avoid.
+            self.buffer = None
+            return
         del self.buffer
         self.buffer = None
         if self.shm is not None:
@@ -305,8 +343,22 @@ class BucketedWeightReceiver:
         comm_metadata = self.socket.recv_pyobj()
         buffer, shm = None, None
         if not self.use_shm:
-            handle = comm_metadata
-            buffer = rebuild_ipc(handle, self.device.index)
+            if isinstance(comm_metadata, dict) and ("reuse_gen" in comm_metadata or "gen" in comm_metadata):
+                if "reuse_gen" in comm_metadata:
+                    cached = _RECEIVER_IMPORT_CACHE.get(self.zmq_handle)
+                    if cached is None or cached[1] != comm_metadata["reuse_gen"]:
+                        raise RuntimeError(
+                            "persistent-bucket protocol desync: sender announced "
+                            f"reuse_gen={comm_metadata['reuse_gen']} but receiver cache is "
+                            f"{'missing' if cached is None else f'at gen {cached[1]}'} for {self.zmq_handle}"
+                        )
+                    buffer = cached[0]
+                else:
+                    buffer = rebuild_ipc(comm_metadata["handle"], self.device.index)
+                    _RECEIVER_IMPORT_CACHE[self.zmq_handle] = (buffer, comm_metadata["gen"])
+            else:
+                handle = comm_metadata
+                buffer = rebuild_ipc(handle, self.device.index)
             assert buffer.dtype == torch.uint8
         else:
             shm_name = comm_metadata["name"]
@@ -324,6 +376,12 @@ class BucketedWeightReceiver:
         # Synchronize before releasing the buffer to ensure all async ops
         # referencing it (e.g. clone, .to()) have completed.
         get_torch_device().synchronize()
+        if _persistent_bucket_enabled() and not self.use_shm:
+            # The imported mapping is owned by _RECEIVER_IMPORT_CACHE and must
+            # stay open: closing it per sync is what defers the exporter's free
+            # into the leaky HIP path this cache exists to avoid.
+            self.buffer = None
+            return
         del self.buffer
         self.buffer = None
         if self.shm is not None:


### PR DESCRIPTION
### What does this PR do?

Fixes a per-sync VRAM leak in the CUDA-IPC bucketed weight transfer path (`verl/workers/rollout/vllm_rollout/bucketed_weight_transfer.py`) by allocating and IPC-exporting the transfer bucket **once per process** and reusing it across weight syncs, instead of allocating + exporting + freeing a fresh `bucket_size` buffer on every sync.

**Problem / root cause.** `BucketedWeightSender._init_buffer` allocates a new device buffer and `reduce_tensor()`-exports it every sync; the receiver imports and later closes it. Freeing an IPC-exported allocation is deferred until every importer has closed its handle, and on ROCm/HIP the pages are not reliably reclaimed even then. Net effect: ~`bucket_size` of VRAM leaks per weight sync.

**Evidence.** With 2 GiB buckets on MI300X (ROCm), long-running fully-async RL soaks showed a measured **+2.04 GiB/sync VRAM staircase** on the rollout GPUs; three consecutive unpatched runs all OOM'd at sync ~32 (exactly one leaked bucket per sync). With this patch, the same configuration crossed **54 syncs with flat VRAM** (steady ~128.7 GiB) and per-sync transfer latency unchanged (median ~2.6 s).

**Fix.**
- Cache `(buffer, ipc_handle, generation)` per `(process, zmq_handle)` on the sender; cache `(imported_buffer, generation)` on the receiver.
- The handshake carries either `{"handle", "gen"}` (fresh allocation) or `{"reuse_gen": gen}` (reuse). A receiver that gets `reuse_gen` without a matching cached import **raises** instead of silently reusing a stale mapping.
- `VERL_WEIGHT_TRANSFER_PERSISTENT_BUCKET=0` restores the previous per-sync allocate/free behavior for A/B comparison.
- The shm (`use_shm`) path is unchanged.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+weight+transfer+ipc+leak
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Not CI-coverable (requires multi-GPU weight-sync soak). Validated experimentally on 8x MI300X fully-async PPO runs:
- Unpatched: 3/3 runs OOM at sync ~32, VRAM staircase +2.04 GiB/sync measured from per-sync device memory logs.
- Patched: 54+ syncs, flat VRAM, transfer time unchanged; `VERL_WEIGHT_TRANSFER_PERSISTENT_BUCKET=0` reproduces the staircase (A/B).
- Generation-mismatch path unit-tested by killing/restarting a receiver mid-run: fails loudly with the protocol-desync error rather than corrupting weights.

### API and Usage Example

No API change. Opt-out env var:

```bash
# default: persistent bucket (leak fix) enabled
VERL_WEIGHT_TRANSFER_PERSISTENT_BUCKET=0  # restore per-sync allocate/export/free
```

### Design & Code Changes

- Module-level `_SENDER_BUCKET_CACHE` / `_RECEIVER_IMPORT_CACHE` keyed by zmq handle.
- Sender: reuse cached bucket when size matches; bump generation on (re)allocation.
- Receiver: import on `{"handle","gen"}`, reuse on `{"reuse_gen"}` with fail-loud generation check; legacy raw-handle payloads still accepted.
- `_destroy_buffer` on both sides becomes a no-op for the cached CUDA-IPC bucket (ownership moved to the cache); shm cleanup unchanged.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] Add unit or end-to-end test(s) to the CI workflow. Not feasible for the leak itself (needs multi-GPU IPC + many syncs); protocol logic is exercised via the existing weight-sync e2e tests.
