### PR TITLE
[ckpt,trainer] feat: block-placement sharded delta sync + Automodel FSDP2+EP support

### DIFF
--- a/tests/checkpoint_engine/test_block_placement.py
+++ b/tests/checkpoint_engine/test_block_placement.py
@@ -67,7 +67,7 @@ def test_translate_matches_full_coordinates(full_shape, grid):
     full = torch.randn(full_shape)
     flat = full.reshape(-1)
     for place in _blocks_for_grid(full_shape, grid):
-        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
         local = full[slices].contiguous().reshape(-1)
         lidx = torch.arange(local.numel(), dtype=torch.int64)
         gidx = translate_flat_indices(lidx, place)
@@ -79,7 +79,7 @@ def test_translate_sparse_subset():
     torch.manual_seed(1)
     full = torch.randn(full_shape)
     place = BlockPlacement((2, 2, 6), (4, 2, 0), full_shape)
-    slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+    slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
     local = full[slices].contiguous().reshape(-1)
     lidx = torch.tensor([0, 5, 11, 23], dtype=torch.int64)
     gidx = translate_flat_indices(lidx, place)
@@ -121,12 +121,10 @@ def test_block_nan_rebuild_matches_full_convert_then_diff():
     # ep=4 x ep_shard=2 grid of blocks, like the (Shard(0), Shard(1)) expert mesh
     full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
     for place in _blocks_for_grid(full_shape, {0: 4, 1: 2}):
-        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape, strict=False))
         lo = old[slices].contiguous().reshape(-1)
         ln = new[slices].contiguous().reshape(-1)
-        changed = (
-            (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1)).any(dim=-1)
-        )
+        changed = (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1)).any(dim=-1)
         lidx = changed.nonzero(as_tuple=False).view(-1)
         buf = torch.full((lo.numel(),), float("nan"), dtype=old.dtype)
         buf[lidx] = ln[lidx]

--- a/tests/checkpoint_engine/test_block_placement.py
+++ b/tests/checkpoint_engine/test_block_placement.py
@@ -1,0 +1,151 @@
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the block-placement machinery behind FSDP+EP support.
+
+``BlockPlacement`` describes a rank's local shard as one hyper-rectangular block
+of the full tensor (e.g. automodel's grouped experts on the ``(ep, ep_shard)``
+mesh with ``(Shard(0), Shard(1))``). These tests pin down the two pure-math
+pieces the engine relies on -- the local->global flat index translation, and the
+NaN-sentinel full-tensor rebuild feeding a qwen3-moe-style ``to_hf`` permutation
+(per-expert slice + gate/up split + transpose) -- without torch.distributed.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+from verl.workers.engine.spec import BlockPlacement, translate_flat_indices
+
+
+def _blocks_for_grid(full_shape, grid):
+    """Split ``full_shape`` into an even grid of blocks; yield BlockPlacements.
+
+    ``grid`` maps tensor dim -> number of splits (even division assumed here;
+    uneven splits are covered by the distributed test via DTensor itself).
+    """
+    per_dim = []
+    for d, size in enumerate(full_shape):
+        n = grid.get(d, 1)
+        assert size % n == 0
+        step = size // n
+        per_dim.append([(o, step) for o in range(0, size, step)])
+    for combo in itertools.product(*per_dim):
+        goff = tuple(o for o, _ in combo)
+        lshape = tuple(sz for _, sz in combo)
+        yield BlockPlacement(lshape, goff, tuple(full_shape))
+
+
+def test_translate_int_fast_path():
+    lidx = torch.tensor([0, 3, 17], dtype=torch.int64)
+    assert torch.equal(translate_flat_indices(lidx, 0), lidx)
+    assert torch.equal(translate_flat_indices(lidx, 100), lidx + 100)
+
+
+@pytest.mark.parametrize(
+    "full_shape,grid",
+    [
+        ((8, 4, 6), {0: 4, 1: 2}),  # automodel experts: ep=4 x ep_shard=2 (Shard(0), Shard(1))
+        ((16, 8), {1: 4}),  # plain Shard(1)
+        ((6, 5, 7), {2: 7}),  # shard the last dim, odd sizes
+        ((12,), {0: 3}),  # 1-D block degenerates to the flat case
+    ],
+)
+def test_translate_matches_full_coordinates(full_shape, grid):
+    torch.manual_seed(0)
+    full = torch.randn(full_shape)
+    flat = full.reshape(-1)
+    for place in _blocks_for_grid(full_shape, grid):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+        local = full[slices].contiguous().reshape(-1)
+        lidx = torch.arange(local.numel(), dtype=torch.int64)
+        gidx = translate_flat_indices(lidx, place)
+        assert torch.equal(flat[gidx], local), f"block {place} mistranslated"
+
+
+def test_translate_sparse_subset():
+    full_shape = (8, 4, 6)
+    torch.manual_seed(1)
+    full = torch.randn(full_shape)
+    place = BlockPlacement((2, 2, 6), (4, 2, 0), full_shape)
+    slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+    local = full[slices].contiguous().reshape(-1)
+    lidx = torch.tensor([0, 5, 11, 23], dtype=torch.int64)
+    gidx = translate_flat_indices(lidx, place)
+    assert torch.equal(full.reshape(-1)[gidx], local[lidx])
+
+
+def _qwen3_style_to_hf(full_shape, inter_dim):
+    """Mimic the automodel expert closure: fused [n, dim, 2I] -> per-expert
+    gate/up [I, dim] via slice + split + transpose -- a pure permutation."""
+
+    def to_hf(shards):
+        (full_flat,) = shards
+        fused = full_flat.view(full_shape)
+        out = []
+        for e in range(full_shape[0]):
+            w = fused[e]
+            out.append((f"experts.{e}.gate_proj.weight", w[:, :inter_dim].transpose(0, 1)))
+            out.append((f"experts.{e}.up_proj.weight", w[:, inter_dim:].transpose(0, 1)))
+        return out
+
+    return to_hf
+
+
+def test_block_nan_rebuild_matches_full_convert_then_diff():
+    """Replicate the engine's block converter profile end to end on CPU:
+    per-block local diff -> translate-free local NaN rebuild -> slice-assign into
+    a full NaN tensor -> to_hf -> isnan scan == diff of the converted tensors."""
+    torch.manual_seed(2)
+    n_experts, dim, inter = 8, 4, 3
+    full_shape = (n_experts, dim, 2 * inter)
+    to_hf = _qwen3_style_to_hf(full_shape, inter)
+
+    old = torch.randn(full_shape, dtype=torch.bfloat16)
+    new = old.clone()
+    new[0, 1, 2] += 1.0
+    new[3, 0, 5] -= 0.5
+    new[7, 3, 0] += 0.25
+
+    # ep=4 x ep_shard=2 grid of blocks, like the (Shard(0), Shard(1)) expert mesh
+    full_nan = torch.full(full_shape, float("nan"), dtype=old.dtype)
+    for place in _blocks_for_grid(full_shape, {0: 4, 1: 2}):
+        slices = tuple(slice(o, o + sz) for o, sz in zip(place.global_offset, place.local_shape))
+        lo = old[slices].contiguous().reshape(-1)
+        ln = new[slices].contiguous().reshape(-1)
+        changed = (
+            (lo.view(torch.uint8).view(lo.numel(), -1) != ln.view(torch.uint8).view(ln.numel(), -1)).any(dim=-1)
+        )
+        lidx = changed.nonzero(as_tuple=False).view(-1)
+        buf = torch.full((lo.numel(),), float("nan"), dtype=old.dtype)
+        buf[lidx] = ln[lidx]
+        full_nan[slices] = buf.view(place.local_shape)
+
+    seen = 0
+    ref_new = dict(to_hf([new.reshape(-1)]))
+    ref_old = dict(to_hf([old.reshape(-1)]))
+    for hf_name, hf_tensor in to_hf([full_nan.reshape(-1)]):
+        fl = hf_tensor.reshape(-1)
+        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        rn, ro = ref_new[hf_name].reshape(-1), ref_old[hf_name].reshape(-1)
+        ref_changed = (
+            (rn.view(torch.uint8).view(rn.numel(), -1) != ro.view(torch.uint8).view(ro.numel(), -1))
+            .any(dim=-1)
+            .nonzero(as_tuple=False)
+            .view(-1)
+        )
+        assert torch.equal(pos, ref_changed), f"{hf_name}: positions diverge"
+        assert torch.equal(fl[pos], rn[pos]), f"{hf_name}: values diverge"
+        seen += int(pos.numel())
+    assert seen == 3

--- a/verl/checkpoint_engine/delta_checkpoint_engine.py
+++ b/verl/checkpoint_engine/delta_checkpoint_engine.py
@@ -42,12 +42,13 @@ import zmq
 with patch("importlib.metadata.distributions", return_value=[]):
     import cupy as cp
 
-from verl.workers.engine.spec import derive_placement
+from verl.workers.engine.spec import BlockPlacement, derive_placement, translate_flat_indices
 
 from .base import CheckpointEngineRegistry
 from .delta_sync.encode import DeltaFlush, DeltaParam
 from .delta_sync.encode import checksum as _checksum
 from .delta_sync.sparse_gather import (
+    gather_dense_blocks_to_rank0,
     gather_dense_to_rank0,
     gather_shards_to_rank0,
     gather_v_batched_to_rank0,
@@ -353,19 +354,30 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             snap.copy_(local, non_blocking=True)
             self._shard_snap[name] = snap
 
-            offset, contributes, pg = self._placement(name, spec)
+            place, contributes, pg = self._placement(name, spec)
             shard = local if contributes else torch.empty(0, dtype=local.dtype, device=local.device)
             if spec.to_hf is None:
                 # the spec's placements map the shard straight into the full tensor
                 if pg is None:
                     if is_r0 and contributes:
                         _bucket_dense(name, local.view(spec.full_shape))
+                elif isinstance(place, BlockPlacement):
+                    full = gather_dense_blocks_to_rank0(shard, place, group=pg)
+                    if is_r0 and full is not None:
+                        _bucket_dense(name, full.view(spec.full_shape))
                 else:
                     full = gather_dense_to_rank0(
-                        shard, offset if contributes else 0, _prodshape(spec.full_shape), group=pg
+                        shard, place if contributes else 0, _prodshape(spec.full_shape), group=pg
                     )
                     if is_r0 and full is not None:
                         _bucket_dense(name, full.view(spec.full_shape))
+            elif isinstance(place, BlockPlacement):
+                # block converter profile: assemble the full logical tensor from
+                # per-rank blocks, then convert -- to_hf receives ``[full]``.
+                full = gather_dense_blocks_to_rank0(shard, place, group=pg)
+                if is_r0 and full is not None:
+                    for hf_name, hf_tensor in spec.to_hf([full]):
+                        _bucket_dense(hf_name, hf_tensor)
             else:
                 # converter profile (e.g. Megatron): rebuild dense shards via to_hf
                 shards = gather_shards_to_rank0(shard, group=pg)
@@ -475,45 +487,89 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
 
         nan_group: list = []  # rebuild-profile params batched per gather_group
 
+        def _consume_hf(hf_name, hf_tensor):
+            nonlocal total_elems
+            fl = hf_tensor.reshape(-1)
+            total_elems += int(fl.numel())
+            pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+            if pos.numel():
+                # total_elems is added inside _consume too; compensate
+                total_elems -= int(fl.numel())
+                _consume(
+                    hf_name,
+                    str(fl.dtype).replace("torch.", ""),
+                    tuple(hf_tensor.shape),
+                    int(fl.numel()),
+                    pos,
+                    fl[pos],
+                )
+
         def _flush_nan_group():
             nonlocal nan_group, total_elems
             if not nan_group:
                 return
             pg = nan_group[0][2]
             dev = nan_group[0][5].device
+            is_block = isinstance(nan_group[0][7], BlockPlacement)
+            assert all(isinstance(g[7], BlockPlacement) == is_block for g in nan_group), (
+                "a converter gather group must be uniformly block- or flat-placed"
+            )
             idx_concat = torch.cat([g[5] for g in nan_group])
             val_concat = torch.cat([g[6] for g in nan_group])
             counts = torch.tensor([int(g[5].numel()) for g in nan_group], dtype=torch.int64, device=dev)
             gathered = gather_v_batched_to_rank0(idx_concat, val_concat, counts, group=pg, grouped=True)
+
+            blocks = None
+            if is_block:
+                # every rank ships its per-param (local_shape, global_offset); rank 0
+                # needs them to place each rank's NaN-rebuilt block into the full tensor.
+                import torch.distributed as dist
+
+                maxd = max(len(g[7].full_shape) for g in nan_group)
+                meta = torch.zeros(len(nan_group), 1 + 2 * maxd, dtype=torch.int64, device=dev)
+                for i, g in enumerate(nan_group):
+                    pl = g[7]
+                    d = len(pl.full_shape)
+                    meta[i, 0] = d
+                    meta[i, 1 : 1 + d] = torch.tensor(pl.local_shape, dtype=torch.int64)
+                    meta[i, 1 + d : 1 + 2 * d] = torch.tensor(pl.global_offset, dtype=torch.int64)
+                world = dist.get_world_size(pg)
+                metas = [torch.zeros_like(meta) for _ in range(world)]
+                dist.all_gather(metas, meta, group=pg)
+                blocks = [m.cpu().tolist() for m in metas]  # [world][K][1+2*maxd]
+
             if is_r0 and gathered is not None:
-                for (name, local_dtype, _pg, spec, shard_shape, _gi, _gv), per_rank in zip(
-                    nan_group, gathered, strict=False
+                for k, ((name, local_dtype, _pg, spec, shard_shape, _gi, _gv, place), per_rank) in enumerate(
+                    zip(nan_group, gathered, strict=False)
                 ):
-                    shard_list = []
-                    for gi, gv in per_rank:
-                        buf = torch.full(shard_shape, float("nan"), dtype=local_dtype, device=dev)
-                        buf.view(-1)[gi.to(torch.int64)] = gv  # index ops need Long
-                        shard_list.append(buf)
-                    for hf_name, hf_tensor in spec.to_hf(shard_list):
-                        fl = hf_tensor.reshape(-1)
-                        total_elems += int(fl.numel())
-                        pos = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
-                        if pos.numel():
-                            # total_elems is added inside _consume too; compensate
-                            total_elems -= int(fl.numel())
-                            _consume(
-                                hf_name,
-                                str(fl.dtype).replace("torch.", ""),
-                                tuple(hf_tensor.shape),
-                                int(fl.numel()),
-                                pos,
-                                fl[pos],
-                            )
+                    if is_block:
+                        # block converter profile: rebuild the FULL logical tensor with NaN
+                        # sentinels (per-rank slice assignment), then hand ``[full]`` to to_hf.
+                        full = torch.full(spec.full_shape, float("nan"), dtype=local_dtype, device=dev)
+                        for r, (gi, gv) in enumerate(per_rank):
+                            m = blocks[r][k]
+                            d = int(m[0])
+                            lshape = [int(x) for x in m[1 : 1 + d]]
+                            goff = [int(x) for x in m[1 + d : 1 + 2 * d]]
+                            buf = torch.full((_prodshape(lshape),), float("nan"), dtype=local_dtype, device=dev)
+                            buf[gi.to(torch.int64)] = gv  # index ops need Long
+                            slices = tuple(slice(o, o + sz) for o, sz in zip(goff, lshape, strict=False))
+                            full[slices] = buf.view(lshape)
+                        for hf_name, hf_tensor in spec.to_hf([full.reshape(-1)]):
+                            _consume_hf(hf_name, hf_tensor)
+                    else:
+                        shard_list = []
+                        for gi, gv in per_rank:
+                            buf = torch.full(shard_shape, float("nan"), dtype=local_dtype, device=dev)
+                            buf.view(-1)[gi.to(torch.int64)] = gv  # index ops need Long
+                            shard_list.append(buf)
+                        for hf_name, hf_tensor in spec.to_hf(shard_list):
+                            _consume_hf(hf_name, hf_tensor)
             nan_group = []
 
         for name, local, spec in weights:
             local = local.detach().contiguous().view(-1)
-            offset, contributes, pg = self._placement(name, spec)
+            place, contributes, pg = self._placement(name, spec)
             snap = self._shard_snap.get(name)
             if snap is None or snap.numel() != local.numel():
                 snap = torch.empty_like(local, device="cpu", pin_memory=True)
@@ -534,7 +590,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
                     _flush_nan_group()
                 # shard-local coordinates are bounded by the shard's numel, so the
                 # full-tensor <2^31 assert in _assemble_flush covers them too.
-                nan_group.append((name, local.dtype, pg, spec, tuple(local.shape), lidx.to(torch.int32), lval))
+                nan_group.append((name, local.dtype, pg, spec, tuple(local.shape), lidx.to(torch.int32), lval, place))
                 if len(nan_group) >= max(batch_k, 1):
                     _flush_nan_group()
                 continue
@@ -542,7 +598,7 @@ class DeltaShardedCheckpointEngine(NCCLCheckpointEngine):
             # placement profile: translate rank-locally, gather without boundaries.
             # int32 halves the gather's position bytes; the wire is int32 anyway and
             # the per-parameter <2^31 assert in _assemble_flush covers the range.
-            gidx = ((lidx + offset) if lidx.numel() else lidx).to(torch.int32)
+            gidx = (translate_flat_indices(lidx, place) if lidx.numel() else lidx).to(torch.int32)
             gval = lval
             full_numel = _prodshape(spec.full_shape)
             if group and group[-1][6] is not pg:

--- a/verl/checkpoint_engine/delta_sync/sparse_gather.py
+++ b/verl/checkpoint_engine/delta_sync/sparse_gather.py
@@ -171,6 +171,53 @@ def gather_dense_to_rank0(
     return full
 
 
+def gather_dense_blocks_to_rank0(
+    local_val: torch.Tensor,
+    place,
+    group=None,
+) -> torch.Tensor | None:
+    """Assemble a full flat parameter on rank 0 from per-rank hyper-rectangular blocks.
+
+    Block-placement counterpart of :func:`gather_dense_to_rank0`: each rank's shard
+    is one block ``full[o0:o0+l0, ...]`` described by ``place`` (a
+    ``BlockPlacement``), not a contiguous flat range. Each rank ships
+    ``(local_shape, global_offset)`` in a fixed-size meta all_gather, then the
+    values ride one padded gather; rank 0 slice-assigns every block into the full
+    tensor. Returns the flat full tensor on rank 0, ``None`` elsewhere.
+    """
+    rank = dist.get_rank(group)
+    world = dist.get_world_size(group)
+    dst = dist.get_global_rank(group, 0) if group is not None else 0
+    dev = local_val.device
+    ndim = len(place.full_shape)
+
+    n = int(local_val.numel())
+    meta = torch.tensor([n, *place.local_shape, *place.global_offset], dtype=torch.long, device=dev)
+    metas = [torch.zeros(1 + 2 * ndim, dtype=torch.long, device=dev) for _ in range(world)]
+    dist.all_gather(metas, meta, group=group)
+    metas_cpu = torch.stack(metas).cpu().tolist()
+    counts = [int(m[0]) for m in metas_cpu]
+    max_n = max(counts) if counts else 0
+    if max_n == 0:
+        return torch.empty(0, dtype=local_val.dtype, device=dev) if rank == 0 else None
+
+    val_pad = torch.zeros(max_n, dtype=local_val.dtype, device=dev)
+    val_pad[:n] = local_val
+    val_list = [torch.zeros(max_n, dtype=local_val.dtype, device=dev) for _ in range(world)] if rank == 0 else None
+    dist.gather(val_pad, val_list, dst=dst, group=group)
+    if rank != 0:
+        return None
+    full = torch.empty(place.full_shape, dtype=local_val.dtype, device=dev)
+    for r in range(world):
+        if not counts[r]:
+            continue
+        lshape = [int(x) for x in metas_cpu[r][1 : 1 + ndim]]
+        goff = [int(x) for x in metas_cpu[r][1 + ndim : 1 + 2 * ndim]]
+        slices = tuple(slice(o, o + sz) for o, sz in zip(goff, lshape, strict=False))
+        full[slices] = val_list[r][: counts[r]].view(lshape)
+    return full.reshape(-1)
+
+
 def gather_v_grouped_to_rank0(
     local_idx: torch.Tensor,
     local_val: torch.Tensor,

--- a/verl/trainer/config/actor/automodel_actor.yaml
+++ b/verl/trainer/config/actor/automodel_actor.yaml
@@ -1,0 +1,18 @@
+# automodel actor config, inheriting from trainer/config/actor/actor.yaml
+defaults:
+  # automodel optimizer config
+  - ../optim@optim: automodel
+
+  # automodel engine config
+  - ../engine@automodel: automodel
+
+  - actor
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
+_target_: verl.workers.config.AutomodelActorConfig
+
+strategy: automodel
+
+use_remove_padding: ${oc.select:actor_rollout_ref.model.use_remove_padding,false}

--- a/verl/trainer/config/critic/automodel_critic.yaml
+++ b/verl/trainer/config/critic/automodel_critic.yaml
@@ -1,0 +1,22 @@
+# defaults specify the default config from each component
+defaults:
+
+  # automodel optimizer config
+  - ../optim@optim: automodel
+
+  # automodel engine config
+  - ../engine@automodel: automodel
+
+  # critic config, inheriting from trainer/config/critic/critic.yaml
+  - critic
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
+# Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+_target_: verl.workers.config.AutomodelCriticConfig
+
+strategy: automodel
+
+# seed for data loader
+data_loader_seed: ${oc.select:actor_rollout_ref.actor.data_loader_seed,null}

--- a/verl/trainer/config/model_engine/automodel.yaml
+++ b/verl/trainer/config/model_engine/automodel.yaml
@@ -1,0 +1,2 @@
+# @package _global_
+model_engine: automodel

--- a/verl/trainer/config/ref/automodel_ref.yaml
+++ b/verl/trainer/config/ref/automodel_ref.yaml
@@ -1,0 +1,24 @@
+# automodel ref config, inheriting from trainer/config/ref/ref.yaml
+defaults:
+  - ref
+
+  # automodel engine config
+  - ../engine@automodel: automodel
+
+  # load the reference default config, then apply the fields in the current yaml
+  - _self_
+
+_target_: verl.workers.config.AutomodelActorConfig
+
+strategy: automodel
+
+automodel:
+  tp_size: ${oc.select:actor_rollout_ref.actor.automodel.tp_size,1}
+  cp_size: ${oc.select:actor_rollout_ref.actor.automodel.cp_size,1}
+  ep_size: ${oc.select:actor_rollout_ref.actor.automodel.ep_size,1}
+  dp_replicate_size: ${oc.select:actor_rollout_ref.actor.automodel.dp_replicate_size,1}
+  distributed_strategy: ${oc.select:actor_rollout_ref.actor.automodel.distributed_strategy,fsdp2}
+  attn_implementation: ${oc.select:actor_rollout_ref.actor.automodel.attn_implementation,sdpa}
+  model_dtype: ${oc.select:actor_rollout_ref.actor.automodel.model_dtype,bf16}
+  backend_config: ${oc.select:actor_rollout_ref.actor.automodel.backend_config,null}
+  forward_only: True

--- a/verl/workers/config/actor.py
+++ b/verl/workers/config/actor.py
@@ -24,6 +24,7 @@ from verl.utils.qat import QATConfig
 
 from .checkpoint import McoreCheckpointConfig, MindSpeedCheckpointConfig
 from .engine import (
+    AutomodelEngineConfig,
     FSDPEngineConfig,
     McoreEngineConfig,
     MindSpeedEngineConfig,
@@ -39,6 +40,7 @@ __all__ = [
     "ActorConfig",
     "FSDPActorConfig",
     "McoreActorConfig",
+    "AutomodelActorConfig",
     "VeOmniActorConfig",
     "QATConfig",
     "TorchTitanActorConfig",
@@ -367,6 +369,26 @@ class VeOmniActorConfig(ActorConfig):
                 "configuration for MoE routing replay. Set "
                 "actor.use_remove_padding=True or router_replay.mode='disabled'."
             )
+
+
+@dataclass
+class AutomodelActorConfig(ActorConfig):
+    """Configuration for Automodel (nemo_automodel) actor models.
+
+    Args:
+        strategy (str): Training strategy set to 'automodel'.
+        automodel (AutomodelEngineConfig): Automodel engine settings (FSDP2/EP/TP/CP).
+    """
+
+    strategy: str = "automodel"
+    automodel: AutomodelEngineConfig = field(default_factory=AutomodelEngineConfig)
+    use_remove_padding: bool = False
+    use_rollout_log_probs: bool = False
+
+    def __post_init__(self):
+        """Validate Automodel actor configuration parameters."""
+        super().__post_init__()
+        self.engine = self.automodel
 
 
 @dataclass

--- a/verl/workers/config/critic.py
+++ b/verl/workers/config/critic.py
@@ -23,6 +23,7 @@ from verl.utils.profiler import ProfilerConfig
 
 from .checkpoint import McoreCheckpointConfig, MindSpeedCheckpointConfig
 from .engine import (
+    AutomodelEngineConfig,
     FSDPEngineConfig,
     McoreEngineConfig,
     MindSpeedEngineConfig,
@@ -39,6 +40,7 @@ __all__ = [
     "TorchTitanCriticConfig",
     "FSDPCriticModelCfg",
     "MindSpeedCriticConfig",
+    "AutomodelCriticConfig",
     "VeOmniCriticConfig",
 ]
 
@@ -303,6 +305,27 @@ class MindSpeedCriticConfig(CriticConfig):
     def validate(self, n_gpus: int, train_batch_size: int):
         """Validate mindspeed critic configuration with runtime parameters."""
         super().validate(n_gpus, train_batch_size)
+
+
+@dataclass
+class AutomodelCriticConfig(CriticConfig):
+    """Configuration for Automodel (nemo_automodel) critic model training.
+
+    Mirrors AutomodelActorConfig for the critic role.
+
+    Args:
+        strategy (str): Training strategy set to 'automodel'.
+        automodel (AutomodelEngineConfig): Automodel engine configuration.
+    """
+
+    strategy: str = "automodel"
+    automodel: AutomodelEngineConfig = field(default_factory=AutomodelEngineConfig)
+    grad_clip: float = 1.0
+
+    def __post_init__(self):
+        """Set engine to Automodel config."""
+        super().__post_init__()
+        self.engine = self.automodel
 
 
 @dataclass

--- a/verl/workers/engine/automodel/transformer_impl.py
+++ b/verl/workers/engine/automodel/transformer_impl.py
@@ -420,6 +420,63 @@ class AutomodelEngine(BaseEngine):
         if self._is_offload_optimizer and self.optimizer is not None:
             offload_automodel_optimizer(self.optimizer)
 
+    def get_per_tensor_param_shard(self, **kwargs):
+        """Yield each rank's *local* shard with its declarative :class:`ShardSpec` --
+        consumed by the ``delta_sharded`` checkpoint engine, which diffs on shards
+        and gathers only the changes.
+
+        Dense (non-expert) params pass their DTensor placement through verbatim
+        (FSDP2 ``Shard(0)``: existing flat fast path). Grouped-expert params
+        (``experts.gate_and_up_projs`` / ``experts.down_projs``) live on the 2-D
+        ``(ep, ep_shard)`` MoE mesh as ``(Shard(0), Shard(1))``; their spec carries a
+        ``to_hf`` closure over the model's HF state-dict adapter (a pure permutation:
+        per-expert slice + gate/up split + transpose), so the engine's block
+        converter profile rebuilds the fused tensor and emits per-expert HF names.
+        Requires ``backend_config.enable_hf_state_dict_adapter=true`` for MoE.
+        """
+        load_automodel_model_to_gpu(self.module)
+        params = self.module.state_dict()
+        params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
+
+        device = get_device_id()
+        adapter = getattr(self.module, "state_dict_adapter", None)
+
+        from ..spec import ShardSpec
+
+        def _expert_to_hf(fqn, full_shape):
+            def to_hf(shards):
+                # Block profile (ep_shard > 1) hands [full]; the flat Shard(0)
+                # profile (ep_shard == 1: experts split only across ep ranks)
+                # hands per-rank flat shards in group rank order, whose
+                # concatenation IS the full flat tensor (row split).
+                full_flat = shards[0] if len(shards) == 1 else torch.cat([sh.reshape(-1) for sh in shards])
+                return adapter.convert_single_tensor_to_hf(fqn, full_flat.view(full_shape))
+
+            return to_hf
+
+        def _gen():
+            for name, param in params.items():
+                is_grouped_expert = name.endswith((".gate_and_up_projs", ".down_projs")) and ".experts" in name
+                spec = ShardSpec.from_param(param)
+                if is_grouped_expert:
+                    assert adapter is not None, (
+                        "grouped-expert export needs the model's HF state-dict adapter; "
+                        "set backend_config.enable_hf_state_dict_adapter=true"
+                    )
+                    spec = ShardSpec(
+                        full_shape=spec.full_shape,
+                        mesh=spec.mesh,
+                        placements=spec.placements,
+                        to_hf=_expert_to_hf(name, spec.full_shape),
+                    )
+                p = param.to(device, non_blocking=True)
+                if p.is_floating_point():
+                    p = p.to(torch.bfloat16, non_blocking=True)
+                local = p.to_local() if hasattr(p, "to_local") else p
+                yield name, local.reshape(-1), spec
+
+        return _gen(), None
+
     def get_per_tensor_param(self, **kwargs):
         load_automodel_model_to_gpu(self.module)
 

--- a/verl/workers/engine/spec.py
+++ b/verl/workers/engine/spec.py
@@ -39,7 +39,7 @@ import torch
 from torch.distributed.tensor import DTensor
 from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
 
-__all__ = ["ShardSpec", "derive_placement"]
+__all__ = ["BlockPlacement", "ShardSpec", "derive_placement", "translate_flat_indices"]
 
 
 @dataclass
@@ -68,17 +68,75 @@ def _prod(xs) -> int:
     return n
 
 
+def _row_major_strides(shape) -> tuple:
+    strides, acc = [], 1
+    for d in reversed([int(x) for x in shape]):
+        strides.append(acc)
+        acc *= d
+    return tuple(reversed(strides))
+
+
+@dataclass(frozen=True)
+class BlockPlacement:
+    """This rank's local shard is one hyper-rectangular block of the full tensor:
+    ``full[o0:o0+l0, o1:o1+l1, ...]`` with ``local_shape=(l0, l1, ...)`` and
+    ``global_offset=(o0, o1, ...)``. Produced by :func:`derive_placement` whenever
+    the block is not a contiguous range of the flat full tensor (e.g. ``Shard(1)``,
+    or EP x FSDP ``(Shard(0), Shard(1))``); the flat-contiguous case stays a plain
+    ``int`` offset so the existing fast path is untouched."""
+
+    local_shape: tuple
+    global_offset: tuple
+    full_shape: tuple
+
+    @property
+    def local_strides(self) -> tuple:
+        return _row_major_strides(self.local_shape)
+
+    @property
+    def full_strides(self) -> tuple:
+        return _row_major_strides(self.full_shape)
+
+
+def translate_flat_indices(lidx: torch.Tensor, place) -> torch.Tensor:
+    """Map shard-local flat positions to full-tensor flat positions.
+
+    ``place`` is what :func:`derive_placement` returned: an ``int`` when the local
+    shard is a contiguous flat range (translate = add), else a :class:`BlockPlacement`
+    (mixed-radix decompose by the local shape, add the per-dim offset, recompose with
+    the full-tensor strides -- a few divmods on the nnz tensor, no collectives).
+    """
+    if isinstance(place, int):
+        return lidx + place if place else lidx
+    out = torch.zeros_like(lidx)
+    rem = lidx
+    for lstride, off, fstride in zip(place.local_strides, place.global_offset, place.full_strides, strict=False):
+        coord = torch.div(rem, lstride, rounding_mode="floor")
+        rem = rem - coord * lstride
+        out = out + (coord + int(off)) * fstride
+    return out
+
+
 def derive_placement(spec: ShardSpec):
-    """Derive ``(flat_offset, contributes, gather_group)`` for THIS rank from the spec.
+    """Derive ``(place, contributes, gather_group)`` for THIS rank from the spec.
 
-    * unsharded (``mesh is None``): offset 0; only global rank 0 contributes; no group
+    ``place`` feeds :func:`translate_flat_indices`:
+
+    * unsharded (``mesh is None``): ``0``; only global rank 0 contributes; no group
       (the local tensor is already the full parameter).
-    * ``Shard(0)`` over one mesh dim (+ any number of ``Replicate`` dims): the flat
-      offset comes from ``compute_local_shape_and_global_offset`` (pure math, no
-      collective); only ranks at coordinate 0 of every Replicate dim contribute; the
-      gather group is the Shard dim's subgroup.
+    * flat-contiguous block (``Shard(0)`` over one mesh dim + any number of
+      ``Replicate`` dims -- the FSDP2 default): a plain ``int`` flat offset from
+      ``compute_local_shape_and_global_offset`` (pure math, no collective); only
+      ranks at coordinate 0 of every Replicate dim contribute; the gather group is
+      the Shard dim's subgroup.
+    * any other single block (``Shard(k)``, or several Shard dims, e.g. automodel's
+      EP x FSDP ``(Shard(0), Shard(1))`` expert mesh): a :class:`BlockPlacement`;
+      with more than one Shard dim every rank holds a distinct block, the gather
+      group spans the whole mesh (created once and cached by the engine's caller),
+      and Replicate dims are not supported alongside multiple Shard dims.
 
-    Other shard dims raise -- same scope as the export that produces the spec.
+    ``_StridedShard`` placements (interleaved local tensors, from some HSDP/TP
+    orderings) are rejected: the local tensor is not a single block.
     """
     import torch.distributed as dist
 
@@ -86,13 +144,13 @@ def derive_placement(spec: ShardSpec):
         return 0, (dist.get_rank() == 0 if dist.is_initialized() else True), None
 
     placements = spec.placements
-    shard_dims = [d for d, p in enumerate(placements) if p.is_shard()]
-    for d in shard_dims:
-        if placements[d].dim != 0:
+    for p in placements:
+        if type(p).__name__ == "_StridedShard":
             raise NotImplementedError(
-                f"sharded delta only supports Shard(0) (FSDP2 default); got placements={placements}"
+                f"sharded delta does not support _StridedShard (local tensor is not one block); "
+                f"got placements={placements}"
             )
-    assert len(shard_dims) <= 1, f"at most one Shard dim is supported; got placements={placements}"
+    shard_dims = [d for d, p in enumerate(placements) if p.is_shard()]
 
     coord = spec.mesh.get_coordinate()
     contributes = True
@@ -106,8 +164,40 @@ def derive_placement(spec: ShardSpec):
         # replicated across every mesh dim: full tensor on each rank, no gather
         return 0, contributes, None
 
-    _, global_offset = compute_local_shape_and_global_offset(spec.full_shape, spec.mesh, list(placements))
-    inner = _prod(spec.full_shape[1:])
-    offset = int(global_offset[0]) * inner
-    group = spec.mesh.get_group(mesh_dim=shard_dims[0])
-    return offset, contributes, group
+    local_shape, global_offset = compute_local_shape_and_global_offset(spec.full_shape, spec.mesh, list(placements))
+
+    if len(shard_dims) == 1:
+        group = spec.mesh.get_group(mesh_dim=shard_dims[0])
+        tdim = placements[shard_dims[0]].dim
+        if tdim == 0:
+            # flat-contiguous: rows [o0, o0+l0) of the flat tensor
+            return int(global_offset[0]) * _prod(spec.full_shape[1:]), contributes, group
+        return BlockPlacement(tuple(local_shape), tuple(global_offset), tuple(spec.full_shape)), contributes, group
+
+    # several Shard dims: every rank owns a distinct block; gather spans the whole mesh.
+    assert all(p.is_shard() for p in placements), (
+        f"Replicate dims are not supported alongside multiple Shard dims; got placements={placements}"
+    )
+    group = _flattened_mesh_group(spec.mesh)
+    return BlockPlacement(tuple(local_shape), tuple(global_offset), tuple(spec.full_shape)), contributes, group
+
+
+_FLAT_GROUPS: dict = {}
+
+
+def _flattened_mesh_group(mesh):
+    """One process group spanning every rank of ``mesh``, created once per mesh.
+
+    ``dist.new_group`` must be called by all processes in the same order; every
+    trainer rank walks the export in an identical order, so the cache stays in
+    lockstep. The group's rank 0 is the mesh's smallest global rank, which keeps
+    the gathered result on the engine master whenever it is part of the mesh.
+    """
+    import torch.distributed as dist
+
+    ranks = tuple(sorted(int(r) for r in mesh.mesh.flatten().tolist()))
+    got = _FLAT_GROUPS.get(ranks)
+    if got is None:
+        got = dist.new_group(list(ranks))
+        _FLAT_GROUPS[ranks] = got
+    return got

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -146,11 +146,14 @@ def _masked_copy():
     orig_copy = torch.Tensor.copy_
 
     def masked_copy_(self, src, *args, **kwargs):
+        # Sync-free masked overwrite: boolean advanced indexing (and a
+        # ``mask.all()`` early-out) would force a device->host sync per
+        # parameter -- ruinous for MoE flushes carrying >10k per-expert
+        # entries. ``torch.where`` keeps everything on-stream; a NaN-free
+        # (dense) source degenerates to a plain copy.
         if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
-            mask = ~torch.isnan(src)
-            if not bool(mask.all()):
-                self[mask] = src[mask].to(self.dtype)
-                return self
+            cast = src.to(self.dtype)
+            return orig_copy(self, torch.where(torch.isnan(cast), self, cast))
         return orig_copy(self, src, *args, **kwargs)
 
     torch.Tensor.copy_ = masked_copy_


### PR DESCRIPTION
## What does this PR do?

Extends the sharded delta weight sync (`delta_sharded`, #6974) beyond the flat FSDP2 `Shard(0)` fast path to **block placements** — `Shard(k)` and multi-Shard-dim meshes — and wires the **Automodel (nemo_automodel) engine with expert parallelism** into it end to end. Item 1 of the roadmap in #7060, and the `Shard(1)` support requested in the #6974 review.

### Engine: block placement

- `ShardSpec` gains `BlockPlacement` (`local_shape`, `global_offset`): a rank's shard as one hyper-rectangular block of the full tensor. `translate_flat_indices` maps shard-local flat positions to full-tensor flat positions (mixed-radix decompose + per-dim offset + recompose); the existing `int` flat-offset fast path is untouched, so FSDP2 `Shard(0)` behavior is bit-identical.
- `derive_placement`: `Shard(k!=0)` and multi-Shard-dim placements (e.g. an `(ep, ep_shard)` expert mesh with `(Shard(0), Shard(1))`) return a `BlockPlacement`; multi-Shard meshes gather over one flattened whole-mesh group (created once, cached). `_StridedShard` and Replicate-alongside-multi-Shard are rejected loudly.
- Dense first sync places per-rank blocks via `gather_dense_blocks_to_rank0` (fixed-size block-meta all_gather + padded gather + rank-0 slice assignment).
- The converter (`to_hf`) profile gains a block variant: rebuild the **full** logical tensor with NaN sentinels (per-rank block slice-assign), then hand `[full]` to `to_hf`. The Megatron-style shard-list contract is unchanged.

### Automodel + EP

- `AutomodelEngine.get_per_tensor_param_shard`: dense params pass their DTensor placement through verbatim; grouped experts (`experts.gate_and_up_projs` / `experts.down_projs` on the `(ep, ep_shard)` moe mesh) carry a `to_hf` closure over the model's HF state-dict adapter — a pure permutation (per-expert slice + gate/up split + transpose), so the NaN-sentinel rebuild emits classic per-expert HF names that SGLang's loader consumes directly. The `ep_shard == 1` degenerate case (experts split only across `ep`) takes the flat `Shard(0)` profile; the closure accepts both.
- PPO wiring: `model_engine=automodel` hydra group (actor/ref/critic configs mirroring the veomni wiring; the SFT-side engine and optim configs are reused). Previously automodel was SFT-only.
- Sync-free masked apply in the SGLang delta loader: the previous masked `copy_` hook did a `bool(mask.all())` early-out plus boolean indexing **per parameter** — each a device→host sync. MoE flushes carry >10k per-expert entries (vs a few hundred for dense models), which pushed a single flush apply past the server adapter's HTTP timeout. Rewritten as an on-stream `torch.where` copy.

## Test

- CPU: `tests/checkpoint_engine/test_block_placement.py` — translate math against full-tensor coordinates (incl. `(8,4,6)` split ep=4 × shard=2, `Shard(1)`, odd sizes), and the block NaN rebuild against a qwen3-moe-style conversion (slice+split+transpose), bit-exact. Existing checkpoint-engine suites pass (18 total).
- E2E: Qwen3-30B-A3B-Instruct, automodel `ep_size=4` (moe mesh `(ep_shard, ep)=(2,4)`, placements `(Shard(1), Shard(0))`) + FSDP2 dense params, SGLang rollout TP4, 2×8 GPU disaggregated, `delta_sharded`: 3/3 GRPO steps green, steady-state `update_weights` 9.6–12.3 s, `changed_ratio` 0.15–0.5%, no HTTP retries. (`ep_size=8` / `ep_shard=1` degenerate profile also exercised.)
- Regression: 0.5B FSDP2 `delta_sharded` smoke on this branch (flat fast path) — running, will report in a comment.

## Notes for reviewers

- nemo-automodel API drift: verl's automodel engine targets the **0.4.0** API (`create_device_mesh`, `MoEParallelizerConfig`); 0.5.0 and current main renamed these, so the engine does not import there. This PR follows the existing 0.4.0-era code; tracking the rename is left to the automodel engine owners.
- The expert-mesh placements tuple order follows **mesh dim order**, not tensor dim order (`(ep_shard, ep)` mesh ⇒ `(Shard(1), Shard(0))`); all placement math goes through `compute_local_shape_and_global_offset`, so no ordering assumptions are made.
- veomni/torchtitan EP express the expert split outside DTensor placements (rank-local expert namespaces); they need the converter route with an expert-id renaming closure and are follow-ups per #7060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
