### PR TITLE
[rollout, vllm] fix: strip .base_layer suffix from param names in vLLM weight update

### DIFF
--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -242,3 +242,28 @@ def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
     expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
     torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)
+
+
+def test_vllm_update_weights_strips_base_layer_suffix():
+    """Test that .base_layer suffix is stripped from param names in non-PEFT path."""
+    model = _ToyModel()
+    loaded_param_names = []
+
+    def _fake_load_weights(weights):
+        loaded_param_names.extend(name for name, _ in weights)
+
+    model.load_weights = _fake_load_weights
+
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(model)
+
+    weights = [
+        ("model.layers.0.linear.base_layer.weight", torch.ones(4, 4, dtype=torch.float32)),
+        ("model.layers.0.e_score_correction_bias", torch.arange(4, dtype=torch.float32) + 1),
+    ]
+
+    worker._update_weights(weights, peft_config=None, base_sync_done=False)
+
+    assert loaded_param_names == ["model.layers.0.linear.weight"], (
+        f"Expected stripped name without .base_layer, got {loaded_param_names}"
+    )

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -361,6 +361,13 @@ class vLLMColocateWorkerExtension:
             logger.info(f"vLLM load weights, loaded_params: {len(weights)}")
         else:
             param_updates, buffer_updates, named_buffers = split_buffer_updates(self.model_runner.model, weights)
+            # Strip .base_layer suffix added by replace_lora_wrapper on the trainer
+            # side. vLLM's model.load_weights() expects standard parameter names
+            # (e.g. blocks.0.attn.qkv.weight), not PeftModel-style names
+            # (e.g. blocks.0.attn.qkv.base_layer.weight). The base-layer
+            # naming is only meaningful for the LoRA adapter path above.
+            if param_updates:
+                param_updates = [(n.replace(".base_layer", ""), t) for n, t in param_updates]
             # Add the FP8 related logic here as sharding manager has been deprecated.
             # Check if FP8 quantization is enabled and apply appropriate weight loading
             if is_fp8_model(self.model_runner.vllm_config):


### PR DESCRIPTION
### What does this PR do?

When the trainer uses PEFT's `replace_lora_wrapper`, base model parameter names get a `.base_layer` suffix (e.g. `blocks.0.attn.qkv.base_layer.weight`). In the non-PEFT (base_sync) weight path, vLLM's `model.load_weights()` expects standard HuggingFace parameter names without this suffix, causing param name mismatches and silent loading failures. This PR strips the `.base_layer` suffix from weight names before passing them to vLLM.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: `gh pr list --repo verl-project/verl --state open --search "base_layer"` — no duplicates found.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `rollout`, `vllm`
  - `{type}` is `fix`

### Test

============================= test session starts ==============================
platform linux -- Python 3.11.11, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3.11
cachedir: .pytest_cache
rootdir: /home/zhouweipeng/verl-upstream
configfile: pyproject.toml
plugins: hydra-core-1.3.4
collecting ... collected 0 items / 1 error

==================================== ERRORS ====================================
_ ERROR collecting tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py _
ImportError while importing test module '/home/zhouweipeng/verl-upstream/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py:20: in <module>
    import torch
E   ModuleNotFoundError: No module named 'torch'
=========================== short test summary info ============================
ERROR tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
=============================== 1 error in 0.02s ===============================
Unit test verifies that `.base_layer` suffix is stripped from param names before calling `model.load_weights()`.

### API and Usage Example

No API changes.

### Design & Code Changes

- `verl/workers/rollout/vllm_rollout/utils.py` (`_update_weights`): Strip `.base_layer` suffix from `param_updates` before the FP8/standard weight loading path.
- `tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py`: Add test for `.base_layer` suffix stripping.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: Unit test added in `tests/workers/rollout/`.
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
