### PR TITLE
[fully_async] fix: pre-compute total_training_steps before trainer init

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_main.py
+++ b/verl/experimental/fully_async_policy/fully_async_main.py
@@ -20,7 +20,7 @@ from pprint import pprint
 
 import hydra
 import ray
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, open_dict
 
 from verl.experimental.fully_async_policy.fully_async_rollouter import FullyAsyncRollouter
 from verl.experimental.fully_async_policy.fully_async_trainer import FullyAsyncTrainer
@@ -73,6 +73,35 @@ class FullyAsyncTaskRunner:
         role_worker_mapping, ray_worker_group_cls = create_role_worker_mapping(config)
         self.components["role_worker_mapping"] = role_worker_mapping
         self.components["ray_worker_group_cls"] = ray_worker_group_cls
+
+        # Pre-compute total_training_steps from config before trainer init.
+        # Megatron's OptimizerParamScheduler requires lr_decay_steps > 0 at __init__ time,
+        # but set_total_train_steps is only called after rollouter init (which happens after
+        # trainer init). Compute the value here to avoid the assertion failure.
+        # This mirrors the logic in v1/trainer_base.py::_init_dataloader.
+        trigger_step = config.async_training.trigger_parameter_sync_step
+        total_training_steps = config.trainer.get("total_training_steps", None)
+        if total_training_steps is None:
+            required_samples = (
+                config.actor_rollout_ref.actor.ppo_mini_batch_size * config.async_training.require_batches
+            )
+            total_rollout_steps = config.rollout.total_rollout_steps
+            total_training_steps = int(total_rollout_steps / (required_samples * trigger_step))
+
+        optim_total_training_steps = total_training_steps * trigger_step
+        try:
+            OmegaConf.set_struct(config, True)
+            with open_dict(config):
+                if OmegaConf.select(config, "actor_rollout_ref.actor.optim"):
+                    config.actor_rollout_ref.actor.optim.total_training_steps = optim_total_training_steps
+                if OmegaConf.select(config, "critic.optim"):
+                    config.critic.optim.total_training_steps = optim_total_training_steps
+        except Exception as e:
+            print(f"[ASYNC MAIN] Warning: Could not set total_training_steps: {e}")
+        print(
+            f"[ASYNC MAIN] total_training_steps={total_training_steps}, "
+            f"optim_total_training_steps={optim_total_training_steps}"
+        )
 
         print("[ASYNC MAIN] Creating FullyAsyncTrainer first (needed for hybrid worker group injection)...")
         self._create_trainer(config)


### PR DESCRIPTION
### What does this PR do?

Fix `AssertionError: assert self.lr_decay_steps > 0` when using `fully_async_policy` with Megatron model engine. The root cause is an initialization ordering issue where Megatron's `OptimizerParamScheduler` requires `total_training_steps > 0` at `__init__` time, but the value is only computed after rollouter initialization.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+fully_async+total_training_steps
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Reproduced with Qwen3.5-122B-A10B MoE on NPU (H910-64G) cluster using `fully_async_main` entry point with Megatron engine (TP=2, PP=4, CP=2, EP=16). Without this fix, training crashes immediately at `init_workers()`. With the fix, training proceeds normally.

Not feasible to add to CI: requires multi-node Megatron + fully_async setup with actual model weights.

### Design & Code Changes

**Root Cause**: In `fully_async_main.py`, the initialization order is:
1. `_create_trainer(config)` → `trainer.init_workers()` → Megatron optimizer init (needs `total_training_steps > 0`)
2. `_create_rollouter(config)` → `rollouter.init_workers()`
3. `trainer.set_total_train_steps(rollouter.get_total_train_steps())` ← too late

The v1 trainer (sync/colocate modes) doesn't hit this because it lazily initializes the optimizer after dataloader setup.

**Fix**: Pre-compute `total_training_steps` from already-available config values before creating the trainer. Mirrors the logic in `v1/trainer_base.py::_init_dataloader`:
- Respects explicit `config.trainer.total_training_steps` if set by the user
- Multiplies by `trigger_parameter_sync_step` for optimizer schedule (consistent with v1)
- Sets both `actor.optim` and `critic.optim` (consistent with v1)

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `ruff check` and `ruff format` pass.
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). (N/A - bug fix, no new API)
- [ ] Add unit or end-to-end test(s). Not feasible: requires multi-node Megatron + fully_async setup.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.

---

> AI-assisted: Claude was used for investigation and implementation. A human reviewer has verified all changes.

> This is not duplicating an existing PR: no open PRs address this issue (searched "fully_async total_training_steps", "OptimizerParamScheduler lr_decay_steps").