### PR TITLE
[ckpt, model] fix: prevent key corruption during HuggingFace export

### DIFF
--- a/verl/model_merger/base_model_merger.py
+++ b/verl/model_merger/base_model_merger.py
@@ -24,7 +24,7 @@ from accelerate import init_empty_weights
 from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForTokenClassification, GenerationConfig
 
 from verl.utils import hf_processor, hf_tokenizer
-from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
+from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq, get_hf_save_kwargs
 
 AutoModelForVision2Seq = get_auto_model_for_vision2seq()
 
@@ -403,7 +403,7 @@ class BaseModelMerger(ABC):
         drop_tied_target_keys(state_dict, model, self.model_config)
 
         print(f"Saving model to {self.config.target_dir}")
-        model.save_pretrained(self.config.target_dir, state_dict=state_dict)
+        model.save_pretrained(self.config.target_dir, **get_hf_save_kwargs(model, state_dict))
         del state_dict
         del model
 

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -32,7 +32,7 @@ from verl.utils.device import is_cuda_available
 from verl.utils.fs import copy_to_local, is_non_local, local_mkdir_safe
 from verl.utils.fsdp_utils import fsdp_version, get_fsdp_full_state_dict, get_fsdp_state_ctx
 from verl.utils.logger import log_with_rank
-from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq
+from verl.utils.transformers_compat import drop_tied_target_keys, get_auto_model_for_vision2seq, get_hf_save_kwargs
 
 from .checkpoint_manager import BaseCheckpointManager
 
@@ -378,7 +378,7 @@ class FSDPCheckpointManager(BaseCheckpointManager):
 
                 drop_tied_target_keys(state_dict, save_model, model_config)
 
-                save_model.save_pretrained(hf_local_path, state_dict=state_dict)
+                save_model.save_pretrained(hf_local_path, **get_hf_save_kwargs(save_model, state_dict))
                 log_with_rank(
                     f"Saved hf_model to {os.path.abspath(hf_local_path)}",
                     rank=self.rank,

--- a/verl/utils/transformers_compat.py
+++ b/verl/utils/transformers_compat.py
@@ -17,8 +17,9 @@ Compatibility utilities for different versions of transformers library.
 """
 
 import importlib.metadata
+import inspect
 from functools import lru_cache
-from typing import Optional
+from typing import Any, Optional
 
 from packaging import version
 
@@ -72,6 +73,14 @@ def get_auto_model_for_vision2seq():
         return AutoModelForVision2Seq
 
     return AutoModelForImageTextToText
+
+
+def get_hf_save_kwargs(model: Any, state_dict: dict[str, Any]) -> dict[str, Any]:
+    """Build version-compatible kwargs for saving an externally supplied HF state dict."""
+    kwargs: dict[str, Any] = {"state_dict": state_dict}
+    if "save_original_format" in inspect.signature(model.save_pretrained).parameters:
+        kwargs["save_original_format"] = False
+    return kwargs
 
 
 def unpack_visual_output(visual_output):


### PR DESCRIPTION
### What does this PR do?

Prevents HuggingFace checkpoint key corruption when verl saves an externally supplied full state dict.

For example, Transformers v5.2.0 defines `save_original_format=True` by default in `PreTrainedModel.save_pretrained` ([source](https://github.com/huggingface/transformers/blob/7d9754a05193eb79b1d86aa744b622b8068008cd/src/transformers/modeling_utils.py#L3125-L3136)). When enabled, Transformers applies `revert_weight_conversion` to the state dict before saving ([source](https://github.com/huggingface/transformers/blob/7d9754a05193eb79b1d86aa744b622b8068008cd/src/transformers/modeling_utils.py#L3309-L3312)).

verl already assembles the exported state dict using the current model key format. Applying this reverse conversion again can incorrectly rename keys for composite VLMs such as Qwen3.5, producing keys such as:

```text
model.language_model.language_model.language_model.*
model.language_model.visual.*
```

The checkpoint is written successfully, but downstream loaders may report missing or uninitialized weights.

This PR adds a small compatibility helper that passes `save_original_format=False` only when the installed Transformers version supports the argument. It is used by both the offline model merger and the FSDP HuggingFace checkpoint exporter. Older Transformers versions remain unchanged.

This is independent of #5326 and #6409, which preserve PEFT/LoRA training metadata during adapter export. It is also separate from #5599, which addresses Megatron Qwen3.5 LoRA and MTP weight synchronization rather than HuggingFace `save_pretrained` serialization.

### Checklist Before Starting

- [x] Search for similar PRs:
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+save_original_format
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+HuggingFace+state_dict+export
  - https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+Qwen3.5+checkpoint+key+corruption
- [x] Format the PR title as `[ckpt, model] fix: prevent key corruption during HuggingFace export`.

### API and Usage Example

No public API, CLI, or checkpoint format changes are introduced. Existing usage remains unchanged:

```bash
python -m verl.model_merger merge \
  --backend fsdp \
  --local_dir /path/to/global_step_x/actor \
  --target_dir /path/to/hf_export
```

### Design & Code Changes

- Add a version-compatible helper in `transformers_compat.py`.
- Inspect the `save_pretrained` signature and pass `save_original_format=False` only when supported.
- Use the helper in the offline model merger and FSDP HuggingFace exporter.
- Keep the existing state-dict assembly, LoRA metadata, and checkpoint logic unchanged.
- Use Python's standard-library `inspect` module, with no new dependency.

Validation: `PATH="$PWD/.venv/bin:$PATH" .venv/bin/pre-commit run --all-files --show-diff-on-failure --color=never` and `git diff --check` both passed.

AI assistance was used for implementation and PR preparation. The human submitter will review every changed line and remains responsible for the final change before requesting maintainer review.