### PR TITLE
[trainer, perf] fix: include standalone rollout GPUs in throughput denominator for separate async

### DIFF
--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -536,6 +536,15 @@ class PPOTrainer(ABC):
 
     # ------------------------------ common methods ------------------------------
 
+    def _get_n_gpus_for_throughput(self) -> int:
+        """Return the total number of GPUs used for throughput normalization.
+
+        By default this is the trainer-side GPU count from the resource pool
+        manager.  Modes that use additional dedicated GPUs (e.g. separate-async
+        standalone rollout) should override this to include them.
+        """
+        return self.resource_pool_manager.get_n_gpus()
+
     def _init_tokenizer(self):
         """Initialize tokenizer."""
         # Download the checkpoint from HDFS to the local machine.
@@ -1574,7 +1583,7 @@ class PPOTrainer(ABC):
         )
         metrics.update(compute_data_metrics(batch=metrics_batch, use_critic=self.use_critic))
         metrics.update(compute_timing_metrics(batch=batch, timing_raw=timing_raw))
-        n_gpus = self.resource_pool_manager.get_n_gpus()
+        n_gpus = self._get_n_gpus_for_throughput()
         metrics.update(compute_throughout_metrics(batch=batch, timing_raw=timing_raw, n_gpus=n_gpus))
         gradient_norm = metrics.get("actor/grad_norm", None)
         metrics.update(compute_variance_proxy_metrics(batch=metrics_batch, gradient_norm=gradient_norm))

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -128,6 +128,20 @@ class PPOTrainerSeparateAsync(PPOTrainer):
             # wake up all replicas to update weights
             self.standalone_checkpoint_manager.update_weights(self.global_steps)
 
+    def _get_n_gpus_for_throughput(self) -> int:
+        """Include standalone rollout GPUs in the throughput denominator.
+
+        The standalone rollout runs on GPUs that are not part of the trainer
+        resource pool, so ``resource_pool_manager.get_n_gpus()`` alone
+        undercounts the total hardware footprint.
+        """
+        trainer_gpus = self.resource_pool_manager.get_n_gpus()
+        rollout_gpus = (
+            self.config.actor_rollout_ref.rollout.n_gpus_per_node
+            * self.config.actor_rollout_ref.rollout.nnodes
+        )
+        return trainer_gpus + rollout_gpus
+
     def switch_to_rollout(self):
         # TODO: disable auto offload in config and offload according to the switch strategy
         self.checkpoint_manager.update_weights(self.global_steps)

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -137,8 +137,7 @@ class PPOTrainerSeparateAsync(PPOTrainer):
         """
         trainer_gpus = self.resource_pool_manager.get_n_gpus()
         rollout_gpus = (
-            self.config.actor_rollout_ref.rollout.n_gpus_per_node
-            * self.config.actor_rollout_ref.rollout.nnodes
+            self.config.actor_rollout_ref.rollout.n_gpus_per_node * self.config.actor_rollout_ref.rollout.nnodes
         )
         return trainer_gpus + rollout_gpus
 


### PR DESCRIPTION

### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

In separate-async mode, the standalone rollout runs on dedicated GPUs that are not part of the trainer resource pool. However, compute_throughout_metrics used resource_pool_manager.get_n_gpus() as the denominator, which only counts trainer-side GPUs. This caused perf/throughput to be inflated in separate-async mode, making it incomparable with sync and colocate-async modes.

Before: `throughput = total_tokens / (step_time * trainer_gpus)`
After: `throughput = total_tokens / (step_time * (trainer_gpus + rollout_gpus))`

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/pulls?q=is%3Apr+separate_async+is%3Aopen
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
