### PR TITLE
[trainer] fix: exclude the never-routed final response token from rollout MoE load-balance metrics

### DIFF
--- a/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
@@ -131,6 +131,15 @@ def test_rollout_moe_load_balance_metrics_single_token_response_yields_nothing()
     assert compute_rollout_moe_load_balance_metrics(routed_experts, response_mask, num_experts=4) == {}
 
 
+def test_rollout_moe_load_balance_metrics_zero_width_response_mask_yields_nothing():
+    # A zero-width response mask must not crash (amax over an empty dim, and
+    # routed_experts[:, -0:] would silently select the whole tensor).
+    routed_experts = torch.zeros(1, 3, 1, 1, dtype=torch.long)
+    response_mask = torch.zeros(1, 0, dtype=torch.bool)
+
+    assert compute_rollout_moe_load_balance_metrics(routed_experts, response_mask, num_experts=4) == {}
+
+
 def test_rollout_moe_load_balance_accumulator_spans_updates():
     accumulator = RolloutMoELoadBalanceMetricsAccumulator()
     # one real record plus the trailing filler slot of the final sampled token

--- a/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
+++ b/tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py
@@ -30,6 +30,9 @@ from verl.trainer.ppo.metric_utils import (
 
 
 def test_rollout_moe_load_balance_metrics_response_tokens_only():
+    # The last valid response position holds zero-filler, not a routing
+    # record: the final sampled token never re-enters the model. Metrics must
+    # come from the four real records only.
     routed_experts = torch.tensor(
         [
             [
@@ -39,11 +42,12 @@ def test_rollout_moe_load_balance_metrics_response_tokens_only():
                 [[2, 3], [2, 2]],
                 [[0, 1], [2, 2]],
                 [[2, 3], [2, 2]],
+                [[0, 0], [0, 0]],
             ]
         ],
         dtype=torch.long,
     )
-    response_mask = torch.tensor([[True, True, True, True]], dtype=torch.bool)
+    response_mask = torch.tensor([[True, True, True, True, True]], dtype=torch.bool)
 
     metrics = compute_rollout_moe_load_balance_metrics(
         routed_experts=routed_experts,
@@ -70,12 +74,70 @@ def test_rollout_moe_load_balance_metrics_skips_invalid_inputs():
     )
 
 
+def test_rollout_moe_load_balance_metrics_last_token_filler_is_ignored():
+    # The final sampled token has no routing record; whatever the batch
+    # assembly left in its slot must not reach the counts. The default
+    # zero-fill would otherwise credit expert 0 with layers * topk phantom
+    # assignments per sequence.
+    real = torch.tensor([[[[1, 2]], [[3, 1]], [[2, 3]]]], dtype=torch.long)
+    response_mask = torch.ones(1, 4, dtype=torch.bool)
+    expected = torch.bincount(real.flatten(), minlength=4).unsqueeze(0)
+
+    for filler_value in (0, 3):
+        routed_experts = torch.cat([real, torch.full((1, 1, 1, 2), filler_value, dtype=torch.long)], dim=1)
+        counts = metric_utils._compute_rollout_moe_load_counts(
+            routed_experts=routed_experts, response_mask=response_mask, num_experts=4
+        )
+        assert torch.equal(counts, expected)
+    assert expected[0, 0] == 0  # no phantom expert-0 load
+
+
+def test_rollout_moe_load_balance_metrics_survive_negative_filler():
+    # A -1 sentinel in the never-routed last slot must not disable the whole
+    # metric via the expert-id range guard.
+    real = torch.tensor([[[[1, 2]], [[3, 1]]]], dtype=torch.long)
+    filler = torch.full((1, 1, 1, 2), -1, dtype=torch.long)
+    response_mask = torch.ones(1, 3, dtype=torch.bool)
+
+    metrics = compute_rollout_moe_load_balance_metrics(
+        routed_experts=torch.cat([real, filler], dim=1),
+        response_mask=response_mask,
+        num_experts=4,
+    )
+
+    assert metrics
+
+
+def test_rollout_moe_load_balance_metrics_drop_last_valid_per_sequence():
+    # Ragged batch: each sequence drops its own final valid position, not a
+    # shared column.
+    routed_experts = torch.zeros(2, 4, 1, 1, dtype=torch.long)
+    routed_experts[0, :, 0, 0] = torch.tensor([1, 2, 3, 0])  # filler at position 3
+    routed_experts[1, :, 0, 0] = torch.tensor([2, 0, 0, 0])  # filler at position 1
+    response_mask = torch.tensor([[True, True, True, True], [True, True, False, False]])
+
+    counts = metric_utils._compute_rollout_moe_load_counts(
+        routed_experts=routed_experts, response_mask=response_mask, num_experts=4
+    )
+
+    assert torch.equal(counts, torch.tensor([[0, 1, 2, 1]]))
+
+
+def test_rollout_moe_load_balance_metrics_single_token_response_yields_nothing():
+    # A one-token response consists solely of the never-routed final token.
+    routed_experts = torch.zeros(1, 1, 1, 1, dtype=torch.long)
+    response_mask = torch.ones(1, 1, dtype=torch.bool)
+
+    assert compute_rollout_moe_load_balance_metrics(routed_experts, response_mask, num_experts=4) == {}
+
+
 def test_rollout_moe_load_balance_accumulator_spans_updates():
     accumulator = RolloutMoELoadBalanceMetricsAccumulator()
-    response_mask = torch.tensor([[True]], dtype=torch.bool)
+    # one real record plus the trailing filler slot of the final sampled token
+    response_mask = torch.tensor([[True, True]], dtype=torch.bool)
 
     for expert_id in range(4):
-        routed_experts = torch.tensor([[[[expert_id]]]], dtype=torch.long)
+        routed_experts = torch.tensor([[[[expert_id]], [[0]]]], dtype=torch.long)
         assert accumulator.update(routed_experts=routed_experts, response_mask=response_mask, num_experts=4)
 
     assert accumulator.total_assignments() == 4
@@ -90,8 +152,8 @@ def test_rollout_moe_load_balance_accumulator_spans_updates():
 
 def test_rollout_moe_load_balance_accumulator_infers_num_experts(monkeypatch):
     accumulator = RolloutMoELoadBalanceMetricsAccumulator(model_config={"num_experts": 4})
-    response_mask = torch.tensor([[True]], dtype=torch.bool)
-    routed_experts = torch.tensor([[[[1]]]], dtype=torch.long)
+    response_mask = torch.tensor([[True, True]], dtype=torch.bool)
+    routed_experts = torch.tensor([[[[1]], [[0]]]], dtype=torch.long)
 
     monkeypatch.setattr(
         metric_utils,
@@ -107,8 +169,8 @@ def test_compute_moe_lb_metrics_accumulates_until_interval():
     accumulator = RolloutMoELoadBalanceMetricsAccumulator(model_config={"num_experts": 2})
     batch = SimpleNamespace(
         batch={
-            "routed_experts": torch.tensor([[[[0]], [[1]]]], dtype=torch.long),
-            "response_mask": torch.tensor([[True, True]], dtype=torch.bool),
+            "routed_experts": torch.tensor([[[[0]], [[1]], [[0]]]], dtype=torch.long),
+            "response_mask": torch.tensor([[True, True, True]], dtype=torch.bool),
         }
     )
 

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -207,7 +207,12 @@ def _compute_rollout_moe_load_counts(
     response_mask: torch.Tensor | None,
     num_experts: int | None,
 ) -> torch.Tensor | None:
-    """Count routed experts in response tokens as [num_layers, num_experts]."""
+    """Count routed experts in response tokens as [num_layers, num_experts].
+
+    Each sequence's last valid response position is excluded: that token is
+    sampled but never fed back through the model, so it carries no routing
+    record (its slot is filler, not data).
+    """
     if routed_experts is None or response_mask is None or num_experts is None or num_experts <= 0:
         return None
     if routed_experts.dim() != 4:
@@ -230,6 +235,17 @@ def _compute_rollout_moe_load_counts(
 
     response_routed_experts = routed_experts[:, -response_len:]
     response_mask = response_mask.to(device=response_routed_experts.device, dtype=torch.bool)
+    # The final response token is sampled but never fed back through the model,
+    # so it has no routing record; its slot holds filler from batch assembly
+    # (zeros, see AgentLoopWorker._postprocess). Counting it would credit
+    # expert 0 with num_layers * topk phantom assignments per sequence, so drop
+    # each sequence's last valid position. This is the metrics counterpart of
+    # build_r3_replay_mask, which skips the same row on the replay side.
+    positions = torch.arange(response_len, device=response_mask.device)
+    last_valid = torch.where(response_mask, positions, positions.new_full((), -1)).amax(dim=-1)
+    has_valid = last_valid >= 0
+    response_mask = response_mask.clone()
+    response_mask[has_valid.nonzero(as_tuple=True)[0], last_valid[has_valid]] = False
     selected = response_routed_experts[response_mask]
     selected = selected.detach().to(device="cpu", dtype=torch.long)
     if selected.numel() == 0:

--- a/verl/trainer/ppo/metric_utils.py
+++ b/verl/trainer/ppo/metric_utils.py
@@ -225,6 +225,8 @@ def _compute_rollout_moe_load_counts(
         return None
 
     response_len = response_mask.shape[1]
+    if response_len == 0:
+        return None
     if routed_experts.shape[1] < response_len:
         logger.warning(
             "routed_experts sequence length %s is shorter than response length %s",
@@ -244,8 +246,8 @@ def _compute_rollout_moe_load_counts(
     positions = torch.arange(response_len, device=response_mask.device)
     last_valid = torch.where(response_mask, positions, positions.new_full((), -1)).amax(dim=-1)
     has_valid = last_valid >= 0
-    response_mask = response_mask.clone()
-    response_mask[has_valid.nonzero(as_tuple=True)[0], last_valid[has_valid]] = False
+    is_last_valid = (positions.unsqueeze(0) == last_valid.unsqueeze(1)) & has_valid.unsqueeze(1)
+    response_mask = response_mask & ~is_last_valid
     selected = response_routed_experts[response_mask]
     selected = selected.detach().to(device="cpu", dtype=torch.long)
     if selected.numel() == 0:


### PR DESCRIPTION
### What does this PR do?

Fixes a systematic bias in the rollout MoE load-balance metrics introduced in #6853.

The last generated token of each sequence (EOS / max-length stop) is sampled but never fed back through the model, so it has **no routing record**: SGLang's capturer intentionally returns `seqlen - 1` records per request (see sgl-project/sglang#20964 for the design), and `AgentLoopWorker._postprocess` zero-fills the assembly buffer, leaving zeros at each sequence's last valid response position.

`_compute_rollout_moe_load_counts` selects response tokens via `response_mask`, which marks that position as valid (it is a real token — it just has no routing data), and bincounts the filler. Every sequence therefore credits expert 0 with `num_layers * topk` phantom assignments:

- expert 0's measured load is inflated by roughly `num_experts / avg_response_len` — ~6% relative at 2k response length with 128 experts, ~25% at 512, identically in every layer;
- the bias does not average out (every sequence contributes it) and looks exactly like a routing hotspot on expert 0 — in a metric whose purpose is to measure imbalance.

This PR drops each sequence's last valid response position before counting. It is the metrics-side counterpart of `build_r3_replay_mask` (#6473), which skips the same row on the replay side ("skip only the final response row, whose logits are not used"). It also makes the metric robust to a future negative sentinel filler, which today would silently disable the whole metric every step via the expert-id range guard.

### Checklist Before Starting

- [x] Search for similar PRs: https://github.com/verl-project/verl/pulls?q=is%3Apr+routed_experts+metrics
- [x] Format the PR title as `[{modules}] {type}: {description}`

### Test

`tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py`:

- Existing fixtures updated to carry an explicit trailing filler slot; **all original assertions are unchanged**, demonstrating that the same real records plus the structural filler row produce the same metrics.
- New tests:
  - `..._last_token_filler_is_ignored`: counts are independent of the filler value (0 or junk); no phantom expert-0 load.
  - `..._survive_negative_filler`: a `-1` sentinel in the never-routed slot no longer disables the whole metric via the range guard.
  - `..._drop_last_valid_per_sequence`: ragged batches drop each sequence's own final valid position, not a shared column.
  - `..._single_token_response_yields_nothing`: a one-token response consists solely of the never-routed token and contributes no counts.

Verification: without the fix, 8 of the 14 tests fail; with it, 14/14 pass.

### API and Usage Example

No API change. Metric keys and shapes are unchanged; only the counted token set is corrected.

### Design & Code Changes

- `verl/trainer/ppo/metric_utils.py`: in `_compute_rollout_moe_load_counts`, compute each row's last valid index from `response_mask` (vectorized, handles ragged masks and rows with no valid tokens) and clear it on a cloned mask before selecting tokens.
- `tests/trainer/ppo/test_rollout_moe_lb_metrics_on_cpu.py`: fixture updates + 4 new tests as above.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Apply pre-commit checks (ruff check + format pass on the changed files).
- [ ] Add / Update the documentation — not applicable (internal metric correctness).
- [x] Covered by unit tests in the existing CPU CI test file.
