### PR TITLE
[fully_async, rollout] fix: preserve extra_fields when merging partial rollout segments

### DIFF
--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -42,6 +42,19 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 DEFAULT_ROUTING_CACHE_SIZE = 10000
 
 
+def _routed_experts_tensor_for_merge(value: Any) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        tensor = value
+    else:
+        tensor = torch.as_tensor(value, dtype=torch.int64)
+    if tensor.ndim != 3:
+        raise TypeError(
+            "routed_experts must be a 3D tensor/list for fully-async merge, "
+            f"got shape={tuple(tensor.shape)}"
+        )
+    return tensor
+
+
 @ray.remote
 class GlobalRequestLoadBalancer:
     """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers.
@@ -317,11 +330,15 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             # On partial rollout resume the model version may differ, so keep
             # existing routing and only append routing for newly generated tokens.
             if output.routed_experts is not None and len(output.token_ids) > 0:
+                output_routed_experts = _routed_experts_tensor_for_merge(output.routed_experts)
                 if final_output.routed_experts is None:
-                    final_output.routed_experts = output.routed_experts
+                    final_output.routed_experts = output_routed_experts
                 else:
                     final_output.routed_experts = torch.cat(
-                        [final_output.routed_experts, output.routed_experts[-len(output.token_ids) :]],
+                        [
+                            _routed_experts_tensor_for_merge(final_output.routed_experts),
+                            output_routed_experts[-len(output.token_ids) :],
+                        ],
                         dim=0,
                     )
             if output.num_preempted is not None:
@@ -333,6 +350,9 @@ class FullyAsyncLLMServerClient(LLMServerClient):
             if min_global_steps is None:
                 min_global_steps = global_steps
             max_global_steps = global_steps
+            for key, value in output.extra_fields.items():
+                if key not in {"global_steps", "min_global_steps", "max_global_steps"}:
+                    final_output.extra_fields[key] = value
 
             # 3. update max_new_tokens
             if original_max_tokens is not None:


### PR DESCRIPTION
### What does this PR do?

Fixes `FullyAsyncLLMServerClient` partial-rollout merge (`verl/workers/rollout/llm_server.py`) dropping `TokenOutput.extra_fields`, and hardens the `routed_experts` merge.

**Problem / root cause.** When a request is resumed across engine versions (partial rollout), the client merges per-segment `TokenOutput`s into `final_output`. Only `routed_experts`, `num_preempted`, and `global_steps` bookkeeping are carried over — every other key an engine puts into `output.extra_fields` (per-response metadata such as logprob/routing attestations, engine diagnostics) is silently dropped and never reaches the trainer batch. Additionally, `torch.cat` on `routed_experts` assumes both sides are already tensors; engines that return lists raise.

**Fix.**
- Copy `extra_fields` from each merged segment onto `final_output` (later segments win), excluding the step-bookkeeping keys (`global_steps`, `min_global_steps`, `max_global_steps`) which keep their existing min/max merge semantics.
- `_routed_experts_tensor_for_merge()`: normalize `routed_experts` to an int64 tensor and validate 3-D shape before `torch.cat`, with a clear `TypeError` otherwise.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+extra_fields+partial+rollout
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- Fully-async run with engine-provided `extra_fields` + forced partial-rollout resume (weight-version bump mid-generation): fields now present on the merged output; previously lost on every resumed sample.
- List-typed `routed_experts` from the engine merges correctly; malformed (non-3D) payloads raise `TypeError` with the observed shape.

### API and Usage Example

No API change. `TokenOutput.extra_fields` set by a rollout server now survives partial-rollout merging.

### Design & Code Changes

Two localized changes in `FullyAsyncLLMServerClient` merge loop; no change for non-resumed requests.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation (not needed).
- [ ] CI: a unit test for the merge loop (mock TokenOutputs) can be added on request.
