### PR TITLE
[trainer] fix: only set CUDA_DEVICE_MAX_CONNECTIONS=1 for megatron in Hopper/Ampere

### DIFF
--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -36,13 +36,34 @@ _rocm_ray_env = {}
 if torch.version.hip is not None:
     _rocm_ray_env = {"RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0"}
 
+# CUDA_DEVICE_MAX_CONNECTIONS=1 is only needed by the Megatron engine on
+# pre-Blackwell Hopper/Ampere GPUs (compute capability 8.x/9.x) to serialize
+# kernel launches for TP/CP communication overlap. Blackwell/GB200 (>=10) does
+# not need it, and Torch-FSDP2 / Megatron-FSDP must NOT set it to 1. So we set
+# it conditionally at runtime (see get_ppo_ray_runtime_env), not unconditionally.
+#
+# https://github.com/NVIDIA/Megatron-LM/blob/core_v0.18.0/skills/mcore-run-on-slurm/SKILL.md#cuda_device_max_connections
+_is_hopper_or_ampere = (_major or 0) in (8, 9)
+
+
+def _uses_megatron(config) -> bool:
+    """Return True if any trainable engine in the config uses the Megatron strategy."""
+    if config is None:
+        return False
+    from omegaconf import OmegaConf
+
+    for key in ("actor_rollout_ref.actor.strategy", "critic.strategy"):
+        if OmegaConf.select(config, key, default=None) == "megatron":
+            return True
+    return False
+
+
 PPO_RAY_RUNTIME_ENV = {
     "env_vars": {
         "TOKENIZERS_PARALLELISM": "true",
         "NCCL_DEBUG": "WARN",
         "VLLM_LOGGING_LEVEL": "WARN",
         "VLLM_ALLOW_RUNTIME_LORA_UPDATING": "true",
-        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
         # TODO: disable compile cache due to cache corruption issue
         # https://github.com/vllm-project/vllm/issues/31199
         "VLLM_DISABLE_COMPILE_CACHE": "1",
@@ -57,10 +78,14 @@ PPO_RAY_RUNTIME_ENV = {
 }
 
 
-def get_ppo_ray_runtime_env():
+def get_ppo_ray_runtime_env(config=None):
     """
     A filter function to return the PPO Ray runtime environment.
     To avoid repeat of some environment variables that are already set.
+
+    Args:
+        config: Optional training config. When the engine strategy is Megatron
+            and the GPU is Hopper/Ampere, CUDA_DEVICE_MAX_CONNECTIONS=1 is set.
     """
     working_dir = (
         json.loads(os.environ.get(RAY_JOB_CONFIG_JSON_ENV_VAR, "{}")).get("runtime_env", {}).get("working_dir", None)
@@ -70,6 +95,9 @@ def get_ppo_ray_runtime_env():
         "env_vars": PPO_RAY_RUNTIME_ENV["env_vars"].copy(),
         **({"working_dir": None} if working_dir is None else {}),
     }
+    # Only Megatron on Hopper/Ampere needs CUDA_DEVICE_MAX_CONNECTIONS=1.
+    if _is_hopper_or_ampere and _uses_megatron(config):
+        runtime_env["env_vars"]["CUDA_DEVICE_MAX_CONNECTIONS"] = "1"
     for key in list(runtime_env["env_vars"].keys()):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)

--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -54,7 +54,7 @@ def run_ppo(config, task_runner_class) -> None:
         # Set environment variables in the runtime environment to control tokenizer parallelism,
         # NCCL debug level, VLLM logging level, and allow runtime LoRA updating
         # `num_cpus` specifies the number of CPU cores Ray can use, obtained from the configuration
-        default_runtime_env = get_ppo_ray_runtime_env()
+        default_runtime_env = get_ppo_ray_runtime_env(config)
         ray_init_kwargs = config.ray_kwargs.get("ray_init", {})
         runtime_env_kwargs = ray_init_kwargs.get("runtime_env", {})
 


### PR DESCRIPTION
### What does this PR do?

`CUDA_DEVICE_MAX_CONNECTIONS` ontrols the number of concurrent compute and copy engine connections (work queues).
- megatron: set `CUDA_DEVICE_MAX_CONNECTIONS=1` to make sure collective(all-gather/all-reduce) scheduled before compute kernels.
- fsdp/veomni/torchtitan/automodel: these backends are based on FSDP2, set `CUDA_DEVICE_MAX_CONNECTIONS=1` make multi-streams computation and prefetch overlap serial.

Conduct experiment on veomni:
- CUDA_DEVICE_MAX_CONNECTIONS=1
<img width="3356" height="540" alt="image" src="https://github.com/user-attachments/assets/d93d6cdd-6254-48e7-8661-91ed626702c2" />

- CUDA_DEVICE_MAX_CONNECTIONS unset(default to 8)
<img width="3346" height="524" alt="image" src="https://github.com/user-attachments/assets/2b238cca-e43b-48e8-9fda-6929f0d963c8" />
