### PR TITLE
[training_utils] fix: make fused linear-cross-entropy backward grad buffers contiguous

### DIFF
--- a/verl/utils/kernel/linear_cross_entropy.py
+++ b/verl/utils/kernel/linear_cross_entropy.py
@@ -97,6 +97,11 @@ class LinearCrossEntropy(torch.autograd.Function):
             should_return_fp32_grad = ctx.should_return_fp32_grad
             temperature = ctx.temperature
 
+            # Autograd can hand us strided views after downstream masking/slicing.
+            # The fused entropy backward kernels expect contiguous 1D grad buffers.
+            dlogprobs = dlogprobs.contiguous()
+            dentropy = dentropy.contiguous()
+
             d_hidden, d_weight = kernels.efficient_entropy_backward(
                 dlogprobs,
                 dentropy,


### PR DESCRIPTION
### What does this PR do?

Makes `LinearCrossEntropy.backward` (`verl/utils/kernel/linear_cross_entropy.py`) call `.contiguous()` on the incoming `dlogprobs` / `dentropy` grads before invoking `kernels.efficient_entropy_backward`.

**Problem / root cause.** Autograd can hand `backward` **strided views** for the grad tensors when downstream code masks/slices the forward outputs (e.g. response masking on logprobs). The fused entropy backward kernels assume contiguous 1D buffers; with strided inputs they read at wrong offsets and silently produce incorrect `d_hidden` / `d_weight`.

**Fix.** `.contiguous()` on both grads (no-op copy when already contiguous).

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+linear_cross_entropy+contiguous
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Reproduced by feeding a non-contiguous grad (e.g. `dlogprobs = base[::2]`-style view produced by masked downstream ops) through `LinearCrossEntropy.backward`: gradients diverge from the torch reference implementation without the fix and match (within bf16 kernel tolerance) with it. Matches the reference fused-CE integration used in production RL training.

### API and Usage Example

No API change.

### Design & Code Changes

Two-line guard in `backward` before the fused kernel call.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation (not needed).
- [ ] CI: existing `linear_cross_entropy` kernel tests cover the contiguous path; a non-contiguous-grad case could be added to `tests/utils/test_linear_cross_entropy*` if maintainers want it in this PR.
