### PR TITLE
[vllm] fix: use data-parallel rank in vLLM ZMQ handles

### DIFF
--- a/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_cli_args_on_cpu.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
-from verl.workers.rollout.vllm_rollout.utils import build_cli_args_from_config
+from verl.workers.rollout.vllm_rollout.utils import (
+    _resolve_vllm_weight_sync_local_rank,
+    build_cli_args_from_config,
+    vLLMColocateWorkerExtension,
+)
 
 
 class TestBuildCliArgsFromConfig:
@@ -127,6 +132,62 @@ class TestBuildCliArgsFromConfig:
         config = {"sizes": [42]}
         result = build_cli_args_from_config(config)
         assert result == ["--sizes", "42"]
+
+
+class TestVllmColocateZmqHandle:
+    def test_dp_local_rank_offsets_tensor_parallel_rank(self):
+        """DP workers on the same node must not reuse the same TP-local socket."""
+        parallel_config = SimpleNamespace(
+            tensor_parallel_size=2,
+            data_parallel_size=4,
+            data_parallel_size_local=2,
+            data_parallel_rank_local=1,
+        )
+
+        assert _resolve_vllm_weight_sync_local_rank(1, parallel_config) == 3
+        assert _resolve_vllm_weight_sync_local_rank(3, parallel_config) == 3
+
+    def test_single_dp_keeps_local_rank(self):
+        """The old single-DP handle layout remains unchanged."""
+        parallel_config = SimpleNamespace(
+            tensor_parallel_size=2,
+            data_parallel_size=1,
+            data_parallel_size_local=1,
+            data_parallel_rank_local=0,
+        )
+
+        assert _resolve_vllm_weight_sync_local_rank(1, parallel_config) == 1
+
+    def test_uses_global_dp_rank_when_local_rank_is_unset(self):
+        parallel_config = SimpleNamespace(
+            tensor_parallel_size=2,
+            data_parallel_size=4,
+            data_parallel_size_local=2,
+            data_parallel_rank_local=None,
+            data_parallel_rank=3,
+        )
+
+        assert _resolve_vllm_weight_sync_local_rank(0, parallel_config) == 2
+
+    def test_zmq_handle_uses_resolved_dp_rank(self, monkeypatch):
+        parallel_config = SimpleNamespace(
+            tensor_parallel_size=2,
+            data_parallel_size=4,
+            data_parallel_size_local=2,
+            data_parallel_rank_local=1,
+        )
+        worker = SimpleNamespace(
+            local_rank=1,
+            model_runner=SimpleNamespace(
+                vllm_config=SimpleNamespace(parallel_config=parallel_config),
+            ),
+        )
+        monkeypatch.setenv("VERL_REPLICA_RANK", "2")
+        monkeypatch.setenv("VERL_RAY_JOB_ID", "job-123")
+
+        handle = vLLMColocateWorkerExtension._get_zmq_handle(worker)
+
+        assert handle == "ipc:///tmp/rl-colocate-zmq-job-123-replica-2-rank-3.sock"
 
 
 if __name__ == "__main__":

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -40,6 +40,32 @@ VLLM_LORA_PATH = "simon_lora_path"
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
 
 
+def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
+    worker_local_rank = int(worker_local_rank)
+    if parallel_config is None:
+        return worker_local_rank
+
+    tp_size = max(int(getattr(parallel_config, "tensor_parallel_size", 1) or 1), 1)
+    dp_size = int(getattr(parallel_config, "data_parallel_size", 1) or 1)
+    dp_local_size = int(getattr(parallel_config, "data_parallel_size_local", 1) or 1)
+    if dp_size <= 1 and dp_local_size <= 1:
+        return worker_local_rank
+
+    dp_local_rank = getattr(parallel_config, "data_parallel_rank_local", None)
+    if dp_local_rank is None:
+        dp_rank = getattr(parallel_config, "data_parallel_rank", None)
+        if dp_rank is None:
+            dp_rank = getattr(parallel_config, "data_parallel_index", None)
+        if dp_rank is not None and dp_local_size > 0:
+            dp_local_rank = int(dp_rank) % dp_local_size
+
+    if dp_local_rank is None:
+        return worker_local_rank
+
+    tp_rank = worker_local_rank % tp_size
+    return int(dp_local_rank) * tp_size + tp_rank
+
+
 def set_death_signal():
     """Kill the current process when the parent process exits."""
     if platform.system() != "Linux":
@@ -289,16 +315,15 @@ class vLLMColocateWorkerExtension:
 
     def _get_zmq_handle(self) -> str:
         """Get ZMQ handle for communication.
-        Uses Ray job id + replica_rank + local_rank to form the handle so it
-        matches the sender side regardless of CUDA_VISIBLE_DEVICES differences,
-        avoids collisions when multiple replicas share the same node, and is
-        unique per Ray job to avoid cross-job collisions on shared hosts. The
-        job id is forwarded by the vLLMHttpServer actor as VERL_RAY_JOB_ID and
-        inherited by this vLLM worker subprocess.
+        Uses Ray job id + replica_rank + rollout-local rank to match the sender
+        side and avoid cross-job collisions on shared hosts.
         """
         replica_rank = os.environ.get("VERL_REPLICA_RANK", "0")
         job_id = os.environ.get("VERL_RAY_JOB_ID", "0")
-        return f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{self.local_rank}.sock"
+        vllm_config = getattr(self.model_runner, "vllm_config", None)
+        parallel_config = getattr(vllm_config, "parallel_config", None)
+        local_rank = _resolve_vllm_weight_sync_local_rank(self.local_rank, parallel_config)
+        return f"ipc:///tmp/rl-colocate-zmq-{job_id}-replica-{replica_rank}-rank-{local_rank}.sock"
 
 
 class SuppressSignalInThread:


### PR DESCRIPTION
### What does this PR do?

cherry-pick from main to fix #6615. 

relate PR https://github.com/verl-project/verl/pull/6620

- derive the colocated vLLM weight-sync receiver socket rank from the vLLM data-parallel local rank and tensor-parallel rank
- keep the existing single-DP socket layout unchanged
- add coverage for DP-local rank offsetting, global-DP fallback, and the generated ZMQ handle

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pull/6620
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
