### PR TITLE
[fully_async] fix: release state lock while waiting for rollout capacity

### DIFF
--- a/tests/experimental/fully_async_policy/test_rollouter_lock_on_cpu.py
+++ b/tests/experimental/fully_async_policy/test_rollouter_lock_on_cpu.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from verl.experimental.fully_async_policy import fully_async_rollouter
+
+
+class _RolloutSample:
+    sample_id = "test_sample"
+
+
+@pytest.mark.asyncio
+async def test_processor_releases_lock_while_waiting_for_capacity(monkeypatch):
+    rollouter_class = fully_async_rollouter.FullyAsyncRollouter.__ray_metadata__.modified_class
+    rollouter = object.__new__(rollouter_class)
+    rollouter.paused = False
+    rollouter.pending_queue = asyncio.Queue()
+    rollouter.staleness_samples = 0
+    rollouter.max_concurrent_samples = 1
+    rollouter.lock = asyncio.Lock()
+    rollouter._resume_event = asyncio.Event()
+    rollouter._resume_event.set()
+
+    async def should_not_pause():
+        return False
+
+    sample_processed = asyncio.Event()
+
+    async def process_sample(_sample):
+        sample_processed.set()
+
+    rollouter._should_pause_generation = should_not_pause
+    rollouter._process_single_sample_streaming = process_sample
+
+    blocker_release = asyncio.Event()
+    blocker_task = asyncio.create_task(blocker_release.wait())
+    rollouter.active_tasks = {blocker_task}
+    await rollouter.pending_queue.put(_RolloutSample())
+    await rollouter.pending_queue.put(None)
+
+    wait_started = asyncio.Event()
+    original_wait = asyncio.wait
+
+    async def observed_wait(*args, **kwargs):
+        wait_started.set()
+        return await original_wait(*args, **kwargs)
+
+    monkeypatch.setattr(fully_async_rollouter.asyncio, "wait", observed_wait)
+    processor_task = asyncio.create_task(rollouter._processor_worker())
+
+    try:
+        await asyncio.wait_for(wait_started.wait(), timeout=1)
+        await asyncio.wait_for(rollouter.lock.acquire(), timeout=0.5)
+        rollouter.lock.release()
+    finally:
+        blocker_release.set()
+        await asyncio.gather(blocker_task, return_exceptions=True)
+
+        if not processor_task.done():
+            try:
+                await asyncio.wait_for(processor_task, timeout=1)
+            except TimeoutError:
+                processor_task.cancel()
+                await asyncio.gather(processor_task, return_exceptions=True)
+
+    assert sample_processed.is_set()

--- a/verl/experimental/fully_async_policy/fully_async_rollouter.py
+++ b/verl/experimental/fully_async_policy/fully_async_rollouter.py
@@ -813,13 +813,19 @@ class FullyAsyncRollouter(SeparateRayPPOTrainer):
 
             # Check whether the number of concurrent tasks exceeds the limit
             while len(self.active_tasks) >= self.max_concurrent_samples:
+                active_tasks = set(self.active_tasks)
+                if not active_tasks:
+                    break
+
+                # reset_staleness() needs the same lock after every weight
+                # update. Waiting for a long-running rollout while holding it
+                # serializes training behind the rollout tail.
+                done_tasks, _pending = await asyncio.wait(active_tasks, return_when=asyncio.FIRST_COMPLETED)
                 async with self.lock:
-                    if self.active_tasks:
-                        done_tasks, self.active_tasks = await asyncio.wait(
-                            self.active_tasks, return_when=asyncio.FIRST_COMPLETED
-                        )
-                        for task in done_tasks:
-                            await task
+                    for task in done_tasks:
+                        self.active_tasks.discard(task)
+                for task in done_tasks:
+                    await task
 
             # Submit single sample processing
             if self.paused:


### PR DESCRIPTION
### What does this PR do?

`FullyAsyncRollouter._processor_worker()` currently waits for rollout capacity while holding `self.lock`. A long-running rollout can therefore block `reset_staleness()`, which needs the same lock after a parameter update, and serialize training behind the rollout tail.

This change snapshots the active tasks, waits for the first completion without holding the state lock, removes completed tasks under the lock, and propagates task results after releasing it. It does not change task selection, filtering, rollout contents, optimizer behavior, or public APIs.

Related work is adjacent but does not fix this max-concurrency branch:

- #6090 made the separate pause/drain loop interruptible.
- #4230 fixed async primitive initialization and task monitoring.

### Checklist Before Starting

- [x] Searched for similar open PRs and issues:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+fully_async+lock+reset_staleness
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+max_concurrent_samples+asyncio.wait
  - https://github.com/verl-project/verl/issues?q=is%3Aissue+is%3Aopen+fully_async+lock+reset_staleness
- [x] PR title follows the required format: `[fully_async] fix: release state lock while waiting for rollout capacity`

### Test

#### Regression test

The new CPU test starts a capacity-blocking rollout, waits until `_processor_worker()` enters `asyncio.wait()`, and then attempts to acquire `self.lock`.

- Before the production change: failed with `TimeoutError` while acquiring `rollouter.lock`.
- After the production change: passed.
- Repeated in 20 fresh pytest processes: 20/20 passed.

```bash
uv run --no-sync pytest -q tests/experimental/fully_async_policy
# 6 passed
```

The test is named `test_rollouter_lock_on_cpu.py`, so the existing CPU workflow's `tests/**/test_*_on_cpu.py` discovery includes it without a workflow change.

#### Broader CPU checks

```bash
uv run --no-sync pytest -q $(find tests/experimental -maxdepth 2 -type f \
  \( -name 'test_*_on_cpu.py' -o -name 'test_*cpu*.py' \) \
  ! -name 'test_rate_limited_reward_manager_on_cpu.py' | sort)
# 42 passed
```

`test_rate_limited_reward_manager_on_cpu.py` was excluded because its fixture requires the unavailable local path `~/models/Qwen/Qwen2.5-0.5B-Instruct`; an attempted run reached 42 passes before its 13 model-setup errors.

```bash
pre-commit run --all-files --show-diff-on-failure --color=never
# all 13 hooks passed
```

#### End-to-end test

The exact lock-scope change was also tested in a three-node Qwen3-14B fully-async RL run on AMD cluster: one trainer node, two rollout nodes, 24 GPUs total, identical resolved training settings, `rollout.n=8`, and 16 kept samples per update.

| Metric | Unmodified | Lock fix | Change |
|---|---:|---:|---:|
| Median step, first 4 matched updates | 205.65 s | 165.25 s | -19.6% |
| Median step, updates 2-4 after first-update warmup | 157.47 s | 119.85 s | -23.9% |
| Median total tokens, updates 2-4 | 298,806 | 294,681 | -1.38% |
| Median throughput, updates 2-4 | 77.51 | 85.05 | +9.73% |
| Kept samples per update | 16 | 16 | unchanged |
| Aborted / clipped response ratio | 0 / 0 | 0 / 0 | unchanged |

The baseline's 128 generated input rows are row-for-row identical to the first 128 rows of the lock-fix run. The lock-fix run had 256 rows only so it could continue beyond the baseline's finite-input stop; the task bundle is identical, and resolved configs differ only in run description and ID. This is one run per arm, so the timing result is performance evidence rather than a statistical benchmark.

### API and Usage Example

No API, configuration, or usage change.

### Design & Code Changes

- Wait on a snapshot of `active_tasks` without holding `self.lock`.
- Reacquire the lock only to discard completed tasks from shared state.
- Await completed tasks outside the lock so exceptions still propagate without blocking state updates.
- Add a focused CPU regression test for lock availability during capacity waits.

### Checklist Before Submitting

- [x] Read the Contribute Guide and `AGENTS.md`.
- [x] Applied repository-wide pre-commit checks.
- [x] Added a CPU test covered by the existing workflow.
- [x] Documentation is unchanged because this is an internal concurrency fix with no user-facing behavior or API change.
- [X] Human submitter reviewed every changed line and can defend the change end-to-end.
- [ ] Request CI in the project channel when ready for review.

### AI assistance disclosure

I have identified the issue during RL training runs with verl. I have reviewed the patch in full. The patch follows similar fix pattern for related linked PRs.
OpenAI Codex assisted with reproducing the lock contention, preparing the minimal patch and regression test, running validation, checking for duplicate work, and drafting this PR description.