### PR TITLE
[data] feat: auto-download TinyLLaVA-Video-R1 dataset when --data_dir is not given

### DIFF
--- a/examples/data_preprocess/tinyllava_video_r1.py
+++ b/examples/data_preprocess/tinyllava_video_r1.py
@@ -38,9 +38,11 @@ import argparse
 import json
 import os
 import sys
+import zipfile
 from typing import Optional
 
 import datasets
+from huggingface_hub import hf_hub_download
 
 from verl.utils.hdfs_io import copy, makedirs
 
@@ -132,7 +134,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if not args.data_dir:
-        parser.error("--data_dir is required")
+        args.data_dir = os.path.expanduser("~/data/tinyllava-video-r1")
+        os.makedirs(args.data_dir, exist_ok=True)
+        if not os.path.exists(os.path.join(args.data_dir, "nextqa_0-30s.jsonl")):
+            hf_hub_download(
+                repo_id=DATA_SOURCE, filename="nextqa_0-30s.jsonl", repo_type="dataset", local_dir=args.data_dir
+            )
+        if not os.path.isdir(os.path.join(args.data_dir, "NextQA")):
+            zip_path = hf_hub_download(
+                repo_id=DATA_SOURCE, filename="NextQA.zip", repo_type="dataset", local_dir=args.data_dir
+            )
+            with zipfile.ZipFile(zip_path) as zf:
+                zf.extractall(args.data_dir)
 
     # ---- Load ----
     jsonl_path = os.path.join(args.data_dir, "nextqa_0-30s.jsonl")


### PR DESCRIPTION
### What does this PR do?

`examples/data_preprocess/tinyllava_video_r1.py` currently requires `--data_dir`
to already point at a manually downloaded + extracted copy of
`Zhang199/TinyLLaVA-Video-R1-training-data` (jsonl + `NextQA.zip`), otherwise
it exits with `--data_dir is required`.

This PR makes `--data_dir` optional: when omitted, the script downloads
`nextqa_0-30s.jsonl` and `NextQA.zip` from HuggingFace into
`~/data/tinyllava-video-r1` via `hf_hub_download`, extracts the zip, and then
proceeds through the existing (unchanged) load/map/save pipeline. Each
download step is skipped if its output already exists, so re-running the
script is cheap. Passing `--data_dir` continues to work exactly as before for
users who already have the raw dataset locally.


### API and Usage Example

```bash
# Before: --data_dir was required and had to be pre-populated manually.
# Now, --data_dir is optional; if omitted, the dataset is downloaded automatically.
python examples/data_preprocess/tinyllava_video_r1.py \
    --local_save_dir ~/data/tinyllava_video_r1
```