### PR TITLE
[rocm] feat: enable DeepSeek-V4-Flash GRPO on AMD GPUs

### DIFF
--- a/docker/rocm/Dockerfile.rocm.deepseek-v4
+++ b/docker/rocm/Dockerfile.rocm.deepseek-v4
@@ -1,0 +1,49 @@
+# From upstream, vllm - rocm 7.2.3
+FROM vllm/vllm-openai-rocm:v0.26.0 AS verl_base
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install \
+    https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/apex-1.9.0%2Brocm7.2.3.git355db9b8-cp312-cp312-linux_x86_64.whl \
+    https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/transformer_engine-2.6.0-py3-none-any.whl \
+    https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/transformer_engine_rocm-2.6.0-py3-none-manylinux_2_28_x86_64.whl
+
+RUN pip install --no-build-isolation  https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/transformer_engine_torch-2.6.0.tar.gz
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -U git+https://github.com/ISEEKYAN/mbridge.git@v0.15.1 && \
+    pip install mathruler && \
+    pip install qwen_vl_utils && \
+    pip install flash-linear-attention
+
+ARG MEGATRON_LM_REPO="https://github.com/NVIDIA/Megatron-LM.git"
+ARG MEGATRON_LM_COMMIT="fd1121b8ff7e3a4f83a28d35aed172d7bc0260e1"
+
+COPY docker/rocm/patches /opt/patches
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --no-deps "nvidia-modelopt>=0.37.0" "pulp<4.0" && \
+    git clone ${MEGATRON_LM_REPO} /opt/Megatron-LM && \
+    cd /opt/Megatron-LM && \
+    git fetch --depth 1 origin ${MEGATRON_LM_COMMIT} && \
+    git checkout ${MEGATRON_LM_COMMIT} && \
+    git apply /opt/patches/non-leaf-fix.patch && \
+    pip install -e . --no-deps
+
+ARG MEGATRON_BRIDGE_REPO="https://github.com/NVIDIA-NeMo/Megatron-Bridge"
+ARG MEGATRON_BRIDGE_COMMIT="v0.5.0"
+
+RUN pip install --no-deps --no-build-isolation --ignore-requires-python \
+    git+${MEGATRON_BRIDGE_REPO}@${MEGATRON_BRIDGE_COMMIT}
+
+RUN pip install "transformers==5.12.1"  "TransferQueue==0.1.8"
+
+ARG BUILD_DATE="2026-08-07"
+RUN --mount=type=cache,target=/root/.cache/pip \
+    git clone https://github.com/verl-project/verl.git && \
+    cd verl && \
+    pip install -e .
+
+ENV VLLM_ROCM_USE_AITER=1
+ENV VLLM_ROCM_USE_AITER_MOE=1
+
+WORKDIR /app/verl
+CMD ["/bin/bash"]

--- a/docker/rocm/patches/non-leaf-fix.patch
+++ b/docker/rocm/patches/non-leaf-fix.patch
@@ -1,0 +1,27 @@
+diff --git a/megatron/core/optimizer/distrib_optimizer.py b/megatron/core/optimizer/distrib_optimizer.py
+index 0b6fb468c..1fc541dda 100644
+--- a/megatron/core/optimizer/distrib_optimizer.py
++++ b/megatron/core/optimizer/distrib_optimizer.py
+@@ -465,7 +465,12 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+ 
+                 # fp32 params.
+                 elif model_param.type() == 'torch.cuda.FloatTensor':
+-                    shard_model_param = model_param.view(-1)[param_range.start : param_range.end]
++                    # Detach so the shard is a leaf tensor: it is handed to the inner optimizer,
++                    # and torch.optim rejects non-leaf params. Detaching shares storage, so
++                    # in-place updates of the shard still land in the model param.
++                    shard_model_param = model_param.detach().view(-1)[
++                        param_range.start : param_range.end
++                    ]
+                     model_fp32_params_this_group.append(model_param)
+                     shard_fp32_params_this_group.append(shard_model_param)
+                     tensor_parallel.copy_tensor_model_parallel_attributes(
+@@ -2554,7 +2559,7 @@ class DistributedOptimizer(MixedPrecisionOptimizer):
+             self.model_float16_groups,
+             self.model_fp32_groups,
+             self.shard_float16_groups,  # grad empty/unused here?
+-            self.shard_fp32_groups,  # throws grad-access warning
++            self.shard_fp32_groups,
+         ]
+         if not self.config.use_precision_aware_optimizer_no_fp8_or_ds_fp8:
+             total_groups.append(self.shard_fp32_from_float16_groups)

--- a/examples/grpo_trainer/README.md
+++ b/examples/grpo_trainer/README.md
@@ -88,7 +88,7 @@ bash examples/grpo_trainer/run_qwen3_8b_fsdp.sh
 | Qwen3.5-35B-A3B (MoE) |        | ✓        |          | VeOmni          | nvidia    |
 | Qwen3.5-122B-A10B     | ✓      |          |          | Megatron        | nvidia    |
 | DeepSeek-V3 671B      | ✓      |          |          | Megatron        | nvidia    |
-| DeepSeek-V4-Flash     | ✓      |          |          | Megatron        | nvidia    |
+| DeepSeek-V4-Flash     | ✓      |          |          | Megatron        | nvidia, amd    |
 | GLM-4.1V-9B           | ✓      |          |          | FSDP            | nvidia    |
 | MiniCPM-o-2.6         | ✓      |          |          | FSDP            | nvidia    |
 | Moonlight-16B-A3B     | ✓      |          |          | Megatron        | nvidia    |

--- a/examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh
+++ b/examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh
@@ -20,7 +20,7 @@ export PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:Tr
 
 ############################### configs ################################
 
-MODEL_PATH=$HDFS_ROOT/model/DeepSeek-V4-Flash
+MODEL_PATH=${MODEL_PATH:-$HDFS_ROOT/model/DeepSeek-V4-Flash}
 NNODES=${NNODES:-8}
 NGPUS_PER_NODE=${NGPUS_PER_NODE:-8}
 
@@ -70,8 +70,8 @@ PROJECT_NAME=${PROJECT_NAME:-wuxibin_dapo}
 EXPERIMENT_NAME=${EXPERIMENT_NAME:-deepseek_v4_flash_grpo_vllm_megatron}
 CKPTS_DIR=${CKPTS_DIR:-"${HOME}/verl/ckpts/${PROJECT_NAME}/${EXPERIMENT_NAME}"}
 
-TRAIN_FILE=$DATA_ROOT/dataset/BytedTsinghua-SIA/DAPO-Math-17k/data/dapo-math-17k.parquet
-TEST_FILE=$DATA_ROOT/dataset/aime25_test.parquet
+TRAIN_FILE=${TRAIN_FILE:-$DATA_ROOT/dataset/BytedTsinghua-SIA/DAPO-Math-17k/data/dapo-math-17k.parquet}
+TEST_FILE=${TEST_FILE:-$DATA_ROOT/dataset/aime25_test.parquet}
 OVERLONG_BUFFER_LEN=${OVERLONG_BUFFER_LEN:-${MAX_RESPONSE_LENGTH}}
 OVERLONG_BUFFER_ENABLE=${OVERLONG_BUFFER_ENABLE:-False}
 OVERLONG_PENALTY_FACTOR=${OVERLONG_PENALTY_FACTOR:-1.0}

--- a/verl/utils/vllm/rocm_vllm_moe_expert_map.py
+++ b/verl/utils/vllm/rocm_vllm_moe_expert_map.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+
+
+def restore_moe_expert_maps(model):
+    """Rebuild the EP expert maps of every ``RoutedExperts`` layer, in place.
+
+    A rollout engine comes up on dummy weights, whose init zeroes the int32
+    ``_expert_map`` / ``expert_mask`` buffers on ROCm. No refit restores them --
+    the maps come from the parallel layout, not from a checkpoint -- and a zeroed
+    map routes every token to local expert 0 instead of to the owning rank.
+
+    Written in place so addresses a CUDA graph captured stay valid, and safe to
+    call on every refit: the maps are a pure function of the layout, so a rebuild
+    is either a no-op or a repair. Layers without expert parallelism are skipped.
+    """
+    from vllm.model_executor.layers.fused_moe import RoutedExperts
+    from vllm.model_executor.layers.fused_moe.expert_map_manager import determine_expert_map
+
+    repaired = 0
+    for module in model.modules():
+        if not isinstance(module, RoutedExperts):
+            continue
+        manager = getattr(module, "expert_map_manager", None)
+        if manager is None or not module.moe_config.moe_parallel_config.use_ep:
+            continue
+
+        # Deliberately not ExpertMapManager._calculate_expert_maps: that folds the
+        # fused shared experts into local_num_experts on every call, so replaying
+        # it would inflate the count.
+        _, expert_map, expert_mask = determine_expert_map(
+            ep_size=manager.ep_size,
+            ep_rank=manager.ep_rank,
+            global_num_experts=manager.global_num_experts,
+            expert_placement_strategy=manager.placement_strategy,
+            num_fused_shared_experts=manager.num_fused_shared_experts,
+            return_expert_mask=manager.rocm_aiter_enabled,
+        )
+
+        for name, rebuilt in (("_expert_map", expert_map), ("expert_mask", expert_mask)):
+            live = getattr(module, name, None)
+            if live is None or rebuilt is None:
+                continue
+            if live.shape != rebuilt.shape:
+                raise RuntimeError(
+                    f"Rebuilt {name} is {tuple(rebuilt.shape)} but the live buffer is "
+                    f"{tuple(live.shape)}; the expert layout changed under the rollout engine."
+                )
+            live.copy_(rebuilt.to(device=live.device))
+            repaired += 1
+
+    if repaired:
+        logger.info("Rebuilt %d expert-parallel routing buffers on the rollout model", repaired)
+    return repaired

--- a/verl/utils/vllm/vllm_fp4_utils.py
+++ b/verl/utils/vllm/vllm_fp4_utils.py
@@ -93,6 +93,7 @@ def _refittable_mxfp4_backends():
         Mxfp4MoeBackend.DEEPGEMM_MXFP4,
         Mxfp4MoeBackend.MARLIN,
         Mxfp4MoeBackend.BATCHED_MARLIN,
+        Mxfp4MoeBackend.AITER_MXFP4_BF16,
     )
 
 

--- a/verl/utils/vllm/vllm_quant_utils.py
+++ b/verl/utils/vllm/vllm_quant_utils.py
@@ -253,6 +253,24 @@ def apply_mxfp8_transformation_after_loading(model):
                 module.quant_method.process_weights_after_loading(module)
 
 
+def clear_rocm_attention_weight_caches(model):
+    """Drop the bf16 ``wo_a`` copy vLLM derives from the loaded weight.
+
+    ``rocm_aiter_mla_sparse._get_cached_wo_a_bf16`` caches a dequantized ``wo_a``
+    on the module, assuming the weight is static. A refit updates the weight but
+    not the cache, so attention would keep using the previous step's copy. The
+    rebuild is lazy, so dropping the cache here is enough.
+
+    Only ROCm DeepSeek-V4 builds this cache, hence the guard below.
+    """
+    if torch.version.hip is None or not is_deepseek_v4_model(model):
+        return
+
+    for module in model.modules():
+        if hasattr(module, "_dsv4_wo_a_bf16"):
+            del module._dsv4_wo_a_bf16
+
+
 def quant_weights(weights, model, quant_config, dtype=torch.bfloat16):
     """Quantize weights to FP8 format using a memory-efficient generator.
 
@@ -330,6 +348,7 @@ def prepare_quanted_weights_for_loading(model):
 
 def process_quanted_weights_after_loading(model, reload_state):
     """Re-apply the inference layout undone by ``prepare_quanted_weights_for_loading``."""
+    clear_rocm_attention_weight_caches(model)
     apply_mxfp8_transformation_after_loading(model)
     reload_state = reload_state or {}
     process_fp8_weights_after_loading(reload_state.get("fp8_layers") or [])

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -241,6 +241,15 @@ class vLLMColocateWorkerExtension:
         # =========================== step 1: prepare for weight loading ===========================
         quant_reload_states = None
 
+        # The engine came up on dummy weights, whose init zeroes integer buffers on
+        # ROCm -- including the expert-parallel routing maps, which no weight stream
+        # restores. Repair them before the reload so the rollout routes correctly.
+        if torch.version.hip is not None:
+            from verl.utils.vllm.rocm_vllm_moe_expert_map import restore_moe_expert_maps
+
+            for model in self._iter_all_models():
+                restore_moe_expert_maps(model)
+
         if self._is_qat_model:
             # QAT (compressed-tensors): Prepare for weight loading BEFORE receiving any buckets
             from verl.utils.qat import prepare_qat_for_load_weights


### PR DESCRIPTION
### What does this PR do?

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.
run script
run commands :
```
bash "${REPO_ROOT}/examples/grpo_trainer/run_deepseek_v4_flash_megatron.sh" \
    trainer.logger='["console"]' \
    trainer.val_before_train=True \
    trainer.rollout_data_dir="${CKPTS_DIR}/rollout_dump" \
    data.gen_batch_size=${TRAIN_BATCH_SIZE} \
    ++actor_rollout_ref.actor.megatron.override_transformer_config.pipeline_model_parallel_layout=null \
    ++actor_rollout_ref.ref.megatron.override_transformer_config.pipeline_model_parallel_layout=null \
    ++actor_rollout_ref.actor.megatron.override_transformer_config.apply_dsa_kernel_fusion=False \
    ++actor_rollout_ref.ref.megatron.override_transformer_config.apply_dsa_kernel_fusion=False \
    +actor_rollout_ref.rollout.engine_kwargs.vllm.disable_custom_all_reduce=True \
    +actor_rollout_ref.rollout.engine_kwargs.vllm.moe_backend=${ROLLOUT_MOE_BACKEND} \
    +actor_rollout_ref.rollout.engine_kwargs.vllm.tokenizer_mode=deepseek_v4 \
    +actor_rollout_ref.rollout.engine_kwargs.vllm.reasoning_parser=deepseek_v4 \
    actor_rollout_ref.rollout.enforce_eager=True \
    actor_rollout_ref.rollout.enable_prefix_caching=False \
    data.dataloader_num_workers=0 \
    +ray_kwargs.ray_init.runtime_env.env_vars.WANDB_API_KEY=${WK} \
    "$@"
```


### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.

## results
step3:
```
training/rollout_probs_diff_valid:1.0
training/rollout_probs_diff_max:0.4204995036125183
training/rollout_probs_diff_mean:0.0069715604186058044
training/rollout_probs_diff_std:0.017698492854833603
training/rollout_actor_probs_pearson_corr:0.9964592456817627
rollout_corr/training_ppl:1.1608881950378418
rollout_corr/training_log_ppl:0.14657101035118103
rollout_corr/kl:0.0015341324033215642
rollout_corr/k3_kl:0.001540864584967494
rollout_corr/rollout_ppl:1.1591999530792236
rollout_corr/rollout_log_ppl:0.14516547322273254
rollout_corr/log_ppl_diff:0.0014055281644687057
rollout_corr/log_ppl_abs_diff:0.0032031850423663855
rollout_corr/log_ppl_diff_max:0.01963585615158081
rollout_corr/log_ppl_diff_min:-0.011343628168106079
rollout_corr/ppl_ratio:1.0014148950576782
rollout_corr/chi2_token:0.0029715299606323242
rollout_corr/chi2_seq:0.4806104898452759
```
