### PR TITLE
[tool] fix: remove circular fallback in BaseTool.__init__

### DIFF
--- a/verl/tools/base_tool.py
+++ b/verl/tools/base_tool.py
@@ -35,7 +35,7 @@ class BaseTool:
 
     def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema):
         self.config = config
-        self.tool_schema = tool_schema or self.get_openai_tool_schema()
+        self.tool_schema = tool_schema
         assert self.tool_schema is not None, "Tool schema is not set!"
         self.name = self.tool_schema.function.name
         print(json.dumps(self.tool_schema.model_dump(exclude_unset=True, exclude_none=True), indent=2))


### PR DESCRIPTION
### What does this PR do?

   Remove the `or self.get_openai_tool_schema()` fallback in
   `BaseTool.__init__`. It creates a circular reference:
   `get_openai_tool_schema()` returns `self.tool_schema`, but when
   `tool_schema=None` the `or` calls it before the attribute exists
   → `AttributeError`.

   The fix: `tool_schema` must be explicitly provided. The existing
   assertion catches the `None` case with a clear error message.

   ### Checklist Before Starting

   - [x] Search for similar PRs. Query: `base_tool get_openai_tool_schema circular`
   - [x] Format the PR title as `[tool] fix: ...`

   ### Test

   Not covered by CI; verified locally:

   | Scenario | Result |
   |---|---|
   | `BaseTool(config, valid_schema)` | works as before |
   | `BaseTool(config, None)` | `AssertionError: Tool schema is not set!` (clear, no crash) |
   | Subclass constructs schema in `__init__` | works correctly |
   | `get_openai_tool_schema()` as getter after init | works as before |

   ### API and Usage Example

   No API change. `tool_schema` must always be provided to `__init__`.
   Subclasses that need to construct their own schema should do it in
   `__init__` and pass it to `super().__init__()`:

   ```python
   class MyTool(BaseTool):
       def __init__(self, config: dict, tool_schema: OpenAIFunctionToolSchema = None):
           if tool_schema is None:
               tool_schema = OpenAIFunctionToolSchema.model_validate({...})
           super().__init__(config, tool_schema)
 ```

 ### Design & Code Changes

 1 file: verl/tools/base_tool.py (+1, −1)

 ```diff
   -        self.tool_schema = tool_schema or self.get_openai_tool_schema()
   +        self.tool_schema = tool_schema
 ```

 ### Checklist Before Submitting

 - Read the Contribute Guide.
 - Apply pre-commit checks
 - Add / Update the documentation — not needed
 - Add unit or end-to-end test(s) — not feasible: latent init bug, existing path always passes tool_schema