### PR TITLE
[megatron] fix: align teacher tensor seqlen with student for forward_kl_topk CP split

### DIFF
--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -284,13 +284,31 @@ def compute_forward_kl_topk(
     assert teacher_topk_log_probs.is_nested and teacher_topk_ids.is_nested
 
     # 1. split across cp groups (bsz, seqlen, topk) => (bsz, seqlen/cp_size, topk)
+    # When CP > 1, teacher and student nested tensors may have different per-sample
+    # lengths (due to padding differences), causing preprocess_bshd_engine to compute
+    # different aligned max_seqlen values. Force teacher to use the same total seqlen
+    # as student so that after CP zigzag split, local dimensions match.
+    from megatron.core import parallel_state as mpu
+
+    cp_size = mpu.get_context_parallel_world_size()
+    forced_max_seqlen = student_logits.shape[1] * cp_size if cp_size > 1 else None
+
     if data_format == "thd":
         teacher_topk_log_probs_cp_split, *_ = preprocess_thd_engine(teacher_topk_log_probs, pre_process=True)
         teacher_topk_ids_cp_split, *_ = preprocess_thd_engine(teacher_topk_ids, pre_process=True)
     else:
-        teacher_topk_log_probs_cp_split, *_ = preprocess_bshd_engine(teacher_topk_log_probs, pre_process=True)
-        teacher_topk_ids_cp_split, *_ = preprocess_bshd_engine(teacher_topk_ids, pre_process=True)
-    assert teacher_topk_log_probs_cp_split.shape[:2] == teacher_topk_ids_cp_split.shape[:2] == student_logits.shape[:2]
+        teacher_topk_log_probs_cp_split, *_ = preprocess_bshd_engine(
+            teacher_topk_log_probs, pre_process=True, forced_max_seqlen=forced_max_seqlen
+        )
+        teacher_topk_ids_cp_split, *_ = preprocess_bshd_engine(
+            teacher_topk_ids, pre_process=True, forced_max_seqlen=forced_max_seqlen
+        )
+    assert (
+        teacher_topk_log_probs_cp_split.shape[:2] == teacher_topk_ids_cp_split.shape[:2] == student_logits.shape[:2]
+    ), (
+        f"Shape mismatch after CP split: teacher_logprobs={teacher_topk_log_probs_cp_split.shape[:2]}, "
+        f"teacher_ids={teacher_topk_ids_cp_split.shape[:2]}, student_logits={student_logits.shape[:2]}"
+    )
 
     # 2. compute token-wise KL divergence across tp groups
     distillation_loss_config: DistillationLossConfig = config.distillation_loss

--- a/verl/trainer/distillation/megatron/losses.py
+++ b/verl/trainer/distillation/megatron/losses.py
@@ -291,7 +291,7 @@ def compute_forward_kl_topk(
     from megatron.core import parallel_state as mpu
 
     cp_size = mpu.get_context_parallel_world_size()
-    forced_max_seqlen = student_logits.shape[1] * cp_size if cp_size > 1 else None
+    forced_max_seqlen = student_logits.shape[1] * cp_size
 
     if data_format == "thd":
         teacher_topk_log_probs_cp_split, *_ = preprocess_thd_engine(teacher_topk_log_probs, pre_process=True)


### PR DESCRIPTION
### What does this PR do?

Fixes an `AssertionError` in `compute_forward_kl_topk` when `context_parallel_size > 1` and batch samples have variable lengths.

**Root cause**: `preprocess_bshd_engine` independently computes `aligned_max_seqlen` for teacher and student nested tensors from their respective offsets. With variable-length samples, teacher and student can produce different aligned totals → CP zigzag split yields mismatched local sequence dimensions → assertion at L293 fails.

**Fix**: Derive the expected total seqlen from the already-split student logits (`student_logits.shape[1] * cp_size`) and pass it as `forced_max_seqlen` to `preprocess_bshd_engine` for teacher tensors. This ensures both sides pad to the same aligned length before CP split.

Related: #5826 added CP support for bshd format but tested only with fixed-length data (gsm8k), which doesn't trigger the alignment divergence.

### Checklist Before Starting

- [x] Search for similar PRs. Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+forward_kl_topk+cp
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Tested on production workload:
- Model: Qwen3.5-35B-A3B (MoE), student + 122B teacher
- Topology: 10 nodes × 16 NPU (H910-64G), TP=2 PP=2 CP=2 EP=8
- Config: `forward_kl_topk`, `topk=128`, `use_chunked_topk=true`
- Result: Training proceeds normally with distillation metrics (`actor/distillation/loss`, `student_mass`, `teacher_mass`) reported correctly. Previously crashed at step 1 with `AssertionError`.

### API and Usage Example

No API change. Existing configs with `loss_mode: forward_kl_topk` + `context_parallel_size > 1` now work correctly without modification.

### Design & Code Changes

Single-point fix in `verl/trainer/distillation/megatron/losses.py`:
- Before CP split of teacher tensors, compute `forced_max_seqlen = student_logits.shape[1] * cp_size`
- Pass this to `preprocess_bshd_engine(..., forced_max_seqlen=forced_max_seqlen)` for both teacher log_probs and teacher ids
- Improved assertion error message to include actual shapes for easier debugging

### Checklist Before Submitting

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting)
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s). Not feasible: the bug only manifests in multi-node distributed settings with CP > 1 and variable-length batches — cannot be reproduced in CI's single-node environment.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.