### PR TITLE
[ckpt] feat: add save_lora_only checkpoint support

### DIFF
--- a/tests/utils/ckpt/test_fsdp_lora_only_checkpoint_on_cpu.py
+++ b/tests/utils/ckpt/test_fsdp_lora_only_checkpoint_on_cpu.py
@@ -245,8 +245,8 @@ class _FakeFSDPModel:
     def state_dict(self):
         return self._fsdp_wrapped_module.state_dict()
 
-    def load_state_dict(self, state_dict, assign=False):
-        return self._fsdp_wrapped_module.load_state_dict(state_dict, assign=assign)
+    def load_state_dict(self, state_dict, strict=True, assign=False):
+        return self._fsdp_wrapped_module.load_state_dict(state_dict, strict=strict, assign=assign)
 
     def named_buffers(self):
         return {}.items()
@@ -281,7 +281,7 @@ class _FakePEFTModel:
             d["base_model.model.lora_B.lora_B.weight"] = self.lora_B_weight
         return d
 
-    def load_state_dict(self, state_dict, assign=False):
+    def load_state_dict(self, state_dict, strict=True, assign=False):
         for key, tensor in state_dict.items():
             if "base.weight" in key or key == "base.weight":
                 self.base_weight.data.copy_(tensor)

--- a/tests/utils/ckpt/test_fsdp_lora_only_checkpoint_on_cpu.py
+++ b/tests/utils/ckpt/test_fsdp_lora_only_checkpoint_on_cpu.py
@@ -1,0 +1,291 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for save_lora_only checkpoint support in FSDPCheckpointManager."""
+
+import pytest
+
+from verl.utils.checkpoint.checkpoint_manager import BaseCheckpointManager
+
+
+class TestBaseCheckpointManagerLoraOnly:
+    """Tests for LoRA-only checkpoint properties on BaseCheckpointManager."""
+
+    def test_should_save_lora_only_default(self):
+        """Default (no config, or no save_lora_only) returns False."""
+        mgr = self._make_manager(checkpoint_config=None)
+        assert mgr.should_save_lora_only is False
+
+    def test_should_save_lora_only_false(self):
+        """Explicit False returns False."""
+        mgr = self._make_manager(checkpoint_config={"save_lora_only": False})
+        assert mgr.should_save_lora_only is False
+
+    def test_should_save_lora_only_true(self):
+        """When save_lora_only=True, returns True."""
+        mgr = self._make_manager(checkpoint_config={"save_lora_only": True})
+        assert mgr.should_save_lora_only is True
+
+    def test_is_lora_only_state_dict_empty(self):
+        """Empty state dict returns False."""
+        assert BaseCheckpointManager.is_lora_only_state_dict({}) is False
+
+    def test_is_lora_only_state_dict_none(self):
+        """None-like state dict returns False."""
+        assert BaseCheckpointManager.is_lora_only_state_dict(None) is False
+
+    def test_is_lora_only_state_dict_full(self):
+        """Full state dict with base model weights returns False."""
+        state_dict = {
+            "model.layers.0.self_attn.q_proj.weight": None,
+            "model.layers.0.self_attn.k_proj.weight": None,
+            "lm_head.weight": None,
+        }
+        assert BaseCheckpointManager.is_lora_only_state_dict(state_dict) is False
+
+    def test_is_lora_only_state_dict_lora(self):
+        """State dict with only LoRA keys returns True."""
+        state_dict = {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": None,
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight": None,
+        }
+        assert BaseCheckpointManager.is_lora_only_state_dict(state_dict) is True
+
+    def test_is_lora_only_state_dict_adapter_key(self):
+        """Keys containing .adapter_ are also recognized as LoRA."""
+        state_dict = {
+            "model.layers.0.attn.adapter_A.weight": None,
+            "model.layers.0.attn.adapter_B.weight": None,
+        }
+        assert BaseCheckpointManager.is_lora_only_state_dict(state_dict) is True
+
+    def test_is_lora_only_state_dict_mixed(self):
+        """Even one base key makes it not LoRA-only."""
+        state_dict = {
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight": None,
+            "model.layers.0.self_attn.q_proj.weight": None,
+        }
+        assert BaseCheckpointManager.is_lora_only_state_dict(state_dict) is False
+
+    @staticmethod
+    def _make_manager(checkpoint_config):
+        import torch.distributed
+
+        class MockModel:
+            pass
+
+        class MockOptimizer:
+            pass
+
+        return BaseCheckpointManager(
+            model=MockModel(),
+            optimizer=MockOptimizer(),
+            lr_scheduler=None,
+            processing_class=None,
+            checkpoint_config=checkpoint_config,
+        )
+
+
+class TestFSDPCheckpointManagerLoraOnly:
+    """Tests for LoRA-only checkpoint logic on FSDPCheckpointManager."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_dist(self, monkeypatch):
+        import torch.distributed
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+        monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+
+    def _make_fsdp_manager(self, checkpoint_config, model=None):
+        from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+
+        if model is None:
+            model = _FakeFSDPModel(has_lora=True)
+
+        return FSDPCheckpointManager(
+            model=model,
+            optimizer=None,
+            lr_scheduler=None,
+            processing_class=None,
+            checkpoint_config=checkpoint_config,
+        )
+
+    def test_has_lora_true(self):
+        """Model with peft_config returns True."""
+        mgr = self._make_fsdp_manager(checkpoint_config={"save_lora_only": True})
+        assert mgr._has_lora() is True
+
+    def test_has_lora_false(self):
+        """Model without peft_config returns False."""
+        model = _FakeFSDPModel(has_lora=False)
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": True}, model=model
+        )
+        assert mgr._has_lora() is False
+
+    def test_save_lora_only_filters_state_dict(self, tmp_path):
+        """When save_lora_only=True and model has LoRA, only LoRA keys are saved."""
+        model = _FakeFSDPModel(has_lora=True)
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": True, "save_contents": ["model"]},
+            model=model,
+        )
+
+        save_dir = tmp_path / "ckpt"
+        mgr.save_checkpoint(local_path=str(save_dir), global_step=1)
+
+        saved_path = save_dir / "model_world_size_1_rank_0.pt"
+        import torch
+        state_dict = torch.load(saved_path, weights_only=False)
+        for key in state_dict:
+            assert "lora_" in key or ".adapter_" in key, "Unexpected base key: {}".format(key)
+        assert len(state_dict) == 2
+
+    def test_save_lora_only_no_lora_saves_full(self, tmp_path):
+        """When model has no LoRA, save_lora_only should NOT filter."""
+        model = _FakeFSDPModel(has_lora=False)
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": True, "save_contents": ["model"]},
+            model=model,
+        )
+
+        save_dir = tmp_path / "ckpt"
+        mgr.save_checkpoint(local_path=str(save_dir), global_step=1)
+
+        saved_path = save_dir / "model_world_size_1_rank_0.pt"
+        import torch
+        state_dict = torch.load(saved_path, weights_only=False)
+        assert "base.weight" in state_dict
+        assert "lora_A.weight" in state_dict
+
+    def test_save_lora_only_disabled_saves_full(self, tmp_path):
+        """When save_lora_only=False, everything is saved."""
+        model = _FakeFSDPModel(has_lora=True)
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": False, "save_contents": ["model"]},
+            model=model,
+        )
+
+        save_dir = tmp_path / "ckpt"
+        mgr.save_checkpoint(local_path=str(save_dir), global_step=1)
+
+        saved_path = save_dir / "model_world_size_1_rank_0.pt"
+        import torch
+        state_dict = torch.load(saved_path, weights_only=False)
+        assert "base.weight" in state_dict
+        assert "lora_A.weight" in state_dict
+
+    def test_load_lora_only_checkpoint_merges(self, tmp_path):
+        """Loading a LoRA-only checkpoint merges it into the existing model state."""
+        import torch
+
+        model_before = _FakeFSDPModel(has_lora=True)
+        model_before._fsdp_wrapped_module.base_weight.data.fill_(1.0)
+
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": True, "save_contents": ["model"]},
+            model=model_before,
+        )
+        save_dir = tmp_path / "lora_only"
+        mgr.save_checkpoint(local_path=str(save_dir), global_step=1)
+
+        model_after = _FakeFSDPModel(has_lora=True)
+        model_after._fsdp_wrapped_module.base_weight.data.fill_(99.0)
+
+        mgr2 = self._make_fsdp_manager(
+            checkpoint_config={"load_contents": ["model"]},
+            model=model_after,
+        )
+        mgr2.load_checkpoint(local_path=str(save_dir))
+
+        assert model_after._fsdp_wrapped_module.base_weight.item() == 99.0
+        assert model_after._fsdp_wrapped_module.lora_A_weight.item() == 0.5
+
+    def test_load_full_checkpoint_still_works(self, tmp_path):
+        """Loading a full (non-LoRA) checkpoint works normally (backward compat)."""
+        import torch
+
+        model = _FakeFSDPModel(has_lora=True)
+        model._fsdp_wrapped_module.base_weight.data.fill_(42.0)
+        mgr = self._make_fsdp_manager(
+            checkpoint_config={"save_lora_only": False, "save_contents": ["model"]},
+            model=model,
+        )
+        save_dir = tmp_path / "full_ckpt"
+        mgr.save_checkpoint(local_path=str(save_dir), global_step=1)
+
+        model_after = _FakeFSDPModel(has_lora=True)
+        model_after._fsdp_wrapped_module.base_weight.data.fill_(0.0)
+        mgr2 = self._make_fsdp_manager(
+            checkpoint_config={"load_contents": ["model"]},
+            model=model_after,
+        )
+        mgr2.load_checkpoint(local_path=str(save_dir))
+
+        assert model_after._fsdp_wrapped_module.base_weight.item() == 42.0
+
+
+class _FakeFSDPModel:
+    """A fake FSDP-wrapped model that mimics the interface used by FSDPCheckpointManager."""
+
+    def __init__(self, has_lora=True):
+        import torch
+        self._fsdp_wrapped_module = _FakePEFTModel(has_lora=has_lora)
+
+    def state_dict(self):
+        return self._fsdp_wrapped_module.state_dict()
+
+    def load_state_dict(self, state_dict, assign=False):
+        return self._fsdp_wrapped_module.load_state_dict(state_dict, assign=assign)
+
+    def named_buffers(self):
+        return {}.items()
+
+
+class _FakePEFTModel:
+    """Fake PEFT-style model with a peft_config."""
+
+    def __init__(self, has_lora=True):
+        import torch
+        self.base_weight = torch.nn.Parameter(torch.tensor(1.0))
+        self.lora_A_weight = torch.nn.Parameter(torch.tensor(0.5))
+        self.lora_B_weight = torch.nn.Parameter(torch.tensor(0.3))
+        self.config = None
+        self.can_generate = lambda: False
+
+        if has_lora:
+            self.peft_config = {
+                "default": type("Cfg", (), {
+                    "r": 8, "lora_alpha": 16, "task_type": "CAUSAL_LM"
+                })()
+            }
+
+    def state_dict(self):
+        d = {
+            "base.weight": self.base_weight,
+            "lora_A.weight": self.lora_A_weight,
+            "lora_B.weight": self.lora_B_weight,
+        }
+        if hasattr(self, "peft_config"):
+            d["base_model.model.lora_A.lora_A.weight"] = self.lora_A_weight
+            d["base_model.model.lora_B.lora_B.weight"] = self.lora_B_weight
+        return d
+
+    def load_state_dict(self, state_dict, assign=False):
+        for key, tensor in state_dict.items():
+            if "base.weight" in key or key == "base.weight":
+                self.base_weight.data.copy_(tensor)
+            elif "lora_A" in key:
+                self.lora_A_weight.data.copy_(tensor)
+            elif "lora_B" in key:
+                self.lora_B_weight.data.copy_(tensor)

--- a/verl/trainer/config/config.py
+++ b/verl/trainer/config/config.py
@@ -36,12 +36,19 @@ class CheckpointConfig(BaseConfig):
         load_contents (list[str]): Contents to load from checkpoint. Defaults to same as save_contents.
         async_save (bool): Whether to save checkpoints asynchronously. Only implemented for Megatron as of now.
         strict (bool): Whether to perform strict validation during weight export
+        save_lora_only (bool): When True and the model has LoRA adapters, only
+            save LoRA adapter weights instead of the full model state dict.
+            Dramatically reduces checkpoint size (e.g. ~150 MiB vs ~54 GiB for a
+            27B model). Loaded LoRA-only checkpoints are auto-detected and merged
+            into the current model state. Has no effect when the model has no LoRA
+            adapters.
     """
 
     save_contents: list[str] = field(default_factory=lambda: ["model", "optimizer", "extra"])
     load_contents: list[str] = field(default_factory=lambda: ["model", "optimizer", "extra"])
     async_save: bool = False
     strict: bool = True
+    save_lora_only: bool = False
 
 
 @dataclass

--- a/verl/utils/checkpoint/checkpoint_manager.py
+++ b/verl/utils/checkpoint/checkpoint_manager.py
@@ -98,6 +98,27 @@ class BaseCheckpointManager:
         return "hf_model" in self.checkpoint_save_contents
 
     @property
+    def should_save_lora_only(self) -> bool:
+        """
+        Returns True if save_lora_only is enabled in checkpoint config.
+        When True and the model has LoRA adapters, only LoRA adapter weights are saved.
+        """
+        if not self.checkpoint_config:
+            return False
+        return getattr(self.checkpoint_config, "save_lora_only", False)
+
+    @staticmethod
+    def is_lora_only_state_dict(state_dict: dict) -> bool:
+        """
+        Detect whether a saved state dict contains only LoRA adapter parameters.
+        Returns True when every key contains ``lora_`` or ``.adapter_``.
+        This is used on load to distinguish LoRA-only checkpoints from full checkpoints.
+        """
+        if not state_dict:
+            return False
+        return all("lora_" in k or ".adapter_" in k for k in state_dict)
+
+    @property
     def should_load_model(self) -> bool:
         """
         Returns True if 'model' is in checkpoint_load_contents, indicating the model state should be loaded.

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -181,9 +181,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 local_model_path = copy_to_local(remote_model_path)
                 model_state_dict = torch.load(local_model_path, weights_only=False)
                 if self.is_lora_only_state_dict(model_state_dict):
-                    current_sd = self.model.state_dict()
-                    current_sd.update(model_state_dict)
-                    self.model.load_state_dict(current_sd)
+                    self.model.load_state_dict(model_state_dict, strict=False)
                     log_with_rank(
                         f"Loaded LoRA-only checkpoint ({len(model_state_dict)} keys) from {remote_model_path}",
                         rank=self.rank,

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -135,6 +135,11 @@ class FSDPCheckpointManager(BaseCheckpointManager):
         )
         return lora_meta_path
 
+    def _has_lora(self) -> bool:
+        """Check whether the model has LoRA adapters attached."""
+        unwrap = getattr(self.model, "_fsdp_wrapped_module", self.model)
+        return hasattr(unwrap, "peft_config")
+
     def load_checkpoint(self, local_path: str, hdfs_path: str = None, del_local_after_load=False):
         """
         Load an FSDP checkpoint for this rank.
@@ -175,8 +180,18 @@ class FSDPCheckpointManager(BaseCheckpointManager):
                 remote_model_path = os.path.join(local_path, f"model_world_size_{self.world_size}_rank_{self.rank}.pt")
                 local_model_path = copy_to_local(remote_model_path)
                 model_state_dict = torch.load(local_model_path, weights_only=False)
-                self.model.load_state_dict(model_state_dict)
-                log_with_rank(f"Loaded model from {remote_model_path}", rank=self.rank, logger=logger)
+                if self.is_lora_only_state_dict(model_state_dict):
+                    current_sd = self.model.state_dict()
+                    current_sd.update(model_state_dict)
+                    self.model.load_state_dict(current_sd)
+                    log_with_rank(
+                        f"Loaded LoRA-only checkpoint ({len(model_state_dict)} keys) from {remote_model_path}",
+                        rank=self.rank,
+                        logger=logger,
+                    )
+                else:
+                    self.model.load_state_dict(model_state_dict)
+                    log_with_rank(f"Loaded model from {remote_model_path}", rank=self.rank, logger=logger)
 
             if self.should_load_optimizer:
                 remote_optim_path = os.path.join(local_path, f"optim_world_size_{self.world_size}_rank_{self.rank}.pt")
@@ -267,6 +282,22 @@ class FSDPCheckpointManager(BaseCheckpointManager):
 
                 if self.should_save_model:
                     model_state_dict = self.model.state_dict()
+                    if self.should_save_lora_only and self._has_lora():
+                        n_total = len(model_state_dict)
+                        model_state_dict = {
+                            k: v
+                            for k, v in model_state_dict.items()
+                            if "lora_" in k or ".adapter_" in k
+                        }
+                        lora_mib = (
+                            sum(v.numel() * v.element_size() for v in model_state_dict.values()) / 1024**2
+                        )
+                        log_with_rank(
+                            f"LoRA-only save: {len(model_state_dict)}/{n_total} params ({lora_mib:.1f} MiB)",
+                            rank=self.rank,
+                            logger=logger,
+                            log_only_rank_0=True,
+                        )
                     torch.save(model_state_dict, model_path)
                     log_with_rank(f"Saved model to {os.path.abspath(model_path)}", rank=self.rank, logger=logger)
 


### PR DESCRIPTION
When `save_lora_only=True` and the model has LoRA adapters, only LoRA adapter weights are saved instead of the full model state dict. Reduces checkpoint size from ~54 GiB to ~150 MiB for a 27B model.

### Duplicate check
No duplicate found. PR #6409 only saves metadata JSON (`lora_train_meta.json`), not weight filtering. PR #5575 is Megatron-only HF PEFT format export.

### Changes
- `CheckpointConfig`: add `save_lora_only` bool field (default False)
- `BaseCheckpointManager`: add `should_save_lora_only` property + `is_lora_only_state_dict()` static method
- `FSDPCheckpointManager`: filter state_dict on save; auto-merge LoRA-only checkpoints on load (backward compatible)
- Tests: 13 unit tests covering save/load/merge/edge cases

### AI assistance
AI assistance was used while preparing this PR. All changed lines were reviewed by the human submitter.