### PR TITLE
[trainer] feat: queue TransferQueue agent batches

### DIFF
--- a/verl/trainer/ppo/v1/agent_loop_tq.py
+++ b/verl/trainer/ppo/v1/agent_loop_tq.py
@@ -50,9 +50,46 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
         super().__init__(*args, **kwargs)
         tq.init()
         self.background_tasks = set()
+        self.batch_queue = asyncio.Queue(maxsize=0)
+        self.batch_scheduler_task = None
 
     async def generate_sequences(self, batch: TensorDict) -> None:
-        """Spawn agent loop for each sample in the batch without waiting for the results."""
+        """Enqueue one batch chunk and return without waiting for rollout completion."""
+        await self.batch_queue.put(batch)
+        self._ensure_batch_scheduler()
+
+    def _ensure_batch_scheduler(self) -> None:
+        if self.batch_scheduler_task is not None and not self.batch_scheduler_task.done():
+            return
+
+        self.batch_scheduler_task = asyncio.create_task(self._batch_scheduler())
+        self.batch_scheduler_task.add_done_callback(self._on_batch_scheduler_done)
+
+    def _on_batch_scheduler_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("AgentLoopWorkerTQ batch scheduler failed", exc_info=(type(exc), exc, exc.__traceback__))
+
+    async def _batch_scheduler(self) -> None:
+        """Run queued batch chunks serially while keeping prompt-level parallelism within each chunk."""
+        while True:
+            batch = await self.batch_queue.get()
+            validate = batch["validate"] if "validate" in batch else False
+            try:
+                await self._run_batch(batch)
+            except Exception:
+                logger.exception("Failed to run queued agent loop batch")
+                try:
+                    await self._mark_batch_failure(batch, validate=validate)
+                except Exception:
+                    logger.exception("Failed to mark batch failure in TransferQueue")
+            finally:
+                self.batch_queue.task_done()
+
+    async def _run_batch(self, batch: TensorDict) -> None:
+        """Spawn agent loops for all prompts in one batch chunk and wait for the chunk to finish."""
         validate = batch["validate"] if "validate" in batch else False
         batch.pop("validate", None)
         config = self.config.actor_rollout_ref.rollout
@@ -77,7 +114,9 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
 
         trajectory_info = await get_trajectory_info(batch["global_steps"], batch["index"], validate)
 
-        # create background tasks for each sample in the batch
+        # create tasks for each sample in the batch. The batch scheduler waits for
+        # all of them before launching the next queued batch chunk on this worker.
+        tasks = []
         for i in range(len(batch)):
             # TODO(wuxibin): add trace support
             trace_this_sample = False
@@ -96,8 +135,19 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
             task = asyncio.create_task(
                 self._run_prompt(prompt, sampling_params, trajectory=trajectory_info[i], trace=trace_this_sample)
             )
-            self.background_tasks.add(task)
-            task.add_done_callback(self.background_tasks.discard)
+            tasks.append(task)
+
+        await asyncio.gather(*tasks)
+
+    async def _mark_batch_failure(self, batch: TensorDict, validate: bool) -> None:
+        partition_id = "val" if validate else "train"
+        if "uid" not in batch:
+            return
+
+        for uid in list(batch["uid"]):
+            if isinstance(uid, NonTensorData):
+                uid = uid.data
+            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
 
     async def _run_prompt(self, prompt: dict, sampling_params: dict, trajectory: dict, trace: bool = False) -> None:
         """Spawn multiple agent loops in parallel according to rollout.n or rollout.val_kwargs.n."""


### PR DESCRIPTION
### What does this PR do?

Queues TransferQueue agent-loop batch submissions in `AgentLoopWorkerTQ` so each worker processes queued batch chunks serially while preserving prompt-level concurrency within a batch.

Previously, repeated `generate_sequences()` calls spawned fully fire-and-forget prompt tasks across batch chunks. This PR introduces a per-worker batch queue and scheduler so the next queued batch chunk starts only after the current chunk's prompt tasks complete. If a queued batch fails before prompt-level handling completes, the batch uids are marked as `failure` in TransferQueue.

This is not duplicating an existing PR. Exact searches for `AgentLoopWorkerTQ batch_queue` and `TransferQueue add batch agent_loop_tq` found no open PRs. A broader search found #6641, but that PR changes `main_ppo_sync.py` / replay-buffer failure detection for incomplete rollouts, while this PR changes `agent_loop_tq.py` batch submission scheduling.

AI assistance was used for this change.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+AgentLoopWorkerTQ+batch_queue
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+TransferQueue+add+batch+agent_loop_tq
  - https://github.com/verl-project/verl/pull/6641
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

```bash
python -m py_compile verl/trainer/ppo/v1/agent_loop_tq.py
.venv/bin/pre-commit run --all-files --show-diff-on-failure --color=always
```

Both passed.

### API and Usage Example

No public API or config changes.

### Design & Code Changes

- Add an unbounded `asyncio.Queue` for batch chunks in `AgentLoopWorkerTQ`.
- Start one scheduler task per worker to drain queued batches.
- Move the original per-batch rollout submission logic into `_run_batch`.
- Await all prompt tasks within a batch before scheduling the next queued batch.
- Mark batch uids as failed if a queued batch raises before prompt-level handling completes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs). Not applicable: internal scheduling fix only.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. Not added: this path requires TransferQueue/Ray runtime integration; covered by py_compile and full pre-commit.
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`. Not applicable.
