### PR TITLE
[fsdp, vllm, doc] feat: add experimental W4A8 QAT simulation

### DIFF
--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -1,6 +1,6 @@
 # NVFP4 QAT (Quantization-Aware Training) in verl
 
-Last updated: 07/06/2026
+Last updated: 2026-07-09
 
 verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quantization during training so the model learns to tolerate NVFP4 quantization error. At rollout time, weights are packed into real NVFP4 format for vLLM inference. This closes the precision gap between training and inference, preventing KL divergence explosion.
 
@@ -11,7 +11,7 @@ verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quanti
 | **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
 
 > [!WARNING]
-> W4A8 is an FSDP-only numerical simulation for dense models and the standard vLLM 0.15 NVFP4 MarlinExperts path. During rollout, weights use the existing NVFP4 W4A16 `compressed-tensors` kernels. Dense layer inputs are blockwise FP8 E4M3 quantized and dequantized; for fused MoE, both the gate/up input and the post-activation down-projection input receive the same Q/DQ. This does not execute a native W4A8 kernel and must not be used to claim W4A8 latency, throughput, or memory improvements. Within vLLM, non-Marlin NVFP4 backends and batched expert classes are rejected.
+> W4A8 is an FSDP-only numerical simulation for dense models and the standard NVFP4 MarlinExperts path. During rollout, weights use the existing NVFP4 W4A16 `compressed-tensors` kernels. Dense layer inputs are blockwise FP8 E4M3 quantized and dequantized; for fused MoE, both the gate/up input and the post-activation down-projection input receive the same Q/DQ. This does not execute a native W4A8 kernel and must not be used to claim W4A8 latency, throughput, or memory improvements. Other NVFP4 MoE backends are not supported.
 
 > [!TIP]
 > For ready-to-run scripts, environment setup, and experimental results, see the [QAT recipe](https://github.com/verl-project/verl-recipe/tree/main/qat).
@@ -42,7 +42,7 @@ actor_rollout_ref:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `fsdp_config.qat.enable` | Enable QAT | `False` |
-| `fsdp_config.qat.mode` | Quantization mode: `"w4a16"`, experimental `"w4a8"`, or `"w4a4"` | `"w4a16"` |
+| `fsdp_config.qat.mode` | Quantization mode; use experimental `"w4a8"` for W4A8 simulation | `"w4a16"` |
 | `fsdp_config.qat.group_size` | Quantization group size | `16` |
 | `fsdp_config.qat.ignore_patterns` | Layers to skip. Supports `re:` prefix for regex, otherwise substring match | `["lm_head", "embed_tokens", "re:.*mlp.gate$"]` |
 | `fsdp_config.qat.quantization_config_path` | vLLM quantization config JSON path | Required |
@@ -100,9 +100,8 @@ actor_rollout_ref:
 |---|---|---|---|---|
 | W4A16 | FSDP, Megatron | Dense, MoE | Native NVFP4 W4A16 | Supported |
 | W4A8 simulation | FSDP | Dense, MoE (Marlin) | FP8 Q/DQ + W4A16 kernel | Experimental |
-| W4A4 | FSDP | Dense, MoE | NVFP4 W4A4 | Experimental |
 
-Full and FFN-only quantization strategies are available in the linked recipe. W4A16 has been verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base; W4A8 numerical-simulation recipes cover both the dense Qwen3-8B-Base model and the MoE Qwen3-30B-A3B-Base model.
+Full and FFN-only quantization strategies are available in the linked recipe. W4A16 has been verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base; W4A8 example configurations target dense Qwen3-8B-Base and MoE Qwen3-30B-A3B-Base.
 
 ---
 
@@ -111,5 +110,4 @@ Full and FFN-only quantization strategies are available in the linked recipe. W4
 - FSDP backend has scalability limitations for very large models. For large-scale training, use the Megatron backend.
 - FSDP uses `re:` prefix regex for `ignore_patterns`, while Megatron uses `fnmatch` glob syntax. The two are not interchangeable.
 - W4A8 uses dynamic per-token FP8 E4M3 activation blocks of shape `1 x 128`; no activation scale is stored in checkpoints or sent with the packed weights.
-- W4A8 fused-MoE rollout currently requires vLLM 0.15's standard NVFP4 MarlinExperts path. Other vLLM NVFP4 backends and batched expert classes are rejected. Independent TensorRT-LLM and SGLang rollouts are outside this simulation's scope and have not been validated.
 - Native W4A8 kernels and Megatron W4A8 support are outside the scope of the current simulation.

--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -11,7 +11,7 @@ verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quanti
 | **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
 
 > [!WARNING]
-> W4A8 is currently a dense-model, FSDP-only numerical simulation. During vLLM rollout, weights use the existing NVFP4 W4A16 `compressed-tensors` path, while activations are blockwise FP8 E4M3 quantized and dequantized before the W4A16 kernel. It does not execute a native W4A8 kernel and must not be used to claim W4A8 latency, throughput, or memory improvements. Fused MoE models are rejected because the existing W4A16 path cannot reproduce FP8 quantization at both expert GEMM inputs.
+> W4A8 is an FSDP-only numerical simulation for dense models and the standard vLLM 0.15 NVFP4 MarlinExperts path. During rollout, weights use the existing NVFP4 W4A16 `compressed-tensors` kernels. Dense layer inputs are blockwise FP8 E4M3 quantized and dequantized; for fused MoE, both the gate/up input and the post-activation down-projection input receive the same Q/DQ. This does not execute a native W4A8 kernel and must not be used to claim W4A8 latency, throughput, or memory improvements. Within vLLM, non-Marlin NVFP4 backends and batched expert classes are rejected.
 
 > [!TIP]
 > For ready-to-run scripts, environment setup, and experimental results, see the [QAT recipe](https://github.com/verl-project/verl-recipe/tree/main/qat).
@@ -60,6 +60,7 @@ actor_rollout_ref:
         ignore_patterns:
           - "lm_head"
           - "embed_tokens"
+          - "re:.*mlp.gate$"
         quantization_config_path: "recipe/qat/config/nvfp4_w4a16.json"
 ```
 
@@ -98,10 +99,10 @@ actor_rollout_ref:
 | Mode | Training Backend | Model Type | Rollout Path | Status |
 |---|---|---|---|---|
 | W4A16 | FSDP, Megatron | Dense, MoE | Native NVFP4 W4A16 | Supported |
-| W4A8 simulation | FSDP | Dense | FP8 Q/DQ + W4A16 kernel | Experimental |
+| W4A8 simulation | FSDP | Dense, MoE (Marlin) | FP8 Q/DQ + W4A16 kernel | Experimental |
 | W4A4 | FSDP | Dense, MoE | NVFP4 W4A4 | Experimental |
 
-Full and FFN-only quantization strategies are available in the linked recipe. W4A16 has been verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base; the W4A8 numerical baseline targets Qwen3-8B-Base.
+Full and FFN-only quantization strategies are available in the linked recipe. W4A16 has been verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base; W4A8 numerical-simulation recipes cover both the dense Qwen3-8B-Base model and the MoE Qwen3-30B-A3B-Base model.
 
 ---
 
@@ -110,4 +111,5 @@ Full and FFN-only quantization strategies are available in the linked recipe. W4
 - FSDP backend has scalability limitations for very large models. For large-scale training, use the Megatron backend.
 - FSDP uses `re:` prefix regex for `ignore_patterns`, while Megatron uses `fnmatch` glob syntax. The two are not interchangeable.
 - W4A8 uses dynamic per-token FP8 E4M3 activation blocks of shape `1 x 128`; no activation scale is stored in checkpoints or sent with the packed weights.
+- W4A8 fused-MoE rollout currently requires vLLM 0.15's standard NVFP4 MarlinExperts path. Other vLLM NVFP4 backends and batched expert classes are rejected. Independent TensorRT-LLM and SGLang rollouts are outside this simulation's scope and have not been validated.
 - Native W4A8 kernels and Megatron W4A8 support are outside the scope of the current simulation.

--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -1,13 +1,17 @@
 # NVFP4 QAT (Quantization-Aware Training) in verl
 
-Last updated: 04/02/2026
+Last updated: 07/06/2026
 
 verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quantization during training so the model learns to tolerate NVFP4 quantization error. At rollout time, weights are packed into real NVFP4 format for vLLM inference. This closes the precision gap between training and inference, preventing KL divergence explosion.
 
 | Training Backend | Training Precision | Rollout Precision | vLLM Quant Method |
 |---|---|---|---|
 | **FSDP** | BF16 + fake quantization | NVFP4 W4A16 | `compressed-tensors` |
+| **FSDP (experimental)** | FP4 weight + FP8 activation fake quantization | W4A8 numerical simulation | `compressed-tensors` |
 | **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
+
+> [!WARNING]
+> W4A8 is currently a dense-model, FSDP-only numerical simulation. During vLLM rollout, weights use the existing NVFP4 W4A16 `compressed-tensors` path, while activations are blockwise FP8 E4M3 quantized and dequantized before the W4A16 kernel. It does not execute a native W4A8 kernel and must not be used to claim W4A8 latency, throughput, or memory improvements. Fused MoE models are rejected because the existing W4A16 path cannot reproduce FP8 quantization at both expert GEMM inputs.
 
 > [!TIP]
 > For ready-to-run scripts, environment setup, and experimental results, see the [QAT recipe](https://github.com/verl-project/verl-recipe/tree/main/qat).
@@ -38,10 +42,28 @@ actor_rollout_ref:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `fsdp_config.qat.enable` | Enable QAT | `False` |
-| `fsdp_config.qat.mode` | Quantization mode | `"w4a16"` |
+| `fsdp_config.qat.mode` | Quantization mode: `"w4a16"`, experimental `"w4a8"`, or `"w4a4"` | `"w4a16"` |
 | `fsdp_config.qat.group_size` | Quantization group size | `16` |
 | `fsdp_config.qat.ignore_patterns` | Layers to skip. Supports `re:` prefix for regex, otherwise substring match | `["lm_head", "embed_tokens", "re:.*mlp.gate$"]` |
 | `fsdp_config.qat.quantization_config_path` | vLLM quantization config JSON path | Required |
+
+For the experimental W4A8 simulation, set `mode: "w4a8"` but continue to use the W4A16 weight configuration:
+
+```yaml
+actor_rollout_ref:
+  actor:
+    fsdp_config:
+      qat:
+        enable: true
+        mode: "w4a8"
+        group_size: 16
+        ignore_patterns:
+          - "lm_head"
+          - "embed_tokens"
+        quantization_config_path: "recipe/qat/config/nvfp4_w4a16.json"
+```
+
+The W4A16 configuration is intentional: W4A8 simulation changes activation numerics only. FSDP still exports the same packed FP4 weights as W4A16, and verl automatically enables FP8 activation simulation in the vLLM subprocesses.
 
 ### Megatron Backend
 
@@ -73,11 +95,13 @@ actor_rollout_ref:
 
 ## Support Matrix
 
-- NVFP4 W4A16 (weight-only FP4 quantization)
-- Dense models and MoE models
-- FSDP and Megatron training backends
-- Full quantization and FFN-only quantization strategies
-- Verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base
+| Mode | Training Backend | Model Type | Rollout Path | Status |
+|---|---|---|---|---|
+| W4A16 | FSDP, Megatron | Dense, MoE | Native NVFP4 W4A16 | Supported |
+| W4A8 simulation | FSDP | Dense | FP8 Q/DQ + W4A16 kernel | Experimental |
+| W4A4 | FSDP | Dense, MoE | NVFP4 W4A4 | Experimental |
+
+Full and FFN-only quantization strategies are available in the linked recipe. W4A16 has been verified on Qwen3-8B-Base and Qwen3-30B-A3B-Base; the W4A8 numerical baseline targets Qwen3-8B-Base.
 
 ---
 
@@ -85,3 +109,5 @@ actor_rollout_ref:
 
 - FSDP backend has scalability limitations for very large models. For large-scale training, use the Megatron backend.
 - FSDP uses `re:` prefix regex for `ignore_patterns`, while Megatron uses `fnmatch` glob syntax. The two are not interchangeable.
+- W4A8 uses dynamic per-token FP8 E4M3 activation blocks of shape `1 x 128`; no activation scale is stored in checkpoints or sent with the packed weights.
+- Native W4A8 kernels and Megatron W4A8 support are outside the scope of the current simulation.

--- a/docs/low_precision/nvfp4_qat.md
+++ b/docs/low_precision/nvfp4_qat.md
@@ -7,7 +7,7 @@ verl supports NVFP4 Quantization-Aware Training (QAT), which applies fake quanti
 | Training Backend | Training Precision | Rollout Precision | vLLM Quant Method |
 |---|---|---|---|
 | **FSDP** | BF16 + fake quantization | NVFP4 W4A16 | `compressed-tensors` |
-| **FSDP (experimental)** | FP4 weight + FP8 activation fake quantization | W4A8 numerical simulation | `compressed-tensors` |
+| **FSDP (experimental)** | BF16 parameters + FP4 weight / FP8 activation fake quantization | W4A8 numerical simulation | `compressed-tensors` |
 | **Megatron** | BF16 + fake quantization | NVFP4 W4A16 | `modelopt` |
 
 > [!WARNING]

--- a/tests/utils/test_qat_w4a8.py
+++ b/tests/utils/test_qat_w4a8.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""GPU unit tests for the experimental dense W4A8 QAT simulation."""
+"""GPU unit tests for the experimental dense and MoE W4A8 QAT simulation."""
+
+import os
 
 import pytest
 
@@ -145,11 +147,105 @@ def test_rollout_wrapper_follows_configured_simulation_mode(monkeypatch):
     assert len(received) == 2
 
 
-def test_w4a8_simulation_rejects_fused_moe(monkeypatch):
-    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+def test_w4a8_mode_selects_marlin_for_moe_workers(monkeypatch):
+    monkeypatch.delenv(vllm_patch.W4A8_SIMULATION_ENV, raising=False)
+    monkeypatch.setenv(vllm_patch._VLLM_USE_FLASHINFER_MOE_ENV, "1")
+    monkeypatch.setenv(vllm_patch._VLLM_FORCE_MARLIN_ENV, "0")
 
-    with pytest.raises(NotImplementedError, match="supports dense models only"):
-        vllm_patch.patched_nvfp4_moe_process_weights_after_loading(None, None)
+    vllm_patch.set_w4a8_simulation(True)
+
+    assert vllm_patch.is_w4a8_simulation_enabled()
+    assert os.environ[vllm_patch._VLLM_USE_FLASHINFER_MOE_ENV] == "0"
+    assert os.environ[vllm_patch._VLLM_FORCE_MARLIN_ENV] == "1"
+
+    vllm_patch.set_w4a8_simulation(False)
+
+    assert not vllm_patch.is_w4a8_simulation_enabled()
+    assert os.environ[vllm_patch._VLLM_USE_FLASHINFER_MOE_ENV] == "1"
+    assert os.environ[vllm_patch._VLLM_FORCE_MARLIN_ENV] == "0"
+
+
+def test_w4a8_moe_wrapper_quantizes_both_expert_gemm_inputs(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
+
+    class RecordingMarlinExperts(MarlinExperts):
+        def __init__(self):
+            self.gate_up_input = None
+
+        def apply(self, output, hidden_states, *args, **kwargs):
+            self.gate_up_input = hidden_states
+            return hidden_states
+
+        def activation(self, activation, output, input):
+            output.copy_(input * 2)
+
+    quantized_inputs = []
+
+    def fake_quant(value):
+        quantized_inputs.append(value.clone())
+        return value + 1
+
+    monkeypatch.setattr(qat_linear, "fp8_e4m3_fake_quant", fake_quant)
+    wrapped_cls = vllm_patch._make_w4a8_moe_experts_cls(RecordingMarlinExperts)
+    experts = wrapped_cls()
+
+    hidden_states = torch.zeros(2, 16, device="cuda")
+    gate_up_result = experts.apply(torch.empty_like(hidden_states), hidden_states)
+    torch.testing.assert_close(gate_up_result, hidden_states + 1)
+    torch.testing.assert_close(experts.gate_up_input, hidden_states + 1)
+
+    activation_input = torch.full((2, 16), 2.0, device="cuda")
+    down_input = torch.empty_like(activation_input)
+    experts.activation("silu", down_input, activation_input)
+    torch.testing.assert_close(down_input, activation_input * 2 + 1)
+    assert len(quantized_inputs) == 2
+
+
+def test_w4a8_moe_wrapper_factory_is_idempotent():
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
+
+    wrapped_cls = vllm_patch._make_w4a8_moe_experts_cls(MarlinExperts)
+
+    assert vllm_patch._make_w4a8_moe_experts_cls(MarlinExperts) is wrapped_cls
+    assert vllm_patch._make_w4a8_moe_experts_cls(wrapped_cls) is wrapped_cls
+
+
+def test_w4a8_moe_rejects_non_marlin_backend(monkeypatch):
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+    method = SimpleNamespace(nvfp4_backend=NvFp4MoeBackend.FLASHINFER_CUTLASS)
+
+    with pytest.raises(NotImplementedError, match="requires the vLLM NVFP4 Marlin backend"):
+        vllm_patch.patched_nvfp4_moe_process_weights_after_loading(method, None)
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_w4a8_moe_process_uses_mode_specific_marlin_experts(monkeypatch, enabled):
+    from types import SimpleNamespace
+
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
+    from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+
+    processed = []
+    method = SimpleNamespace(nvfp4_backend=NvFp4MoeBackend.MARLIN, experts_cls=MarlinExperts)
+    layer = SimpleNamespace()
+
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1" if enabled else "0")
+    monkeypatch.setattr(vllm_patch, "_check_first_call", lambda _layer: False)
+    monkeypatch.setattr(
+        vllm_patch,
+        "_process_nvfp4_moe_marlin",
+        lambda _method, _layer, is_first_call, experts_cls=None: processed.append((is_first_call, experts_cls)),
+    )
+
+    vllm_patch.patched_nvfp4_moe_process_weights_after_loading(method, layer)
+
+    expected_cls = vllm_patch._make_w4a8_moe_experts_cls(MarlinExperts) if enabled else MarlinExperts
+    assert method.experts_cls is MarlinExperts
+    assert processed == [(False, expected_cls)]
 
 
 def test_apply_qat_patches_installs_real_vllm_w4a8_wrapper(monkeypatch):

--- a/tests/utils/test_qat_w4a8.py
+++ b/tests/utils/test_qat_w4a8.py
@@ -1,4 +1,5 @@
 # Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +33,23 @@ from verl.utils.qat.linear import QATLinear, QATMode, STEFP8Quant, fp8_e4m3_fake
 from verl.utils.qat.quantizer import QATQuantizer  # noqa: E402
 
 
+@pytest.fixture
+def restore_qat_patch_state():
+    """Restore process-wide vLLM patches installed by an integration test."""
+    previous_applied = list(vllm_patch._applied_patches)
+    previous_w4a8_patch = vllm_patch._w4a8_apply_patch
+    previous_original_apply = vllm_patch._original_w4a16_apply_weights
+    yield
+
+    if vllm_patch._w4a8_apply_patch is not previous_w4a8_patch and vllm_patch._w4a8_apply_patch is not None:
+        vllm_patch._w4a8_apply_patch.stop()
+    for patcher in reversed(vllm_patch._applied_patches[len(previous_applied) :]):
+        patcher.stop()
+    vllm_patch._applied_patches = previous_applied
+    vllm_patch._w4a8_apply_patch = previous_w4a8_patch
+    vllm_patch._original_w4a16_apply_weights = previous_original_apply
+
+
 def test_fp8_fake_quant_handles_noncontiguous_3d_input():
     x = torch.randn(2, 130, 3, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
     assert not x.is_contiguous()
@@ -55,6 +73,16 @@ def test_fp8_fake_quant_supports_rectangular_pytorch_fallback(monkeypatch):
     assert result.shape == x.shape
     assert result.dtype == x.dtype
     assert torch.isfinite(result).all()
+
+
+def test_fp8_fake_quant_handles_empty_token_batch():
+    x = torch.empty(0, 130, device="cuda", dtype=torch.bfloat16)
+
+    result = fp8_e4m3_fake_quant(x)
+
+    assert result.shape == x.shape
+    assert result.dtype == x.dtype
+    assert result.numel() == 0
 
 
 def test_fp8_fake_quant_matches_independent_blockwise_reference():
@@ -165,6 +193,26 @@ def test_w4a8_mode_selects_marlin_for_moe_workers(monkeypatch):
     assert os.environ[vllm_patch._VLLM_FORCE_MARLIN_ENV] == "0"
 
 
+def test_w4a8_configuration_rejects_unsupported_quant_method_and_clears_state(monkeypatch):
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+
+    with pytest.raises(ValueError, match="requires the compressed-tensors quantization method"):
+        vllm_patch.configure_w4a8_simulation("w4a8", "modelopt")
+
+    assert not vllm_patch.is_w4a8_simulation_enabled()
+    vllm_patch.configure_w4a8_simulation("w4a16", "compressed-tensors")
+    assert not vllm_patch.is_w4a8_simulation_enabled()
+
+
+def test_w4a8_rejects_unvalidated_vllm_version(monkeypatch):
+    import vllm
+
+    monkeypatch.setattr(vllm, "__version__", "0.16.0")
+
+    with pytest.raises(RuntimeError, match="requires vLLM 0.15.x"):
+        vllm_patch._validate_w4a8_vllm_version()
+
+
 def test_w4a8_moe_wrapper_quantizes_both_expert_gemm_inputs(monkeypatch):
     from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
 
@@ -223,7 +271,7 @@ def test_w4a8_moe_rejects_non_marlin_backend(monkeypatch):
 
 
 @pytest.mark.parametrize("enabled", [True, False])
-def test_w4a8_moe_process_uses_mode_specific_marlin_experts(monkeypatch, enabled):
+def test_w4a8_moe_process_persists_mode_specific_marlin_experts(monkeypatch, enabled):
     from types import SimpleNamespace
 
     from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
@@ -244,11 +292,11 @@ def test_w4a8_moe_process_uses_mode_specific_marlin_experts(monkeypatch, enabled
     vllm_patch.patched_nvfp4_moe_process_weights_after_loading(method, layer)
 
     expected_cls = vllm_patch._make_w4a8_moe_experts_cls(MarlinExperts) if enabled else MarlinExperts
-    assert method.experts_cls is MarlinExperts
+    assert method.experts_cls is expected_cls
     assert processed == [(False, expected_cls)]
 
 
-def test_apply_qat_patches_installs_real_vllm_w4a8_wrapper(monkeypatch):
+def test_apply_qat_patches_installs_real_vllm_w4a8_wrapper(monkeypatch, restore_qat_patch_state):
     from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a16_nvfp4 import (
         CompressedTensorsW4A16Fp4,
     )

--- a/tests/utils/test_qat_w4a8.py
+++ b/tests/utils/test_qat_w4a8.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU unit tests for the experimental dense W4A8 QAT simulation."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("triton")
+
+if not torch.cuda.is_available():
+    pytest.skip("W4A8 fake quantization requires a CUDA GPU", allow_module_level=True)
+
+from verl.utils.qat import linear as qat_linear  # noqa: E402
+from verl.utils.qat import vllm_patch  # noqa: E402
+from verl.utils.qat.linear import QATLinear, QATMode, STEFP8Quant, fp8_e4m3_fake_quant  # noqa: E402
+from verl.utils.qat.quantizer import QATQuantizer  # noqa: E402
+
+
+def test_fp8_fake_quant_handles_noncontiguous_3d_input():
+    x = torch.randn(2, 130, 3, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    assert not x.is_contiguous()
+
+    result = fp8_e4m3_fake_quant(x)
+
+    assert result.shape == x.shape
+    assert result.dtype == x.dtype
+    assert torch.isfinite(result).all()
+    assert not torch.equal(result, x)
+
+
+def test_fp8_fake_quant_supports_rectangular_pytorch_fallback(monkeypatch):
+    from verl.utils.kernel import fp8_kernel
+
+    monkeypatch.setattr(fp8_kernel, "_TRITON_AVAILABLE", False)
+    x = torch.randn(3, 130, device="cuda", dtype=torch.bfloat16)
+
+    result = fp8_e4m3_fake_quant(x)
+
+    assert result.shape == x.shape
+    assert result.dtype == x.dtype
+    assert torch.isfinite(result).all()
+
+
+def test_fp8_fake_quant_matches_independent_blockwise_reference():
+    x = torch.tensor(
+        [[-9.0, -2.5, 0.75, 8.0, -1.0, 0.5, 3.0, 6.5]],
+        device="cuda",
+        dtype=torch.float32,
+    )
+    result = fp8_e4m3_fake_quant(x, block_size=(1, 4))
+
+    blocks = x.reshape(1, 2, 4)
+    descale = blocks.abs().amax(dim=-1, keepdim=True) / 448.0
+    quantized = torch.clamp(blocks / descale, min=-448.0, max=448.0).to(torch.float8_e4m3fn)
+    expected = (quantized.float() * descale).reshape_as(x)
+
+    torch.testing.assert_close(result, expected, rtol=0, atol=0)
+
+
+def test_fp8_ste_passes_gradient_through_unchanged():
+    x = torch.randn(2, 3, 130, device="cuda", dtype=torch.float32, requires_grad=True)
+    upstream = torch.randn_like(x)
+
+    result = STEFP8Quant.apply(x, (1, 128))
+    result.backward(upstream)
+
+    torch.testing.assert_close(x.grad, upstream)
+
+
+def test_qat_linear_uses_fp8_activation_only_in_w4a8(monkeypatch):
+    layer = QATLinear(16, 8, mode=QATMode.W4A8, device=torch.device("cuda"), dtype=torch.float32)
+    x = torch.randn(2, 16, device="cuda")
+    activation_calls = []
+
+    monkeypatch.setattr(layer, "_fake_quantize_weight", lambda weight: weight)
+
+    def fake_activation(value):
+        activation_calls.append(value)
+        return value + 1
+
+    monkeypatch.setattr(layer, "_fake_quantize_activation_fp8", fake_activation)
+    result = layer(x)
+
+    assert len(activation_calls) == 1
+    assert activation_calls[0] is x
+    expected = torch.nn.functional.linear(x + 1, layer.weight, layer.bias)
+    torch.testing.assert_close(result, expected)
+
+
+def test_w4a8_and_w4a16_export_identical_weight_payloads():
+    params = {
+        "model.layers.0.mlp.up_proj.weight": torch.randn(16, 16, dtype=torch.bfloat16),
+    }
+
+    def export(mode):
+        quantizer = QATQuantizer(mode=mode, device=torch.device("cuda"), param_dtype=torch.bfloat16)
+        return dict(quantizer.quantize_with_fusion(params, target_device=torch.device("cpu")))
+
+    w4a8 = export("w4a8")
+    w4a16 = export("w4a16")
+
+    assert w4a8.keys() == w4a16.keys()
+    assert not any("input_global_scale" in name for name in w4a8)
+    for name in w4a8:
+        torch.testing.assert_close(w4a8[name], w4a16[name], rtol=0, atol=0)
+
+
+def test_qat_quantizer_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="Unsupported QAT mode"):
+        QATQuantizer(mode="w4a7", device=torch.device("cuda"))
+
+
+def test_rollout_wrapper_follows_configured_simulation_mode(monkeypatch):
+    received = []
+
+    def original(_self, _layer, x, bias=None):
+        received.append((x, bias))
+        return x
+
+    monkeypatch.setattr(vllm_patch, "_original_w4a16_apply_weights", original)
+    monkeypatch.setattr(qat_linear, "fp8_e4m3_fake_quant", lambda x: x + 1)
+
+    x = torch.zeros(2, 16, device="cuda")
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+    simulated = vllm_patch.patched_w4a16_apply_weights_with_w4a8_simulation(None, None, x)
+    torch.testing.assert_close(simulated, x + 1)
+
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "0")
+    passthrough = vllm_patch.patched_w4a16_apply_weights_with_w4a8_simulation(None, None, x)
+    torch.testing.assert_close(passthrough, x)
+    assert len(received) == 2
+
+
+def test_w4a8_simulation_rejects_fused_moe(monkeypatch):
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+
+    with pytest.raises(NotImplementedError, match="supports dense models only"):
+        vllm_patch.patched_nvfp4_moe_process_weights_after_loading(None, None)
+
+
+def test_apply_qat_patches_installs_real_vllm_w4a8_wrapper(monkeypatch):
+    from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a16_nvfp4 import (
+        CompressedTensorsW4A16Fp4,
+    )
+
+    monkeypatch.setenv(vllm_patch.W4A8_SIMULATION_ENV, "1")
+    vllm_patch.apply_qat_patches()
+
+    assert vllm_patch._w4a8_apply_patch is not None
+    assert CompressedTensorsW4A16Fp4.apply_weights is vllm_patch.patched_w4a16_apply_weights_with_w4a8_simulation

--- a/tests/utils/test_qat_w4a8.py
+++ b/tests/utils/test_qat_w4a8.py
@@ -18,6 +18,8 @@ import pytest
 
 torch = pytest.importorskip("torch")
 pytest.importorskip("triton")
+pytest.importorskip("compressed_tensors")
+pytest.importorskip("vllm")
 
 if not torch.cuda.is_available():
     pytest.skip("W4A8 fake quantization requires a CUDA GPU", allow_module_level=True)

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -292,7 +292,7 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only). "w4a4" is experimental and not recommended.
+  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense simulation), or "w4a4" (experimental).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)
@@ -310,4 +310,3 @@ qat:
 
   # Path to vLLM quantization config JSON file
   quantization_config_path: null
-

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -284,15 +284,17 @@ router_replay:
 #   - QAT is automatically applied to actor model during training
 #   - Fused scales (QKV/GateUp) are automatically enabled for training-inference consistency
 #   - Fast quantization is used when syncing weights to vLLM rollout
-# Supported modes: "w4a16" (NVFP4 weight-only), "w4a8" (dense/supported-MoE numerical simulation),
-# and "w4a4" (experimental; currently has KL divergence issues and is NOT recommended for use).
+# Supported modes: "w4a16" (NVFP4 weight-only) and "w4a8"
+# (dense and standard Marlin MoE numerical simulation).
+# Note: "w4a4" mode is included in the code but currently has KL divergence issues and is NOT recommended for use.
 # For usage examples, see: https://github.com/verl-project/verl-recipe/blob/main/qat/README.md
 qat:
 
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense/supported-MoE simulation), or "w4a4" (experimental).
+  # Quantization mode: "w4a16" (weight-only) or "w4a8" (dense and standard Marlin MoE simulation).
+  # "w4a4" is experimental and not recommended.
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -284,7 +284,7 @@ router_replay:
 #   - QAT is automatically applied to actor model during training
 #   - Fused scales (QKV/GateUp) are automatically enabled for training-inference consistency
 #   - Fast quantization is used when syncing weights to vLLM rollout
-# Supported modes: "w4a16" (NVFP4 weight-only), "w4a8" (dense numerical simulation),
+# Supported modes: "w4a16" (NVFP4 weight-only), "w4a8" (dense/supported-MoE numerical simulation),
 # and "w4a4" (experimental; currently has KL divergence issues and is NOT recommended for use).
 # For usage examples, see: https://github.com/verl-project/verl-recipe/blob/main/qat/README.md
 qat:
@@ -292,7 +292,7 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense simulation), or "w4a4" (experimental).
+  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense/supported-MoE simulation), or "w4a4" (experimental).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -284,8 +284,8 @@ router_replay:
 #   - QAT is automatically applied to actor model during training
 #   - Fused scales (QKV/GateUp) are automatically enabled for training-inference consistency
 #   - Fast quantization is used when syncing weights to vLLM rollout
-# Supported modes: "w4a16" (NVFP4 weight-only)
-# Note: "w4a4" mode is included in the code but currently has KL divergence issues and is NOT recommended for use.
+# Supported modes: "w4a16" (NVFP4 weight-only), "w4a8" (dense numerical simulation),
+# and "w4a4" (experimental; currently has KL divergence issues and is NOT recommended for use).
 # For usage examples, see: https://github.com/verl-project/verl-recipe/blob/main/qat/README.md
 qat:
 

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -74,7 +74,7 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only). "w4a4" is experimental and not recommended.
+  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense simulation), or "w4a4" (experimental).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -74,7 +74,8 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense/supported-MoE simulation), or "w4a4" (experimental).
+  # Quantization mode: "w4a16" (weight-only) or "w4a8" (dense and standard Marlin MoE simulation).
+  # "w4a4" is experimental and not recommended.
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/trainer/config/engine/fsdp.yaml
+++ b/verl/trainer/config/engine/fsdp.yaml
@@ -74,7 +74,7 @@ qat:
   # Whether to enable QAT
   enable: false
 
-  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense simulation), or "w4a4" (experimental).
+  # Quantization mode: "w4a16" (weight-only), "w4a8" (dense/supported-MoE simulation), or "w4a4" (experimental).
   mode: "w4a16"
 
   # Quantization group size (NVFP4 requires 16)

--- a/verl/utils/kernel/fp8_kernel.py
+++ b/verl/utils/kernel/fp8_kernel.py
@@ -246,7 +246,6 @@ def _scaled_fp8_blockwise_pytorch(
     """
     block_size0 = weight_block_size[0]
     block_size1 = weight_block_size[1]
-    assert block_size0 == block_size1, "Block sizes must be equal"
 
     # Save unpadded shape for later cropping
     original_shape = data_hp.shape

--- a/verl/utils/qat/__init__.py
+++ b/verl/utils/qat/__init__.py
@@ -15,7 +15,8 @@
 """
 QAT (Quantization-Aware Training) module for verl.
 
-Supports NVFP4 W4A4/W4A16 and experimental dense W4A8 simulation for FSDP training.
+Supports NVFP4 W4A4/W4A16 and experimental W4A8 simulation for FSDP training,
+including dense layers and the standard vLLM Marlin MoE path.
 
 Module Structure:
 - core.py: QATConfig, apply_qat, enable_qat_fuse (training setup)
@@ -39,10 +40,9 @@ from verl.utils.qat.core import (
 )
 from verl.utils.qat.vllm_patch import (
     apply_qat_patches,
-    is_w4a8_simulation_enabled,
+    configure_w4a8_simulation,
     manual_process_weights_after_loading,
     prepare_qat_for_load_weights,
-    set_w4a8_simulation,
 )
 
 __all__ = [
@@ -54,8 +54,7 @@ __all__ = [
     "invalidate_all_scales",
     # vLLM Patch
     "apply_qat_patches",
+    "configure_w4a8_simulation",
     "manual_process_weights_after_loading",
     "prepare_qat_for_load_weights",
-    "set_w4a8_simulation",
-    "is_w4a8_simulation_enabled",
 ]

--- a/verl/utils/qat/__init__.py
+++ b/verl/utils/qat/__init__.py
@@ -15,7 +15,7 @@
 """
 QAT (Quantization-Aware Training) module for verl.
 
-Supports NVFP4 (W4A4 and W4A16) quantization modes for FSDP training.
+Supports NVFP4 W4A4/W4A16 and experimental dense W4A8 simulation for FSDP training.
 
 Module Structure:
 - core.py: QATConfig, apply_qat, enable_qat_fuse (training setup)
@@ -39,8 +39,10 @@ from verl.utils.qat.core import (
 )
 from verl.utils.qat.vllm_patch import (
     apply_qat_patches,
+    is_w4a8_simulation_enabled,
     manual_process_weights_after_loading,
     prepare_qat_for_load_weights,
+    set_w4a8_simulation,
 )
 
 __all__ = [
@@ -54,4 +56,6 @@ __all__ = [
     "apply_qat_patches",
     "manual_process_weights_after_loading",
     "prepare_qat_for_load_weights",
+    "set_w4a8_simulation",
+    "is_w4a8_simulation_enabled",
 ]

--- a/verl/utils/qat/linear.py
+++ b/verl/utils/qat/linear.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""QAT FakeQuantized Linear module for NVFP4 (W4A4/W4A16) with FSDP compatibility.
+"""QAT FakeQuantized Linear module for NVFP4 (W4A4/W4A8/W4A16) with FSDP compatibility.
 
 Includes Triton kernels for high-performance FP4 quantization.
 """
@@ -24,7 +24,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-__all__ = ["QATLinear", "QATMode"]
+__all__ = ["QATLinear", "QATMode", "W4A8_ACTIVATION_BLOCK_SIZE", "fp8_e4m3_fake_quant"]
 
 
 import triton
@@ -37,6 +37,7 @@ _TORCH_TO_TL_DTYPE = {
 }
 FP4_E2M1_MAX: float = 6.0
 FP8_E4M3_MAX: float = 448.0
+W4A8_ACTIVATION_BLOCK_SIZE: tuple[int, int] = (1, 128)
 
 
 @triton.jit
@@ -185,10 +186,66 @@ class STEFP4QuantTriton(torch.autograd.Function):
         return grad_output, None, None
 
 
+def fp8_e4m3_fake_quant(
+    x: torch.Tensor,
+    block_size: tuple[int, int] = W4A8_ACTIVATION_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Numerically simulate blockwise FP8 E4M3 activations in the input dtype.
+
+    The returned tensor contains FP8 quantize-dequantize noise but remains in
+    ``x.dtype`` so it can be consumed by the existing W4A16 kernels.
+    """
+    from verl.utils.kernel.fp8_kernel import scaled_fp8_blockwise
+
+    if x.ndim == 0:
+        raise ValueError("FP8 activation fake quantization requires at least one dimension")
+
+    block_m, block_n = block_size
+    if block_m <= 0 or block_n <= 0:
+        raise ValueError(f"FP8 block dimensions must be positive, got {block_size}")
+
+    original_shape = x.shape
+    x_2d = x.reshape(-1, x.shape[-1])
+    fp8_data, descale = scaled_fp8_blockwise(x_2d, block_size)
+
+    # The PyTorch fallback retains a trailing singleton dimension while the
+    # Triton path returns a 2D scale tensor. Normalize both representations.
+    if descale.ndim == 3 and descale.shape[-1] == 1:
+        descale = descale.squeeze(-1)
+    if descale.ndim != 2:
+        raise RuntimeError(f"Expected a 2D FP8 descale tensor, got shape {tuple(descale.shape)}")
+
+    rows, cols = x_2d.shape
+    expected_scale_shape = (
+        (rows + block_m - 1) // block_m,
+        (cols + block_n - 1) // block_n,
+    )
+    if tuple(descale.shape) != expected_scale_shape:
+        raise RuntimeError(f"Unexpected FP8 descale shape {tuple(descale.shape)}; expected {expected_scale_shape}")
+
+    descale_expanded = descale.repeat_interleave(block_m, dim=0).repeat_interleave(block_n, dim=1)
+    descale_expanded = descale_expanded[:rows, :cols]
+    dequantized = fp8_data.float() * descale_expanded.float()
+    return dequantized.to(x.dtype).reshape(original_shape)
+
+
+class STEFP8Quant(torch.autograd.Function):
+    """Straight-through estimator for blockwise FP8 E4M3 fake quantization."""
+
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, block_size: tuple[int, int]) -> torch.Tensor:
+        return fp8_e4m3_fake_quant(x, block_size)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor) -> tuple:
+        return grad_output, None
+
+
 class QATMode(str, Enum):
     """QAT quantization mode."""
 
     W4A4 = "w4a4"  # Weight 4-bit, Activation 4-bit (dynamic)
+    W4A8 = "w4a8"  # Weight 4-bit, Activation 8-bit (numerical simulation)
     W4A16 = "w4a16"  # Weight 4-bit, Activation 16-bit (weight only)
 
 
@@ -229,6 +286,10 @@ class QATLinear(nn.Linear):
             )
 
             self._ema_decay: float = 0.01
+
+        # W4A8 uses dynamic per-token, 128-element FP8 activation blocks and
+        # therefore does not need a persistent activation scale.
+        self._w4a8_block_size = W4A8_ACTIVATION_BLOCK_SIZE
 
         self.fake_quant_enabled = True
 
@@ -363,6 +424,10 @@ class QATLinear(nn.Linear):
         result = STEFP4QuantTriton.apply(x_2d, global_amax, self.group_size)
         return result.view(original_shape)
 
+    def _fake_quantize_activation_fp8(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply dynamic FP8 E4M3 fake quantization for W4A8 simulation."""
+        return STEFP8Quant.apply(x, self._w4a8_block_size)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass with fake quantization."""
         if not self.fake_quant_enabled:
@@ -372,6 +437,8 @@ class QATLinear(nn.Linear):
 
         if self.mode == QATMode.W4A4:
             x_fq = self._fake_quantize_activation(x)
+        elif self.mode == QATMode.W4A8:
+            x_fq = self._fake_quantize_activation_fp8(x)
         else:
             x_fq = x
 

--- a/verl/utils/qat/linear.py
+++ b/verl/utils/qat/linear.py
@@ -203,6 +203,8 @@ def fp8_e4m3_fake_quant(
     block_m, block_n = block_size
     if block_m <= 0 or block_n <= 0:
         raise ValueError(f"FP8 block dimensions must be positive, got {block_size}")
+    if x.numel() == 0:
+        return x.clone()
 
     original_shape = x.shape
     x_2d = x.reshape(-1, x.shape[-1])

--- a/verl/utils/qat/quantizer.py
+++ b/verl/utils/qat/quantizer.py
@@ -130,6 +130,12 @@ class QATQuantizer:
         param_dtype: Optional[torch.dtype] = None,
     ):
         self.mode = mode.lower()
+        supported_modes = {"w4a4", "w4a8", "w4a16"}
+        if self.mode not in supported_modes:
+            raise ValueError(f"Unsupported QAT mode {mode!r}; expected one of {sorted(supported_modes)}")
+
+        # W4A8 is currently a numerical simulation: it exports the same NVFP4
+        # weight payload as W4A16, while rollout injects FP8 activation noise.
         self._is_w4a4 = self.mode == "w4a4"  # W4A4 needs input_global_scale
         self.group_size = group_size
         self.ignore_patterns = ignore_patterns or ["lm_head", "embed_tokens", "re:.*mlp.gate$"]

--- a/verl/utils/qat/vllm_patch.py
+++ b/verl/utils/qat/vllm_patch.py
@@ -19,7 +19,7 @@ Enables dynamic weight reloading for NVFP4 quantized models in vLLM.
 
 Supported schemes:
 - Dense: W4A16-FP4, W4A4-FP4, experimental W4A8 simulation
-- MoE: NVFP4-MoE
+- MoE: NVFP4-MoE, experimental W4A8 simulation on the Marlin path
 """
 
 import logging
@@ -36,11 +36,35 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 W4A8_SIMULATION_ENV = "VERL_W4A8_SIMULATION"
+_VLLM_FORCE_MARLIN_ENV = "VLLM_TEST_FORCE_FP8_MARLIN"
+_VLLM_USE_FLASHINFER_MOE_ENV = "VLLM_USE_FLASHINFER_MOE_FP4"
+_W4A8_MOE_EXPERTS_CLASS_CACHE: dict[type, type] = {}
+_W4A8_PREVIOUS_VLLM_ENV: Optional[dict[str, Optional[str]]] = None
 
 
 def set_w4a8_simulation(enabled: bool) -> None:
     """Propagate the configured W4A8 simulation mode to vLLM subprocesses."""
+    global _W4A8_PREVIOUS_VLLM_ENV
+
     os.environ[W4A8_SIMULATION_ENV] = "1" if enabled else "0"
+    if enabled:
+        # vLLM 0.15 exposes Marlin selection for this oracle through these
+        # environment switches. Set them here so qat.mode remains the only
+        # user-facing control and worker subprocesses inherit a valid backend.
+        if _W4A8_PREVIOUS_VLLM_ENV is None:
+            _W4A8_PREVIOUS_VLLM_ENV = {
+                _VLLM_USE_FLASHINFER_MOE_ENV: os.environ.get(_VLLM_USE_FLASHINFER_MOE_ENV),
+                _VLLM_FORCE_MARLIN_ENV: os.environ.get(_VLLM_FORCE_MARLIN_ENV),
+            }
+        os.environ[_VLLM_USE_FLASHINFER_MOE_ENV] = "0"
+        os.environ[_VLLM_FORCE_MARLIN_ENV] = "1"
+    elif _W4A8_PREVIOUS_VLLM_ENV is not None:
+        for name, value in _W4A8_PREVIOUS_VLLM_ENV.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        _W4A8_PREVIOUS_VLLM_ENV = None
 
 
 def is_w4a8_simulation_enabled() -> bool:
@@ -504,8 +528,47 @@ def _marlin_process_scales_experts(scale_hf, param_dtype, size_k, size_n, group_
     return torch.stack(result)
 
 
-def _process_nvfp4_moe_marlin(self, layer: torch.nn.Module, is_first_call: bool) -> None:
-    """Process MoE layer with MARLIN backend (W4A16)."""
+def _make_w4a8_moe_experts_cls(experts_cls: type) -> type:
+    """Wrap standard Marlin experts with FP8 Q/DQ at both expert GEMM inputs."""
+    from vllm.model_executor.layers.fused_moe.fused_marlin_moe import MarlinExperts
+
+    if getattr(experts_cls, "_verl_w4a8_simulation", False):
+        return experts_cls
+    if not isinstance(experts_cls, type) or not issubclass(experts_cls, MarlinExperts):
+        raise NotImplementedError(
+            "W4A8 fused-MoE simulation requires the standard vLLM MarlinExperts path; "
+            "other vLLM NVFP4 backends and batched expert classes are not supported."
+        )
+
+    cached_cls = _W4A8_MOE_EXPERTS_CLASS_CACHE.get(experts_cls)
+    if cached_cls is not None:
+        return cached_cls
+
+    class W4A8MarlinExperts(experts_cls):
+        _verl_w4a8_simulation = True
+
+        def apply(self, output, hidden_states, *args, **kwargs):
+            from verl.utils.qat.linear import fp8_e4m3_fake_quant
+
+            hidden_states = fp8_e4m3_fake_quant(hidden_states)
+            return super().apply(output, hidden_states, *args, **kwargs)
+
+        def activation(self, activation, output, input):
+            from verl.utils.qat.linear import fp8_e4m3_fake_quant
+
+            super().activation(activation, output, input)
+            output.copy_(fp8_e4m3_fake_quant(output))
+
+    W4A8MarlinExperts.__name__ = f"W4A8{experts_cls.__name__}"
+    W4A8MarlinExperts.__qualname__ = W4A8MarlinExperts.__name__
+    _W4A8_MOE_EXPERTS_CLASS_CACHE[experts_cls] = W4A8MarlinExperts
+    return W4A8MarlinExperts
+
+
+def _process_nvfp4_moe_marlin(
+    self, layer: torch.nn.Module, is_first_call: bool, experts_cls: Optional[type] = None
+) -> None:
+    """Process MoE layer with the Marlin W4A16 or W4A8-simulation path."""
     from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import make_nvfp4_moe_kernel
     from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
         marlin_make_workspace_new,
@@ -591,7 +654,7 @@ def _process_nvfp4_moe_marlin(self, layer: torch.nn.Module, is_first_call: bool)
         self.kernel = make_nvfp4_moe_kernel(
             moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
-            experts_cls=self.experts_cls,
+            experts_cls=self.experts_cls if experts_cls is None else experts_cls,
         )
 
 
@@ -692,13 +755,18 @@ def _process_nvfp4_moe_flashinfer_cutlass(self, layer: torch.nn.Module, is_first
 # MoE NVFP4 Patches (entry points)
 def patched_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
     """Patched process_weights_after_loading for NVFP4 MoE layer."""
-    if is_w4a8_simulation_enabled():
-        raise NotImplementedError(
-            "W4A8 simulation currently supports dense models only. A fused MoE kernel cannot reproduce "
-            "FP8 fake quantization at both expert GEMM inputs through the existing W4A16 rollout path."
-        )
-
     from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
+
+    is_marlin = self.nvfp4_backend == NvFp4MoeBackend.MARLIN
+    if is_w4a8_simulation_enabled():
+        if not is_marlin:
+            raise NotImplementedError(
+                "W4A8 fused-MoE simulation requires the vLLM NVFP4 Marlin backend; "
+                f"selected backend: {self.nvfp4_backend}."
+            )
+        experts_cls = _make_w4a8_moe_experts_cls(self.experts_cls)
+    else:
+        experts_cls = self.experts_cls
 
     is_first_call = _check_first_call(layer)
 
@@ -715,9 +783,8 @@ def patched_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module
             if param is not None and hasattr(param, "weight_loader"):
                 layer._weight_loaders[pname] = param.weight_loader
 
-    is_marlin = self.nvfp4_backend == NvFp4MoeBackend.MARLIN
     if is_marlin:
-        _process_nvfp4_moe_marlin(self, layer, is_first_call)
+        _process_nvfp4_moe_marlin(self, layer, is_first_call, experts_cls=experts_cls)
     else:
         _process_nvfp4_moe_flashinfer_cutlass(self, layer, is_first_call)
 
@@ -755,7 +822,7 @@ _original_w4a16_apply_weights = None
 
 
 def patched_w4a16_apply_weights_with_w4a8_simulation(self, layer, x, bias=None):
-    """Inject FP8 activation noise before the existing dense W4A16 kernel."""
+    """Inject FP8 activation Q/DQ before the existing dense W4A16 kernel."""
     if is_w4a8_simulation_enabled():
         from verl.utils.qat.linear import fp8_e4m3_fake_quant
 
@@ -793,7 +860,8 @@ def apply_qat_patches():
         _w4a8_apply_patch = patch(target, patched_w4a16_apply_weights_with_w4a8_simulation)
         _w4a8_apply_patch.start()
         logger.warning(
-            "Enabled experimental dense W4A8 simulation: activations are FP8 fake-quantized before the W4A16 kernel"
+            "Enabled experimental W4A8 simulation: dense and supported fused-MoE inputs are FP8 "
+            "fake-quantized before W4A16 Marlin kernels"
         )
 
     return _applied_patches

--- a/verl/utils/qat/vllm_patch.py
+++ b/verl/utils/qat/vllm_patch.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 W4A8_SIMULATION_ENV = "VERL_W4A8_SIMULATION"
+_W4A8_SUPPORTED_VLLM_PREFIX = "0.15."
 _VLLM_FORCE_MARLIN_ENV = "VLLM_TEST_FORCE_FP8_MARLIN"
 _VLLM_USE_FLASHINFER_MOE_ENV = "VLLM_USE_FLASHINFER_MOE_FP4"
 _W4A8_MOE_EXPERTS_CLASS_CACHE: dict[type, type] = {}
@@ -70,6 +71,28 @@ def set_w4a8_simulation(enabled: bool) -> None:
 def is_w4a8_simulation_enabled() -> bool:
     """Return whether the current process is running the W4A8 simulation."""
     return os.environ.get(W4A8_SIMULATION_ENV, "0") == "1"
+
+
+def configure_w4a8_simulation(qat_mode: str, quant_method: Optional[str]) -> None:
+    """Enable W4A8 only for the supported compressed-tensors rollout path."""
+    set_w4a8_simulation(False)
+    if qat_mode.lower() != "w4a8":
+        return
+    if quant_method != "compressed-tensors":
+        raise ValueError(f"W4A8 simulation requires the compressed-tensors quantization method; got {quant_method!r}.")
+    set_w4a8_simulation(True)
+
+
+def _validate_w4a8_vllm_version() -> None:
+    """Fail clearly when vLLM does not provide the validated internal APIs."""
+    import vllm
+
+    version = getattr(vllm, "__version__", "unknown")
+    if not version.startswith(_W4A8_SUPPORTED_VLLM_PREFIX):
+        raise RuntimeError(
+            "W4A8 simulation currently requires vLLM 0.15.x because it patches version-specific "
+            f"Marlin APIs; found vLLM {version}."
+        )
 
 
 class ParamMetaDict(dict):
@@ -764,7 +787,12 @@ def patched_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module
                 "W4A8 fused-MoE simulation requires the vLLM NVFP4 Marlin backend; "
                 f"selected backend: {self.nvfp4_backend}."
             )
-        experts_cls = _make_w4a8_moe_experts_cls(self.experts_cls)
+        # vLLM may defer kernel construction to select_gemm_impl() for
+        # non-naive all-to-all paths, where it reads self.experts_cls again.
+        # Persist the wrapper so both eager and deferred construction apply
+        # activation Q/DQ at the two expert GEMM inputs.
+        self.experts_cls = _make_w4a8_moe_experts_cls(self.experts_cls)
+        experts_cls = self.experts_cls
     else:
         experts_cls = self.experts_cls
 
@@ -836,6 +864,9 @@ def patched_w4a16_apply_weights_with_w4a8_simulation(self, layer, x, bias=None):
 def apply_qat_patches():
     """Apply NVFP4 patches to support dynamic weight updates. Call before model loading."""
     global _applied_patches, _original_w4a16_apply_weights, _w4a8_apply_patch
+
+    if is_w4a8_simulation_enabled():
+        _validate_w4a8_vllm_version()
 
     if not _applied_patches:
         logger.info("Applying NVFP4 patches for dynamic weight loading...")
@@ -937,8 +968,7 @@ def manual_process_weights_after_loading(model):
 
 __all__ = [
     "apply_qat_patches",
+    "configure_w4a8_simulation",
     "prepare_qat_for_load_weights",
     "manual_process_weights_after_loading",
-    "set_w4a8_simulation",
-    "is_w4a8_simulation_enabled",
 ]

--- a/verl/utils/qat/vllm_patch.py
+++ b/verl/utils/qat/vllm_patch.py
@@ -18,7 +18,7 @@ vLLM NVFP4 Patches for Dynamic Weight Updates.
 Enables dynamic weight reloading for NVFP4 quantized models in vLLM.
 
 Supported schemes:
-- Dense: W4A16-FP4, W4A4-FP4
+- Dense: W4A16-FP4, W4A4-FP4, experimental W4A8 simulation
 - MoE: NVFP4-MoE
 """
 
@@ -34,6 +34,18 @@ from verl.utils.device import get_device_name
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+W4A8_SIMULATION_ENV = "VERL_W4A8_SIMULATION"
+
+
+def set_w4a8_simulation(enabled: bool) -> None:
+    """Propagate the configured W4A8 simulation mode to vLLM subprocesses."""
+    os.environ[W4A8_SIMULATION_ENV] = "1" if enabled else "0"
+
+
+def is_w4a8_simulation_enabled() -> bool:
+    """Return whether the current process is running the W4A8 simulation."""
+    return os.environ.get(W4A8_SIMULATION_ENV, "0") == "1"
 
 
 class ParamMetaDict(dict):
@@ -680,6 +692,12 @@ def _process_nvfp4_moe_flashinfer_cutlass(self, layer: torch.nn.Module, is_first
 # MoE NVFP4 Patches (entry points)
 def patched_nvfp4_moe_process_weights_after_loading(self, layer: torch.nn.Module) -> None:
     """Patched process_weights_after_loading for NVFP4 MoE layer."""
+    if is_w4a8_simulation_enabled():
+        raise NotImplementedError(
+            "W4A8 simulation currently supports dense models only. A fused MoE kernel cannot reproduce "
+            "FP8 fake quantization at both expert GEMM inputs through the existing W4A16 rollout path."
+        )
+
     from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import NvFp4MoeBackend
 
     is_first_call = _check_first_call(layer)
@@ -732,24 +750,52 @@ _PATCH_TARGETS = [
 ]
 
 _applied_patches = []
+_w4a8_apply_patch = None
+_original_w4a16_apply_weights = None
+
+
+def patched_w4a16_apply_weights_with_w4a8_simulation(self, layer, x, bias=None):
+    """Inject FP8 activation noise before the existing dense W4A16 kernel."""
+    if is_w4a8_simulation_enabled():
+        from verl.utils.qat.linear import fp8_e4m3_fake_quant
+
+        x = fp8_e4m3_fake_quant(x)
+
+    if _original_w4a16_apply_weights is None:
+        raise RuntimeError("Original vLLM W4A16 apply_weights method was not initialized")
+    return _original_w4a16_apply_weights(self, layer, x, bias)
 
 
 def apply_qat_patches():
     """Apply NVFP4 patches to support dynamic weight updates. Call before model loading."""
-    global _applied_patches
+    global _applied_patches, _original_w4a16_apply_weights, _w4a8_apply_patch
 
-    if _applied_patches:
-        logger.warning("QAT patches already applied, skipping")
-        return _applied_patches
+    if not _applied_patches:
+        logger.info("Applying NVFP4 patches for dynamic weight loading...")
 
-    logger.info("Applying NVFP4 patches for dynamic weight loading...")
+        for target, replacement in _PATCH_TARGETS:
+            p = patch(target, replacement)
+            _applied_patches.append(p)
+            p.start()
 
-    for target, replacement in _PATCH_TARGETS:
-        p = patch(target, replacement)
-        _applied_patches.append(p)
-        p.start()
+        logger.info(f"Applied {len(_applied_patches)} NVFP4 patches for dynamic weight loading")
 
-    logger.info(f"Applied {len(_applied_patches)} NVFP4 patches for dynamic weight loading")
+    if is_w4a8_simulation_enabled() and _w4a8_apply_patch is None:
+        from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a16_nvfp4 import (
+            CompressedTensorsW4A16Fp4,
+        )
+
+        _original_w4a16_apply_weights = CompressedTensorsW4A16Fp4.apply_weights
+        target = (
+            "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+            "compressed_tensors_w4a16_nvfp4.CompressedTensorsW4A16Fp4.apply_weights"
+        )
+        _w4a8_apply_patch = patch(target, patched_w4a16_apply_weights_with_w4a8_simulation)
+        _w4a8_apply_patch.start()
+        logger.warning(
+            "Enabled experimental dense W4A8 simulation: activations are FP8 fake-quantized before the W4A16 kernel"
+        )
+
     return _applied_patches
 
 
@@ -825,4 +871,6 @@ __all__ = [
     "apply_qat_patches",
     "prepare_qat_for_load_weights",
     "manual_process_weights_after_loading",
+    "set_w4a8_simulation",
+    "is_w4a8_simulation_enabled",
 ]

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -132,7 +132,7 @@ class QATEngineConfig(BaseConfig):
     Args:
         enable (bool): Whether to enable QAT, default False
         mode (str): Quantization mode, "w4a16", "w4a8", or "w4a4", default "w4a16".
-            W4A8 is an experimental dense-model numerical simulation.
+            W4A8 is an experimental dense and Marlin fused-MoE numerical simulation.
         group_size (int): Group size for blockwise quantization, default 16
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -131,7 +131,8 @@ class QATEngineConfig(BaseConfig):
 
     Args:
         enable (bool): Whether to enable QAT, default False
-        mode (str): Quantization mode, "w4a16" or "w4a4", default "w4a16"
+        mode (str): Quantization mode, "w4a16", "w4a8", or "w4a4", default "w4a16".
+            W4A8 is an experimental dense-model numerical simulation.
         group_size (int): Group size for blockwise quantization, default 16
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)

--- a/verl/workers/config/engine.py
+++ b/verl/workers/config/engine.py
@@ -132,7 +132,7 @@ class QATEngineConfig(BaseConfig):
     Args:
         enable (bool): Whether to enable QAT, default False
         mode (str): Quantization mode, "w4a16", "w4a8", or "w4a4", default "w4a16".
-            W4A8 is an experimental dense and Marlin fused-MoE numerical simulation.
+            W4A8 is an experimental dense and standard Marlin MoE numerical simulation.
         group_size (int): Group size for blockwise quantization, default 16
         ignore_patterns (list[str]): Module name patterns to exclude from quantization
         activation_observer (str): Observer strategy for activation global_scale (W4A4 only)

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1048,6 +1048,9 @@ class vLLMHttpServer:
             qat_config = QATConfig(**qat_config_dict)
             quantization_config_dict = load_quantization_config(qat_config)
             quant_method = quantization_config_dict.get("quant_method", None)
+            from verl.utils.qat import configure_w4a8_simulation
+
+            configure_w4a8_simulation(qat_config.mode, quant_method)
 
             if quant_method == "modelopt":
                 from verl.utils.modelopt import apply_modelopt_nvfp4_patches
@@ -1055,9 +1058,8 @@ class vLLMHttpServer:
                 apply_modelopt_nvfp4_patches()
                 quantization = "modelopt"
             elif quant_method == "compressed-tensors":
-                from verl.utils.qat import apply_qat_patches, set_w4a8_simulation
+                from verl.utils.qat import apply_qat_patches
 
-                set_w4a8_simulation(qat_config.mode.lower() == "w4a8")
                 apply_qat_patches()
                 quantization = "compressed-tensors"
             else:

--- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
@@ -1055,8 +1055,9 @@ class vLLMHttpServer:
                 apply_modelopt_nvfp4_patches()
                 quantization = "modelopt"
             elif quant_method == "compressed-tensors":
-                from verl.utils.qat import apply_qat_patches
+                from verl.utils.qat import apply_qat_patches, set_w4a8_simulation
 
+                set_w4a8_simulation(qat_config.mode.lower() == "w4a8")
                 apply_qat_patches()
                 quantization = "compressed-tensors"
             else:


### PR DESCRIPTION
### What does this PR do?

This draft adds an experimental W4A8 numerical simulation for FSDP QAT, covering dense models and the standard vLLM Marlin MoE path.

- Training fake-quantizes weights to NVFP4 and activations to dynamic FP8 E4M3 blocks of shape `1 x 128`, with an STE backward.
- vLLM rollout reuses the W4A16 `compressed-tensors` weight format and Marlin kernels. Dense layers quantize-dequantize the GEMM input; fused MoE layers do so for both the gate/up input and the post-activation down-projection input.
- `qat.mode=w4a8` propagates the simulation mode to vLLM workers, selects the supported Marlin path, and rejects incompatible quantization methods, MoE backends, and batched expert classes.

This remains a draft because it is a numerical baseline, not a native W4A8 kernel path. It does not establish W4A8 latency, throughput, or memory gains. Megatron W4A8 is outside the scope of this change.

Related foundations are [FSDP NVFP4 QAT #5190](https://github.com/verl-project/verl/pull/5190), [unified FSDP engine QAT #5411](https://github.com/verl-project/verl/pull/5411), and [NVFP4 QAT docs #5861](https://github.com/verl-project/verl/pull/5861). Open W4A8 and FP8-activation PR searches found no equivalent QAT implementation, so this does not duplicate existing work.

AI assistance disclosure: OpenAI Codex was used to inspect the legacy implementation, port the scoped changes to current `main`, and help draft tests and documentation.

### Checklist Before Starting

- [x] Search for similar PRs: [open W4A8 PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+W4A8), [open FP8-activation PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22FP8+activation%22)
- [x] Format the PR title as `[fsdp, vllm, doc] feat: add experimental W4A8 QAT simulation`.

### Test

- Repository pre-commit hooks and `git diff --check`: passed.
- GPU unit tests on NVIDIA GB200 with PyTorch `2.9.1+cu129` and vLLM `0.15.0`: `18 passed`.
- Qwen3-8B-Base FFN-only smoke on 4 GB200 GPUs: two steps completed, including rollout, log-prob calculation, reward, actor update, and packed-weight synchronization.
- Qwen3-30B-A3B FFN-only MoE smoke on 2 nodes / 8 GB200 GPUs: one complete non-eager step completed, including CUDA graph capture, initial and post-update weight synchronization, rollout, reward, and actor update.

These smoke runs validate the execution path, not performance.

Coverage includes:

- FP8 E4M3 blockwise quantize-dequantize numerics, empty inputs, and STE backward.
- W4A8/W4A16 packed-weight export equivalence.
- Dense and fused-MoE activation Q/DQ, including both expert GEMM inputs.
- Mode propagation, backend rejection, and patch cleanup.

### API and Usage Example

```yaml
actor_rollout_ref:
  actor:
    fsdp_config:
      qat:
        enable: true
        mode: "w4a8"
        group_size: 16
        ignore_patterns:
          - "lm_head"
          - "embed_tokens"
          - "re:.*mlp.gate$"
        # Intentional: rollout weights retain the W4A16 NVFP4 format.
        quantization_config_path: "recipe/qat/config/nvfp4_w4a16.json"
```

No additional rollout environment variable is required.

### Design & Code Changes

1. Add shared dynamic FP8 E4M3 activation fake quantization for FSDP training and vLLM rollout.
2. Allow the FP8 fallback to support rectangular `1 x 128` blocks.
3. Export W4A8 weights through the existing W4A16 packed-weight path.
4. Propagate `qat.mode` to vLLM subprocesses.
5. Wrap dense W4A16 GEMM inputs only while W4A8 simulation is enabled.
6. Wrap both expert GEMM inputs for the standard vLLM Marlin MoE path.
7. Fail clearly for unsupported quantization methods and MoE backends.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply pre-commit checks to every changed file.
- [x] Add or update documentation.
- [x] Add GPU unit tests. Environments without the optional vLLM / `compressed-tensors` dependencies skip this module; the vLLM 0.15 GB200 environment ran all 18 tests.
- [ ] Human submitter has reviewed every changed line and can explain the implementation.
- [ ] Request CI in the `ci-request` channel when the draft is ready.
- [ ] Update the recipe submodule reference after the companion recipe PR is merged.
