### PR TITLE
[trainer] fix: ref_policy_wg KeyError when LoRA is enabled

### DIFF
--- a/verl/trainer/main_ppo_sync.py
+++ b/verl/trainer/main_ppo_sync.py
@@ -682,7 +682,10 @@ class PPOTrainer:
             lora_rank = self.config.actor_rollout_ref.model.get("lora_rank", 0)
         self.ref_in_actor = lora_rank > 0 or self.config.actor_rollout_ref.model.get("lora_adapter_path") is not None
         if self.use_reference_policy:
-            self.ref_policy_wg = all_wg[str(Role.ActorRolloutRef)]
+            if self.ref_in_actor:
+                self.ref_policy_wg = self.actor_rollout_wg
+            else:
+                self.ref_policy_wg = all_wg[str(Role.ActorRolloutRef)]
 
         # 7. initialize reward loop manager
         resource_pool = (


### PR DESCRIPTION
## Summary

When LoRA is enabled (`lora_rank > 0` or `lora_adapter_path` is set), `add_actor_rollout_worker` registers the worker under `Role.ActorRollout`, not `Role.ActorRolloutRef`. However, `init_model` unconditionally looked up `all_wg[str(Role.ActorRolloutRef)]`, causing a `KeyError` at startup.

This mirrors the correct logic already present in the legacy trainer (`verl/trainer/ppo/ray_trainer.py:897-898`).

## Root Cause

PR #5401 introduced `main_ppo_sync.py` as a rewrite. The `add_actor_rollout_worker` and `_compute_ref_log_prob` LoRA branches were correctly ported, but the `ref_policy_wg` assignment in `init_model` was simplified and dropped the `ref_in_actor` check.

## Verification

- Syntax check: `python3 -c "import ast; ast.parse(...)"` passes.
- Logic matches the confirmed-working legacy trainer at `verl/trainer/ppo/ray_trainer.py:897-898`.

This PR was created with AI assistance. The submitting human has reviewed every changed line and verified the logic against the legacy trainer implementation.