### PR TITLE
[trainer] fix: stabilize Qwen3 Next 80B FSDP rollout on NPU

### DIFF
--- a/examples/ascend_extras/grpo_trainer/run_qwen3_next_80b_fsdp.sh
+++ b/examples/ascend_extras/grpo_trainer/run_qwen3_next_80b_fsdp.sh
@@ -42,7 +42,7 @@ warmup_steps=0
 
 # performance
 sp_size=8
-gen_tp=4
+gen_tp=8
 use_dynamic_bsz=True
 actor_ppo_max_token_len=$(((max_prompt_length + max_response_length) / sp_size))
 infer_ppo_max_token_len=$(((max_prompt_length + max_response_length) / sp_size))
@@ -99,7 +99,7 @@ ROLLOUT=(
     actor_rollout_ref.rollout.name=vllm
     actor_rollout_ref.rollout.n=${rollout_n}
     actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp}
-    actor_rollout_ref.rollout.gpu_memory_utilization=0.8
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6
     actor_rollout_ref.rollout.load_format=auto
     actor_rollout_ref.rollout.enforce_eager=True
     actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length))


### PR DESCRIPTION
### What does this PR do?

Adjust the Qwen3 Next 80B FSDP Ascend GRPO example to reduce rollout memory pressure after verl-project/verl#6346.

This is the `main` branch counterpart of verl-project/verl#6971.

That PR added NPU expandable segment support. In this example, the `update_weights` stage can now see a higher peak NPU memory footprint, so this PR makes the rollout configuration more conservative:

- increase `gen_tp` from 4 to 8
- lower `actor_rollout_ref.rollout.gpu_memory_utilization` from 0.8 to 0.6

### Checklist Before Starting

- [x] Search for similar PRs. Related context: verl-project/verl#6346 and verl-project/verl#6971. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+qwen3+next+80b+npu+memory
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

- [x] `bash -n examples/ascend_extras/grpo_trainer/run_qwen3_next_80b_fsdp.sh`
- [ ] Full local pre-commit was not run in this workspace. The earlier release-branch attempt did not complete because `hydra-core` is not installed for `autogen-trainer-cfg`, and an unrelated untracked example script in the main checkout triggers `check-example-naming`.

### API and Usage Example

No API changes.

```python
# No API changes.
```

### Design & Code Changes

This PR only updates the Ascend example script configuration:

- `gen_tp=8` spreads rollout generation across more tensor-parallel ranks.
- `actor_rollout_ref.rollout.gpu_memory_utilization=0.6` leaves more headroom for the NPU memory peak during `update_weights`.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not needed for this example-only configuration adjustment.
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Not feasible for this NPU runtime stability adjustment; validated with shell syntax check.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.
