### PR TITLE
[fsdp] fix: Fix the conflict caused by different data types between to…

### DIFF
--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -408,13 +408,9 @@ def forward_with_triton_backend(
     else:
         raise RuntimeError("To use forward_with_triton_backend, either labels or input_ids must be provided.")
 
-    vocab_weights = self.lm_head.weight
-    if isinstance(vocab_weights, DTensor):
-        vocab_weights = vocab_weights.full_tensor().to(hidden_states.device)
-
     log_probs, entropy = linear_cross_entropy(
         hidden_states,
-        vocab_weights,
+        self.lm_head.weight,
         rolled_labels,
         temperature,
         "none",

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -349,6 +349,7 @@ def forward_with_torch_backend(
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
     from torch.distributed.tensor import DTensor
+
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = self.model(input_ids, **kwargs)
@@ -398,6 +399,7 @@ def forward_with_triton_backend(
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
     from torch.distributed.tensor import DTensor
+
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = self.model(input_ids, **kwargs)

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from torch.distributed.tensor import DTensor
 from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLCausalLMOutputWithPast,
     Qwen3VLForConditionalGeneration,
@@ -348,8 +349,6 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
-    from torch.distributed.tensor import DTensor
-
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = self.model(input_ids, **kwargs)
@@ -369,12 +368,7 @@ def forward_with_torch_backend(
 
     vocab_weights = self.lm_head.weight
     if isinstance(vocab_weights, DTensor):
-        vocab_weights = vocab_weights.full_tensor()
-
-    if isinstance(hidden_states, DTensor):
-        hidden_states = hidden_states.full_tensor()
-
-    vocab_weights = vocab_weights.to(hidden_states.device)
+        vocab_weights = vocab_weights.full_tensor().to(hidden_states.device)
 
     fused_linear_for_ppo = FusedLinearForPPO()
     log_probs, entropy = fused_linear_for_ppo.forward(
@@ -398,8 +392,6 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
-    from torch.distributed.tensor import DTensor
-
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = self.model(input_ids, **kwargs)
@@ -418,12 +410,7 @@ def forward_with_triton_backend(
 
     vocab_weights = self.lm_head.weight
     if isinstance(vocab_weights, DTensor):
-        vocab_weights = vocab_weights.full_tensor()
-
-    if isinstance(hidden_states, DTensor):
-        hidden_states = hidden_states.full_tensor()
-
-    vocab_weights = vocab_weights.to(hidden_states.device)
+        vocab_weights = vocab_weights.full_tensor().to(hidden_states.device)
 
     log_probs, entropy = linear_cross_entropy(
         hidden_states,

--- a/verl/models/transformers/qwen3_vl.py
+++ b/verl/models/transformers/qwen3_vl.py
@@ -348,6 +348,7 @@ def forward_with_torch_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
+    from torch.distributed.tensor import DTensor
     from verl.utils.experimental.torch_functional import FusedLinearForPPO
 
     outputs = self.model(input_ids, **kwargs)
@@ -365,10 +366,19 @@ def forward_with_torch_backend(
     else:
         raise RuntimeError("To use forward_with_torch_backend, either labels or input_ids must be provided.")
 
+    vocab_weights = self.lm_head.weight
+    if isinstance(vocab_weights, DTensor):
+        vocab_weights = vocab_weights.full_tensor()
+
+    if isinstance(hidden_states, DTensor):
+        hidden_states = hidden_states.full_tensor()
+
+    vocab_weights = vocab_weights.to(hidden_states.device)
+
     fused_linear_for_ppo = FusedLinearForPPO()
     log_probs, entropy = fused_linear_for_ppo.forward(
         hidden_states=hidden_states,
-        vocab_weights=self.lm_head.weight,
+        vocab_weights=vocab_weights,
         input_ids=rolled_labels,
         temperature=temperature,
     )
@@ -387,6 +397,7 @@ def forward_with_triton_backend(
     shift_labels: Optional[torch.LongTensor] = None,
     **kwargs,
 ) -> "Qwen3VLCausalLMOutputForPPO":
+    from torch.distributed.tensor import DTensor
     from verl.utils.kernel.linear_cross_entropy import linear_cross_entropy
 
     outputs = self.model(input_ids, **kwargs)
@@ -403,9 +414,18 @@ def forward_with_triton_backend(
     else:
         raise RuntimeError("To use forward_with_triton_backend, either labels or input_ids must be provided.")
 
+    vocab_weights = self.lm_head.weight
+    if isinstance(vocab_weights, DTensor):
+        vocab_weights = vocab_weights.full_tensor()
+
+    if isinstance(hidden_states, DTensor):
+        hidden_states = hidden_states.full_tensor()
+
+    vocab_weights = vocab_weights.to(hidden_states.device)
+
     log_probs, entropy = linear_cross_entropy(
         hidden_states,
-        self.lm_head.weight,
+        vocab_weights,
         rolled_labels,
         temperature,
         "none",


### PR DESCRIPTION
…rch.Tensorand DTensor.

### What does this PR do?

Fix the conflict caused by different data types between torch.Tensorand DTensor.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

