### PR TITLE
[rollout] fix: accept dataset output fields in agent loop

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -14,7 +14,12 @@
 
 from __future__ import annotations
 
+import importlib.util
+import inspect
+import sys
+import types
 import warnings
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
@@ -308,6 +313,30 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
     torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
     assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0
     assert torch.count_nonzero(internal.routed_experts[:, 6:]) == 0
+
+
+def _assert_output_field_is_preserved(postprocess):
+    agent_output = object()
+    bound = inspect.signature(postprocess).bind(object(), agent_output, False, output="dataset-output")
+
+    assert bound.arguments["output"] is agent_output
+    assert bound.arguments["kwargs"]["output"] == "dataset-output"
+
+
+def test_agent_loop_postprocess_preserves_output_field_on_cpu():
+    _assert_output_field_is_preserved(AgentLoopWorker._agent_loop_postprocess)
+
+
+def test_transfer_queue_agent_loop_postprocess_preserves_output_field_on_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "transfer_queue", types.ModuleType("transfer_queue"))
+    module_path = Path(__file__).parents[3] / "verl" / "trainer" / "ppo" / "v1" / "agent_loop_tq.py"
+    spec = importlib.util.spec_from_file_location("_agent_loop_tq_signature_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    worker_class = module.AgentLoopWorkerTQ.__ray_metadata__.modified_class
+
+    _assert_output_field_is_preserved(worker_class._agent_loop_postprocess)
 
 
 class _FakeTokenizerCustomPad:

--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -14,8 +14,13 @@
 
 from __future__ import annotations
 
+import importlib.util
+import inspect
+import sys
+import types
 import warnings
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
@@ -359,6 +364,30 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
     torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
     assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0
     assert torch.count_nonzero(internal.routed_experts[:, 6:]) == 0
+
+
+def _assert_output_field_is_preserved(postprocess):
+    agent_output = object()
+    bound = inspect.signature(postprocess).bind(object(), agent_output, False, output="dataset-output")
+
+    assert bound.arguments["output"] is agent_output
+    assert bound.arguments["kwargs"]["output"] == "dataset-output"
+
+
+def test_agent_loop_postprocess_preserves_output_field_on_cpu():
+    _assert_output_field_is_preserved(AgentLoopWorker._agent_loop_postprocess)
+
+
+def test_transfer_queue_agent_loop_postprocess_preserves_output_field_on_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "transfer_queue", types.ModuleType("transfer_queue"))
+    module_path = Path(__file__).parents[3] / "verl" / "trainer" / "ppo" / "v1" / "agent_loop_tq.py"
+    spec = importlib.util.spec_from_file_location("_agent_loop_tq_signature_test", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    worker_class = module.AgentLoopWorkerTQ.__ray_metadata__.modified_class
+
+    _assert_output_field_is_preserved(worker_class._agent_loop_postprocess)
 
 
 class _FakeTokenizerCustomPad:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -724,7 +724,7 @@ class AgentLoopWorker:
                 padded["attention_mask"] = padded["attention_mask"].unsqueeze(0)
         return padded
 
-    async def _agent_loop_postprocess(self, output, validate, **kwargs) -> _InternalAgentLoopOutput:
+    async def _agent_loop_postprocess(self, output, /, validate, **kwargs) -> _InternalAgentLoopOutput:
         """Perform post-processing operations on the output of each individual agent loop."""
         output.extra_fields["raw_prompt"] = kwargs["raw_prompt"]
 

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -692,7 +692,7 @@ class AgentLoopWorker:
                 padded["attention_mask"] = padded["attention_mask"].unsqueeze(0)
         return padded
 
-    async def _agent_loop_postprocess(self, output, validate, **kwargs) -> _InternalAgentLoopOutput:
+    async def _agent_loop_postprocess(self, output, /, validate, **kwargs) -> _InternalAgentLoopOutput:
         """Perform post-processing operations on the output of each individual agent loop."""
         output.extra_fields["raw_prompt"] = kwargs["raw_prompt"]
 

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -148,7 +148,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
 
     async def _agent_loop_postprocess(
-        self, output: AgentLoopOutput | list[AgentLoopOutput], validate, **kwargs
+        self, output: AgentLoopOutput | list[AgentLoopOutput], /, validate, **kwargs
     ) -> None:
         """Put agent loop outputs into TransferQueue."""
         uid, session_id = kwargs["uid"], kwargs["session_id"]

--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -128,7 +128,7 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
 
     async def _agent_loop_postprocess(
-        self, output: AgentLoopOutput | list[AgentLoopOutput], validate, **kwargs
+        self, output: AgentLoopOutput | list[AgentLoopOutput], /, validate, **kwargs
     ) -> None:
         """Put agent loop outputs into TransferQueue."""
         uid, session_id = kwargs["uid"], kwargs["session_id"]


### PR DESCRIPTION
### What does this PR do?

Fixes #5388.

Agent-loop samples can contain an `output` field in their non-tensor data. `_run_agent_loop()` forwards those fields through `**kwargs` while also passing the runtime `AgentLoopOutput` positionally, so Python raises `TypeError: got multiple values for argument 'output'` before post-processing starts.

This change makes the runtime `output` argument positional-only in both `AgentLoopWorker` and its TransferQueue override. The dataset field remains available in `kwargs` for reward and teacher processing instead of being removed.

This does not duplicate an existing fix. Searches for [PRs linked to #5388](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+5388+in%3Abody) and [the reported error](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+%22got+multiple+values+for+argument%22) returned no matching implementation. Open PRs touching agent-loop post-processing address unrelated behavior.

### Checklist Before Starting

- [x] Search for similar PRs. Queries are linked above.
- [x] Format the PR title as `[{modules}] {type}: {description}`.

### Test

- `.venv/Scripts/python.exe -m pytest -q tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py tests/experimental/agent_loop/test_audio_server_contract_on_cpu.py tests/experimental/agent_loop/test_call_tool_on_cpu.py tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py tests/experimental/agent_loop/test_tool_call_id_on_cpu.py`: 22 passed.
- `pre-commit run ruff --files <changed files>`: passed.
- `pre-commit run ruff-format --files <changed files>`: passed.
- `pre-commit run mypy --files <changed files>`: passed.
- Changed-file `compileall` with warnings treated as errors: passed.
- PR title validation: passed.
- `git diff origin/main...HEAD --check`: clean.

The regression binds the real base method and the Ray-wrapped TransferQueue override with both a positional runtime result and `output="dataset-output"`. It fails with the reported `TypeError` before this change and confirms that the dataset field remains in `kwargs` afterward.

The full all-files pre-commit run was also attempted. Diff-relevant hooks passed; the Windows run still reports unrelated existing `SIGALRM` typing errors, existing root-level test-layout violations, and Unix shell/config-generation environment failures. None involve the changed files.

### API and Usage Example

No public API or configuration changes.

### Design & Code Changes

- Treat the internal runtime `output` parameter as positional-only in both worker implementations.
- Cover both signatures without requiring TransferQueue to be installed in the CPU test environment.

### Checklist Before Submitting

- [x] Read the contribution guide and current `AGENTS.md`.
- [ ] Run the complete all-files pre-commit suite without platform or baseline failures. See the test notes above.
- [x] Documentation is not required because there is no user-facing API or configuration change.
- [x] Add CPU regression coverage for the base and TransferQueue worker signatures.
- [ ] Request upstream CI after the submitter reviews the draft.

