### PR TITLE
[perf, model] feat: add MFU flops estimation for Qwen3.5 (qwen3_5)

### DIFF
--- a/tests/utils/test_flops_counter.py
+++ b/tests/utils/test_flops_counter.py
@@ -366,6 +366,44 @@ CONFIG = {
             709446422495232 / 1e12,
         ),
     },
+    "qwen3_5": {
+        "config": {  # Qwen/Qwen3.5-9B: hybrid linear/full attention, dense MLP, MTP head
+            "model_type": "qwen3_5",
+            "text_config": {
+                "vocab_size": 248320,
+                "hidden_size": 4096,
+                "intermediate_size": 12288,
+                "num_hidden_layers": 32,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 4,
+                "head_dim": 256,
+                "attn_output_gate": True,
+                "full_attention_interval": 4,
+                # 8 full-attention layers (every 4th), 24 GatedDeltaNet linear-attention layers
+                "layer_types": [
+                    "linear_attention",
+                    "linear_attention",
+                    "linear_attention",
+                    "full_attention",
+                ]
+                * 8,
+                "linear_key_head_dim": 128,
+                "linear_value_head_dim": 128,
+                "linear_num_key_heads": 16,
+                "linear_num_value_heads": 32,
+                "linear_conv_kernel_dim": 4,
+                "mtp_num_hidden_layers": 1,
+            },
+        },
+        "batch_seqlens_tuple": ([512, 1024, 2048], [4096, 4096, 4096]),
+        # Only the 8 full-attention layers carry the O(L^2) softmax term; the 24 linear
+        # (GatedDeltaNet) layers contribute weight-only projections plus an O(L) recurrence
+        # term. NOTE: the recurrence term is an approximation (chunked delta-rule kernel
+        # detail omitted); it is < 1% of total, so it does not meaningfully move MFU. The
+        # expected values below are produced by the estimator itself, not an independent
+        # closed form, precisely because of that approximated term.
+        "expected_flops_tuple": (198399303352320 / 1e12, 686410935828480 / 1e12),
+    },
     "qwen3_vl_moe": {
         "config": {  # Qwen/Qwen3-VL-30B-A3B
             "model_type": "qwen3_vl_moe",
@@ -447,6 +485,7 @@ CONFIG = {
         "gemma3_text",
         "apertus",
         "gpt_oss",
+        "qwen3_5",
         "qwen3_vl",
         "qwen3_vl_moe",
     ],

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -543,7 +543,7 @@ def _estimate_qwen3_5_flops(config, tokens_sum, batch_seqlens, delta_time, **kar
     # Every `full_attention_interval`-th layer is standard softmax attention (O(L^2)); the rest
     # are GatedDeltaNet linear-attention layers (O(L), no seqlen-square term). Fields live under
     # config.text_config (top level also holds vision_config), matching qwen3_next in transformers.
-    text_config = config.text_config
+    text_config = getattr(config, "text_config", config)
 
     hidden_size = text_config.hidden_size
     vocab_size = text_config.vocab_size

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -576,14 +576,17 @@ def _estimate_qwen3_5_flops(config, tokens_sum, batch_seqlens, delta_time, **kar
     attn_linear_N_full = hidden_size * (q_size + k_size + v_size + o_size)
 
     # --- linear-attention (GatedDeltaNet) layers: in_proj(qkvz) + in_proj(ba) + conv + out_proj ---
-    key_dim = text_config.linear_key_head_dim * text_config.linear_num_key_heads
-    value_dim = text_config.linear_value_head_dim * text_config.linear_num_value_heads
-    conv_kernel = text_config.linear_conv_kernel_dim
-    in_proj_qkvz_N = hidden_size * (2 * key_dim + 2 * value_dim)
-    in_proj_ba_N = hidden_size * (2 * text_config.linear_num_value_heads)
-    conv_N = (2 * key_dim + value_dim) * conv_kernel  # depthwise conv1d
-    out_proj_N = value_dim * hidden_size
-    linear_attn_N = in_proj_qkvz_N + in_proj_ba_N + conv_N + out_proj_N
+    if num_linear_layers > 0:
+        key_dim = text_config.linear_key_head_dim * text_config.linear_num_key_heads
+        value_dim = text_config.linear_value_head_dim * text_config.linear_num_value_heads
+        conv_kernel = text_config.linear_conv_kernel_dim
+        in_proj_qkvz_N = hidden_size * (2 * key_dim + 2 * value_dim)
+        in_proj_ba_N = hidden_size * (2 * text_config.linear_num_value_heads)
+        conv_N = (2 * key_dim + value_dim) * conv_kernel  # depthwise conv1d
+        out_proj_N = value_dim * hidden_size
+        linear_attn_N = in_proj_qkvz_N + in_proj_ba_N + conv_N + out_proj_N
+    else:
+        linear_attn_N = 0
 
     # --- MTP head: approximate as one extra dense decoder layer (full attn linear + MLP) ---
     mtp_layers = getattr(text_config, "mtp_num_hidden_layers", 0)
@@ -608,14 +611,17 @@ def _estimate_qwen3_5_flops(config, tokens_sum, batch_seqlens, delta_time, **kar
     # --- GatedDeltaNet recurrence core: O(L) chunked delta rule. Approximated (chunk_size
     # implementation detail omitted); scales as tokens * per-head state (k_dim * v_dim). This
     # term is non-dominant vs the linear projections above (< 1% for the 9B config). ---
-    linear_recurrence_flops = (
-        6
-        * tokens_sum
-        * text_config.linear_num_value_heads
-        * text_config.linear_key_head_dim
-        * text_config.linear_value_head_dim
-        * num_linear_layers
-    )
+    if num_linear_layers > 0:
+        linear_recurrence_flops = (
+            6
+            * tokens_sum
+            * text_config.linear_num_value_heads
+            * text_config.linear_key_head_dim
+            * text_config.linear_value_head_dim
+            * num_linear_layers
+        )
+    else:
+        linear_recurrence_flops = 0
 
     # --- ViT: only when images are actually in the batch (text-only training skips it) ---
     images_seqlens = kargs.get("images_seqlens", None)

--- a/verl/utils/flops_counter.py
+++ b/verl/utils/flops_counter.py
@@ -538,6 +538,97 @@ def _estimate_gpt_oss_flops(config, tokens_sum, batch_seqlens, delta_time):
     return flops_achieved
 
 
+def _estimate_qwen3_5_flops(config, tokens_sum, batch_seqlens, delta_time, **kargs):
+    # Qwen3.5 (model_type "qwen3_5"): hybrid attention + dense SwiGLU MLP + 1 MTP layer + ViT.
+    # Every `full_attention_interval`-th layer is standard softmax attention (O(L^2)); the rest
+    # are GatedDeltaNet linear-attention layers (O(L), no seqlen-square term). Fields live under
+    # config.text_config (top level also holds vision_config), matching qwen3_next in transformers.
+    text_config = config.text_config
+
+    hidden_size = text_config.hidden_size
+    vocab_size = text_config.vocab_size
+    num_hidden_layers = text_config.num_hidden_layers
+    num_key_value_heads = text_config.num_key_value_heads
+    num_attention_heads = text_config.num_attention_heads
+    intermediate_size = text_config.intermediate_size
+    head_dim = getattr(text_config, "head_dim", hidden_size // num_attention_heads)
+
+    # Split layers into full vs linear. Prefer the explicit per-layer list; fall back to the
+    # interval so a config that only sets full_attention_interval still works.
+    layer_types = getattr(text_config, "layer_types", None)
+    if layer_types is not None:
+        num_full_layers = sum(1 for t in layer_types if t == "full_attention")
+    else:
+        interval = getattr(text_config, "full_attention_interval", 1)
+        num_full_layers = num_hidden_layers // interval
+    num_linear_layers = num_hidden_layers - num_full_layers
+
+    # --- dense SwiGLU MLP (present in every layer) + embedding/lm_head (once) ---
+    mlp_N = hidden_size * intermediate_size * 3
+    emd_and_lm_head_N = vocab_size * hidden_size * 2
+
+    # --- full-attention layers: q_proj is doubled when attn_output_gate is set (q + gate) ---
+    q_mult = 2 if getattr(text_config, "attn_output_gate", False) else 1
+    q_size = num_attention_heads * head_dim * q_mult
+    k_size = num_key_value_heads * head_dim
+    v_size = num_key_value_heads * head_dim
+    o_size = num_attention_heads * head_dim
+    attn_linear_N_full = hidden_size * (q_size + k_size + v_size + o_size)
+
+    # --- linear-attention (GatedDeltaNet) layers: in_proj(qkvz) + in_proj(ba) + conv + out_proj ---
+    key_dim = text_config.linear_key_head_dim * text_config.linear_num_key_heads
+    value_dim = text_config.linear_value_head_dim * text_config.linear_num_value_heads
+    conv_kernel = text_config.linear_conv_kernel_dim
+    in_proj_qkvz_N = hidden_size * (2 * key_dim + 2 * value_dim)
+    in_proj_ba_N = hidden_size * (2 * text_config.linear_num_value_heads)
+    conv_N = (2 * key_dim + value_dim) * conv_kernel  # depthwise conv1d
+    out_proj_N = value_dim * hidden_size
+    linear_attn_N = in_proj_qkvz_N + in_proj_ba_N + conv_N + out_proj_N
+
+    # --- MTP head: approximate as one extra dense decoder layer (full attn linear + MLP) ---
+    mtp_layers = getattr(text_config, "mtp_num_hidden_layers", 0)
+    mtp_N = (attn_linear_N_full + mlp_N) * mtp_layers
+
+    # non-attn parameter count across the whole model (weight-only linear algebra)
+    dense_N = (
+        mlp_N * num_hidden_layers
+        + attn_linear_N_full * num_full_layers
+        + linear_attn_N * num_linear_layers
+        + emd_and_lm_head_N
+        + mtp_N
+    )
+    dense_N_flops = 6 * dense_N * tokens_sum
+
+    # --- softmax attention QK^T/AV: O(L^2), applied ONLY to full-attention layers ---
+    seqlen_square_sum = 0
+    for seqlen in batch_seqlens:
+        seqlen_square_sum += seqlen * seqlen
+    attn_qkv_flops = 6 * seqlen_square_sum * head_dim * num_attention_heads * num_full_layers
+
+    # --- GatedDeltaNet recurrence core: O(L) chunked delta rule. Approximated (chunk_size
+    # implementation detail omitted); scales as tokens * per-head state (k_dim * v_dim). This
+    # term is non-dominant vs the linear projections above (< 1% for the 9B config). ---
+    linear_recurrence_flops = (
+        6
+        * tokens_sum
+        * text_config.linear_num_value_heads
+        * text_config.linear_key_head_dim
+        * text_config.linear_value_head_dim
+        * num_linear_layers
+    )
+
+    # --- ViT: only when images are actually in the batch (text-only training skips it) ---
+    images_seqlens = kargs.get("images_seqlens", None)
+    if images_seqlens is not None:
+        vit_flops = _estimate_qwen3_vit_flop(images_seqlens, config.vision_config)
+    else:
+        vit_flops = 0
+
+    flops_all_token = dense_N_flops + attn_qkv_flops + linear_recurrence_flops + vit_flops
+    flops_achieved = flops_all_token * (1.0 / delta_time) / 1e12
+    return flops_achieved
+
+
 def _estimate_unknown_flops(config, tokens_sum, batch_seqlens, delta_time):
     return 0
 
@@ -552,6 +643,7 @@ ESTIMATE_FUNC = {
     "qwen3_moe": _estimate_qwen2_moe_flops,
     "qwen3_vl": _estimate_qwen3_vl_flops,
     "qwen3_vl_moe": _estimate_qwen3_vl_moe_flops,
+    "qwen3_5": _estimate_qwen3_5_flops,
     "deepseek_v3": _estimate_deepseek_v3_flops,
     "minicpmv": _estimate_qwen2_flops,
     "minicpmo": _estimate_qwen2_flops,


### PR DESCRIPTION
### What does this PR do?

Adds MFU FLOPs estimation for **Qwen3.5** (`model_type: "qwen3_5"`). Without it, `qwen3_5` falls through to `_estimate_unknown_flops`, which returns `0`, so `perf/mfu/*` is always zero for Qwen3.5 training runs.

Qwen3.5 differs from the models already covered by `flops_counter.py` in several ways, so none of the existing estimators can be reused:
- **Hybrid attention**: every `full_attention_interval`-th layer is standard softmax attention (O(L²)); the remaining layers are **GatedDeltaNet linear attention** (O(L), no seqlen-square term). Reusing `_estimate_qwen2_flops` would apply the quadratic term to *all* layers and miss the linear-attention projections entirely.
- **Nested config**: fields live under `config.text_config` (top level holds `vision_config`), like `qwen3_next` / `qwen3_vl` in transformers.
- **Gated q_proj**: `attn_output_gate=true` doubles the q projection width.
- **Dense SwiGLU MLP** (not MoE), an **MTP** head, and an optional **ViT**.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+flops+qwen3_5 — none adding qwen3_5 flops.
- [x] PR title formatted as `[{modules}] {type}: {description}`.

### Test

Added a `qwen3_5` case to `tests/utils/test_flops_counter.py` (config based on the public Qwen/Qwen3.5-9B: 32 layers, 8 full + 24 linear, `head_dim=256`, MTP=1). Full suite passes:

```
tests/utils/test_flops_counter.py ... 12 passed
```

`pre-commit` (ruff check + format) passes on both changed files.

> [!NOTE]
> **Honesty about accuracy**: the GatedDeltaNet recurrence core is modeled with an **O(L) analytical approximation** (the chunked delta-rule kernel's exact FLOPs depend on implementation details). For the 9B config this term is **< 1% of total FLOPs**, so it does not meaningfully move MFU. The estimate is dominated by the deterministic linear-algebra terms (MLP + projections + embeddings ≈ 91%). I did **not** have real Qwen3.5-9B weights to calibrate MFU end-to-end against a live training run — validation covers magnitude, per-term breakdown, and a degeneration check (an all-`full_attention` variant lands within ~8% of the stock `qwen2` estimator, the difference being the q-gate doubling). Feedback from anyone with a real training curve is very welcome.

### Design & Code Changes

- `verl/utils/flops_counter.py`: add `_estimate_qwen3_5_flops`, register `"qwen3_5"` in `ESTIMATE_FUNC`.
- `tests/utils/test_flops_counter.py`: add `qwen3_5` test case.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks.
- [ ] Add / Update the documentation — n/a (internal FLOPs estimator, no user-facing API).
- [x] Add unit test(s) to cover the code.