### PR TITLE
[fsdp] fix: Fix fsdp model loading on async

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -245,8 +245,7 @@ class FSDPEngine(BaseEngine):
         # I/O in custom models (e.g. ApertusForCausalLM) that override _load_pretrained_model.
         is_fsdp2 = self.engine_config.strategy == "fsdp2"
         if is_fsdp2:
-            _coord = self.device_mesh.get_coordinate() if self.device_mesh is not None else None
-            _is_fsdp2_src = (_coord[-1] == 0) if _coord is not None else (torch.distributed.get_rank() == 0)
+            _is_fsdp2_src = torch.distributed.get_rank() == 0
 
         # For fsdp1: keep original behaviour (meta tensors when tie_word_embeddings is False)
         use_meta_tensor = not is_fsdp2 and (not self.model_config.hf_config.tie_word_embeddings)
@@ -254,10 +253,9 @@ class FSDPEngine(BaseEngine):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            from accelerate import init_empty_weights
 
             if self.model_config.model_type == "language_model":
-                from accelerate import init_empty_weights
-
                 auto_class = get_hf_auto_model_class(hf_config=self.model_config.hf_config)
 
                 if is_fsdp2 and not _is_fsdp2_src:
@@ -295,13 +293,56 @@ class FSDPEngine(BaseEngine):
                 self.model_config.hf_config.classifier_dropout = 0.0
                 self.model_config.hf_config.hidden_dropout = "0"
                 self.model_config.hf_config.summary_dropout_prob = 0.0
-                with init_context():
-                    module = load_valuehead_model(
-                        local_path=self.model_config.local_path,
-                        torch_dtype=torch_dtype,
-                        model_config=self.model_config.hf_config,
-                        trust_remote_code=self.model_config.trust_remote_code,
-                    )
+
+                if is_fsdp2 and not _is_fsdp2_src:
+                    # Non-rank-0 for fsdp2: create model structure only.
+                    # Weights are broadcast from rank 0 via fsdp2_load_full_state_dict.
+                    # Receive a flag from rank 0 indicating which branch load_valuehead_model
+                    # took: 0 = AutoModelForTokenClassification, 1 = TRL AutoModelForCausalLMWithValueHead.
+                    logger.info("fsdp2 non-rank-0: creating value model structure from config (no file I/O)")
+                    use_trl = torch.tensor([0], dtype=torch.int32, device="cpu")
+                    torch.distributed.broadcast(use_trl, src=0)
+
+                    from transformers import AutoModelForTokenClassification
+
+                    if not use_trl.item():
+                        with init_empty_weights():
+                            module = AutoModelForTokenClassification.from_config(
+                                self.model_config.hf_config,
+                                trust_remote_code=self.model_config.trust_remote_code,
+                            )
+                    else:
+                        from transformers import AutoModelForCausalLM
+                        from trl import AutoModelForCausalLMWithValueHead
+
+                        from verl.utils.model import AutoModelForVision2Seq as _V2S
+                        from verl.utils.model import patch_valuehead_model
+
+                        base_cls = (
+                            _V2S
+                            if (_V2S is not None and type(self.model_config.hf_config) in _V2S._model_mapping.keys())
+                            else AutoModelForCausalLM
+                        )
+                        with init_empty_weights():
+                            ori_model = base_cls.from_config(
+                                self.model_config.hf_config,
+                                trust_remote_code=self.model_config.trust_remote_code,
+                            )
+                        module = AutoModelForCausalLMWithValueHead.from_pretrained(ori_model)
+                        patch_valuehead_model(module)
+                else:
+                    with init_context():
+                        module = load_valuehead_model(
+                            local_path=self.model_config.local_path,
+                            torch_dtype=torch_dtype,
+                            model_config=self.model_config.hf_config,
+                            trust_remote_code=self.model_config.trust_remote_code,
+                        )
+                    if is_fsdp2:
+                        # Rank 0: broadcast which branch load_valuehead_model took so that
+                        # non-rank-0 ranks can create the matching model structure.
+                        use_trl = torch.tensor([1 if hasattr(module, "v_head") else 0], dtype=torch.int32, device="cpu")
+                        torch.distributed.broadcast(use_trl, src=0)
 
             use_liger = self.model_config.use_liger
             # Apply Liger kernel; disable fused_linear_cross_entropy (conflicts with verl's forward patching)

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -239,9 +239,13 @@ class FSDPEngine(BaseEngine):
 
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
-        init_context = get_init_weight_context_manager(
-            use_meta_tensor=not self.model_config.hf_config.tie_word_embeddings, mesh=self.device_mesh
+        # fsdp2 uses broadcast_from_rank0 in fsdp2_load_full_state_dict, so only rank 0 needs
+        # real weights. Force meta tensors on non-rank-0 workers regardless of tie_word_embeddings
+        # (fsdp1 with tied embeddings still needs cpu_init_weights on all ranks for sync_module_states).
+        use_meta_tensor = (self.engine_config.strategy == "fsdp2") or (
+            not self.model_config.hf_config.tie_word_embeddings
         )
+        init_context = get_init_weight_context_manager(use_meta_tensor=use_meta_tensor, mesh=self.device_mesh)
 
         with init_context(), warnings.catch_warnings():
             warnings.simplefilter("ignore")

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -444,7 +444,10 @@ class FSDPEngine(BaseEngine):
                 "offload_policy": offload_policy,
                 "reshard_after_forward": self.engine_config.reshard_after_forward,
             }
-            full_state = module.state_dict()
+            # Only rank 0 holds the full state dict; fsdp2_load_full_state_dict
+            # broadcasts it to all other ranks via broadcast_from_rank0=True.
+            # Loading on every rank would OOM for large models (e.g. 4 workers × 140 GB = 560 GB).
+            full_state = module.state_dict() if torch.distributed.get_rank() == 0 else {}
             apply_fsdp2(module, fsdp_kwargs, self.engine_config)
             fsdp2_load_full_state_dict(module, full_state, fsdp_mesh, offload_policy)
         else:

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -239,26 +239,44 @@ class FSDPEngine(BaseEngine):
 
         torch_dtype = PrecisionType.to_dtype(torch_dtype)
 
-        # fsdp2 uses broadcast_from_rank0 in fsdp2_load_full_state_dict, so only rank 0 needs
-        # real weights. Force meta tensors on non-rank-0 workers regardless of tie_word_embeddings
-        # (fsdp1 with tied embeddings still needs cpu_init_weights on all ranks for sync_module_states).
-        use_meta_tensor = (self.engine_config.strategy == "fsdp2") or (
-            not self.model_config.hf_config.tie_word_embeddings
-        )
+        # For fsdp2, only rank 0 loads weights from disk; all others receive via
+        # broadcast_from_rank0 in fsdp2_load_full_state_dict. We bypass from_pretrained
+        # entirely for non-rank-0 because init_empty_weights cannot reliably prevent file
+        # I/O in custom models (e.g. ApertusForCausalLM) that override _load_pretrained_model.
+        is_fsdp2 = self.engine_config.strategy == "fsdp2"
+        if is_fsdp2:
+            _coord = self.device_mesh.get_coordinate() if self.device_mesh is not None else None
+            _is_fsdp2_src = (_coord[-1] == 0) if _coord is not None else (torch.distributed.get_rank() == 0)
+
+        # For fsdp1: keep original behaviour (meta tensors when tie_word_embeddings is False)
+        use_meta_tensor = not is_fsdp2 and (not self.model_config.hf_config.tie_word_embeddings)
         init_context = get_init_weight_context_manager(use_meta_tensor=use_meta_tensor, mesh=self.device_mesh)
 
-        with init_context(), warnings.catch_warnings():
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore")
 
             if self.model_config.model_type == "language_model":
+                from accelerate import init_empty_weights
+
                 auto_class = get_hf_auto_model_class(hf_config=self.model_config.hf_config)
 
-                module = auto_class.from_pretrained(
-                    pretrained_model_name_or_path=self.model_config.local_path,
-                    torch_dtype=torch_dtype,
-                    config=self.model_config.hf_config,
-                    trust_remote_code=self.model_config.trust_remote_code,
-                )
+                if is_fsdp2 and not _is_fsdp2_src:
+                    # Non-rank-0 for fsdp2: create model structure only.
+                    # Weights are broadcast from rank 0 via fsdp2_load_full_state_dict.
+                    logger.info("fsdp2 non-rank-0: creating model structure from config (no file I/O)")
+                    with init_empty_weights():
+                        module = auto_class.from_config(
+                            self.model_config.hf_config,
+                            trust_remote_code=self.model_config.trust_remote_code,
+                        )
+                else:
+                    with init_context():
+                        module = auto_class.from_pretrained(
+                            pretrained_model_name_or_path=self.model_config.local_path,
+                            torch_dtype=torch_dtype,
+                            config=self.model_config.hf_config,
+                            trust_remote_code=self.model_config.trust_remote_code,
+                        )
 
                 # Strip sub-modules listed in _verl_strip_modules (e.g.
                 # talker / code2wav for Qwen3-Omni Thinker-only training).
@@ -277,12 +295,13 @@ class FSDPEngine(BaseEngine):
                 self.model_config.hf_config.classifier_dropout = 0.0
                 self.model_config.hf_config.hidden_dropout = "0"
                 self.model_config.hf_config.summary_dropout_prob = 0.0
-                module = load_valuehead_model(
-                    local_path=self.model_config.local_path,
-                    torch_dtype=torch_dtype,
-                    model_config=self.model_config.hf_config,
-                    trust_remote_code=self.model_config.trust_remote_code,
-                )
+                with init_context():
+                    module = load_valuehead_model(
+                        local_path=self.model_config.local_path,
+                        torch_dtype=torch_dtype,
+                        model_config=self.model_config.hf_config,
+                        trust_remote_code=self.model_config.trust_remote_code,
+                    )
 
             use_liger = self.model_config.use_liger
             # Apply Liger kernel; disable fused_linear_cross_entropy (conflicts with verl's forward patching)


### PR DESCRIPTION
### What does this PR do?

This fix ensures that FSDP initial weights are indeed loaded only by rank0 and subsequently broadcast over the network.

### Test

Logs before the fix (weights are loaded by all ranks):
```
Loading weights:   0%|          | 0/451 [00:00<?, ?it/s] [repeated 31x across cluster]
Loading weights:  21%|██        | 93/451 [00:11<00:26, 13.47it/s] [repeated 92x across cluster]
Loading weights:  30%|██▉       | 135/451 [00:15<00:34,  9.10it/s] [repeated 144x across cluster]
Loading weights:  43%|████▎     | 193/451 [00:20<00:24, 10.68it/s] [repeated 178x across cluster]
Loading weights:  61%|██████    | 275/451 [00:26<00:12, 13.80it/s] [repeated 279x across cluster]
Loading weights:  71%|███████   | 319/451 [00:31<00:14,  8.82it/s] [repeated 144x across cluster]
Loading weights:  86%|████████▌ | 387/451 [00:37<00:05, 10.78it/s] [repeated 153x across cluster]
Loading weights:  92%|█████████▏| 415/451 [00:39<00:02, 12.75it/s]
Loading weights: 100%|██████████| 451/451 [00:41<00:00, 10.80it/s]
(WorkerDict pid=118609, ip=172.28.32.212) ApertusForCausalLM contains 8.05B parameters
```
Logs after the fix (only rank0 loads weights):
```
Loading weights:  18%|█▊        | 79/451 [00:08<00:30, 12.38it/s] 
Loading weights:  22%|██▏       | 97/451 [00:10<00:27, 12.87it/s]
Loading weights:  24%|██▍       | 108/451 [00:10<00:26, 13.06it/s]
Loading weights:  27%|██▋       | 121/451 [00:11<00:24, 13.64it/s]
Loading weights:  28%|██▊       | 126/451 [00:11<00:21, 14.81it/s]
Loading weights:  30%|██▉       | 135/451 [00:12<00:20, 15.32it/s]
...
Loading weights:  95%|█████████▌| 429/451 [00:30<00:00, 22.10it/s]
Loading weights:  96%|█████████▌| 432/451 [00:30<00:00, 22.02it/s]
Loading weights: 100%|██████████| 451/451 [00:32<00:00, 14.07it/s]
(WorkerDict pid=184875, ip=172.28.32.144) ApertusForCausalLM contains 8.05B parameters
```
As seen in the logs, the weights are now correctly loaded only by the FSDP rank-0 trainer and later broadcast over the network.

