### PR TITLE
[reward] feat: support deterministic reward for user-defined generative RM paths

### DIFF
--- a/.github/workflows/vllm.yml
+++ b/.github/workflows/vllm.yml
@@ -58,9 +58,12 @@ on:
       # Entrypoints
       - ".github/workflows/vllm.yml"
       - "tests/special_e2e/generation"
+      - "tests/experimental/reward_loop/run_determinism_e2e_with_rm.py"
       - "tests/workers/rollout"
       - "verl/trainer/main_generation.py"
       - "verl/trainer/config/generation.yaml"
+      - "verl/trainer/main_ppo.py"
+      - "verl/trainer/config/ppo_trainer.yaml"
 
 # Cancel jobs on the same ref if a new one is triggered
 concurrency:
@@ -123,7 +126,7 @@ jobs:
       - name: Prepare gsm8k dataset
         run: |
           ray stop --force
-          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k
+          python3 examples/data_preprocess/gsm8k.py --local_dataset_path ${HOME}/models/hf_data/gsm8k --local_dir ${HOME}/data/gsm8k
       - name: Test the latest vLLM Rollout async with agent loop
         run: |
           ROLLOUT_NAME=vllm pytest -svvv tests/experimental/agent_loop

--- a/docs/advance/determinism.md
+++ b/docs/advance/determinism.md
@@ -16,11 +16,15 @@ Useful for:
 
 ## Quick Start
 
+`full_determinism` is supported on all training engines (FSDP, Megatron, etc.) via each engine's config. The example below uses FSDP; for Megatron set `actor_rollout_ref.actor.megatron_config.full_determinism=true` (and similarly for the ref model).
+
 ```yaml
 actor_rollout_ref:
   rollout:
     full_determinism: true
     seed: 42
+    # If the policy model is not covered by vLLM batch invariance, set to 1.
+    # max_num_seqs: 1
   actor:
     fsdp_config:
       full_determinism: true
@@ -34,7 +38,17 @@ reward:
     rollout:
       full_determinism: true
       seed: 42
+      # If the RM model is not covered by vLLM batch invariance, set to 1.
+      # max_num_seqs: 1
+
+trainer:
+  # REQUIRED: use the V0 trainer backend. The default V1 backend collects rollout
+  # outputs in completion order (via a TransferQueue), which varies across runs and
+  # breaks bitwise reproducibility. V0 uses asyncio.gather (submission order).
+  use_v1: false
 ```
+
+Both actor rollout and generative RM (VLM scoring) rely on vLLM batch invariance for co-batching. If your model or hardware is not covered, set `max_num_seqs=1` to serialize. Discriminative RM (score-outputting, e.g. Skywork-Reward) is forced to `1` automatically (see Reward model routing).
 
 Or via Hydra overrides:
 
@@ -47,84 +61,69 @@ python -m verl.trainer.main_ppo \
   reward.reward_model.enable=true \
   reward.reward_model.rollout.full_determinism=true \
   reward.reward_model.rollout.seed=42 \
+  trainer.use_v1=false \
   [other config overrides...]
 ```
 
-> **Important:** `PYTHONHASHSEED` must be set **before the Python interpreter starts**. verl handles this automatically — it sets `PYTHONHASHSEED` from `rollout.seed` before `ray.init()` and propagates it to all Ray actors. Do NOT set it manually.
+If the policy or RM model is not covered by vLLM batch invariance, add `actor_rollout_ref.rollout.max_num_seqs=1` and/or `reward.reward_model.rollout.max_num_seqs=1` to serialize. Discriminative RM (score-outputting) is forced to 1 automatically.
 
 ## Configuration Reference
 
 | Parameter | Default | Scope | Description |
 |-----------|---------|-------|-------------|
 | `actor_rollout_ref.rollout.full_determinism` | `false` | Rollout | Enables deterministic rollout generation |
+| `actor_rollout_ref.rollout.max_num_seqs` | `1024` | Rollout | Set to `1` to serialize if the policy model is not covered by vLLM batch invariance |
 | `actor_rollout_ref.rollout.seed` | `42` | Rollout | Base seed; each replica uses `replica_rank + seed` |
 | `actor_rollout_ref.actor.fsdp_config.full_determinism` | `false` | Actor | Enables deterministic PyTorch ops for actor |
 | `actor_rollout_ref.ref.fsdp_config.full_determinism` | `false` | Ref model | Enables deterministic PyTorch ops for reference model |
-| `reward.reward_model.rollout.full_determinism` | `false` | Reward model | Enables deterministic RM inference (forces `max_num_seqs=1`) |
+| `reward.reward_model.rollout.full_determinism` | `false` | Reward model | Enables deterministic RM inference |
+| `reward.reward_model.rollout.max_num_seqs` | `1024` | Reward model | Discriminative RM forced to 1 under full_determinism; set to 1 for generative RM if not covered by batch invariance |
 | `reward.reward_model.rollout.seed` | `42` | Reward model | Base seed for RM vLLM server |
+| `trainer.use_v1` | `true` | Trainer | Must be `false` under `full_determinism`. V1 (AgentLoopManagerTQ) collects outputs in completion order, which varies across runs; V0 (AgentLoopManager) uses submission order. |
 
 ## How It Works
 
-Determinism is enforced at five layers. All must be enabled for full E2E reproducibility:
+`full_determinism=true` is enforced at five layers. The training entrypoint sets `PYTHONHASHSEED` (from `rollout.seed`), `VERL_FULL_DETERMINISM`, `VLLM_BATCH_INVARIANT`, and the NCCL/cuBLAS determinism env vars (`CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, `NCCL_DETERMINISTIC`, `NCCL_ALGO`) before `ray.init()` and forwards them to all Ray actors via `PPO_RAY_RUNTIME_ENV`. These must be set before torch/NCCL init, so the entrypoint exports them rather than `enable_full_determinism()` (which runs after the actor is already up). Do NOT set `PYTHONHASHSEED` manually — the entrypoint handles it.
 
-### PyTorch-level
+### Floating-point determinism
 
-`enable_full_determinism(seed)` sets `PYTHONHASHSEED`, `CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, seeds all RNGs, calls `torch.use_deterministic_algorithms(True, warn_only=True)`, and disables cuDNN benchmarking. Applied in all training engine implementations.
+`enable_full_determinism(seed)` sets `CUBLAS_WORKSPACE_CONFIG`, `FLASH_ATTENTION_DETERMINISTIC`, `NCCL_DETERMINISTIC`, `NCCL_ALGO`, seeds all RNGs, calls `torch.use_deterministic_algorithms(True, warn_only=True)`, and disables cuDNN benchmarking. Applied in all training engine implementations (FSDP, Megatron, etc.). The flash-attn Triton cross-entropy kernel (used to compute log-probs) has a non-deterministic reduction not covered by the env vars above, so `VERL_DISABLE_FLASH_ATTN_CE=1` is set by default to force the pure-PyTorch `log_softmax`+gather path.
 
-### Environment propagation
+### Sampling seeds
 
-`main_ppo.run_ppo()` sets three env vars before `ray.init()`:
+- **Replica seed**: each replica uses `replica_rank + config.seed`, producing different but internally reproducible outputs across replicas. Two runs with the same config produce bitwise-aligned results.
+- **Per-request seed**: each `generate()` call injects `SamplingParams.seed = replica_rank + config.seed` to reset the sampler RNG per request, so the same prompt+seed yields the same tokens regardless of batch.
 
-- `PYTHONHASHSEED` — freezes Python hash() and dict ordering
-- `VERL_FULL_DETERMINISM` — signals subprocesses to apply determinism
-- `VLLM_BATCH_INVARIANT` — makes vLLM outputs independent of batch composition
+### Deterministic routing
 
-These are forwarded to all Ray actors via `PPO_RAY_RUNTIME_ENV`.
+- **Actor rollout**: `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` (priority from `non_tensor_batch["priority"]`), and `GlobalRequestLoadBalancer` (with `full_determinism=True`) routes with `hash(request_id) % len(servers)` — the same request always routes to the same vLLM server across runs. (`priority` is vLLM-only; `LLMServerClient.generate()` filters it for non-vLLM backends.) When `full_determinism=True`, `LLMServerClient._vllm_request_id()` forwards this stable `request_id` to vLLM itself.
+- **Reward**: `NaiveRouter` routes with `binascii.crc32(request body) % len(candidates)` among equally-loaded RM replicas, so the same reward request always routes to the same replica. This neutralizes replica-level floating-point differences that seed alone cannot equalize.
 
-### vLLM batch invariance + per-request seed
+### Trainer backend (V0 required)
 
-`VLLM_BATCH_INVARIANT=1` ensures vLLM outputs don't depend on which other requests are batched together. Each `generate()` call injects `SamplingParams.seed = replica_rank + config.seed` to reset RNG per request.
+Full determinism requires the **V0** trainer backend (`trainer.use_v1=false`, i.e. `AgentLoopManager`). The default V1 backend (`AgentLoopManagerTQ`) decouples rollout submission from collection via a fire-and-forget TransferQueue: outputs are collected **in completion order**, which depends on per-request latency and varies across runs, so the output concatenation order (and thus the training batch) differs run-to-run. V0 instead uses `asyncio.gather`, which returns outputs in **submission order** — stable across runs.
 
-### Priority scheduling + deterministic routing
+Set `trainer.use_v1=false` explicitly when enabling `full_determinism`.
 
-Without determinism, request order depends on arrival timing and server selection on dict iteration order. When `full_determinism=true`:
+### Batch invariance
 
-- Each sample gets a globally unique priority injected into the batch (`non_tensor_batch["priority"]`), so each rollout request is scheduled with a stable, distinct priority
-- `SingleTurnAgentLoop` uses `request_id=f"det-{priority}"` instead of random UUID
-- `GlobalRequestLoadBalancer` tie-breaking uses `hash(request_id) % len(candidates)` — deterministic with frozen `PYTHONHASHSEED`
+`VLLM_BATCH_INVARIANT=1` makes vLLM outputs independent of batch composition. Coverage is model- and hardware-dependent — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/) (and [tested models](https://docs.vllm.ai/en/latest/features/batch_invariance/#tested-models)). If not covered, set `max_num_seqs=1` to serialize.
 
-> **Note:** `priority` is a vLLM-only parameter. `LLMServerClient.generate()` automatically filters it for non-vLLM backends.
+For reward specifically:
+- **Discriminative RM** (score-outputting, e.g. Skywork-Reward; no custom reward fn): `max_num_seqs` is **forced to 1** — batch invariance is verified on generation models, not score-outputting RM architectures.
+- **Generative RM** (VLM that outputs text scores, via custom reward fn): `max_num_seqs` is **not forced** — user-managed; rely on batch invariance + per-request seed.
 
-### Reward model serialization
+## Side Effects
 
-vLLM's `/classify` endpoint (used by RM) does not support priority or batch invariance. When `full_determinism=true`, `RewardModelManager` forces `max_num_seqs=1`, serializing RM inference one request at a time.
+- **Performance**: deterministic PyTorch kernels are slower and cuDNN benchmarking is disabled. Discriminative RM is serialized (`max_num_seqs=1`) under full_determinism.
+- **Recommendation**: Only enable for debugging, regression testing, or research. Leave disabled for production training.
 
-## Side Effects and Limitations
+## Limitations
 
-**Performance**: deterministic PyTorch kernels are slower, cuDNN benchmarking is disabled, and RM `max_num_seqs=1` causes severe throughput loss. Typical E2E throughput drops 10–30% without RM; RM determinism can drop significantly more.
-
-**Recommendation**: Only enable for debugging, regression testing, or research. Leave disabled for production training.
-
-**Nondeterministic fallbacks**: Some GPU ops have no deterministic implementation. `torch.use_deterministic_algorithms(True, warn_only=True)` warns when these are encountered.
-
-**Backend support**:
-
-| Backend | Rollout | Reward model |
-|---------|---------|--------------|
-| vLLM | ✅ | ✅ (serialized) |
-| SGLang | ❌ | ❌ |
-| TensorRT-LLM | ❌ | ❌ |
-
-**PYTHONHASHSEED**: Must be set before process start. verl handles this automatically; manual Ray actor creation must propagate it via `runtime_env`.
-
-**Data parallelism**: Each replica uses `replica_rank + seed`, producing different but internally reproducible outputs. Two runs with the same config produce bitwise-aligned results.
-
-**Multi-turn agent not supported**: Full determinism only works for single-turn rollouts (`single_turn_agent_loop`). Multi-turn rollouts (`tool_agent_loop`) are **not** bitwise reproducible, for two reasons:
-
-- `tool_agent_loop` uses a random UUID per trajectory as `request_id` and does not pass `priority` to `server_manager.generate()`, so the deterministic routing and priority scheduling described above do not apply.
-- Even with those added, each turn is interleaved with external tool calls whose execution time varies across runs, so the order in which requests arrive at vLLM cannot be made deterministic. This is inherent to multi-turn agentic workloads.
-
-For bitwise-reproducible rollouts, use `single_turn_agent_loop`. (The per-request sampling seed is still applied to multi-turn requests inside the vLLM server, but this alone is not sufficient for end-to-end reproducibility.)
+- **Hardware**: vLLM batch invariance (and some deterministic GPU ops) requires specific hardware — see the [vLLM batch invariance docs](https://docs.vllm.ai/en/latest/features/batch_invariance/) for requirements. On unsupported hardware, set `max_num_seqs=1` to serialize. `torch.use_deterministic_algorithms(True, warn_only=True)` warns when a deterministic kernel is unavailable.
+- **Backend**: only vLLM is supported.
+- **Trainer backend**: the V0 trainer (`trainer.use_v1=false`) is required. The default V1 backend's TransferQueue collects outputs in completion order, which is nondeterministic (see [Trainer backend](#trainer-backend-v0-required) above).
+- **Multi-turn agent**: not supported. Full determinism only works for single-turn rollouts (`single_turn_agent_loop`). Multi-turn rollouts (`tool_agent_loop`) are **not** bitwise reproducible — `tool_agent_loop` uses a random UUID per trajectory as `request_id`, does not pass `priority`, and each turn is interleaved with external tool calls whose timing varies across runs. Use `single_turn_agent_loop` for bitwise-reproducible rollouts.
 
 ## Verifying Determinism
 
@@ -136,7 +135,7 @@ VLLM_DETERMINISM_N_GPUS=2 \
 pytest tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py -v -s
 ```
 
-E2E training (bitwise-aligned reward curves across two full PPO runs):
+E2E training (bitwise-aligned reward curves across two full PPO runs). Runs PPO twice with identical seeds, compares per-step reward curves in float32; exit code 0 = aligned, 1 = not aligned / error (usable as a CI gate):
 
 ```bash
 python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
@@ -144,5 +143,7 @@ python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
   --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
   --train_files ~/data/gsm8k/train.parquet \
   --val_files ~/data/gsm8k/test.parquet \
-  --n_gpus 2 --n_steps 5
+  --n_gpus 2 --n_steps 2
 ```
+
+See the script's module docstring for the full argument reference (e.g. `--plot`, `--save_metrics`, multi-replica coverage, and why the RM `max_num_seqs` is forced to 1 for discriminative RMs but allowed `>1` for generative RMs).

--- a/tests/experimental/agent_loop/test_basic_agent_loop.py
+++ b/tests/experimental/agent_loop/test_basic_agent_loop.py
@@ -427,12 +427,12 @@ class TestLoadBalancerRouting:
     """Least-loaded selection."""
 
     def test_distributes_across_servers(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         servers = [ray.get(lb.acquire_server.remote(request_id=f"r{i}"))[0] for i in range(3)]
         assert sorted(servers) == ["s0", "s1", "s2"]
 
     def test_new_requests_route_to_least_loaded(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         # Load s0 with 3 inflight requests
         ray.get(lb.acquire_server.remote(request_id="a"))[0]  # -> s0
         ray.get(lb.acquire_server.remote(request_id="a"))[0]  # sticky -> s0
@@ -444,7 +444,7 @@ class TestLoadBalancerRouting:
         assert s_new == "s2"
 
     def test_release_rebalances(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         s0 = ray.get(lb.acquire_server.remote(request_id="r0"))[0]
         s1 = ray.get(lb.acquire_server.remote(request_id="r1"))[0]
         assert s0 != s1
@@ -456,13 +456,13 @@ class TestLoadBalancerRouting:
 
     def test_release_invalid_server_silently_ignored(self, ray_for_lb):
         """Releasing a nonexistent server is silently ignored (hybrid-safe)."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Should not raise
         ray.get(lb.release_server.remote(server_id="nonexistent"))
 
     def test_release_without_inflight_silently_ignored(self, ray_for_lb):
         """Releasing a server with no inflight requests is silently ignored (hybrid-safe)."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Should not raise even though s1 has 0 inflight
         ray.get(lb.release_server.remote(server_id="s1"))
 
@@ -471,7 +471,7 @@ class TestLoadBalancerStickySession:
     """Request-level sticky session."""
 
     def test_same_request_id_same_server(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None, "s3": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None, "s3": None})
         s0 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))[0]
         ray.get(lb.release_server.remote(server_id=s0))
         s1 = ray.get(lb.acquire_server.remote(request_id="conv-abc"))[0]
@@ -482,14 +482,14 @@ class TestLoadBalancerHybrid:
     """Dynamic server add/remove for hybrid scaling."""
 
     def test_add_server(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.add_servers.remote(servers={"s2": None}))
         status = ray.get(lb.get_status.remote())
         assert "s2" in status["servers"]
         assert status["servers"]["s2"] == 0
 
     def test_remove_server_purges_handle(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         # remove_server now purges from both _inflight_requests and _servers
         status = ray.get(lb.get_status.remote())
@@ -501,7 +501,7 @@ class TestLoadBalancerHybrid:
 
     def test_removed_server_invalidates_sticky_session(self, ray_for_lb):
         """When a sticky session points to a removed server, cache is invalidated."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         # Occupy s0 so that the sticky request is assigned to s1
         ray.get(lb.acquire_server.remote(request_id="occupy-s0"))[0]  # -> s0
         # Pin request to s1 (least-loaded now)
@@ -516,7 +516,7 @@ class TestLoadBalancerHybrid:
 
     def test_remove_server_also_purges_registry(self, ray_for_lb):
         """remove_servers atomically purges from both LB pool and handle registry."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         status = ray.get(lb.get_status.remote())
         # Both _inflight_requests and _servers are cleaned up (no separate cleanup step needed)
@@ -524,7 +524,7 @@ class TestLoadBalancerHybrid:
         assert "s1" not in status["registered_handles"]
 
     def test_get_all_servers_excludes_removed(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         all_servers = ray.get(lb.get_all_servers.remote())
         assert "s0" in all_servers
@@ -532,14 +532,14 @@ class TestLoadBalancerHybrid:
         assert "s1" not in all_servers
 
     def test_no_available_servers_raises(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s0", "s1"]))
         with pytest.raises(ray.exceptions.RayTaskError, match="No available servers"):
             ray.get(lb.acquire_server.remote(request_id="r1"))
 
     def test_add_server_readds_previously_removed(self, ray_for_lb):
         """Re-adding a previously removed server makes it routable again."""
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         # s1 is removed, only s0 is available
         assert ray.get(lb.acquire_server.remote(request_id="r1"))[0] == "s0"
@@ -550,13 +550,13 @@ class TestLoadBalancerHybrid:
         assert s in ("s0", "s1")
 
     def test_get_inflight_count(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None})
         assert ray.get(lb.get_inflight_count.remote(server_id="s0")) == 0
         ray.get(lb.acquire_server.remote(request_id="r1"))[0]  # -> s0 (least loaded)
         assert ray.get(lb.get_inflight_count.remote(server_id="s0")) == 1
 
     def test_get_status_reports_active_correctly(self, ray_for_lb):
-        lb = GlobalRequestLoadBalancer.remote(servers={"s0": None, "s1": None, "s2": None})
+        lb = ray.remote(GlobalRequestLoadBalancer).remote(servers={"s0": None, "s1": None, "s2": None})
         ray.get(lb.remove_servers.remote(server_ids=["s1"]))
         status = ray.get(lb.get_status.remote())
         assert status["active_servers"] == 2  # s0 and s2

--- a/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
+++ b/tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2024 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,38 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-E2E determinism verification: run PPO training twice, verify reward curves bitwise aligned.
+E2E determinism gate: run PPO twice with identical seeds, verify the per-step
+reward curves are bitwise aligned in float32.
 
-Uses colocate mode: RM shares the same GPU pool with actor/ref/rollout,
-so RM scoring goes through the ``_compute_reward_colocate`` path with
-sleep/wake GPU memory management.
+Reward curves are parsed from the training subprocess stdout (the ``console``
+logger prints ``step:N - key:V - ...`` per step), so no intermediate files are
+needed. ``--save_metrics`` also writes a per-run JSONL; ``--plot`` also saves a
+comparison PNG (needs matplotlib). Exit code is the verdict: 0 = aligned,
+1 = not aligned / a run crashed.
+
+Colocate mode (RM shares the actor/ref/rollout GPU pool). Replica count is
+``n_gpus // *_tp``, so the defaults launch 2 rollout + 2 RM replicas — this
+exercises both the deterministic load-balancer's hash routing (rollout) and
+``NaiveRouter`` crc32 routing (RM). Uses the V0 trainer backend (V1's TQ
+collects outputs in completion order, breaking bitwise reproducibility).
+
+RM ``max_num_seqs`` is pinned to 1 in the Hydra command: this script uses a
+discriminative RM (no custom reward fn), whose ``/classify`` pooling path is
+not covered by ``VLLM_BATCH_INVARIANT`` and would drift under co-batching.
+Generative RMs (custom reward fn) are not forced and may run ``>1``. See
+``RewardLoopManager`` for the runtime force-to-1 guard.
 
 Usage:
-  python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \
-    --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \
-    --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \
-    --train_files ~/data/gsm8k/train.parquet \
-    --val_files ~/data/gsm8k/test.parquet \
-    --n_gpus 2 --n_steps 5
-
-Defaults to 2 GPUs: all shared by actor/ref/rollout/RM in colocate mode.
-
-After both runs complete, verifies bitwise alignment of reward curves and
-saves a comparison plot to output_dir/determinism_reward_curves.png.
+  python tests/experimental/reward_loop/run_determinism_e2e_with_rm.py \\
+    --policy_model ~/models/Qwen/Qwen2.5-0.5B-Instruct \\
+    --rm_model ~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B \\
+    --train_files ~/data/gsm8k/train.parquet \\
+    --val_files ~/data/gsm8k/test.parquet \\
+    --n_gpus 2 --n_steps 2
 """
 
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 # Seed used for all determinism configs — same across both runs.
 SEED = 42
+
+# Matches a console-logger line of the form
+#   step:0 - critic/rewards/mean:0.123 - other/key:1.0
+# Captures the step index and the named metric value (as a string token).
+_STEP_LINE_RE = re.compile(r"(?<![\w:])step\s*:\s*(\d+)\s*-?\s*(.*)$")
 
 
 def run_training(
@@ -58,34 +73,32 @@ def run_training(
     rm_tp=1,
     train_files=None,
     val_files=None,
+    temperature=0.7,
+    max_num_seqs=4,
+    save_metrics=False,
 ):
     """Run one PPO training session via main_ppo using Hydra overrides.
 
-    Uses colocate mode (RM shares the same GPU pool with actor/ref/rollout)
-    so that RM scoring goes through the well-tested ``_compute_reward_colocate``
-    path with sleep/wake GPU memory management.
+    Captures stdout so the caller can parse the per-step reward curve. No JSONL
+    is written unless ``save_metrics`` is set.
 
-    Args:
-        n_gpus: Total GPUs visible to the trainer.  All are shared by
-            actor/ref/rollout/RM in colocate mode.
-        rollout_tp: Rollout TP per replica.
-        rm_tp: RM TP per replica.  In colocate mode, RM replicas share the
-            same GPUs as rollout; ``n_gpus // rollout_tp`` rollout replicas and
-            ``n_gpus // rm_tp`` RM replicas are created.
+    Colocate mode: RM shares the actor/ref/rollout GPU pool, so ``n_gpus // *_tp``
+    rollout and RM replicas are created.
     """
-    env = os.environ.copy()
-    jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
     env = os.environ.copy()
     env["VLLM_DISABLE_COMPILE_CACHE"] = "1"
     env["TOKENIZERS_PARALLELISM"] = "true"
     env["NCCL_DEBUG"] = "WARN"
     env["VLLM_LOGGING_LEVEL"] = "WARN"
-    env["VERL_FILE_LOGGER_PATH"] = jsonl_path
-    # PYTHONHASHSEED must be set before Python starts; this ensures deterministic
-    # hash() across all processes spawned by this training run (driver, Ray actors,
-    # NaiveRouter subprocess, etc.).
+    # PYTHONHASHSEED must be set before Python starts for deterministic hash().
     env["PYTHONHASHSEED"] = str(SEED)
-    env["VERL_DETERMINISM_DEBUG"] = "1"
+
+    # Default: console only. --save_metrics adds the file logger.
+    loggers = ["console"]
+    jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
+    if save_metrics:
+        loggers = ["console", "file"]
+        env["VERL_FILE_LOGGER_PATH"] = jsonl_path
 
     cmd = [
         sys.executable,
@@ -98,44 +111,41 @@ def run_training(
         f"actor_rollout_ref.rollout.seed={SEED}",
         "actor_rollout_ref.rollout.scheduling_policy=priority",
         "actor_rollout_ref.rollout.enforce_eager=true",
-        "actor_rollout_ref.rollout.temperature=0.7",
+        f"actor_rollout_ref.rollout.temperature={temperature}",
         "actor_rollout_ref.rollout.calculate_log_probs=true",
         "actor_rollout_ref.rollout.n=1",
         "actor_rollout_ref.rollout.prompt_length=64",
         "actor_rollout_ref.rollout.response_length=64",
         "actor_rollout_ref.rollout.max_model_len=128",
-        "actor_rollout_ref.rollout.max_num_seqs=4",
+        f"actor_rollout_ref.rollout.max_num_seqs={max_num_seqs}",
         f"actor_rollout_ref.rollout.tensor_model_parallel_size={rollout_tp}",
         "actor_rollout_ref.rollout.agent.num_workers=1",
         "actor_rollout_ref.rollout.disable_log_stats=true",
         # Actor
         "actor_rollout_ref.actor.fsdp_config.full_determinism=true",
         f"actor_rollout_ref.actor.fsdp_config.seed={SEED}",
-        "actor_rollout_ref.actor.fsdp_config.param_offload=true",
-        "actor_rollout_ref.actor.fsdp_config.optimizer_offload=true",
+        "actor_rollout_ref.actor.fsdp_config.param_offload=false",
+        "actor_rollout_ref.actor.fsdp_config.optimizer_offload=false",
         "actor_rollout_ref.actor.fsdp_config.fsdp_size=1",
         "actor_rollout_ref.actor.use_dynamic_bsz=true",
         "actor_rollout_ref.actor.ppo_mini_batch_size=4",
+        "actor_rollout_ref.actor.shuffle=false",
         # Ref
         "actor_rollout_ref.ref.fsdp_config.full_determinism=true",
         f"actor_rollout_ref.ref.fsdp_config.seed={SEED}",
         # Model
         f"actor_rollout_ref.model.path={policy_model}",
         "actor_rollout_ref.model.trust_remote_code=true",
-        # RM — colocate mode: shares GPU pool with actor/ref/rollout.
-        # RM scoring goes through _compute_reward_colocate path with
-        # sleep/wake GPU memory management (not agent-loop HTTP path).
+        # RM — colocate (shares GPU pool with actor/ref/rollout; _compute_reward_colocate path).
         "reward.reward_model.enable=true",
         f"reward.reward_model.model_path={rm_model}",
         "reward.reward_model.rollout.name=vllm",
         "reward.reward_model.rollout.full_determinism=true",
         f"reward.reward_model.rollout.seed={SEED}",
         "reward.reward_model.rollout.enforce_eager=true",
-        "reward.reward_model.rollout.gpu_memory_utilization=0.4",
+        "reward.reward_model.rollout.gpu_memory_utilization=0.3",
         f"reward.reward_model.rollout.tensor_model_parallel_size={rm_tp}",
         "reward.reward_model.rollout.max_model_len=512",
-        # Serialize RM inference for determinism: max_num_seqs=1 ensures
-        # each RM forward pass processes one request at a time.
         "reward.reward_model.rollout.max_num_seqs=1",
         "reward.reward_model.rollout.skip_tokenizer_init=false",
         "reward.reward_model.rollout.disable_log_stats=true",
@@ -146,11 +156,13 @@ def run_training(
         # Trainer
         f"trainer.n_gpus_per_node={n_gpus}",
         "trainer.nnodes=1",
+        # V0 backend (V1's TQ collects outputs in completion order → nondeterministic concat).
+        "trainer.use_v1=false",
         f"trainer.total_training_steps={n_steps}",
         "trainer.total_epochs=1",
         "data.train_batch_size=8",
         f"trainer.experiment_name={run_name}",
-        "trainer.logger=[console,file]",
+        f"trainer.logger={list(loggers)}".replace(" ", ""),  # e.g. ['console','file']
         # Data
         "data.shuffle=true",
         f"data.seed={SEED}",
@@ -167,18 +179,23 @@ def run_training(
         cmd.append(f"data.val_files={val_files}")
 
     print(f"\n{'=' * 60}")
-    print(f"Starting {run_name}")
+    print(f"Starting {run_name} (metrics: {', '.join(loggers)})")
     print(f"{'=' * 60}\n")
 
     subprocess.run(["ray", "stop"], env=env, capture_output=True)
     time.sleep(3)
 
-    result = subprocess.run(cmd, env=env)
-    if result.returncode != 0:
-        print(f"ERROR: {run_name} failed (return code {result.returncode})")
-        # Print the JSONL file if it exists — it may contain partial metrics useful for debugging.
-        jsonl_path = os.path.join(output_dir, f"{run_name}.jsonl")
-        if os.path.exists(jsonl_path):
+    proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+    stdout_lines = []
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        stdout_lines.append(line)
+        sys.stdout.write(line)
+        sys.stdout.flush()
+    returncode = proc.wait()
+    if returncode != 0:
+        print(f"ERROR: {run_name} failed (return code {returncode})")
+        if save_metrics and os.path.exists(jsonl_path):
             print(f"Partial metrics in {jsonl_path}:")
             with open(jsonl_path) as f:
                 for line in f:
@@ -186,10 +203,73 @@ def run_training(
         sys.exit(1)
 
     print(f"\n{run_name} completed.")
+    return "".join(stdout_lines)
+
+
+_NP_WRAP = re.compile(r"np\.(?:float|int|uint|bool)\d*\((.+)\)")
+_NUM_RE = re.compile(r"(?<![A-Za-z0-9._])[-+]?(?:\d+\.\d+|\d+\.|\.\d+|\d+)(?:[eE][-+]?\d+)?")
+
+
+def _parse_float(token: str) -> float:
+    """Parse a metric value to float (handles ``np.float64(x)``, ``np.int32(n)``, plain floats)."""
+    token = token.strip()
+    m = _NP_WRAP.match(token)
+    if m:
+        token = m.group(1).strip()
+    try:
+        return float(token)
+    except ValueError:
+        m = _NUM_RE.search(token)
+        return float(m.group(0)) if m else float("nan")
+
+
+def parse_reward_curve_from_stdout(stdout: str):
+    """Parse per-step reward metrics from training stdout.
+
+    Console logger lines look like ``step:1 - critic/rewards/mean:0.5 - ...``.
+    Returns ``(steps, rewards)`` using the reward key picked per step, or
+    ``(None, None)`` if no step line with a reward key was found.
+    """
+    metrics_by_step = {}
+    for line in stdout.splitlines():
+        m = _STEP_LINE_RE.search(line)
+        if not m:
+            continue
+        step = int(m.group(1))
+        rest = m.group(2)
+        data = {}
+        # Values may contain ':'; split on " - " first, then on the FIRST ':' only.
+        for chunk in rest.split(" - "):
+            chunk = chunk.strip()
+            if not chunk or ":" not in chunk:
+                continue
+            key, _, value = chunk.partition(":")
+            data[key.strip()] = value.strip()
+        if data:
+            metrics_by_step[step] = data
+
+    if not metrics_by_step:
+        return None, None
+
+    steps = sorted(metrics_by_step)
+    rewards = []
+    for s in steps:
+        key = _pick_reward_key(metrics_by_step[s])
+        if key is None:
+            print(f"ERROR: No reward key found in step {s}")
+            print(f"  Available keys: {list(metrics_by_step[s].keys())}")
+            return None, None
+        rewards.append(_parse_float(metrics_by_step[s][key]))
+
+    train_key = _pick_reward_key(metrics_by_step.get(1, {}))
+    val_key = _pick_reward_key(metrics_by_step.get(0, {}))
+    print(f"Using training reward key: {train_key}, validation reward key: {val_key}")
+
+    return steps, rewards
 
 
 def read_metrics_from_jsonl(output_dir, run_name):
-    """Read per-step metrics from FileLogger JSONL output."""
+    """Read per-step metrics from FileLogger JSONL output (opt-in path)."""
     filepath = os.path.join(output_dir, f"{run_name}.jsonl")
     if not os.path.exists(filepath):
         print(f"ERROR: Metrics file not found at {filepath}")
@@ -205,32 +285,21 @@ def read_metrics_from_jsonl(output_dir, run_name):
 
 
 def _pick_reward_key(data: dict) -> str | None:
-    """Pick the best reward key from a single step's data dict.
-
-    Training steps use ``critic/rewards/mean``; validation (step 0) uses
-    ``val-core/.../reward/mean@1``.  Returns None if nothing matches.
-    """
-    # Training-step keys (preferred order)
+    """Pick the reward key from a step's data dict (training or validation)."""
     for key in ["critic/rewards/mean", "reward/mean", "train/reward/mean"]:
         if key in data:
             return key
-    # Validation-step keys
     for key in ["val-core/unknown/reward/mean@1", "val-core/reward/mean"]:
         if key in data:
             return key
-    # Fallback: any key containing both "reward" and "mean"
-    for key in data:
+    for key in data:  # fallback: any key with "reward" and "mean"
         if "reward" in key.lower() and "mean" in key.lower():
             return key
     return None
 
 
 def extract_reward_curve(metrics_by_step):
-    """Extract mean reward per step from metrics dict.
-
-    Step 0 (validation) uses a different key namespace than training steps,
-    so we pick the best key for each step independently.
-    """
+    """Extract mean reward per step from a metrics dict (JSONL path)."""
     steps = sorted(metrics_by_step.keys())
     rewards = []
     for s in steps:
@@ -239,7 +308,7 @@ def extract_reward_curve(metrics_by_step):
             print(f"ERROR: No reward key found in step {s}")
             print(f"  Available keys: {list(metrics_by_step[s].keys())}")
             sys.exit(1)
-        rewards.append(metrics_by_step[s][key])
+        rewards.append(float(metrics_by_step[s][key]))
 
     train_key = _pick_reward_key(metrics_by_step.get(1, {}))
     val_key = _pick_reward_key(metrics_by_step.get(0, {}))
@@ -249,13 +318,20 @@ def extract_reward_curve(metrics_by_step):
 
 
 def verify_bitwise_alignment(rewards1, rewards2):
-    """Verify two reward curves are bitwise aligned (float32)."""
+    """Verify two reward curves are bitwise aligned (float32).
+
+    Returns ``(aligned, reason)`` so the caller surfaces a concrete failure cause.
+    """
     r1 = np.array(rewards1, dtype=np.float32)
     r2 = np.array(rewards2, dtype=np.float32)
 
-    assert len(r1) == len(r2), f"Length mismatch: {len(r1)} vs {len(r2)}"
+    if len(r1) != len(r2):
+        return (
+            False,
+            f"length mismatch: run1 has {len(r1)} steps, run2 has {len(r2)} steps",
+        )
 
-    aligned = np.all(r1 == r2)
+    aligned = bool(np.all(r1 == r2))
     max_diff = float(np.max(np.abs(r1 - r2))) if not aligned else 0.0
 
     print(f"\n{'=' * 60}")
@@ -268,14 +344,36 @@ def verify_bitwise_alignment(rewards1, rewards2):
     if not aligned:
         for i in range(len(r1)):
             if r1[i] != r2[i]:
-                print(f"  Step {i + 1} DIFF: {float(r1[i])} vs {float(r2[i])}, diff={abs(float(r1[i]) - float(r2[i]))}")
+                print(f"  Step {i} DIFF: {float(r1[i])} vs {float(r2[i])}, diff={abs(float(r1[i]) - float(r2[i]))}")
     print(f"{'=' * 60}")
 
-    return aligned
+    if aligned:
+        return True, "reward curves are bitwise aligned"
+    return False, f"reward curves differ (max_diff={max_diff:.3e})"
+
+
+def print_reward_table(steps, rewards1, rewards2, aligned):
+    """Print a compact side-by-side reward comparison to stdout."""
+    print(f"\n{'Step':>6} | {'Run 1':>16} | {'Run 2':>16} | {'Diff':>12} | {'Match':>5}")
+    print("-" * 64)
+    for i, s in enumerate(steps):
+        r1 = float(rewards1[i])
+        r2 = float(rewards2[i])
+        diff = abs(r1 - r2)
+        match = "✓" if r1 == r2 else "✗"
+        print(f"{s:>6} | {r1:>16.8f} | {r2:>16.8f} | {diff:>12.3e} | {match:>5}")
+    print("-" * 64)
+    status = "✓ BITWISE ALIGNED" if aligned else "✗ NOT ALIGNED"
+    print(f"Verdict: {status}\n")
 
 
 def plot_reward_curves(steps1, rewards1, rewards2, output_path):
     """Plot two reward curves overlaid for visual comparison."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
     r1 = [float(r) for r in rewards1]
     r2 = [float(r) for r in rewards2]
     steps = [s for s in steps1]
@@ -316,18 +414,40 @@ def plot_reward_curves(steps1, rewards1, rewards2, output_path):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="E2E determinism verification: run twice, compare reward curves")
-    parser.add_argument("--policy_model", default="~/models/Qwen/Qwen2.5-0.5B-Instruct")
-    parser.add_argument("--rm_model", default="~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B")
-    # All GPUs shared by actor/ref/rollout/RM in colocate mode.
-    parser.add_argument("--n_gpus", type=int, default=2)
-    parser.add_argument("--rollout_tp", type=int, default=1)
-    parser.add_argument("--rm_tp", type=int, default=1)
-    parser.add_argument("--n_steps", type=int, default=2)
-    parser.add_argument("--train_files", default=None, help="Path to training data parquet")
-    parser.add_argument("--val_files", default=None, help="Path to validation data parquet")
-    parser.add_argument("--output_dir", default="/tmp/determinism_e2e")
-    parser.add_argument("--project_name", default="determinism_e2e")
+    parser = argparse.ArgumentParser(
+        description="E2E determinism gate: run PPO twice, verify reward curves bitwise aligned.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--policy_model", default="~/models/Qwen/Qwen2.5-0.5B-Instruct", help="Policy (actor) model path."
+    )
+    parser.add_argument(
+        "--rm_model",
+        default="~/models/Skywork/Skywork-Reward-V2-Llama-3.2-1B",
+        help="Reward model path (discriminative → max_num_seqs forced to 1).",
+    )
+    parser.add_argument("--n_gpus", type=int, default=2, help="Total GPUs (single node); replicas = n_gpus // *_tp.")
+    parser.add_argument("--rollout_tp", type=int, default=1, help="Rollout tensor-parallel size per replica.")
+    parser.add_argument("--rm_tp", type=int, default=1, help="RM tensor-parallel size per replica.")
+    parser.add_argument("--n_steps", type=int, default=2, help="PPO steps per run (raise to 10 for a longer curve).")
+    parser.add_argument("--train_files", default=None, help="Training parquet (omitted → synthetic dataset).")
+    parser.add_argument("--val_files", default=None, help="Validation parquet (omitted → reuse train set).")
+    parser.add_argument(
+        "--output_dir", default="/tmp/determinism_e2e", help="Where tables / plots / optional JSONL go."
+    )
+    parser.add_argument(
+        "--temperature", type=float, default=0.7, help="Rollout temperature (0 = greedy, deterministic without a seed)."
+    )
+    parser.add_argument(
+        "--max_num_seqs",
+        type=int,
+        default=4,
+        help="Actor ROLLOUT max_num_seqs (the RM's is forced to 1). Lower to 1 to serialize if the policy "
+        "model is not batch-invariant.",
+    )
+    parser.add_argument("--project_name", default="determinism_e2e", help="Tracking project name.")
+    parser.add_argument("--save_metrics", action="store_true", help="Also write {output_dir}/{run_name}.jsonl per run.")
+    parser.add_argument("--plot", action="store_true", help="Also save a comparison PNG (needs matplotlib).")
     args = parser.parse_args()
 
     policy_model = os.path.expanduser(args.policy_model)
@@ -343,38 +463,62 @@ def main():
         output_dir=output_dir,
         rollout_tp=args.rollout_tp,
         rm_tp=args.rm_tp,
+        temperature=args.temperature,
+        max_num_seqs=args.max_num_seqs,
         train_files=args.train_files,
         val_files=args.val_files,
+        save_metrics=args.save_metrics,
     )
 
     # ── Run 1 ──
-    run_training(run_name="run1", **common_kwargs)
+    stdout1 = run_training(run_name="run1", **common_kwargs)
 
     # ── Run 2 ──
-    run_training(run_name="run2", **common_kwargs)
+    stdout2 = run_training(run_name="run2", **common_kwargs)
 
-    # ── Read metrics ──
-    metrics1 = read_metrics_from_jsonl(output_dir, "run1")
-    metrics2 = read_metrics_from_jsonl(output_dir, "run2")
-
-    steps1, rewards1 = extract_reward_curve(metrics1)
-    steps2, rewards2 = extract_reward_curve(metrics2)
+    # ── Extract reward curves ──
+    if args.save_metrics:
+        metrics1 = read_metrics_from_jsonl(output_dir, "run1")
+        metrics2 = read_metrics_from_jsonl(output_dir, "run2")
+        steps1, rewards1 = extract_reward_curve(metrics1)
+        steps2, rewards2 = extract_reward_curve(metrics2)
+    else:
+        steps1, rewards1 = parse_reward_curve_from_stdout(stdout1)
+        steps2, rewards2 = parse_reward_curve_from_stdout(stdout2)
+        if steps1 is None or steps2 is None:
+            print("\n❌ FAILURE: could not parse reward metrics from stdout.")
+            sys.exit(1)
 
     # ── Verify ──
-    aligned = verify_bitwise_alignment(rewards1, rewards2)
+    aligned, reason = verify_bitwise_alignment(rewards1, rewards2)
 
-    # ── Plot ──
-    plot_path = os.path.join(output_dir, "determinism_reward_curves.png")
-    plot_reward_curves(steps1, rewards1, rewards2, plot_path)
+    # ── Show results ──
+    if steps1 == steps2:
+        print_reward_table(steps1, rewards1, rewards2, aligned)
+    else:  # length mismatch already reported; dump both raw curves
+        print("\nRun 1 reward curve:")
+        for s, r in zip(steps1, rewards1, strict=False):
+            print(f"  step {s}: {float(r):.8f}")
+        print("Run 2 reward curve:")
+        for s, r in zip(steps2, rewards2, strict=False):
+            print(f"  step {s}: {float(r):.8f}")
 
+    # ── Plot (opt-in) ──
+    if args.plot:
+        try:
+            plot_path = os.path.join(output_dir, "determinism_reward_curves.png")
+            plot_steps = steps1 if steps1 == steps2 else list(range(min(len(rewards1), len(rewards2))))
+            plot_reward_curves(plot_steps, rewards1[: len(plot_steps)], rewards2[: len(plot_steps)], plot_path)
+        except ImportError:
+            print("matplotlib not installed; skipping plot.")
+
+    # ── Exit code is the verdict (CI gate) ──
     if aligned:
-        print("\n🎉 SUCCESS: E2E determinism verified — reward curves are bitwise aligned!")
+        print("\n🎉 SUCCESS: reward curves are bitwise aligned!")
+        sys.exit(0)
     else:
-        print("\n❌ FAILURE: Reward curves are NOT bitwise aligned.")
-        print(
-            "Check: actor/critic full_determinism, rollout seed + priority"
-            " + batch_invariant, RM full_determinism, data shuffle seed"
-        )
+        print(f"\n❌ FAILURE: {reason}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
+++ b/tests/trainer/ppo/test_reinforce_pp_multiturn_on_cpu.py
@@ -47,9 +47,7 @@ class TestReinforcePPMultiTurn:
         expanded_mask = torch.tensor([[1.0, 1.0, 0.0, 0.0, 1.0, 1.0]])
         expanded_rewards = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])
 
-        _, compact_returns = compute_reinforce_plus_plus_outcome_advantage(
-            compact_rewards, compact_mask, config=config
-        )
+        _, compact_returns = compute_reinforce_plus_plus_outcome_advantage(compact_rewards, compact_mask, config=config)
         _, expanded_returns = compute_reinforce_plus_plus_outcome_advantage(
             expanded_rewards, expanded_mask, config=config
         )
@@ -111,14 +109,18 @@ class TestReinforcePPMultiTurn:
     def test_batch_dimension(self):
         """Verify correct behavior across a batch of sequences."""
         config = _config(gamma=1.0)
-        mask = torch.tensor([
-            [1.0, 0.0, 1.0, 1.0],  # observation at position 1
-            [1.0, 1.0, 1.0, 0.0],  # padding at position 3
-        ])
-        rewards = torch.tensor([
-            [0.0, 0.0, 0.0, 1.0],
-            [0.0, 0.0, 1.0, 0.0],
-        ])
+        mask = torch.tensor(
+            [
+                [1.0, 0.0, 1.0, 1.0],  # observation at position 1
+                [1.0, 1.0, 1.0, 0.0],  # padding at position 3
+            ]
+        )
+        rewards = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ]
+        )
 
         _, returns = compute_reinforce_plus_plus_outcome_advantage(rewards, mask, config=config)
 

--- a/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
+++ b/tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py
@@ -23,9 +23,6 @@ Tests:
 2. Cross-instance vLLM: two separate server instances produce identical logprobs.
 3. Cross-instance AgentLoop: two full AgentLoopManager pipelines produce identical logprobs.
 
-Cross-instance RewardLoop determinism is verified by the separate E2E script:
-  tests/experimental/reward_loop/run_determinism_e2e_with_rm.py
-
 Environment overrides:
   VLLM_DETERMINISM_DENSE_MODEL_PATH  - policy model (default Qwen2.5-0.5B-Instruct)
   VLLM_DETERMINISM_N_GPUS            - GPUs for AgentLoop tests (default 1)

--- a/verl/experimental/reward_loop/reward_loop.py
+++ b/verl/experimental/reward_loop/reward_loop.py
@@ -279,6 +279,26 @@ class RewardLoopManager:
     def __init__(self, config: DictConfig, rm_resource_pool: RayResourcePool = None):
         self.config = config
         if self.config.reward.reward_model.enable:
+            rm_rollout = self.config.reward.reward_model.rollout
+            # The discriminative /classify (pooling) path is not covered by
+            # VLLM_BATCH_INVARIANT (vLLM batch invariance is verified on generation
+            # models, not pooling RM architectures). Serialize /classify with
+            # max_num_seqs=1 to keep it bitwise reproducible. The generative
+            # /v1/chat/completions path (custom reward fn) is user-managed and not
+            # forced here — rely on VLLM_BATCH_INVARIANT + per-request seed.
+            if (
+                rm_rollout.full_determinism
+                and self.config.reward.custom_reward_function.path is None
+                and rm_rollout.max_num_seqs != 1
+            ):
+                logger.warning(
+                    "[reward_model] full_determinism=True: forcing rollout.max_num_seqs "
+                    "from %s to 1 for the /classify pooling path (batch invariance not "
+                    "verified for pooling RM). See the determinism doc.",
+                    rm_rollout.max_num_seqs,
+                )
+                with open_dict(self.config):
+                    rm_rollout.max_num_seqs = 1
             self.reward_model_manager = RewardModelManager(config.reward.reward_model, rm_resource_pool)
             self.reward_router_address = self.reward_model_manager.get_router_address()
         else:

--- a/verl/experimental/reward_loop/reward_model.py
+++ b/verl/experimental/reward_loop/reward_model.py
@@ -42,20 +42,6 @@ class RewardModelManager:
         self.config = config
         self.resource_pool = resource_pool
 
-        # Determinism workaround: vLLM /classify (pooling path) does not honor
-        # `priority` and is not covered by VLLM_BATCH_INVARIANT, so co-batched RM
-        # forward passes break bitwise reproducibility. Force max_num_seqs=1 to
-        # serialize RM inference whenever full_determinism is enabled.
-        if self.config.rollout.full_determinism and self.config.rollout.max_num_seqs != 1:
-            logger.warning(
-                "[reward_model] full_determinism=True: forcing rollout.max_num_seqs "
-                "from %d to 1. vLLM pooling/classify does not support priority "
-                "scheduling or batch invariance; serializing RM inference is "
-                "currently the only way to keep RM scores bitwise reproducible.",
-                self.config.rollout.max_num_seqs,
-            )
-            self.config.rollout.max_num_seqs = 1
-
         self._initialize_llm_servers()
         self._initialize_router()
         assert self.config.rollout.skip_tokenizer_init is False, "Reward model should not skip tokenizer init."

--- a/verl/experimental/reward_loop/router/naive_router.py
+++ b/verl/experimental/reward_loop/router/naive_router.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import binascii
 import logging
 import multiprocessing
 import os
@@ -94,6 +95,7 @@ class NaiveRouter:
         self.app = FastAPI()
         self.worker_urls = worker_urls
         self.request_counts = {url: 0 for url in worker_urls}
+        self.full_determinism = os.getenv("VERL_FULL_DETERMINISM", "0") == "1"
 
         self.max_connections = max_connections
         self.timeout = timeout
@@ -137,15 +139,16 @@ class NaiveRouter:
         if not self.worker_urls:
             return JSONResponse(status_code=503, content={"error": "No available workers"})
 
-        worker_url = self._select_worker()
+        # Read the body first so it can seed deterministic routing under
+        # full_determinism (same body → same worker across runs).
+        body = await request.body()
+        headers = dict(request.headers)
+
+        worker_url = self._select_worker(body if self.full_determinism else None)
         target_url = f"{worker_url}/{endpoint}"
 
         if self.verbose:
             logger.debug(f"[router] Forwarding request → {target_url}")
-
-        # Copy request data
-        body = await request.body()
-        headers = dict(request.headers)
 
         try:
             for attempt in range(self.max_attempts):
@@ -177,9 +180,23 @@ class NaiveRouter:
             # worker's count leaks upward and skews load balancing permanently.
             self._release_worker(worker_url)
 
-    def _select_worker(self) -> str:
-        """Select the least-loaded worker (simple round-robin by request count)."""
-        url = min(self.request_counts, key=self.request_counts.get)
+    def _select_worker(self, request_id: bytes | None = None) -> str:
+        """Select the least-loaded worker.
+
+        Under ``full_determinism`` (signalled by a non-None ``request_id`` derived
+        from the request body), tie-break among equally-loaded workers with
+        ``binascii.crc32(request_id)`` so the same request always routes to the same
+        worker across runs — otherwise each replica may diverge in floating-point state.
+        crc32 is platform-independent and does not rely on PYTHONHASHSEED.
+        """
+        min_count = min(self.request_counts.values())
+        candidates = [url for url, c in self.request_counts.items() if c == min_count]
+        if len(candidates) == 1:
+            url = candidates[0]
+        elif request_id is not None:
+            url = candidates[binascii.crc32(request_id) % len(candidates)]
+        else:
+            url = candidates[0]
         self.request_counts[url] += 1
         return url
 

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -153,9 +153,11 @@ class TeacherModelManager:
                 )
 
     def _initialize_load_balancer_handle(self):
+        import ray
+
         from verl.workers.rollout.llm_server import GlobalRequestLoadBalancer
 
-        self.load_balancer_handle = GlobalRequestLoadBalancer.remote(
+        self.load_balancer_handle = ray.remote(GlobalRequestLoadBalancer).remote(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True))
         )
 

--- a/verl/trainer/constants_ppo.py
+++ b/verl/trainer/constants_ppo.py
@@ -116,6 +116,17 @@ def get_ppo_ray_runtime_env(config=None):
         if os.environ.get(key) is not None:
             runtime_env["env_vars"].pop(key, None)
     # Always forward these at call-time, not import-time.
-    for key in ("PYTHONHASHSEED", "VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT", "VERL_RL_INSIGHT_ENABLE"):
+    for key in ("VERL_FULL_DETERMINISM", "VLLM_BATCH_INVARIANT", "VERL_RL_INSIGHT_ENABLE"):
         runtime_env["env_vars"][key] = os.environ.get(key, "0")
+    # Forward only when set: empty string breaks vLLM ParallelConfig int parsing.
+    for key in (
+        "PYTHONHASHSEED",
+        "CUBLAS_WORKSPACE_CONFIG",
+        "FLASH_ATTENTION_DETERMINISTIC",
+        "NCCL_DETERMINISTIC",
+        "NCCL_ALGO",
+    ):
+        val = os.environ.get(key)
+        if val is not None:
+            runtime_env["env_vars"][key] = val
     return runtime_env

--- a/verl/utils/torch_functional.py
+++ b/verl/utils/torch_functional.py
@@ -16,6 +16,7 @@ Contain small torch utilities
 """
 
 import math
+import os
 from contextlib import contextmanager
 from typing import Optional
 
@@ -86,7 +87,13 @@ def logprobs_from_logits(logits, labels, inplace_backward=True):
     Returns:
         Tensor: Log-probabilities of the target labels, shape logits.shape[:-1].
     """
-    if FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE:
+    # The flash-attn Triton cross-entropy kernel's reduction may be non-deterministic
+    # and is NOT controlled by FLASH_ATTENTION_DETERMINISTIC (that only governs the
+    # attention kernels) nor by torch.use_deterministic_algorithms (Triton custom ops
+    # don't trigger warn_only). Set VERL_DISABLE_FLASH_ATTN_CE=1 to force the pure
+    # PyTorch log_softmax+gather path for bitwise-reproducible log_probs.
+    _use_flash_ce = FLAH_ATTN_CROSS_ENTROPY_LOSS_AVAILABLE and os.environ.get("VERL_DISABLE_FLASH_ATTN_CE", "0") != "1"
+    if _use_flash_ce:
         batch_dim = logits.shape[:-1]
         last_dim = logits.shape[-1]
         logits = logits.reshape(-1, last_dim)

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -37,6 +37,15 @@ def enable_full_determinism(seed: int):
     os.environ["PYTHONHASHSEED"] = str(seed)
     os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
     os.environ["FLASH_ATTENTION_DETERMINISTIC"] = "1"
+    os.environ["NCCL_DETERMINISTIC"] = "1"
+    os.environ["NCCL_ALGO"] = "Ring"
+    os.environ["NCCL_PROTO"] = "Simple"
+    # flash-attn's Triton cross-entropy kernel (used by logprobs_from_logits to
+    # compute log_probs) has a non-deterministic reduction that is NOT covered by
+    # FLASH_ATTENTION_DETERMINISTIC (only governs attention kernels' backward) nor
+    # by torch.use_deterministic_algorithms (Triton custom ops don't trigger
+    # warn_only). Force the pure-PyTorch log_softmax+gather path instead.
+    os.environ.setdefault("VERL_DISABLE_FLASH_ATTN_CE", "1")
     if is_npu_available:
         # The environment variable required to enable deterministic mode on Ascend NPUs.
         os.environ["HCCL_DETERMINISTIC"] = "true"

--- a/verl/workers/rollout/llm_server.py
+++ b/verl/workers/rollout/llm_server.py
@@ -43,12 +43,15 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 DEFAULT_ROUTING_CACHE_SIZE = 10000
 
 
-@ray.remote
 class GlobalRequestLoadBalancer:
     """Global sticky-session + in-flight load balancer shared by all AgentLoopWorkers.
 
     When a sticky session points to a removed server, the cache entry is
     automatically invalidated and a new server is selected.
+
+    This is a plain Python class (not a Ray actor). It is wrapped with
+    ``ray.remote(...)`` at instantiation time so callers can subclass it and
+    override :meth:`acquire_server` before registering the subclass as an actor.
 
     Key features:
     - **Atomic acquire**: ``acquire_server()`` returns ``(server_id, handle)``
@@ -56,9 +59,9 @@ class GlobalRequestLoadBalancer:
       multi-turn conversations route to the same server.
     - **Least-loaded Selection**: When no sticky session exists, selects the
       server with the fewest in-flight requests.
-    - **Deterministic Routing**: When ``full_determinism=True``, tie-breaking
-      among equally-loaded servers uses ``hash(request_id)`` so the same
-      request always routes to the same server across runs.
+    - **Deterministic Routing**: When ``full_determinism=True``, routes every
+      request by ``hash(request_id) % len(servers)`` over the full pool so the
+      same request always routes to the same replica across runs.
     - **Dynamic Server Management**: Supports add/remove servers at runtime
       for hybrid scaling.
     """
@@ -97,14 +100,14 @@ class GlobalRequestLoadBalancer:
         if not self._inflight_requests:
             raise RuntimeError("No available servers in load balancer")
 
-        min_count = min(self._inflight_requests.values())
-        candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
-        if len(candidates) == 1:
-            server_id = candidates[0]
-        elif self._full_determinism:
-            # Deterministic tie-breaking: same request_id → same server across runs
-            server_id = candidates[hash(request_id) % len(candidates)]
+        if self._full_determinism:
+            # Full-hash routing: same request_id always lands on the same replica
+            # across runs. Least-loaded selection depends on async arrival timing,
+            # which varies run-to-run, so it is bypassed entirely here.
+            server_id = list(self._servers)[hash(request_id) % len(self._servers)]
         else:
+            min_count = min(self._inflight_requests.values())
+            candidates = [sid for sid, count in self._inflight_requests.items() if count == min_count]
             server_id = candidates[0]
         self._request_id_to_server[request_id] = server_id
         self._inflight_requests[server_id] += 1
@@ -225,6 +228,14 @@ class LLMServerClient:
         # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
         self._load_balancer.release_server.remote(server_id=server_id)
 
+    def _vllm_request_id(self, request_id: str) -> str:
+        # request_id passed to vLLM. Default: a fresh uuid per turn so each turn
+        # is an independent vLLM request. Under full_determinism the caller's
+        # request_id is passed straight through so vLLM sees a stable id across runs.
+        if getattr(self.config.actor_rollout_ref.rollout, "full_determinism", False):
+            return request_id
+        return uuid4().hex
+
     @rollout_trace_op
     async def generate(
         self,
@@ -261,7 +272,7 @@ class LLMServerClient:
                 {"priority": priority} if priority != 0 and self.config.actor_rollout_ref.rollout.name == "vllm" else {}
             )
             output: TokenOutput = await server.generate.remote(
-                request_id=uuid4().hex,  # use new request_id for each turn
+                request_id=self._vllm_request_id(request_id),  # use new request_id for each turn
                 prompt_ids=prompt_ids,
                 sampling_params=sampling_params,
                 image_data=image_data,
@@ -462,6 +473,12 @@ class LLMServerManager:
             else init standalone server with a new resource pool.
         rollout_resource_pool (RayResourcePool): Resource pool for the server replicas, only needed for TensorRT-LLM.
         start_rank (int): First ``replica_rank`` to assign.  Defaults to 0.
+        load_balancer_cls: Optional subclass of
+            :class:`GlobalRequestLoadBalancer` to use as the routing actor
+            (wrapped with ``ray.remote`` at instantiation). Defaults to
+            :class:`GlobalRequestLoadBalancer`, whose routing honors the
+            ``full_determinism`` flag. Pass a subclass that overrides
+            :meth:`acquire_server` to take full control of routing.
     """
 
     def __init__(
@@ -470,6 +487,7 @@ class LLMServerManager:
         worker_group: RayWorkerGroup = None,
         rollout_resource_pool: RayResourcePool = None,
         start_rank: int = 0,
+        load_balancer_cls: type | None = None,
     ):
         self.config = config
         self.rollout_config = config.actor_rollout_ref.rollout
@@ -477,6 +495,7 @@ class LLMServerManager:
         self.worker_group = worker_group
         self.rollout_resource_pool = rollout_resource_pool
         self.start_rank = start_rank
+        self._load_balancer_cls = load_balancer_cls or GlobalRequestLoadBalancer
 
         assert worker_group is not None or self.rollout_config.nnodes > 0, "nnodes must be > 0 in standalone mode"
 
@@ -579,20 +598,30 @@ class LLMServerManager:
                 )
 
     async def _init_global_load_balancer(self) -> None:
-        self.global_load_balancer = GlobalRequestLoadBalancer.remote(
+        load_balancer_cls = self._load_balancer_cls
+        kwargs = dict(
             servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
             max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
-            full_determinism=getattr(self.rollout_config, "full_determinism", False),
         )
+        # The default GlobalRequestLoadBalancer honors the full_determinism flag
+        # in acquire_server. A custom subclass overrides acquire_server and takes
+        # full control of routing, so the flag is not forwarded to it.
+        if load_balancer_cls is GlobalRequestLoadBalancer:
+            kwargs["full_determinism"] = getattr(self.rollout_config, "full_determinism", False)
+        self.global_load_balancer = ray.remote(load_balancer_cls).remote(**kwargs)
 
-    def get_client(self, client_cls=LLMServerClient, **kwargs) -> LLMServerClient:
+    def get_client(self, client_cls: type[LLMServerClient] | None = None, **kwargs) -> LLMServerClient:
         """Get the LLMServerClient to request LLM server replicas.
 
         Args:
-            client_cls: The client class to instantiate (default: ``LLMServerClient``).
-                Pass ``FullyAsyncLLMServerClient`` for abort-resume support.
+            client_cls: The client class to instantiate. Defaults to
+                :class:`LLMServerClient`. Pass a subclass to customize
+                request-id handling (e.g. a deterministic client that forwards
+                the caller's ``request_id`` straight to vLLM), or
+                :class:`FullyAsyncLLMServerClient` for abort-resume support.
             **kwargs: Forwarded to the client constructor.
         """
+        client_cls = client_cls or LLMServerClient
         return client_cls(
             config=self.config,
             load_balancer_handle=self.global_load_balancer,


### PR DESCRIPTION
### What does this PR do?

Makes the reward path bitwise-deterministic across two identical PPO runs, closing the remaining gaps for generative RM (GRM) determinism: floating-point determinism primitives for NCCL/cuBLAS/flash-attn cross-entropy, RM-type-aware `max_num_seqs`, and deterministic multi-replica reward routing.

The LLM rollout routing layer stays neutral in verl: determinism there is driven by the existing `full_determinism` flag (and, for verl-omni, by subclasses passed in via a new injection point). The two `Deterministic*` subclasses live in verl-omni, since the LLM layer itself carries no determinism mode.

#### Background

verl already had four determinism layers — PyTorch seeds, env propagation, vLLM batch invariance + per-request seed, and the `full_determinism` flag on the rollout LB/client. Two gaps remained on the reward path:

1. **No floating-point determinism for the reward path.** NCCL all-reduce, cuBLAS matmul, and the flash-attn Triton cross-entropy kernel (`logprobs_from_logits`) are not covered by `FLASH_ATTENTION_DETERMINISTIC` (governs attention backward only) nor `torch.use_deterministic_algorithms` (Triton custom ops don't trigger `warn_only`). They must be set before torch/NCCL init — too late if only set inside the actor's `enable_full_determinism()`.
2. **RM `max_num_seqs` was unconditionally forced to 1**, serializing even generative RM (`/v1/chat/completions`), which is covered by batch invariance + per-request seed and does not need serialization. And the RM router (`NaiveRouter`) had no deterministic tie-breaking, so multi-replica reward routing depended on arrival timing and varied run-to-run.

#### What this PR changes

1. **Floating-point determinism primitives.** `enable_full_determinism()` sets `NCCL_DETERMINISTIC`/`NCCL_ALGO=Ring`/`NCCL_PROTO=Simple` and `VERL_DISABLE_FLASH_ATTN_CE=1`; `logprobs_from_logits` forces the pure-PyTorch `log_softmax+gather` path under `VERL_DISABLE_FLASH_ATTN_CE=1` to bypass the non-deterministic flash-attn CE kernel; `constants_ppo` forwards the `CUBLAS/FLASH/NCCL` env vars via `runtime_env` so actors inherit them at startup. (The entrypoint-side env export before `ray.init()` and the V0-backend enforcement live in verl-omni's entrypoint — verl's `main_ppo` V0 entrypoint is deprecated and pending removal.)

2. **RM-type-aware `max_num_seqs`.** `RewardLoopManager` (which sees `custom_reward_function.path`) forces `max_num_seqs=1` only for discriminative RM (no custom reward fn → `/classify` pooling, not covered by batch invariance). Generative RM (custom reward fn → `/v1/chat/completions`) is not forced and may run `>1`, relying on batch invariance + per-request seed. Logic moved out of `RewardModelManager` (no signature change).

3. **Deterministic multi-replica routing.** The rollout LB (`GlobalRequestLoadBalancer`) routes every request by `hash(request_id) % len(servers)` when `full_determinism=True`, bypassing least-loaded selection (whose candidate set depends on async arrival timing and varies run-to-run); `LLMServerClient._vllm_request_id()` forwards the caller's stable `request_id` to vLLM under `full_determinism` so KV-cache/scheduling keys stay reproducible. verl keeps the `full_determinism` flag driving this default behavior — V0 PPO (`main_ppo`) needs no subclass injection to be deterministic. For callers that want full control of routing (verl-omni's diffusion entrypoint), `LLMServerManager.create(..., load_balancer_cls=...)` and `get_client(client_cls=...)` accept a subclass; verl-omni defines `DeterministicGlobalRequestLoadBalancer`/`DeterministicLLMServerClient` there and passes them in. `GlobalRequestLoadBalancer` is now a plain Python class wrapped with `ray.remote(...)` at instantiation, so it can be subclassed. For the RM path, `NaiveRouter` tie-breaks equally-loaded replicas with `binascii.crc32(request_id) % len(candidates)` (request_id derived from the request body; platform-independent, no `PYTHONHASHSEED` dependency). Same request → same replica across runs, neutralizing replica-level floating-point differences that seed alone cannot equalize.

4. **V0 trainer backend required.** Full determinism requires the V0 trainer (`trainer.use_v1=false`, i.e. `AgentLoopManager`). The default V1 backend (`AgentLoopManagerTQ`) decouples rollout submission from collection via a fire-and-forget TransferQueue: outputs are collected in **completion order**, which varies with async timing across runs and breaks bitwise reproducibility at the output-concat stage — a property no amount of seeding or env config can fix. V0 uses `asyncio.gather` and collects in **submission order**, which is stable. Set `trainer.use_v1=false` explicitly when enabling `full_determinism`.

### Related Issues

Enhances `df35e73` (full determinism for vLLM rollout and reward model, PR #6572).
Fixes #7216 ; verl-omni https://github.com/verl-project/verl-omni/issues/111 https://github.com/verl-project/verl-omni/pull/115

### Test

The determinism primitives are covered by unit tests in `tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py` (same-instance + cross-instance vLLM + cross-instance AgentLoop). The reward-side E2E gate (`tests/experimental/reward_loop/run_determinism_e2e_with_rm.py`) runs PPO twice and compares reward curves bitwise; it requires A100/H100-class GPUs (vLLM's batch-invariant `matmul_persistent` Triton kernel needs 128KB shared memory, exceeding the L20's 99KB limit) and is therefore not wired into the L20 CI — run it manually on suitable hardware.

Generative RM determinism is verified downstream in verl-omni (production GRM = `compute_score_ocr` + per-request seed); verl has no production GRM custom function.

### Files

| File | Change |
|---|---|
| `verl/workers/engine/utils.py` | `enable_full_determinism()` sets NCCL env + `VERL_DISABLE_FLASH_ATTN_CE=1`. |
| `verl/utils/torch_functional.py` | `logprobs_from_logits` bypasses flash-attn CE kernel under `VERL_DISABLE_FLASH_ATTN_CE=1`. |
| `verl/trainer/constants_ppo.py` | Forwards `CUBLAS/FLASH/NCCL` env via `runtime_env` to actors. |
| `verl/experimental/reward_loop/reward_loop.py` | `RewardLoopManager` forces `max_num_seqs=1` for discriminative RM only. |
| `verl/experimental/reward_loop/reward_model.py` | Removed unconditional force (moved to `RewardLoopManager`). |
| `verl/experimental/reward_loop/router/naive_router.py` | `NaiveRouter` crc32 deterministic routing under `full_determinism`. |
| `verl/workers/rollout/llm_server.py` | `GlobalRequestLoadBalancer` (plain class, wrapped with `ray.remote` at instantiation) routes by full hash under `full_determinism`; `LLMServerClient._vllm_request_id` forwards stable id under `full_determinism`; `LLMServerManager` adds `load_balancer_cls`/`client_cls` injection points for caller-supplied subclasses. |
| `verl/experimental/teacher_loop/teacher_model.py` | Adapt LB instantiation to `ray.remote(...)`. |
| `tests/experimental/reward_loop/run_determinism_e2e_with_rm.py` | E2E gate: run twice, parse reward from stdout, compare float32, exit 0/1. Not wired into CI — the RM pooling classifier hits vLLM's batch-invariant `matmul_persistent` Triton kernel (128KB shared memory), which exceeds the L20's 99KB limit; run manually on A100/H100. |
| `tests/workers/rollout/rollout_vllm/test_vllm_generation_determinism.py` | Removed GRM cross-instance test (verl-omni scope). Added to CI. |
| `.github/workflows/vllm.yml` | Added generation-determinism CI step reusing pre-baked Qwen2.5-0.5B. |
| `docs/advance/determinism.md` | V0 backend requirement; RM `max_num_seqs` by RM type; NCCL/flash-CE details; E2E verification. |

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize your PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1).
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote`.

### CC Lists
@SamitHuang @zhtmike
