### PR TITLE
[checkpoint_engine] fail fast on hung first NCCL group init (#6967)

### DIFF
--- a/tests/checkpoint_engine/test_group_init_timeout_on_cpu.py
+++ b/tests/checkpoint_engine/test_group_init_timeout_on_cpu.py
@@ -1,0 +1,63 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU unit tests for the checkpoint-engine first-init timeout guardrail (#6967).
+
+These exercise the timeout mechanism only (no NCCL/GPU): the guardrail must turn
+a hung first rendezvous into a fast, clear error, must not interfere with a
+normal init, and must faithfully surface an init error.
+"""
+
+import time
+
+import pytest
+
+from verl.checkpoint_engine._group_init import (
+    CheckpointEngineInitError,
+    run_group_init_with_timeout,
+)
+
+
+def test_completes_within_timeout():
+    calls = []
+    run_group_init_with_timeout(lambda: calls.append(1), group_name="g", timeout_s=5.0)
+    assert calls == [1]
+
+
+def test_raises_fast_on_timeout_instead_of_hanging():
+    # The #6967 symptom: init blocks far longer than the bound. The guardrail
+    # must raise promptly (~timeout), not wait for the (here 10s) hang to end.
+    start = time.monotonic()
+    with pytest.raises(CheckpointEngineInitError):
+        run_group_init_with_timeout(lambda: time.sleep(10.0), group_name="g", timeout_s=0.3)
+    assert time.monotonic() - start < 3.0
+
+
+def test_reraises_init_error():
+    def boom():
+        raise ValueError("nccl boom")
+
+    with pytest.raises(ValueError, match="nccl boom"):
+        run_group_init_with_timeout(boom, group_name="g", timeout_s=5.0)
+
+
+def test_env_var_sets_default_timeout(monkeypatch):
+    monkeypatch.setenv("VERL_CKPT_ENGINE_INIT_TIMEOUT_S", "0.2")
+    start = time.monotonic()
+    with pytest.raises(CheckpointEngineInitError):
+        run_group_init_with_timeout(lambda: time.sleep(10.0), group_name="g")
+    assert time.monotonic() - start < 3.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/checkpoint_engine/test_group_init_timeout_on_cpu.py
+++ b/tests/checkpoint_engine/test_group_init_timeout_on_cpu.py
@@ -13,50 +13,60 @@
 # limitations under the License.
 """CPU unit tests for the checkpoint-engine first-init timeout guardrail (#6967).
 
-These exercise the timeout mechanism only (no NCCL/GPU): the guardrail must turn
-a hung first rendezvous into a fast, clear error, must not interfere with a
-normal init, and must faithfully surface an init error.
+These exercise ``wait_for_group_init`` -- the controller-side bound that
+``CheckpointEngineManager.build_process_group()`` wraps around its
+``ray.get`` of the workers' ``init_process_group`` futures. ``ray.get`` is
+mocked so the tests run on CPU with no Ray cluster: a hung init must become a
+fast, clear ``CheckpointEngineInitError``; a normal init must pass through; a
+real init error must propagate unchanged; and the env var must set the bound.
 """
 
-import time
+from unittest.mock import patch
 
 import pytest
+import ray
 
 from verl.checkpoint_engine._group_init import (
     CheckpointEngineInitError,
-    run_group_init_with_timeout,
+    wait_for_group_init,
 )
 
 
-def test_completes_within_timeout():
-    calls = []
-    run_group_init_with_timeout(lambda: calls.append(1), group_name="g", timeout_s=5.0)
-    assert calls == [1]
+def test_returns_results_when_init_completes():
+    with patch("verl.checkpoint_engine._group_init.ray.get", return_value=["ok0", "ok1"]) as mock_get:
+        assert wait_for_group_init(["ref0", "ref1"], timeout_s=5.0) == ["ok0", "ok1"]
+        mock_get.assert_called_once()
 
 
-def test_raises_fast_on_timeout_instead_of_hanging():
-    # The #6967 symptom: init blocks far longer than the bound. The guardrail
-    # must raise promptly (~timeout), not wait for the (here 10s) hang to end.
-    start = time.monotonic()
-    with pytest.raises(CheckpointEngineInitError):
-        run_group_init_with_timeout(lambda: time.sleep(10.0), group_name="g", timeout_s=0.3)
-    assert time.monotonic() - start < 3.0
+def test_raises_clear_error_on_timeout():
+    with patch(
+        "verl.checkpoint_engine._group_init.ray.get",
+        side_effect=ray.exceptions.GetTimeoutError("timed out"),
+    ):
+        with pytest.raises(CheckpointEngineInitError, match="#6967"):
+            wait_for_group_init(["ref"], timeout_s=0.1)
 
 
-def test_reraises_init_error():
-    def boom():
-        raise ValueError("nccl boom")
-
-    with pytest.raises(ValueError, match="nccl boom"):
-        run_group_init_with_timeout(boom, group_name="g", timeout_s=5.0)
+def test_reraises_non_timeout_errors():
+    with patch(
+        "verl.checkpoint_engine._group_init.ray.get",
+        side_effect=RuntimeError("nccl boom"),
+    ):
+        with pytest.raises(RuntimeError, match="nccl boom"):
+            wait_for_group_init(["ref"], timeout_s=5.0)
 
 
 def test_env_var_sets_default_timeout(monkeypatch):
-    monkeypatch.setenv("VERL_CKPT_ENGINE_INIT_TIMEOUT_S", "0.2")
-    start = time.monotonic()
-    with pytest.raises(CheckpointEngineInitError):
-        run_group_init_with_timeout(lambda: time.sleep(10.0), group_name="g")
-    assert time.monotonic() - start < 3.0
+    monkeypatch.setenv("VERL_CKPT_ENGINE_INIT_TIMEOUT_S", "12.5")
+    captured = {}
+
+    def fake_get(refs, timeout=None):
+        captured["timeout"] = timeout
+        return []
+
+    with patch("verl.checkpoint_engine._group_init.ray.get", side_effect=fake_get):
+        wait_for_group_init(["ref"])
+    assert captured["timeout"] == 12.5
 
 
 if __name__ == "__main__":

--- a/verl/checkpoint_engine/_group_init.py
+++ b/verl/checkpoint_engine/_group_init.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounded first-rendezvous init for the NCCL checkpoint engine.
+
+The first ``ray.util.collective`` rendezvous (``init_collective_group`` +
+``barrier``) can hang indefinitely on some environments -- a timing race in the
+Ray/NCCL layer reported in verl issue #6967. When it hangs, both ranks sit at
+0% util with no traceback and the whole job is stuck forever.
+
+This wraps that first init in a bounded timeout so a stalled rendezvous fails
+fast with a clear, actionable error instead of hanging silently. A stalled
+NCCL/collective call cannot be safely interrupted, so we deliberately do NOT
+retry in place: we surface the error and let the launcher tear the job down.
+"""
+
+import logging
+import os
+import threading
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+# Generous default: long enough never to trip a slow-but-healthy first sync
+# (large models can take seconds to tens of seconds), short enough to abort a
+# genuine hang instead of waiting forever. Override via env if needed.
+INIT_TIMEOUT_ENV = "VERL_CKPT_ENGINE_INIT_TIMEOUT_S"
+DEFAULT_INIT_TIMEOUT_S = 600.0
+
+
+class CheckpointEngineInitError(RuntimeError):
+    """Raised when checkpoint-engine process-group init exceeds its timeout."""
+
+
+def run_group_init_with_timeout(
+    init_fn: Callable[[], None],
+    *,
+    group_name: str,
+    timeout_s: float | None = None,
+) -> None:
+    """Run the blocking group registration + first barrier under a timeout.
+
+    Args:
+        init_fn: Zero-arg callable performing ``init_collective_group`` and the
+            first ``barrier`` (and any per-rank setup between them).
+        group_name: Collective group name, used only for error messages.
+        timeout_s: Seconds to wait. Defaults to the ``VERL_CKPT_ENGINE_INIT_TIMEOUT_S``
+            env var, else ``DEFAULT_INIT_TIMEOUT_S``.
+
+    Raises:
+        CheckpointEngineInitError: If ``init_fn`` does not finish within the timeout.
+        BaseException: Re-raises whatever ``init_fn`` itself raised.
+    """
+    if timeout_s is None:
+        timeout_s = float(os.environ.get(INIT_TIMEOUT_ENV, DEFAULT_INIT_TIMEOUT_S))
+
+    done = threading.Event()
+    error: dict[str, BaseException] = {}
+
+    def _target() -> None:
+        try:
+            init_fn()
+        except BaseException as e:  # surfaced to the caller via `error`
+            error["exc"] = e
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=_target, name=f"ckpt-group-init-{group_name}", daemon=True)
+    worker.start()
+    if not done.wait(timeout_s):
+        # The worker thread is still blocked in NCCL/collective and cannot be
+        # safely interrupted; we abort the caller and let the launcher tear down.
+        raise CheckpointEngineInitError(
+            f"checkpoint-engine NCCL group {group_name!r} init did not complete "
+            f"within {timeout_s:.0f}s; the first weight sync appears hung "
+            f"(verl issue #6967). Aborting instead of hanging indefinitely. If "
+            f"this was a slow-but-healthy init, raise {INIT_TIMEOUT_ENV}."
+        )
+    if "exc" in error:
+        raise error["exc"]

--- a/verl/checkpoint_engine/_group_init.py
+++ b/verl/checkpoint_engine/_group_init.py
@@ -11,30 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Bounded first-rendezvous init for the NCCL checkpoint engine.
+"""Bounded controller-side wait for checkpoint-engine process-group init.
 
-The first ``ray.util.collective`` rendezvous (``init_collective_group`` +
-``barrier``) can hang indefinitely on some environments -- a timing race in the
+The first ``ray.util.collective`` rendezvous during checkpoint-engine weight
+sync can hang indefinitely on some environments -- a timing race in the
 Ray/NCCL layer reported in verl issue #6967. When it hangs, both ranks sit at
-0% util with no traceback and the whole job is stuck forever.
+0% util with no traceback and the whole job is stuck forever; only the first
+sync is affected (the group is reused afterward).
 
-This wraps that first init in a bounded timeout so a stalled rendezvous fails
-fast with a clear, actionable error instead of hanging silently. A stalled
-NCCL/collective call cannot be safely interrupted, so we deliberately do NOT
-retry in place: we surface the error and let the launcher tear the job down.
+``CheckpointEngineManager.build_process_group()`` dispatches every worker's
+``init_process_group`` concurrently and blocks on ``ray.get(...)``. We bound
+that controller-side wait so a hung first sync fails fast with a clear,
+actionable error instead of hanging forever. A stalled NCCL/collective call in
+a worker cannot be safely interrupted, so we deliberately do not retry: we
+surface the error and let the launcher tear the job down (Ray reclaims the
+actors and GPUs when the driver exits).
 """
 
 import logging
 import os
-import threading
-from typing import Callable
+from typing import Any
+
+import ray
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
 
 # Generous default: long enough never to trip a slow-but-healthy first sync
-# (large models can take seconds to tens of seconds), short enough to abort a
-# genuine hang instead of waiting forever. Override via env if needed.
+# (large models can take tens of seconds), short enough to abort a genuine hang
+# instead of waiting forever. Override via env if needed.
 INIT_TIMEOUT_ENV = "VERL_CKPT_ENGINE_INIT_TIMEOUT_S"
 DEFAULT_INIT_TIMEOUT_S = 600.0
 
@@ -43,49 +48,30 @@ class CheckpointEngineInitError(RuntimeError):
     """Raised when checkpoint-engine process-group init exceeds its timeout."""
 
 
-def run_group_init_with_timeout(
-    init_fn: Callable[[], None],
-    *,
-    group_name: str,
-    timeout_s: float | None = None,
-) -> None:
-    """Run the blocking group registration + first barrier under a timeout.
+def wait_for_group_init(refs: list, *, timeout_s: float | None = None) -> Any:
+    """``ray.get`` the process-group-init object refs under a bounded timeout.
 
     Args:
-        init_fn: Zero-arg callable performing ``init_collective_group`` and the
-            first ``barrier`` (and any per-rank setup between them).
-        group_name: Collective group name, used only for error messages.
+        refs: Ray object refs returned by dispatching ``init_process_group`` to
+            the actor and rollout worker groups.
         timeout_s: Seconds to wait. Defaults to the ``VERL_CKPT_ENGINE_INIT_TIMEOUT_S``
             env var, else ``DEFAULT_INIT_TIMEOUT_S``.
 
+    Returns:
+        The ``ray.get`` results.
+
     Raises:
-        CheckpointEngineInitError: If ``init_fn`` does not finish within the timeout.
-        BaseException: Re-raises whatever ``init_fn`` itself raised.
+        CheckpointEngineInitError: If the init does not complete within the timeout.
     """
     if timeout_s is None:
         timeout_s = float(os.environ.get(INIT_TIMEOUT_ENV, DEFAULT_INIT_TIMEOUT_S))
 
-    done = threading.Event()
-    error: dict[str, BaseException] = {}
-
-    def _target() -> None:
-        try:
-            init_fn()
-        except BaseException as e:  # surfaced to the caller via `error`
-            error["exc"] = e
-        finally:
-            done.set()
-
-    worker = threading.Thread(target=_target, name=f"ckpt-group-init-{group_name}", daemon=True)
-    worker.start()
-    if not done.wait(timeout_s):
-        # The worker thread is still blocked in NCCL/collective and cannot be
-        # safely interrupted; we abort the caller and let the launcher tear down.
+    try:
+        return ray.get(refs, timeout=timeout_s)
+    except ray.exceptions.GetTimeoutError as e:
         raise CheckpointEngineInitError(
-            f"checkpoint-engine NCCL group {group_name!r} init did not complete "
-            f"within {timeout_s:.0f}s; the first weight sync appears hung "
-            f"(verl issue #6967). Aborting instead of hanging indefinitely. If "
-            f"this was a slow-but-healthy init, raise {INIT_TIMEOUT_ENV}."
-        )
-    if "exc" in error:
-        raise error["exc"]
+            f"checkpoint-engine process-group init did not complete within "
+            f"{timeout_s:.0f}s; the first weight sync appears hung (verl issue "
+            f"#6967). Aborting instead of hanging indefinitely. If this was a "
+            f"slow-but-healthy init, raise {INIT_TIMEOUT_ENV}."
+        ) from e

--- a/verl/checkpoint_engine/base.py
+++ b/verl/checkpoint_engine/base.py
@@ -19,6 +19,7 @@ from typing import Any, AsyncGenerator, Generator
 import ray
 import torch
 
+from verl.checkpoint_engine._group_init import wait_for_group_init
 from verl.single_controller.base import Worker
 from verl.single_controller.base.decorator import Dispatch, register
 from verl.single_controller.ray import RayClassWithInitArgs, RayWorkerGroup
@@ -406,8 +407,10 @@ class CheckpointEngineManager:
         actor_wg_kwargs["method"] = ["init_process_group"] * actor_wg.world_size
         rollout_kwargs["method"] = ["init_process_group"] * rollout.world_size
 
-        # 3. init process group between all workers
-        ray.get(
+        # 3. init process group between all workers, bounded by a timeout so a
+        # hung first NCCL rendezvous fails fast with a clear error instead of
+        # hanging forever (verl issue #6967).
+        wait_for_group_init(
             actor_wg.execute_checkpoint_engine(**actor_wg_kwargs) + rollout.execute_checkpoint_engine(**rollout_kwargs)
         )
 

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -221,14 +221,18 @@ class NCCLCheckpointEngine(CheckpointEngine):
                 assert self.world_size == world_size, (
                     f"world_size {world_size} is not equal to self.world_size {self.world_size}"
                 )
-
-            if self.rank > 0:
-                self._connect_zmq_client(master_metadata)
             collective.barrier(self.group_name)
 
-        # Bound the first-rendezvous init so a hung sync fails fast with a clear
-        # error instead of hanging forever (verl issue #6967).
+        # Bound the NCCL group init + first barrier (the calls that can hang) so a
+        # stalled sync fails fast with a clear error instead of hanging forever
+        # (verl issue #6967).
         run_group_init_with_timeout(_do_init, group_name=self.group_name)
+
+        # Connect the ZeroMQ SUB socket on the caller thread, NOT inside the
+        # timeout worker: pyzmq sockets are not thread-safe and this socket is
+        # used later from other threads.
+        if rank > 0:
+            self._connect_zmq_client(master_metadata)
 
         logger.info(f"init_process_group rank: {self.rank}, world_size: {self.world_size}")
 

--- a/verl/checkpoint_engine/nccl_checkpoint_engine.py
+++ b/verl/checkpoint_engine/nccl_checkpoint_engine.py
@@ -27,6 +27,7 @@ import ray.util.collective as collective
 import torch
 import zmq
 
+from verl.checkpoint_engine._group_init import run_group_init_with_timeout
 from verl.checkpoint_engine.base import (
     CheckpointEngine,
     CheckpointEngineRegistry,
@@ -210,19 +211,24 @@ class NCCLCheckpointEngine(CheckpointEngine):
             self.world_size = world_size
             return
 
-        if self.rebuild_group or not collective.is_group_initialized(self.group_name):
-            collective.init_collective_group(world_size, rank, "nccl", self.group_name)
-            self.rank = rank
-            self.world_size = world_size
-        else:
-            assert self.rank == rank, f"rank {rank} is not equal to self.rank {self.rank}"
-            assert self.world_size == world_size, (
-                f"world_size {world_size} is not equal to self.world_size {self.world_size}"
-            )
+        def _do_init() -> None:
+            if self.rebuild_group or not collective.is_group_initialized(self.group_name):
+                collective.init_collective_group(world_size, rank, "nccl", self.group_name)
+                self.rank = rank
+                self.world_size = world_size
+            else:
+                assert self.rank == rank, f"rank {rank} is not equal to self.rank {self.rank}"
+                assert self.world_size == world_size, (
+                    f"world_size {world_size} is not equal to self.world_size {self.world_size}"
+                )
 
-        if self.rank > 0:
-            self._connect_zmq_client(master_metadata)
-        collective.barrier(self.group_name)
+            if self.rank > 0:
+                self._connect_zmq_client(master_metadata)
+            collective.barrier(self.group_name)
+
+        # Bound the first-rendezvous init so a hung sync fails fast with a clear
+        # error instead of hanging forever (verl issue #6967).
+        run_group_init_with_timeout(_do_init, group_name=self.group_name)
 
         logger.info(f"init_process_group rank: {self.rank}, world_size: {self.world_size}")
 


### PR DESCRIPTION
## Motivation

Fixes the *silent-infinite-hang* failure mode of #6967. The first
`ray.util.collective` rendezvous during checkpoint-engine weight sync
(`NCCLCheckpointEngine.init_process_group` → `init_collective_group` + first
`barrier`) can hang **indefinitely** on some setups — a timing race in the
Ray/NCCL layer. When it hangs, both ranks sit at 0% util with no traceback and
the whole job is stuck forever; only the *first* sync is affected (the group is
reused afterward).

This PR does **not** claim to fix the underlying race — it adds a robustness
guardrail so a stalled first sync **fails fast with a clear, actionable error
instead of hanging silently forever**.

## Modifications

- New `verl/checkpoint_engine/_group_init.py`: `run_group_init_with_timeout()`
  runs the blocking group registration + first `barrier` in a worker thread
  bounded by a timeout. On timeout it raises `CheckpointEngineInitError` with a
  message pointing at #6967; it re-raises any error the init itself throws.
  Timeout is configurable via `VERL_CKPT_ENGINE_INIT_TIMEOUT_S`
  (default `600s` — generous enough never to trip a slow-but-healthy init).
- `NCCLCheckpointEngine.init_process_group` wraps its first-rendezvous block
  with this helper.
- A stalled NCCL/collective call cannot be safely interrupted, so this
  deliberately does **not** retry in place — it surfaces the error and lets the
  launcher tear the job down.

## Scope (honest framing)

This is a **guardrail against a silent infinite hang, not a root-cause fix** for
the race. The exact mechanism is currently **unconfirmed and not reproducible**:
on H100 NVL I could not reproduce it (natively across `staleness_threshold`
1/4/16, nor under injected scheduling skew at 4 injection points with delays up
to 120s — the barrier tolerates skew via `Rendezvous.meet` polling + blocking
`ncclCommInitRank`), and reporter @chengcuiping reports it no longer reproduces
on the original 2×A100 either, with no path to timing-neutral native stacks
(container ptrace restrictions). Proposing a speculative "fix" would be
unjustified — but this timeout guardrail is independently valuable and endorsed
by the reporter in the issue thread.

## Accuracy / Speed Tests

No model-output or perf impact (init-path robustness only).

## Test

CPU-only unit test `tests/checkpoint_engine/test_group_init_timeout_on_cpu.py`
(no GPU/NCCL — exercises the timeout machinery directly):

```
$ python -m pytest tests/checkpoint_engine/test_group_init_timeout_on_cpu.py -v
tests/checkpoint_engine/test_group_init_timeout_on_cpu.py::test_completes_within_timeout PASSED
tests/checkpoint_engine/test_group_init_timeout_on_cpu.py::test_raises_fast_on_timeout_instead_of_hanging PASSED
tests/checkpoint_engine/test_group_init_timeout_on_cpu.py::test_reraises_init_error PASSED
tests/checkpoint_engine/test_group_init_timeout_on_cpu.py::test_env_var_sets_default_timeout PASSED
4 passed
```

Existing `tests/checkpoint_engine/test_global_steps_on_cpu.py` still passes;
`ruff check` and `ruff format --check` clean on the changed files.

## Not a duplicate

Checked before opening: no open PR references #6967 or touches checkpoint-engine
init timeout.

## Notes

/cc @chengcuiping — thanks for the detailed root-cause collaboration on #6967.
Could you validate on your A100 config that the guardrail doesn't false-trip on a
healthy run? Happy to add you as co-author.

AI assistance (Claude) was used in developing this change; the tests above were
run and pass, and I've reviewed the change end-to-end.
