### PR TITLE
[fully_async] fix: honor rollout.checkpoint_manager_class like other trainers

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -38,6 +38,7 @@ from verl.trainer.ppo.utils import Role, WorkerType, need_critic, need_reference
 from verl.utils.checkpoint.checkpoint_manager import find_latest_ckpt_path, should_save_ckpt_esi
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
+from verl.utils.import_utils import load_class_from_fqn
 from verl.utils.tracking import Tracking
 
 logger = logging.getLogger(__name__)
@@ -168,10 +169,29 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
         """Setup checkpoint manager after rollouter is initialized"""
         replicas = await self.rollouter.get_replicas.remote()
         checkpoint_engine_config = omega_conf_to_dataclass(self.config.actor_rollout_ref.rollout.checkpoint_engine)
-        self.checkpoint_manager = CheckpointEngineManager(
+        checkpoint_manager_class_fqn = self.config.actor_rollout_ref.rollout.get("checkpoint_manager_class")
+        if checkpoint_manager_class_fqn:
+            checkpoint_manager_cls = load_class_from_fqn(checkpoint_manager_class_fqn, "CheckpointEngineManager")
+        else:
+            checkpoint_manager_cls = CheckpointEngineManager
+        self.checkpoint_manager = checkpoint_manager_cls(
             config=checkpoint_engine_config, actor_wg=self.actor_wg, replicas=replicas
         )
+        self._set_checkpoint_manager_context()
         print("[FullyAsyncTrainer] Checkpoint manager initialized")
+
+    def _set_checkpoint_manager_context(self):
+        """Expose fully-async handles to custom checkpoint managers that need them."""
+        if self.checkpoint_manager is None:
+            return
+        set_async_context = getattr(self.checkpoint_manager, "set_async_context", None)
+        if callable(set_async_context):
+            set_async_context(
+                full_config=self.config,
+                trainer=self,
+                rollouter=self.rollouter,
+                message_queue_client=self.message_queue_client,
+            )
 
     async def _setup_hybrid_checkpoint_manager(self):
         """Setup hybrid checkpoint manager and perform initial sleep of hybrid replicas.
@@ -245,6 +265,7 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
     def set_message_queue_client(self, message_queue_client: MessageQueueClient):
         """Set message queue client"""
         self.message_queue_client = message_queue_client
+        self._set_checkpoint_manager_context()
 
     async def set_rollouter(self, rollouter):
         """Set rollouter reference and initialize all checkpoint managers."""


### PR DESCRIPTION
### What does this PR do?

Makes `FullyAsyncTrainer` honor the existing `actor_rollout_ref.rollout.checkpoint_manager_class` config hook (`verl/workers/config/rollout.py` already declares it) instead of hardcoding `CheckpointEngineManager`.

**Problem.** The rollout config exposes `checkpoint_manager_class` as an extension seam, but the fully-async trainer ignores it — custom checkpoint/weight-sync managers can't be plugged into the fully-async path without forking the trainer.

**Fix.**
- `_setup_checkpoint_manager` loads the configured class via `verl.utils.import_utils.load_class_from_fqn`, defaulting to `CheckpointEngineManager` when unset (no behavior change by default).
- Adds `_set_checkpoint_manager_context()`: if the manager defines an optional `set_async_context(full_config=, trainer=, rollouter=, message_queue_client=)` method, the trainer calls it after manager construction and again when the message-queue client is attached, so custom managers can integrate with the async loop without new abstract APIs.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+checkpoint_manager_class
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- Default config (option unset): fully-async runs construct `CheckpointEngineManager` exactly as before.
- With a custom FQN: subclass is constructed with the same `(config, actor_wg, replicas)` signature and receives `set_async_context(...)`; validated in a production fully-async PPO run using a custom manager for weight-sync instrumentation.

### API and Usage Example

```yaml
actor_rollout_ref:
  rollout:
    checkpoint_manager_class: my_pkg.checkpoint.MyCheckpointEngineManager
```

```python
class MyCheckpointEngineManager(CheckpointEngineManager):
    def set_async_context(self, *, full_config, trainer, rollouter, message_queue_client):
        ...  # optional; only called if defined
```

### Design & Code Changes

- `fully_async_trainer.py`: FQN load + fallback; duck-typed optional context injection (mirrors how other trainers consume `checkpoint_manager_class`).

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation (config field already documented on `RolloutConfig`).
- [ ] CI: could add a unit test constructing a dummy manager via FQN if desired.
