### PR TITLE
[fsdp] fix: drop per-micro-batch model_output in training to fix actor-update OOM

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -668,6 +668,9 @@ class FSDPEngine(BaseEngine):
                         scaler.scale(loss).backward()
                     else:
                         loss.backward()
+                    # Training discards model_output (train_batch pops it); keeping it accumulates
+                    # full-length nested tensors across the mini-batch (∝ ppo_mini_batch * rollout_n) → OOM.
+                    meta_info.pop("model_output", None)
 
             output_lst.append(meta_info)
 


### PR DESCRIPTION
### What does this PR do?

`FSDPEngine.forward_backward_batch` appends each micro-batch's `meta_info` — including `model_output` (grad-connected, **full-length** `log_probs` + `entropy` nested tensors) — to `output_lst`, and only postprocesses the list **after** the whole mini-batch loop finishes.

In **training** that per-micro-batch `model_output` is never used: `engine_workers.train_batch` drops it immediately (`output.pop("model_output")`, comment *"we don't need model_output in training"*). Retaining it merely accumulates full-length activation tensors across **every micro-batch of the mini-batch**. Resident GPU memory then scales with the mini-batch **token count** = `ppo_mini_batch_size * rollout_n * seq_len` (recall `ray_trainer` does `ppo_mini_batch_size *= rollout.n`), and OOMs at high `rollout_n` — even though `use_dynamic_bsz` bounds *per-micro-batch* compute. Because the growth is count-driven, config mitigations (Ulysses SP, param/optimizer offload, lower `gpu_memory_utilization`) don't help.

This PR pops `model_output` in the training (`not forward_only`) path right after backward, before appending to `output_lst`, bounding the retained output to a single micro-batch.
- The forward-only path (`compute_log_prob`) still keeps `model_output`.
- `postprocess_batch_func` already guards on `"model_output" in o`, so downstream is unaffected.

### Checklist Before Starting

- [x] Searched for similar PRs/issues.
- [x] Formatted the PR title as `[modules] type: Title` (`[fsdp_engine]`).

### Test

2-node MI300X GRPO run, `rollout_n=32` (batch 32, prompt 24576 / response 16384): previously OOMed (`HSA_STATUS_ERROR_OUT_OF_RESOURCES`) at the **step-1 actor update**; with this change it clears — peak allocated **55.8 GB** / reserved 83.5 GB (of 192 GB), `update_actor` completes with real rollouts (response_length/mean 5422, num_turns 9.6). No change to the forward-only / `compute_log_prob` path.

### API and Usage Example

No API change.

### Design & Code Changes

Single-line behavioral change in `verl/workers/engine/fsdp/transformer_impl.py` (plus an explanatory comment).

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/volcengine/verl?tab=readme-ov-file#contribution-guide).
- [x] Change is one self-contained commit.
- [x] Added/verified the reasoning in the PR description.