### PR TITLE
[fully_async, trainer] fix: fail loud when requested rollout log-probs are missing

### DIFF
--- a/verl/experimental/fully_async_policy/detach_utils.py
+++ b/verl/experimental/fully_async_policy/detach_utils.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import numpy as np
 import torch
+from omegaconf import OmegaConf
 
 from verl import DataProto
 from verl.trainer.ppo.ray_trainer import compute_response_mask
@@ -117,12 +118,34 @@ def assemble_batch_from_rollout_samples(
         rollout_samples_batch.append(batch)
     final_batch = DataProto.concat(rollout_samples_batch)
 
+    require_rollout_log_probs = bool(
+        OmegaConf.select(config, "actor_rollout_ref.rollout.calculate_log_probs", default=False)
+        or OmegaConf.select(config, "actor_rollout_ref.actor.use_rollout_log_probs", default=False)
+    )
+    if require_rollout_log_probs:
+        if "rollout_log_probs" not in final_batch.batch:
+            raise ValueError(
+                "fully_async: rollout logprobs were requested but the assembled "
+                "trainer batch is missing rollout_log_probs"
+            )
+        if final_batch.batch["rollout_log_probs"].shape != final_batch.batch["responses"].shape:
+            raise ValueError(
+                "fully_async: rollout_log_probs shape must match responses shape "
+                f"({final_batch.batch['rollout_log_probs'].shape} != {final_batch.batch['responses'].shape})"
+            )
+
     # Calculate response_mask (if not present)
     if "response_mask" not in final_batch.batch.keys():
         final_batch.batch["response_mask"] = compute_response_mask(final_batch)
 
     if balance_batch:
         balance_batch(final_batch, metrics={})
+
+    if require_rollout_log_probs and "rollout_log_probs" not in final_batch.batch:
+        raise ValueError(
+            "fully_async: rollout logprobs were present after assembly but missing after batch balancing. "
+            f"Available batch keys: {list(final_batch.batch.keys())}"
+        )
 
     # Calculate the global valid token number
     if "attention_mask" in final_batch.batch:

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -839,6 +839,15 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
             [f"uid_{rollout_sample.sample_id}"] * len(rollout_sample.full_batch), dtype=object
         )
         ret = await self.async_rollout_manager.generate_sequences_single(rollout_sample.full_batch)
+        require_rollout_log_probs = bool(
+            getattr(self.config.actor_rollout_ref.rollout, "calculate_log_probs", False)
+            or getattr(self.config.actor_rollout_ref.actor, "use_rollout_log_probs", False)
+        )
+        if require_rollout_log_probs and "rollout_log_probs" not in ret.batch:
+            raise RuntimeError(
+                "fully_async: rollout logprobs were requested but agent-loop generation "
+                "returned no rollout_log_probs"
+            )
         rollout_sample.full_batch = ret
         # Re-set uid on output — agent loop worker returns a new DataProto without the input's non_tensor_batch
         rollout_sample.full_batch.non_tensor_batch["uid"] = np.array(

--- a/verl/experimental/separation/ray_trainer.py
+++ b/verl/experimental/separation/ray_trainer.py
@@ -500,6 +500,10 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
         #   Note: π_old computed once per data batch, serves as stable reference during mini-batch updates
         rollout_corr_config = self.config.algorithm.get("rollout_correction", None)
         bypass_recomputing_logprobs = rollout_corr_config and rollout_corr_config.get("bypass_mode", False)
+        require_rollout_log_probs = bool(
+            OmegaConf.select(self.config, "actor_rollout_ref.rollout.calculate_log_probs", default=False)
+            or OmegaConf.select(self.config, "actor_rollout_ref.actor.use_rollout_log_probs", default=False)
+        )
         if bypass_recomputing_logprobs:  # Use `rollout_log_probs`
             from verl.trainer.ppo.rollout_corr_helper import apply_bypass_mode
 
@@ -533,6 +537,11 @@ class SeparateRayPPOTrainer(RayPPOTrainer):
                     else:
                         old_log_prob.batch.pop("routed_experts")
                 batch = batch.union(old_log_prob)
+                if require_rollout_log_probs and "rollout_log_probs" not in batch.batch:
+                    raise ValueError(
+                        "rollout logprobs are required but missing before rollout-vs-actor debug metrics. "
+                        f"Available batch keys: {list(batch.batch.keys())}"
+                    )
                 if "rollout_log_probs" in batch.batch.keys():
                     # TODO: we may want to add diff of probs too.
                     from verl.utils.debug.metrics import calculate_debug_metrics

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -86,6 +86,8 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     fields = ["response_mask", "old_log_probs", "advantages"]
     if "rollout_is_weights" in data:
         fields.append("rollout_is_weights")
+    if "rollout_log_probs" in data:
+        fields.append("rollout_log_probs")
     if "ref_log_prob" in data:
         fields.append("ref_log_prob")
     data = data.select(*fields).to_padded_tensor()
@@ -95,6 +97,7 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
     old_log_prob = data["old_log_probs"]
     advantages = data["advantages"]
     rollout_is_weights = data.get("rollout_is_weights", None)
+    rollout_log_prob = data.get("rollout_log_probs", None)
 
     loss_agg_mode = config.loss_agg_mode
 
@@ -110,6 +113,17 @@ def ppo_loss(config: ActorConfig, model_output, data: TensorDict, dp_group=None)
         config=config,
         rollout_is_weights=rollout_is_weights,
     )
+
+    if loss_mode != "bypass_mode" and rollout_log_prob is not None:
+        if response_mask.any():
+            from verl.trainer.ppo.rollout_corr_helper import compute_rollout_corr_metrics_from_logprobs
+
+            rollout_corr_metrics = compute_rollout_corr_metrics_from_logprobs(
+                log_prob=log_prob,
+                rollout_log_prob=rollout_log_prob,
+                response_mask=response_mask,
+            )
+            pg_metrics.update(rollout_corr_metrics)
 
     # AggregationType.MEAN for pg metrics: assumes policy_loss_fn normalizes by local_bsz/local_tokens
     # Ex: in compute_policy_loss_vanilla, pg_metrics are pg_clipfrac, ppo_kl, pg_clipfrac_lower


### PR DESCRIPTION
### What does this PR do?

Adds fail-loud invariants so that when rollout log-probs are **requested** (`rollout.calculate_log_probs` or `actor.use_rollout_log_probs`), a batch that silently loses `rollout_log_probs` raises instead of quietly degrading importance-correction / debug metrics to recomputed values.

**Problem.** In the fully-async path there are several seams where `rollout_log_probs` can be dropped (agent-loop output assembly, batch balancing, union with recomputed old_log_probs). Today every consumer degrades silently (`if "rollout_log_probs" in batch`), so a wiring bug produces subtly wrong training (e.g. TIS/IS-correction silently off) with no error.

**Fix.** Explicit checks at each seam, gated on the config request:
- `assemble_batch_from_rollout_samples` (`detach_utils.py`): require presence and `shape == responses.shape`, both before and after `balance_batch`.
- `FullyAsyncRollouter._generate_single`: require agent-loop generation to return `rollout_log_probs`.
- `SeparateRayPPOTrainer.fit`: require the field before rollout-vs-actor debug metrics.
- `update_policy_loss` (`verl/workers/utils/losses.py`): carry `rollout_log_probs` through the padded `data.select(...)`, and in non-bypass mode report rollout-correction metrics (`compute_rollout_corr_metrics_from_logprobs`) so rollout-vs-actor drift is visible in the losses path too.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+rollout_log_probs+missing
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

- Fully-async PPO run with `calculate_log_probs=true`: passes all invariants; metrics include rollout-corr KL/PPL diagnostics from the losses path.
- Fault injection (dropping the key at assembly / after balancing / at generation): each site raises with a precise message naming the seam and available batch keys, instead of training silently without correction.
- With the options unset: no checks run; behavior unchanged.

### API and Usage Example

No API change; errors only fire when rollout log-probs were explicitly requested but are missing.

### Design & Code Changes

Four independent guard sites + metric wiring in `update_policy_loss`; no change to happy-path data flow.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation.
- [ ] CI: a unit test for `assemble_batch_from_rollout_samples` invariants can be added if maintainers want it in this PR.
