### PR TITLE
[rollout, trainer] feat: add lightweight GPU stall diagnostics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,6 +110,7 @@ verl is fast with:
    perf/verl_profiler_system.md
    perf/nsight_profiling.md
    perf/torch_profiling.md
+   perf/gpu_stall_diagnostics.md
 
 .. toctree::
    :maxdepth: 1

--- a/docs/perf/gpu_stall_diagnostics.md
+++ b/docs/perf/gpu_stall_diagnostics.md
@@ -1,0 +1,103 @@
+# GPU stall diagnostics
+
+This optional diagnostic is for investigating long periods of low GPU utilization
+during PPO rollout. It is disabled by default and is deliberately independent
+of `global_profiler.tool`, Nsight, PyTorch profiler, and RL Insight.
+
+It does not change `enforce_eager`, CUDA Graph settings, fused-kernel settings,
+SGLang server arguments, cache-release settings, or scheduling behavior. It is
+an observability aid, not a claimed root-cause fix for [#3114](https://github.com/verl-project/verl/issues/3114).
+
+## Enable it for a controlled run
+
+    global_profiler:
+      gpu_stall_diagnostics:
+        enable: true
+        sample_interval_s: 0.25
+        zero_utilization_threshold: 1.0
+
+The sample interval is validated in the range 0.2--0.5 seconds. No CUDA
+context, Ray actor, sampler thread, NVML import, or diagnostics RPC occurs
+while `enable: false`. Controllers execute only local disabled-state guards at
+coarse phase boundaries; no rollout worker or per-token path is instrumented.
+
+The built-in V1 `sync`, `colocate_async`, and `separate_async` trainers, as
+well as the legacy `trainer.use_v1: false` controller, consume this setting.
+The single controller creates one zero-GPU Ray actor pinned to each live Ray
+node that advertises GPU resources. The actor imports `pynvml` lazily and
+samples physical NVML devices from a daemon thread. Devices are identified by
+PCI bus ID rather than by `CUDA_VISIBLE_DEVICES` ordinal, so the output remains
+meaningful across multi-node jobs and differing local device masks.
+
+The sampler is node-wide: it reports all physical GPUs visible to its node
+actor. It does not infer Ray's per-process fractional allocation or attribute
+a device to an individual co-tenant. Treat results from shared nodes as
+node-level evidence, and correlate them with your resource-pool topology.
+
+If NVML, its Python binding, or a node actor is unavailable, diagnostics logs a
+warning and normal training continues. A transient per-device NVML sampling
+failure is retried. After three consecutive failures, that physical device is
+quarantined for the sampler lifetime and the actor logs the PCI bus ID and
+failure reason. The feature never installs dependencies or falls back to
+shelling out to a GPU utility.
+
+The real-GPU qualification covered the sampler coordinator on one local Ray
+node and GPU 0 with real NVML. V1 lifecycle wiring and hardening are covered
+only by CPU tests. Multi-node node filtering, strict actor placement,
+aggregation, RPC failure, and cleanup semantics are covered by CPU-only fake
+Ray tests. No real multi-node GPU run or real V1 training run has been validated.
+
+## Metrics
+
+Metrics are emitted through the normal trainer tracking dictionary. The
+logical node index is stable for one run because live Ray nodes are sorted by
+NodeID before actors are created.
+
+Typical keys are:
+
+- `gpu_stall/training_step/node_0/utilization_mean`
+- `gpu_stall/rollout_generate/node_1/gpu_0000_86_00_0/zero_utilization_fraction`
+- `gpu_stall/rollout_wait/node_0/utilization_min`
+- `gpu_stall/rollout_release_or_switch/node_0/sample_count`
+- `gpu_stall/actor_update/node_0/sample_count`
+- `gpu_stall/weight_sync_and_wake_or_resume/node_0/utilization_max`
+- `gpu_stall/standalone_rollout_weight_sync/node_0/utilization_mean`
+
+For every phase/node pair the diagnostic can emit `device_count`,
+`sample_count`, `utilization_mean`, `utilization_min`, `utilization_max`, and
+`zero_utilization_fraction`; per-device `sample_count`, mean, and zero-fraction
+keys use the NVML PCI bus identifier. Empty windows are valid and emit a zero
+sample count without a division-by-zero failure.
+
+The legacy trainer records a full `training_step` window and nested,
+non-contaminating windows for `rollout_generate`,
+`rollout_sleep_or_release`, `actor_update`, and
+`weight_sync_and_wake_or_resume`. In the current checkpoint-manager API,
+weight synchronization and rollout wake/resume occur in one `update_weights()`
+call, so the last label is intentionally combined rather than falsely
+attributing samples to a separate wake stage.
+
+V1 agent-loop generation is asynchronous: dispatch and server generation can
+overlap controller work. V1 therefore records `rollout_wait` while the
+controller waits for a generated trajectory from the replay buffer, and
+`rollout_release_or_switch` while its mode releases replicas or switches the
+hybrid engine. It records `actor_update` in the real actor update call. V1
+`sync` and `colocate_async` use `weight_sync_and_wake_or_resume`; V1
+`separate_async` instead uses `standalone_rollout_weight_sync`, because its
+step-end operation synchronizes the always-running standalone rollout. V1 does
+not currently emit a separate validation phase. These are diagnostic boundaries,
+not conclusions about whether SGLang's cache lifecycle is responsible.
+
+## Reading a result
+
+A low legacy `rollout_generate` or V1 `rollout_wait` utilization window points
+to a need for more request lifecycle evidence: queueing, Ray scheduling,
+SGLang request admission, or server-side generation can all be inside that
+caller-visible period. Low
+utilization concentrated in `weight_sync_and_wake_or_resume` is a useful
+signal to compare with SGLang release/resume and CUDA-Graph behavior, but does
+not prove a verl-side defect.
+
+Use this alongside existing profiler traces and RL Insight. The sampler adds
+aggregate NVML evidence; it does not replace a timeline, request trace, or a
+reproduction on current verl and SGLang versions.

--- a/tests/trainer/ppo/v1/test_gpu_stall_diagnostics_integration_on_cpu.py
+++ b/tests/trainer/ppo/v1/test_gpu_stall_diagnostics_integration_on_cpu.py
@@ -1,0 +1,509 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only production-path tests for V1 GPU stall diagnostics lifecycle wiring."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+
+class _FakeKVBatchMeta:
+    def __init__(self, partition_id, keys, tags):
+        self.partition_id = partition_id
+        self.keys = keys
+        self.tags = tags
+
+
+if "transfer_queue" not in sys.modules:
+    # The unit-test environment may omit this optional runtime dependency. The
+    # V1 modules only need this name at import time; every exercised operation
+    # is replaced by a local fake below.
+    _transfer_queue = ModuleType("transfer_queue")
+    _transfer_queue.KVBatchMeta = _FakeKVBatchMeta
+    _transfer_queue.__version__ = "0.0.0"
+    sys.modules["transfer_queue"] = _transfer_queue
+
+from verl.trainer.ppo import ray_trainer  # noqa: E402
+from verl.trainer.ppo.v1 import trainer_base  # noqa: E402
+from verl.trainer.ppo.v1.trainer_base import PPOTrainer, get_trainer_cls  # noqa: E402
+from verl.trainer.ppo.v1.trainer_colocate_async import PPOTrainerColocateAsync  # noqa: E402
+from verl.trainer.ppo.v1.trainer_separate_async import HybridEngineMode, PPOTrainerSeparateAsync  # noqa: E402
+from verl.trainer.ppo.v1.trainer_sync import PPOTrainerSync  # noqa: E402
+from verl.trainer.ppo.v1.utils import MetricsAggregator  # noqa: E402
+
+
+class _FakeDiagnostics:
+    def __init__(self, events, *, begin_errors=(), end_errors=(), close_error=False, include_collision=False):
+        self.events = events
+        self.begin_errors = set(begin_errors)
+        self.end_errors = set(end_errors)
+        self.close_error = close_error
+        self.include_collision = include_collision
+
+    def begin_phase(self, phase):
+        self.events.append(f"begin:{phase}")
+        if phase in self.begin_errors:
+            raise RuntimeError(f"begin {phase}")
+
+    def end_phase(self, phase):
+        self.events.append(f"end:{phase}")
+        if phase in self.end_errors:
+            raise RuntimeError(f"end {phase}")
+        updates = {
+            f"gpu_stall/{phase}/node_0/sample_count": 2.0,
+            f"gpu_stall/{phase}/node_0/utilization_mean": 50.0,
+        }
+        if self.include_collision:
+            updates["existing"] = 999.0
+        return updates
+
+    def close(self):
+        self.events.append("close")
+        if self.close_error:
+            raise RuntimeError("close")
+
+
+class _FakeTracking:
+    def __init__(self):
+        self.logs = []
+
+    def log(self, data, step):
+        self.logs.append((dict(data), step))
+
+
+class _FakeCheckpointManager:
+    def __init__(self, events, name):
+        self.events = events
+        self.name = name
+
+    def update_weights(self, *args):
+        self.events.append(f"{self.name}:update_weights")
+
+    def resume_generation_replicas(self):
+        self.events.append(f"{self.name}:resume_generation")
+
+    def abort_replicas(self):
+        self.events.append(f"{self.name}:abort")
+
+    def sleep_replicas(self):
+        self.events.append(f"{self.name}:sleep")
+
+
+class _FakeProgress:
+    def update(self, _count):
+        return None
+
+    def close(self):
+        return None
+
+
+class _Batch:
+    def __init__(self):
+        self.extra_info = {}
+        self.keys = []
+        self.partition_id = "train"
+        self.tags = []
+
+
+def _config(*, mode="sync", enable=True, val_before_train=False, val_only=False):
+    return OmegaConf.create(
+        {
+            "trainer": {
+                "project_name": "test",
+                "experiment_name": "v1-gpu-stall",
+                "logger": [],
+                "val_before_train": val_before_train,
+                "val_only": val_only,
+                "total_epochs": 1,
+                "save_freq": -1,
+                "test_freq": -1,
+                "rollout_data_dir": None,
+                "critic_warmup": 0,
+                "v1": {
+                    "trainer_mode": mode,
+                    "colocate_async": {"num_warmup_batches": 0},
+                    "separate_async": {"num_warmup_batches": 0},
+                },
+            },
+            "global_profiler": {
+                "steps": None,
+                "gpu_stall_diagnostics": {
+                    "enable": enable,
+                    "sample_interval_s": 0.25,
+                    "zero_utilization_threshold": 1.0,
+                },
+            },
+            "skip": {"rollout_tq": {"enable": True}},
+            "actor_rollout_ref": {"rollout": {"temperature": 1.0}},
+        }
+    )
+
+
+def _make_fit_trainer(
+    monkeypatch, trainer_cls, *, enable=True, val_before_train=False, val_only=False, step_error=None
+):
+    events = []
+    diagnostics_events = []
+    diagnostics = _FakeDiagnostics(diagnostics_events, include_collision=True)
+    tracking = _FakeTracking()
+    starts = []
+    trainer = object.__new__(trainer_cls)
+    trainer.config = _config(
+        mode={
+            PPOTrainerSync: "sync",
+            PPOTrainerColocateAsync: "colocate_async",
+            PPOTrainerSeparateAsync: "separate_async",
+        }[trainer_cls],
+        enable=enable,
+        val_before_train=val_before_train,
+        val_only=val_only,
+    )
+    trainer.global_steps = 0
+    trainer.steps_per_epoch = 1
+    trainer.total_training_steps = 2
+    trainer.checkpoint_manager = _FakeCheckpointManager(events, "checkpoint")
+    if trainer_cls is PPOTrainerSeparateAsync:
+        trainer.standalone_checkpoint_manager = _FakeCheckpointManager(events, "standalone")
+
+    def step(metrics, _timing_raw):
+        events.append("step")
+        metrics["existing"] = 1.0
+        if step_error is not None:
+            raise step_error
+        return _Batch()
+
+    trainer.step = step
+    trainer._reissue_inflight_prompts = lambda: 0
+    trainer._start_profiling = lambda: events.append("profile:start")
+    trainer._stop_profiling = lambda: events.append("profile:stop")
+    trainer._compute_metrics = lambda _batch, metrics, *_args, **_kwargs: metrics.setdefault("computed", 1.0)
+    trainer._shutdown_dump_executor = lambda: events.append("shutdown")
+    trainer._save_checkpoint = lambda: events.append("checkpoint:save")
+    trainer._log_rollout_data = lambda *_args: events.append("rollout:log")
+    trainer._validate = lambda: {"validation/reward": 1.0}
+
+    monkeypatch.setattr(trainer_base, "Tracking", lambda **_kwargs: tracking)
+    monkeypatch.setattr(trainer_base, "ValidationGenerationsLogger", lambda **_kwargs: object())
+    monkeypatch.setattr(trainer_base, "tqdm", lambda **_kwargs: _FakeProgress())
+    monkeypatch.setattr(trainer_base, "pprint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(trainer_base.SkipManager, "init", staticmethod(lambda _config: None))
+    monkeypatch.setattr(trainer_base.SkipManager, "set_step", staticmethod(lambda _step: None))
+    monkeypatch.setattr(trainer_base.tq, "kv_clear", lambda **_kwargs: None, raising=False)
+
+    def start(config):
+        starts.append(config)
+        return diagnostics
+
+    monkeypatch.setattr(trainer_base, "start_gpu_stall_diagnostics", start)
+    return trainer, diagnostics, starts, tracking, events, diagnostics_events
+
+
+def test_main_ppo_selects_v1_or_legacy_task_runner_without_starting_ray(monkeypatch):
+    from verl.trainer import main_ppo
+    from verl.trainer.main_ppo_v0 import TaskRunner as LegacyTaskRunner
+
+    selected = []
+    monkeypatch.setattr(main_ppo, "auto_set_device", lambda _config: None)
+    monkeypatch.setattr(main_ppo, "validate_config", lambda **_kwargs: None)
+    monkeypatch.setattr(main_ppo, "need_reference_policy", lambda _config: False)
+    monkeypatch.setattr(main_ppo, "need_critic", lambda _config: False)
+    monkeypatch.setattr(
+        main_ppo, "run_ppo", lambda config, task_runner_class: selected.append((config, task_runner_class))
+    )
+
+    main_ppo.main.__wrapped__(OmegaConf.create({"trainer": {"use_v1": True}}))
+    main_ppo.main.__wrapped__(OmegaConf.create({"trainer": {"use_v1": False}}))
+
+    assert selected[0][1] is main_ppo.TaskRunnerV1
+    assert selected[1][1] is LegacyTaskRunner
+    assert get_trainer_cls("sync") is PPOTrainerSync
+    assert get_trainer_cls("colocate_async") is PPOTrainerColocateAsync
+    assert get_trainer_cls("separate_async") is PPOTrainerSeparateAsync
+
+
+def test_legacy_val_only_path_still_starts_and_closes_diagnostics(monkeypatch):
+    events = []
+    diagnostics_events = []
+    diagnostics = _FakeDiagnostics(diagnostics_events)
+    starts = []
+    tracking = _FakeTracking()
+    trainer = object.__new__(ray_trainer.RayPPOTrainer)
+    trainer.config = OmegaConf.create(
+        {
+            "trainer": {
+                "project_name": "test",
+                "experiment_name": "legacy-gpu-stall",
+                "logger": [],
+                "val_before_train": True,
+                "val_only": True,
+            },
+            "global_profiler": {"gpu_stall_diagnostics": {"enable": True}},
+        }
+    )
+    trainer._dump_executor = SimpleNamespace(_shutdown=False)
+    trainer._load_checkpoint = lambda: events.append("load_checkpoint")
+    trainer.checkpoint_manager = _FakeCheckpointManager(events, "checkpoint")
+    trainer.train_dataloader = [object()]
+    trainer._validate = lambda: {"validation/reward": 1.0}
+    trainer._shutdown_dump_executor = lambda: events.append("shutdown")
+
+    def start(config):
+        starts.append(config)
+        return diagnostics
+
+    monkeypatch.setattr(ray_trainer, "start_gpu_stall_diagnostics", start)
+    monkeypatch.setattr(ray_trainer, "pprint", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ray_trainer.SkipManager, "init", staticmethod(lambda _config: None))
+    monkeypatch.setattr("verl.utils.tracking.Tracking", lambda **_kwargs: tracking)
+
+    trainer.fit()
+
+    assert starts == [trainer.config.global_profiler.gpu_stall_diagnostics]
+    assert diagnostics_events == ["close"]
+    assert events == ["load_checkpoint", "checkpoint:update_weights", "shutdown"]
+    assert tracking.logs == [({"validation/reward": 1.0}, 0)]
+
+
+@pytest.mark.parametrize(
+    ("trainer_cls", "step_end_phase", "expected_checkpoint_event"),
+    [
+        (PPOTrainerSync, "weight_sync_and_wake_or_resume", "checkpoint:update_weights"),
+        (PPOTrainerColocateAsync, "weight_sync_and_wake_or_resume", "checkpoint:resume_generation"),
+        (PPOTrainerSeparateAsync, "standalone_rollout_weight_sync", "standalone:update_weights"),
+    ],
+)
+def test_v1_enabled_creates_one_coordinator_merges_metrics_and_closes(
+    monkeypatch, trainer_cls, step_end_phase, expected_checkpoint_event
+):
+    trainer, diagnostics, starts, tracking, events, diagnostic_events = _make_fit_trainer(monkeypatch, trainer_cls)
+
+    trainer.fit(object())
+
+    assert starts == [trainer.config.global_profiler.gpu_stall_diagnostics]
+    assert diagnostic_events == [
+        "begin:training_step",
+        f"begin:{step_end_phase}",
+        f"end:{step_end_phase}",
+        "end:training_step",
+        "close",
+    ]
+    assert expected_checkpoint_event in events
+    logged_metrics, logged_step = tracking.logs[-1]
+    assert logged_step == 1
+    assert logged_metrics["existing"] == 1.0
+    assert logged_metrics["gpu_stall/training_step/node_0/sample_count"] == 2.0
+    assert logged_metrics[f"gpu_stall/{step_end_phase}/node_0/utilization_mean"] == 50.0
+    assert trainer._gpu_stall_diagnostics is None
+    assert diagnostics.events is diagnostic_events
+
+
+def test_v1_default_off_does_not_start_diagnostics_or_change_step_order(monkeypatch):
+    trainer, _diagnostics, starts, _tracking, events, diagnostic_events = _make_fit_trainer(
+        monkeypatch, PPOTrainerSync, enable=False
+    )
+    monkeypatch.setattr(
+        trainer_base,
+        "gpu_stall_diagnostics_phase",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("default-off entered diagnostics phase helper")),
+    )
+
+    trainer.fit(object())
+
+    assert starts == []
+    assert diagnostic_events == []
+    assert events == ["profile:start", "step", "profile:stop", "checkpoint:update_weights", "shutdown"]
+
+
+def test_v1_default_off_does_not_enter_phase_helper_in_rollout_substep(monkeypatch):
+    events = []
+    trainer = object.__new__(PPOTrainerSync)
+    trainer.config = _config(mode="sync", enable=False)
+    trainer.global_steps = 1
+    trainer.use_reference_policy = False
+    trainer.use_critic = False
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=[])
+    trainer.replay_buffer = SimpleNamespace(sample=lambda **_kwargs: (_Batch(), {}))
+    trainer.checkpoint_manager = _FakeCheckpointManager(events, "checkpoint")
+    trainer._gpu_stall_diagnostics = None
+    trainer._balance_batch = lambda batch, **_kwargs: batch
+    trainer._compute_old_log_prob = lambda batch, **_kwargs: batch
+    trainer._compute_advantage = lambda batch, **_kwargs: batch
+    trainer._update_actor = lambda batch, **_kwargs: events.append("actor_update") or batch
+    monkeypatch.setattr(
+        trainer_base,
+        "gpu_stall_diagnostics_phase",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("default-off entered diagnostics phase helper")),
+    )
+
+    result = PPOTrainer._step_once(trainer, {}, {}, sample_batch_size=1)
+
+    assert isinstance(result, _Batch)
+    assert events == ["checkpoint:sleep", "actor_update"]
+
+
+def test_v1_val_only_and_exception_paths_close_diagnostics(monkeypatch):
+    val_trainer, _diagnostics, starts, tracking, _events, diagnostic_events = _make_fit_trainer(
+        monkeypatch, PPOTrainerSync, val_before_train=True, val_only=True
+    )
+
+    val_trainer.fit(object())
+
+    assert len(starts) == 1
+    assert diagnostic_events == ["close"]
+    assert tracking.logs == [({"validation/reward": 1.0}, 0)]
+
+    validation_error = RuntimeError("validation failed")
+    validation_trainer, _diagnostics, _starts, _tracking, _events, diagnostic_events = _make_fit_trainer(
+        monkeypatch, PPOTrainerSync, val_before_train=True
+    )
+    validation_trainer._validate = lambda: (_ for _ in ()).throw(validation_error)
+    with pytest.raises(RuntimeError, match="validation failed"):
+        validation_trainer.fit(object())
+
+    assert diagnostic_events == ["close"]
+
+    error = RuntimeError("training failed")
+    trainer, _diagnostics, _starts, _tracking, _events, diagnostic_events = _make_fit_trainer(
+        monkeypatch, PPOTrainerSync, step_error=error
+    )
+    with pytest.raises(RuntimeError, match="training failed"):
+        trainer.fit(object())
+
+    assert diagnostic_events == ["begin:training_step", "end:training_step", "close"]
+
+
+def test_v1_diagnostics_fail_open_for_start_phase_and_close_errors(monkeypatch):
+    trainer, _diagnostics, _starts, _tracking, events, _diagnostic_events = _make_fit_trainer(
+        monkeypatch, PPOTrainerSync
+    )
+    monkeypatch.setattr(
+        trainer_base, "start_gpu_stall_diagnostics", lambda _config: (_ for _ in ()).throw(RuntimeError("start"))
+    )
+
+    trainer.fit(object())
+
+    assert "step" in events
+
+    trainer, diagnostics, _starts, _tracking, events, diagnostic_events = _make_fit_trainer(monkeypatch, PPOTrainerSync)
+    diagnostics.begin_errors.add("training_step")
+    diagnostics.end_errors.add("weight_sync_and_wake_or_resume")
+    diagnostics.close_error = True
+
+    trainer.fit(object())
+
+    assert "step" in events
+    assert diagnostic_events[-1] == "close"
+
+
+@pytest.mark.parametrize(
+    ("trainer_cls", "expected_release_events"),
+    [
+        (PPOTrainerSync, ["checkpoint:sleep"]),
+        (PPOTrainerColocateAsync, ["checkpoint:abort", "checkpoint:sleep"]),
+        (PPOTrainerSeparateAsync, ["switch_to_trainer"]),
+    ],
+)
+def test_v1_real_step_once_emits_mode_accurate_phases(monkeypatch, trainer_cls, expected_release_events):
+    events = []
+    diagnostic_events = []
+    trainer = object.__new__(trainer_cls)
+    trainer.config = _config(
+        mode={
+            PPOTrainerSync: "sync",
+            PPOTrainerColocateAsync: "colocate_async",
+            PPOTrainerSeparateAsync: "separate_async",
+        }[trainer_cls]
+    )
+    trainer.global_steps = 1
+    trainer.use_reference_policy = False
+    trainer.use_critic = False
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=[])
+    trainer.replay_buffer = SimpleNamespace(sample=lambda **_kwargs: (_Batch(), {}))
+    trainer.checkpoint_manager = _FakeCheckpointManager(events, "checkpoint")
+    trainer._gpu_stall_diagnostics = _FakeDiagnostics(diagnostic_events)
+    trainer._balance_batch = lambda batch, **_kwargs: batch
+    trainer._compute_old_log_prob = lambda batch, **_kwargs: batch
+    trainer._compute_advantage = lambda batch, **_kwargs: batch
+    trainer._update_actor = lambda batch, **_kwargs: events.append("actor_update") or batch
+    if trainer_cls is PPOTrainerSeparateAsync:
+        trainer.current_mode = HybridEngineMode.ROLLOUT
+        trainer.switch_to_trainer = lambda: events.append("switch_to_trainer")
+
+    result = PPOTrainer._step_once(trainer, {}, {}, sample_batch_size=1)
+
+    assert isinstance(result, _Batch)
+    assert diagnostic_events == [
+        "begin:rollout_wait",
+        "end:rollout_wait",
+        "begin:rollout_release_or_switch",
+        "end:rollout_release_or_switch",
+        "begin:actor_update",
+        "end:actor_update",
+    ]
+    assert events[-len(expected_release_events) - 1 : -1] == expected_release_events
+    assert events[-1] == "actor_update"
+
+
+def test_v1_rollout_wait_phase_ends_when_sampling_raises():
+    diagnostic_events = []
+    trainer = object.__new__(PPOTrainerSync)
+    trainer.config = _config(mode="sync")
+    trainer.global_steps = 1
+    trainer.use_reference_policy = False
+    trainer.use_critic = False
+    trainer.reward_loop_manager = SimpleNamespace(reward_loop_worker_handles=[])
+    trainer.replay_buffer = SimpleNamespace(sample=lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("sample")))
+    trainer._gpu_stall_diagnostics = _FakeDiagnostics(diagnostic_events)
+
+    with pytest.raises(RuntimeError, match="sample"):
+        PPOTrainer._step_once(trainer, {}, {}, sample_batch_size=1)
+
+    assert diagnostic_events == ["begin:rollout_wait", "end:rollout_wait"]
+
+
+def test_v1_metrics_aggregator_uses_nvml_sample_counts_for_multiple_async_updates():
+    aggregator = MetricsAggregator()
+    phase = "gpu_stall/rollout_wait/node_0"
+    device = f"{phase}/gpu_0000_10_00_0"
+    aggregator.add_step_metrics(
+        {
+            f"{phase}/sample_count": 1.0,
+            f"{phase}/utilization_mean": 100.0,
+            f"{phase}/zero_utilization_fraction": 0.0,
+            f"{device}/sample_count": 1.0,
+            f"{device}/utilization_mean": 100.0,
+        },
+        sample_count=64,
+    )
+    aggregator.add_step_metrics(
+        {
+            f"{phase}/sample_count": 3.0,
+            f"{phase}/utilization_mean": 0.0,
+            f"{phase}/zero_utilization_fraction": 1.0,
+            f"{device}/sample_count": 3.0,
+            f"{device}/utilization_mean": 0.0,
+        },
+        sample_count=64,
+    )
+
+    metrics = aggregator.get_aggregated_metrics()
+    assert metrics[f"{phase}/sample_count"] == 4.0
+    assert metrics[f"{phase}/utilization_mean"] == 25.0
+    assert metrics[f"{phase}/zero_utilization_fraction"] == 0.75
+    assert metrics[f"{device}/sample_count"] == 4.0
+    assert metrics[f"{device}/utilization_mean"] == 25.0

--- a/tests/utils/test_gpu_stall_diagnostics_on_cpu.py
+++ b/tests/utils/test_gpu_stall_diagnostics_on_cpu.py
@@ -1,0 +1,529 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only tests for the optional GPU stall diagnostic sampler."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import logging
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from verl.utils.config import omega_conf_to_dataclass
+from verl.utils.profiler.config import GPUStallDiagnosticsConfig
+from verl.utils.profiler.gpu_stall_diagnostics import (
+    GPUStallDiagnostics,
+    _Device,
+    _LocalNVMLSampler,
+    _NodeGPUStallSampler,
+    start_gpu_stall_diagnostics,
+)
+
+
+class _FakeNVML:
+    def __init__(self, utilizations: dict[int, object] | None = None):
+        self.initializations = 0
+        self.shutdowns = 0
+        self.utilizations = utilizations or {0: 0.0, 1: 75.0}
+        self.bus_ids = {0: b"0000:01:00.0", 1: b"0000:02:00.0"}
+        self.calls = {index: 0 for index in self.bus_ids}
+
+    def nvmlInit(self) -> None:
+        self.initializations += 1
+
+    def nvmlShutdown(self) -> None:
+        self.shutdowns += 1
+
+    def nvmlDeviceGetCount(self) -> int:
+        return len(self.bus_ids)
+
+    def nvmlDeviceGetHandleByIndex(self, index: int) -> int:
+        return index
+
+    def nvmlDeviceGetPciInfo(self, handle: int) -> SimpleNamespace:
+        return SimpleNamespace(busId=self.bus_ids[handle])
+
+    def nvmlDeviceGetUtilizationRates(self, handle: int) -> SimpleNamespace:
+        self.calls[handle] += 1
+        utilization = self.utilizations[handle]
+        if isinstance(utilization, list):
+            utilization = utilization.pop(0) if len(utilization) > 1 else utilization[0]
+        if isinstance(utilization, Exception):
+            raise utilization
+        return SimpleNamespace(gpu=utilization)
+
+
+class _SignalingNVML(_FakeNVML):
+    def __init__(self):
+        super().__init__({0: 25.0})
+        self.bus_ids = {0: b"0000:01:00.0"}
+        self.calls = {0: 0}
+        self.sampled = threading.Event()
+
+    def nvmlDeviceGetUtilizationRates(self, handle: int) -> SimpleNamespace:
+        self.sampled.set()
+        return super().nvmlDeviceGetUtilizationRates(handle)
+
+
+class _ControlledThread:
+    def __init__(self):
+        self.alive = True
+        self.join_timeouts: list[float] = []
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+    def join(self, timeout: float) -> None:
+        self.join_timeouts.append(timeout)
+
+
+class _FakeRemoteMethod:
+    def __init__(self, callback):
+        self._callback = callback
+
+    def remote(self, *args):
+        return self._callback(*args)
+
+
+class _FakeActor:
+    def __init__(self, index: int):
+        self.index = index
+        self.begin_phases: list[str] = []
+        self.end_phases: list[str] = []
+        self.close_calls = 0
+        self.end_result = ({}, 0, None)
+        self.begin_phase = _FakeRemoteMethod(self._begin_phase)
+        self.end_phase = _FakeRemoteMethod(self._end_phase)
+        self.close = _FakeRemoteMethod(self._close)
+
+    def _begin_phase(self, phase: str) -> None:
+        self.begin_phases.append(phase)
+
+    def _end_phase(self, phase: str):
+        self.end_phases.append(phase)
+        return self.end_result
+
+    def _close(self) -> None:
+        self.close_calls += 1
+
+
+class _FakeNodeAffinitySchedulingStrategy:
+    def __init__(self, node_id: str, soft: bool):
+        self.node_id = node_id
+        self.soft = soft
+
+
+class _FakeRemoteClassCall:
+    def __init__(self, fake_ray, options: dict[str, object]):
+        self._fake_ray = fake_ray
+        self._options = options
+
+    def remote(self, *args):
+        actor = _FakeActor(len(self._fake_ray.created))
+        if self._fake_ray.remote_creation_error_at == len(self._fake_ray.created):
+            raise RuntimeError("actor creation failed")
+        self._fake_ray.created.append((actor, self._options, args))
+        return actor
+
+
+class _FakeRemoteClass:
+    def __init__(self, fake_ray):
+        self._fake_ray = fake_ray
+
+    def options(self, **options):
+        return _FakeRemoteClassCall(self._fake_ray, options)
+
+
+class _FakeRay(ModuleType):
+    def __init__(self, nodes: list[dict[str, object]] | None = None):
+        super().__init__("ray")
+        self.__path__ = []
+        self._nodes = nodes or []
+        self.created: list[tuple[_FakeActor, dict[str, object], tuple[object, ...]]] = []
+        self.remote_creation_error_at: int | None = None
+        self.get_timeouts: list[float] = []
+        self.get_errors: list[Exception] = []
+        self.kill_attempts: list[tuple[_FakeActor, bool]] = []
+        self.kill_failures: set[_FakeActor] = set()
+
+    def nodes(self):
+        return self._nodes
+
+    def remote(self, _target):
+        return _FakeRemoteClass(self)
+
+    def get(self, refs, timeout: float):
+        self.get_timeouts.append(timeout)
+        if self.get_errors:
+            raise self.get_errors.pop(0)
+        return refs
+
+    def kill(self, actor: _FakeActor, no_restart: bool) -> None:
+        self.kill_attempts.append((actor, no_restart))
+        if actor in self.kill_failures:
+            raise RuntimeError(f"cannot kill actor {actor.index}")
+
+
+def _install_fake_nvml(monkeypatch: pytest.MonkeyPatch, fake_nvml: _FakeNVML) -> None:
+    monkeypatch.setitem(sys.modules, "pynvml", fake_nvml)
+
+
+def _install_fake_ray(monkeypatch: pytest.MonkeyPatch, fake_ray: _FakeRay) -> None:
+    util_module = ModuleType("ray.util")
+    util_module.__path__ = []
+    scheduling_module = ModuleType("ray.util.scheduling_strategies")
+    scheduling_module.NodeAffinitySchedulingStrategy = _FakeNodeAffinitySchedulingStrategy
+    fake_ray.util = util_module
+    util_module.scheduling_strategies = scheduling_module
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setitem(sys.modules, "ray.util", util_module)
+    monkeypatch.setitem(sys.modules, "ray.util.scheduling_strategies", scheduling_module)
+
+
+def test_start_stop_is_idempotent_and_restartable(monkeypatch):
+    fake_nvml = _FakeNVML()
+    _install_fake_nvml(monkeypatch, fake_nvml)
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+
+    assert sampler.start() is None
+    assert sampler.start() is None
+    assert sampler.started
+    sampler.sample_once()
+    assert sampler.snapshot_and_reset()["0000:01:00.0"]["sample_count"] == 1.0
+    sampler.close()
+    sampler.close()
+
+    assert not sampler.started
+    assert fake_nvml.initializations == 1
+    assert fake_nvml.shutdowns == 1
+
+    assert sampler.start() is None
+    sampler.close()
+    assert fake_nvml.initializations == 2
+    assert fake_nvml.shutdowns == 2
+
+
+def test_sampler_thread_starts_and_stops_without_sleep(monkeypatch):
+    fake_nvml = _SignalingNVML()
+    _install_fake_nvml(monkeypatch, fake_nvml)
+    sampler = _LocalNVMLSampler(sample_interval_s=0.0, zero_utilization_threshold=1.0)
+
+    assert sampler.start() is None
+    assert fake_nvml.sampled.wait(timeout=1.0)
+    thread = sampler._thread
+
+    sampler.close()
+
+    assert thread is not None
+    assert not thread.is_alive()
+    assert not sampler.started
+    assert fake_nvml.shutdowns == 1
+
+
+def test_close_timeout_leaves_nvml_initialized_until_thread_exits(caplog):
+    fake_nvml = _FakeNVML()
+    thread = _ControlledThread()
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+    sampler._nvml = fake_nvml
+    sampler._thread = thread
+    sampler._started = True
+
+    with caplog.at_level(logging.WARNING):
+        sampler.close()
+
+    assert thread.join_timeouts == [1.2]
+    assert sampler._thread is thread
+    assert sampler.started
+    assert fake_nvml.shutdowns == 0
+    assert "leaving NVML initialized" in caplog.text
+
+    thread.alive = False
+    sampler.close()
+    sampler.close()
+
+    assert sampler._thread is None
+    assert not sampler.started
+    assert fake_nvml.shutdowns == 1
+
+
+def test_missing_pynvml_degrades_without_raising(monkeypatch):
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+
+    reason = sampler.start()
+
+    assert reason is not None
+    assert "NVML is unavailable" in reason
+    assert not sampler.started
+    sampler.close()
+
+
+def test_transient_device_failure_is_retried():
+    fake_nvml = _FakeNVML({0: [RuntimeError("transient"), 42.0]})
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+    sampler._nvml = fake_nvml
+    sampler._devices = [_Device("0000:01:00.0", 0)]
+
+    sampler.sample_once()
+    sampler.sample_once()
+
+    assert sampler.snapshot_and_reset()["0000:01:00.0"]["mean"] == 42.0
+    assert sampler._failed_devices == set()
+    assert sampler._consecutive_device_failures == {}
+    assert fake_nvml.calls[0] == 2
+
+
+def test_consecutive_device_failures_do_not_drop_healthy_device(caplog):
+    fake_nvml = _FakeNVML({0: 42.0, 1: RuntimeError("bad device")})
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+    sampler._nvml = fake_nvml
+    sampler._devices = [
+        _Device("0000:01:00.0", 0),
+        _Device("0000:02:00.0", 1),
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(sampler._MAX_CONSECUTIVE_DEVICE_FAILURES):
+            sampler.sample_once()
+        sampler.sample_once()
+    summary = sampler.snapshot_and_reset()
+
+    assert summary == {
+        "0000:01:00.0": {
+            "mean": 42.0,
+            "min": 42.0,
+            "max": 42.0,
+            "zero_fraction": 0.0,
+            "sample_count": 4.0,
+        }
+    }
+    assert sampler._failed_devices == {"0000:02:00.0"}
+    assert fake_nvml.calls[1] == sampler._MAX_CONSECUTIVE_DEVICE_FAILURES
+    assert "after 3 consecutive NVML failures" in caplog.text
+
+
+def test_statistics_are_per_pci_device_and_empty_windows_are_safe():
+    sampler = _LocalNVMLSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+    sampler._samples = [
+        ("0000:01:00.0", 0.0),
+        ("0000:01:00.0", 2.0),
+        ("0000:02:00.0", 50.0),
+    ]
+
+    summary = sampler.snapshot_and_reset()
+
+    assert set(summary) == {"0000:01:00.0", "0000:02:00.0"}
+    assert summary["0000:01:00.0"] == {
+        "mean": 1.0,
+        "min": 0.0,
+        "max": 2.0,
+        "zero_fraction": 0.5,
+        "sample_count": 2.0,
+    }
+    assert summary["0000:02:00.0"]["mean"] == 50.0
+    assert sampler.snapshot_and_reset() == {}
+
+
+def test_nested_phase_windows_do_not_contaminate_each_other(monkeypatch):
+    fake_nvml = _FakeNVML()
+    _install_fake_nvml(monkeypatch, fake_nvml)
+    node_sampler = _NodeGPUStallSampler(sample_interval_s=0.2, zero_utilization_threshold=1.0)
+    try:
+        node_sampler.begin_phase("training_step")
+        node_sampler._sampler._samples.append(("0000:01:00.0", 10.0))
+        node_sampler.begin_phase("rollout_generate")
+        node_sampler._sampler._samples.append(("0000:02:00.0", 20.0))
+
+        child_summary, _, reason = node_sampler.end_phase("rollout_generate")
+        parent_summary, _, _ = node_sampler.end_phase("training_step")
+
+        assert reason is None
+        assert set(child_summary) == {"0000:02:00.0"}
+        assert set(parent_summary) == {"0000:01:00.0", "0000:02:00.0"}
+        assert node_sampler._sampler.snapshot_and_reset() == {}
+    finally:
+        node_sampler.close()
+
+
+def test_fake_ray_creates_one_zero_gpu_actor_per_live_gpu_node_and_aggregates(monkeypatch):
+    fake_ray = _FakeRay(
+        [
+            {"NodeID": "gpu-b", "Alive": True, "Resources": {"GPU": 2}},
+            {"NodeID": "dead-gpu", "Alive": False, "Resources": {"GPU": 8}},
+            {"NodeID": "cpu-only", "Alive": True, "Resources": {"CPU": 4}},
+            {"NodeID": "gpu-a", "Alive": True, "Resources": {"GPU": 1}},
+        ]
+    )
+    _install_fake_ray(monkeypatch, fake_ray)
+
+    diagnostics = start_gpu_stall_diagnostics(GPUStallDiagnosticsConfig(enable=True))
+
+    assert diagnostics is not None
+    assert diagnostics._node_ids == ["gpu-a", "gpu-b"]
+    assert len(fake_ray.created) == 2
+    for index, (_, options, args) in enumerate(fake_ray.created):
+        assert options["num_cpus"] == 0
+        assert options["num_gpus"] == 0
+        strategy = options["scheduling_strategy"]
+        assert isinstance(strategy, _FakeNodeAffinitySchedulingStrategy)
+        assert strategy.node_id == diagnostics._node_ids[index]
+        assert strategy.soft is False
+        assert args == (0.25, 1.0)
+
+    diagnostics._actors[0].end_result = (
+        {
+            "0000:01:00.0": {
+                "mean": 20.0,
+                "min": 10.0,
+                "max": 30.0,
+                "zero_fraction": 0.25,
+                "sample_count": 4.0,
+            },
+            "0000:02:00.0": {
+                "mean": 50.0,
+                "min": 50.0,
+                "max": 50.0,
+                "zero_fraction": 0.0,
+                "sample_count": 2.0,
+            },
+        },
+        2,
+        None,
+    )
+    diagnostics._actors[1].end_result = (
+        {
+            "0000:03:00.0": {
+                "mean": 0.0,
+                "min": 0.0,
+                "max": 0.0,
+                "zero_fraction": 1.0,
+                "sample_count": 3.0,
+            }
+        },
+        1,
+        None,
+    )
+
+    diagnostics.begin_phase("rollout_generate")
+    metrics = diagnostics.end_phase("rollout_generate")
+
+    assert [actor.begin_phases for actor in diagnostics._actors] == [
+        ["rollout_generate"],
+        ["rollout_generate"],
+    ]
+    assert metrics["gpu_stall/rollout_generate/node_0/device_count"] == 2.0
+    assert metrics["gpu_stall/rollout_generate/node_0/sample_count"] == 6.0
+    assert metrics["gpu_stall/rollout_generate/node_0/utilization_mean"] == 30.0
+    assert metrics["gpu_stall/rollout_generate/node_0/utilization_min"] == 10.0
+    assert metrics["gpu_stall/rollout_generate/node_0/utilization_max"] == 50.0
+    assert metrics["gpu_stall/rollout_generate/node_0/zero_utilization_fraction"] == pytest.approx(1 / 6)
+    assert metrics["gpu_stall/rollout_generate/node_1/sample_count"] == 3.0
+    assert metrics["gpu_stall/rollout_generate/node_1/zero_utilization_fraction"] == 1.0
+
+    diagnostics.close()
+    diagnostics.close()
+
+    assert [actor.close_calls for actor in diagnostics._actors] == [1, 1]
+    assert fake_ray.kill_attempts == [(diagnostics._actors[0], True), (diagnostics._actors[1], True)]
+
+
+def test_partial_actor_creation_failure_cleans_up_created_actors(monkeypatch):
+    fake_ray = _FakeRay(
+        [
+            {"NodeID": "gpu-b", "Alive": True, "Resources": {"GPU": 1}},
+            {"NodeID": "gpu-a", "Alive": True, "Resources": {"GPU": 1}},
+        ]
+    )
+    fake_ray.remote_creation_error_at = 1
+    _install_fake_ray(monkeypatch, fake_ray)
+
+    diagnostics = start_gpu_stall_diagnostics(GPUStallDiagnosticsConfig(enable=True))
+
+    assert diagnostics is None
+    assert len(fake_ray.created) == 1
+    assert fake_ray.kill_attempts == [(fake_ray.created[0][0], True)]
+
+
+def test_ray_rpc_timeout_is_fail_open(monkeypatch):
+    fake_ray = _FakeRay()
+    _install_fake_ray(monkeypatch, fake_ray)
+    actor = _FakeActor(0)
+    diagnostics = GPUStallDiagnostics([actor], ["gpu-node"])
+    fake_ray.get_errors = [TimeoutError("begin timeout"), TimeoutError("end timeout")]
+
+    diagnostics.begin_phase("rollout_generate")
+    metrics = diagnostics.end_phase("rollout_generate")
+
+    assert metrics == {}
+    assert fake_ray.get_timeouts == [diagnostics._RPC_TIMEOUT_S, diagnostics._RPC_TIMEOUT_S]
+
+    diagnostics.close()
+    assert fake_ray.kill_attempts == [(actor, True)]
+
+
+def test_one_actor_kill_failure_does_not_block_other_cleanup(monkeypatch, caplog):
+    fake_ray = _FakeRay()
+    _install_fake_ray(monkeypatch, fake_ray)
+    actors = [_FakeActor(0), _FakeActor(1), _FakeActor(2)]
+    fake_ray.kill_failures.add(actors[0])
+    diagnostics = GPUStallDiagnostics(actors, ["a", "b", "c"])
+
+    with caplog.at_level(logging.WARNING):
+        diagnostics.close()
+        diagnostics.close()
+
+    assert fake_ray.kill_attempts == [(actor, True) for actor in actors]
+    assert [actor.close_calls for actor in actors] == [1, 1, 1]
+    assert "could not destroy node sampler 0" in caplog.text
+
+
+def test_default_off_path_does_not_import_ray_or_pynvml(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name in {"ray", "pynvml"}:
+            raise AssertionError(f"default-off diagnostics imported optional dependency: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    module = importlib.reload(sys.modules["verl.utils.profiler.gpu_stall_diagnostics"])
+    assert module.start_gpu_stall_diagnostics(GPUStallDiagnosticsConfig()) is None
+
+
+def test_gpu_stall_diagnostics_config_hydra_conversion_and_validation():
+    config = omega_conf_to_dataclass(
+        OmegaConf.create(
+            {
+                "_target_": "verl.utils.profiler.config.GPUStallDiagnosticsConfig",
+                "enable": True,
+                "sample_interval_s": 0.2,
+                "zero_utilization_threshold": 0.0,
+            }
+        )
+    )
+
+    assert isinstance(config, GPUStallDiagnosticsConfig)
+    assert config.enable
+    assert config.sample_interval_s == 0.2
+    with pytest.raises(AssertionError, match="sample_interval_s"):
+        GPUStallDiagnosticsConfig(sample_interval_s=0.1)
+    with pytest.raises(AssertionError, match="zero_utilization_threshold"):
+        GPUStallDiagnosticsConfig(zero_utilization_threshold=101.0)

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -952,6 +952,11 @@ global_profiler:
   steps: null
   profile_continuous_steps: false
   save_path: outputs/profile
+  gpu_stall_diagnostics:
+    _target_: verl.utils.profiler.config.GPUStallDiagnosticsConfig
+    enable: false
+    sample_interval_s: 0.25
+    zero_utilization_threshold: 1.0
   global_tool_config:
     nsys:
       _target_: verl.utils.profiler.config.NsightToolConfig

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -874,6 +874,11 @@ global_profiler:
   steps: null
   profile_continuous_steps: false
   save_path: outputs/profile
+  gpu_stall_diagnostics:
+    _target_: verl.utils.profiler.config.GPUStallDiagnosticsConfig
+    enable: false
+    sample_interval_s: 0.25
+    zero_utilization_threshold: 1.0
   global_tool_config:
     nsys:
       _target_: verl.utils.profiler.config.NsightToolConfig

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -890,6 +890,11 @@ global_profiler:
   steps: null
   profile_continuous_steps: false
   save_path: outputs/profile
+  gpu_stall_diagnostics:
+    _target_: verl.utils.profiler.config.GPUStallDiagnosticsConfig
+    enable: false
+    sample_interval_s: 0.25
+    zero_utilization_threshold: 1.0
   global_tool_config:
     nsys:
       _target_: verl.utils.profiler.config.NsightToolConfig

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -888,6 +888,11 @@ global_profiler:
   steps: null
   profile_continuous_steps: false
   save_path: outputs/profile
+  gpu_stall_diagnostics:
+    _target_: verl.utils.profiler.config.GPUStallDiagnosticsConfig
+    enable: false
+    sample_interval_s: 0.25
+    zero_utilization_threshold: 1.0
   global_tool_config:
     nsys:
       _target_: verl.utils.profiler.config.NsightToolConfig

--- a/verl/trainer/config/ppo_trainer.yaml
+++ b/verl/trainer/config/ppo_trainer.yaml
@@ -267,6 +267,23 @@ global_profiler:
   # Path to save profiling contents
   save_path: "outputs/profile"
 
+  # Optional node-local NVML sampling for rollout stalls. This is independent
+  # of global_profiler.tool and has no CUDA, NVML, thread, or Ray-actor work
+  # unless explicitly enabled.
+  gpu_stall_diagnostics:
+
+    # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+    _target_: verl.utils.profiler.config.GPUStallDiagnosticsConfig
+
+    # Enable node-local physical GPU utilization diagnostics.
+    enable: False
+
+    # Bounded to [0.2, 0.5] seconds by GPUStallDiagnosticsConfig.
+    sample_interval_s: 0.25
+
+    # A utilization value at or below this percentage counts as "zero".
+    zero_utilization_threshold: 1.0
+
   # Specific tool configs, can use +profiler.tool_config.[tool].xxx to config
   global_tool_config:
 

--- a/verl/trainer/ppo/ray_trainer.py
+++ b/verl/trainer/ppo/ray_trainer.py
@@ -23,6 +23,7 @@ import os
 import uuid
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from pprint import pprint
 from typing import Any, Optional
 
@@ -65,6 +66,7 @@ from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.debug import marked_timer
 from verl.utils.import_utils import deprecated, load_class_from_fqn
 from verl.utils.metric import reduce_metrics
+from verl.utils.profiler import close_gpu_stall_diagnostics_on_exit, start_gpu_stall_diagnostics
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.skip.skip_manager import SkipManager
@@ -1365,6 +1367,7 @@ class RayPPOTrainer:
         critic_output = DataProto.from_single_dict(data={}, meta_info={"metrics": output})
         return critic_output
 
+    @close_gpu_stall_diagnostics_on_exit
     def fit(self):
         """
         The training loop of PPO.
@@ -1391,6 +1394,10 @@ class RayPPOTrainer:
         # load checkpoint and update weights before doing anything
         self._load_checkpoint()
         self.checkpoint_manager.update_weights(self.global_steps)
+
+        self._gpu_stall_diagnostics = start_gpu_stall_diagnostics(
+            self.config.global_profiler.get("gpu_stall_diagnostics", None)
+        )
 
         current_epoch = self.global_steps // len(self.train_dataloader)
 
@@ -1432,6 +1439,8 @@ class RayPPOTrainer:
                 metrics = {}
                 timing_raw = {}
 
+                diagnostics = self._gpu_stall_diagnostics
+
                 with marked_timer("start_profile", timing_raw):
                     self._start_profiling(
                         not prev_step_profile and curr_step_profile
@@ -1468,13 +1477,25 @@ class RayPPOTrainer:
                     num_sampled_prompts = len(gen_batch_output)
 
                 is_last_step = self.global_steps >= self.total_training_steps
+                if diagnostics is not None:
+                    diagnostics.begin_phase("training_step")
                 with marked_timer("step", timing_raw):
                     # generate a batch
                     with marked_timer("gen", timing_raw, color="red"):
                         if curr_step_profile:
                             self.llm_server_manager.start_profile()
-                        combined_gen_output = self.async_rollout_manager.generate_sequences(combined_gen_batch)
-                        self.checkpoint_manager.sleep_replicas()
+                        with (
+                            diagnostics.phase("rollout_generate") if diagnostics is not None else nullcontext({})
+                        ) as rollout_generate_metrics:
+                            combined_gen_output = self.async_rollout_manager.generate_sequences(combined_gen_batch)
+                        metrics.update(rollout_generate_metrics)
+                        with (
+                            diagnostics.phase("rollout_sleep_or_release")
+                            if diagnostics is not None
+                            else nullcontext({})
+                        ) as rollout_sleep_metrics:
+                            self.checkpoint_manager.sleep_replicas()
+                        metrics.update(rollout_sleep_metrics)
                         if curr_step_profile:
                             self.llm_server_manager.stop_profile()
 
@@ -1646,11 +1667,21 @@ class RayPPOTrainer:
                     # implement critic warmup
                     if self.config.trainer.critic_warmup > self.global_steps:
                         # Still in critic warmup, only update weights to wake up rollout replicas.
-                        self.checkpoint_manager.update_weights(self.global_steps)
+                        with (
+                            diagnostics.phase("weight_sync_and_wake_or_resume")
+                            if diagnostics is not None
+                            else nullcontext({})
+                        ) as weight_sync_metrics:
+                            self.checkpoint_manager.update_weights(self.global_steps)
+                        metrics.update(weight_sync_metrics)
                     else:
                         # update actor
                         with marked_timer("update_actor", timing_raw, color="red"):
-                            actor_output = self._update_actor(batch)
+                            with (
+                                diagnostics.phase("actor_update") if diagnostics is not None else nullcontext({})
+                            ) as actor_update_metrics:
+                                actor_output = self._update_actor(batch)
+                        metrics.update(actor_update_metrics)
 
                         # Check if the ESI (Elastic Server Instance)/training plan is close to expiration.
                         esi_close_to_expiration = should_save_ckpt_esi(
@@ -1676,7 +1707,13 @@ class RayPPOTrainer:
 
                         # update weights from trainer to rollout
                         with marked_timer("update_weights", timing_raw, color="red"):
-                            self.checkpoint_manager.update_weights(self.global_steps)
+                            with (
+                                diagnostics.phase("weight_sync_and_wake_or_resume")
+                                if diagnostics is not None
+                                else nullcontext({})
+                            ) as weight_sync_metrics:
+                                self.checkpoint_manager.update_weights(self.global_steps)
+                        metrics.update(weight_sync_metrics)
 
                         actor_output_metrics = reduce_metrics(actor_output.meta_info["metrics"])
                         metrics.update(actor_output_metrics)
@@ -1685,6 +1722,8 @@ class RayPPOTrainer:
                     rollout_data_dir = self.config.trainer.get("rollout_data_dir", None)
                     if rollout_data_dir:
                         self._log_rollout_data(batch, reward_extra_infos_dict, timing_raw, rollout_data_dir)
+                if diagnostics is not None:
+                    metrics.update(diagnostics.end_phase("training_step"))
 
                 # validate
                 if self.config.trainer.test_freq > 0 and (

--- a/verl/trainer/ppo/v1/trainer_base.py
+++ b/verl/trainer/ppo/v1/trainer_base.py
@@ -20,6 +20,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from functools import partial
 from pprint import pprint
 from typing import Any, Optional
@@ -83,6 +84,11 @@ from verl.utils.debug.metrics import calculate_debug_metrics
 from verl.utils.fs import copy_to_local
 from verl.utils.import_utils import load_extern_type
 from verl.utils.metric import reduce_metrics
+from verl.utils.profiler import (
+    close_gpu_stall_diagnostics_on_exit,
+    gpu_stall_diagnostics_phase,
+    start_gpu_stall_diagnostics,
+)
 from verl.utils.py_functional import rename_dict
 from verl.utils.seqlen_balancing import calculate_workload, get_seqlen_balanced_partitions, log_seqlen_unbalance
 from verl.utils.skip import SkipManager
@@ -123,6 +129,8 @@ class PPOTrainer(ABC):
     Args:
         config: DictConfig from yaml config file.
     """
+
+    _gpu_stall_step_end_phase = "weight_sync_and_wake_or_resume"
 
     def __init__(self, config: DictConfig):
         self.config = config
@@ -321,6 +329,7 @@ class PPOTrainer(ABC):
         """Get the handles of reward loop workers."""
         return self.reward_loop_manager.reward_loop_worker_handles
 
+    @close_gpu_stall_diagnostics_on_exit
     def fit(self, agent_loop_manager: AgentLoopManager):
         """Fit the trainer with the agent loop manager.
 
@@ -328,6 +337,16 @@ class PPOTrainer(ABC):
             agent_loop_manager: The agent loop manager to generate sequences.
         """
         self.agent_loop_manager = agent_loop_manager
+
+        # ``fit`` runs in the single TaskRunnerV1 controller actor after Ray,
+        # workers, checkpoint engines, and the agent-loop manager are ready.
+        self._gpu_stall_diagnostics = None
+        diagnostics_config = self.config.global_profiler.get("gpu_stall_diagnostics", None)
+        if diagnostics_config is not None and getattr(diagnostics_config, "enable", False):
+            try:
+                self._gpu_stall_diagnostics = start_gpu_stall_diagnostics(diagnostics_config)
+            except Exception as error:
+                logger.warning("GPU stall diagnostics disabled: could not initialize coordinator: %s", error)
 
         # initialize SkipManager for V1 rollout skip support
         SkipManager.init(self.config)
@@ -377,24 +396,35 @@ class PPOTrainer(ABC):
             is_last_step = self.global_steps >= self.total_training_steps
             metrics = {}
             self.timing_raw = {}
+            diagnostics = self._gpu_stall_diagnostics
 
             # 1. perform rollout and actor/critic training
-            with marked_timer("step", self.timing_raw):
-                self.on_step_begin()
+            training_step_context = (
+                gpu_stall_diagnostics_phase(diagnostics, "training_step", metrics)
+                if diagnostics is not None
+                else nullcontext()
+            )
+            with training_step_context:
+                with marked_timer("step", self.timing_raw):
+                    self.on_step_begin()
 
-                self._start_profiling()
-                batch = self.step(metrics, self.timing_raw)
-                self._stop_profiling()
+                    self._start_profiling()
+                    batch = self.step(metrics, self.timing_raw)
+                    self._stop_profiling()
 
-                # 2. save checkpoint
-                if self.config.trainer.save_freq > 0 and (
-                    is_last_step or self.global_steps % self.config.trainer.save_freq == 0
-                ):
-                    with marked_timer("save_checkpoint", self.timing_raw, color="green"):
-                        self._save_checkpoint()
+                    # 2. save checkpoint
+                    if self.config.trainer.save_freq > 0 and (
+                        is_last_step or self.global_steps % self.config.trainer.save_freq == 0
+                    ):
+                        with marked_timer("save_checkpoint", self.timing_raw, color="green"):
+                            self._save_checkpoint()
 
-                self.on_step_end()
-                metrics.update(self._consume_sync_metrics())
+                    if diagnostics is None:
+                        self.on_step_end()
+                    else:
+                        with gpu_stall_diagnostics_phase(diagnostics, self._gpu_stall_step_end_phase, metrics):
+                            self.on_step_end()
+                    metrics.update(self._consume_sync_metrics())
 
             # 4. validate
             if self.config.trainer.test_freq > 0 and (
@@ -464,17 +494,31 @@ class PPOTrainer(ABC):
 
     def _step_once(self, metrics: dict, timing_raw: dict, sample_batch_size: int) -> KVBatchMeta:
         """Run a single local update: sample one mini-batch and perform the full PPO pipeline once."""
+        diagnostics = getattr(self, "_gpu_stall_diagnostics", None)
+
         # 1. sample batch from replay buffer
         with marked_timer("gen", timing_raw, color="red"):
             self.on_sample_begin()
-            batch, off_policy_metrics = self.replay_buffer.sample(
-                global_steps=self.global_steps,
-                partition_id="train",
-                batch_size=sample_batch_size,
-            )
+            if diagnostics is None:
+                batch, off_policy_metrics = self.replay_buffer.sample(
+                    global_steps=self.global_steps,
+                    partition_id="train",
+                    batch_size=sample_batch_size,
+                )
+            else:
+                with gpu_stall_diagnostics_phase(diagnostics, "rollout_wait", metrics):
+                    batch, off_policy_metrics = self.replay_buffer.sample(
+                        global_steps=self.global_steps,
+                        partition_id="train",
+                        batch_size=sample_batch_size,
+                    )
             metrics.update(off_policy_metrics)
             batch.extra_info["temperature"] = self.config.actor_rollout_ref.rollout.temperature
-            self.on_sample_end()
+            if diagnostics is None:
+                self.on_sample_end()
+            else:
+                with gpu_stall_diagnostics_phase(diagnostics, "rollout_release_or_switch", metrics):
+                    self.on_sample_end()
 
         # 2. [OPTIONAL] compute reward score with colocated reward model
         if self.reward_loop_manager.reward_loop_worker_handles is None:
@@ -510,7 +554,11 @@ class PPOTrainer(ABC):
         # 9. update actor
         if self.config.trainer.critic_warmup <= self.global_steps:
             with marked_timer("update_actor", timing_raw, color="red"):
-                batch = self._update_actor(batch, metrics=metrics)
+                if diagnostics is None:
+                    batch = self._update_actor(batch, metrics=metrics)
+                else:
+                    with gpu_stall_diagnostics_phase(diagnostics, "actor_update", metrics):
+                        batch = self._update_actor(batch, metrics=metrics)
 
         return batch
 

--- a/verl/trainer/ppo/v1/trainer_separate_async.py
+++ b/verl/trainer/ppo/v1/trainer_separate_async.py
@@ -41,6 +41,8 @@ class PPOTrainerSeparateAsync(PPOTrainer):
     2. Partial rollout is enabled.
     """
 
+    _gpu_stall_step_end_phase = "standalone_rollout_weight_sync"
+
     def __init__(self, config: DictConfig):
         train_batch_size = config.data.train_batch_size
         ppo_mini_batch_size = config.actor_rollout_ref.actor.ppo_mini_batch_size

--- a/verl/trainer/ppo/v1/utils.py
+++ b/verl/trainer/ppo/v1/utils.py
@@ -59,8 +59,17 @@ class MetricsAggregator:
                 self.metric_values[key].append(float(value.item()))
                 self.metric_weights[key].append(self._get_metric_weight(key, metrics, sample_count))
 
-    def _get_metric_weight(self, metric_name: str, metrics: dict[str, Any], sample_count: int) -> int:
+    def _get_metric_weight(self, metric_name: str, metrics: dict[str, Any], sample_count: int) -> float:
         """Return the sample weight used when reducing per-iteration average metrics."""
+        if metric_name.startswith("gpu_stall/") and metric_name.endswith(
+            ("/utilization_mean", "/zero_utilization_fraction")
+        ):
+            diagnostic_sample_count = metrics.get(f"{metric_name.rsplit('/', 1)[0]}/sample_count", sample_count)
+            if isinstance(diagnostic_sample_count, torch.Tensor):
+                return float(diagnostic_sample_count.item()) if diagnostic_sample_count.numel() == 1 else sample_count
+            if isinstance(diagnostic_sample_count, int | float | np.number):
+                return float(diagnostic_sample_count)
+
         if metric_name.endswith("/off_policy/dropped_samples_staleness/mean"):
             prefix = metric_name.rsplit("_staleness/mean", 1)[0]
             dropped_samples = metrics.get(prefix, sample_count)
@@ -71,6 +80,12 @@ class MetricsAggregator:
         return sample_count
 
     def _get_aggregation_type(self, metric_name: str) -> str:
+        if metric_name.startswith("gpu_stall/"):
+            if metric_name.endswith("/sample_count"):
+                return "sum"
+            if metric_name.endswith("/device_count"):
+                return "last"
+
         for agg_type, metric_list in self.aggregation_rules.items():
             if metric_name in metric_list:
                 return agg_type

--- a/verl/utils/profiler/__init__.py
+++ b/verl/utils/profiler/__init__.py
@@ -14,7 +14,13 @@
 
 from ..device import is_npu_available
 from ..import_utils import is_nvtx_available
-from .config import build_sglang_profiler_args, build_vllm_profiler_args
+from .config import GPUStallDiagnosticsConfig, build_sglang_profiler_args, build_vllm_profiler_args
+from .gpu_stall_diagnostics import (
+    GPUStallDiagnostics,
+    close_gpu_stall_diagnostics_on_exit,
+    gpu_stall_diagnostics_phase,
+    start_gpu_stall_diagnostics,
+)
 from .performance import GPUMemoryLogger, log_gpu_memory_usage, simple_timer
 from .profile import DistProfiler, DistProfilerExtension, ProfilerConfig
 
@@ -29,6 +35,8 @@ else:
 
 __all__ = [
     "GPUMemoryLogger",
+    "GPUStallDiagnostics",
+    "GPUStallDiagnosticsConfig",
     "log_gpu_memory_usage",
     "mark_start_range",
     "mark_end_range",
@@ -37,6 +45,9 @@ __all__ = [
     "DistProfilerExtension",
     "ProfilerConfig",
     "simple_timer",
+    "close_gpu_stall_diagnostics_on_exit",
+    "gpu_stall_diagnostics_phase",
+    "start_gpu_stall_diagnostics",
     "marked_timer",
     "build_vllm_profiler_args",
     "build_sglang_profiler_args",

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -162,6 +162,22 @@ class NPUToolConfig(NsightToolConfig):
 
 
 @dataclass
+class GPUStallDiagnosticsConfig(BaseConfig):
+    """Optional node-local NVML sampling, independent of ``ProfilerConfig.tool``."""
+
+    enable: bool = False
+    sample_interval_s: float = 0.25
+    zero_utilization_threshold: float = 1.0
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.enable, bool), "gpu_stall_diagnostics.enable must be a bool"
+        assert 0.2 <= self.sample_interval_s <= 0.5, "gpu_stall_diagnostics.sample_interval_s must be in [0.2, 0.5]"
+        assert 0.0 <= self.zero_utilization_threshold <= 100.0, (
+            "gpu_stall_diagnostics.zero_utilization_threshold must be in [0, 100]"
+        )
+
+
+@dataclass
 class ProfilerConfig(BaseConfig):
     """Worker profiler config.
 
@@ -182,6 +198,7 @@ class ProfilerConfig(BaseConfig):
     save_path: Optional[str] = MISSING
     tool_config: Any = MISSING  # Just a placeholder, will use configs above directly
     global_tool_config: Optional[Any] = None  # Global tool configuration for all profiling tools
+    gpu_stall_diagnostics: GPUStallDiagnosticsConfig = field(default_factory=GPUStallDiagnosticsConfig)
 
     def union(self, other: "ProfilerConfig") -> "ProfilerConfig":
         assert self.tool == other.tool, f"Cannot union ProfilerConfig with different tools: {self.tool} vs {other.tool}"
@@ -193,6 +210,11 @@ class ProfilerConfig(BaseConfig):
             save_path=self.save_path,
             tool_config=self.tool_config,
             global_tool_config=self.global_tool_config or other.global_tool_config,
+            gpu_stall_diagnostics=GPUStallDiagnosticsConfig(
+                enable=self.gpu_stall_diagnostics.enable or other.gpu_stall_diagnostics.enable,
+                sample_interval_s=self.gpu_stall_diagnostics.sample_interval_s,
+                zero_utilization_threshold=self.gpu_stall_diagnostics.zero_utilization_threshold,
+            ),
         )
 
     def intersect(self, other: "ProfilerConfig") -> "ProfilerConfig":
@@ -207,6 +229,11 @@ class ProfilerConfig(BaseConfig):
             save_path=self.save_path,
             tool_config=self.tool_config,
             global_tool_config=self.global_tool_config if self.global_tool_config else other.global_tool_config,
+            gpu_stall_diagnostics=GPUStallDiagnosticsConfig(
+                enable=self.gpu_stall_diagnostics.enable and other.gpu_stall_diagnostics.enable,
+                sample_interval_s=self.gpu_stall_diagnostics.sample_interval_s,
+                zero_utilization_threshold=self.gpu_stall_diagnostics.zero_utilization_threshold,
+            ),
         )
 
     def __post_init__(self) -> None:

--- a/verl/utils/profiler/gpu_stall_diagnostics.py
+++ b/verl/utils/profiler/gpu_stall_diagnostics.py
@@ -1,0 +1,464 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Low-overhead, phase-aware GPU utilization diagnostics.
+
+When enabled, the trainer creates one zero-GPU Ray actor on every live GPU
+node. Every actor polls NVML in a daemon thread and returns only aggregate
+statistics for explicitly delimited phases. NVML is imported lazily and this
+module never calls torch.cuda, so it cannot create a CUDA context.
+
+The metrics include a logical node index and an NVML PCI bus ID. This makes the
+multi-node scope explicit and avoids treating CUDA_VISIBLE_DEVICES ordinals as
+NVML indices.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+logger = logging.getLogger(__name__)
+
+
+def _merge_gpu_stall_metrics(metrics: dict[str, float], updates: dict[str, float]) -> None:
+    """Merge diagnostics without replacing metrics already owned by the trainer."""
+    collisions = sorted(metrics.keys() & updates.keys())
+    if collisions:
+        logger.warning("GPU stall diagnostics did not overwrite existing metric key(s): %s", collisions)
+    metrics.update({key: value for key, value in updates.items() if key not in metrics})
+
+
+@contextmanager
+def gpu_stall_diagnostics_phase(diagnostics: Any, phase: str, metrics: dict[str, float]) -> Iterator[None]:
+    """Run one optional phase without allowing diagnostics failures into training."""
+    if diagnostics is None:
+        yield
+        return
+
+    began = False
+    try:
+        diagnostics.begin_phase(phase)
+        began = True
+    except Exception as error:
+        logger.warning("GPU stall diagnostics could not begin phase %s: %s", phase, error)
+
+    try:
+        yield
+    finally:
+        if began:
+            try:
+                updates = diagnostics.end_phase(phase)
+            except Exception as error:
+                logger.warning("GPU stall diagnostics could not end phase %s: %s", phase, error)
+            else:
+                _merge_gpu_stall_metrics(metrics, updates)
+
+
+def close_gpu_stall_diagnostics_on_exit(method):
+    """Close an owner's optional diagnostics on every decorated method exit."""
+
+    @functools.wraps(method)
+    def wrapped(self, *args, **kwargs):
+        try:
+            return method(self, *args, **kwargs)
+        finally:
+            diagnostics = getattr(self, "_gpu_stall_diagnostics", None)
+            if diagnostics is not None:
+                try:
+                    diagnostics.close()
+                except Exception as error:
+                    logger.warning("GPU stall diagnostics could not close cleanly: %s", error)
+                finally:
+                    self._gpu_stall_diagnostics = None
+
+    return wrapped
+
+
+@dataclass(frozen=True)
+class _Device:
+    """An NVML device named by its physical PCI bus identifier."""
+
+    bus_id: str
+    handle: Any
+
+
+class _LocalNVMLSampler:
+    """Background NVML sampler that never raises into its caller."""
+
+    _MAX_CONSECUTIVE_DEVICE_FAILURES = 3
+
+    def __init__(self, sample_interval_s: float, zero_utilization_threshold: float):
+        self._sample_interval_s = sample_interval_s
+        self._zero_utilization_threshold = zero_utilization_threshold
+        self._samples: list[tuple[str, float]] = []
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._nvml: Any = None
+        self._devices: list[_Device] = []
+        self._failed_devices: set[str] = set()
+        self._consecutive_device_failures: dict[str, int] = {}
+        self._started = False
+
+    @staticmethod
+    def _pci_bus_id(pci_info: Any) -> str:
+        bus_id = getattr(pci_info, "busId", "unknown")
+        if isinstance(bus_id, bytes):
+            bus_id = bus_id.decode("utf-8")
+        return str(bus_id).lower()
+
+    @property
+    def device_count(self) -> int:
+        return len(self._devices)
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    def start(self) -> str | None:
+        """Start sampling, returning a reason when NVML cannot be used."""
+        if self._started:
+            return None
+        self._stop_event.clear()
+        self._failed_devices.clear()
+        self._consecutive_device_failures.clear()
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            self._nvml = pynvml
+            self._devices = [
+                _Device(
+                    bus_id=self._pci_bus_id(pynvml.nvmlDeviceGetPciInfo(handle)),
+                    handle=handle,
+                )
+                for handle in (pynvml.nvmlDeviceGetHandleByIndex(index) for index in range(pynvml.nvmlDeviceGetCount()))
+            ]
+        except Exception as error:
+            if self._nvml is not None:
+                try:
+                    self._nvml.nvmlShutdown()
+                except Exception:
+                    pass
+            self._nvml = None
+            self._devices = []
+            return f"NVML is unavailable: {error}"
+
+        if not self._devices:
+            try:
+                self._nvml.nvmlShutdown()
+            except Exception:
+                pass
+            self._nvml = None
+            return "NVML reports no GPU devices"
+
+        self._started = True
+        self._thread = threading.Thread(target=self._run, name="verl-gpu-stall-sampler", daemon=True)
+        self._thread.start()
+        return None
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._sample_interval_s):
+            self.sample_once()
+
+    def mark(self) -> int:
+        """Return a boundary that can be summarized later without resetting samples."""
+        with self._lock:
+            return len(self._samples)
+
+    def summarize_since(self, start: int) -> dict[str, dict[str, float]]:
+        """Summarize samples after ``start`` without disturbing overlapping phases."""
+        with self._lock:
+            samples = list(self._samples[start:])
+
+        grouped: dict[str, list[float]] = defaultdict(list)
+        for bus_id, utilization in samples:
+            grouped[bus_id].append(utilization)
+
+        summaries: dict[str, dict[str, float]] = {}
+        for bus_id, values in grouped.items():
+            count = len(values)
+            summaries[bus_id] = {
+                "mean": sum(values) / count,
+                "min": min(values),
+                "max": max(values),
+                "zero_fraction": sum(value <= self._zero_utilization_threshold for value in values) / count,
+                "sample_count": float(count),
+            }
+        return summaries
+
+    def sample_once(self) -> None:
+        """Collect one sample from each healthy NVML device for deterministic tests."""
+        for device in self._devices:
+            if device.bus_id in self._failed_devices:
+                continue
+            try:
+                utilization = float(self._nvml.nvmlDeviceGetUtilizationRates(device.handle).gpu)
+            except Exception as error:
+                failure_count = self._consecutive_device_failures.get(device.bus_id, 0) + 1
+                self._consecutive_device_failures[device.bus_id] = failure_count
+                if failure_count >= self._MAX_CONSECUTIVE_DEVICE_FAILURES:
+                    self._failed_devices.add(device.bus_id)
+                    logger.warning(
+                        "GPU stall diagnostics stopped sampling PCI device %s after %d consecutive NVML failures: %s",
+                        device.bus_id,
+                        failure_count,
+                        error,
+                    )
+                continue
+            self._consecutive_device_failures.pop(device.bus_id, None)
+            with self._lock:
+                self._samples.append((device.bus_id, utilization))
+
+    def snapshot_and_reset(self) -> dict[str, dict[str, float]]:
+        """Summarize samples since the previous boundary without division by zero."""
+        with self._lock:
+            samples = self._samples
+            self._samples = []
+
+        grouped: dict[str, list[float]] = defaultdict(list)
+        for bus_id, utilization in samples:
+            grouped[bus_id].append(utilization)
+
+        summaries: dict[str, dict[str, float]] = {}
+        for bus_id, values in grouped.items():
+            count = len(values)
+            summaries[bus_id] = {
+                "mean": sum(values) / count,
+                "min": min(values),
+                "max": max(values),
+                "zero_fraction": sum(value <= self._zero_utilization_threshold for value in values) / count,
+                "sample_count": float(count),
+            }
+        return summaries
+
+    def close(self) -> None:
+        """Stop the daemon thread and shut down NVML. Idempotent."""
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=self._sample_interval_s + 1.0)
+            if thread.is_alive():
+                logger.warning(
+                    "GPU stall diagnostics sampler thread did not stop before the join timeout; "
+                    "leaving NVML initialized so the thread can finish safely. Call close() again to retry cleanup."
+                )
+                return
+        self._thread = None
+        if self._nvml is not None:
+            try:
+                self._nvml.nvmlShutdown()
+            except Exception:
+                pass
+        self._nvml = None
+        self._devices = []
+        self._failed_devices.clear()
+        self._consecutive_device_failures.clear()
+        self._started = False
+
+
+class _NodeGPUStallSampler:
+    """Implementation run inside one Ray actor on one GPU node."""
+
+    def __init__(self, sample_interval_s: float, zero_utilization_threshold: float):
+        self._sampler = _LocalNVMLSampler(sample_interval_s, zero_utilization_threshold)
+        self._reason = self._sampler.start()
+        self._phase_starts: dict[str, int] = {}
+
+    def begin_phase(self, phase: str) -> None:
+        self._phase_starts[phase] = self._sampler.mark()
+
+    def end_phase(self, phase: str) -> tuple[dict[str, dict[str, float]], int, str | None]:
+        start = self._phase_starts.pop(phase, self._sampler.mark())
+        summary = self._sampler.summarize_since(start)
+        if not self._phase_starts:
+            self._sampler.snapshot_and_reset()
+        return summary, self._sampler.device_count, self._reason
+
+    def close(self) -> None:
+        self._sampler.close()
+
+
+class GPUStallDiagnostics:
+    """Coordinate node-local NVML samplers without affecting normal execution."""
+
+    _RPC_TIMEOUT_S = 5
+
+    def __init__(self, actors: list[Any], node_ids: list[str]):
+        self._actors = actors
+        self._node_ids = node_ids
+        self._closed = False
+        self._warned = False
+        logger.info("GPU stall diagnostics node index mapping: %s", dict(enumerate(node_ids)))
+
+    @classmethod
+    def create(cls, config: Any) -> GPUStallDiagnostics | None:
+        """Create a sampler actor per Ray GPU node only when explicitly enabled."""
+        if config is None or not getattr(config, "enable", False):
+            return None
+
+        actors: list[Any] = []
+        ray_module: Any = None
+        try:
+            import ray
+            from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+            ray_module = ray
+            nodes = sorted(
+                (
+                    node
+                    for node in ray.nodes()
+                    if node.get("Alive") and float(node.get("Resources", {}).get("GPU", 0)) > 0
+                ),
+                key=lambda node: node["NodeID"],
+            )
+            if not nodes:
+                logger.warning("GPU stall diagnostics disabled: Ray reports no live GPU nodes.")
+                return None
+
+            remote_cls = ray.remote(_NodeGPUStallSampler)
+            for node in nodes:
+                actor = remote_cls.options(
+                    num_cpus=0,
+                    num_gpus=0,
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(node_id=node["NodeID"], soft=False),
+                ).remote(config.sample_interval_s, config.zero_utilization_threshold)
+                actors.append(actor)
+            return cls(actors, [node["NodeID"] for node in nodes])
+        except Exception as error:
+            if ray_module is not None:
+                for actor_index, actor in enumerate(actors):
+                    try:
+                        ray_module.kill(actor, no_restart=True)
+                    except Exception as cleanup_error:
+                        logger.warning(
+                            "GPU stall diagnostics could not destroy partially created node sampler %d: %s",
+                            actor_index,
+                            cleanup_error,
+                        )
+            logger.warning("GPU stall diagnostics disabled: could not start node samplers: %s", error)
+            return None
+
+    def _warn_once(self, message: str, *args: object) -> None:
+        if not self._warned:
+            logger.warning(message, *args)
+            self._warned = True
+
+    def _begin_phase(self, phase: str) -> None:
+        if self._closed:
+            return
+        try:
+            import ray
+
+            ray.get([actor.begin_phase.remote(phase) for actor in self._actors], timeout=self._RPC_TIMEOUT_S)
+        except Exception as error:
+            self._warn_once("GPU stall diagnostics could not begin a phase: %s", error)
+
+    @staticmethod
+    def _metric_key(phase: str, node_index: int, suffix: str) -> str:
+        return f"gpu_stall/{phase}/node_{node_index}/{suffix}"
+
+    def _end_phase(self, phase: str) -> dict[str, float]:
+        if self._closed:
+            return {}
+        try:
+            import ray
+
+            summaries = ray.get([actor.end_phase.remote(phase) for actor in self._actors], timeout=self._RPC_TIMEOUT_S)
+        except Exception as error:
+            self._warn_once("GPU stall diagnostics could not finish phase %s: %s", phase, error)
+            return {}
+
+        metrics: dict[str, float] = {}
+        unavailable_nodes: list[int] = []
+        for node_index, (devices, device_count, reason) in enumerate(summaries):
+            if reason is not None:
+                unavailable_nodes.append(node_index)
+            metrics[self._metric_key(phase, node_index, "device_count")] = float(device_count)
+            sample_count = sum(value["sample_count"] for value in devices.values())
+            metrics[self._metric_key(phase, node_index, "sample_count")] = sample_count
+            if sample_count == 0:
+                continue
+
+            values = list(devices.values())
+            metrics[self._metric_key(phase, node_index, "utilization_mean")] = (
+                sum(value["mean"] * value["sample_count"] for value in values) / sample_count
+            )
+            metrics[self._metric_key(phase, node_index, "utilization_min")] = min(value["min"] for value in values)
+            metrics[self._metric_key(phase, node_index, "utilization_max")] = max(value["max"] for value in values)
+            metrics[self._metric_key(phase, node_index, "zero_utilization_fraction")] = (
+                sum(value["zero_fraction"] * value["sample_count"] for value in values) / sample_count
+            )
+
+            for bus_id, value in sorted(devices.items()):
+                safe_bus_id = bus_id.replace(":", "_").replace(".", "_")
+                metrics[self._metric_key(phase, node_index, f"gpu_{safe_bus_id}/sample_count")] = value["sample_count"]
+                metrics[self._metric_key(phase, node_index, f"gpu_{safe_bus_id}/utilization_mean")] = value["mean"]
+                metrics[self._metric_key(phase, node_index, f"gpu_{safe_bus_id}/zero_utilization_fraction")] = value[
+                    "zero_fraction"
+                ]
+
+        if unavailable_nodes:
+            self._warn_once("GPU stall diagnostics unavailable on node sampler(s): %s", unavailable_nodes)
+        return metrics
+
+    def begin_phase(self, phase: str) -> None:
+        """Start a named phase; phases may overlap without cross-contamination."""
+        self._begin_phase(phase)
+
+    def end_phase(self, phase: str) -> dict[str, float]:
+        """Finish a named phase and return its aggregate metric values."""
+        return self._end_phase(phase)
+
+    @contextmanager
+    def phase(self, phase: str) -> Iterator[dict[str, float]]:
+        """Collect continuous, bounded-rate samples during a named phase."""
+        metrics: dict[str, float] = {}
+        self._begin_phase(phase)
+        try:
+            yield metrics
+        finally:
+            metrics.update(self._end_phase(phase))
+
+    def close(self) -> None:
+        """Stop and destroy all Ray actors. Safe to call more than once."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            import ray
+        except Exception as error:
+            self._warn_once("GPU stall diagnostics could not cleanly stop: %s", error)
+            return
+
+        try:
+            ray.get([actor.close.remote() for actor in self._actors], timeout=self._RPC_TIMEOUT_S)
+        except Exception as error:
+            self._warn_once("GPU stall diagnostics could not cleanly stop: %s", error)
+
+        for actor_index, actor in enumerate(self._actors):
+            try:
+                ray.kill(actor, no_restart=True)
+            except Exception as error:
+                logger.warning("GPU stall diagnostics could not destroy node sampler %d: %s", actor_index, error)
+
+
+def start_gpu_stall_diagnostics(config: Any) -> GPUStallDiagnostics | None:
+    """Construct the optional coordinator without importing NVML while disabled."""
+    return GPUStallDiagnostics.create(config)


### PR DESCRIPTION
## Summary

Adds opt-in, phase-aware GPU stall diagnostics for PPO rollout investigation.

- Disabled by default.
- Samples node-local physical GPU utilization through lazy NVML imports in
  zero-GPU Ray sampler actors.
- Supports the built-in V1 `sync`, `colocate_async`, and `separate_async`
  trainers, plus the legacy `trainer.use_v1: false` controller.
- Emits low-cardinality node/phase aggregate metrics and bounded per-device
  PCI-keyed metrics.

## Scope

This PR is an observability feature for investigating the behavior reported in
#3114. It does not claim to fix or identify the root cause of that issue.

The diagnostics are independent of `global_profiler.tool` and do not modify
CUDA Graph configuration, `enforce_eager`, fused-kernel behavior, SGLang
arguments, cache lifecycle, or rollout scheduling behavior.

## Validation

- CPU-only sampler tests cover fake NVML, deterministic sampler-thread cleanup,
  transient and consecutive device failures, fake-Ray node filtering, strict
  placement, aggregation, RPC fail-open behavior, partial creation cleanup,
  and independent actor cleanup.
- CPU-only production-path tests cover V1 trainer selection, lifecycle wiring,
  phase boundaries, default-off behavior, all built-in V1 modes, metrics
  merging, exception and early-return cleanup, and the legacy validation-only
  path.
- The real-GPU qualification predates the cleanup hardening and V1 wiring. It
  validated the sampler coordinator only on one isolated local-Ray node and
  GPU 0 with real NVML. It did not start SGLang, NCCL, or a training workload.
- No real V1 training run or real multi-node GPU validation is claimed.
  Multi-node semantics are covered by fake-Ray CPU tests.

The local qualification environment exposed SGLang 0.5.2, but SGLang was not
started during that qualification. Current main declares SGLang 0.5.8 as a
static dependency fact; neither fact is presented as evidence of the root cause
of #3114.

Related to #3114
