### PR TITLE
[trainer] feat: early stopping via early_stop_patience config

### DIFF
--- a/docs/examples/config.rst
+++ b/docs/examples/config.rst
@@ -629,6 +629,10 @@ Trainer
   checkpoints after loading them. Default is False.
 - ``trainer.ray_wait_register_center_timeout``: The timeout for waiting
   for the ray register center to be ready. Default is 300 seconds.
+- ``trainer.early_stop_patience``: Number of consecutive steps without
+  ``critic/rewards/mean`` improvement before training terminates early.
+  Default is ``0`` (disabled). When set > 0, training stops after patience
+  is exhausted, triggering normal checkpoint saving and cleanup.
 
 
 This figure illustrates how the configurations affect the training.

--- a/verl/models/mcore/util.py
+++ b/verl/models/mcore/util.py
@@ -563,7 +563,7 @@ def postprocess_thd_engine(
 def _build_npu_attn_mask(original_attention_mask: torch.Tensor) -> torch.Tensor:
     """Build attn_mask for torch_npu.npu_fusion_attention (B1SS / [B, 1, Sq, Skv])"""
     _, seq_len = original_attention_mask.shape
-    causal_mask = torch.tril(torch.ones(seq_len, seq_len, device=original_attention_mask.device)).to(torch.bool)
+    causal_mask = torch.tril(torch.ones(seq_len, seq_len, device=original_attention_mask.device, dtype=torch.bool))
     attn_mask = original_attention_mask.unsqueeze(-1) & original_attention_mask.unsqueeze(-2)
     attn_mask = attn_mask & causal_mask
     return (~attn_mask).unsqueeze(1).contiguous()

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -1753,6 +1753,28 @@ class RayPPOTrainer:
                 # TODO: make a canonical logger that supports various backend
                 logger.log(data=metrics, step=self.global_steps)
 
+                # early stopping
+                early_stop_patience = self.config.trainer.get("early_stop_patience", 0)
+                if early_stop_patience > 0:
+                    reward = metrics.get("critic/rewards/mean", None)
+                    if reward is not None:
+                        if not hasattr(self, "_best_reward"):
+                            self._best_reward = reward
+                            self._patience_counter = 0
+                        if reward > self._best_reward:
+                            self._best_reward = reward
+                            self._patience_counter = 0
+                        else:
+                            self._patience_counter += 1
+                        if self._patience_counter >= early_stop_patience:
+                            pprint(
+                                f"Early stopping triggered after {self.global_steps} steps "
+                                f"(best reward {self._best_reward:.4f}, "
+                                f"no improvement for {early_stop_patience} steps)"
+                            )
+                            self.total_training_steps = self.global_steps
+                            is_last_step = True
+
                 progress_bar.update(1)
                 self.global_steps += 1
                 SkipManager.set_step(self.global_steps)


### PR DESCRIPTION
### What does this PR do?

Add optional `early_stop_patience` config field for `RayPPOTrainer`. When set > 0 and `critic/rewards/mean` does not improve for that many consecutive steps, the training loop terminates early. This helps avoid wasting compute when the model has converged.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: `gh pr list --search "early stop early_stop"` — no duplicates found.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

Set `early_stop_patience=3` in the trainer config and verify that training stops after 3 steps without reward improvement. The feature is disabled by default (`early_stop_patience=0`) and has no side effects when not configured.

### API and Usage Example

```yaml
trainer:
  early_stop_patience: 5  # stop training if reward doesn't improve for 5 consecutive steps
```

### Design & Code Changes

- `verl/trainer/ppo/ray_trainer.py`: Insert ~20 lines of early stopping logic before `progress_bar.update(1)` in the training loop.
  - Reads `self.config.trainer.get("early_stop_patience", 0)` — no config schema change needed.
  - Tracks best reward via `self._best_reward` and a patience counter.
  - On patience exhaustion, sets `is_last_step = True` and `self.total_training_steps = self.global_steps` to trigger normal loop termination, checkpoint saving, and cleanup.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: End-to-end test requires multi-GPU training setup not available in CI. The change is small (~20 lines) and guarded by an explicit config flag (default off).
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.