### PR TITLE
[vllm, rollout, worker] fix: refresh Ascend MoE comm state after L2 wake to fix ep+sleep level2 precision issue

### DIFF
--- a/verl/utils/vllm/npu_vllm_patch.py
+++ b/verl/utils/vllm/npu_vllm_patch.py
@@ -15,9 +15,42 @@
 # limitations under the License.
 
 
+import logging
 from functools import wraps
-
+import torch
 from verl.utils.device import is_torch_npu_available
+
+logger = logging.getLogger(__name__)
+
+
+def refresh_ascend_moe_comm_state_after_l2_wake() -> None:
+    """Restore All2AllV ``expert_ids_per_ep_rank`` after vLLM L2 (discard) wake + IPC reload.
+
+    L2 discards this persistent NPU tensor; IPC reload and buffer restore do not recreate it,
+    so after wake it can hold garbage and route tokens to wrong local experts under EP>1.
+    Uses process-global ``_MoECommMethods`` (populated at MoE layer init), not the ``nn.Module``.
+
+    TODO: remove when vllm-ascend restores expert_ids in ``NPUWorker.wake_up`` after L2.
+    """
+    try:
+        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
+
+        for comm_method in list(_MoECommMethods.values()):
+            dispatcher = getattr(comm_method, "token_dispatcher", None)
+            if dispatcher is None:
+                continue
+            ids = getattr(dispatcher, "expert_ids_per_ep_rank", None)
+            num_local = getattr(dispatcher, "num_local_experts", 0)
+            num_experts = getattr(dispatcher, "num_experts", 0)
+            if ids is None or num_local <= 1 or num_experts <= 0:
+                continue
+            correct = torch.arange(num_experts, dtype=ids.dtype, device=ids.device) % num_local
+            if ids.shape == correct.shape:
+                ids.copy_(correct)
+            else:
+                dispatcher.expert_ids_per_ep_rank = correct
+    except Exception as exc:
+        logger.warning("Failed to restore expert_ids_per_ep_rank after L2 wake: %s", exc)
 
 
 def vllm_v013_weight_loader_method_wrapper(fn):

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -44,34 +44,6 @@ VLLM_LORA_PATH = "simon_lora_path"
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
 
 
-def _refresh_ascend_moe_comm_state_after_l2_wake() -> None:
-    """Restore all2all ``expert_ids_per_ep_rank`` after vLLM L2 (discard) wake + IPC reload.
-
-    L2 discards this persistent NPU tensor; IPC reload and buffer restore do not recreate it,
-    so after wake it can hold garbage and route tokens to wrong local experts under EP>1.
-    Uses process-global ``_MoECommMethods`` (populated at MoE layer init), not the ``nn.Module``.
-    """
-    try:
-        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
-
-        for comm_method in list(_MoECommMethods.values()):
-            dispatcher = getattr(comm_method, "token_dispatcher", None)
-            if dispatcher is None:
-                continue
-            ids = getattr(dispatcher, "expert_ids_per_ep_rank", None)
-            num_local = getattr(dispatcher, "num_local_experts", 0)
-            num_experts = getattr(dispatcher, "num_experts", 0)
-            if ids is None or num_local <= 1 or num_experts <= 0:
-                continue
-            correct = torch.arange(num_experts, dtype=ids.dtype, device=ids.device) % num_local
-            if ids.shape == correct.shape:
-                ids.copy_(correct)
-            else:
-                dispatcher.expert_ids_per_ep_rank = correct
-    except Exception as exc:
-        logger.warning("Failed to restore expert_ids_per_ep_rank after L2 wake: %s", exc)
-
-
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
     worker_local_rank = int(worker_local_rank)
     if parallel_config is None:
@@ -517,6 +489,7 @@ class vLLMColocateWorkerExtension:
                 for model, model_config in self._iter_all_models_with_config():
                     process_weights_after_loading(model, model_config, self.device)
                 if VLLM_SLEEP_LEVEL == 2 and is_npu_available:
+                    from verl.utils.vllm.npu_vllm_patch import refresh_ascend_moe_comm_state_after_l2_wake
                     _refresh_ascend_moe_comm_state_after_l2_wake()
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -44,6 +44,40 @@ VLLM_LORA_PATH = "simon_lora_path"
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
 
 
+def _refresh_ascend_moe_comm_state_after_l2_wake(model: torch.nn.Module) -> int:
+    """Restore all2all ``expert_ids_per_ep_rank`` after vLLM L2 (discard) wake + IPC reload.
+
+    L2 discards this persistent NPU tensor; IPC reload and buffer restore do not recreate it,
+    so after wake it can hold garbage and route tokens to wrong local experts under EP>1.
+    """
+    actions = 0
+    try:
+        from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
+
+        for comm_method in list(_MoECommMethods.values()):
+            dispatcher = getattr(comm_method, "token_dispatcher", None)
+            if dispatcher is None:
+                continue
+            ids = getattr(dispatcher, "expert_ids_per_ep_rank", None)
+            num_local = getattr(dispatcher, "num_local_experts", 0)
+            num_experts = getattr(dispatcher, "num_experts", 0)
+            if ids is None or num_local <= 1 or num_experts <= 0:
+                continue
+            correct = torch.tensor(
+                [i % num_local for i in range(num_experts)],
+                dtype=ids.dtype,
+                device=ids.device,
+            )
+            if ids.shape == correct.shape:
+                ids.copy_(correct)
+            else:
+                dispatcher.expert_ids_per_ep_rank = correct
+            actions += 1
+    except Exception as exc:
+        logger.warning("Failed to restore expert_ids_per_ep_rank after L2 wake: %s", exc)
+    return actions
+
+
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
     worker_local_rank = int(worker_local_rank)
     if parallel_config is None:
@@ -484,9 +518,13 @@ class vLLMColocateWorkerExtension:
             elif use_standard_weight_load and not used_layerwise_reload:
                 # Some post-load transforms are non-idempotent; run once after all buckets.
                 from vllm.model_executor.model_loader.utils import process_weights_after_loading
+                from verl.third_party.vllm import VLLM_SLEEP_LEVEL
 
                 for model, model_config in self._iter_all_models_with_config():
                     process_weights_after_loading(model, model_config, self.device)
+                if VLLM_SLEEP_LEVEL == 2 and is_npu_available:
+                    _refresh_ascend_moe_comm_state_after_l2_wake(self.model_runner.model)
+
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -519,7 +519,6 @@ class vLLMColocateWorkerExtension:
                 if VLLM_SLEEP_LEVEL == 2 and is_npu_available:
                     _refresh_ascend_moe_comm_state_after_l2_wake()
 
-
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):
         """Apply buffer updates to the main model and any synced MTP drafter.
 

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -44,13 +44,13 @@ VLLM_LORA_PATH = "simon_lora_path"
 VLLM_ASCEND_REQUIRED_ENV_VARS = {"VLLM_ALL2ALL_BACKEND": "flashinfer_all2allv", "VLLM_ASCEND_ENABLE_NZ": "0"}
 
 
-def _refresh_ascend_moe_comm_state_after_l2_wake(model: torch.nn.Module) -> int:
+def _refresh_ascend_moe_comm_state_after_l2_wake() -> None:
     """Restore all2all ``expert_ids_per_ep_rank`` after vLLM L2 (discard) wake + IPC reload.
 
     L2 discards this persistent NPU tensor; IPC reload and buffer restore do not recreate it,
     so after wake it can hold garbage and route tokens to wrong local experts under EP>1.
+    Uses process-global ``_MoECommMethods`` (populated at MoE layer init), not the ``nn.Module``.
     """
-    actions = 0
     try:
         from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 
@@ -63,19 +63,13 @@ def _refresh_ascend_moe_comm_state_after_l2_wake(model: torch.nn.Module) -> int:
             num_experts = getattr(dispatcher, "num_experts", 0)
             if ids is None or num_local <= 1 or num_experts <= 0:
                 continue
-            correct = torch.tensor(
-                [i % num_local for i in range(num_experts)],
-                dtype=ids.dtype,
-                device=ids.device,
-            )
+            correct = torch.arange(num_experts, dtype=ids.dtype, device=ids.device) % num_local
             if ids.shape == correct.shape:
                 ids.copy_(correct)
             else:
                 dispatcher.expert_ids_per_ep_rank = correct
-            actions += 1
     except Exception as exc:
         logger.warning("Failed to restore expert_ids_per_ep_rank after L2 wake: %s", exc)
-    return actions
 
 
 def _resolve_vllm_weight_sync_local_rank(worker_local_rank: int, parallel_config: Any) -> int:
@@ -523,7 +517,7 @@ class vLLMColocateWorkerExtension:
                 for model, model_config in self._iter_all_models_with_config():
                     process_weights_after_loading(model, model_config, self.device)
                 if VLLM_SLEEP_LEVEL == 2 and is_npu_available:
-                    _refresh_ascend_moe_comm_state_after_l2_wake(self.model_runner.model)
+                    _refresh_ascend_moe_comm_state_after_l2_wake()
 
 
     def _apply_buffer_updates_all_models(self, buffer_updates, main_named_buffers):


### PR DESCRIPTION
[vllm, rollout, worker] fix: refresh Ascend MoE comm state after L2 wake to fix ep+sleep level2 precision issue

### What does this PR do?

Fixes incorrect rollout outputs on Ascend NPU + vLLM sleep level 2 (L2) + expert parallel (EP > 1) in hybrid (colocated) training.

After engine.sleep(level=2) discards NPU weights and actor weights are reloaded via IPC, vllm-ascend’s all-to-all MoE dispatcher keeps a persistent tensor expert_ids_per_ep_rank that is not recreated by weight reload. Stale/garbage values cause wrong expert routing → fluent but incorrect generations after the first post-sleep sync.

This PR restores expert_ids_per_ep_rank in-place after IPC reload when VLLM_SLEEP_LEVEL == 2 on NPU. It also re-applies patch_vllm_moe_model_weight_loader after process_weights_after_loading, because Ascend MoE post-load transforms recreate Parameter objects without weight_loader (needed for the next IPC sync; applies to L1 and L2).

Scope: single file — verl/workers/rollout/vllm_rollout/utils.py. No API / config changes.

Related context: vllm-ascend TokenDispatcherWithAll2AllV (vllm_ascend/ops/fused_moe/token_dispatcher.py).

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

No public API changes. If you want to use VLLM_SLEEP_LEVEL=2 ,you should change code in /verl/third_party/vllm/__init__.py and /verl/workers/rollout/vllm_rollout/vllm_async_server.py now.

### Design & Code Changes

File changes (verl/workers/rollout/vllm_rollout/utils.py)

Add _refresh_ascend_moe_comm_state_after_l2_wake() — restores [i % num_local for i in range(num_experts)] on each all-to-all dispatcher; no-op when num_local <= 1 or attribute missing; logs warning on failure.
In update_weights_from_ipc(), after process_weights_after_loading on the standard (non-QAT/FP8) path:
Re-apply patch_vllm_moe_model_weight_loader (L1/L2; MoE IPC sync hygiene).
Call refresh only when VLLM_SLEEP_LEVEL == 2 and is_npu_available.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
