### PR TITLE
[megatron, model, doc] fix: improve Megatron-Bridge ImportError guidance and Dockerfile smoke

### DIFF
--- a/docker/Dockerfile.stable.sglang
+++ b/docker/Dockerfile.stable.sglang
@@ -80,6 +80,11 @@ RUN pip install --no-deps megatron-bridge==0.5.0
 
 RUN pip install --no-deps git+https://github.com/NVIDIA/Megatron-LM.git@${MCORE_VERSION}
 
+# Smoke: shim surface used by verl/models/mcore/bridge.py (fails the image build if missing).
+RUN python3 -c "from megatron.bridge import AutoBridge; \
+from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model; \
+print('megatron-bridge OK')"
+
 RUN pip install git+https://github.com/verl-project/verl.git@${VERL_VERSION} && \
     pip uninstall -y verl
 

--- a/docker/Dockerfile.stable.trtllm
+++ b/docker/Dockerfile.stable.trtllm
@@ -42,6 +42,10 @@ RUN pip3 install --no-cache-dir --no-deps trl==0.27.0 && \
     pip install --no-deps --no-cache-dir megatron-bridge==0.5.0 && \
     pip install --no-deps --no-cache-dir nvidia-resiliency-ext==0.6.0
 
+# Smoke: shim surface used by verl/models/mcore/bridge.py (fails the image build if missing).
+RUN python3 -c "from megatron.bridge import AutoBridge; \
+from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model; \
+print('megatron-bridge OK')"
 
 # ==============================================================================
 # Install verl dependencies

--- a/docker/Dockerfile.stable.vllm
+++ b/docker/Dockerfile.stable.vllm
@@ -150,6 +150,11 @@ RUN pip install --no-deps megatron-bridge==0.5.0
 
 RUN pip install --no-deps git+https://github.com/NVIDIA/Megatron-LM.git@${MCORE_VERSION}
 
+# Smoke: shim surface used by verl/models/mcore/bridge.py (fails the image build if missing).
+RUN python3 -c "from megatron.bridge import AutoBridge; \
+from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model; \
+print('megatron-bridge OK')"
+
 RUN pip install torchcodec --index-url=https://download.pytorch.org/whl/cu130
 
 RUN apt-get update && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,6 +86,32 @@ pip3 install -e .[sglang]
 
 ## Release History
 
+### Megatron-Bridge on published tags (issue #7071)
+
+Stable Dockerfiles pin `megatron-bridge==0.5.0` with `--no-deps` (and install
+Megatron-LM / `megatron-core` separately). Some published Hub tags predate that
+pin (for example `verlai/verl:sgl0512.dev2` and `vllm023.dev1`) and do **not**
+include Megatron-Bridge.
+
+If you hit `ModuleNotFoundError: megatron.bridge` on a stale published tag, use
+the CI-proven install (matches the megatron e2e workflow at merge time; do not
+omit `--no-deps`):
+
+```sh
+pip install --ignore-requires-python --no-deps --no-build-isolation \
+  "git+https://github.com/NVIDIA-NeMo/Megatron-Bridge.git@e2cfe7e"
+```
+
+Do **not** install `megatron-bridge==0.3.1` (incomplete for verl; missing
+`LinearForLastLayer` and related symbols). Do **not** run unpinned
+`pip install megatron-bridge` without `--no-deps` inside a container — pip may
+reinstall megatron-core / transformer-engine / torch over the image stack.
+
+New image builds from the stable Dockerfiles should use
+`pip install --no-deps megatron-bridge==0.5.0` together with the Dockerfile's
+Megatron-LM / mcore pin. The preferred long-term fix is a maintainer rebuild and
+republish of the GPU tags with the pin baked in.
+
 - 2026/03/10: update vllm stable image to vllm==0.17.0; update sglang stable image to sglang==0.5.9
 - 2026/01/17: update vllm stable image to torch==2.9.1, cudnn==9.16, deepep==1.2.1
 - 2025/12/23: update vllm stable image to vllm==0.12.0; update sglang stable image to sglang==0.5.6

--- a/docker/rocm/Dockerfile.rocm
+++ b/docker/rocm/Dockerfile.rocm
@@ -178,6 +178,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install qwen_vl_utils && \
     pip install flash-linear-attention
 
+# Smoke: shim surface used by verl/models/mcore/bridge.py (fails the image build if missing).
+# Placed after megatron-core so the shim import surface is fully resolvable.
+RUN python3 -c "from megatron.bridge import AutoBridge; \
+from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model; \
+print('megatron-bridge OK')"
+
 RUN --mount=type=cache,target=/root/.cache/pip \
     cd /workspace && git clone https://github.com/verl-project/verl.git && \
     cd verl && pip install .

--- a/tests/models/test_mcore_bridge_import_error_on_cpu.py
+++ b/tests/models/test_mcore_bridge_import_error_on_cpu.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Hermetic CPU tests for verl/models/mcore/bridge.py ImportError guidance (#7071).
+
+Loads bridge.py by path so we never import the package tree as
+``verl.models.mcore.bridge``. Isolation uses Pattern A (fake parent with empty
+``__path__``) / controlled fakes so a host with real megatron-bridge installed
+still exercises the three message branches.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+import importlib.util
+import sys
+import types
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_BRIDGE_PATH = _REPO_ROOT / "verl" / "models" / "mcore" / "bridge.py"
+_PIN = "0.5.0"
+
+
+def _load_bridge_by_path() -> None:
+    """Execute bridge.py as a fresh module. Raises ImportError from its except."""
+    name = f"_bridge_under_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(name, _BRIDGE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Do not register in sys.modules permanently; just exec.
+    spec.loader.exec_module(module)
+
+
+@contextmanager
+def _isolated_import_env(
+    *,
+    version_value: str | None,
+    install_fakes: bool,
+    train_utils_attrs: dict | None = None,
+    force_import_error: bool = False,
+) -> Iterator[None]:
+    """Save/restore sys.modules + meta_path; install hermetic megatron fakes.
+
+    version_value:
+      None -> PackageNotFoundError for \"megatron-bridge\"
+      str  -> that version string
+    install_fakes:
+      False + force_import_error: Pattern A empty parent, no bridge submodule
+      True: install megatron.bridge (+ nested train_utils) with controlled attrs
+    force_import_error:
+      if True with install_fakes, make train_utils import raise ImportError
+    """
+    saved_modules = {k: sys.modules.get(k) for k in list(sys.modules) if k == "megatron" or k.startswith("megatron.")}
+    saved_meta_path = list(sys.meta_path)
+    real_version = md.version
+
+    def _version(name: str) -> str:
+        if name == "megatron-bridge":
+            if version_value is None:
+                raise md.PackageNotFoundError(name)
+            return version_value
+        return real_version(name)
+
+    # Drop any real megatron* entries so fakes win.
+    for key in list(sys.modules):
+        if key == "megatron" or key.startswith("megatron."):
+            del sys.modules[key]
+
+    md.version = _version  # type: ignore[assignment]
+    try:
+        if force_import_error and not install_fakes:
+            # Pattern A: parent package present with empty path -> no submodule discovery.
+            fake_megatron = types.ModuleType("megatron")
+            fake_megatron.__path__ = []  # type: ignore[attr-defined]
+            sys.modules["megatron"] = fake_megatron
+        elif install_fakes:
+            fake_megatron = types.ModuleType("megatron")
+            fake_megatron.__path__ = []  # type: ignore[attr-defined]
+            sys.modules["megatron"] = fake_megatron
+
+            if force_import_error:
+                # pin-broken: package metadata says 0.5.0 but import fails.
+                class _RaiseBridgeFinder:
+                    def find_spec(self, fullname, path=None, target=None):
+                        if fullname == "megatron.bridge" or fullname.startswith("megatron.bridge."):
+                            raise ImportError(f"simulated pin-broken import: {fullname}")
+                        return None
+
+                sys.meta_path.insert(0, _RaiseBridgeFinder())
+            else:
+                # too-old: AutoBridge present; train_utils missing LinearForLastLayer.
+                fake_bridge = types.ModuleType("megatron.bridge")
+                fake_bridge.AutoBridge = object  # type: ignore[attr-defined]
+                fake_bridge.__path__ = []  # type: ignore[attr-defined]
+                sys.modules["megatron.bridge"] = fake_bridge
+                fake_megatron.bridge = fake_bridge  # type: ignore[attr-defined]
+
+                training = types.ModuleType("megatron.bridge.training")
+                training.__path__ = []  # type: ignore[attr-defined]
+                sys.modules["megatron.bridge.training"] = training
+                fake_bridge.training = training  # type: ignore[attr-defined]
+
+                utils = types.ModuleType("megatron.bridge.training.utils")
+                utils.__path__ = []  # type: ignore[attr-defined]
+                sys.modules["megatron.bridge.training.utils"] = utils
+                training.utils = utils  # type: ignore[attr-defined]
+
+                train_utils = types.ModuleType("megatron.bridge.training.utils.train_utils")
+                attrs = train_utils_attrs or {}
+                for k, v in attrs.items():
+                    setattr(train_utils, k, v)
+                sys.modules["megatron.bridge.training.utils.train_utils"] = train_utils
+                utils.train_utils = train_utils  # type: ignore[attr-defined]
+
+        yield
+    finally:
+        md.version = real_version  # type: ignore[assignment]
+        sys.meta_path[:] = saved_meta_path
+        # Remove any megatron* we introduced.
+        for key in list(sys.modules):
+            if key == "megatron" or key.startswith("megatron."):
+                del sys.modules[key]
+        # Restore prior entries (including None = was absent).
+        for key, mod in saved_modules.items():
+            if mod is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = mod
+
+
+@pytest.mark.parametrize(
+    "case,version_value,install_fakes,train_utils_attrs,force_import_error,must_have,must_not",
+    [
+        (
+            "absent",
+            None,
+            False,
+            None,
+            True,  # Pattern A empty parent
+            ["not installed", "--no-deps", f"=={_PIN}"],
+            [],
+        ),
+        (
+            "too-old",
+            "0.3.1",
+            True,
+            {"freeze_moe_router": object, "make_value_model": object},  # no LinearForLastLayer
+            False,
+            ["0.3.1", "too old", "--no-deps"],
+            ["not installed"],
+        ),
+        (
+            "pin-broken",
+            _PIN,
+            True,
+            None,
+            True,
+            [_PIN, "megatron-core"],
+            ["too old", "not installed"],
+        ),
+    ],
+    ids=["absent", "too-old", "pin-broken"],
+)
+def test_bridge_import_error_message_branches(
+    case,
+    version_value,
+    install_fakes,
+    train_utils_attrs,
+    force_import_error,
+    must_have,
+    must_not,
+):
+    with _isolated_import_env(
+        version_value=version_value,
+        install_fakes=install_fakes,
+        train_utils_attrs=train_utils_attrs,
+        force_import_error=force_import_error,
+    ):
+        with pytest.raises(ImportError) as exc_info:
+            _load_bridge_by_path()
+
+    msg = str(exc_info.value)
+    for fragment in must_have:
+        assert fragment in msg, f"case={case}: expected {fragment!r} in message:\n{msg}"
+    for fragment in must_not:
+        assert fragment not in msg, f"case={case}: did not expect {fragment!r} in message:\n{msg}"

--- a/verl/models/mcore/bridge.py
+++ b/verl/models/mcore/bridge.py
@@ -16,10 +16,38 @@
 try:
     from megatron.bridge import AutoBridge
     from megatron.bridge.training.utils.train_utils import LinearForLastLayer, freeze_moe_router, make_value_model
-except ImportError:
-    # `pip install verl[mcore]` or
-    print("Megatron-Bridge package not found. Please install Megatron-Bridge with `pip install megatron-bridge`")
-    raise
+except ImportError as e:
+    from importlib.metadata import PackageNotFoundError, version
+
+    _PIN = "0.5.0"
+    _CMD = f"`pip install --no-deps megatron-bridge=={_PIN}`"
+    try:
+        _installed = version("megatron-bridge")
+    except PackageNotFoundError:
+        _installed = None
+    if _installed is None:
+        msg = (
+            f"Megatron-Bridge is not installed. For stacks matching verl's stable Dockerfiles, "
+            f"install with {_CMD} (--no-deps is required so pip does not reinstall "
+            "megatron-core/transformer-engine/torch over your container build). "
+            "If you are on a published tag predating that pin "
+            "(e.g. verlai/verl:sgl0512.dev2 or vllm023.dev1), see docker/README.md for the "
+            "CI-proven install command instead of assuming this pin."
+        )
+    elif _installed == _PIN:
+        msg = (
+            f"Megatron-Bridge {_installed} (verl's Dockerfile pin) is installed, but the import "
+            f"failed: {e}. This usually means megatron-core or transformer-engine is missing or "
+            "mismatched - check your Megatron-LM install matches the image/Dockerfile stack."
+        )
+    else:
+        msg = (
+            f"Megatron-Bridge {_installed} is installed but the import failed: {e} - {_installed} "
+            f"is likely too old or incomplete for verl (e.g. 0.3.1 lacks LinearForLastLayer). "
+            f"On a current stable-Dockerfile stack reinstall with {_CMD}; on stale published "
+            "tags see docker/README.md."
+        )
+    raise ImportError(msg) from e
 
 __all__ = [
     "AutoBridge",


### PR DESCRIPTION
## Summary

Mitigation-only PR for #7071. **Does not close #7071** — published GPU tags still lack `megatron-bridge`; the cure is a maintainer image rebuild/republish.

### Problem
Users of published tags such as `verlai/verl:sgl0512.dev2` hit `ModuleNotFoundError: megatron.bridge`. The Dockerfiles on main already pin `megatron-bridge==0.5.0` (`--no-deps`), but published Hub tags predate that pin. The shim at `verl/models/mcore/bridge.py` previously printed an unpinned `pip install megatron-bridge` and did not distinguish absent / too-old / pin-broken.

### Root cause
- **Primary (maintainer track):** published GPU images never contained megatron-bridge; no in-repo GPU publish workflow.
- **Secondary (this PR):** unhelpful ImportError path on the shim surface.

### Fix (this PR)
1. Three-branch ImportError in `verl/models/mcore/bridge.py` (absent / too-old / pin-broken) with `--no-deps` + `==0.5.0` guidance and pointer to `docker/README.md` for stale tags.
2. Hermetic CPU tests: `tests/models/test_mcore_bridge_import_error_on_cpu.py` (3 cases).
3. Dockerfile smoke lines for the **shim import surface only** after Megatron-LM/mcore on: `Dockerfile.stable.sglang`, `.vllm`, `.trtllm`, `rocm/Dockerfile.rocm`.
4. `docker/README.md` note: CI-proven `@e2cfe7e` install for stale tags; forbid `==0.3.1`; never omit `--no-deps`.

Smoke/tests claim only the shim surface (`AutoBridge`, `LinearForLastLayer`, `freeze_moe_router`, `make_value_model`). Direct `megatron.bridge` importers elsewhere remain a tracked follow-up.

### How to test
```bash
# hermetic unit tests
uv venv --python 3.12 && source .venv/bin/activate
uv pip install pytest
PYTHONPATH=. pytest -v tests/models/test_mcore_bridge_import_error_on_cpu.py
# expect 3 passed

# Dockerfile syntax only (does not execute RUN smokes)
docker build --check -f docker/Dockerfile.stable.sglang .
docker build --check -f docker/Dockerfile.stable.vllm .
docker build --check -f docker/Dockerfile.stable.trtllm .
docker build --check -f docker/rocm/Dockerfile.rocm .
```

### Why not duplicate
- No open upstream PR targets #7071 mitigation/cure (checked via `gh pr list --search "7071 in:body"` and megatron-bridge docker keywords).
- Related open PRs (#7081 NPU CI, #4394 gpt-oss example) are unrelated.

### AI assistance
AI-assisted implementation under human plan approval. Human submitter reviewed every changed line and ran the tests listed above.

### Tracked follow-ups (required before #7071 can close)
1. Rebuild/publish GPU tags with megatron-bridge baked in; bump `IMAGE:`; remove CI runtime Bridge pip.
2. Centralize direct `megatron.bridge` importers (or expand smoke beyond shim surface).

Related: #7071 (mitigation only — do not auto-close).
