### PR TITLE
[rollout, vllm] fix: use native reload for NPU MTP weight updates

### DIFF
--- a/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
@@ -17,6 +17,7 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 import torch
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -242,3 +243,246 @@ def test_vllm_update_weights_syncs_buffers_to_mtp_drafter():
     expected = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
     torch.testing.assert_close(main_model.model.layers[0].e_score_correction_bias, expected)
     torch.testing.assert_close(drafter_model.model.layers[0].e_score_correction_bias, expected)
+
+
+def _run_with_fake_modules(fakes, fn):
+    saved = {name: sys.modules.get(name) for name in fakes}
+    try:
+        sys.modules.update(fakes)
+        return fn()
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+
+
+def _make_weight_reload_fakes(events, device_type="npu", initialize_error=None, reload_api_available=True):
+    class _FakeBucketedWeightReceiver:
+        def __init__(self, **kwargs):
+            events.append("receiver:init")
+
+        def receive_weights(self, on_bucket_received):
+            on_bucket_received([("model.layers.0.linear.weight", torch.ones(4, 4))])
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_platforms = types.ModuleType("vllm.platforms")
+    fake_platforms.current_platform = types.SimpleNamespace(device_type=device_type)
+    fake_model_executor = types.ModuleType("vllm.model_executor")
+    fake_model_loader = types.ModuleType("vllm.model_executor.model_loader")
+    fake_reload = types.ModuleType("vllm.model_executor.model_loader.reload")
+    fake_loader_utils = types.ModuleType("vllm.model_executor.model_loader.utils")
+    fake_bucket_transfer = types.ModuleType("verl.workers.rollout.vllm_rollout.bucketed_weight_transfer")
+
+    fake_vllm.platforms = fake_platforms
+    fake_vllm.model_executor = fake_model_executor
+    fake_model_executor.model_loader = fake_model_loader
+    fake_model_loader.reload = fake_reload
+    fake_model_loader.utils = fake_loader_utils
+    fake_bucket_transfer.BucketedWeightReceiver = _FakeBucketedWeightReceiver
+
+    def _initialize(model):
+        events.append(f"initialize:{model._test_reload_name}")
+        if initialize_error is not None:
+            raise initialize_error
+
+    def _finalize(model, model_config):
+        events.append(f"finalize:{model._test_reload_name}")
+
+    if reload_api_available:
+        fake_reload.initialize_layerwise_reload = _initialize
+        fake_reload.finalize_layerwise_reload = _finalize
+    fake_loader_utils.process_weights_after_loading = lambda model, model_config, device: events.append(
+        f"postprocess:{model._test_reload_name}"
+    )
+
+    return {
+        "vllm": fake_vllm,
+        "vllm.platforms": fake_platforms,
+        "vllm.model_executor": fake_model_executor,
+        "vllm.model_executor.model_loader": fake_model_loader,
+        "vllm.model_executor.model_loader.reload": fake_reload,
+        "vllm.model_executor.model_loader.utils": fake_loader_utils,
+        "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer": fake_bucket_transfer,
+    }
+
+
+def _build_weight_reload_worker(target, drafter=None, draft_model_config="draft_config", enforce_eager=False):
+    class _SpecConfig:
+        method = "mtp"
+
+        def __init__(self, model_config):
+            self.draft_model_config = model_config
+
+    class _Drafter:
+        def __init__(self, model):
+            self.model = model
+
+    speculative_config = _SpecConfig(draft_model_config) if drafter is not None else None
+    worker = object.__new__(vLLMColocateWorkerExtension)
+    worker.model_runner = _FakeModelRunner(target, speculative_config=speculative_config)
+    worker.model_runner.vllm_config.model_config = types.SimpleNamespace(enforce_eager=enforce_eager)
+    target._test_reload_name = "target"
+    if drafter is not None:
+        worker.model_runner.drafter = _Drafter(drafter)
+        drafter._test_reload_name = "drafter"
+    worker.device = torch.device("cpu")
+    worker.local_rank = 0
+    worker._is_qat_model = False
+    worker._is_modelopt_qat = False
+    worker._get_zmq_handle = lambda: "ipc://cpu-test"
+    worker.prepare_model_for_native_layerwise_reload = lambda model: None
+    return worker
+
+
+@pytest.mark.parametrize("enforce_eager", [False, True], ids=["graph", "eager"])
+def test_npu_mtp_reload_lifecycle_is_independent_of_execution_mode(enforce_eager):
+    events = []
+    target = _ToyModel()
+    drafter = _ToyModel()
+    target.load_weights = lambda weights: events.append("load:target")
+    drafter.load_weights = lambda weights: events.append("load:drafter")
+    worker = _build_weight_reload_worker(target, drafter, enforce_eager=enforce_eager)
+    worker.prepare_model_for_native_layerwise_reload = lambda model: events.append(f"prepare:{model._test_reload_name}")
+
+    fakes = _make_weight_reload_fakes(events)
+    _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == [
+        "prepare:target",
+        "prepare:drafter",
+        "initialize:target",
+        "initialize:drafter",
+        "receiver:init",
+        "load:target",
+        "load:drafter",
+        "finalize:target",
+        "finalize:drafter",
+    ]
+
+
+def test_cuda_mtp_reload_keeps_direct_weight_loading():
+    events = []
+    target = _ToyModel()
+    drafter = _ToyModel()
+    target.load_weights = lambda weights: events.append("load:target")
+    drafter.load_weights = lambda weights: events.append("load:drafter")
+    worker = _build_weight_reload_worker(target, drafter)
+    worker._native_npu_reload_failure = "a previous NPU-only failure"
+    worker._uses_native_npu_mtp_reload = lambda *_args: pytest.fail("entered NPU-only dispatch")
+
+    fakes = _make_weight_reload_fakes(events, device_type="cuda")
+    _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == [
+        "receiver:init",
+        "load:target",
+        "load:drafter",
+        "postprocess:target",
+        "postprocess:drafter",
+    ]
+
+
+@pytest.mark.parametrize("enforce_eager", [False, True], ids=["graph", "eager"])
+def test_non_mtp_npu_reload_keeps_direct_weight_loading(enforce_eager):
+    events = []
+    target = _ToyModel()
+    target.load_weights = lambda weights: events.append("load:target")
+    worker = _build_weight_reload_worker(target, enforce_eager=enforce_eager)
+
+    fakes = _make_weight_reload_fakes(events)
+    _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == ["receiver:init", "load:target", "postprocess:target"]
+
+
+def test_npu_mtp_reload_validates_draft_config_before_mutation():
+    events = []
+    worker = _build_weight_reload_worker(_ToyModel(), _ToyModel(), draft_model_config=None)
+    worker.prepare_model_for_native_layerwise_reload = lambda model: events.append("prepare")
+
+    fakes = _make_weight_reload_fakes(events)
+    with pytest.raises(RuntimeError, match="draft_model_config is missing"):
+        _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == []
+
+
+def test_npu_mtp_reload_requires_backend_prepare_hook_before_mutation():
+    events = []
+    worker = _build_weight_reload_worker(_ToyModel(), _ToyModel())
+    worker.prepare_model_for_native_layerwise_reload = None
+
+    fakes = _make_weight_reload_fakes(events)
+    with pytest.raises(RuntimeError, match="prepare_model_for_native_layerwise_reload"):
+        _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == []
+
+
+def test_npu_mtp_reload_requires_public_vllm_api_before_mutation():
+    events = []
+    worker = _build_weight_reload_worker(_ToyModel(), _ToyModel())
+
+    fakes = _make_weight_reload_fakes(events, reload_api_available=False)
+    with pytest.raises(RuntimeError, match="public layerwise reload API"):
+        _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == []
+
+
+def test_npu_mtp_reload_failure_makes_worker_fail_stop():
+    events = []
+    failure = RuntimeError("initialize failed")
+    worker = _build_weight_reload_worker(_ToyModel(), _ToyModel())
+
+    fakes = _make_weight_reload_fakes(events, initialize_error=failure)
+    with pytest.raises(RuntimeError, match="initialize failed") as exc_info:
+        _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert exc_info.value is failure
+    assert events == ["initialize:target"]
+
+    with pytest.raises(RuntimeError, match="Recreate the worker"):
+        _run_with_fake_modules(fakes, worker.update_weights_from_ipc)
+
+    assert events == ["initialize:target"]
+
+
+@pytest.mark.parametrize(
+    "has_drafter,use_standard_weight_load,is_qat_model,is_modelopt_qat,expected",
+    [
+        pytest.param(True, True, False, False, True, id="standard-mtp"),
+        pytest.param(False, True, False, False, False, id="non-mtp"),
+        pytest.param(True, False, False, False, False, id="non-standard-mtp"),
+        pytest.param(True, True, True, False, False, id="qat-mtp"),
+        pytest.param(True, True, False, True, False, id="modelopt-mtp"),
+    ],
+)
+def test_native_npu_mtp_reload_selector_is_narrow(
+    has_drafter, use_standard_weight_load, is_qat_model, is_modelopt_qat, expected
+):
+    drafter = _ToyModel() if has_drafter else None
+    worker = _build_weight_reload_worker(_ToyModel(), drafter)
+    worker._is_qat_model = is_qat_model
+    worker._is_modelopt_qat = is_modelopt_qat
+
+    assert worker._uses_native_npu_mtp_reload(use_standard_weight_load) is expected
+
+
+def test_native_layerwise_loader_owns_reused_receiver_buffer():
+    model = _ToyModel()
+    retained_weights = []
+    model.load_weights = lambda weights: retained_weights.extend(weights)
+    reused_buffer = torch.tensor([1.0])
+
+    vLLMColocateWorkerExtension._load_weights_with_native_layerwise([model], [("first.weight", reused_buffer.view(1))])
+    reused_buffer.fill_(2.0)
+    vLLMColocateWorkerExtension._load_weights_with_native_layerwise([model], [("second.weight", reused_buffer.view(1))])
+    reused_buffer.fill_(3.0)
+
+    assert [name for name, _ in retained_weights] == ["first.weight", "second.weight"]
+    torch.testing.assert_close(retained_weights[0][1], torch.tensor([1.0]))
+    torch.testing.assert_close(retained_weights[1][1], torch.tensor([2.0]))
+    assert retained_weights[0][1].untyped_storage().data_ptr() != reused_buffer.untyped_storage().data_ptr()

--- a/verl/workers/rollout/vllm_rollout/utils.py
+++ b/verl/workers/rollout/vllm_rollout/utils.py
@@ -241,6 +241,37 @@ class vLLMColocateWorkerExtension:
             if draft_cfg is not None:
                 yield self._get_drafter_model(), draft_cfg
 
+    def _get_native_npu_reload_models_with_config(self):
+        """Return the validated target/drafter pairs for native NPU reload."""
+        target_model = self.model_runner.model
+        models_with_config = [(target_model, self.model_runner.vllm_config.model_config)]
+
+        if self._use_mtp_drafter_weight_sync():
+            draft_config = self._get_draft_model_config()
+            if draft_config is None:
+                raise RuntimeError(
+                    "Cannot reload NPU MTP weights because speculative_config.draft_model_config is missing."
+                )
+            drafter_model = self._get_drafter_model()
+            if drafter_model is not target_model:
+                models_with_config.append((drafter_model, draft_config))
+
+        return models_with_config
+
+    def _uses_native_npu_mtp_reload(self, use_standard_weight_load: bool) -> bool:
+        """Return whether standard NPU MTP weights require native reload."""
+        if not use_standard_weight_load or self._is_qat_model or self._is_modelopt_qat:
+            return False
+        return self._use_mtp_drafter_weight_sync()
+
+    def _raise_if_native_npu_reload_failed(self):
+        failure = getattr(self, "_native_npu_reload_failure", None)
+        if failure is not None:
+            raise RuntimeError(
+                "This NPU rollout worker cannot reload weights after a native MTP reload failed. "
+                f"Recreate the worker before retrying. Previous error: {failure}"
+            )
+
     def monkey_patch_model(self, vocab_size: int, banned_token_ids: Optional[list[int]] = None):
         for model in self._iter_all_models():
             # patch compute_logits to avoid sampling OOV and other illegal tokens
@@ -248,13 +279,70 @@ class vLLMColocateWorkerExtension:
             # patch weight loader to support MoE model
             patch_vllm_moe_model_weight_loader(model)
 
+    @staticmethod
+    def _load_weights_with_native_layerwise(models, weights):
+        """Load an owned IPC bucket into every model in the native lifecycle."""
+        # The receiver reuses its communication buffer after this callback.
+        # Native layerwise loaders may retain tensors until a later bucket or
+        # finalization, so transfer ownership before invoking model loaders.
+        owned_weights = [(name, tensor.clone()) for name, tensor in weights]
+        for model in models:
+            model.load_weights(owned_weights)
+
+    def _update_weights_from_ipc_with_native_npu_reload(self, receiver_cls, use_shm: bool):
+        """Reload the NPU MTP target and drafter through one native lifecycle."""
+        models_with_config = self._get_native_npu_reload_models_with_config()
+        models = [model for model, _ in models_with_config]
+
+        try:
+            from vllm.model_executor.model_loader.reload import (
+                finalize_layerwise_reload,
+                initialize_layerwise_reload,
+            )
+        except ImportError as error:
+            raise RuntimeError("NPU MTP weight reload requires vLLM's public layerwise reload API.") from error
+
+        prepare_model = getattr(self, "prepare_model_for_native_layerwise_reload", None)
+        if not callable(prepare_model):
+            raise RuntimeError(
+                "NPU MTP weight reload requires the backend worker method prepare_model_for_native_layerwise_reload()."
+            )
+
+        # Native reload is not transactional: once preparation starts, a
+        # failure can leave parameters partially initialized or updated.
+        try:
+            with torch.device(self.device):
+                for model in models:
+                    prepare_model(model)
+                for model in models:
+                    initialize_layerwise_reload(model)
+
+            receiver = receiver_cls(
+                zmq_handle=self._get_zmq_handle(),
+                device=self.device,
+                use_shm=use_shm,
+            )
+            receiver.receive_weights(
+                on_bucket_received=lambda weights: self._load_weights_with_native_layerwise(models, weights)
+            )
+
+            with torch.device(self.device):
+                for model, model_config in models_with_config:
+                    finalize_layerwise_reload(model, model_config)
+        except Exception as error:
+            self._native_npu_reload_failure = f"{type(error).__name__}: {error}"
+            raise
+
     def update_weights_from_ipc(self, peft_config: dict = None, base_sync_done=False, use_shm: bool = False):
         """Update the weights of the rollout model."""
         from vllm.platforms import current_platform
 
         from verl.workers.rollout.vllm_rollout.bucketed_weight_transfer import BucketedWeightReceiver
 
-        if current_platform.device_type == "npu" and self.device is None:
+        is_npu_platform = current_platform.device_type == "npu"
+        if is_npu_platform:
+            self._raise_if_native_npu_reload_failed()
+        if is_npu_platform and self.device is None:
             self.device = torch.device(f"npu:{self.local_rank}")
 
         # In async mode, make sure the old lora is removed before adding the new one
@@ -264,6 +352,12 @@ class vLLMColocateWorkerExtension:
         use_standard_weight_load = not (peft_config and base_sync_done) and not is_fp8_model(
             self.model_runner.vllm_config
         )
+
+        # NPU MTP target and drafter must share the same layerwise lifecycle.
+        # The platform guard keeps all CUDA weight-loading paths unchanged.
+        if is_npu_platform and self._uses_native_npu_mtp_reload(use_standard_weight_load):
+            self._update_weights_from_ipc_with_native_npu_reload(BucketedWeightReceiver, use_shm)
+            return
 
         if self._is_qat_model:
             # QAT (compressed-tensors): Prepare for weight loading BEFORE receiving any buckets


### PR DESCRIPTION
### What does this PR do?

This PR fixes NPU MTP online weight updates when the rollout model uses the standard checkpoint-format weight-loading path.

On Ascend, graph-safe online reload requires two conditions:

1. The target model and the MTP drafter must be updated within the same native layerwise reload lifecycle.
2. Backend-specific runtime parameter storage must be restored before vLLM starts that lifecycle, so a captured ACLGraph continues to reference the updated storage.

The second condition is implemented by the companion vLLM Ascend PR:

- https://github.com/vllm-project/vllm-ascend/pull/12260

This PR implements the veRL orchestration side:

- restricts the new path to NPU + MTP + standard weight loading;
- excludes QAT, ModelOpt QAT, and other non-standard loaders;
- validates the target/drafter configs, the public vLLM reload API, and the backend preparation hook before model mutation starts;
- prepares and initializes both target and drafter before receiving the first IPC bucket;
- passes each received bucket to both models and finalizes each model with its own model config;
- clones each received tensor once because the bucket receiver reuses its communication buffer, while native layerwise loading may retain tensor references until a later bucket or finalization;
- marks the NPU worker as fail-stop if an exception occurs after native reload mutation starts, because native layerwise reload does not provide rollback;
- leaves CUDA, non-MTP NPU, QAT, ModelOpt QAT, and non-standard weight-loading paths on their existing code paths.

The fail-stop behavior is intentionally not transaction rollback or atomic recovery. It prevents a worker that may contain meta or partially updated parameters from being reused after a failed native reload.

### Checklist Before Starting

- [x] Search for similar PRs:
  - [`"MTP online reload"` in open veRL PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr%20is%3Aopen%20%22MTP%20online%20reload%22)
  - [`"layerwise reload"` in open veRL PRs](https://github.com/verl-project/verl/pulls?q=is%3Apr%20is%3Aopen%20%22layerwise%20reload%22)
- [x] Format the PR title as `[{modules}] {type}: {description}`.

The first query returned no matching open PR. The second query found [#5599](https://github.com/verl-project/verl/pull/5599).

PR #5599 is related and also changes `vllm_rollout/utils.py`, but it addresses generic weight-name normalization, LoRA bucket handling, and standard layerwise reload. Its current implementation deliberately falls back from layerwise reload when MTP drafter synchronization is active. This PR addresses that remaining NPU MTP case by coordinating native reload for both target and drafter and by relying on an Ascend backend storage-preservation capability.

The two PRs are therefore not the same fix, but they overlap in one source file and may require coordination or rebasing if #5599 merges first.

No GitHub issue number is currently linked, so the issue-number-specific duplicate lookup is not applicable.

### Test

Targeted CPU regression tests executed during preparation:

```powershell
$env:VERL_USE_EXTERNAL_PLUGINS='none'
uv run --no-project --python 3.12 `
  --with pytest `
  --with torch `
  --with numpy `
  --with ray `
  --with 'tensordict<=0.10.0' `
  --with hydra-core `
  --with transformers `
  python -m pytest -q tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py
```

Result:

```text
20 passed in 2.76s
```

Formatting and static checks executed during preparation:

```powershell
uvx --from ruff==0.12.2 ruff check `
  verl/workers/rollout/vllm_rollout/utils.py `
  tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py

uvx --from ruff==0.12.2 ruff format --check `
  verl/workers/rollout/vllm_rollout/utils.py `
  tests/workers/rollout/test_vllm_weight_update_utils_on_cpu.py

git diff --check
```

All commands above passed.

The added unit coverage verifies:

- target/drafter prepare, initialize, load, and finalize ordering;
- identical dispatch ordering for `enforce_eager=False` and `enforce_eager=True`;
- CUDA MTP remains on the existing direct-loading path;
- non-MTP NPU remains on the existing direct-loading path;
- missing draft config, backend hook, or public vLLM API fails before mutation;
- QAT, ModelOpt QAT, and non-standard loading do not select the native path;
- reused IPC receiver buffers are cloned before a loader can retain them;
- an exception after native reload starts is re-raised, records fail-stop state, and prevents subsequent NPU updates before receiver or model side effects.

The `enforce_eager` unit test uses CPU fakes. It proves that dispatch and lifecycle selection do not depend on that flag; it does not execute a real ACLGraph or an NPU kernel.

Not yet executed on this latest-main PR commit:

- full `pre-commit run --all-files`;
- Ascend A3 end-to-end training/rollout;
- exact-commit ACLGraph/eager comparison;
- performance measurement of the additional IPC tensor clone.

This PR remains Draft until the human submitter completes line-by-line review and exact-commit NPU validation.

### API and Usage Example

There is no new user-facing CLI argument, environment variable, configuration field, or public veRL API.

The path is selected automatically only when all of the following are true:

- the current vLLM platform is NPU;
- MTP drafter synchronization is active;
- standard weight loading is selected;
- QAT and ModelOpt QAT are not active.

The companion Ascend backend must provide:

```python
prepare_model_for_native_layerwise_reload(model)
```

If the backend capability or vLLM's public layerwise reload API is unavailable, the update fails before model mutation.

### Design & Code Changes

#### 1. Narrow platform and loader dispatch

The native path is guarded by the NPU platform check and the existing MTP drafter predicate. CUDA never evaluates the NPU-only selector.

Specialized loaders retain their existing behavior instead of being implicitly routed through a lifecycle they do not support.

#### 2. Target and drafter lifecycle

The target model and MTP drafter are collected with their respective model configs. Both models are prepared and initialized before any IPC bucket is consumed. Every bucket is then loaded into both models, followed by per-model finalization.

#### 3. IPC buffer ownership

`BucketedWeightReceiver` may reuse its communication buffer after the bucket callback returns. Native layerwise loaders may retain incoming tensors until a later bucket or finalization.

The native NPU MTP path therefore creates one owned clone per incoming tensor and shares that owned list between target and drafter. This cost is limited to the new NPU MTP path and occurs during weight synchronization, not token generation.

#### 4. Preflight and failure semantics

Configuration, API, and backend capability checks occur before mutation.

Once backend preparation starts, native reload is not rollback-safe. Any subsequent exception is propagated unchanged and records fail-stop state. Later NPU updates reject the worker before LoRA removal, receiver creation, or model mutation and require worker recreation.

#### 5. Compatibility boundary

This PR does not add:

- a model implementation or model patch;
- an environment variable;
- a configuration option;
- mutable module-level state;
- a CUDA behavior change;
- a replacement for specialized QAT/ModelOpt loaders.

### AI assistance and human accountability

OpenAI Codex was used to help analyze the failure, prepare the implementation and tests, and draft this PR description.

ZhangMinjie is the human submitter and is responsible for understanding and defending the change. The PR is intentionally Draft until ZhangMinjie has reviewed every changed line and personally completed the required latest-commit tests before requesting maintainer review.

### Checklist Before Submitting

- [ ] Human submitter has completed line-by-line review of the latest diff.
- [ ] Run `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Documentation impact reviewed: no public API, configuration, or user workflow was added.
- [x] Targeted unit tests were added to an existing `*_on_cpu.py` test file, which is discovered by the existing CPU unit-test workflow.
- [ ] Run exact-commit Ascend A3 graph/eager validation and attach logs or results.
- [ ] Request CI after this Draft is ready for maintainer review.
- [x] Recipe submodule update is not applicable.
