### PR TITLE
[fsdp] fix: skip the whole-shard staging round trip in FSDP2 weight export

### DIFF
--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -823,7 +823,14 @@ class FSDPEngine(BaseEngine):
         # FSDP2 CPUOffloadPolicy owns CPU<->GPU placement; calling model.to(device) here
         # leaves the module half-moved and crashes state_dict() below (#5995). The
         # per-DTensor .to(device).full_tensor() below still produces GPU tensors.
-        if not self._uses_fsdp2_cpu_offload_policy:
+        #
+        # FSDP2 state_dict() only collects DTensor refs and the generator below already
+        # stages each shard lazily via .to(device).full_tensor(), so the whole-shard
+        # round trip is only needed for FSDP1 (state_dict unshards on-device) and LoRA
+        # (adapter merge does real weight math on the module).
+        _is_peft = hasattr(getattr(self.module, "_fsdp_wrapped_module", self.module), "peft_config")
+        _skip_staging = fsdp_version(self.module) == 2 and not _is_peft
+        if not self._uses_fsdp2_cpu_offload_policy and not _skip_staging:
             load_fsdp_model_to_gpu(self.module)
 
         log_gpu_memory_usage("After load_fsdp_model_to_gpu", logger=logger)
@@ -852,7 +859,7 @@ class FSDPEngine(BaseEngine):
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
 
         log_gpu_memory_usage("Before offload_fsdp_model_to_cpu", logger=logger)
-        if self._is_offload_param:
+        if self._is_offload_param and not _skip_staging:
             offload_fsdp_model_to_cpu(self.module)
         log_gpu_memory_usage("After offload_fsdp_model_to_cpu", logger=logger)
 


### PR DESCRIPTION
### What does this PR do?

`get_per_tensor_param` stages the entire local shard onto the GPU (`load_fsdp_model_to_gpu`) before `state_dict()` and offloads it back afterwards. That round trip is an **FSDP1 requirement** — FSDP1's state_dict export runs through the unshard machinery, which asserts flat params are on the compute device — but for **FSDP2 (fully_shard) it is pure overhead**: `state_dict()` only collects DTensor references, and the export generator already moves each shard to the GPU lazily via `.to(device).full_tensor()` (the same pattern this function relies on for CPUOffloadPolicy, see #5995).

This PR skips the staging for FSDP2 non-LoRA exports. FSDP1 and LoRA paths (`collect_lora_params` / `merged_lora_context` do real weight math on the module) are unchanged.

### Why it matters

With manual param offload, the staging moves every parameter's **separate pageable buffer twice per weight sync** (hundreds of small blocking H2D + D2H copies — ~340 params for a 7B model).

Measured on a 2-node disaggregated one-step-off run (Qwen2.5-7B, 8-GPU FSDP2 trainer + 8-GPU SGLang rollout, `param_offload=True optimizer_offload=True`, `checkpoint_engine.backend=nccl`):

| | before | after |
|---|---|---|
| export/generator creation (profiled, actor rank0) | 3.3–4.5 s | **0.07 s** |
| `timing_s/sync_rollout_weights` per step | 6.65–6.93 s | **3.36–3.49 s** |

Send-phase internals are otherwise unchanged (the per-param H2D shifts into the lazy generator pull where it overlaps with the bucketed broadcast); training metrics (reward/KL) match the baseline run.

### Test

- 2-node disaggregated GRPO on GSM8K, Qwen2.5-7B, 3 steps, both configurations, same node pair: no errors, matching reward band, timing as above.
- Not applicable to FSDP1 / LoRA (behavior unchanged by construction; FSDP1 still stages).

### Checklist
- [x] Measured before/after on real hardware
- [x] FSDP1 / LoRA behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)