### PR TITLE
[veomni] fix: use default moe param handler

### DIFF
--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -50,6 +50,7 @@ from ..utils import enable_full_determinism, postprocess_batch_func, prepare_mic
 from .utils import (
     MOE_PARAM_HANDERS,
     VL_TYPE2INDEX,
+    default_moe_param_handler,
     load_veomni_model_to_gpu,
     load_veomni_optimizer,
     offload_veomni_model_to_cpu,
@@ -586,7 +587,7 @@ class VeOmniEngine(FSDPEngine):
 
         ps = parallel_state.get_parallel_state()
         model_type = getattr(self.module.config, "model_type", "default")
-        process_func = MOE_PARAM_HANDERS.get(model_type, lambda n, t, ep_rank: iter([(n, t)]))
+        process_func = MOE_PARAM_HANDERS.get(model_type, default_moe_param_handler)
 
         def param_generator():
             for name, param in params.items():

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -116,7 +116,7 @@ def _map_moe_params_common(name, tensor, ep_rank):
         yield new_key, tensor[i].to(get_device_id(), non_blocking=True)
 
 
-def _map_moe_params_qwen3_moe(name, tensor, ep_rank):
+def default_moe_param_handler(name, tensor, ep_rank):
     if "gate_up_proj" in name:
         gate, up = tensor.chunk(2, dim=1)
         params = {
@@ -130,8 +130,5 @@ def _map_moe_params_qwen3_moe(name, tensor, ep_rank):
         yield from _map_moe_params_common(key, value, ep_rank)
 
 
-MOE_PARAM_HANDERS = {
-    "qwen3_moe": _map_moe_params_common,
-    "deepseek_v3": _map_moe_params_common,
-    "qwen3_5_moe": _map_moe_params_qwen3_moe,
-}
+# This is used to override the default mapping of MoE parameters
+MOE_PARAM_HANDERS = {}


### PR DESCRIPTION
### What does this PR do?

veomni fuse all model's `gate_proj` and `up_proj` into `gate_up_proj`, so all models should use `default_moe_param_handler` to split gate_up_proj.
