### PR TITLE
[algo, doc] feat: add UP-GRPO unbounded positive asymmetric policy loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ verl is fast with:
 - **vLLM**, **SGLang** and **HF Transformers** for rollout generation.
 - Compatible with Hugging Face Transformers and Modelscope Hub: Qwen3.5, Qwen3, Qwen-2.5, Llama3.1, Gemma2, DeepSeek-LLM, etc
 - Supervised fine-tuning.
-- Reinforcement learning with [PPO](examples/ppo_trainer/), [GRPO](examples/grpo_trainer/), [GSPO](https://github.com/verl-project/verl-recipe/tree/main/gspo/), [ReMax](examples/remax_trainer/), [REINFORCE++](https://verl.readthedocs.io/en/latest/examples/config.html#algorithm), [RLOO](examples/rloo_trainer/), [PRIME](https://github.com/verl-project/verl-recipe/tree/main/prime/), [DAPO](https://github.com/verl-project/verl-recipe/tree/main/dapo/), [DrGRPO](https://github.com/verl-project/verl-recipe/tree/main/drgrpo), [KL_Cov & Clip_Cov](https://github.com/verl-project/verl-recipe/tree/main/entropy) etc.
+- Reinforcement learning with [PPO](examples/ppo_trainer/), [GRPO](examples/grpo_trainer/), [UP-GRPO](https://verl.readthedocs.io/en/latest/algo/up.html), [GSPO](https://github.com/verl-project/verl-recipe/tree/main/gspo/), [ReMax](examples/remax_trainer/), [REINFORCE++](https://verl.readthedocs.io/en/latest/examples/config.html#algorithm), [RLOO](examples/rloo_trainer/), [PRIME](https://github.com/verl-project/verl-recipe/tree/main/prime/), [DAPO](https://github.com/verl-project/verl-recipe/tree/main/dapo/), [DrGRPO](https://github.com/verl-project/verl-recipe/tree/main/drgrpo), [KL_Cov & Clip_Cov](https://github.com/verl-project/verl-recipe/tree/main/entropy) etc.
   - Support model-based reward and function-based reward (verifiable reward) for math, [coding](https://github.com/verl-project/verl-recipe/tree/main/dapo), etc
   - Support vision-language models (VLMs) and [multi-modal RL](examples/grpo_trainer/run_qwen2_5_vl_7b_fsdp.sh) with Qwen2.5-vl, Kimi-VL
   - [Multi-turn with tool calling](examples/tutorial/agent_loop_get_started/)
@@ -115,6 +115,7 @@ verl is fast with:
 - [Programming Guide](https://verl.readthedocs.io/en/latest/hybrid_flow.html) & [Tech Talk](https://hcqnc.xetlk.com/sl/3vACOK) (in Chinese)
 - [PPO in verl](https://verl.readthedocs.io/en/latest/algo/ppo.html)
 - [GRPO in verl](https://verl.readthedocs.io/en/latest/algo/grpo.html)
+- [UP-GRPO in verl](https://verl.readthedocs.io/en/latest/algo/up.html)
 
 **Running a PPO example step-by-step:**
 

--- a/docs/algo/up.md
+++ b/docs/algo/up.md
@@ -1,0 +1,70 @@
+# UP-GRPO: Unbounded Positive Asymmetric Optimization
+
+Last updated: 07/12/2026.
+
+UP (Unbounded Positive) is a plug-and-play modification of the GRPO policy loss that targets the **exploration-stability dilemma** in RL for LLMs. Standard GRPO/PPO uses a symmetric clip (single `ε`) together with importance sampling against the old policy `π_old`. For rare, low-confidence but *correct* tokens (large positive advantage, small probability), the symmetric upper clip and the `π_old` anchor suppress exactly the gradient signal that would encourage the model to explore, while lifting the clip risks importance-sampling induced gradient explosion. UP resolves this by treating the two signs of the advantage asymmetrically.
+
+For more details, refer to the paper [UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma](https://arxiv.org/pdf/2607.06987).
+
+## Key Components
+
+- **Probability Capacity view**: the improvement a token can contribute is bounded by how much probability mass it can still gain. Low-probability correct tokens have the most capacity, yet the symmetric clip caps their update the hardest. UP is designed to unlock this capacity.
+- **Unbounded positive**: for positive advantages, UP removes both the clip and the `π_old` importance-sampling anchor, so low-confidence correct tokens are free to grow.
+- **Asymmetric design**: positive and negative advantages are optimized with different objectives — unbounded exploration on the positive side, conservative clipping on the negative side for stability.
+
+## The Objective
+
+UP-GRPO uses the following token-level objective (paper Eq. 15), applied per token `(i, t)`:
+
+- **Positive advantages (Â > 0)**: an *unbounded, self-anchored* REINFORCE objective
+
+  \[
+  \hat{A}_{i,t} \cdot \log \pi_\theta(o_{i,t}\mid q, o_{i,<t})
+  \]
+
+  This is implemented with the stop-gradient trick: the self-anchored ratio `r̃ = πθ / sg(πθ)` equals `1` in value but has gradient `∇ log πθ`. There is no `π_old` term and no upper clip, so the effective update reduces to REINFORCE and maximizes exploration.
+
+- **Negative advantages (Â ≤ 0)**: the standard GRPO symmetric clip plus a dual-clip safeguard
+
+  \[
+  \min\!\big(r\,\hat{A},\; \operatorname{clip}(r, 1-\varepsilon, 1+\varepsilon)\,\hat{A}\big)
+  \]
+
+  with the dual-clip lower bound (`clip_ratio_c`) retained as a stability guard against destructive large-ratio negative updates.
+
+The KL regularization term `β D_KL` is **not** part of this loss. It is handled separately by verl through `use_kl_loss` / `kl_loss_coef` (KL loss added to the actor loss), consistent with GRPO.
+
+## Configuration
+
+To enable UP-GRPO, set the policy loss mode to `up` and keep the standard GRPO advantage estimator and KL-loss configuration:
+
+```yaml
+algorithm:
+  adv_estimator: grpo
+actor_rollout_ref:
+  actor:
+    policy_loss:
+      loss_mode: "up"
+    clip_ratio: 0.2
+    use_kl_loss: True
+    kl_loss_coef: 0.001
+    loss_agg_mode: "token-mean"
+```
+
+Notes:
+
+- `actor_rollout_ref.actor.policy_loss.loss_mode=up`: selects the UP-GRPO policy loss.
+- `algorithm.adv_estimator=grpo`: UP-GRPO builds on GRPO group-relative advantages.
+- `actor_rollout_ref.actor.clip_ratio=0.2`: the clip range. It only affects **negative** advantages; for positive advantages the upper clip is removed entirely, so raising or lowering it does not change the positive-advantage update.
+- `actor_rollout_ref.actor.use_kl_loss=True` and `kl_loss_coef=0.001`: KL regularization is applied by verl outside the policy loss.
+- `actor_rollout_ref.actor.loss_agg_mode=token-mean`: token-level aggregation, matching the paper.
+
+## Reference Example
+
+```bash
+bash examples/grpo_trainer/run_up_grpo_qwen3_8b_fsdp.sh
+```
+
+## Reference
+
+UP: Unbounded Positive Asymmetric Optimization for Breaking the Exploration-Stability Dilemma. Chongyu Fan et al., ByteDance Seed & Michigan State University. arXiv:2607.06987. Project page: <https://chongyu-fan.netlify.app/posts/up/>.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,6 +72,7 @@ verl is fast with:
 
    algo/ppo.md
    algo/grpo.md
+   algo/up.md
    algo/dapo.md
    algo/spin.md
    algo/sppo.md

--- a/examples/grpo_trainer/run_up_grpo_qwen3_8b_fsdp.sh
+++ b/examples/grpo_trainer/run_up_grpo_qwen3_8b_fsdp.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# UP-GRPO | Qwen3-8B | FSDP training | NVIDIA GPUs or Ascend NPUs
+#
+# UP-GRPO (Unbounded Positive Asymmetric Optimization, arXiv:2607.06987) is a
+# plug-and-play policy-loss modification of GRPO. It is enabled purely by setting
+# `actor_rollout_ref.actor.policy_loss.loss_mode=up`; everything else follows the
+# standard GRPO recipe (grpo advantage estimator + KL loss via use_kl_loss).
+#
+# Default hyperparameters follow Table A3 of the paper.
+#
+# Knobs:
+#   INFER_BACKEND   rollout backend: vllm | sglang | trtllm        (default: vllm)
+#   MACHINE         free-form tag for hardware tweaks (e.g. gb200)  (default: unset)
+# (DEVICE is auto-detected from torch_npu; export DEVICE=gpu|npu only to override.)
+#
+# TensorRT-LLM is GPU-only.
+# `MACHINE=gb200` (Blackwell SM100) bundles: enforce_eager=True, FSDP
+# model_dtype=bfloat16, SGLang attention_backend=flashinfer (FA3 unsupported on
+# SM>90), and ray_init.num_gpus pinned (Docker --privileged bypasses GPU
+# autodetect). Unknown MACHINE values are accepted and only affect experiment_name.
+
+set -xeuo pipefail
+
+########################### user-adjustable ###########################
+# DEVICE is auto-detected by probing torch_npu; override only for special cases.
+DEVICE=${DEVICE:-$(python3 -c 'import torch_npu' 2>/dev/null && echo npu || echo gpu)}
+INFER_BACKEND=${INFER_BACKEND:-vllm}
+MACHINE=${MACHINE:-}
+
+MODEL_PATH=${MODEL_PATH:-Qwen/Qwen3-8B}
+NNODES=${NNODES:-1}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-}
+NPUS_PER_NODE=${NPUS_PER_NODE:-}
+
+# UP-GRPO defaults follow Table A3 of arXiv:2607.06987.
+train_batch_size=${TRAIN_BATCH_SIZE:-128}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-32}
+max_prompt_length=${MAX_PROMPT_LENGTH:-1024}
+max_response_length=${MAX_RESPONSE_LENGTH:-3072}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-24576}
+
+actor_lr=${ACTOR_LR:-1e-6}
+clip_ratio=${CLIP_RATIO:-0.2}
+kl_loss_coef=${KL_LOSS_COEF:-0.001}
+entropy_coeff=${ENTROPY_COEFF:-0}
+
+rollout_tp=${ROLLOUT_TP:-}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-}
+rollout_n=${ROLLOUT_N:-8}
+sp_size=${SP_SIZE:-1}
+
+total_epochs=${TOTAL_EPOCHS:-15}
+save_freq=${SAVE_FREQ:-20}
+test_freq=${TEST_FREQ:-5}
+
+PROJECT_NAME=${PROJECT_NAME:-verl_up_grpo_gsm8k_math}
+EXPERIMENT_NAME=${EXPERIMENT_NAME:-qwen3_8b_up_grpo_${INFER_BACKEND}_fsdp_$(date +%Y%m%d_%H%M)}
+########################### end user-adjustable ###########################
+
+########################### derived defaults ###########################
+case "${DEVICE}" in
+    gpu | npu) ;;
+    *)
+        echo "DEVICE must be gpu or npu, got: ${DEVICE}" >&2
+        exit 1
+        ;;
+esac
+
+if [ "${DEVICE}" = npu ] && [ "${INFER_BACKEND}" = trtllm ]; then
+    echo "INFER_BACKEND=trtllm is only supported with DEVICE=gpu" >&2
+    exit 1
+fi
+
+# Defaults and extras grouped by device. Backend / machine refinements stay
+# nested in the device branch they apply to.
+EXTRA=()
+case "${DEVICE}" in
+    gpu)
+        actor_param_offload=False
+        actor_optimizer_offload=False
+        rollout_tp=${rollout_tp:-2}
+        rollout_gpu_mem_util=${rollout_gpu_mem_util:-0.6}
+
+        case "${MACHINE}" in
+            gb200)
+                NGPUS_PER_NODE=${NGPUS_PER_NODE:-4}
+                # Blackwell SM100: see header comment for rationale of each override.
+                EXTRA+=(
+                    actor_rollout_ref.rollout.enforce_eager=True
+                    actor_rollout_ref.rollout.free_cache_engine=True
+                    actor_rollout_ref.actor.fsdp_config.model_dtype=bfloat16
+                    "+ray_kwargs.ray_init.num_gpus=${NGPUS_PER_NODE}"
+                )
+                if [ "${INFER_BACKEND}" = sglang ]; then
+                    EXTRA+=(+actor_rollout_ref.rollout.engine_kwargs.sglang.attention_backend=flashinfer)
+                fi
+                ;;
+            *)
+                NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
+                ;;
+        esac
+        n_trainer_devices=${NGPUS_PER_NODE}
+        ;;
+    npu)
+        export HCCL_CONNECT_TIMEOUT=1500
+        export HCCL_HOST_SOCKET_PORT_RANGE=60000-60050
+        export HCCL_NPU_SOCKET_PORT_RANGE=61000-61050
+        export RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES=1
+
+        NPUS_PER_NODE=8
+        n_trainer_devices=${NPUS_PER_NODE}
+        actor_param_offload=True
+        actor_optimizer_offload=True
+        rollout_tp=${rollout_tp:-4}
+        sp_size=4
+        rollout_gpu_mem_util=0.3
+        EXTRA+=(
+            actor_rollout_ref.actor.use_torch_compile=False
+            actor_rollout_ref.actor.fsdp_config.ulysses_sequence_parallel_size=${sp_size}
+            actor_rollout_ref.ref.fsdp_config.ulysses_sequence_parallel_size=${sp_size}
+            actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1
+            actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1
+            actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=4096
+        )
+        if [ "${INFER_BACKEND}" = sglang ]; then
+            EXTRA+=(
+                +actor_rollout_ref.rollout.engine_kwargs.sglang.attention_backend=ascend
+            )
+        fi
+        ;;
+esac
+
+########################### parameter arrays ###########################
+
+DATA=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+    data.train_files="['$HOME/data/gsm8k/train.parquet', '$HOME/data/math/train.parquet']"
+    data.val_files="['$HOME/data/gsm8k/test.parquet', '$HOME/data/math/test.parquet']"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.filter_overlong_prompts=True
+    data.truncation='error'
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.use_remove_padding=True
+    actor_rollout_ref.model.enable_gradient_checkpointing=True
+)
+
+# UP-GRPO: the only algorithmic switch is policy_loss.loss_mode=up.
+# For positive advantages the loss is an unbounded self-anchored REINFORCE objective
+# (clip_ratio no longer affects them); for negative advantages it keeps the GRPO clip.
+ACTOR=(
+    actor_rollout_ref.actor.policy_loss.loss_mode=up
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.clip_ratio=${clip_ratio}
+    actor_rollout_ref.actor.use_dynamic_bsz=True
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_kl_loss=True
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef}
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl
+    actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
+    actor_rollout_ref.actor.loss_agg_mode=token-mean
+    actor_rollout_ref.actor.fsdp_config.param_offload=${actor_param_offload}
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=${actor_optimizer_offload}
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=${INFER_BACKEND}
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${rollout_tp}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=${rollout_n}
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+)
+
+REF=(
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.ref.fsdp_config.param_offload=True
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.logger='["console","wandb"]'
+    trainer.project_name=${PROJECT_NAME}
+    trainer.experiment_name=${EXPERIMENT_NAME}
+    trainer.n_gpus_per_node=${n_trainer_devices}
+    trainer.nnodes=${NNODES}
+    trainer.save_freq=${save_freq}
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+)
+
+########################### launch ###########################
+python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${MODEL[@]}" \
+    "${ACTOR[@]}" \
+    "${ROLLOUT[@]}" \
+    "${REF[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@"

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -58,6 +58,7 @@ policy_loss:
   _target_: verl.workers.config.PolicyLossConfig
 
   # Loss function mode: vanilla / clip-cov / kl-cov /gpg from https://arxiv.org/abs/2505.22617
+  # / up (UP-GRPO) from https://arxiv.org/abs/2607.06987
   loss_mode: "vanilla"
 
   # Ratio of tokens to be clipped for clip-cov loss

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1369,6 +1369,106 @@ def compute_policy_loss_vanilla(
     return pg_loss, pg_metrics
 
 
+@register_policy_loss("up")
+def compute_policy_loss_up(
+    old_log_prob: torch.Tensor,
+    log_prob: torch.Tensor,
+    advantages: torch.Tensor,
+    response_mask: torch.Tensor,
+    loss_agg_mode: str = "token-mean",
+    config: Optional[ActorConfig] = None,
+    rollout_is_weights: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """UP-GRPO token-level objective (paper arXiv:2607.06987, Eq. 15).
+
+    UP (Unbounded Positive) is a plug-and-play, asymmetric modification of the GRPO
+    policy loss that breaks the exploration-stability dilemma:
+
+    - Positive advantages (A > 0): discard clipping/importance-sampling entirely and
+      use an unbounded self-anchored REINFORCE objective. This is realized through the
+      stop-gradient trick: the self-anchored ratio ``r_tilde = pi / sg(pi)`` equals 1 in
+      value but carries gradient ``grad log pi``. Removing the ``pi_old`` anchor and the
+      upper clip maximizes exploration for rare, low-confidence correct tokens without
+      importance-sampling induced gradient explosion.
+    - Negative advantages (A <= 0): keep the standard GRPO symmetric clip (single epsilon)
+      plus the dual-clip safeguard for stability.
+
+    The KL penalty is handled separately by verl via ``use_kl_loss`` / ``kl_loss_coef``,
+    so it is intentionally NOT added inside this policy-loss function.
+
+    Args:
+        old_log_prob (torch.Tensor):
+            Log-probabilities of actions under the old policy, shape (batch_size, response_length).
+        log_prob (torch.Tensor):
+            Log-probabilities of actions under the current policy, shape (batch_size, response_length).
+        advantages (torch.Tensor):
+            Advantage estimates for each action, shape (batch_size, response_length).
+        response_mask (torch.Tensor):
+            Mask indicating which tokens to include in the loss, shape (batch_size, response_length).
+        loss_agg_mode (str, optional):
+            Aggregation mode for `agg_loss`. Defaults to "token-mean".
+        config: `(verl.trainer.config.ActorConfig)`:
+            config for the actor.
+        rollout_is_weights: `(torch.Tensor)`:
+            Optional rollout-correction importance-sampling weights, shape (batch_size, response_length).
+    """
+    assert config is not None
+    assert not isinstance(config, AlgoConfig)
+    clip_ratio = config.clip_ratio  # Clipping parameter ε for standard PPO. See https://arxiv.org/abs/1707.06347.
+    clip_ratio_low = config.clip_ratio_low if config.clip_ratio_low is not None else clip_ratio
+    clip_ratio_high = config.clip_ratio_high if config.clip_ratio_high is not None else clip_ratio
+    clip_ratio_c = config.get(  # Lower bound of the ratio for dual-clip PPO. See https://arxiv.org/pdf/1912.09729.
+        "clip_ratio_c", 3.0
+    )
+
+    assert clip_ratio_c > 1.0, (
+        "The lower bound of the clip_ratio_c for dual-clip PPO should be greater than 1.0,"
+        + f" but get the value: {clip_ratio_c}."
+    )
+
+    negative_approx_kl = torch.clamp(log_prob - old_log_prob, min=-20.0, max=20.0)
+    ratio = torch.exp(negative_approx_kl)
+    ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
+
+    # Positive branch: unbounded self-anchored REINFORCE objective.
+    # r_tilde = pi / sg(pi) is 1 in value but has gradient grad log pi, so this
+    # removes the pi_old anchor and the clip while keeping the REINFORCE gradient.
+    r_tilde = torch.exp(log_prob - log_prob.detach())
+    pg_losses_pos = -advantages * r_tilde
+
+    # Negative branch: standard GRPO symmetric clip + dual-clip safeguard.
+    pg_losses1 = -advantages * ratio
+    pg_losses2 = -advantages * torch.clamp(ratio, 1 - clip_ratio_low, 1 + clip_ratio_high)
+    clip_pg_losses1 = torch.maximum(pg_losses1, pg_losses2)
+    pg_losses3 = -advantages * clip_ratio_c
+    clip_pg_losses2 = torch.min(pg_losses3, clip_pg_losses1)
+    pg_losses_neg = torch.where(advantages < 0, clip_pg_losses2, clip_pg_losses1)
+
+    pg_losses = torch.where(advantages > 0, pg_losses_pos, pg_losses_neg)
+
+    # Apply rollout correction weights if provided
+    if rollout_is_weights is not None:
+        pg_losses = pg_losses * rollout_is_weights
+
+    pg_loss = agg_loss(
+        loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode, **config.global_batch_info
+    )
+
+    # Clip metrics are only meaningful on the (clipped) non-positive branch.
+    neg_mask = response_mask * (advantages <= 0).float()
+    pg_clipfrac = verl_F.masked_mean(torch.gt(pg_losses2, pg_losses1).float(), neg_mask)
+    pg_clipfrac_lower = verl_F.masked_mean(
+        torch.gt(clip_pg_losses1, pg_losses3) * (advantages < 0).float(), response_mask
+    )
+
+    pg_metrics = {
+        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
+        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+    }
+    return pg_loss, pg_metrics
+
+
 @register_policy_loss("dppo_tv")
 def compute_policy_loss_dppo_tv(
     old_log_prob: torch.Tensor,

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -82,7 +82,7 @@ class PolicyLossConfig(BaseConfig):
     The inheritance from BaseConfig provides omegaconf.DictConfig-like interface for a dataclass config.
 
     Args:
-        loss_mode (str): Loss function mode. Options: 'vanilla', 'clip-cov', 'kl-cov', 'gpg'.
+        loss_mode (str): Loss function mode. Options: 'vanilla', 'clip-cov', 'kl-cov', 'gpg', 'up'.
         clip_cov_ratio (float): Ratio of tokens to be clipped for clip-cov loss.
         clip_cov_lb (float): Lower bound for clip-cov loss.
         clip_cov_ub (float): Upper bound for clip-cov loss.


### PR DESCRIPTION
### What does this PR do?

Adds **UP-GRPO** (Unbounded Positive Asymmetric Optimization, [arXiv:2607.06987](https://arxiv.org/pdf/2607.06987)) as a new, plug-and-play policy-loss mode `up`.

**Motivation.** Standard GRPO/PPO combines a symmetric clip (single `ε`) with importance sampling against `π_old`. For rare, low-confidence but *correct* tokens (large positive advantage, small probability), the symmetric upper clip and the `π_old` anchor suppress exactly the gradient signal needed for exploration, while lifting the clip risks IS-induced gradient explosion. UP resolves this **exploration-stability dilemma** by treating the two advantage signs asymmetrically.

**The `up` loss (UP-GRPO, Eq. 15):**
- **Positive advantages (Â > 0):** an *unbounded, self-anchored* REINFORCE objective. Implemented via the stop-gradient trick — the self-anchored ratio `r̃ = πθ / sg(πθ)` equals `1` in value but carries gradient `∇log πθ`, removing the `π_old` anchor and the upper clip to maximize exploration without IS blow-up.
- **Negative advantages (Â ≤ 0):** the standard GRPO symmetric clip + dual-clip safeguard, unchanged for stability.

**KL handling.** The KL term is **not** added inside the policy loss; it is handled separately by verl via `use_kl_loss` / `kl_loss_coef`, consistent with GRPO.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/volcengine/verl/pulls?q=is%3Apr+UP-GRPO
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

Not covered by CI (new algorithm). Validated locally:
- `pre-commit` on changed files — ruff, ruff-format, check-example-naming, check-docs-time-info, check-license, check-docstrings, check-naming-conventions all pass.
- `python -c "from verl.trainer.ppo.core_algos import get_policy_loss_fn; print(get_policy_loss_fn('up'))"` resolves the registered loss.
- End-to-end reference run: `bash examples/grpo_trainer/run_up_grpo_qwen3_8b_fsdp.sh` (Qwen3-8B, GSM8K/MATH, Table A3 hyperparameters). No full training run is included in CI (out of scope).

### API and Usage Example

Enable UP-GRPO by selecting the policy-loss mode; everything else follows the standard GRPO recipe:

```bash
python3 -m verl.trainer.main_ppo \
    algorithm.adv_estimator=grpo \
    actor_rollout_ref.actor.policy_loss.loss_mode=up \
    actor_rollout_ref.actor.clip_ratio=0.2 \
    actor_rollout_ref.actor.use_kl_loss=True \
    actor_rollout_ref.actor.kl_loss_coef=0.001 \
    actor_rollout_ref.actor.loss_agg_mode=token-mean \
    ...
```

The upper clip no longer affects positive advantages under `loss_mode=up`.

### Design & Code Changes

- `verl/trainer/ppo/core_algos.py`: new `@register_policy_loss("up")` `compute_policy_loss_up`, mirroring `vanilla`'s `agg_loss(..., **config.global_batch_info)` call, dual-clip handling, and metric keys.
- `verl/workers/config/actor.py`: add `up` to the `PolicyLossConfig.loss_mode` docstring.
- `verl/trainer/config/actor/actor.yaml`: note `up` (UP-GRPO) in the `loss_mode` comment.
- `docs/algo/up.md`: new algorithm page (motivation, Eq. 15, configuration, reference); registered in the `docs/index.rst` Algorithms toctree after GRPO.
- `examples/grpo_trainer/run_up_grpo_qwen3_8b_fsdp.sh`: runnable example based on the Qwen3-8B GRPO script with `loss_mode=up` and Table A3 hyperparameters.
- `README.md`: cite UP-GRPO in the algorithm lists.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff / ruff-format / sanity hooks pass on changed files).
- [x] Add / Update the documentation (`docs/algo/up.md` + toctree).
- [ ] Add unit or end-to-end test(s) to the CI workflow. Not feasible here: this is a new RL algorithm whose behavior is validated by training experiments rather than CI; a CI smoke test is intentionally out of scope for this PR.
- [ ] Once your PR is ready for CI, send a message in the `ci-request` channel.
- [ ] N/A — this PR does not modify the `recipe` submodule.

Made with [Cursor](https://cursor.com)
