### PR TITLE
[megatron] fix: check versions before importing v0.12.1-only private symbols

### DIFF
--- a/verl/models/mcore/patch.py
+++ b/verl/models/mcore/patch.py
@@ -393,24 +393,27 @@ def apply_patch_mbridge():
 def apply_patch_megatron_v012_with_torch_v28_v29() -> None:
     # Error due to missing serialization_format in _write_item of megatron v012;
     # resolved by using megatron v013's implementation.
-    import inspect
-    import logging
-    import os
-    from pathlib import Path
-
     import megatron.core
     import torch
-    from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
-    from megatron.core.dist_checkpointing.strategies.filesystem_async import _process_memory
     from packaging import version
-    from torch import multiprocessing as mp
-    from torch.distributed.checkpoint.filesystem import _write_item
 
+    # Guard BEFORE importing v0.12.1-only symbols (e.g. _disable_gc) so other
+    # Megatron versions/forks early-return instead of raising ImportError.
     if (
         version.parse(torch.__version__).base_version not in ("2.8.0", "2.9.0")
         or version.parse(megatron.core.__version__).base_version != "0.12.1"
     ):
         return
+
+    import inspect
+    import logging
+    import os
+    from pathlib import Path
+
+    from megatron.core.dist_checkpointing.strategies.async_utils import _disable_gc
+    from megatron.core.dist_checkpointing.strategies.filesystem_async import _process_memory
+    from torch import multiprocessing as mp
+    from torch.distributed.checkpoint.filesystem import _write_item
 
     WriteBucket = tuple[Path, str, tuple[list, list]]
 


### PR DESCRIPTION
### What does this PR do?

Reorders `apply_patch_megatron_v012_with_torch_v28_v29` (`verl/models/mcore/patch.py`) so the megatron/torch **version check runs before** importing v0.12.1-only private symbols.

**Problem / root cause.** The function imports `megatron.core.dist_checkpointing.strategies.async_utils._disable_gc` and `filesystem_async._process_memory` at the top, before checking `megatron.core.__version__ == 0.12.1`. On Megatron versions/forks where those private symbols don't exist, the import raises `ImportError` even though the version check immediately below would have skipped the patch anyway. This breaks any environment that imports the patch module with a non-0.12.1 Megatron.

**Fix.** Move the `torch`/`megatron.core` version check ahead of the version-specific imports; non-matching environments early-return cleanly. No behavior change on megatron 0.12.1 + torch 2.8/2.9.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+_disable_gc+v012
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- `import verl.models.mcore.patch` + `apply_patch_megatron_v012_with_torch_v28_v29()` on a Megatron fork without `_disable_gc`: previously `ImportError`, now clean early-return.
- On megatron-core 0.12.1 + torch 2.8: patch still applies (identical code path, imports just moved below the guard).

### API and Usage Example

No API change.

### Design & Code Changes

Single-function reorder: keep `megatron.core`, `torch`, `packaging.version` imports at top (needed by the guard), move `inspect/logging/os/pathlib`, `_disable_gc`, `_process_memory`, `mp`, `_write_item` imports below the early-return.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation (not needed — internal fix).
- [ ] CI test: not feasible to pin a non-0.12.1 Megatron fork in CI; the guarded path is covered by existing megatron CI images.
