### PR TITLE
[algo] feat: add TOPR (Tapered Off-Policy REINFORCE) policy loss

### DIFF
--- a/docs/algo/topr.md
+++ b/docs/algo/topr.md
@@ -1,0 +1,36 @@
+# TOPR: Tapered Off-Policy REINFORCE
+
+Last updated: 07/08/2026.
+
+Tapered Off-Policy REINFORCE (TOPR) is a REINFORCE-family objective for stable off-policy updates. It treats sequences asymmetrically by advantage sign: positive-advantage sequences are reinforced with unit weight (no importance correction), while negative-advantage sequences are weighted by the sequence-level importance ratio tapered to `[0, 1]`. The tapered weight bounds the update on off-policy negative sequences without zeroing their gradient the way PPO-style clipping does, so the policy keeps learning to suppress bad sequences even when they have drifted off-policy. TOPR uses no KL penalty and no reference model, and it reduces to plain REINFORCE when on-policy. For more details, please refer to the original paper [Tapered Off-Policy REINFORCE: Stable and efficient reinforcement learning for LLMs](https://arxiv.org/abs/2503.14286).
+
+## Key Components
+
+- Asymmetric taper: unit weight for positive-advantage sequences; `clip(ratio, 0, 1)` importance weight for negative-advantage sequences, where the ratio is the length-normalized sequence-level importance ratio between the current and behavior policies.
+- The taper weight is a constant (stop-gradient), so the gradient is the tapered REINFORCE gradient.
+- No KL penalty, no reference model, no critic required.
+- Trajectory-level objective: intended for outcome/group-based advantage estimators (e.g. `grpo`, `rloo`, `reinforce_plus_plus`) where the advantage is constant within a sequence.
+
+## Configuration
+
+To configure TOPR within the framework, use the following YAML settings.
+
+```yaml
+algorithm:
+  adv_estimator: grpo  # any outcome/group-based estimator
+actor_rollout_ref:
+  actor:
+    policy_loss:
+      loss_mode: "topr"
+```
+
+The taper bounds applied to negative-advantage sequences default to the canonical `[0, 1]` and can be adjusted:
+
+```yaml
+actor_rollout_ref:
+  actor:
+    policy_loss:
+      loss_mode: "topr"
+      topr_negative_ratio_lower: 0.0
+      topr_negative_ratio_upper: 1.0
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ verl is fast with:
    algo/otb.md
    algo/dppo.md
    algo/opd.md
+   algo/topr.md
 
 .. toctree::
    :maxdepth: 1

--- a/examples/topr_trainer/README.md
+++ b/examples/topr_trainer/README.md
@@ -1,0 +1,19 @@
+# TOPR
+
+TOPR (Tapered Off-Policy REINFORCE) is a REINFORCE-family policy loss for stable off-policy updates. Positive-advantage sequences are reinforced with unit weight, while negative-advantage sequences are weighted by the sequence-level importance ratio tapered to `[0, 1]`, which bounds the update without zeroing the gradient the way PPO-style clipping does. TOPR uses no KL penalty and no reference model and reduces to REINFORCE when on-policy.
+
+Reference: [Tapered Off-Policy REINFORCE: Stable and efficient reinforcement learning for LLMs](https://arxiv.org/abs/2503.14286).
+
+## Canonical Scripts
+
+| Script                  | Infer | Train | Platform |
+|-------------------------|-------|-------|----------|
+| `run_qwen3_8b_fsdp.sh`  | vLLM  | FSDP  | NVIDIA   |
+
+## Key Flags
+
+- `actor_rollout_ref.actor.policy_loss.loss_mode=topr`
+- `actor_rollout_ref.actor.policy_loss.topr_negative_ratio_lower=0.0` (canonical taper lower bound)
+- `actor_rollout_ref.actor.policy_loss.topr_negative_ratio_upper=1.0` (canonical taper upper bound)
+- `actor_rollout_ref.actor.use_kl_loss=False` (TOPR needs no KL regularization)
+- `algorithm.adv_estimator=grpo` (any outcome/group-based estimator; the advantage is constant per sequence)

--- a/examples/topr_trainer/run_qwen3_8b_fsdp.sh
+++ b/examples/topr_trainer/run_qwen3_8b_fsdp.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# TOPR | text | vLLM rollout | FSDP training | NVIDIA GPUs
+# TOPR (Tapered Off-Policy REINFORCE) reinforces positive-advantage sequences with unit weight and
+# weights negative-advantage sequences by the sequence-level importance ratio tapered to [0, 1].
+# No KL penalty or reference model is needed. https://arxiv.org/abs/2503.14286
+
+set -xeuo pipefail
+
+# ---- user-adjustable ----
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-8B}
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+
+train_batch_size=${TRAIN_BATCH_SIZE:-1024}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-256}
+max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
+max_response_length=${MAX_RESPONSE_LENGTH:-2048}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-24576}
+
+actor_lr=${ACTOR_LR:-1e-6}
+entropy_coeff=${ENTROPY_COEFF:-0}
+
+# canonical TOPR taper bounds for negative-advantage sequences
+topr_negative_ratio_lower=${TOPR_NEGATIVE_RATIO_LOWER:-0.0}
+topr_negative_ratio_upper=${TOPR_NEGATIVE_RATIO_UPPER:-1.0}
+
+rollout_tp=${ROLLOUT_TP:-2}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.6}
+rollout_n=${ROLLOUT_N:-5}
+
+total_epochs=${TOTAL_EPOCHS:-15}
+save_freq=${SAVE_FREQ:-20}
+test_freq=${TEST_FREQ:-5}
+
+project_name=${PROJECT_NAME:-verl_topr_gsm8k_math}
+experiment_name=${EXPERIMENT_NAME:-qwen3_8b_vllm_fsdp}
+# ---- end user-adjustable ----
+
+gsm8k_train=$HOME/data/gsm8k/train.parquet
+gsm8k_test=$HOME/data/gsm8k/test.parquet
+math_train=$HOME/data/math/train.parquet
+math_test=$HOME/data/math/test.parquet
+
+train_files="['$gsm8k_train', '$math_train']"
+val_files="['$gsm8k_test', '$math_test']"
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="$train_files"
+    data.val_files="$val_files"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.filter_overlong_prompts=True
+    data.truncation='error'
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.policy_loss.loss_mode=topr
+    actor_rollout_ref.actor.policy_loss.topr_negative_ratio_lower=${topr_negative_ratio_lower}
+    actor_rollout_ref.actor.policy_loss.topr_negative_ratio_upper=${topr_negative_ratio_upper}
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_kl_loss=False
+    actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
+    actor_rollout_ref.actor.fsdp_config.param_offload=False
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=${rollout_n}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.critic_warmup=0
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+)
+
+EXTRA=(
+)
+
+########################### launch ###########################
+python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@"

--- a/tests/trainer/ppo/test_topr_policy_loss_on_cpu.py
+++ b/tests/trainer/ppo/test_topr_policy_loss_on_cpu.py
@@ -1,0 +1,260 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the TOPR (Tapered Off-Policy REINFORCE) policy loss.
+
+TOPR (https://arxiv.org/abs/2503.14286) reinforces positive-advantage sequences with unit weight
+and weights negative-advantage sequences by the sequence-level importance ratio tapered to
+``[0, 1]``, keeping their gradient bounded but non-zero where PPO-style clipping zeroes it. These
+tests pin the defining properties of the objective on synthetic tensors. No GPU/model needed.
+"""
+
+import pytest
+import torch
+
+from verl.trainer.ppo.core_algos import compute_policy_loss_topr, get_policy_loss_fn
+from verl.workers.config import ActorConfig, PolicyLossConfig
+
+
+def _make_config(**policy_loss_overrides) -> ActorConfig:
+    return ActorConfig(
+        strategy="fsdp",
+        rollout_n=1,
+        use_dynamic_bsz=True,
+        policy_loss=PolicyLossConfig(**policy_loss_overrides),
+    )
+
+
+def _make_batch(seq_advantages, log_ratio_per_token, batch_size=None, resp_len=8, seed=0):
+    """Build a synthetic batch with a constant advantage per sequence (outcome/group style) and a
+    controlled per-token log importance ratio ``log_prob - old_log_prob``."""
+    batch_size = batch_size or len(seq_advantages)
+    g = torch.Generator().manual_seed(seed)
+    old_log_prob = -torch.rand(batch_size, resp_len, generator=g) - 0.5
+    log_prob = (old_log_prob + torch.tensor(log_ratio_per_token).unsqueeze(-1)).detach()
+    log_prob.requires_grad_(True)
+    advantages = torch.tensor(seq_advantages).unsqueeze(-1).expand(batch_size, resp_len).contiguous()
+    response_mask = torch.ones(batch_size, resp_len)
+    return old_log_prob, log_prob, advantages, response_mask
+
+
+def _reference_reinforce_loss(log_prob, advantages, response_mask, seq_weights):
+    """Hand-computed seq-mean-token-mean REINFORCE surrogate with per-sequence weights."""
+    per_token = -advantages * log_prob * seq_weights.unsqueeze(-1)
+    seq_token_counts = response_mask.sum(dim=-1)
+    seq_means = (per_token * response_mask).sum(dim=-1) / (seq_token_counts + 1e-8)
+    seq_valid = (seq_token_counts > 0).float()
+    return (seq_means * seq_valid).sum() / seq_valid.sum()
+
+
+def test_topr_is_registered():
+    assert get_policy_loss_fn("topr") is compute_policy_loss_topr
+
+
+def test_engine_call_convention_pins_sequence_aggregation():
+    """The engine's ``ppo_loss`` always passes ``loss_agg_mode=config.loss_agg_mode`` (default
+    "token-mean") explicitly. Like gspo/sapo, TOPR must pin "seq-mean-token-mean" regardless, so
+    the paper's per-sequence length normalization survives the engine call convention."""
+    config = _make_config()
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[1.0, -1.0, 0.5, -0.5], log_ratio_per_token=[0.0, -1.0, 0.5, -0.5], resp_len=8
+    )
+    # make sequence lengths ragged so token-mean and seq-mean-token-mean genuinely differ
+    mask[0, 4:] = 0.0
+    mask[1, 2:] = 0.0
+
+    loss_default, _ = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+    loss_engine, _ = compute_policy_loss_topr(
+        old_log_prob, log_prob, advantages, mask, loss_agg_mode="token-mean", config=config
+    )
+    torch.testing.assert_close(loss_engine, loss_default)
+
+
+def test_on_policy_reduces_to_reinforce():
+    """With log_prob == old_log_prob every taper weight is 1 and TOPR equals plain REINFORCE, in
+    both loss value and gradient."""
+    config = _make_config()
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[1.0, -1.0, 0.5, -0.25], log_ratio_per_token=[0.0, 0.0, 0.0, 0.0]
+    )
+
+    loss, metrics = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+    grad = torch.autograd.grad(loss, log_prob, retain_graph=True)[0]
+
+    ref = _reference_reinforce_loss(log_prob, advantages, mask, torch.ones(4))
+    ref_grad = torch.autograd.grad(ref, log_prob)[0]
+
+    torch.testing.assert_close(loss, ref)
+    torch.testing.assert_close(grad, ref_grad)
+    assert metrics["actor/topr_taper_weight_mean"] == pytest.approx(1.0)
+
+
+def test_positive_advantage_ignores_importance_ratio():
+    """Positive-advantage sequences get unit weight regardless of how off-policy they are: even
+    with a strongly shifted importance ratio, the loss equals the plain weight-1 REINFORCE
+    surrogate on the same tensors."""
+    config = _make_config()
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[1.0, 2.0, 0.5, 1.5], log_ratio_per_token=[-3.0, 2.0, -1.0, 0.5]
+    )
+    loss, metrics = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+
+    ref = _reference_reinforce_loss(log_prob, advantages, mask, torch.ones(4))
+    torch.testing.assert_close(loss, ref)
+    assert metrics["actor/topr_taper_weight_mean"] == pytest.approx(1.0)
+
+
+def test_negative_advantage_gradient_scales_with_tapered_ratio():
+    """For a negative-advantage sequence the gradient equals ``clip(ratio, 0, 1)`` times the
+    REINFORCE gradient: down-weighted when the sequence became unlikely (ratio < 1) and capped at
+    the on-policy magnitude when it became more likely (ratio > 1)."""
+    config = _make_config()
+    for log_ratio, expected_weight in ((-1.0, torch.exp(torch.tensor(-1.0)).item()), (2.0, 1.0)):
+        old_log_prob, log_prob, advantages, mask = _make_batch(seq_advantages=[-1.0], log_ratio_per_token=[log_ratio])
+        loss, metrics = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+        grad = torch.autograd.grad(loss, log_prob, retain_graph=True)[0]
+
+        ref = _reference_reinforce_loss(log_prob, advantages, mask, torch.ones(1))
+        ref_grad = torch.autograd.grad(ref, log_prob)[0]
+
+        torch.testing.assert_close(grad, expected_weight * ref_grad)
+        assert metrics["actor/topr_taper_weight_mean"] == pytest.approx(expected_weight, rel=1e-5)
+
+
+def test_negative_advantage_gradient_survives_where_ppo_clips_to_zero():
+    """The defining TOPR property: for an off-policy negative-advantage sequence whose ratio fell
+    below PPO's clip window, vanilla PPO's gradient is exactly zero (the clipped branch dominates),
+    while TOPR keeps a non-zero, ratio-tapered gradient."""
+    config = _make_config()
+    vanilla_fn = get_policy_loss_fn("vanilla")
+
+    # every sequence is negative-advantage and strongly off-policy: ratio = e^-5 << 1 - clip_ratio
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[-1.0, -0.5], log_ratio_per_token=[-5.0, -5.0]
+    )
+
+    vanilla_loss, _ = vanilla_fn(old_log_prob, log_prob, advantages, mask, config=config)
+    vanilla_grad = torch.autograd.grad(vanilla_loss, log_prob, retain_graph=True)[0]
+    assert torch.all(vanilla_grad == 0.0), "PPO clipping should zero the gradient in this regime"
+
+    topr_loss, _ = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+    topr_grad = torch.autograd.grad(topr_loss, log_prob)[0]
+    assert torch.all(topr_grad != 0.0)
+
+    # and the surviving gradient is exactly the tapered-ratio-scaled REINFORCE gradient
+    ref = _reference_reinforce_loss(log_prob, advantages, mask, torch.ones(2))
+    ref_grad = torch.autograd.grad(ref, log_prob)[0]
+    torch.testing.assert_close(topr_grad, torch.exp(torch.tensor(-5.0)) * ref_grad)
+
+
+def test_taper_weight_is_stop_gradient():
+    """No gradient flows through the taper weight itself: the TOPR gradient matches the gradient of
+    a reference loss built with the weights as constants."""
+    config = _make_config()
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[-1.0, 1.0, -2.0], log_ratio_per_token=[-0.5, 1.0, 0.3]
+    )
+    loss, _ = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+    grad = torch.autograd.grad(loss, log_prob, retain_graph=True)[0]
+
+    with torch.no_grad():
+        seq_ratio = torch.exp(((log_prob - old_log_prob) * mask).sum(-1) / mask.sum(-1))
+        seq_adv = (advantages * mask).sum(-1) / mask.sum(-1)
+        weights = torch.where(seq_adv >= 0, torch.ones_like(seq_ratio), seq_ratio.clamp(0.0, 1.0))
+    ref = _reference_reinforce_loss(log_prob, advantages, mask, weights)
+    ref_grad = torch.autograd.grad(ref, log_prob)[0]
+
+    torch.testing.assert_close(grad, ref_grad)
+
+
+def test_taper_bounds_are_configurable():
+    """The negative-branch bounds come from PolicyLossConfig: raising the upper bound above 1 lets
+    a ratio > 1 negative sequence be weighted above the canonical cap."""
+    old_log_prob, log_prob, advantages, mask = _make_batch(seq_advantages=[-1.0], log_ratio_per_token=[0.5])
+
+    _, metrics_canonical = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=_make_config())
+    _, metrics_raised = compute_policy_loss_topr(
+        old_log_prob, log_prob, advantages, mask, config=_make_config(topr_negative_ratio_upper=2.0)
+    )
+
+    assert metrics_canonical["actor/topr_taper_weight_mean"] == pytest.approx(1.0)
+    assert metrics_raised["actor/topr_taper_weight_mean"] == pytest.approx(
+        torch.exp(torch.tensor(0.5)).item(), rel=1e-5
+    )
+
+
+def test_padded_tokens_do_not_contribute():
+    """Tokens outside the response mask affect neither the taper weight nor the loss."""
+    config = _make_config()
+    g = torch.Generator().manual_seed(1)
+    old_log_prob = -torch.rand(2, 8, generator=g)
+    log_prob_base = (old_log_prob - 0.5).detach()
+    advantages = torch.tensor([[-1.0], [1.0]]).expand(2, 8).contiguous()
+    mask = torch.ones(2, 8)
+    mask[:, 5:] = 0.0
+
+    log_prob_a = log_prob_base.clone().requires_grad_(True)
+    loss_a, _ = compute_policy_loss_topr(old_log_prob, log_prob_a, advantages, mask, config=config)
+
+    corrupted = log_prob_base.clone()
+    corrupted[:, 5:] += 100.0  # garbage in the padded region
+    log_prob_b = corrupted.requires_grad_(True)
+    loss_b, _ = compute_policy_loss_topr(old_log_prob, log_prob_b, advantages, mask, config=config)
+
+    torch.testing.assert_close(loss_a, loss_b)
+    grad_b = torch.autograd.grad(loss_b, log_prob_b)[0]
+    assert torch.all(grad_b[:, 5:] == 0.0)
+
+
+def test_rollout_is_weights_compose():
+    """Rollout-correction weights multiply the loss exactly like in the other policy losses."""
+    config = _make_config()
+    old_log_prob, log_prob, advantages, mask = _make_batch(seq_advantages=[1.0, -1.0], log_ratio_per_token=[0.0, 0.0])
+    loss_plain, _ = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+    loss_scaled, _ = compute_policy_loss_topr(
+        old_log_prob, log_prob, advantages, mask, config=config, rollout_is_weights=torch.full((2, 8), 0.5)
+    )
+    torch.testing.assert_close(loss_scaled, 0.5 * loss_plain)
+
+
+@pytest.mark.parametrize("num_micro_batches", [2, 4])
+def test_microbatch_invariance_with_global_batch_info(num_micro_batches):
+    """With the engine's global batch info threaded through ``config.global_batch_info``, summing
+    the per-micro-batch TOPR losses equals the whole-mini-batch loss (the same normalization
+    contract the actor's other losses follow)."""
+    batch_size = 8
+    config = _make_config()
+    config.global_batch_info["dp_size"] = 1
+    config.global_batch_info["batch_num_tokens"] = None
+    config.global_batch_info["global_batch_size"] = batch_size
+    config.global_batch_info["loss_scale_factor"] = None
+
+    old_log_prob, log_prob, advantages, mask = _make_batch(
+        seq_advantages=[1.0, -1.0, 0.5, -0.5, 2.0, -2.0, 0.25, -0.25],
+        log_ratio_per_token=[0.0, -1.0, 0.5, -0.5, 1.0, -2.0, 0.0, 0.3],
+    )
+
+    whole, _ = compute_policy_loss_topr(old_log_prob, log_prob, advantages, mask, config=config)
+
+    step = batch_size // num_micro_batches
+    accum = sum(
+        compute_policy_loss_topr(
+            old_log_prob[i : i + step],
+            log_prob[i : i + step],
+            advantages[i : i + step],
+            mask[i : i + step],
+            config=config,
+        )[0]
+        for i in range(0, batch_size, step)
+    )
+    torch.testing.assert_close(accum, whole)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -106,6 +106,8 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      topr_negative_ratio_lower: 0.0
+      topr_negative_ratio_upper: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -72,6 +72,8 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      topr_negative_ratio_lower: 0.0
+      topr_negative_ratio_upper: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -79,6 +79,8 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      topr_negative_ratio_lower: 0.0
+      topr_negative_ratio_upper: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -82,6 +82,8 @@ actor_rollout_ref:
       clip_cov_ub: 5.0
       kl_cov_ratio: 0.0002
       ppo_kl_coef: 0.1
+      topr_negative_ratio_lower: 0.0
+      topr_negative_ratio_upper: 1.0
     clip_ratio_c: 3.0
     loss_agg_mode: token-mean
     loss_scale_factor: null

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -75,6 +75,13 @@ policy_loss:
   # KL divergence penalty coefficient
   ppo_kl_coef: 0.1
 
+  # Lower bound of the tapered importance weight applied to negative-advantage sequences
+  # for topr loss (https://arxiv.org/abs/2503.14286); canonical TOPR uses [0, 1]
+  topr_negative_ratio_lower: 0.0
+
+  # Upper bound of the tapered importance weight applied to negative-advantage sequences for topr loss
+  topr_negative_ratio_upper: 1.0
+
 # Constant C in Dual-clip PPO; clips when advantage < 0 and ratio > C
 clip_ratio_c: 3.0
 

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -2064,6 +2064,99 @@ def compute_policy_loss_cispo(
     return pg_loss, pg_metrics
 
 
+@register_policy_loss("topr")
+def compute_policy_loss_topr(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "seq-mean-token-mean",
+    config: Optional[ActorConfig] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Compute the policy loss for TOPR (Tapered Off-Policy REINFORCE).
+
+    See https://arxiv.org/abs/2503.14286 for more details.
+
+    TOPR treats sequences asymmetrically by advantage sign. Positive-advantage sequences are
+    reinforced with unit weight (no importance correction). Negative-advantage sequences are
+    weighted by the sequence-level importance ratio pi_theta(y|x) / pi_old(y|x) tapered to
+    ``[topr_negative_ratio_lower, topr_negative_ratio_upper]`` (canonically ``[0, 1]``), which
+    bounds the update on off-policy negative sequences without zeroing their gradient the way
+    PPO-style clipping does. The taper weight is treated as a constant (stop-gradient), no KL
+    penalty or reference model is needed, and when on-policy (``log_prob == old_log_prob``) the
+    objective reduces to REINFORCE.
+
+    TOPR is a trajectory-level objective: the taper is decided by the sequence-level advantage,
+    so it is intended for outcome/group-based advantage estimators (e.g. grpo, rloo,
+    reinforce_plus_plus) where the advantage is constant within a sequence.
+
+    Args:
+        old_log_prob (torch.Tensor):
+            Log-probabilities of actions under the behavior policy, shape (batch_size, response_length).
+        log_prob (torch.Tensor):
+            Log-probabilities of actions under the current policy, shape (batch_size, response_length).
+        advantages (torch.Tensor):
+            Advantage estimates for each action, shape (batch_size, response_length).
+        response_mask (torch.Tensor):
+            Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
+        loss_agg_mode (str, optional):
+            Unused; TOPR always aggregates with "seq-mean-token-mean", the paper's per-sequence
+            length normalization (kept for the policy-loss interface).
+        config (ActorConfig, optional):
+            Actor config providing ``policy_loss.topr_negative_ratio_lower`` and
+            ``policy_loss.topr_negative_ratio_upper``.
+        rollout_is_weights (torch.Tensor, optional):
+            Optional rollout-correction weights, shape (batch_size, response_length).
+    """
+    assert config is not None
+    assert isinstance(config, ActorConfig)
+    ratio_lower = config.policy_loss.topr_negative_ratio_lower
+    ratio_upper = config.policy_loss.topr_negative_ratio_upper
+
+    negative_approx_kl = log_prob - old_log_prob
+
+    # sequence-level, length-normalized importance ratio (as in GSPO):
+    # r_i(theta) = exp[(1/|y_i|) * sum_t log(pi_theta(y_i,t|x, y_i,<t) / pi_old(y_i,t|x, y_i,<t))]
+    seq_lengths = torch.sum(response_mask, dim=-1).clamp(min=1)
+    seq_log_ratio = torch.sum(negative_approx_kl * response_mask, dim=-1) / seq_lengths
+    seq_ratio = torch.exp(torch.clamp(seq_log_ratio, max=10.0))  # clamp for numerical stability
+
+    # sequence-level advantage sign decides the taper branch (constant per sequence for
+    # outcome/group-based estimators)
+    seq_advantages = torch.sum(advantages * response_mask, dim=-1) / seq_lengths
+
+    # asymmetric taper: unit weight for positive-advantage sequences, tapered importance
+    # weight for negative-advantage sequences; stop-gradient through the weight
+    taper_weights = torch.where(
+        seq_advantages >= 0,
+        torch.ones_like(seq_ratio),
+        torch.clamp(seq_ratio, min=ratio_lower, max=ratio_upper),
+    ).detach()
+
+    # REINFORCE surrogate: gradient is -taper_weight * A * grad log pi
+    pg_losses = -advantages * log_prob * taper_weights.unsqueeze(-1)
+
+    # Apply rollout correction weights if provided
+    if rollout_is_weights is not None:
+        pg_losses = pg_losses * rollout_is_weights
+
+    # for TOPR, we need to aggregate the loss at the sequence level (seq-mean-token-mean),
+    # matching the paper's per-sequence length normalization (as gspo/sapo do)
+    pg_loss = agg_loss(
+        loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode="seq-mean-token-mean", **config.global_batch_info
+    )
+
+    ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
+    negative_seq_mask = (seq_advantages < 0).float()
+    pg_metrics = {
+        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/topr_negative_seq_frac": negative_seq_mask.mean().detach().item(),
+        "actor/topr_taper_weight_mean": taper_weights.mean().detach().item(),
+    }
+    return pg_loss, pg_metrics
+
+
 def compute_entropy_loss(logits, response_mask, loss_agg_mode: str = "token-mean"):
     """Compute categorical entropy loss (For backward compatibility)
 

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -88,6 +88,10 @@ class PolicyLossConfig(BaseConfig):
         clip_cov_ub (float): Upper bound for clip-cov loss.
         kl_cov_ratio (float): Ratio of tokens to be applied KL penalty for kl-cov loss.
         ppo_kl_coef (float): KL divergence penalty coefficient.
+        topr_negative_ratio_lower (float): Lower bound of the tapered importance weight applied to
+            negative-advantage sequences for topr loss (https://arxiv.org/abs/2503.14286).
+        topr_negative_ratio_upper (float): Upper bound of the tapered importance weight applied to
+            negative-advantage sequences for topr loss.
         rollout_correction (RolloutCorrectionConfig): Configuration for rollout correction.
     """
 
@@ -97,6 +101,8 @@ class PolicyLossConfig(BaseConfig):
     clip_cov_ub: float = 5.0
     kl_cov_ratio: float = 0.0002
     ppo_kl_coef: float = 0.1
+    topr_negative_ratio_lower: float = 0.0
+    topr_negative_ratio_upper: float = 1.0
     rollout_correction: RolloutCorrectionConfig = field(default_factory=RolloutCorrectionConfig)
 
 


### PR DESCRIPTION
### What does this PR do?

This PR adds TOPR (Tapered Off-Policy REINFORCE, https://arxiv.org/abs/2503.14286) as a new policy loss, registered as `policy_loss.loss_mode=topr`.

TOPR is a REINFORCE-family objective for stable off-policy updates that treats sequences asymmetrically by advantage sign: positive-advantage sequences are reinforced with unit weight (no importance correction), while negative-advantage sequences are weighted by the length-normalized sequence-level importance ratio tapered to `[0, 1]` (stop-gradient). The taper bounds the update on off-policy negative sequences without zeroing their gradient the way PPO-style clipping does, so the policy keeps suppressing bad sequences even after they drift off-policy. No KL penalty, reference model, or critic is required, and the objective reduces to plain REINFORCE when on-policy.

### Duplicate check

No open or closed PR, issue, or existing code in the repo covers TOPR.

### Test

Algorithm implementation, validated by CPU unit tests of the objective's defining mathematical properties (`tests/trainer/ppo/test_topr_policy_loss_on_cpu.py`, 12 tests, all passing):

- On-policy (`log_prob == old_log_prob`), TOPR equals plain REINFORCE in both loss value and gradient.
- Positive-advantage sequences get unit weight regardless of how off-policy they are.
- Negative-advantage gradient equals `clip(ratio, 0, 1)` times the REINFORCE gradient, capped at the on-policy magnitude for ratio > 1.
- The defining property versus PPO: on the same off-policy negative-advantage inputs, `vanilla`'s gradient is exactly zero (clipped branch dominates) while TOPR's is non-zero and exactly ratio-tapered.
- The taper weight is a stop-gradient (autograd gradient matches a constant-weight reference).
- Taper bounds plumb from `PolicyLossConfig`; padded tokens contribute nothing; `rollout_is_weights` compose multiplicatively; summed per-micro-batch losses match the whole-mini-batch loss when `global_batch_info` is threaded (the same normalization contract as the other policy losses).
- The engine call convention is respected: `ppo_loss` passes `loss_agg_mode=config.loss_agg_mode` explicitly, so TOPR pins "seq-mean-token-mean" internally (as gspo/sapo do) and a test asserts the paper's per-sequence normalization survives an explicit "token-mean" argument.

Also run locally: `pytest tests/trainer/ppo -k on_cpu` (121 passed, no regressions), `ruff` lint/format, `mypy` on the changed source files, and the license/docstring/docs sanity checks. `scripts/generate_trainer_config.sh` regenerates the reference configs with no further diff. I do not have a GPU cluster, so no training curves are included; the PR scope is the objective, config, tests, docs, and example script.

### API and Usage Example

No breaking changes; a new `loss_mode` plus two config keys with canonical defaults.

```yaml
algorithm:
  adv_estimator: grpo  # any outcome/group-based estimator
actor_rollout_ref:
  actor:
    use_kl_loss: False  # TOPR needs no KL regularization
    policy_loss:
      loss_mode: "topr"
      topr_negative_ratio_lower: 0.0  # canonical taper bounds
      topr_negative_ratio_upper: 1.0
```

### Design & Code Changes

- `verl/trainer/ppo/core_algos.py`: add `compute_policy_loss_topr()` registered via `@register_policy_loss("topr")`. Sequence-level, length-normalized importance ratio `r_i = exp[(1/|y_i|) * sum_t (log pi_theta - log pi_old)]` (as in GSPO); taper weight `w_i = 1` if the sequence advantage is >= 0, else `clamp(r_i, topr_negative_ratio_lower, topr_negative_ratio_upper)`, detached; REINFORCE surrogate `-A * log_prob * w_i` (same convention as the `gpg` loss). Aggregation is pinned to `seq-mean-token-mean` (the paper's per-sequence length normalization) through `agg_loss` with `config.global_batch_info`, following the gspo/sapo pattern for sequence-level objectives. Emits `actor/topr_negative_seq_frac` and `actor/topr_taper_weight_mean` metrics.
- `verl/workers/config/actor.py` + `verl/trainer/config/actor/actor.yaml`: `topr_negative_ratio_lower` / `topr_negative_ratio_upper` in `PolicyLossConfig` (defaults `0.0` / `1.0`, the paper's canonical taper); the four `_generated_*.yaml` reference configs are regenerated.
- `docs/algo/topr.md` (+ `docs/index.rst`): algorithm doc following the existing per-algorithm format.
- `examples/topr_trainer/`: README and a canonical `run_qwen3_8b_fsdp.sh` (vLLM rollout + FSDP), following the cispo example layout.
- `tests/trainer/ppo/test_topr_policy_loss_on_cpu.py`: the unit tests described above.

TOPR is a trajectory-level objective, so it is documented as intended for outcome/group-based advantage estimators (grpo, rloo, reinforce_plus_plus), where the advantage is constant within a sequence.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs)
- [x] Add unit test(s)

---

**AI assistance disclosure**: This PR was developed with AI assistance. The submitting human has reviewed every changed line and is responsible for the change end to end. Test commands and results are listed in the Test section.
