### PR TITLE
[veomni] feat: EP-aware sharded delta export (fused expert stacks)

### DIFF
--- a/docs/advance/delta_weight_sync.md
+++ b/docs/advance/delta_weight_sync.md
@@ -73,7 +73,8 @@ checkpoint engine (including the V1 ``separate_async`` trainer).
   ``get_per_tensor_param_delta_shard()`` — per-parameter entries ``(slots, dtype_str, counts,
   hf_idx, hf_val, gather_group)`` whose coordinates are already final HF coordinates. The engine
   only batches, gathers, buckets and ships.
-- **Diff (backend-owned)**: the default strategy (``verl.workers.engine.utils.hf_delta_export``) byte-diffs each rank's **own shard** against its
+- **Diff (backend-owned)**: the default strategy (shared by the FSDP and veomni backends via
+  ``verl.workers.engine.utils.hf_delta_export``) byte-diffs each rank's **own shard** against its
   pinned-CPU snapshot, refreshed on every export (no rank holds a full-model snapshot). The
   comparison is bit-exact (integer view inequality), so the reconstruction is lossless by
   construction — no thresholds, no drift. A backend that already keeps the previous step's weights
@@ -144,17 +145,22 @@ SGLang rollout, per-step steady-state weight sync. The ``nccl`` baseline is curr
 | Qwen2.5-32B (2+2 nodes) | **11.2-11.9 s** | 17.7-18.1 s | 1.55x |
 | Qwen2.5-32B (2+2 nodes, offload off) | **6.2 s** | 14.2 s | 2.3x |
 | Qwen2.5-72B (4+4 nodes, gen TP8, offload off) | **12.0-13.0 s** | 28.5-29.1 s | 2.3x |
+| Qwen3-30B-A3B (veomni ep8, 1+1 nodes, 50-step medians) | **7.1 s** | 32.2 s | **4.5x** |
+| Qwen3-235B-A22B (veomni ep8 x fsdp8, 8+2 nodes, gen TP16) | **11.4-14.9 s** | 246-266 s | **~21x** |
 
-The delta sync time grows far slower than parameter bytes -- the sharded sparse gather
+The delta sync time stays essentially flat from 32B through 235B -- the sharded sparse gather
 amortizes over the larger trainer world -- while the full broadcast pays a full-model
-materialization that grows linearly with parameter bytes, so the advantage widens with scale.
-The per-step changed ratio is ~1-3% of parameter bytes for dense models and stays there over
-long runs.
+materialization that grows linearly with parameter bytes, so the advantage widens with scale
+and with MoE sparsity. The per-step changed ratio is ~1-3% of parameter bytes for dense models
+(0.02-0.05% for the 235B MoE early steps) and stays there over long runs.
 
 Correctness evidence (details in the PR):
 
 - **200-step GRPO equivalence at 7B** (delta vs nccl, 400 syncs): reward trajectories track
   phase-for-phase, final rewards within sampling noise, zero receiver checksum failures.
+- **50-step GRPO equivalence at 30B-A3B (veomni ep8)**: score trajectories rise in step
+  (0.646->0.719 delta vs 0.639->0.697 nccl), per-step gap at the independent-sampling
+  noise floor, zero checksum failures.
 - **Bit-exact round-trip**: perturb -> apply as delta -> revert -> apply as delta reproduces
   greedy generations byte-identically on every prompt.
 

--- a/tests/checkpoint_engine/test_block_placement.py
+++ b/tests/checkpoint_engine/test_block_placement.py
@@ -224,19 +224,22 @@ def test_explicit_place_block_rebuild_veomni_style():
     assert seen == 2
 
 
-def test_explicit_place_passthrough():
-    """ShardSpec.place / gather_group short-circuit derive_placement."""
-    from verl.workers.engine.spec import ShardSpec, derive_placement
+def test_explicit_place_never_reaches_derive():
+    """Explicit-place specs are dispatched by the caller (which reads the
+    exporter's (place, contributes, gather_group) triple verbatim);
+    derive_dtensor_placement only accepts DTensor-declared specs."""
+    import pytest
+
+    from verl.workers.engine.spec import ShardSpec, derive_dtensor_placement
 
     block = BlockPlacement((2, 3), (4, 0), (8, 3))
-    sentinel = object()
-    spec = ShardSpec(full_shape=(8, 3), place=block, gather_group=sentinel)
-    place, contributes, group = derive_placement(spec)
-    assert place is block and contributes and group is sentinel
+    spec = ShardSpec(full_shape=(8, 3), place=block, gather_group=object())
+    with pytest.raises(AssertionError, match="dispatched by the caller"):
+        derive_dtensor_placement(spec)
 
 
 def test_flat_contiguous_block_matches_int_fast_path():
-    """A dim-0 cut expressed as a BlockPlacement (the unified derive_placement
+    """A dim-0 cut expressed as a BlockPlacement (the unified derive_dtensor_placement
     output for FSDP2 ``Shard(0)``) must translate exactly like the plain-int
     offset it replaces, via the ``is_flat_contiguous`` add fast path."""
     full_shape = (8, 4, 6)

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -160,6 +160,50 @@ def test_prime_then_hf_delta_export_roundtrip():
     assert counts2.tolist() == [0] and hf_idx2.numel() == 0
 
 
+def test_hf_delta_export_converter_param():
+    """A converter param's delta entry carries hf_slots-keyed final coordinates:
+    the NaN probe maps each touched element through to_hf_chunk (the converter
+    machinery is veomni's own -- see verl.workers.engine.veomni.utils)."""
+    import importlib.util
+    import pathlib
+
+    # veomni/utils.py is torch-only, but the veomni package __init__ pulls in the
+    # full engine (heavy deps); load the module by file path to keep this a CPU
+    # unit test.
+    import verl.workers.engine as _eng
+    from verl.workers.engine.spec import BlockPlacement, ShardSpec
+    from verl.workers.engine.utils import hf_delta_export, prime_delta_snapshots
+
+    _p = pathlib.Path(_eng.__file__).parent / "veomni" / "utils.py"
+    _spec = importlib.util.spec_from_file_location("_veomni_delta_utils", _p)
+    _m = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_m)
+    hf_entry_converter = _m.hf_entry_converter
+
+    def to_hf_chunk(dim0_start, segment):
+        return [(f"w.{dim0_start + i}", segment[i]) for i in range(segment.shape[0])]
+
+    spec = ShardSpec(
+        full_shape=(3, 4),
+        place=BlockPlacement((3, 4), (0, 0), (3, 4)),
+        to_hf_chunk=to_hf_chunk,
+        hf_slots=[(f"w.{i}", (4,)) for i in range(3)],
+    )
+    w = torch.arange(12, dtype=torch.float32)
+    snaps: dict = {}
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+
+    w2 = w.clone()
+    w2[5] = -1.0  # row 1, col 1
+    w2[11] = 42.0  # row 2, col 3
+    ((slots, _dt, counts, hf_idx, hf_val, _pg),) = list(
+        hf_delta_export(iter([("w", w2, spec)]), snaps, hf_entry_converter)
+    )
+    assert slots == spec.hf_slots
+    assert counts.tolist() == [0, 1, 1]
+    assert hf_idx.tolist() == [1, 3] and hf_val.tolist() == [-1.0, 42.0]
+
+
 def test_hf_delta_export_requires_seed():
     """A delta export without a prior prime must fail loud, not diff against
     garbage."""

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -204,6 +204,90 @@ def test_hf_delta_export_converter_param():
     assert hf_idx.tolist() == [1, 3] and hf_val.tolist() == [-1.0, 42.0]
 
 
+def _load_veomni_delta_utils():
+    # veomni/utils.py is torch-only, but the veomni package __init__ pulls in the
+    # full engine (heavy deps); load the module by file path to keep this a CPU
+    # unit test.
+    import importlib.util
+    import pathlib
+
+    import verl.workers.engine as _eng
+
+    _p = pathlib.Path(_eng.__file__).parent / "veomni" / "utils.py"
+    _spec = importlib.util.spec_from_file_location("_veomni_delta_utils", _p)
+    _m = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_m)
+    return _m
+
+
+def test_hf_delta_export_converter_nontrivial_block():
+    """The ep x fsdp double cut (veomni's real expert layout): this rank holds a
+    strict sub-block -- experts 2:4, dim-1 window 3:6 of full (8, 6, 4) -- so
+    the entry must translate through both the dim-0 (manual ep) and dim-1
+    (FSDP ``Shard(1)``) offsets before slot attribution."""
+    from verl.workers.engine.spec import BlockPlacement, ShardSpec
+    from verl.workers.engine.utils import hf_delta_export, prime_delta_snapshots
+
+    hf_entry_converter = _load_veomni_delta_utils().hf_entry_converter
+
+    def to_hf_chunk(dim0_start, segment):
+        return [(f"w.{dim0_start + i}", segment[i]) for i in range(segment.shape[0])]
+
+    full_shape = (8, 6, 4)
+    spec = ShardSpec(
+        full_shape=full_shape,
+        place=BlockPlacement((2, 3, 4), (2, 3, 0), full_shape),
+        to_hf_chunk=to_hf_chunk,
+        hf_slots=[(f"w.{i}", (6, 4)) for i in range(8)],
+    )
+    local = torch.arange(24, dtype=torch.float32)  # this rank's block, flat
+    snaps: dict = {}
+    prime_delta_snapshots(iter([("w", local.clone(), spec)]), snaps)
+
+    touched = local.clone()
+    touched[5] = -1.0  # block (0,1,1) -> full (2,4,1) -> slot w.2, row-flat 17
+    touched[23] = 42.0  # block (1,2,3) -> full (3,5,3) -> slot w.3, row-flat 23
+    ((slots, _dt, counts, hf_idx, hf_val, _pg),) = list(
+        hf_delta_export(iter([("w", touched, spec)]), snaps, hf_entry_converter)
+    )
+    assert slots == spec.hf_slots
+    assert counts.tolist() == [0, 0, 1, 1, 0, 0, 0, 0]
+    assert hf_idx.tolist() == [17, 23] and hf_val.tolist() == [-1.0, 42.0]
+
+
+def test_hf_delta_export_replica_rank_stays_lockstep():
+    """A rank whose block is an HSDP replica (``spec.contributes=False``) must
+    emit the full slot enumeration with zero counts -- lockstep intact, nothing
+    on the wire -- and still refresh its snapshot."""
+    from verl.workers.engine.spec import BlockPlacement, ShardSpec
+    from verl.workers.engine.utils import hf_delta_export, prime_delta_snapshots
+
+    hf_entry_converter = _load_veomni_delta_utils().hf_entry_converter
+
+    def to_hf_chunk(dim0_start, segment):
+        return [(f"w.{dim0_start + i}", segment[i]) for i in range(segment.shape[0])]
+
+    spec = ShardSpec(
+        full_shape=(3, 4),
+        place=BlockPlacement((3, 4), (0, 0), (3, 4)),
+        to_hf_chunk=to_hf_chunk,
+        hf_slots=[(f"w.{i}", (4,)) for i in range(3)],
+        contributes=False,
+    )
+    w = torch.arange(12, dtype=torch.float32)
+    snaps: dict = {}
+    prime_delta_snapshots(iter([("w", w.clone(), spec)]), snaps)
+
+    w2 = w.clone()
+    w2[5] = -1.0
+    ((slots, _dt, counts, hf_idx, hf_val, _pg),) = list(
+        hf_delta_export(iter([("w", w2, spec)]), snaps, hf_entry_converter)
+    )
+    assert slots == spec.hf_slots
+    assert counts.tolist() == [0, 0, 0] and hf_idx.numel() == 0 and hf_val.numel() == 0
+    assert torch.equal(snaps["w"], w2)  # replica still tracks its shard
+
+
 def test_hf_delta_export_requires_seed():
     """A delta export without a prior prime must fail loud, not diff against
     garbage."""

--- a/tests/checkpoint_engine/test_sharded_delta.py
+++ b/tests/checkpoint_engine/test_sharded_delta.py
@@ -56,15 +56,15 @@ def test_shard_delta_indices_no_change_is_empty():
     assert gval.numel() == 0
 
 
-def test_derive_placement_unsharded():
+def test_derive_dtensor_placement_unsharded():
     # A non-DTensor (replicated / unsharded) param: offset 0, no gather group,
     # and outside a process group rank 0 is assumed -> contributes.
-    from verl.workers.engine.spec import ShardSpec, derive_placement
+    from verl.workers.engine.spec import ShardSpec, derive_dtensor_placement
 
     t = torch.randn(64, 8, dtype=torch.bfloat16)
     spec = ShardSpec.from_param(t)
     assert spec.mesh is None and spec.full_shape == (64, 8)
-    offset, contributes, group = derive_placement(spec)
+    offset, contributes, group = derive_dtensor_placement(spec)
     assert offset == 0 and contributes is True and group is None
 
 

--- a/tests/special_distributed/test_sharded_delta_gather.py
+++ b/tests/special_distributed/test_sharded_delta_gather.py
@@ -25,7 +25,7 @@ from verl.checkpoint_engine.delta_sync.sparse_gather import (
     gather_slot_entries_to_rank0,
     shard_delta_indices,
 )
-from verl.workers.engine.spec import ShardSpec, derive_placement, translate_flat_indices
+from verl.workers.engine.spec import ShardSpec, derive_dtensor_placement, translate_flat_indices
 
 
 def _run_case(shape, placements, mesh, dev, rank, si):
@@ -43,10 +43,10 @@ def _run_case(shape, placements, mesh, dev, rank, si):
     dt_new = distribute_tensor(full_new, mesh, placements)
 
     # --- sharded path (real module) ---
-    place, contributes, _pg = derive_placement(ShardSpec.from_param(dt_new))
+    place, contributes, _pg = derive_dtensor_placement(ShardSpec.from_param(dt_new))
     loc_new = dt_new.to_local().reshape(-1)
     loc_old = dt_old.to_local().reshape(-1)
-    place2, _, _ = derive_placement(ShardSpec.from_param(dt_old))
+    place2, _, _ = derive_dtensor_placement(ShardSpec.from_param(dt_old))
     assert place == place2
     if contributes:
         # engine convention: diff in shard-local coordinates, then translate

--- a/tests/utils/veomni/test_special_export_unfused_experts.py
+++ b/tests/utils/veomni/test_special_export_unfused_experts.py
@@ -52,7 +52,7 @@ def get_per_tensor_param(model, device_mesh):
         for src_ep_rank in range(ep_size):
             tensor = unsharded_tensor if src_ep_rank == ep_rank else buffer
             torch.distributed.broadcast(tensor, group_src=src_ep_rank, group=ep_group)
-            yield from process_func(name, tensor, ep_rank=src_ep_rank)
+            yield from process_func(name, tensor, expert_id_base=src_ep_rank * tensor.size(0))
 
 
 def test_veomni_export_unfused_experts():

--- a/verl/workers/engine/spec.py
+++ b/verl/workers/engine/spec.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
     from torch.distributed.device_mesh import DeviceMesh
 
-__all__ = ["BlockPlacement", "ShardSpec", "derive_placement", "translate_flat_indices"]
+__all__ = ["BlockPlacement", "ShardSpec", "derive_dtensor_placement", "translate_flat_indices"]
 
 
 @dataclass
@@ -115,7 +115,7 @@ def _row_major_strides(shape: tuple | list) -> tuple:
 class BlockPlacement:
     """This rank's local shard is one hyper-rectangular block of the full tensor:
     ``full[o0:o0+l0, o1:o1+l1, ...]`` with ``local_shape=(l0, l1, ...)`` and
-    ``global_offset=(o0, o1, ...)``. Produced by :func:`derive_placement` for every
+    ``global_offset=(o0, o1, ...)``. Produced by :func:`derive_dtensor_placement` for every
     sharded geometry, including the dim-0 cut (FSDP2 ``Shard(0)``): that block is
     flat-contiguous, and :func:`translate_flat_indices` detects it via
     ``is_flat_contiguous`` and keeps the single-add fast path."""
@@ -150,7 +150,8 @@ class BlockPlacement:
 def translate_flat_indices(lidx: torch.Tensor, place: int | BlockPlacement) -> torch.Tensor:
     """Map shard-local flat positions to full-tensor flat positions.
 
-    ``place`` is what :func:`derive_placement` returned: an ``int`` for the
+    ``place`` is what the caller's dispatch produced (``spec.place`` or
+    :func:`derive_dtensor_placement`): an ``int`` for the
     identity cases (unsharded / replicated / explicit exporter overrides, translate
     = add), or a :class:`BlockPlacement`. A flat-contiguous block (only dim 0 cut,
     e.g. FSDP2 ``Shard(0)``) keeps the single-add fast path; any other block does a
@@ -171,15 +172,19 @@ def translate_flat_indices(lidx: torch.Tensor, place: int | BlockPlacement) -> t
     return out
 
 
-def derive_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optional[ProcessGroup]]:
-    """Derive ``(place, contributes, gather_group)`` for THIS rank from the spec.
+def derive_dtensor_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optional[ProcessGroup]]:
+    """Derive ``(place, contributes, gather_group)`` for THIS rank from a spec
+    whose distribution is fully declared by ``mesh`` + ``placements`` (or is
+    unsharded). Specs carrying an explicit exporter override (``spec.place``)
+    never reach this function -- the caller dispatches on ``spec.place`` and
+    reads the exporter's own ``(place, contributes, gather_group)`` triple
+    verbatim, because a hybrid geometry (e.g. veomni's manual ep split) is not
+    derivable from the DTensor facts alone.
 
     ``place`` feeds :func:`translate_flat_indices`:
 
     * unsharded (``mesh is None``) or fully replicated: ``0``; no group (the local
-      tensor is already the full parameter). Explicit exporter overrides
-      (``spec.place``) may also be plain ``int`` offsets and carry their own
-      ``spec.contributes`` (the exporter knows its replica structure).
+      tensor is already the full parameter).
     * any sharded geometry: a :class:`BlockPlacement` computed from
       ``compute_local_shape_and_global_offset`` (pure math, no collective). For a
       single Shard dim, only ranks at coordinate 0 of every Replicate dim
@@ -195,8 +200,7 @@ def derive_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optio
     """
     import torch.distributed as dist
 
-    if spec.place is not None:
-        return spec.place, spec.contributes, spec.gather_group
+    assert spec.place is None, "explicit-place specs are dispatched by the caller, not derived"
 
     if spec.mesh is None:
         return 0, (dist.get_rank() == 0 if dist.is_initialized() else True), None

--- a/verl/workers/engine/spec.py
+++ b/verl/workers/engine/spec.py
@@ -69,9 +69,11 @@ class ShardSpec:
     # int flat offset or a BlockPlacement in a *virtual* full tensor, and
     # ``gather_group`` is the ProcessGroup covering every rank that holds a block
     # (pass a real group object -- the engine treats ``None`` as "unsharded").
-    # Every rank is assumed to contribute.
+    # ``contributes=False`` marks a rank whose block is a replica owned by a
+    # peer (e.g. HSDP replicate dims): it keeps lockstep with an empty delta.
     place: Optional[int | BlockPlacement] = None
     gather_group: Optional[ProcessGroup] = None
+    contributes: bool = True
     # Optional dim-0-separable converter: ``to_hf_chunk(dim0_start, segment)`` converts a
     # contiguous dim-0 segment ``full[dim0_start : dim0_start + segment.shape[0]]`` of the
     # logical tensor to ``[(hf_name, hf_tensor)]``. When set on a block-converter spec the
@@ -176,7 +178,8 @@ def derive_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optio
 
     * unsharded (``mesh is None``) or fully replicated: ``0``; no group (the local
       tensor is already the full parameter). Explicit exporter overrides
-      (``spec.place``) may also be plain ``int`` offsets.
+      (``spec.place``) may also be plain ``int`` offsets and carry their own
+      ``spec.contributes`` (the exporter knows its replica structure).
     * any sharded geometry: a :class:`BlockPlacement` computed from
       ``compute_local_shape_and_global_offset`` (pure math, no collective). For a
       single Shard dim, only ranks at coordinate 0 of every Replicate dim
@@ -193,7 +196,7 @@ def derive_placement(spec: ShardSpec) -> tuple[int | BlockPlacement, bool, Optio
     import torch.distributed as dist
 
     if spec.place is not None:
-        return spec.place, True, spec.gather_group
+        return spec.place, spec.contributes, spec.gather_group
 
     if spec.mesh is None:
         return 0, (dist.get_rank() == 0 if dist.is_initialized() else True), None

--- a/verl/workers/engine/utils.py
+++ b/verl/workers/engine/utils.py
@@ -198,7 +198,7 @@ def hf_delta_export(gen, snaps: dict, entry_fn):
     pass."""
     from verl.checkpoint_engine.delta_sync.sparse_gather import shard_delta_indices
 
-    from .spec import derive_placement
+    from .spec import derive_dtensor_placement
 
     for name, local, spec in gen:
         local = local.detach().contiguous().view(-1)
@@ -206,7 +206,12 @@ def hf_delta_export(gen, snaps: dict, entry_fn):
         assert snap is not None and snap.numel() == local.numel(), (
             f"{name}: no seed snapshot for this shard; run the seed export first"
         )
-        place, contributes, pg = derive_placement(spec)
+        if spec.place is not None:
+            # explicit exporter override: the backend declared the whole triple
+            # (hybrid geometries are not derivable from DTensor facts alone).
+            place, contributes, pg = spec.place, spec.contributes, spec.gather_group
+        else:
+            place, contributes, pg = derive_dtensor_placement(spec)
         if contributes:
             base = snap.to(local.device, non_blocking=True)
             lidx, lval = shard_delta_indices(local, base, 0)

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -15,7 +15,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
 
 import torch
 import torch.distributed as dist
@@ -30,9 +30,6 @@ from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
 
 import verl.utils.torch_functional as verl_F
-
-if TYPE_CHECKING:
-    pass
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -588,118 +588,13 @@ class VeOmniEngine(FSDPEngine):
 
     def get_per_tensor_param_shard(self, **kwargs):
         """Yield each rank's *local* shard ``(name, local_shard, ShardSpec)`` -- the
-        DTensor export plus veomni's EP declarations. Pure export, no side effects.
-
-        Dense params pass their FSDP DTensor placement through verbatim (flat
-        ``Shard(0)`` fast path). Grouped expert params are split twice: the expert
-        dim (0) is split *manually* across ``ep_group`` (outside DTensor), and the
-        local expert block is FSDP-sharded as a DTensor. That combination is not
-        expressible as DTensor placements, so the spec carries an explicit
-        :class:`BlockPlacement` in a virtual full tensor of all experts
-        (dim-0 offset = ``ep_rank * n_local_experts`` + the DTensor block offset)
-        with the world group as the gather group, and a ``to_hf_chunk`` closure over
-        the veomni MoE param handler (pure slice + rename: fused -> per-expert HF
-        names) plus its ``hf_slots`` output enumeration.
+        DTensor export plus veomni's EP declarations. Pure export, no side effects;
+        the mechanics live in :func:`verl.workers.engine.veomni.utils.veomni_shard_export`.
         """
-        import torch.distributed as dist
+        from .utils import veomni_shard_export
 
         load_veomni_model_to_gpu(self.module)
-        params = self.module.state_dict()
-        params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
-
-        ps = parallel_state.get_parallel_state()
-        model_type = getattr(self.module.config, "model_type", "default")
-        process_func = MOE_PARAM_HANDERS.get(model_type, default_moe_param_handler)
-
-        from torch.distributed.tensor import DTensor
-        from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
-
-        from ..spec import BlockPlacement, ShardSpec
-
-        def _expert_hf_slots(fqn, full_shape):
-            """Full (hf_name, hf_shape) slot table for one fused expert param, in dim-0
-            order matching the default handler's per-segment output order. Only valid
-            for the default handler (custom MOE_PARAM_HANDERS may rename differently),
-            so the caller attaches it only when process_func is the default."""
-            n_experts = int(full_shape[0])
-            slots = []
-            if "gate_up_proj" in fqn:
-                inter = int(full_shape[1]) // 2
-                inner = (inter, *(int(x) for x in full_shape[2:]))
-                for i in range(n_experts):
-                    for proj in ("gate_proj", "up_proj"):
-                        nm = fqn.replace("gate_up_proj", proj)
-                        slots.append((nm.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
-            else:
-                inner = tuple(int(x) for x in full_shape[1:])
-                for i in range(n_experts):
-                    slots.append((fqn.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
-            return slots
-
-        def _is_ep_param(name, param):
-            # Structural check first: veomni's ParallelPlan.apply attaches
-            # ``spec_info`` (para_name="ep") to every expert-parallel-sliced param
-            # -- the sharding fact itself, not a naming convention. Params can lose
-            # the attribute across state_dict/key conversion, so fall back to the
-            # historical name match.
-            si = getattr(param, "spec_info", None)
-            if si is not None:
-                return si.para_name == "ep"
-            return "mlp.experts." in name and any(
-                p in name for p in ["down_proj", "gate_proj", "up_proj", "gate_up_proj"]
-            )
-
-        def _gen():
-            for name, param in params.items():
-                is_expert = ps.ep_enabled and _is_ep_param(name, param)
-                if param.is_floating_point() and param.dtype != torch.bfloat16:
-                    # mixed-precision keeps fp32 master weights; the wire (and the
-                    # rollout side) speak bf16, so cast before diffing.
-                    param = param.to(torch.bfloat16)
-                if not is_expert:
-                    spec = ShardSpec.from_param(param)
-                    local = param.to_local() if isinstance(param, DTensor) else param
-                    yield name, local.reshape(-1), spec
-                    continue
-
-                # local fused block: [n_local_experts, ...] (ep split already applied)
-                if isinstance(param, DTensor):
-                    lshape, goff = compute_local_shape_and_global_offset(
-                        param.shape, param.device_mesh, list(param.placements)
-                    )
-                    local = param.to_local()
-                else:
-                    lshape, goff = tuple(param.shape), (0,) * param.ndim
-                    local = param
-                n_local = int(param.shape[0])
-                full_shape = (n_local * ps.ep_size,) + tuple(param.shape[1:])
-                offset = (ps.ep_rank * n_local + int(goff[0]),) + tuple(int(o) for o in goff[1:])
-                block = BlockPlacement(tuple(int(x) for x in lshape), offset, full_shape)
-
-                # the blocks of one expert tensor are spread over ep x (block fsdp);
-                # v1 requires that to cover the whole trainer world so the world
-                # group doubles as the gather group (rank 0 == engine master).
-                mesh_world = param.device_mesh.size() if isinstance(param, DTensor) else 1
-                assert ps.ep_size * mesh_world == dist.get_world_size(), (
-                    f"expert blocks must tile the trainer world: ep={ps.ep_size} x "
-                    f"block mesh={mesh_world} != world={dist.get_world_size()}"
-                )
-                spec = ShardSpec(
-                    full_shape=full_shape,
-                    place=block,
-                    gather_group=dist.group.WORLD,
-                    # dim-0-separable: a segment is a run of whole experts starting at
-                    # global expert id ``start`` -- exactly the handler's contract.
-                    to_hf_chunk=lambda start, seg, _f=process_func, _n=name: list(_f(_n, seg, expert_id_base=start)),
-                    # slot table enables sender-side conversion; only the default
-                    # handler's naming is enumerable without running the converter.
-                    hf_slots=(
-                        _expert_hf_slots(name, full_shape) if process_func is default_moe_param_handler else None
-                    ),
-                )
-                yield name, local.reshape(-1), spec
-
-        return _gen(), None
+        return veomni_shard_export(self.module)
 
     def _hf_delta_entry(self, name, spec, place, lidx, lval):
         """veomni's per-param entry builder: EP/converter specs (fused expert

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -588,13 +588,25 @@ class VeOmniEngine(FSDPEngine):
 
     def get_per_tensor_param_shard(self, **kwargs):
         """Yield each rank's *local* shard ``(name, local_shard, ShardSpec)`` -- the
-        DTensor export plus veomni's EP declarations. Pure export, no side effects;
-        the mechanics live in :func:`verl.workers.engine.veomni.utils.veomni_shard_export`.
+        DTensor export plus veomni's EP declarations. The mechanics live in
+        :func:`verl.workers.engine.veomni.utils.veomni_shard_export`; this wrapper
+        owns the offload dance (CPUOffloadPolicy manages placement itself -- see
+        #5995 -- and the delta path returns early in update_weights, so the
+        offload-back happens here, after the exporter is exhausted).
         """
         from .utils import veomni_shard_export
 
-        load_veomni_model_to_gpu(self.module)
-        return veomni_shard_export(self.module)
+        manual_offload = not getattr(self, "_uses_fsdp2_cpu_offload_policy", False)
+        if manual_offload:
+            load_veomni_model_to_gpu(self.module)
+        gen, meta = veomni_shard_export(self.module)
+
+        def _with_offload_back():
+            yield from gen
+            if manual_offload and self._is_offload_param:
+                offload_veomni_model_to_cpu(self.module)
+
+        return _with_offload_back(), meta
 
     def _hf_delta_entry(self, name, spec, place, lidx, lval):
         """veomni's per-param entry builder: EP/converter specs (fused expert

--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -15,7 +15,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 import torch
 import torch.distributed as dist
@@ -30,6 +30,9 @@ from veomni.optim import build_lr_scheduler, build_optimizer
 from veomni.utils.seqlen_pos_transform_utils import prepare_fa_kwargs_from_position_ids
 
 import verl.utils.torch_functional as verl_F
+
+if TYPE_CHECKING:
+    pass
 from verl.trainer.config import CheckpointConfig
 from verl.utils import tensordict_utils as tu
 from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
@@ -584,14 +587,137 @@ class VeOmniEngine(FSDPEngine):
             offload_veomni_optimizer(self.optimizer)
 
     def get_per_tensor_param_shard(self, **kwargs):
-        # veomni splits grouped experts twice (manual ep split outside DTensor +
-        # FSDP-sharded local block); the inherited DTensor-identity export would
-        # declare the wrong full tensor for them and corrupt the rollout weights
-        # silently. The EP-aware export lands in the follow-up PR.
-        raise NotImplementedError(
-            "delta_sharded does not support the veomni backend yet (EP-aware shard "
-            "export lands in a follow-up PR); use a full-sync checkpoint backend"
-        )
+        """Yield each rank's *local* shard ``(name, local_shard, ShardSpec)`` -- the
+        DTensor export plus veomni's EP declarations. Pure export, no side effects.
+
+        Dense params pass their FSDP DTensor placement through verbatim (flat
+        ``Shard(0)`` fast path). Grouped expert params are split twice: the expert
+        dim (0) is split *manually* across ``ep_group`` (outside DTensor), and the
+        local expert block is FSDP-sharded as a DTensor. That combination is not
+        expressible as DTensor placements, so the spec carries an explicit
+        :class:`BlockPlacement` in a virtual full tensor of all experts
+        (dim-0 offset = ``ep_rank * n_local_experts`` + the DTensor block offset)
+        with the world group as the gather group, and a ``to_hf_chunk`` closure over
+        the veomni MoE param handler (pure slice + rename: fused -> per-expert HF
+        names) plus its ``hf_slots`` output enumeration.
+        """
+        import torch.distributed as dist
+
+        load_veomni_model_to_gpu(self.module)
+        params = self.module.state_dict()
+        params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))
+
+        ps = parallel_state.get_parallel_state()
+        model_type = getattr(self.module.config, "model_type", "default")
+        process_func = MOE_PARAM_HANDERS.get(model_type, default_moe_param_handler)
+
+        from torch.distributed.tensor import DTensor
+        from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+        from ..spec import BlockPlacement, ShardSpec
+
+        def _expert_hf_slots(fqn, full_shape):
+            """Full (hf_name, hf_shape) slot table for one fused expert param, in dim-0
+            order matching the default handler's per-segment output order. Only valid
+            for the default handler (custom MOE_PARAM_HANDERS may rename differently),
+            so the caller attaches it only when process_func is the default."""
+            n_experts = int(full_shape[0])
+            slots = []
+            if "gate_up_proj" in fqn:
+                inter = int(full_shape[1]) // 2
+                inner = (inter, *(int(x) for x in full_shape[2:]))
+                for i in range(n_experts):
+                    for proj in ("gate_proj", "up_proj"):
+                        nm = fqn.replace("gate_up_proj", proj)
+                        slots.append((nm.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
+            else:
+                inner = tuple(int(x) for x in full_shape[1:])
+                for i in range(n_experts):
+                    slots.append((fqn.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
+            return slots
+
+        def _is_ep_param(name, param):
+            # Structural check first: veomni's ParallelPlan.apply attaches
+            # ``spec_info`` (para_name="ep") to every expert-parallel-sliced param
+            # -- the sharding fact itself, not a naming convention. Params can lose
+            # the attribute across state_dict/key conversion, so fall back to the
+            # historical name match.
+            si = getattr(param, "spec_info", None)
+            if si is not None:
+                return si.para_name == "ep"
+            return "mlp.experts." in name and any(
+                p in name for p in ["down_proj", "gate_proj", "up_proj", "gate_up_proj"]
+            )
+
+        def _gen():
+            for name, param in params.items():
+                is_expert = ps.ep_enabled and _is_ep_param(name, param)
+                if param.is_floating_point() and param.dtype != torch.bfloat16:
+                    # mixed-precision keeps fp32 master weights; the wire (and the
+                    # rollout side) speak bf16, so cast before diffing.
+                    param = param.to(torch.bfloat16)
+                if not is_expert:
+                    spec = ShardSpec.from_param(param)
+                    local = param.to_local() if isinstance(param, DTensor) else param
+                    yield name, local.reshape(-1), spec
+                    continue
+
+                # local fused block: [n_local_experts, ...] (ep split already applied)
+                if isinstance(param, DTensor):
+                    lshape, goff = compute_local_shape_and_global_offset(
+                        param.shape, param.device_mesh, list(param.placements)
+                    )
+                    local = param.to_local()
+                else:
+                    lshape, goff = tuple(param.shape), (0,) * param.ndim
+                    local = param
+                n_local = int(param.shape[0])
+                full_shape = (n_local * ps.ep_size,) + tuple(param.shape[1:])
+                offset = (ps.ep_rank * n_local + int(goff[0]),) + tuple(int(o) for o in goff[1:])
+                block = BlockPlacement(tuple(int(x) for x in lshape), offset, full_shape)
+
+                # the blocks of one expert tensor are spread over ep x (block fsdp);
+                # v1 requires that to cover the whole trainer world so the world
+                # group doubles as the gather group (rank 0 == engine master).
+                mesh_world = param.device_mesh.size() if isinstance(param, DTensor) else 1
+                assert ps.ep_size * mesh_world == dist.get_world_size(), (
+                    f"expert blocks must tile the trainer world: ep={ps.ep_size} x "
+                    f"block mesh={mesh_world} != world={dist.get_world_size()}"
+                )
+                spec = ShardSpec(
+                    full_shape=full_shape,
+                    place=block,
+                    gather_group=dist.group.WORLD,
+                    # dim-0-separable: a segment is a run of whole experts starting at
+                    # global expert id ``start`` -- exactly the handler's contract.
+                    to_hf_chunk=lambda start, seg, _f=process_func, _n=name: list(_f(_n, seg, expert_id_base=start)),
+                    # slot table enables sender-side conversion; only the default
+                    # handler's naming is enumerable without running the converter.
+                    hf_slots=(
+                        _expert_hf_slots(name, full_shape) if process_func is default_moe_param_handler else None
+                    ),
+                )
+                yield name, local.reshape(-1), spec
+
+        return _gen(), None
+
+    def _hf_delta_entry(self, name, spec, place, lidx, lval):
+        """veomni's per-param entry builder: EP/converter specs (fused expert
+        stacks) go through this backend's own converter machinery (see
+        :mod:`verl.workers.engine.veomni.utils`); everything else falls back to
+        the FSDP engine's DTensor identity handling."""
+        from ..spec import BlockPlacement
+        from .utils import NO_SLOTS_MSG, hf_entry_converter
+
+        if spec.to_hf_chunk is not None and isinstance(place, BlockPlacement) and spec.hf_slots is not None:
+            return hf_entry_converter(name, spec, place, lidx, lval)
+        if spec.to_hf_chunk is not None:
+            raise NotImplementedError(f"{name}: {NO_SLOTS_MSG}")
+        return super()._hf_delta_entry(name, spec, place, lidx, lval)
+
+    # get_per_tensor_param_delta_shard is inherited from FSDPEngine and
+    # prime_delta_snapshots from BaseEngine; both consume this class's
+    # get_per_tensor_param_shard and _hf_delta_entry overrides.
 
     def get_per_tensor_param(self, **kwargs):
         # FSDP2 CPUOffloadPolicy owns CPU<->accelerator placement; calling model.to(device)
@@ -624,11 +750,11 @@ class VeOmniEngine(FSDPEngine):
                     for src_ep_rank in range(ep_size):
                         tensor = unsharded_tensor if src_ep_rank == ep_rank else buffer
                         torch.distributed.broadcast(tensor, group_src=src_ep_rank, group=ps.ep_group)
-                        yield from process_func(name, tensor, ep_rank=src_ep_rank)
+                        yield from process_func(name, tensor, expert_id_base=src_ep_rank * tensor.size(0))
 
                 else:
                     if is_expert_layer:
-                        yield from process_func(name, unsharded_tensor, ep_rank=0)
+                        yield from process_func(name, unsharded_tensor, expert_id_base=0)
                     else:
                         yield name, unsharded_tensor
 

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -15,6 +15,7 @@
 import torch
 
 from verl.utils.device import get_device_id, get_torch_device
+from verl.workers.engine.utils import _prodshape
 
 VL_TYPE2INDEX = {
     "qwen2_5_vl": {
@@ -108,15 +109,18 @@ def load_veomni_optimizer(optimizer, device_id):
                         state[key] = value.to(device_id, non_blocking=True)
 
 
-def _map_moe_params_common(name, tensor, ep_rank):
-    num_experts_per_rank = tensor.size(0)
-    for i in range(num_experts_per_rank):
-        idx = ep_rank * num_experts_per_rank + i
+def _map_moe_params_common(name, tensor, expert_id_base):
+    for i in range(tensor.size(0)):
+        idx = expert_id_base + i
         new_key = name.replace("mlp.experts.", f"mlp.experts.{idx}.") + ".weight"
         yield new_key, tensor[i].to(get_device_id(), non_blocking=True)
 
 
-def default_moe_param_handler(name, tensor, ep_rank):
+def default_moe_param_handler(name, tensor, expert_id_base):
+    """Project a stacked expert tensor ``[k, ...]`` (dim 0 = a contiguous run of
+    experts) onto per-expert HF-named tensors. ``expert_id_base`` is the global
+    expert id of slice 0: an ep rank's local stack passes
+    ``ep_rank * experts_per_rank``; an already-global stack passes ``0``."""
     if "gate_up_proj" in name:
         gate, up = tensor.chunk(2, dim=1)
         params = {
@@ -127,8 +131,83 @@ def default_moe_param_handler(name, tensor, ep_rank):
         params = {name: tensor}
 
     for key, value in params.items():
-        yield from _map_moe_params_common(key, value, ep_rank)
+        yield from _map_moe_params_common(key, value, expert_id_base)
 
 
-# This is used to override the default mapping of MoE parameters
+# Overrides the default MoE parameter mapping per model_type. Handlers follow the
+# ``default_moe_param_handler`` contract: (name, stacked_tensor, expert_id_base).
 MOE_PARAM_HANDERS = {}
+
+
+# ---- EP delta export (veomni-specific converter machinery) ----------------
+# The NaN row probe and the converter entry builder for fused expert params;
+# the DTensor-generic delta pipeline lives in verl.workers.engine.utils.
+
+NO_SLOTS_MSG = (
+    "converter specs without an enumerable slot table (hf_slots) are not supported by "
+    "the sender-side HF delta export; rewrite the converter as a dim-0-separable "
+    "to_hf_chunk + hf_slots (see #7060)"
+)
+
+
+def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):
+    """NaN-probe one dim-0 row through the spec's converter: scatter the row's
+    (within-row position, value) pairs into a NaN-filled row buffer, run
+    ``to_hf_chunk`` on it, and extract each output slot's surviving positions and
+    values (the converter is a pure permutation, so non-NaN survivors are exactly
+    the input pairs in final HF coordinates). Returns
+    ``[(slot_offset_in_row, idx_int32, val), ...]``, skipping empty slots."""
+    full_shape = spec.full_shape
+    inner = max(_prodshape(full_shape[1:]), 1)
+    slots_per_row = len(spec.hf_slots) // int(full_shape[0])
+    buf = torch.full((inner,), float("nan"), dtype=ref.dtype, device=ref.device)
+    buf[pos_in_row] = vals
+    outs = spec.to_hf_chunk(int(r), buf.view(1, *full_shape[1:]))
+    assert len(outs) == slots_per_row, (
+        f"{name}: to_hf_chunk gave {len(outs)} outputs/row, slot table expects {slots_per_row}"
+    )
+    res = []
+    for s_i, (_hf_name, hf_tensor) in enumerate(outs):
+        fl = hf_tensor.reshape(-1)
+        p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
+        if p_.numel():
+            res.append((s_i, p_.to(torch.int32), fl[p_]))
+    return res
+
+
+def hf_entry_converter(name, spec, place, lidx, lval):
+    """Turn one converter param's shard-local delta into its final HF-coordinate
+    entry ``(slots, dtype_str, counts, idx_concat, val_concat)``: only the touched
+    dim-0 rows go through the NaN probe; every rank enumerates the same slot list
+    (zero counts when untouched) so the engine's batched gather stays aligned."""
+    from verl.workers.engine.spec import translate_flat_indices
+
+    full_shape = spec.full_shape
+    inner = max(_prodshape(full_shape[1:]), 1)
+    K = len(spec.hf_slots)
+    slots_per_row = K // int(full_shape[0])
+    counts = torch.zeros(K, dtype=torch.int64)
+    idx_pieces: list = []
+    val_pieces: list = []
+    if lidx.numel():
+        g = translate_flat_indices(lidx, place)
+        order = torch.argsort(g)
+        g, gv = g[order], lval[order]
+        rows = torch.div(g, inner, rounding_mode="floor")
+        urows, rcounts = torch.unique_consecutive(rows, return_counts=True)
+        pos = 0
+        for r, cnt in zip(urows.tolist(), rcounts.tolist(), strict=False):
+            sel_g = g[pos : pos + cnt]
+            sel_v = gv[pos : pos + cnt]
+            pos += cnt
+            for s_i, pidx, pval in convert_row_to_hf(name, spec, r, sel_g - r * inner, sel_v, lval):
+                counts[int(r) * slots_per_row + s_i] = pidx.numel()
+                idx_pieces.append(pidx)
+                val_pieces.append(pval)
+    if idx_pieces:
+        my_idx = torch.cat(idx_pieces)
+        my_val = torch.cat(val_pieces)
+    else:
+        my_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
+        my_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
+    return spec.hf_slots, str(lval.dtype).replace("torch.", ""), counts, my_idx, my_val

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -183,39 +183,42 @@ def enumerate_hf_slots(process_func, fqn, full_shape, dtype, device=None) -> lis
     return slots
 
 
-def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):
+def convert_row_to_hf(name, spec, expert_id: int, pos_in_row, vals, like):
     """NaN-probe one dim-0 row through the spec's converter: scatter the row's
     (within-row position, value) pairs into a NaN-filled row buffer, run
     ``to_hf_chunk`` on it, and extract each output slot's surviving positions and
     values (the converter is a pure permutation, so non-NaN survivors are exactly
-    the input pairs in final HF coordinates). Returns
-    ``[(slot_offset_in_row, idx_int32, val), ...]``, skipping empty slots.
+    the input pairs in final HF coordinates). ``like`` only lends its
+    dtype/device to the buffer. Returns
+    ``[(slot_in_row, idx_int32, val), ...]``, skipping empty slots.
 
     NaN is the sentinel, so a delta whose NEW value is literally NaN is
     indistinguishable from "untouched" and silently dropped -- acceptable
     because NaN weights are already a fatal training failure, and the
     idempotence verify sweep surfaces the divergence on its next pass."""
-    full_shape = spec.full_shape
-    inner = max(_prodshape(full_shape[1:]), 1)
-    slots_per_row = len(spec.hf_slots) // int(full_shape[0])
-    buf = torch.full((inner,), float("nan"), dtype=ref.dtype, device=ref.device)
-    buf[pos_in_row] = vals
-    outs = spec.to_hf_chunk(int(r), buf.view(1, *full_shape[1:]))
-    assert len(outs) == slots_per_row, (
-        f"{name}: to_hf_chunk gave {len(outs)} outputs/row, slot table expects {slots_per_row}"
+    row_shape = spec.full_shape[1:]
+    row_numel = max(_prodshape(row_shape), 1)
+    slots_per_row = len(spec.hf_slots) // int(spec.full_shape[0])
+
+    row_buf = torch.full((row_numel,), float("nan"), dtype=like.dtype, device=like.device)
+    row_buf[pos_in_row] = vals
+    hf_outputs = spec.to_hf_chunk(int(expert_id), row_buf.view(1, *row_shape))
+    assert len(hf_outputs) == slots_per_row, (
+        f"{name}: to_hf_chunk gave {len(hf_outputs)} outputs/row, slot table expects {slots_per_row}"
     )
-    res = []
-    for s_i, (_hf_name, hf_tensor) in enumerate(outs):
-        fl = hf_tensor.reshape(-1)
-        if fl.device != ref.device:
+
+    converted = []
+    for slot_in_row, (_hf_name, hf_tensor) in enumerate(hf_outputs):
+        flat = hf_tensor.reshape(-1)
+        if flat.device != like.device:
             # handlers move outputs to the accelerator; under CPUOffloadPolicy the
             # shard (and the rest of this entry) lives on CPU -- normalize so the
             # gather queue never cats mixed-device pieces.
-            fl = fl.to(ref.device)
-        p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
-        if p_.numel():
-            res.append((s_i, p_.to(torch.int32), fl[p_]))
-    return res
+            flat = flat.to(like.device)
+        survivor_pos = (~torch.isnan(flat)).nonzero(as_tuple=False).view(-1)
+        if survivor_pos.numel():
+            converted.append((slot_in_row, survivor_pos.to(torch.int32), flat[survivor_pos]))
+    return converted
 
 
 def hf_entry_converter(name, spec, place, lidx, lval):
@@ -225,35 +228,37 @@ def hf_entry_converter(name, spec, place, lidx, lval):
     (zero counts when untouched) so the engine's batched gather stays aligned."""
     from verl.workers.engine.spec import translate_flat_indices
 
-    full_shape = spec.full_shape
-    inner = max(_prodshape(full_shape[1:]), 1)
-    K = len(spec.hf_slots)
-    slots_per_row = K // int(full_shape[0])
-    counts = torch.zeros(K, dtype=torch.int64)
+    row_numel = max(_prodshape(spec.full_shape[1:]), 1)
+    n_slots = len(spec.hf_slots)
+    slots_per_row = n_slots // int(spec.full_shape[0])
+    counts = torch.zeros(n_slots, dtype=torch.int64)
     idx_pieces: list = []
     val_pieces: list = []
     if lidx.numel():
-        g = translate_flat_indices(lidx, place)
-        order = torch.argsort(g)
-        g, gv = g[order], lval[order]
-        rows = torch.div(g, inner, rounding_mode="floor")
-        urows, rcounts = torch.unique_consecutive(rows, return_counts=True)
-        pos = 0
-        for r, cnt in zip(urows.tolist(), rcounts.tolist(), strict=False):
-            sel_g = g[pos : pos + cnt]
-            sel_v = gv[pos : pos + cnt]
-            pos += cnt
-            for s_i, pidx, pval in convert_row_to_hf(name, spec, r, sel_g - r * inner, sel_v, lval):
-                counts[int(r) * slots_per_row + s_i] = pidx.numel()
-                idx_pieces.append(pidx)
-                val_pieces.append(pval)
+        # shard-local flat positions -> full-tensor flat positions, sorted so
+        # every touched expert row becomes one contiguous run
+        full_idx = translate_flat_indices(lidx, place)
+        order = torch.argsort(full_idx)
+        full_idx, full_val = full_idx[order], lval[order]
+        row_of = torch.div(full_idx, row_numel, rounding_mode="floor")
+        touched_rows, run_lengths = torch.unique_consecutive(row_of, return_counts=True)
+        cursor = 0
+        for expert_id, run_len in zip(touched_rows.tolist(), run_lengths.tolist(), strict=False):
+            run_idx = full_idx[cursor : cursor + run_len]
+            run_val = full_val[cursor : cursor + run_len]
+            cursor += run_len
+            pos_in_row = run_idx - expert_id * row_numel
+            for slot_in_row, hf_idx, hf_val in convert_row_to_hf(name, spec, expert_id, pos_in_row, run_val, lval):
+                counts[int(expert_id) * slots_per_row + slot_in_row] = hf_idx.numel()
+                idx_pieces.append(hf_idx)
+                val_pieces.append(hf_val)
     if idx_pieces:
-        my_idx = torch.cat(idx_pieces)
-        my_val = torch.cat(val_pieces)
+        entry_idx = torch.cat(idx_pieces)
+        entry_val = torch.cat(val_pieces)
     else:
-        my_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
-        my_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
-    return spec.hf_slots, str(lval.dtype).replace("torch.", ""), counts, my_idx, my_val
+        entry_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
+        entry_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
+    return spec.hf_slots, str(lval.dtype).replace("torch.", ""), counts, entry_idx, entry_val
 
 
 def veomni_shard_export(module):

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -153,19 +153,20 @@ NO_SLOTS_MSG = (
 _SLOT_TABLES: dict = {}
 
 
-def enumerate_hf_slots(process_func, fqn, full_shape, dtype) -> list:
+def enumerate_hf_slots(process_func, fqn, full_shape, dtype, device=None) -> list:
     """Let the handler itself reveal its slot table: run it once per expert row
-    on a zero dummy segment (CPU, one expert) and record the ``(hf_name,
-    hf_shape)`` sequence in the handler's own output order. Same philosophy as
-    the mcore probe -- the converter owns its output structure, nothing is
-    hand-copied -- so ANY handler following the ``(name, segment,
-    expert_id_base)`` contract is supported, not just the default one.
-    Cached per (handler, fqn, shape, dtype): the export runs every sync but the
-    table is static, and the handler moves each dummy row to the device."""
+    on a zero dummy segment (one expert) and record the ``(hf_name, hf_shape)``
+    sequence in the handler's own output order. Same philosophy as the mcore
+    probe -- the converter owns its output structure, nothing is hand-copied --
+    so ANY handler following the ``(name, segment, expert_id_base)`` contract
+    is supported, not just the default one. Cached per (handler, fqn, shape,
+    dtype): the export runs every sync but the table is static. Pass the
+    param's device: the handler moves its outputs to the accelerator, so an
+    on-device dummy makes that a no-op view instead of a per-row H2D copy."""
     key = (process_func, fqn, tuple(int(x) for x in full_shape), dtype)
     got = _SLOT_TABLES.get(key)
     if got is None:
-        dummy = torch.zeros((1, *key[2][1:]), dtype=dtype)
+        dummy = torch.zeros((1, *key[2][1:]), dtype=dtype, device=device)
         got = []
         for r in range(key[2][0]):
             for nm, t in process_func(fqn, dummy, expert_id_base=r):
@@ -250,7 +251,9 @@ def veomni_shard_export(module):
     (dim-0 offset = ``ep_rank * n_local_experts`` + the DTensor block offset)
     with the world group as the gather group, and a ``to_hf_chunk`` closure over
     the veomni MoE param handler (pure slice + rename: fused -> per-expert HF
-    names) plus its ``hf_slots`` output enumeration.
+    names) plus its ``hf_slots`` output enumeration. ``ep_size=1`` is the same
+    geometry with the manual split degenerate; Replicate dims on the block mesh
+    (newer veomni HSDPs the expert block) dedupe via ``spec.contributes``.
     """
     import torch.distributed as dist
     from veomni.distributed import parallel_state
@@ -269,20 +272,32 @@ def veomni_shard_export(module):
 
     from ..spec import BlockPlacement, ShardSpec
 
+    # Structural fact source: ParallelPlan.apply hangs fqn -> SpecInfo on the
+    # model itself (it survives state_dict, unlike per-param attributes). Every
+    # param gets an entry when EP is on -- non-sliced ones with
+    # placement=Replicate() and the SAME para_name -- so the discriminator is
+    # the placement type, never ``para_name`` (veomni's own DCP checkpointer
+    # keys off ``isinstance(placement, Shard)`` too).
+    fqn2si = getattr(module, "_fqn2spec_info", None) or getattr(
+        getattr(module, "_fsdp_wrapped_module", module), "_fqn2spec_info", None
+    )
+
     def _is_ep_param(name, param):
-        # Structural check first: veomni's ParallelPlan.apply attaches
-        # ``spec_info`` (para_name="ep") to every expert-parallel-sliced param
-        # -- the sharding fact itself, not a naming convention. Params can lose
-        # the attribute across state_dict/key conversion, so fall back to the
-        # historical name match.
-        si = getattr(param, "spec_info", None)
-        if si is not None:
-            return si.para_name == "ep"
+        if fqn2si is not None:
+            si = fqn2si.get(name)
+            if si is not None:
+                from torch.distributed.tensor import Shard
+
+                return isinstance(si.placement, Shard)
+        # fallback: key conversion may have renamed the fqn; historical name match.
         return "mlp.experts." in name and any(p in name for p in ["down_proj", "gate_proj", "up_proj", "gate_up_proj"])
 
     def _gen():
         for name, param in params.items():
-            is_expert = ps.ep_enabled and _is_ep_param(name, param)
+            # NOT gated on ep_enabled: the fused expert stack exists (and needs
+            # the per-expert HF renaming, like the seed path does) even with
+            # ep_size=1 -- that is just the degenerate ep_rank=0 geometry.
+            is_expert = _is_ep_param(name, param)
             if param.is_floating_point() and param.dtype != torch.bfloat16:
                 # mixed-precision keeps fp32 master weights; the wire (and the
                 # rollout side) speak bf16, so cast before diffing.
@@ -294,37 +309,51 @@ def veomni_shard_export(module):
                 continue
 
             # local fused block: [n_local_experts, ...] (ep split already applied)
+            contributes = True
             if isinstance(param, DTensor):
                 lshape, goff = compute_local_shape_and_global_offset(
                     param.shape, param.device_mesh, list(param.placements)
                 )
                 local = param.to_local()
+                # Replicate mesh dims (newer veomni HSDPs the expert block:
+                # (ep_replicate, ep_fsdp) mesh) yield identical blocks on every
+                # replica -- offsets are already 0 there, so the block math is
+                # untouched; only coord-0 ranks contribute, the rest keep
+                # lockstep with an empty delta.
+                coord = param.device_mesh.get_coordinate()
+                rep_dims = [d for d, p in enumerate(param.placements) if p.is_replicate()]
+                if coord is not None:
+                    contributes = all(int(coord[d]) == 0 for d in rep_dims)
             else:
                 lshape, goff = tuple(param.shape), (0,) * param.ndim
                 local = param
+            ep_size = ps.ep_size if ps.ep_enabled else 1
+            ep_rank = ps.ep_rank if ps.ep_enabled else 0
             n_local = int(param.shape[0])
-            full_shape = (n_local * ps.ep_size,) + tuple(param.shape[1:])
-            offset = (ps.ep_rank * n_local + int(goff[0]),) + tuple(int(o) for o in goff[1:])
+            full_shape = (n_local * ep_size,) + tuple(param.shape[1:])
+            offset = (ep_rank * n_local + int(goff[0]),) + tuple(int(o) for o in goff[1:])
             block = BlockPlacement(tuple(int(x) for x in lshape), offset, full_shape)
 
-            # the blocks of one expert tensor are spread over ep x (block fsdp);
-            # v1 requires that to cover the whole trainer world so the world
-            # group doubles as the gather group (rank 0 == engine master).
+            # the blocks of one expert tensor are spread over ep x (block mesh,
+            # replicas included); v1 requires that to cover the whole trainer
+            # world so the world group doubles as the gather group (rank 0 ==
+            # engine master). Replicas are deduplicated via ``contributes``.
             mesh_world = param.device_mesh.size() if isinstance(param, DTensor) else 1
-            assert ps.ep_size * mesh_world == dist.get_world_size(), (
-                f"expert blocks must tile the trainer world: ep={ps.ep_size} x "
+            assert ep_size * mesh_world == dist.get_world_size(), (
+                f"expert blocks must cover the trainer world: ep={ep_size} x "
                 f"block mesh={mesh_world} != world={dist.get_world_size()}"
             )
             spec = ShardSpec(
                 full_shape=full_shape,
                 place=block,
                 gather_group=dist.group.WORLD,
+                contributes=contributes,
                 # dim-0-separable: a segment is a run of whole experts starting at
                 # global expert id ``start`` -- exactly the handler's contract.
                 to_hf_chunk=lambda start, seg, _f=process_func, _n=name: list(_f(_n, seg, expert_id_base=start)),
                 # slot table enables sender-side conversion; probed once from
                 # the handler itself, so any handler is supported.
-                hf_slots=enumerate_hf_slots(process_func, name, full_shape, torch.bfloat16),
+                hf_slots=enumerate_hf_slots(process_func, name, full_shape, torch.bfloat16, device=local.device),
             )
             yield name, local.reshape(-1), spec
 

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -181,7 +181,12 @@ def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):
     ``to_hf_chunk`` on it, and extract each output slot's surviving positions and
     values (the converter is a pure permutation, so non-NaN survivors are exactly
     the input pairs in final HF coordinates). Returns
-    ``[(slot_offset_in_row, idx_int32, val), ...]``, skipping empty slots."""
+    ``[(slot_offset_in_row, idx_int32, val), ...]``, skipping empty slots.
+
+    NaN is the sentinel, so a delta whose NEW value is literally NaN is
+    indistinguishable from "untouched" and silently dropped -- acceptable
+    because NaN weights are already a fatal training failure, and the
+    idempotence verify sweep surfaces the divergence on its next pass."""
     full_shape = spec.full_shape
     inner = max(_prodshape(full_shape[1:]), 1)
     slots_per_row = len(spec.hf_slots) // int(full_shape[0])
@@ -194,6 +199,11 @@ def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):
     res = []
     for s_i, (_hf_name, hf_tensor) in enumerate(outs):
         fl = hf_tensor.reshape(-1)
+        if fl.device != ref.device:
+            # handlers move outputs to the accelerator; under CPUOffloadPolicy the
+            # shard (and the rest of this entry) lives on CPU -- normalize so the
+            # gather queue never cats mixed-device pieces.
+            fl = fl.to(ref.device)
         p_ = (~torch.isnan(fl)).nonzero(as_tuple=False).view(-1)
         if p_.numel():
             res.append((s_i, p_.to(torch.int32), fl[p_]))

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -155,24 +155,32 @@ _SLOT_TABLES: dict = {}
 
 def enumerate_hf_slots(process_func, fqn, full_shape, dtype, device=None) -> list:
     """Let the handler itself reveal its slot table: run it once per expert row
-    on a zero dummy segment (one expert) and record the ``(hf_name, hf_shape)``
-    sequence in the handler's own output order. Same philosophy as the mcore
-    probe -- the converter owns its output structure, nothing is hand-copied --
-    so ANY handler following the ``(name, segment, expert_id_base)`` contract
-    is supported, not just the default one. Cached per (handler, fqn, shape,
-    dtype): the export runs every sync but the table is static. Pass the
-    param's device: the handler moves its outputs to the accelerator, so an
-    on-device dummy makes that a no-op view instead of a per-row H2D copy."""
-    key = (process_func, fqn, tuple(int(x) for x in full_shape), dtype)
-    got = _SLOT_TABLES.get(key)
-    if got is None:
-        dummy = torch.zeros((1, *key[2][1:]), dtype=dtype, device=device)
-        got = []
-        for r in range(key[2][0]):
-            for nm, t in process_func(fqn, dummy, expert_id_base=r):
-                got.append((nm, tuple(int(x) for x in t.shape)))
-        _SLOT_TABLES[key] = got
-    return got
+    on a zero dummy row and record the ``(hf_name, hf_shape)`` sequence in the
+    handler's own output order. Same philosophy as the mcore probe -- the
+    converter owns its output structure, nothing is hand-copied -- so ANY
+    handler following the ``(name, segment, expert_id_base)`` contract is
+    supported, not just the default one.
+
+    The table is static metadata (names/shapes depend on the arguments only,
+    never on weight values), so it is enumerated once per (handler, fqn, shape,
+    dtype) and cached for the process lifetime -- the export calls this every
+    sync. Pass the param's device: the handler moves its outputs to the
+    accelerator, so an on-device dummy makes that a no-op view instead of a
+    per-row H2D copy."""
+    n_experts = int(full_shape[0])
+    row_shape = tuple(int(dim) for dim in full_shape[1:])
+    cache_key = (process_func, fqn, (n_experts, *row_shape), dtype)
+    cached = _SLOT_TABLES.get(cache_key)
+    if cached is not None:
+        return cached
+
+    dummy_row = torch.zeros((1, *row_shape), dtype=dtype, device=device)
+    slots = []
+    for expert_id in range(n_experts):
+        for hf_name, hf_tensor in process_func(fqn, dummy_row, expert_id_base=expert_id):
+            slots.append((hf_name, tuple(hf_tensor.shape)))
+    _SLOT_TABLES[cache_key] = slots
+    return slots
 
 
 def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -211,3 +211,117 @@ def hf_entry_converter(name, spec, place, lidx, lval):
         my_idx = torch.empty(0, dtype=torch.int32, device=lval.device)
         my_val = torch.empty(0, dtype=lval.dtype, device=lval.device)
     return spec.hf_slots, str(lval.dtype).replace("torch.", ""), counts, my_idx, my_val
+
+
+def veomni_shard_export(module):
+    """Build the per-rank shard export ``(gen, None)`` for
+    :meth:`VeOmniEngine.get_per_tensor_param_shard`.
+
+    Dense params pass their FSDP DTensor placement through verbatim (flat
+    ``Shard(0)`` fast path). Grouped expert params are split twice: the expert
+    dim (0) is split *manually* across ``ep_group`` (outside DTensor), and the
+    local expert block is FSDP-sharded as a DTensor. That combination is not
+    expressible as DTensor placements, so the spec carries an explicit
+    :class:`BlockPlacement` in a virtual full tensor of all experts
+    (dim-0 offset = ``ep_rank * n_local_experts`` + the DTensor block offset)
+    with the world group as the gather group, and a ``to_hf_chunk`` closure over
+    the veomni MoE param handler (pure slice + rename: fused -> per-expert HF
+    names) plus its ``hf_slots`` output enumeration.
+    """
+    import torch.distributed as dist
+    from veomni.distributed import parallel_state
+
+    from verl.utils.model import convert_weight_keys
+
+    params = module.state_dict()
+    params = convert_weight_keys(params, getattr(module, "_fsdp_wrapped_module", module))
+
+    ps = parallel_state.get_parallel_state()
+    model_type = getattr(module.config, "model_type", "default")
+    process_func = MOE_PARAM_HANDERS.get(model_type, default_moe_param_handler)
+
+    from torch.distributed.tensor import DTensor
+    from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
+
+    from ..spec import BlockPlacement, ShardSpec
+
+    def _expert_hf_slots(fqn, full_shape):
+        """Full (hf_name, hf_shape) slot table for one fused expert param, in dim-0
+        order matching the default handler's per-segment output order. Only valid
+        for the default handler (custom MOE_PARAM_HANDERS may rename differently),
+        so the caller attaches it only when process_func is the default."""
+        n_experts = int(full_shape[0])
+        slots = []
+        if "gate_up_proj" in fqn:
+            inter = int(full_shape[1]) // 2
+            inner = (inter, *(int(x) for x in full_shape[2:]))
+            for i in range(n_experts):
+                for proj in ("gate_proj", "up_proj"):
+                    nm = fqn.replace("gate_up_proj", proj)
+                    slots.append((nm.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
+        else:
+            inner = tuple(int(x) for x in full_shape[1:])
+            for i in range(n_experts):
+                slots.append((fqn.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
+        return slots
+
+    def _is_ep_param(name, param):
+        # Structural check first: veomni's ParallelPlan.apply attaches
+        # ``spec_info`` (para_name="ep") to every expert-parallel-sliced param
+        # -- the sharding fact itself, not a naming convention. Params can lose
+        # the attribute across state_dict/key conversion, so fall back to the
+        # historical name match.
+        si = getattr(param, "spec_info", None)
+        if si is not None:
+            return si.para_name == "ep"
+        return "mlp.experts." in name and any(p in name for p in ["down_proj", "gate_proj", "up_proj", "gate_up_proj"])
+
+    def _gen():
+        for name, param in params.items():
+            is_expert = ps.ep_enabled and _is_ep_param(name, param)
+            if param.is_floating_point() and param.dtype != torch.bfloat16:
+                # mixed-precision keeps fp32 master weights; the wire (and the
+                # rollout side) speak bf16, so cast before diffing.
+                param = param.to(torch.bfloat16)
+            if not is_expert:
+                spec = ShardSpec.from_param(param)
+                local = param.to_local() if isinstance(param, DTensor) else param
+                yield name, local.reshape(-1), spec
+                continue
+
+            # local fused block: [n_local_experts, ...] (ep split already applied)
+            if isinstance(param, DTensor):
+                lshape, goff = compute_local_shape_and_global_offset(
+                    param.shape, param.device_mesh, list(param.placements)
+                )
+                local = param.to_local()
+            else:
+                lshape, goff = tuple(param.shape), (0,) * param.ndim
+                local = param
+            n_local = int(param.shape[0])
+            full_shape = (n_local * ps.ep_size,) + tuple(param.shape[1:])
+            offset = (ps.ep_rank * n_local + int(goff[0]),) + tuple(int(o) for o in goff[1:])
+            block = BlockPlacement(tuple(int(x) for x in lshape), offset, full_shape)
+
+            # the blocks of one expert tensor are spread over ep x (block fsdp);
+            # v1 requires that to cover the whole trainer world so the world
+            # group doubles as the gather group (rank 0 == engine master).
+            mesh_world = param.device_mesh.size() if isinstance(param, DTensor) else 1
+            assert ps.ep_size * mesh_world == dist.get_world_size(), (
+                f"expert blocks must tile the trainer world: ep={ps.ep_size} x "
+                f"block mesh={mesh_world} != world={dist.get_world_size()}"
+            )
+            spec = ShardSpec(
+                full_shape=full_shape,
+                place=block,
+                gather_group=dist.group.WORLD,
+                # dim-0-separable: a segment is a run of whole experts starting at
+                # global expert id ``start`` -- exactly the handler's contract.
+                to_hf_chunk=lambda start, seg, _f=process_func, _n=name: list(_f(_n, seg, expert_id_base=start)),
+                # slot table enables sender-side conversion; only the default
+                # handler's naming is enumerable without running the converter.
+                hf_slots=(_expert_hf_slots(name, full_shape) if process_func is default_moe_param_handler else None),
+            )
+            yield name, local.reshape(-1), spec
+
+    return _gen(), None

--- a/verl/workers/engine/veomni/utils.py
+++ b/verl/workers/engine/veomni/utils.py
@@ -150,6 +150,30 @@ NO_SLOTS_MSG = (
 )
 
 
+_SLOT_TABLES: dict = {}
+
+
+def enumerate_hf_slots(process_func, fqn, full_shape, dtype) -> list:
+    """Let the handler itself reveal its slot table: run it once per expert row
+    on a zero dummy segment (CPU, one expert) and record the ``(hf_name,
+    hf_shape)`` sequence in the handler's own output order. Same philosophy as
+    the mcore probe -- the converter owns its output structure, nothing is
+    hand-copied -- so ANY handler following the ``(name, segment,
+    expert_id_base)`` contract is supported, not just the default one.
+    Cached per (handler, fqn, shape, dtype): the export runs every sync but the
+    table is static, and the handler moves each dummy row to the device."""
+    key = (process_func, fqn, tuple(int(x) for x in full_shape), dtype)
+    got = _SLOT_TABLES.get(key)
+    if got is None:
+        dummy = torch.zeros((1, *key[2][1:]), dtype=dtype)
+        got = []
+        for r in range(key[2][0]):
+            for nm, t in process_func(fqn, dummy, expert_id_base=r):
+                got.append((nm, tuple(int(x) for x in t.shape)))
+        _SLOT_TABLES[key] = got
+    return got
+
+
 def convert_row_to_hf(name, spec, r: int, pos_in_row, vals, ref):
     """NaN-probe one dim-0 row through the spec's converter: scatter the row's
     (within-row position, value) pairs into a NaN-filled row buffer, run
@@ -245,26 +269,6 @@ def veomni_shard_export(module):
 
     from ..spec import BlockPlacement, ShardSpec
 
-    def _expert_hf_slots(fqn, full_shape):
-        """Full (hf_name, hf_shape) slot table for one fused expert param, in dim-0
-        order matching the default handler's per-segment output order. Only valid
-        for the default handler (custom MOE_PARAM_HANDERS may rename differently),
-        so the caller attaches it only when process_func is the default."""
-        n_experts = int(full_shape[0])
-        slots = []
-        if "gate_up_proj" in fqn:
-            inter = int(full_shape[1]) // 2
-            inner = (inter, *(int(x) for x in full_shape[2:]))
-            for i in range(n_experts):
-                for proj in ("gate_proj", "up_proj"):
-                    nm = fqn.replace("gate_up_proj", proj)
-                    slots.append((nm.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
-        else:
-            inner = tuple(int(x) for x in full_shape[1:])
-            for i in range(n_experts):
-                slots.append((fqn.replace("mlp.experts.", f"mlp.experts.{i}.") + ".weight", inner))
-        return slots
-
     def _is_ep_param(name, param):
         # Structural check first: veomni's ParallelPlan.apply attaches
         # ``spec_info`` (para_name="ep") to every expert-parallel-sliced param
@@ -318,9 +322,9 @@ def veomni_shard_export(module):
                 # dim-0-separable: a segment is a run of whole experts starting at
                 # global expert id ``start`` -- exactly the handler's contract.
                 to_hf_chunk=lambda start, seg, _f=process_func, _n=name: list(_f(_n, seg, expert_id_base=start)),
-                # slot table enables sender-side conversion; only the default
-                # handler's naming is enumerable without running the converter.
-                hf_slots=(_expert_hf_slots(name, full_shape) if process_func is default_moe_param_handler else None),
+                # slot table enables sender-side conversion; probed once from
+                # the handler itself, so any handler is supported.
+                hf_slots=enumerate_hf_slots(process_func, name, full_shape, torch.bfloat16),
             )
             yield name, local.reshape(-1), spec
 


### PR DESCRIPTION
## What does this PR do?

Second half of the review-requested split (engine core + FSDP moved to #7144, which this PR is stacked on — the first commit here is #7144; review the second commit only): wires **veomni FSDP2+EP** into the sharded delta sync end to end. Supersedes #7080 (veomni replaces automodel as the first EP consumer since it has PPO wiring and an EP-correct full-weight baseline upstream).

### veomni FSDP2+EP export

`VeOmniEngine.get_per_tensor_param_shard`: dense params pass their DTensor placement through verbatim (flat fast path). Grouped experts are split twice — the expert dim manually across `ep_group` (outside DTensor) and the local block FSDP-sharded as a DTensor — which no placement tuple can express, so the exporter synthesizes a `BlockPlacement` in the virtual all-experts tensor (dim-0 offset = `ep_rank * n_local_experts` + the DTensor block offset), uses the world group as the gather group (asserted to be exactly tiled by ep × block mesh), and declares veomni's own MoE param handler as a dim-0-separable `to_hf_chunk` + `hf_slots` enumeration (fused → per-expert HF names, e.g. `mlp.experts.gate_up_proj [128,1536,2048]` → `mlp.experts.{i}.gate_proj/up_proj.weight`).

`_hf_delta_entry` routes converter specs through the NaN row probe (`convert_row_to_hf` / `hf_entry_converter` in `verl/workers/engine/veomni/utils.py`): only the touched dim-0 rows are probed, the converter is a pure permutation so non-NaN survivors are exactly this rank's contributions in final HF coordinates; every rank enumerates the same slot list so the batched gather stays aligned. Mixed-precision fp32 master weights are cast to bf16 before diffing (the wire and the rollout side speak bf16).

## Test

- CPU: `test_hf_delta_export_converter_param` — converter param's delta entry carries hf_slots-keyed final coordinates (veomni utils file-loaded to keep it a CPU unit test). Full checkpoint-engine suite: 24 pass on the stack.
- E2E: Qwen3-30B-A3B, veomni `expert_parallel_size=8`, SGLang rollout TP4, 2×8 GPU disaggregated, `delta_sharded`: steady syncs 5.8–7.9 s (nccl baseline 32.2 s median → **4.5×**); Qwen3-235B-A22B (ep8 × fsdp8, 8+2 nodes, gen TP16): **8.8–9.0 s** vs 246–266 s nccl (**~21×**), seed 68.7 s / 437.9 GB.
- **50-step GRPO training equivalence at 30B-A3B** (public W&B report): score/pg_loss/grad_norm/ppo_kl trajectories overlap within independent-sampling noise across the whole run: https://api.wandb.ai/links/liquid-ai/55u99gwy

🤖 Generated with [Claude Code](https://claude.com/claude-code)