### PR TITLE
[wandb] fix: fixes async training finish sequence

### DIFF
--- a/verl/experimental/fully_async_policy/fully_async_trainer.py
+++ b/verl/experimental/fully_async_policy/fully_async_trainer.py
@@ -404,12 +404,16 @@ class FullyAsyncTrainer(SeparateRayPPOTrainer):
                 break
 
         self.progress_bar.close()
-        if self.current_param_version % self.config.trainer.test_freq != 0 or self.local_trigger_step > 1:
-            weights_updated = await self._fit_update_weights()
-            if weights_updated:
-                self._fit_log_aggregated_training_metrics()
-            await self._fit_validate()
-        self._fit_save_checkpoint(force=True)
+        try:
+            if self.current_param_version % self.config.trainer.test_freq != 0 or self.local_trigger_step > 1:
+                weights_updated = await self._fit_update_weights()
+                if weights_updated:
+                    self._fit_log_aggregated_training_metrics()
+                await self._fit_validate()
+            self._fit_save_checkpoint(force=True)
+        finally:
+            if hasattr(self, "logger"):
+                self.logger.finish()
 
     async def fit_step(self, batch_dict: dict = None):
         """

--- a/verl/utils/tracking.py
+++ b/verl/utils/tracking.py
@@ -185,7 +185,7 @@ class Tracking:
             if backend is None or default_backend in backend:
                 logger_instance.log(data=data, step=step)
 
-    def __del__(self):
+    def finish(self):
         if "wandb" in self.logger:
             self.logger["wandb"].finish(exit_code=0)
         if "swanlab" in self.logger:
@@ -200,6 +200,9 @@ class Tracking:
             self.logger["trackio"].finish()
         if "file" in self.logger:
             self.logger["file"].finish()
+
+    def __del__(self):
+        self.finish()
 
 
 class ClearMLLogger:


### PR DESCRIPTION
### What does this PR do?

Fixes the finish training sequence that might cause wandb logger to crash.


### Test

Log output before fix is applied indicates wandb is not correctly shut down.

```
(TaskRunner pid=47918) 'Final validation metrics: None'
(TaskRunner pid=47918) 
(TaskRunner pid=47918) Exception ignored in atexit callback: <function _start_and_connect_service.<locals>.teardown_atexit at 0x4026990787c0>
(TaskRunner pid=47918) Traceback (most recent call last):
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/service/service_connection.py", line 73, in teardown_atexit
(TaskRunner pid=47918)     conn.teardown(hooks.exit_code)
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/service/service_connection.py", line 375, in teardown
(TaskRunner pid=47918)     self._asyncer.run(publish_teardown_and_close)
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/asyncio_manager.py", line 137, in run
(TaskRunner pid=47918)     return future.result()
(TaskRunner pid=47918)            ^^^^^^^^^^^^^^^
(TaskRunner pid=47918)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 456, in result
(TaskRunner pid=47918)     return self.__get_result()
(TaskRunner pid=47918)            ^^^^^^^^^^^^^^^^^^^
(TaskRunner pid=47918)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(TaskRunner pid=47918)     raise self._exception
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/asyncio_manager.py", line 223, in _wrap
(TaskRunner pid=47918)     return await fn()
(TaskRunner pid=47918)            ^^^^^^^^^^
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/service/service_connection.py", line 373, in publish_teardown_and_close
(TaskRunner pid=47918)     await self._client.close()
(TaskRunner pid=47918)   File "/usr/local/lib/python3.12/dist-packages/wandb/sdk/lib/service/service_client.py", line 111, in close
(TaskRunner pid=47918)     await self._writer.wait_closed()
(TaskRunner pid=47918)   File "/usr/lib/python3.12/asyncio/streams.py", line 364, in wait_closed
(TaskRunner pid=47918)     await self._protocol._get_close_waiter(self)
(TaskRunner pid=47918) BrokenPipeError: [Errno 32] Broken pipe
(WorkerDict pid=31335, ip=172.28.26.156) INFO:2026-07-10 12:58:10,843:[Rank 14] Saved optim to /capstor/scratch/cscs/palmee/RL/Apertus-8B-Instruct-2509/checkpoints/Apertus-8B-Instruct-2509-grpo-gsm8k-Sync-on-8-nodes-run-2716921/global_step_87/actor/optim_world_size_32_rank_14.pt [repeated 31x across cluster]
(WorkerDict pid=31335, ip=172.28.26.156) INFO:2026-07-10 12:58:10,846:[Rank 14] Saved extra_state to /capstor/scratch/cscs/palmee/RL/Apertus-8B-Instruct-2509/checkpoints/Apertus-8B-Instruct-2509-grpo-gsm8k-Sync-on-8-nodes-run-2716921/global_step_87/actor/extra_state_world_size_32_rank_14.pt [repeated 31x across cluster]
(WorkerDict pid=30403, ip=172.28.26.96) /workspace/verl/verl/utils/device.py:146: FutureWarning: torch.cuda._set_allocator_settings is deprecated. Use torch._C._accelerator_setAllocatorSettings instead. [repeated 31x across cluster]
(WorkerDict pid=30403, ip=172.28.26.96)   torch.cuda.memory._set_allocator_settings(f"expandable_segments:{enable}") [repeated 31x across cluster]
(SGLangHttpServer pid=32420, ip=172.28.26.76) [2026-07-10 12:58:17] Subprocess detokenizer (pid=32689) crashed with exit code -9. Triggering SIGQUIT for cleanup...
(SGLangHttpServer pid=53963) [2026-07-10 12:58:17] Subprocess detokenizer (pid=54567) crashed with exit code -9. Triggering SIGQUIT for cleanup...
```
