### PR TITLE
[vllm, rollout, perf]feat: add extra-prefix-cache for agentic system prefix rollout

### DIFF
--- a/tests/workers/rollout/extra_prefix_cache/test_extra_prefix_cache.py
+++ b/tests/workers/rollout/extra_prefix_cache/test_extra_prefix_cache.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from verl.workers.rollout.extra_prefix_cache.config import ExtraPrefixCacheConfig, enabled
+from verl.workers.rollout.extra_prefix_cache.controller import ExtraPrefixCacheController, compute_store_token_limit
+from verl.workers.rollout.extra_prefix_cache.prefix_provider import ExplicitPrefixProvider
+from verl.workers.rollout.extra_prefix_cache.protocol import (
+    PrefixMetadata,
+    build_cache_salt,
+    build_request_id,
+    parse_request_id,
+)
+
+
+def test_config_is_disabled_by_default() -> None:
+    cfg = ExtraPrefixCacheConfig.from_any(None)
+    assert not cfg.enable
+    assert not enabled(None)
+
+
+def test_explicit_provider_requires_len_and_fingerprint() -> None:
+    provider = ExplicitPrefixProvider()
+    assert provider.resolve([1, 2, 3], None) is None
+    assert provider.resolve([1, 2, 3], {"stable_prefix_token_len": 2}) is None
+    assert provider.resolve([1, 2, 3], {"stable_prefix_token_len": 4, "stable_prefix_fingerprint": "abc"}) is None
+
+    metadata = provider.resolve(
+        [1, 2, 3],
+        {"stable_prefix_token_len": 2, "stable_prefix_fingerprint": "abc", "prefix_source": "unit"},
+    )
+    assert metadata is not None
+    assert metadata.stable_prefix_token_len == 2
+    assert metadata.stable_prefix_fingerprint == "abc"
+    assert metadata.prefix_source == "unit"
+
+
+def test_store_token_limit_aligns_down_to_chunk() -> None:
+    assert compute_store_token_limit(130, 64) == 128
+    assert compute_store_token_limit(63, 64) == 0
+    assert compute_store_token_limit(63, 0) == 63
+
+
+def test_request_id_policy_roundtrip() -> None:
+    request_id = build_request_id(read=True, write=False, store_token_limit=128, base_request_id="abc")
+    policy = parse_request_id(request_id)
+    assert request_id == "vepc__r1__w0__l128__abc"
+    assert policy.read
+    assert not policy.write
+    assert policy.store_token_limit == 128
+    assert policy.tagged
+
+    untagged = parse_request_id("plain", allow_untagged=False)
+    assert not untagged.read
+    assert not untagged.write
+    assert not untagged.tagged
+
+
+def test_salt_is_epoch_and_prefix_scoped() -> None:
+    metadata = PrefixMetadata(stable_prefix_token_len=4, stable_prefix_fingerprint="sys-a")
+    cfg = ExtraPrefixCacheConfig.from_any(
+        {"enable": True, "namespace": "unit", "model_cache_epoch": "epoch0", "model_namespace": "model-a"}
+    )
+    salt = build_cache_salt(cfg, metadata)
+    assert salt.startswith("unit:")
+    assert ":epoch0:" in salt
+    assert salt.endswith(":pfxsys-a")
+
+    cfg_next = ExtraPrefixCacheConfig.from_any({**cfg.__dict__, "runtime_model_cache_epoch": "step-1"})
+    assert build_cache_salt(cfg_next, metadata) != salt
+
+
+@pytest.mark.asyncio
+async def test_controller_builds_warmup_then_dedups() -> None:
+    controller = ExtraPrefixCacheController(
+        {
+            "enable": True,
+            "namespace": "unit",
+            "model_cache_epoch": "epoch0",
+            "model_namespace": "model-a",
+            "chunk_size": 4,
+        }
+    )
+    metadata = {"stable_prefix_token_len": 10, "stable_prefix_fingerprint": "abc"}
+    prepared = await controller.prepare(prompt_ids=list(range(20)), metadata=metadata)
+    assert prepared.enabled
+    assert prepared.cache_salt is not None
+    assert prepared.backend_request_id is not None
+    assert prepared.store_token_limit == 8
+    assert prepared.warmup_prompt_ids == list(range(8))
+    assert prepared.warmup_backend_request_id is not None
+    assert parse_request_id(prepared.backend_request_id).read
+    assert not parse_request_id(prepared.backend_request_id).write
+    assert not parse_request_id(prepared.warmup_backend_request_id).read
+    assert parse_request_id(prepared.warmup_backend_request_id).write
+
+    second = await controller.prepare(prompt_ids=list(range(20)), metadata=metadata)
+    assert second.enabled
+    assert second.cache_salt == prepared.cache_salt
+    assert second.warmup_prompt_ids is None
+    assert second.warmup_backend_request_id is None
+
+
+@pytest.mark.asyncio
+async def test_controller_disabled_or_missing_metadata_is_noop() -> None:
+    disabled = ExtraPrefixCacheController({"enable": False})
+    assert not (await disabled.prepare(prompt_ids=[1, 2], metadata=None)).enabled
+
+    enabled_controller = ExtraPrefixCacheController({"enable": True})
+    assert not (await enabled_controller.prepare(prompt_ids=[1, 2], metadata=None)).enabled

--- a/verl/trainer/ppo/v1/trainer_colocate_async.py
+++ b/verl/trainer/ppo/v1/trainer_colocate_async.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
+from verl.trainer.ppo.v1.weight_update_hooks import maybe_run_weight_update_hooks
 from verl.utils.debug import marked_timer
 from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient
 
@@ -36,6 +37,7 @@ class PPOTrainerColocateAsync(PPOTrainer):
     def on_init_end(self):
         # update weights after loading checkpoint
         self.checkpoint_manager.update_weights(self.global_steps)
+        maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
 
     def on_train_begin(self):
         num_warmup_batches = self.config.trainer.v1.colocate_async.num_warmup_batches
@@ -47,6 +49,7 @@ class PPOTrainerColocateAsync(PPOTrainer):
         with marked_timer("update_weights", self.timing_raw, color="red"):
             # wake up all replicas to update weights
             self.checkpoint_manager.update_weights(self.global_steps)
+            maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
             # resume generation
             self.checkpoint_manager.resume_generation_replicas()
 

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -21,6 +21,7 @@ from omegaconf import DictConfig
 from verl.checkpoint_engine import CheckpointEngineManager
 from verl.trainer.ppo.utils import need_reward_model
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
+from verl.trainer.ppo.v1.weight_update_hooks import maybe_run_weight_update_hooks
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.workers.rollout.llm_server import FullyAsyncLLMServerClient, LLMServerManager
@@ -99,6 +100,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         # update weights after loading checkpoint
         self.standalone_checkpoint_manager.update_weights(self.global_steps)
         self.checkpoint_manager.update_weights(self.global_steps)
+        maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
 
     def on_train_begin(self):
         num_warmup_batches = self.config.trainer.v1.separate_async.num_warmup_batches
@@ -122,13 +124,16 @@ class PPOTrainerSeparateAsync(PPOTrainer):
             self.switch_to_trainer()
 
     def on_step_end(self):
-        with marked_timer("update_weights", self.timing_raw, color="red"):
-            # wake up all replicas to update weights
-            self.standalone_checkpoint_manager.update_weights(self.global_steps)
+        if self.global_steps % self.config.trainer.v1.separate_async.parameter_sync_step == 0:
+            with marked_timer("update_weights", self.timing_raw, color="red"):
+                # wake up all replicas to update weights
+                self.standalone_checkpoint_manager.update_weights(self.global_steps)
+                maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
 
     def switch_to_rollout(self):
         # TODO: disable auto offload in config and offload according to the switch strategy
         self.checkpoint_manager.update_weights(self.global_steps)
+        maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
         self.checkpoint_manager.resume_generation_replicas()
         self.add_replicas_to_balancer()
         self.current_mode = HybridEngineMode.ROLLOUT

--- a/verl/trainer/ppo/v1/trainer_sync.py
+++ b/verl/trainer/ppo/v1/trainer_sync.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 from verl.trainer.ppo.v1.trainer_base import PPOTrainer, register_trainer
+from verl.trainer.ppo.v1.weight_update_hooks import maybe_run_weight_update_hooks
 from verl.utils.debug import marked_timer
 
 logger = logging.getLogger(__name__)
@@ -31,11 +32,13 @@ class PPOTrainerSync(PPOTrainer):
     def on_init_end(self):
         # update weights after loading checkpoint
         self.checkpoint_manager.update_weights(self.global_steps)
+        maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
 
     def on_step_end(self):
         with marked_timer("update_weights", self.timing_raw, color="red"):
             # wake up all replicas to update weights
             self.checkpoint_manager.update_weights(self.global_steps)
+            maybe_run_weight_update_hooks(self.config, self.global_steps, log=logger)
 
     def on_sample_end(self):
         # sleep all replicas to discard weights and kv cache

--- a/verl/trainer/ppo/v1/weight_update_hooks.py
+++ b/verl/trainer/ppo/v1/weight_update_hooks.py
@@ -1,0 +1,130 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from verl.workers.rollout.extra_prefix_cache import maybe_advance_extra_prefix_cache_epoch
+
+logger = logging.getLogger(__name__)
+
+
+def _select(config: Any, key: str, default: Any = None) -> Any:
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(config):
+            value = OmegaConf.select(config, key)
+            return default if value is None else value
+    except Exception:
+        pass
+
+    value = config
+    for part in key.split("."):
+        if value is None:
+            return default
+        if isinstance(value, Mapping):
+            value = value.get(part, default)
+        else:
+            value = getattr(value, part, default)
+    return value
+
+
+def _to_container(value: Any) -> Any:
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(value):
+            return OmegaConf.to_container(value, resolve=True)
+    except Exception:
+        pass
+    return value
+
+
+def _as_hook_specs(value: Any) -> list[Any]:
+    value = _to_container(value)
+    if value is None:
+        return []
+    if isinstance(value, str) or isinstance(value, Mapping):
+        return [value]
+    if isinstance(value, Sequence):
+        return list(value)
+    return [value]
+
+
+def _load_callable(path: str):
+    if ":" in path:
+        module_name, attr_name = path.split(":", 1)
+    else:
+        module_name, _, attr_name = path.rpartition(".")
+    if not module_name or not attr_name:
+        raise ValueError(f"Hook path must be 'module.attr' or 'module:attr', got {path!r}")
+    module = importlib.import_module(module_name)
+    hook = getattr(module, attr_name)
+    if not callable(hook):
+        raise TypeError(f"Weight update hook {path!r} is not callable")
+    return hook
+
+
+def _parse_hook_spec(spec: Any) -> tuple[str | None, dict[str, Any], bool]:
+    spec = _to_container(spec)
+    if isinstance(spec, str):
+        return spec, {}, False
+    if not isinstance(spec, Mapping):
+        return None, {}, False
+    required = bool(spec.get("required", False))
+    enabled = bool(spec.get("enable", spec.get("enabled", True)))
+    if not enabled:
+        return None, {}, required
+    path = spec.get("path") or spec.get("callable") or spec.get("target") or spec.get("_target_")
+    kwargs = spec.get("kwargs") or {}
+    if not isinstance(kwargs, Mapping):
+        raise TypeError(f"Weight update hook kwargs must be a mapping, got {type(kwargs).__name__}")
+    return path, dict(kwargs), required
+
+
+def maybe_run_weight_update_hooks(
+    config: Any,
+    global_step: int | str | None,
+    *,
+    log: logging.Logger | None = None,
+) -> list[Any]:
+    """Run optional trainer weight-update hooks.
+
+    This is intentionally backend-agnostic: verl never imports downstream
+    projects directly. Integrations can opt in by setting
+    ``trainer.weight_update_hooks`` to a callable path or a list of hook specs.
+    """
+
+    run_logger = log or logger
+    results: list[Any] = []
+    epc_epoch = maybe_advance_extra_prefix_cache_epoch(config, global_step, log=run_logger)
+    if epc_epoch is not None:
+        results.append(epc_epoch)
+    hooks = _as_hook_specs(_select(config, "trainer.weight_update_hooks"))
+    for spec in hooks:
+        try:
+            path, kwargs, required = _parse_hook_spec(spec)
+            if not path:
+                continue
+            hook = _load_callable(str(path))
+            results.append(hook(config, global_step, log=run_logger, **kwargs))
+        except Exception as exc:
+            message = f"Weight update hook failed spec={spec} error={exc}"
+            if isinstance(spec, Mapping) and bool(spec.get("required", False)):
+                raise RuntimeError(message) from exc
+            run_logger.warning(message)
+    return results

--- a/verl/utils/chat_template.py
+++ b/verl/utils/chat_template.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .tokenizer.chat_template import apply_chat_template, initialize_system_prompt
+
+__all__ = ["apply_chat_template", "initialize_system_prompt"]

--- a/verl/workers/config/rollout.py
+++ b/verl/workers/config/rollout.py
@@ -147,6 +147,7 @@ class RolloutConfig(BaseConfig):
         "max_model_len",
         "load_format",
         "engine_kwargs",
+        "extra_prefix_cache",
         "prompt_length",
         "response_length",
         "expert_parallel_size",
@@ -214,6 +215,7 @@ class RolloutConfig(BaseConfig):
 
     multi_stage_wake_up: bool = False
     engine_kwargs: dict = field(default_factory=dict)
+    extra_prefix_cache: dict = field(default_factory=dict)
 
     calculate_log_probs: bool = False
 

--- a/verl/workers/rollout/extra_prefix_cache/README.md
+++ b/verl/workers/rollout/extra_prefix_cache/README.md
@@ -1,0 +1,107 @@
+# Extra Prefix Cache
+
+Extra Prefix Cache (EPC) is a rollout-side helper for reusing a stable prompt
+prefix through an external KV cache. It is intended for agent workloads where
+many rollout requests share the same system/tool prefix while the user/task
+content changes.
+
+## What It Does
+
+EPC prepares two requests for a shared prefix:
+
+- A warmup request that writes only the stable prefix into the external KV cache.
+- A rollout request that is allowed to read that prefix but is not allowed to
+  write its dynamic prompt/response tokens back into the prefix cache.
+
+The controller receives prefix metadata from the caller, computes a cache salt,
+aligns the stored token range to the backend chunk size, deduplicates warmup by
+cache salt, and tags backend request ids with per-request read/write policy.
+
+The important layer here is the verl-side policy and prefix protocol. A generic
+external KV cache stores and retrieves blocks after the rollout backend asks it
+to do so; EPC decides which part of a request is a stable prefix, which request
+is allowed to populate that prefix, which rollout requests may read it, and when
+the namespace should move forward after model updates. This keeps agent-specific
+knowledge, such as the system/tool prefix boundary, outside the KV server.
+
+Model-weight invalidation is handled by the runtime cache epoch. When
+`advance_epoch_on_weight_update=True`, the epoch can advance after weight
+updates so requests use a new cache namespace instead of reusing old KV from a
+previous model version.
+
+## Prefix Metadata
+
+The default provider is `explicit`. It expects request metadata containing:
+
+- `stable_prefix_token_len`, also accepted as `system_prefix_len`.
+- `stable_prefix_fingerprint`, also accepted as `system_prefix_fingerprint`.
+
+In the uni-agent integration, this metadata is produced by the agent model code
+and passed to verl as `extra_prefix_cache_metadata`. The stable prefix is the
+part of the tokenized prompt that remains shared when the task-specific user
+content changes.
+
+The optional `heuristic` provider still requires `stable_prefix_token_len`, but
+computes the fingerprint from `prompt_ids[:stable_prefix_token_len]` together
+with tokenizer/template fingerprints. If no usable metadata is supplied, EPC
+skips the request instead of guessing a prefix boundary.
+
+## How To Enable
+
+EPC is disabled by default. Enable it under the rollout config:
+
+```bash
++actor_rollout_ref.rollout.extra_prefix_cache.enable=True
++actor_rollout_ref.rollout.extra_prefix_cache.backend=lmcache
++actor_rollout_ref.rollout.extra_prefix_cache.scope=system_prefix
++actor_rollout_ref.rollout.extra_prefix_cache.read_policy=rollout
++actor_rollout_ref.rollout.extra_prefix_cache.write_policy=warmup_only
++actor_rollout_ref.rollout.extra_prefix_cache.namespace=uni-agent-system-prefix
++actor_rollout_ref.rollout.extra_prefix_cache.model_cache_epoch=epoch0
++actor_rollout_ref.rollout.extra_prefix_cache.advance_epoch_on_weight_update=False
++actor_rollout_ref.rollout.extra_prefix_cache.chunk_size=64
+```
+
+For the verified vLLM + LMCache path, also configure vLLM KV transfer to use
+the EPC-aware LMCache connector:
+
+```bash
++actor_rollout_ref.rollout.engine_kwargs.vllm.disable_hybrid_kv_cache_manager=True
++actor_rollout_ref.rollout.engine_kwargs.vllm.kv_transfer_config="{kv_connector:VerlLMCacheExtraPrefixConnector,kv_connector_module_path:verl.workers.rollout.extra_prefix_cache.lmcache_connector,kv_role:kv_both,kv_connector_extra_config:{lmcache.mp.host:tcp://127.0.0.1,lmcache.mp.port:5555,lmcache.mp.mp_transfer_mode:engine_driven}}"
+```
+
+The training examples wire these settings in
+`examples/agent_train/v1/single_node_v1_collocate_async_lmcache.sh`.
+
+## Current Adapter
+
+The confirmed working integration is:
+
+- Rollout backend: vLLM.
+- External KV server: LMCache MP server.
+- Connector:
+  `verl.workers.rollout.extra_prefix_cache.lmcache_connector.VerlLMCacheExtraPrefixConnector`.
+
+vLLM carries namespace isolation through `cache_salt`. The connector reads the
+EPC read/write policy from the request id prefix and enforces it before LMCache
+loads or stores KV blocks. This lets the integration reuse existing vLLM and
+LMCache extension points without modifying vLLM or LMCache source code.
+
+The LMCache server remains responsible for block storage and transfer. The EPC
+module does not replace that backend; it supplies verl-specific request tagging,
+warmup orchestration, prefix scoping, and model-epoch invalidation around it.
+
+## Adapting Other Backends
+
+The EPC controller is backend-lightweight. A new rollout backend or KV server
+can reuse the same idea if it can accept:
+
+- A per-request cache namespace or salt.
+- A request id or equivalent metadata channel carrying read/write policy.
+- A way to warm up/store a prefix-only request.
+- A way to prevent rollout requests from storing dynamic suffix tokens.
+
+This should make other rollout backends that support external KV cache, and
+other independent KV cache servers, quick to connect. Those integrations are
+not yet confirmed and should be validated with functional reuse and epoch
+invalidation tests before being treated as supported.

--- a/verl/workers/rollout/extra_prefix_cache/__init__.py
+++ b/verl/workers/rollout/extra_prefix_cache/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config import ExtraPrefixCacheConfig, enabled, normalize_config
+from .controller import ExtraPrefixCacheController, compute_store_token_limit
+from .epoch import maybe_advance_extra_prefix_cache_epoch, resolve_runtime_model_cache_epoch
+from .protocol import PrefixMetadata, PreparedRequest, build_cache_salt, build_request_id, parse_request_id
+
+__all__ = [
+    "ExtraPrefixCacheConfig",
+    "ExtraPrefixCacheController",
+    "PrefixMetadata",
+    "PreparedRequest",
+    "build_cache_salt",
+    "build_request_id",
+    "compute_store_token_limit",
+    "enabled",
+    "maybe_advance_extra_prefix_cache_epoch",
+    "normalize_config",
+    "parse_request_id",
+    "resolve_runtime_model_cache_epoch",
+]

--- a/verl/workers/rollout/extra_prefix_cache/config.py
+++ b/verl/workers/rollout/extra_prefix_cache/config.py
@@ -1,0 +1,122 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_NAMESPACE = "verl-extra-prefix"
+DEFAULT_MODEL_CACHE_EPOCH = "epoch0"
+_SAFE_SALT_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+
+
+def normalize_config(config: Any) -> dict[str, Any]:
+    if config is None:
+        return {}
+    if isinstance(config, dict):
+        return dict(config)
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(config):
+            return OmegaConf.to_container(config, resolve=True) or {}
+    except Exception:
+        pass
+    if hasattr(config, "items"):
+        return dict(config.items())
+    return {}
+
+
+def enabled(config: Any) -> bool:
+    cfg = normalize_config(config)
+    return bool(cfg.get("enable", cfg.get("enabled", False)))
+
+
+def sanitize_salt(value: str) -> str:
+    value = value.replace("@", ":").replace("/", ":").replace("\\", ":").replace("\x00", "")
+    value = _SAFE_SALT_RE.sub("_", value).strip("_.:-")
+    if not value:
+        value = "default"
+    if len(value) <= 192:
+        return value
+
+    import hashlib
+
+    return f"{value[:160]}:{hashlib.sha256(value.encode('utf-8')).hexdigest()[:24]}"
+
+
+@dataclass(frozen=True)
+class ExtraPrefixCacheConfig:
+    enable: bool = False
+    backend: str = "lmcache"
+    scope: str = "system_prefix"
+    prefix_provider: str = "explicit"
+    namespace: str = DEFAULT_NAMESPACE
+    model_cache_epoch: str = DEFAULT_MODEL_CACHE_EPOCH
+    runtime_model_cache_epoch: str | None = None
+    advance_epoch_on_weight_update: bool = True
+    chunk_size: int = 0
+    read_policy: str = "rollout"
+    write_policy: str = "warmup_only"
+    warmup: bool = True
+    validation_mode: str = "off"
+    trace_mode: str = "aggregate"
+    model_namespace: str | None = None
+    tokenizer_fingerprint: str | None = None
+    template_fingerprint: str | None = None
+    allow_untagged: bool = True
+    heuristic_min_prefix_len: int = 0
+
+    @classmethod
+    def from_any(cls, config: Any) -> "ExtraPrefixCacheConfig":
+        cfg = normalize_config(config)
+        return cls(
+            enable=enabled(cfg),
+            backend=str(cfg.get("backend", "lmcache")),
+            scope=str(cfg.get("scope", "system_prefix")),
+            prefix_provider=str(cfg.get("prefix_provider", "explicit")),
+            namespace=sanitize_salt(str(cfg.get("namespace", DEFAULT_NAMESPACE))),
+            model_cache_epoch=str(cfg.get("model_cache_epoch", cfg.get("epoch", DEFAULT_MODEL_CACHE_EPOCH))),
+            runtime_model_cache_epoch=(
+                str(cfg["runtime_model_cache_epoch"]) if cfg.get("runtime_model_cache_epoch") is not None else None
+            ),
+            advance_epoch_on_weight_update=bool(cfg.get("advance_epoch_on_weight_update", True)),
+            chunk_size=_positive_int(cfg.get("chunk_size", 0)),
+            read_policy=str(cfg.get("read_policy", "rollout")),
+            write_policy=str(cfg.get("write_policy", "warmup_only")),
+            warmup=bool(cfg.get("warmup", True)),
+            validation_mode=str(cfg.get("validation_mode", "off")),
+            trace_mode=str(cfg.get("trace_mode", "aggregate")),
+            model_namespace=str(cfg["model_namespace"]) if cfg.get("model_namespace") is not None else None,
+            tokenizer_fingerprint=(
+                str(cfg["tokenizer_fingerprint"]) if cfg.get("tokenizer_fingerprint") is not None else None
+            ),
+            template_fingerprint=(
+                str(cfg["template_fingerprint"]) if cfg.get("template_fingerprint") is not None else None
+            ),
+            allow_untagged=bool(cfg.get("allow_untagged", True)),
+            heuristic_min_prefix_len=_positive_int(cfg.get("heuristic_min_prefix_len", 0)),
+        )
+
+    @property
+    def epoch(self) -> str:
+        return self.runtime_model_cache_epoch or self.model_cache_epoch or DEFAULT_MODEL_CACHE_EPOCH
+
+
+def _positive_int(value: Any, default: int = 0) -> int:
+    try:
+        parsed = int(value or default)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/verl/workers/rollout/extra_prefix_cache/controller.py
+++ b/verl/workers/rollout/extra_prefix_cache/controller.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections import Counter
+from typing import Any
+
+from .config import ExtraPrefixCacheConfig
+from .epoch import resolve_runtime_model_cache_epoch
+from .prefix_provider import get_prefix_provider
+from .protocol import PreparedRequest, build_cache_salt, build_request_id
+
+logger = logging.getLogger(__name__)
+
+
+class ExtraPrefixCacheMetrics:
+    def __init__(self) -> None:
+        self._counters: Counter[str] = Counter()
+
+    def incr(self, name: str, value: int = 1) -> None:
+        self._counters[name] += value
+
+    def snapshot(self) -> dict[str, int]:
+        return dict(self._counters)
+
+
+def compute_store_token_limit(stable_prefix_token_len: int, chunk_size: int = 0) -> int:
+    prefix_len = max(int(stable_prefix_token_len or 0), 0)
+    chunk_size = max(int(chunk_size or 0), 0)
+    if prefix_len <= 0:
+        return 0
+    if chunk_size <= 0:
+        return prefix_len
+    return (prefix_len // chunk_size) * chunk_size
+
+
+def rollout_read_enabled(read_policy: str) -> bool:
+    return str(read_policy or "rollout").lower() != "off"
+
+
+def warmup_write_enabled(write_policy: str) -> bool:
+    return str(write_policy or "warmup_only").lower() != "off"
+
+
+class ExtraPrefixCacheController:
+    def __init__(self, config: Any, *, model_path: str | None = None, log: logging.Logger | None = None) -> None:
+        self.config = ExtraPrefixCacheConfig.from_any(config)
+        self.model_path = model_path
+        self.logger = log or logger
+        self.metrics = ExtraPrefixCacheMetrics()
+        self._warmed_cache_salts: set[str] = set()
+        self._prefix_provider = get_prefix_provider(self.config)
+
+    @property
+    def enabled(self) -> bool:
+        return self.config.enable
+
+    async def prepare(
+        self,
+        *,
+        prompt_ids: list[int],
+        metadata: Any,
+    ) -> PreparedRequest:
+        if not self.config.enable:
+            return PreparedRequest(enabled=False)
+
+        runtime_epoch = await resolve_runtime_model_cache_epoch(self.config.__dict__, log=self.logger)
+        if runtime_epoch != self.config.epoch:
+            self.config = ExtraPrefixCacheConfig.from_any(
+                {**self.config.__dict__, "runtime_model_cache_epoch": runtime_epoch}
+            )
+
+        prefix = self._prefix_provider.resolve(prompt_ids, metadata)
+        if prefix is None:
+            self.metrics.incr("invalid_prefix_metadata")
+            return PreparedRequest(enabled=False)
+
+        store_token_limit = min(
+            compute_store_token_limit(prefix.stable_prefix_token_len, self.config.chunk_size),
+            len(prompt_ids),
+        )
+        if store_token_limit <= 0:
+            self.metrics.incr("invalid_prefix_metadata")
+            return PreparedRequest(enabled=False)
+
+        cache_salt = build_cache_salt(self.config, prefix, model_path=self.model_path)
+        read = rollout_read_enabled(self.config.read_policy)
+        backend_request_id = build_request_id(read=read, write=False)
+
+        warmup_prompt_ids = None
+        warmup_backend_request_id = None
+        if (
+            self.config.warmup
+            and warmup_write_enabled(self.config.write_policy)
+            and cache_salt not in self._warmed_cache_salts
+        ):
+            warmup_prompt_ids = list(prompt_ids[:store_token_limit])
+            warmup_backend_request_id = build_request_id(
+                read=False,
+                write=True,
+                store_token_limit=store_token_limit,
+            )
+            self._warmed_cache_salts.add(cache_salt)
+            self.metrics.incr("warmup_requests")
+        else:
+            self.metrics.incr("warmup_skipped")
+
+        self.metrics.incr("rollout_requests")
+        return PreparedRequest(
+            enabled=True,
+            cache_salt=cache_salt,
+            backend_request_id=backend_request_id,
+            stable_prefix_token_len=prefix.stable_prefix_token_len,
+            store_token_limit=store_token_limit,
+            warmup_prompt_ids=warmup_prompt_ids,
+            warmup_backend_request_id=warmup_backend_request_id,
+        )

--- a/verl/workers/rollout/extra_prefix_cache/epoch.py
+++ b/verl/workers/rollout/extra_prefix_cache/epoch.py
@@ -1,0 +1,238 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from .config import ExtraPrefixCacheConfig, enabled, normalize_config
+
+logger = logging.getLogger(__name__)
+
+_ACTOR_NAME = "verl_extra_prefix_cache_epoch_registry"
+_INTERNAL_KV_NAMESPACE = "verl_extra_prefix_cache"
+_INTERNAL_KV_PREFIX = "epoch:"
+
+
+class _ExtraPrefixCacheEpochRegistry:
+    def __init__(self) -> None:
+        self._epochs: dict[str, str] = {}
+
+    def get(self, namespace: str, default: str) -> str:
+        return self._epochs.get(namespace, default)
+
+    def set(self, namespace: str, epoch: str) -> str:
+        self._epochs[namespace] = epoch
+        return epoch
+
+
+def build_epoch(global_step: int | str | None) -> str:
+    try:
+        step = int(global_step or 0)
+    except (TypeError, ValueError):
+        step = 0
+    return f"step-{max(step, 0)}"
+
+
+def _try_get_ray():
+    try:
+        import ray
+    except Exception:
+        return None
+    try:
+        if not ray.is_initialized():
+            return None
+    except Exception:
+        return None
+    return ray
+
+
+def _internal_kv_key(namespace: str) -> str:
+    return f"{_INTERNAL_KV_PREFIX}{namespace}"
+
+
+def _internal_kv_available() -> bool:
+    if _try_get_ray() is None:
+        return False
+    try:
+        from ray.experimental.internal_kv import _internal_kv_initialized
+
+        return bool(_internal_kv_initialized())
+    except Exception:
+        return False
+
+
+def _internal_kv_get_epoch(namespace: str) -> str | None:
+    if not _internal_kv_available():
+        return None
+    try:
+        from ray.experimental.internal_kv import _internal_kv_get
+
+        value = _internal_kv_get(_internal_kv_key(namespace), namespace=_INTERNAL_KV_NAMESPACE)
+    except Exception:
+        return None
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return str(value)
+
+
+def _internal_kv_set_epoch(namespace: str, epoch: str) -> bool:
+    if not _internal_kv_available():
+        return False
+    try:
+        from ray.experimental.internal_kv import _internal_kv_put
+
+        _internal_kv_put(
+            _internal_kv_key(namespace),
+            str(epoch),
+            overwrite=True,
+            namespace=_INTERNAL_KV_NAMESPACE,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _get_epoch_registry(*, create: bool):
+    ray = _try_get_ray()
+    if ray is None:
+        return None
+
+    try:
+        return ray.get_actor(_ACTOR_NAME)
+    except Exception:
+        if not create:
+            return None
+
+    actor_cls = ray.remote(num_cpus=0)(_ExtraPrefixCacheEpochRegistry)
+    try:
+        return actor_cls.options(name=_ACTOR_NAME, get_if_exists=True).remote()
+    except TypeError:
+        try:
+            return actor_cls.options(name=_ACTOR_NAME).remote()
+        except Exception:
+            try:
+                return ray.get_actor(_ACTOR_NAME)
+            except Exception:
+                return None
+    except Exception:
+        try:
+            return ray.get_actor(_ACTOR_NAME)
+        except Exception:
+            return None
+
+
+def extract_extra_prefix_cache_config(config: Any) -> dict[str, Any]:
+    try:
+        from omegaconf import OmegaConf
+
+        if OmegaConf.is_config(config):
+            extra_cfg = OmegaConf.select(config, "actor_rollout_ref.rollout.extra_prefix_cache")
+            if extra_cfg is not None:
+                return normalize_config(extra_cfg)
+    except Exception:
+        pass
+
+    rollout_cfg = None
+    try:
+        rollout_cfg = config.actor_rollout_ref.rollout
+    except Exception:
+        pass
+    if rollout_cfg is None and isinstance(config, Mapping):
+        rollout_cfg = (config.get("actor_rollout_ref") or {}).get("rollout")
+    if rollout_cfg is None:
+        return normalize_config(config)
+    try:
+        return normalize_config(rollout_cfg.get("extra_prefix_cache", None))
+    except Exception:
+        return normalize_config(getattr(rollout_cfg, "extra_prefix_cache", None))
+
+
+def maybe_advance_extra_prefix_cache_epoch(
+    config: Any,
+    global_step: int | str | None,
+    *,
+    log: logging.Logger | None = None,
+) -> str | None:
+    run_logger = log or logger
+    cfg = ExtraPrefixCacheConfig.from_any(extract_extra_prefix_cache_config(config))
+    if not enabled(cfg.__dict__):
+        return None
+    if not cfg.advance_epoch_on_weight_update:
+        run_logger.info("ExtraPrefixCache epoch advance skipped reason=policy_off namespace=%s", cfg.namespace)
+        return None
+
+    epoch = build_epoch(global_step)
+    if _internal_kv_set_epoch(cfg.namespace, epoch):
+        run_logger.info(
+            "ExtraPrefixCache epoch advanced namespace=%s epoch=%s global_step=%s backend=ray_internal_kv",
+            cfg.namespace,
+            epoch,
+            global_step,
+        )
+        return epoch
+
+    actor = _get_epoch_registry(create=True)
+    ray = _try_get_ray()
+    if actor is None or ray is None:
+        run_logger.warning(
+            "ExtraPrefixCache epoch advance skipped namespace=%s epoch=%s reason=registry_unavailable",
+            cfg.namespace,
+            epoch,
+        )
+        return None
+    try:
+        epoch = ray.get(actor.set.remote(cfg.namespace, epoch))
+    except Exception as exc:
+        run_logger.warning(
+            "ExtraPrefixCache epoch advance failed namespace=%s global_step=%s error=%s",
+            cfg.namespace,
+            global_step,
+            exc,
+        )
+        return None
+    run_logger.info(
+        "ExtraPrefixCache epoch advanced namespace=%s epoch=%s global_step=%s backend=ray_actor",
+        cfg.namespace,
+        epoch,
+        global_step,
+    )
+    return str(epoch)
+
+
+async def resolve_runtime_model_cache_epoch(config: Any, *, log: logging.Logger | None = None) -> str:
+    cfg = ExtraPrefixCacheConfig.from_any(config)
+    if not cfg.enable or not cfg.advance_epoch_on_weight_update:
+        return cfg.epoch
+
+    internal_epoch = _internal_kv_get_epoch(cfg.namespace)
+    if internal_epoch:
+        return internal_epoch
+
+    actor = _get_epoch_registry(create=False)
+    if actor is None:
+        return cfg.epoch
+    try:
+        return str(await actor.get.remote(cfg.namespace, cfg.epoch))
+    except Exception as exc:
+        run_logger = log or logger
+        run_logger.warning(
+            "ExtraPrefixCache epoch resolve failed namespace=%s default_epoch=%s error=%s",
+            cfg.namespace,
+            cfg.epoch,
+            exc,
+        )
+        return cfg.epoch

--- a/verl/workers/rollout/extra_prefix_cache/lmcache_connector.py
+++ b/verl/workers/rollout/extra_prefix_cache/lmcache_connector.py
@@ -1,0 +1,144 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any
+
+from .config import normalize_config
+from .protocol import parse_request_id
+
+logger = logging.getLogger(__name__)
+
+try:
+    from lmcache.integration.vllm.lmcache_mp_connector import (
+        LMCacheMPConnector,
+        LMCacheMPConnectorMetadata,
+        LMCacheMPRequestMetadata,
+    )
+    from lmcache.utils import init_logger as lmcache_init_logger
+
+    logger = lmcache_init_logger(__name__)
+except Exception:  # pragma: no cover - exercised only when LMCache is installed.
+    LMCacheMPConnector = object
+    LMCacheMPConnectorMetadata = object
+    LMCacheMPRequestMetadata = None
+
+
+class VerlLMCacheExtraPrefixConnector(LMCacheMPConnector):
+    """LMCache connector adapter for verl extra prefix cache.
+
+    vLLM still carries namespace isolation through ``cache_salt``. The adapter
+    reads per-request EPC policy from the existing vLLM request id so vLLM and
+    LMCache do not need source changes.
+    """
+
+    def _allow_untagged(self) -> bool:
+        extra_config = getattr(self, "_kv_connector_extra_config", None)
+        cfg = normalize_config(extra_config)
+        return bool(cfg.get("extra_prefix_cache.allow_untagged", cfg.get("allow_untagged", True)))
+
+    def _policy_from_request_id(self, request_id: str):
+        return parse_request_id(request_id, allow_untagged=self._allow_untagged())
+
+    def get_num_new_matched_tokens(self, request: Any, num_computed_tokens: int) -> tuple[int | None, bool]:
+        policy = self._policy_from_request_id(request.request_id)
+        if not policy.read:
+            tracker = self._get_or_create_request_tracker(request)
+            logger.info(
+                "ExtraPrefixCache read deny request_id=%s cache_salt=%s",
+                request.request_id,
+                tracker.cache_salt,
+            )
+            return 0, False
+
+        ret, will_load = super().get_num_new_matched_tokens(request, num_computed_tokens)
+        if ret is not None and policy.tagged:
+            tracker = self._get_or_create_request_tracker(request)
+            logger.info(
+                "ExtraPrefixCache read allow request_id=%s cache_salt=%s new_external_tokens=%s will_load=%s",
+                request.request_id,
+                tracker.cache_salt,
+                ret,
+                will_load,
+            )
+        return ret, will_load
+
+    def _process_new_requests(self, scheduler_output: Any, metadata: LMCacheMPConnectorMetadata) -> None:
+        lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+        for new_request in scheduler_output.scheduled_new_reqs:
+            request_tracker = self._get_request_tracker(new_request.req_id)
+            num_new_tokens = scheduler_output.num_scheduled_tokens[new_request.req_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+            self._maybe_add_store_metadata(request_tracker, lmcache_tokens_per_chunk, metadata)
+
+    def _process_cached_requests(
+        self,
+        scheduler_output: Any,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        lmcache_tokens_per_chunk = self.scheduler_adapter.lmcache_tokens_per_chunk
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, request_id in enumerate(cached_reqs.req_ids):
+            request_tracker = self._get_request_tracker(request_id)
+            new_block_ids = cached_reqs.new_block_ids[idx] or ()
+            if request_id not in cached_reqs.resumed_req_ids:
+                request_tracker.append_block_ids(new_block_ids)
+            num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
+            request_tracker.increase_num_scheduled_tokens(num_new_tokens)
+            self._maybe_add_store_metadata(request_tracker, lmcache_tokens_per_chunk, metadata)
+
+    def _maybe_add_store_metadata(
+        self,
+        request_tracker: Any,
+        lmcache_tokens_per_chunk: int,
+        metadata: LMCacheMPConnectorMetadata,
+    ) -> None:
+        if LMCacheMPRequestMetadata is None:
+            return
+        r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(
+            request_tracker,
+            lmcache_tokens_per_chunk,
+            self._group_tokens_per_block,
+        )
+        policy = self._policy_from_request_id(request_tracker.request_id)
+        if r_meta is None:
+            return
+        if not policy.write:
+            logger.info(
+                "ExtraPrefixCache write deny request_id=%s cache_salt=%s range=%d-%d reason=policy",
+                request_tracker.request_id,
+                request_tracker.cache_salt,
+                r_meta.op.start,
+                r_meta.op.end,
+            )
+            return
+        limit = policy.store_token_limit
+        if limit > 0 and r_meta.op.end > limit:
+            logger.info(
+                "ExtraPrefixCache write deny request_id=%s cache_salt=%s range=%d-%d limit=%d",
+                request_tracker.request_id,
+                request_tracker.cache_salt,
+                r_meta.op.start,
+                r_meta.op.end,
+                limit,
+            )
+            return
+        metadata.add_request_metadata(r_meta)
+        logger.info(
+            "ExtraPrefixCache write allow request_id=%s cache_salt=%s range=%d-%d",
+            request_tracker.request_id,
+            request_tracker.cache_salt,
+            r_meta.op.start,
+            r_meta.op.end,
+        )

--- a/verl/workers/rollout/extra_prefix_cache/prefix_provider.py
+++ b/verl/workers/rollout/extra_prefix_cache/prefix_provider.py
@@ -1,0 +1,96 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+from typing import Any
+
+from .config import ExtraPrefixCacheConfig
+from .protocol import PrefixMetadata, short_hash
+
+
+class ExplicitPrefixProvider:
+    def resolve(self, prompt_ids: list[int], metadata: Any) -> PrefixMetadata | None:
+        if metadata is None:
+            return None
+        if not isinstance(metadata, dict):
+            return None
+
+        stable_len = metadata.get("stable_prefix_token_len", metadata.get("system_prefix_len"))
+        fingerprint = metadata.get("stable_prefix_fingerprint", metadata.get("system_prefix_fingerprint"))
+        try:
+            stable_len = int(stable_len)
+        except (TypeError, ValueError):
+            return None
+        if stable_len <= 0 or not fingerprint:
+            return None
+        if stable_len > len(prompt_ids):
+            return None
+
+        return PrefixMetadata(
+            stable_prefix_token_len=stable_len,
+            stable_prefix_fingerprint=str(fingerprint),
+            prefix_source=str(metadata.get("prefix_source", "explicit")),
+            tokenizer_fingerprint=(
+                str(metadata["tokenizer_fingerprint"]) if metadata.get("tokenizer_fingerprint") is not None else None
+            ),
+            template_fingerprint=(
+                str(metadata["template_fingerprint"]) if metadata.get("template_fingerprint") is not None else None
+            ),
+            extra=dict(metadata),
+        )
+
+
+class HeuristicPrefixProvider:
+    def __init__(self, config: ExtraPrefixCacheConfig) -> None:
+        self.config = config
+
+    def resolve(self, prompt_ids: list[int], metadata: Any) -> PrefixMetadata | None:
+        if not isinstance(metadata, dict):
+            return None
+        stable_len = metadata.get("stable_prefix_token_len")
+        try:
+            stable_len = int(stable_len)
+        except (TypeError, ValueError):
+            return None
+        min_len = self.config.heuristic_min_prefix_len
+        if stable_len <= 0 or stable_len > len(prompt_ids) or (min_len and stable_len < min_len):
+            return None
+        fingerprint = short_hash(
+            {
+                "tokens": hashlib.sha256(bytes(_token_bytes(prompt_ids[:stable_len]))).hexdigest(),
+                "tokenizer": self.config.tokenizer_fingerprint,
+                "template": self.config.template_fingerprint,
+            }
+        )
+        return PrefixMetadata(
+            stable_prefix_token_len=stable_len,
+            stable_prefix_fingerprint=fingerprint,
+            prefix_source="heuristic",
+            tokenizer_fingerprint=self.config.tokenizer_fingerprint,
+            template_fingerprint=self.config.template_fingerprint,
+            extra=dict(metadata),
+        )
+
+
+def get_prefix_provider(config: ExtraPrefixCacheConfig):
+    provider = config.prefix_provider.lower()
+    if provider == "heuristic":
+        return HeuristicPrefixProvider(config)
+    return ExplicitPrefixProvider()
+
+
+def _token_bytes(tokens: list[int]):
+    for token in tokens:
+        value = max(int(token), 0)
+        yield from value.to_bytes(8, "little", signed=False)

--- a/verl/workers/rollout/extra_prefix_cache/protocol.py
+++ b/verl/workers/rollout/extra_prefix_cache/protocol.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import hashlib
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from .config import ExtraPrefixCacheConfig, sanitize_salt
+
+REQUEST_ID_PREFIX = "vepc"
+_REQUEST_ID_RE = re.compile(r"^vepc__r(?P<read>[01])__w(?P<write>[01])__l(?P<limit>\d+)__")
+
+
+@dataclass(frozen=True)
+class PrefixMetadata:
+    stable_prefix_token_len: int
+    stable_prefix_fingerprint: str
+    prefix_source: str = "explicit"
+    tokenizer_fingerprint: str | None = None
+    template_fingerprint: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PreparedRequest:
+    enabled: bool
+    cache_salt: str | None = None
+    backend_request_id: str | None = None
+    stable_prefix_token_len: int = 0
+    store_token_limit: int = 0
+    warmup_prompt_ids: list[int] | None = None
+    warmup_backend_request_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RequestPolicy:
+    read: bool
+    write: bool
+    store_token_limit: int = 0
+    tagged: bool = True
+
+
+def short_hash(value: Any, length: int = 16) -> str:
+    payload = json.dumps(value, sort_keys=True, ensure_ascii=True, default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:length]
+
+
+def build_cache_salt(config: ExtraPrefixCacheConfig, metadata: PrefixMetadata, *, model_path: str | None = None) -> str:
+    model_namespace = config.model_namespace or model_path or "model"
+    model_hash = short_hash(model_namespace, length=10)
+    prefix_fingerprint = sanitize_salt(metadata.stable_prefix_fingerprint)
+    return sanitize_salt(f"{config.namespace}:{model_hash}:{config.epoch}:pfx{prefix_fingerprint}")
+
+
+def build_request_id(
+    *,
+    read: bool,
+    write: bool,
+    store_token_limit: int = 0,
+    base_request_id: str | None = None,
+) -> str:
+    base = base_request_id or uuid.uuid4().hex
+    read_flag = 1 if read else 0
+    write_flag = 1 if write else 0
+    limit = max(int(store_token_limit or 0), 0)
+    return f"{REQUEST_ID_PREFIX}__r{read_flag}__w{write_flag}__l{limit}__{base}"
+
+
+def parse_request_id(request_id: str, *, allow_untagged: bool = True) -> RequestPolicy:
+    match = _REQUEST_ID_RE.match(request_id or "")
+    if match is None:
+        return RequestPolicy(
+            read=allow_untagged,
+            write=allow_untagged,
+            store_token_limit=0,
+            tagged=False,
+        )
+    return RequestPolicy(
+        read=match.group("read") == "1",
+        write=match.group("write") == "1",
+        store_token_limit=int(match.group("limit")),
+        tagged=True,
+    )

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -33,6 +33,8 @@ from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
 from verl.utils import normalize_token_ids
 from verl.utils.ray_utils import auto_await
 from verl.utils.rollout_trace import rollout_trace_op
+from verl.workers.rollout.extra_prefix_cache import ExtraPrefixCacheController
+from verl.workers.rollout.extra_prefix_cache import enabled as extra_prefix_cache_enabled
 from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
 from verl.workers.rollout.utils import update_prometheus_config
 
@@ -185,6 +187,14 @@ class LLMServerClient:
         """
         self.config = config
         self._load_balancer = load_balancer_handle
+        rollout_config = self.config.actor_rollout_ref.rollout
+        epc_config = getattr(rollout_config, "extra_prefix_cache", None)
+        model_path = getattr(self.config.actor_rollout_ref.model, "path", None)
+        self._extra_prefix_cache = (
+            ExtraPrefixCacheController(epc_config, model_path=model_path, log=logger)
+            if rollout_config.name == "vllm" and extra_prefix_cache_enabled(epc_config)
+            else None
+        )
 
     async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
         # Atomic acquire: returns (server_id, handle) in one Ray RPC.
@@ -221,6 +231,7 @@ class LLMServerClient:
         """
         server_id, server = await self._acquire_server(request_id)
         try:
+            extra_prefix_cache_metadata = kwargs.pop("extra_prefix_cache_metadata", None)
             multimodal_kwargs = {}
             if audio_data is not None:
                 multimodal_kwargs["audio_data"] = audio_data
@@ -228,11 +239,42 @@ class LLMServerClient:
                 multimodal_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
             # priority is only supported by vLLM rollout server.
             priority = kwargs.pop("priority", 0)
+            backend_request_id = kwargs.pop("backend_request_id", uuid4().hex)
+            cache_salt = kwargs.pop("cache_salt", None)
+            if self._extra_prefix_cache is not None:
+                prepared = await self._extra_prefix_cache.prepare(
+                    prompt_ids=prompt_ids,
+                    metadata=extra_prefix_cache_metadata,
+                )
+                if prepared.enabled:
+                    backend_request_id = prepared.backend_request_id or backend_request_id
+                    cache_salt = prepared.cache_salt or cache_salt
+                    if prepared.warmup_prompt_ids is not None and prepared.warmup_backend_request_id is not None:
+                        warmup_sampling_params = dict(sampling_params)
+                        warmup_sampling_params["max_tokens"] = 1
+                        warmup_sampling_params.setdefault("temperature", 0.0)
+                        warmup_priority_kwargs = (
+                            {"priority": priority}
+                            if priority != 0 and self.config.actor_rollout_ref.rollout.name == "vllm"
+                            else {}
+                        )
+                        await server.generate.remote(
+                            request_id=prepared.warmup_backend_request_id,
+                            prompt_ids=prepared.warmup_prompt_ids,
+                            sampling_params=warmup_sampling_params,
+                            image_data=image_data,
+                            video_data=video_data,
+                            **multimodal_kwargs,
+                            **warmup_priority_kwargs,
+                            cache_salt=cache_salt,
+                        )
             priority_kwargs = (
                 {"priority": priority} if priority != 0 and self.config.actor_rollout_ref.rollout.name == "vllm" else {}
             )
+            if cache_salt:
+                kwargs["cache_salt"] = cache_salt
             output: TokenOutput = await server.generate.remote(
-                request_id=uuid4().hex,  # use new request_id for each turn
+                request_id=backend_request_id,  # use new request_id for each turn unless caller tags it
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=image_data,
@@ -299,6 +341,11 @@ class FullyAsyncLLMServerClient(LLMServerClient):
 
         while True:
             # 1. generate tokens
+            turn_kwargs = dict(kwargs)
+            if "backend_request_id" in turn_kwargs and final_output.token_ids:
+                turn_kwargs["backend_request_id"] = (
+                    f"{turn_kwargs['backend_request_id']}__resume{len(final_output.token_ids)}"
+                )
             output = await super().generate(
                 request_id=request_id,
                 prompt_ids=prompt_ids + final_output.token_ids,
@@ -307,7 +354,7 @@ class FullyAsyncLLMServerClient(LLMServerClient):
                 video_data=video_data,
                 audio_data=audio_data,
                 mm_processor_kwargs=mm_processor_kwargs,
-                **kwargs,
+                **turn_kwargs,
             )
 
             # 2. merge output into final_output

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -527,11 +527,13 @@ class vLLMHttpServer:
         mm_processor_kwargs: Optional[dict[str, Any]] = None,
         priority: int = 0,
         kv_transfer_params: Optional[dict] = None,
+        cache_salt: Optional[str] = None,
     ) -> TokenOutput:
         """Generate sequence with token-in-token-out.
 
         Args:
             kv_transfer_params: vLLM KV-transfer payload for PD requests.
+            cache_salt: Optional cache namespace used by vLLM prefix/KV cache.
         """
         if self._disaggregation_role == "prefill" and self._pd_decode_peers and kv_transfer_params is None:
             return await self._pd_dispatch(
@@ -603,6 +605,8 @@ class vLLMHttpServer:
             multi_modal_data["audio"] = audio_data
 
         prompt_kwargs = {"prompt_token_ids": prompt_ids, "multi_modal_data": multi_modal_data}
+        if cache_salt:
+            prompt_kwargs["cache_salt"] = cache_salt
         if mm_processor_kwargs:
             prompt_kwargs["mm_processor_kwargs"] = mm_processor_kwargs
         try:


### PR DESCRIPTION
### What does this PR do?

This PR adds **Extra Prefix Cache (EPC)** support on the verl rollout side.

EPC targets agent workloads where many rollout requests share the same stable system/tool prefix while the task-specific user content changes. It adds a verl-side policy and prefix protocol layer to:

- receive stable prefix metadata from the caller, such as `system_prefix_len` / `stable_prefix_token_len` and prefix fingerprint;
- issue prefix-only warmup requests to populate an external KV cache;
- allow rollout requests to read the warmed stable prefix from the external KV cache;
- prevent rollout requests from writing dynamic suffix tokens back into the prefix cache;
- isolate cache namespaces across model update steps to avoid reading stale KV.

The currently verified path is vLLM rollout backend + LMCache MP server through `VerlLMCacheExtraPrefixConnector`. The implementation reuses existing vLLM and LMCache extension points and does not require source changes in vLLM or LMCache.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`


### Test

Validated with local functional reuse and invalidation tests.

Covered scenarios:

- prefix warmup writes stable prefix KV into the external cache;
- rollout requests can reuse the warmed stable prefix;
- rollout requests do not write dynamic suffix tokens into the prefix cache;
- cache reuse is invalidated across model update steps.

Because train steps and parameter updates invalidate KV cache correctness, EPC uses a namespace hash salt strategy. Each step can be assigned an independent cache namespace, preventing rollout requests from reading KV produced by an earlier model version.

EPC is expected to provide larger benefits when:

- rollout batch size is large, e.g. `bsz >= 64`;
- the model is large;
- context length is long, e.g. `>64k`;
- GPU memory left for the rollout backend's own KV cache is limited.

When the rollout backend can already retain most shared prefixes in its own KV cache, most requests should be served by the backend-local cache and will not take the EPC path. In that case, EPC should not introduce meaningful runtime overhead except for the prefix warmup cost at the beginning of each step.

### API and Usage Example

EPC is disabled by default. It can be enabled under rollout config:

```bash
+actor_rollout_ref.rollout.extra_prefix_cache.enable=True
+actor_rollout_ref.rollout.extra_prefix_cache.backend=lmcache
+actor_rollout_ref.rollout.extra_prefix_cache.scope=system_prefix
+actor_rollout_ref.rollout.extra_prefix_cache.read_policy=rollout
+actor_rollout_ref.rollout.extra_prefix_cache.write_policy=warmup_only
+actor_rollout_ref.rollout.extra_prefix_cache.namespace=uni-agent-system-prefix
+actor_rollout_ref.rollout.extra_prefix_cache.model_cache_epoch=epoch0
+actor_rollout_ref.rollout.extra_prefix_cache.advance_epoch_on_weight_update=False
+actor_rollout_ref.rollout.extra_prefix_cache.chunk_size=64
```

For the verified vLLM + LMCache path, configure vLLM KV transfer to use the EPC-aware connector:

```bash
+actor_rollout_ref.rollout.engine_kwargs.vllm.disable_hybrid_kv_cache_manager=True
+actor_rollout_ref.rollout.engine_kwargs.vllm.kv_transfer_config="{kv_connector:VerlLMCacheExtraPrefixConnector,kv_connector_module_path:verl.workers.rollout.extra_prefix_cache.lmcache_connector,kv_role:kv_both,kv_connector_extra_config:{lmcache.mp.host:tcp://127.0.0.1,lmcache.mp.port:5555,lmcache.mp.mp_transfer_mode:engine_driven}}"
```

The caller may pass prefix metadata through request metadata:

```python
extra_prefix_cache_metadata = {
    "stable_prefix_token_len": system_prefix_len,
    "stable_prefix_fingerprint": system_prefix_fingerprint,
}
```

The default provider is `explicit`. It accepts either:

```python
{
    "stable_prefix_token_len": stable_prefix_token_len,
    "stable_prefix_fingerprint": stable_prefix_fingerprint,
}
```

or the uni-agent-compatible aliases:

```python
{
    "system_prefix_len": system_prefix_len,
    "system_prefix_fingerprint": system_prefix_fingerprint,
}
```

If no usable prefix metadata is provided, EPC skips the request instead of guessing the prefix boundary.

### Design & Code Changes

This PR adds a verl-side EPC module under:

```text
verl/workers/rollout/extra_prefix_cache
```

The main components are:

- EPC config and protocol definitions;
- prefix metadata providers;
- cache namespace / epoch management;
- rollout-side EPC controller;
- vLLM + LMCache connector integration;
- documentation for usage and backend adaptation.

At a high level, EPC prepares two request types for a shared prefix:

- a warmup request that writes only the stable prefix into the external KV cache;
- a rollout request that may read the stable prefix but must not write dynamic prompt or response tokens back into that prefix cache.

The external KV cache remains responsible for block storage and transfer. EPC supplies the verl-specific policy layer around it: prefix boundary selection, warmup orchestration, request tagging, namespace isolation, and model-epoch invalidation.

For cache correctness after training progresses, EPC can advance the runtime cache epoch after model weight updates. The namespace hash salt gives each step or epoch an independent cache namespace, preventing cross-step reuse of stale KV.

The current confirmed adapter uses vLLM `cache_salt` for namespace isolation and request-id tagging for read/write policy. The LMCache connector reads this policy before loading or storing KV blocks.

Other rollout backends or independent KV cache servers can adopt the same design if they support:

- a per-request cache namespace or salt;
- a request metadata channel for read/write policy;
- prefix-only warmup/store requests;
- preventing rollout requests from storing dynamic suffix KV.

Those integrations are expected to be lightweight, but they are not yet confirmed and should be validated with functional reuse and epoch invalidation tests.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: EPC requires an external LMCache MP server and a vLLM runtime with KV transfer enabled, so full end-to-end coverage may need to remain in integration/performance tests rather than default CI.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
