### PR TITLE
[vllm, hardware] fix: disable MM processor cache for Qwen3.5 Ascend training

### DIFF
--- a/examples/ascend_extras/grpo_trainer/run_qwen3_5_122b_a10b_32k_megatron.sh
+++ b/examples/ascend_extras/grpo_trainer/run_qwen3_5_122b_a10b_32k_megatron.sh
@@ -138,6 +138,7 @@ ROLLOUT=(
     +actor_rollout_ref.rollout.engine_kwargs.vllm.compilation_config.cudagraph_capture_sizes="[4,12,24,48,64]"
     ++actor_rollout_ref.rollout.engine_kwargs.vllm.additional_config.enable_cpu_binding=True
     ++actor_rollout_ref.rollout.engine_kwargs.vllm.async_scheduling=True
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.mm_processor_cache_gb=0
 )
 
 TRAINER=(


### PR DESCRIPTION
### What does this PR do?

This PR disables the vLLM multimodal processor cache in the Qwen3.5-122B-A10B Ascend Megatron GRPO example by setting:

```bash
+actor_rollout_ref.rollout.engine_kwargs.vllm.mm_processor_cache_gb=0
```

During vLLM sleep/wake cycles, the P1 multimodal receiver cache could be cleared while the P0 sender cache remained populated. When a previously seen `mm_hash` was reused, P0 treated it as a cache hit and omitted the multimodal payload, while P1 no longer had the corresponding entry. This caused a cache desynchronization and could trigger an assertion failure in `MultiModalReceiverCache`.

The root cause and upstream fix are documented in [vllm-project/vllm#43001](https://github.com/vllm-project/vllm/pull/43001).

Disabling the processor cache avoids retaining stale sender-cache entries and provides a configuration-level workaround for the Ascend training example.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
