### PR TITLE
[trainer] fix: gen_batch_size falls back to train_batch_size 

### DIFF
--- a/tests/utils/test_utils_skip.py
+++ b/tests/utils/test_utils_skip.py
@@ -101,7 +101,7 @@ def _local_rollout_config(cfg: OmegaConf) -> RolloutSkipConfig:
 def _project_dump_root(dump_dir: Path, cfg: OmegaConf) -> Path:
     exp = cfg.trainer.experiment_name
     proj = cfg.trainer.project_name
-    gbs = cfg.data.gen_batch_size
+    gbs = cfg.data.gen_batch_size or cfg.data.train_batch_size
     n = int(OmegaConf.select(cfg, "actor_rollout_ref.rollout.n", default=0))
     inp = cfg.data.max_prompt_length
     out = cfg.data.max_response_length

--- a/tests/workers/rollout/perf/vllm_async_rollout.py
+++ b/tests/workers/rollout/perf/vllm_async_rollout.py
@@ -94,7 +94,7 @@ def initialize(config, backend) -> tuple[AgentLoopManager | RayWorkerGroup, Stat
     )
     dataloader = StatefulDataLoader(
         dataset=dataset,
-        batch_size=config.data.get("gen_batch_size", config.data.train_batch_size),
+        batch_size=config.data.get("gen_batch_size", None) or config.data.train_batch_size,
         num_workers=config.data.get("dataloader_num_workers", 8),
         drop_last=True,
         collate_fn=default_collate_fn,

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -404,7 +404,7 @@ class RayPPOTrainer:
 
         self.train_dataloader = StatefulDataLoader(
             dataset=self.train_dataset,
-            batch_size=self.config.data.get("gen_batch_size", self.config.data.train_batch_size),
+            batch_size=self.config.data.get("gen_batch_size", None) or self.config.data.train_batch_size,
             num_workers=num_workers,
             drop_last=True,
             collate_fn=collate_fn,


### PR DESCRIPTION
### What does this PR do?

Legacy trainer assumes `gen_batch_size` not in the config by default. V1 trainer introduces it so legacy `gen_batch_size` should fall back to `train_batch_size` correctly.