### PR TITLE
[rollout] fix: handle malformed Qwen3 XML tool calls

### DIFF
--- a/tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py
+++ b/tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py
@@ -79,3 +79,32 @@ def test_array_param_does_not_execute_arbitrary_code(tmp_path):
     assert not marker.exists(), "ast.literal_eval must not execute arbitrary code"
     # ... and the unparseable value degenerates to the original string unchanged.
     assert json.loads(result.arguments)["items"] == payload
+
+
+def test_malformed_parameter_is_skipped_but_valid_parameter_is_preserved():
+    """A truncated parameter must not discard preceding valid parameters."""
+    parser = Qwen3XMLToolParser(tokenizer=None)
+    tool = _make_tool("items", "string")
+    function_call_str = "list_tool><parameter=items>valid</parameter><parameter=truncated"
+
+    result = parser._parse_xml_function_call(function_call_str, [tool])
+
+    assert result is not None
+    assert json.loads(result.arguments) == {"items": "valid"}
+
+
+def test_malformed_function_header_returns_none():
+    """A truncated function header must be ignored without raising."""
+    parser = Qwen3XMLToolParser(tokenizer=None)
+
+    assert parser._parse_xml_function_call("list_tool", []) is None
+
+
+def test_missing_tools_defaults_to_empty_list():
+    """Tool-call parsing must tolerate the public API's default tools value."""
+    parser = Qwen3XMLToolParser(tokenizer=None)
+
+    result = parser._parse_xml_function_call("list_tool><parameter=items>value</parameter>", None)
+
+    assert result is not None
+    assert json.loads(result.arguments) == {"items": "value"}

--- a/verl/experimental/agent_loop/tool_parser.py
+++ b/verl/experimental/agent_loop/tool_parser.py
@@ -210,7 +210,9 @@ class Qwen3XMLToolParser(ToolParser):
 
     def _parse_xml_function_call(
         self, function_call_str: str, tools: Optional[list[OpenAIFunctionToolSchema]]
-    ) -> FunctionCall:
+    ) -> Optional[FunctionCall]:
+        tools = tools or []
+
         def get_arguments_config(func_name: str) -> dict:
             for config in tools:
                 if config.type == "function" and config.function.name == func_name:
@@ -295,15 +297,26 @@ class Qwen3XMLToolParser(ToolParser):
                     )
                 return param_value
 
-        # Extract function name
-        end_index = function_call_str.index(">")
+        # Extract function name. A truncated function header is not recoverable.
+        end_index = function_call_str.find(">")
+        if end_index == -1:
+            logger.warning(f"Skipping malformed function call without '>' separator: {function_call_str!r}")
+            return None
+
         function_name = function_call_str[:end_index]
         param_config = get_arguments_config(function_name)
         parameters = function_call_str[end_index + 1 :]
         param_dict = {}
         for match in self.tool_call_parameter_regex.findall(parameters):
             match_text = match[0] if match[0] else match[1]
-            idx = match_text.index(">")
+            idx = match_text.find(">")
+            if idx == -1:
+                logger.warning(
+                    f"Skipping malformed parameter without '>' separator in tool call for function "
+                    f"'{function_name}': {match_text!r}"
+                )
+                continue
+
             param_name = match_text[:idx]
             param_value = str(match_text[idx + 1 :])
             # Remove prefix and trailing \n
@@ -348,6 +361,7 @@ class Qwen3XMLToolParser(ToolParser):
             tool_calls = [
                 self._parse_xml_function_call(function_call_str, tools) for function_call_str in function_calls
             ]
+            tool_calls = [tool_call for tool_call in tool_calls if tool_call is not None]
 
             # Extract content before tool calls
             content_index = text.find(self.tool_call_start_token)


### PR DESCRIPTION
### What does this PR do?

This PR makes `Qwen3XMLToolParser` tolerate malformed XML tool-call headers instead of raising `ValueError: substring not found` and discarding the entire extraction result.

- A function header without the `>` separator is treated as unrecoverable and ignored.
- A malformed parameter is skipped while valid parameters in the same function call are preserved.
- `tools=None`, which is accepted by the public `extract_tool_calls` API, is normalized to an empty list before schema lookup.
- The original generated token IDs, response masks, and log probabilities are not rewritten.

This is the same malformed-parameter failure mode reported in [vLLM issue #39771](https://github.com/vllm-project/vllm/issues/39771) and fixed in [vLLM PR #39772](https://github.com/vllm-project/vllm/pull/39772). VERL maintains an independent full-response parser, so this PR applies the focused defensive fix without porting vLLM's larger streaming parser engine from [vLLM PR #45413](https://github.com/vllm-project/vllm/pull/45413).

### Checklist Before Starting

- [x] Search for similar PRs: [Qwen3 XML tool parser](https://github.com/verl-project/verl/pulls?q=is%3Apr+Qwen3+XML+tool+parser). No other open PR addresses this malformed XML failure; #6434 concerns reasoning-block stripping and is a different parser behavior.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[rollout] fix: handle malformed Qwen3 XML tool calls`.

### Test

Focused parser tests in the production-like Docker environment on remote145:

```bash
PYTHONPATH=/home/zxh/verl-qwen3-malformed-pr \
python3 -m pytest -q tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py
```

Result:

```text
5 passed, 3 warnings in 20.71s
```

Repository checks for both changed files:

```bash
pre-commit run --files \
  verl/experimental/agent_loop/tool_parser.py \
  tests/experimental/agent_loop/test_qwen3_tool_parser_on_cpu.py

python3 -m compileall -q verl/experimental/agent_loop/tool_parser.py
git diff --check
```

All pre-commit hooks, `compileall`, and `git diff --check` passed.

### API and Usage Example

No public API or configuration change. Existing callers continue to use `extract_tool_calls` unchanged.

### Design & Code Changes

- Replace `str.index(">")` with `str.find(">")` for function and parameter headers.
- Return `None` for a function header that cannot be recovered, then filter invalid calls before returning extraction results.
- Skip malformed parameters with a warning while retaining valid parameters already parsed from the same call.
- Normalize `tools=None` to `[]` before argument-schema lookup, addressing the review feedback on this PR.
- Add CPU regression coverage for malformed function headers, mixed valid/malformed parameters, and `tools=None`.
- Keep the existing permissive rollout behavior: a recoverable function call may continue with its valid parameters; this change does not rewrite model output tokens.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting) to both changed files; all hooks passed.
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs): not applicable, because this is internal parser error handling with no public API or configuration change.
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows): `test_qwen3_tool_parser_on_cpu.py` matches the existing `cpu_unit_tests.yml` discovery rule (`tests/**/test_*_on_cpu.py`) and is also collected by the existing vLLM and SGLang agent-loop workflows; no workflow YAML change is required.
- [ ] Once this PR is ready for CI, send a message in the [`ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in the [`verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). If Slack is not accessible, use the [Feishu group](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).
- [x] Recipe submodule update: not applicable; this PR does not modify `recipe`.

AI assistance was used for repository analysis, implementation, and test execution. The submitter reviewed the changed lines and should understand and defend the change end to end.
