### PR TITLE
[worker, perf] feat: defer scalar metric materialization

### DIFF
--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -15,6 +15,7 @@
 Tests for the metric utilities in verl.trainer.ppo.metric_utils.
 """
 
+import pickle
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -35,7 +36,34 @@ from verl.utils.metric import (
 from verl.utils.metric.utils import (
     AggregationType,
     Metric,
+    materialize_metric_tensors,
 )
+
+
+class _DeferredScalar(torch.Tensor):
+    item_calls = 0
+    cpu_calls = 0
+
+    @staticmethod
+    def __new__(cls, value, dtype=torch.float32):
+        return torch.Tensor._make_subclass(cls, torch.tensor(value, dtype=dtype), require_grad=False)
+
+    @property
+    def device(self):
+        return torch.device("cuda:0")
+
+    def item(self):
+        type(self).item_calls += 1
+        return self.as_subclass(torch.Tensor).item()
+
+    def cpu(self):
+        type(self).cpu_calls += 1
+        return self.as_subclass(torch.Tensor)
+
+    @classmethod
+    def reset_calls(cls):
+        cls.item_calls = 0
+        cls.cpu_calls = 0
 
 
 class TestReduceMetrics(unittest.TestCase):
@@ -116,6 +144,69 @@ class TestMetric(unittest.TestCase):
         metric.append(torch.tensor(3.0))
         metric.append(torch.tensor(4.0))
         self.assertEqual(metric.values, [3.0, 4.0])
+
+    def test_append_device_tensor_defers_host_materialization(self):
+        """Device scalar metrics stay detached until the aggregation boundary."""
+        _DeferredScalar.reset_calls()
+        metric = Metric(aggregation="mean")
+
+        metric.append(_DeferredScalar(3.0))
+        metric.append(_DeferredScalar(4.0))
+
+        self.assertEqual(_DeferredScalar.item_calls, 0)
+        self.assertEqual(_DeferredScalar.cpu_calls, 0)
+        self.assertTrue(all(isinstance(value, _DeferredScalar) for value in metric.values))
+        self.assertEqual(metric.aggregate(), 3.5)
+        self.assertEqual(_DeferredScalar.item_calls, 0)
+        self.assertEqual(_DeferredScalar.cpu_calls, 1)
+
+    def test_materialize_metric_tensors_batches_nested_scalars(self):
+        """Scalar tensors sharing type/device/dtype use one device-to-host copy."""
+        _DeferredScalar.reset_calls()
+        metrics = {
+            "mean": Metric("mean", _DeferredScalar(1.0)),
+            "plain": [_DeferredScalar(2.0), {"nested": _DeferredScalar(3.0)}],
+        }
+
+        materialize_metric_tensors(metrics)
+
+        self.assertEqual(_DeferredScalar.item_calls, 0)
+        self.assertEqual(_DeferredScalar.cpu_calls, 1)
+        self.assertEqual(metrics["mean"].values, [1.0])
+        self.assertEqual(metrics["plain"], [2.0, {"nested": 3.0}])
+
+    def test_materialize_metric_tensors_groups_dtypes(self):
+        """Different dtypes are copied independently without implicit promotion."""
+        _DeferredScalar.reset_calls()
+        metrics = {
+            "fp32": Metric("mean", _DeferredScalar(1.0, torch.float32)),
+            "fp64": Metric("mean", _DeferredScalar(2.0, torch.float64)),
+        }
+
+        materialize_metric_tensors(metrics)
+
+        self.assertEqual(_DeferredScalar.cpu_calls, 2)
+        self.assertEqual(metrics["fp32"].values, [1.0])
+        self.assertEqual(metrics["fp64"].values, [2.0])
+
+    def test_materialize_metric_tensors_rejects_non_scalar_tensor(self):
+        """Object-bound metrics must not silently serialize tensor payloads."""
+        with self.assertRaisesRegex(ValueError, r"must be scalar.*\(2,\)"):
+            materialize_metric_tensors({"invalid": torch.tensor([1.0, 2.0])})
+
+    def test_materialized_metrics_are_pickleable_without_tensors(self):
+        """Worker-bound metrics serialize as ordinary host values."""
+        metrics = {
+            "metric": Metric("mean", _DeferredScalar(1.0)),
+            "plain": [_DeferredScalar(2.0)],
+        }
+
+        materialize_metric_tensors(metrics)
+        restored = pickle.loads(pickle.dumps(metrics))
+
+        self.assertEqual(restored["metric"].values, [1.0])
+        self.assertEqual(restored["plain"], [2.0])
+        self.assertFalse(any(isinstance(value, torch.Tensor) for value in restored["metric"].values))
 
     def test_append_non_scalar_tensor_raises(self):
         """Test that appending non-scalar tensor raises ValueError."""

--- a/tests/trainer/ppo/test_metric_utils_on_cpu.py
+++ b/tests/trainer/ppo/test_metric_utils_on_cpu.py
@@ -189,6 +189,17 @@ class TestMetric(unittest.TestCase):
         self.assertEqual(metrics["fp32"].values, [1.0])
         self.assertEqual(metrics["fp64"].values, [2.0])
 
+    def test_materialize_metric_tensors_normalizes_single_element_shapes(self):
+        """Zero-dimensional and one-element metrics can share one transfer."""
+        metrics = {
+            "scalar": torch.tensor(1.0),
+            "singleton": torch.tensor([2.0]),
+        }
+
+        materialize_metric_tensors(metrics)
+
+        self.assertEqual(metrics, {"scalar": 1.0, "singleton": 2.0})
+
     def test_materialize_metric_tensors_rejects_non_scalar_tensor(self):
         """Object-bound metrics must not silently serialize tensor payloads."""
         with self.assertRaisesRegex(ValueError, r"must be scalar.*\(2,\)"):

--- a/tests/trainer/ppo/test_rollout_corr_integration.py
+++ b/tests/trainer/ppo/test_rollout_corr_integration.py
@@ -22,6 +22,7 @@ from verl.trainer.ppo.rollout_corr_helper import (
     compute_offpolicy_metrics,
     compute_rollout_correction_and_rejection_mask,
 )
+from verl.utils.metric import AggregationType, Metric, materialize_metric_tensors
 from verl.workers.config.actor import ActorConfig
 
 
@@ -92,6 +93,25 @@ class TestRolloutISIntegration:
         assert pg_loss.ndim == 0  # Scalar
         assert not torch.isnan(pg_loss)
         assert not torch.isinf(pg_loss)
+
+    def test_policy_loss_metrics_defer_host_materialization(self, sample_data, config_with_rollout_is):
+        """Policy metrics stay detached on device until the worker boundary."""
+        _, pg_metrics = compute_policy_loss_vanilla(
+            old_log_prob=sample_data["old_log_prob"],
+            log_prob=sample_data["log_prob"],
+            advantages=sample_data["advantages"],
+            response_mask=sample_data["response_mask"],
+            loss_agg_mode="token-mean",
+            config=config_with_rollout_is,
+        )
+
+        assert set(pg_metrics) == {"actor/pg_clipfrac", "actor/ppo_kl", "actor/pg_clipfrac_lower"}
+        assert all(torch.is_tensor(value) and value.ndim == 0 for value in pg_metrics.values())
+        assert all(value.grad_fn is None and torch.isfinite(value) for value in pg_metrics.values())
+
+        wrapped = Metric.from_dict(pg_metrics, aggregation=AggregationType.MEAN)
+        materialize_metric_tensors(wrapped)
+        assert all(isinstance(metric.values[0], float) for metric in wrapped.values())
 
     def test_rollout_is_weights_computation(self, sample_data):
         """Test rollout correction weights and metrics computation."""

--- a/tests/workers/test_deferred_metric_materialization_on_cpu.py
+++ b/tests/workers/test_deferred_metric_materialization_on_cpu.py
@@ -15,6 +15,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
 from verl.utils.metric import Metric
@@ -59,12 +60,52 @@ def _contains_tensor(value):
     return False
 
 
-def test_postprocess_batches_loss_and_metric_materialization_before_object_gather():
-    _DeferredScalar.reset_calls()
+def _make_worker():
     worker = object.__new__(TrainingWorker)
     worker.device_name = "cpu"
-    worker.engine = SimpleNamespace(get_data_parallel_group=lambda: object())
+    worker.engine = SimpleNamespace(get_data_parallel_group=lambda: None)
     worker.flops_counter = None
+    return worker
+
+
+@pytest.mark.parametrize(
+    "losses,expected",
+    [
+        (torch.tensor(3.0, requires_grad=True), 3.0),
+        (torch.tensor([1.0, 2.0]), 3.0),
+        ([torch.tensor(1.0, requires_grad=True), torch.tensor(2.0, requires_grad=True)], 3.0),
+        ((torch.tensor(1.0), torch.tensor(2.0)), 3.0),
+        ([1.0, 2.0], 3.0),
+        (3.0, 3.0),
+        ([], 0.0),
+    ],
+)
+def test_postprocess_accepts_single_and_batched_loss_values(losses, expected):
+    worker = _make_worker()
+    output = {"loss": losses, "metrics": {}, "model_output": {}}
+    device = SimpleNamespace(
+        max_memory_allocated=lambda: 0,
+        max_memory_reserved=lambda: 0,
+    )
+
+    with patch("verl.workers.engine_workers.get_torch_device", return_value=device):
+        result = worker._postprocess_output(
+            output,
+            global_token_num=None,
+            delta_time=1.0,
+            forward_only=False,
+            images_seqlens=None,
+        )
+
+    loss = result.get_non_tensor("metrics")["loss"]
+    assert loss == expected
+    assert not isinstance(loss, torch.Tensor)
+
+
+def test_postprocess_batches_loss_and_metric_materialization_before_object_gather():
+    _DeferredScalar.reset_calls()
+    worker = _make_worker()
+    worker.engine = SimpleNamespace(get_data_parallel_group=lambda: object())
     metric = Metric("mean")
     metric.extend([_DeferredScalar(3.0), _DeferredScalar(5.0)])
     output = {

--- a/tests/workers/test_deferred_metric_materialization_on_cpu.py
+++ b/tests/workers/test_deferred_metric_materialization_on_cpu.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from verl.utils.metric import Metric
+from verl.workers.engine_workers import TrainingWorker
+
+
+class _DeferredScalar(torch.Tensor):
+    item_calls = 0
+    cpu_calls = 0
+
+    @staticmethod
+    def __new__(cls, value):
+        return torch.Tensor._make_subclass(cls, torch.tensor(value), require_grad=False)
+
+    @property
+    def device(self):
+        return torch.device("cuda:0")
+
+    def item(self):
+        type(self).item_calls += 1
+        return self.as_subclass(torch.Tensor).item()
+
+    def cpu(self):
+        type(self).cpu_calls += 1
+        return self.as_subclass(torch.Tensor)
+
+    @classmethod
+    def reset_calls(cls):
+        cls.item_calls = 0
+        cls.cpu_calls = 0
+
+
+def _contains_tensor(value):
+    if isinstance(value, torch.Tensor):
+        return True
+    if isinstance(value, Metric):
+        return any(_contains_tensor(metric_value) for metric_value in value.values)
+    if isinstance(value, dict):
+        return any(_contains_tensor(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_tensor(child) for child in value)
+    return False
+
+
+def test_postprocess_batches_loss_and_metric_materialization_before_object_gather():
+    _DeferredScalar.reset_calls()
+    worker = object.__new__(TrainingWorker)
+    worker.device_name = "cpu"
+    worker.engine = SimpleNamespace(get_data_parallel_group=lambda: object())
+    worker.flops_counter = None
+    metric = Metric("mean")
+    metric.extend([_DeferredScalar(3.0), _DeferredScalar(5.0)])
+    output = {
+        "loss": [_DeferredScalar(1.0), _DeferredScalar(2.0)],
+        "metrics": {
+            "metric": metric,
+            "plain": [_DeferredScalar(7.0)],
+        },
+        "model_output": {},
+    }
+    captured_metrics = None
+
+    def fake_allgather(data, group):
+        nonlocal captured_metrics
+        captured_metrics = data
+        assert not _contains_tensor(data)
+        return {key: [value] for key, value in data.items()}
+
+    device = SimpleNamespace(
+        max_memory_allocated=lambda: 0,
+        max_memory_reserved=lambda: 0,
+    )
+    with (
+        patch("verl.workers.engine_workers.torch.distributed.all_reduce"),
+        patch("verl.workers.engine_workers.allgather_dict_into_dict", side_effect=fake_allgather),
+        patch("verl.workers.engine_workers.get_torch_device", return_value=device),
+    ):
+        result = worker._postprocess_output(
+            output,
+            global_token_num=None,
+            delta_time=1.0,
+            forward_only=False,
+            images_seqlens=None,
+        )
+
+    assert captured_metrics is not None
+    assert captured_metrics["metric"].values == [3.0, 5.0]
+    assert captured_metrics["plain"] == [7.0]
+    assert _DeferredScalar.item_calls == 0
+    assert _DeferredScalar.cpu_calls == 1
+    result_metrics = result.get_non_tensor("metrics")
+    assert result_metrics["loss"] == 3.0

--- a/tests/workers/test_distillation_topk_symmetry_on_cpu.py
+++ b/tests/workers/test_distillation_topk_symmetry_on_cpu.py
@@ -45,6 +45,7 @@ from verl.trainer.distillation.fsdp.losses import compute_forward_kl_topk as com
 from verl.trainer.distillation.losses import compute_forward_kl_topk as collect_forward_kl_topk_metrics
 from verl.utils import tensordict_utils as tu
 from verl.utils.dataset.dataset_utils import DatasetPadMode
+from verl.utils.metric import materialize_metric_tensors
 from verl.workers.engine.fsdp.transformer_impl import FSDPEngineWithLMHead
 
 _VOCAB_SIZE = 8
@@ -244,5 +245,15 @@ def test_forward_kl_topk_metric_aggregation_for_overlap_outputs():
         data=data,
     )
 
+    assert all(
+        torch.is_tensor(metrics[key]) and metrics[key].grad_fn is None
+        for key in (
+            "distillation/overlap_ratio",
+            "distillation/overlap_token_advantage",
+            "distillation/student_mass",
+            "distillation/teacher_mass",
+        )
+    )
+    materialize_metric_tensors(metrics)
     assert metrics["distillation/overlap_ratio"] == pytest.approx(0.75)
     assert metrics["distillation/overlap_token_advantage"] == pytest.approx(-0.3)

--- a/verl/trainer/distillation/losses.py
+++ b/verl/trainer/distillation/losses.py
@@ -333,11 +333,11 @@ def compute_forward_kl_topk(
         # Diagnostics for tracking teacher/student top-k overlap in OPD, following
         # "Rethinking On-Policy Distillation of Large Language Models" (arXiv:2604.13016):
         # overlap ratio and average teacher-token KL contribution on overlapped tokens.
-        overlap_metrics["distillation/overlap_ratio"] = (valid_overlap_count.float().mean() / k).item()
+        overlap_metrics["distillation/overlap_ratio"] = (valid_overlap_count.float().mean() / k).detach()
         overlap_position_mask = response_mask_bool & (overlap_count > 0)
         if overlap_position_mask.any():
             overlap_metrics["distillation/overlap_token_advantage"] = (
-                overlap_token_advantage[overlap_position_mask].mean().item()
+                overlap_token_advantage[overlap_position_mask].mean().detach()
             )
         else:
             overlap_metrics["distillation/overlap_token_advantage"] = 0.0
@@ -346,10 +346,10 @@ def compute_forward_kl_topk(
     student_mass = student_mass[response_mask_bool]
     teacher_mass = teacher_mass[response_mask_bool]
     distillation_metrics = {
-        "distillation/student_mass": student_mass.mean().item(),
+        "distillation/student_mass": student_mass.mean().detach(),
         "distillation/student_mass_min": Metric(AggregationType.MIN, student_mass.min()),
         "distillation/student_mass_max": Metric(AggregationType.MAX, student_mass.max()),
-        "distillation/teacher_mass": teacher_mass.mean().item(),
+        "distillation/teacher_mass": teacher_mass.mean().detach(),
         "distillation/teacher_mass_min": Metric(AggregationType.MIN, teacher_mass.min()),
         "distillation/teacher_mass_max": Metric(AggregationType.MAX, teacher_mass.max()),
         **overlap_metrics,

--- a/verl/trainer/ppo/core_algos.py
+++ b/verl/trainer/ppo/core_algos.py
@@ -1362,9 +1362,9 @@ def compute_policy_loss_vanilla(
     )
 
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1443,9 +1443,9 @@ def compute_policy_loss_dppo_tv(
     pg_clipfrac_lower = verl_F.masked_mean((ratio > clip_ratio_c).float() * valid_mask, response_mask)
 
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1528,9 +1528,9 @@ def compute_policy_loss_dppo_kl(
     pg_clipfrac_lower = verl_F.masked_mean((ratio > clip_ratio_c).float() * valid_mask, response_mask)
 
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1604,9 +1604,9 @@ def compute_policy_loss_gspo(
 
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1688,9 +1688,9 @@ def compute_policy_loss_sapo(
     ppo_kl = verl_F.masked_mean(-negative_approx_kl, response_mask)
     # return metrics dict
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
 
     return pg_loss, pg_metrics
@@ -1831,8 +1831,8 @@ def compute_policy_loss_clip_cov(
         loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode, **config.global_batch_info
     )
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1912,7 +1912,7 @@ def compute_policy_loss_kl_cov(
         loss_mat=pg_losses, loss_mask=response_mask, loss_agg_mode=loss_agg_mode, **config.global_batch_info
     )
     pg_metrics = {
-        "actor/ppo_kl": ppo_kl_abs.detach().item(),
+        "actor/ppo_kl": ppo_kl_abs.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -1996,9 +1996,9 @@ def compute_policy_loss_geo_mean(
     pg_clipfrac = verl_F.masked_mean((clipped * (advantages > 0)).float(), response_mask)
     pg_clipfrac_lower = verl_F.masked_mean((clipped * (advantages < 0)).float(), response_mask)
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -2057,9 +2057,9 @@ def compute_policy_loss_cispo(
     pg_clipfrac_lower = torch.tensor(0.0, device=pg_loss.device)
 
     pg_metrics = {
-        "actor/pg_clipfrac": pg_clipfrac.detach().item(),
-        "actor/ppo_kl": ppo_kl.detach().item(),
-        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach().item(),
+        "actor/pg_clipfrac": pg_clipfrac.detach(),
+        "actor/ppo_kl": ppo_kl.detach(),
+        "actor/pg_clipfrac_lower": pg_clipfrac_lower.detach(),
     }
     return pg_loss, pg_metrics
 
@@ -2363,7 +2363,7 @@ def compute_policy_loss_reinforce(
     kl_divergence = verl_F.masked_mean(-negative_approx_kl, response_mask)
 
     pg_metrics = {
-        "actor/ppo_kl": kl_divergence.detach().item(),
+        "actor/ppo_kl": kl_divergence.detach(),
     }
 
     return pg_loss, pg_metrics

--- a/verl/utils/metric/__init__.py
+++ b/verl/utils/metric/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .utils import AggregationType, Metric, reduce_metrics
+from .utils import AggregationType, Metric, materialize_metric_tensors, reduce_metrics
 
-__all__ = ["reduce_metrics", "AggregationType", "Metric"]
+__all__ = ["reduce_metrics", "materialize_metric_tensors", "AggregationType", "Metric"]

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -94,7 +94,7 @@ def materialize_metric_tensors(metrics: dict[str, Any]) -> None:
             if value.numel() != 1:
                 raise ValueError(f"Metric tensors must be scalar, got shape {tuple(value.shape)}")
             group_key = (type(value), value.device, value.dtype)
-            tensor_refs.setdefault(group_key, []).append((container, key, value.detach()))
+            tensor_refs.setdefault(group_key, []).append((container, key, value.detach().reshape(())))
 
     for metric_key, metric_value in metrics.items():
         collect(metrics, metric_key, metric_value)

--- a/verl/utils/metric/utils.py
+++ b/verl/utils/metric/utils.py
@@ -69,6 +69,42 @@ NumericType = int, float, torch.Tensor, np.ndarray
 Numeric = int | float | torch.Tensor | np.ndarray
 
 
+def materialize_metric_tensors(metrics: dict[str, Any]) -> None:
+    """Batch-convert deferred scalar metric tensors to host values in place.
+
+    Raises:
+        ValueError: If a metric contains a non-scalar tensor.
+    """
+    tensor_refs: dict[
+        tuple[type[torch.Tensor], torch.device, torch.dtype],
+        list[tuple[dict | list, str | int, torch.Tensor]],
+    ] = {}
+
+    def collect(container: dict | list, key: str | int, value: Any) -> None:
+        if isinstance(value, Metric):
+            for index, metric_value in enumerate(value.values):
+                collect(value.values, index, metric_value)
+        elif isinstance(value, dict):
+            for child_key, child_value in value.items():
+                collect(value, child_key, child_value)
+        elif isinstance(value, list):
+            for index, child_value in enumerate(value):
+                collect(value, index, child_value)
+        elif isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                raise ValueError(f"Metric tensors must be scalar, got shape {tuple(value.shape)}")
+            group_key = (type(value), value.device, value.dtype)
+            tensor_refs.setdefault(group_key, []).append((container, key, value.detach()))
+
+    for metric_key, metric_value in metrics.items():
+        collect(metrics, metric_key, metric_value)
+
+    for refs in tensor_refs.values():
+        host_values = torch.stack([value for _, _, value in refs]).cpu().tolist()
+        for (container, key, _), host_value in zip(refs, host_values, strict=True):
+            container[key] = host_value
+
+
 class Metric:
     """
     A metric aggregator for collecting and aggregating numeric values.
@@ -107,7 +143,9 @@ class Metric:
         if isinstance(value, torch.Tensor):
             if value.numel() != 1:
                 raise ValueError("Only scalar tensors can be converted to float")
-            value = value.detach().item()
+            value = value.detach()
+            if value.device.type == "cpu":
+                value = value.item()
         if not isinstance(value, NumericType):
             raise ValueError(f"Unsupported value type: {type(value)}")
         self.values.append(value)
@@ -121,6 +159,7 @@ class Metric:
             self.append(value)
 
     def aggregate(self) -> float:
+        materialize_metric_tensors({"metric": self})
         return self._aggregate(self.values, self.aggregation)
 
     @classmethod
@@ -139,6 +178,7 @@ class Metric:
     def aggregate_dp(cls, metric_lists: list["Metric"]) -> float:
         if not metric_lists:
             raise ValueError("Cannot aggregate an empty list of metrics.")
+        materialize_metric_tensors({str(index): metric for index, metric in enumerate(metric_lists)})
         value_lists = [ml.values for ml in metric_lists]
         if not all(len(ls) == len(value_lists[0]) for ls in value_lists):
             raise ValueError(

--- a/verl/workers/engine/automodel/transformer_impl.py
+++ b/verl/workers/engine/automodel/transformer_impl.py
@@ -713,7 +713,7 @@ class AutomodelEngineWithLMHead(AutomodelEngine):
 
             output = {
                 "model_output": model_output,
-                "loss": loss.detach().item(),
+                "loss": loss.detach(),
                 "metrics": metrics,
             }
 

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -1440,7 +1440,7 @@ class FSDPEngineWithLMHead(FSDPEngine):
             }
             output = {
                 "model_output": model_output,
-                "loss": loss.detach().item(),
+                "loss": loss.detach(),
                 "metrics": metrics,
             }
 

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -1142,7 +1142,7 @@ class MegatronEngineWithLMHead(MegatronEngine):
 
         output = {
             "model_output": model_output,
-            "loss": loss.detach().item(),
+            "loss": loss.detach(),
             "metrics": metrics,
         }
 

--- a/verl/workers/engine/torchtitan/transformer_impl.py
+++ b/verl/workers/engine/torchtitan/transformer_impl.py
@@ -759,7 +759,7 @@ class TorchTitanEngineWithLMHead(TorchTitanEngine):
 
             output = {
                 "model_output": model_output,
-                "loss": loss.detach().item(),
+                "loss": loss.detach(),
                 "metrics": metrics,
             }
 

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -184,8 +184,10 @@ class TrainingWorker(Worker, DistProfilerExtension):
         # Here each metric in metrics can be a list (micro-batch metrics) or a singleton
         # we should always sum the loss of each micro-batch as we scale by global_bsz/global_token
         losses = output.pop("loss")
-        if losses and all(isinstance(loss, torch.Tensor) for loss in losses):
-            loss = torch.stack(losses).sum()
+        if isinstance(losses, torch.Tensor):
+            loss = losses.detach().to(self.device_name).sum()
+        elif isinstance(losses, list | tuple) and losses and all(isinstance(loss, torch.Tensor) for loss in losses):
+            loss = torch.stack([loss.detach() for loss in losses]).sum()
         else:
             loss = torch.tensor(losses, device=self.device_name).sum()
         dp_group = self.engine.get_data_parallel_group()

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -38,7 +38,7 @@ from verl.utils.distributed import initialize_global_process_group_ray, set_numa
 from verl.utils.flops_counter import FlopsCounter
 from verl.utils.import_utils import import_external_libs
 from verl.utils.memory_utils import aggressive_empty_cache
-from verl.utils.metric.utils import Metric
+from verl.utils.metric import Metric, materialize_metric_tensors
 from verl.utils.profiler import DistProfiler, DistProfilerExtension, ProfilerConfig, log_gpu_memory_usage
 from verl.utils.py_functional import append_to_dict
 from verl.utils.tensordict_utils import maybe_fix_3d_position_ids
@@ -183,17 +183,28 @@ class TrainingWorker(Worker, DistProfilerExtension):
         # perform all gather in dp group to ensure that it's correct.
         # Here each metric in metrics can be a list (micro-batch metrics) or a singleton
         # we should always sum the loss of each micro-batch as we scale by global_bsz/global_token
-        loss = torch.sum(torch.tensor(output.pop("loss"), device=self.device_name))
+        losses = output.pop("loss")
+        if losses and all(isinstance(loss, torch.Tensor) for loss in losses):
+            loss = torch.stack(losses).sum()
+        else:
+            loss = torch.tensor(losses, device=self.device_name).sum()
         dp_group = self.engine.get_data_parallel_group()
         if dp_group is not None:
             torch.distributed.all_reduce(loss, op=torch.distributed.ReduceOp.AVG, group=dp_group)
-        loss = loss.item()
 
         # For grad_norm, we do not perform all reduce because it is already been done when clipping grad
         grad_norm = metrics.pop("grad_norm", None)
         if isinstance(grad_norm, torch.Tensor):
             grad_norm = grad_norm.detach().item()
         lr = metrics.pop("lr", None)
+
+        # Scalar values stay on device across micro-batches. Materialize loss
+        # and metrics together before object collectives or Ray serialization.
+        host_values = {"metrics": metrics, "loss": loss, "lr": lr}
+        materialize_metric_tensors(host_values)
+        metrics = host_values["metrics"]
+        loss = host_values["loss"]
+        lr = host_values["lr"]
 
         # For other metrics, we perform all gather in dp group (only if DP > 1)
         if dp_group is not None:

--- a/verl/workers/utils/losses.py
+++ b/verl/workers/utils/losses.py
@@ -198,8 +198,8 @@ def value_loss(config: CriticConfig, model_output, data: TensorDict, dp_group=No
 
     metrics = {
         "critic/vf_loss": Metric(value=vf_loss, aggregation=metric_aggregation),
-        "critic/vf_clipfrac": vf_clipfrac.detach().item(),
-        "critic/vpred_mean": masked_mean(vpreds, response_mask).detach().item(),
+        "critic/vf_clipfrac": vf_clipfrac.detach(),
+        "critic/vpred_mean": masked_mean(vpreds, response_mask).detach(),
     }
 
     return vf_loss, metrics


### PR DESCRIPTION
### What does this PR do?

Actor and critic losses currently convert every scalar metric to a Python
number inside each micro-batch. On accelerators, every `.item()` is a
device-to-host synchronization point.

For a standard PPO actor micro-batch, this includes policy loss, KL,
clip-fraction metrics, and the detached micro-batch loss. With multiple
micro-batches, the number of synchronization points grows with:

```text
micro_batches x scalar_metrics
```

This PR keeps detached scalar loss and metric tensors on the accelerator across
micro-batches, then materializes all compatible scalars in one stacked
device-to-host transfer at `TrainingWorker._postprocess_output`, before
`all_gather_object` or Ray serialization.

The change covers FSDP/FSDP2, Megatron, TorchTitan, and AutoModel engine output
paths, PPO-family policy metrics, critic metrics, and top-k distillation
metrics.

It intentionally does **not** defer scalars used for control flow, including
gradient-finiteness checks, token counts, sequence lengths, and sampling
decisions.

### Checklist Before Starting

- [x] Searched all open PRs for `Metric.append`, `defer metric`,
  `local_scalar_dense`, and `GPU synchronization metrics`.
- [x] No open PR implements deferred/batched scalar metric materialization.
- [x] #5600 is adjacent but not a duplicate: it replaces list-backed metrics
  with aggregation state, but its current `_flatten_values()` still performs
  `value.detach().cpu().flatten().tolist()` for every metric at every
  micro-batch. This PR changes the synchronization boundary and batches device
  scalars before object communication. If #5600 lands first, this helper can be
  rebased onto its state representation without changing the performance goal.
- [x] #7083 is not a duplicate: it adds an explicit CUDA stream
  synchronization for checkpoint broadcasting; this PR removes unnecessary
  per-micro-batch metric synchronizations.
- [x] The title follows the repository format:
  `[worker, perf] feat: defer scalar metric materialization`.

### Test

Focused CPU tests:

```bash
PYTHONPATH=$PWD python -m pytest -q \
  tests/trainer/ppo/test_metric_utils_on_cpu.py \
  tests/workers/test_deferred_metric_materialization_on_cpu.py \
  tests/trainer/ppo/test_core_algos_on_cpu.py \
  tests/trainer/ppo/test_value_loss_normalization_on_cpu.py \
  tests/trainer/ppo/test_rollout_corr_integration.py \
  tests/workers/test_distillation_topk_symmetry_on_cpu.py
```

Result:

```text
117 passed, 4 warnings
```

Coverage includes:

- accelerator-like scalar tensors are detached without immediate `.item()`;
- CPU tensors retain the existing eager Python-scalar behavior;
- nested `Metric`/dict/list scalars sharing type/device/dtype use one batch
  transfer;
- mixed dtypes are materialized independently without promotion;
- non-scalar metric tensors fail closed with their shape;
- materialized metrics are pickleable and contain no tensors;
- worker postprocessing materializes before DP object collectives;
- multiple micro-batch losses and metrics share one host transfer;
- worker postprocessing accepts single tensor losses, tensor lists/tuples,
  numeric lists, scalar numbers, and empty lists without retaining autograd
  graphs;
- policy-loss metrics are detached 0-d tensors and retain their values;
- top-k distillation metrics follow the same protocol; and
- SUM/MEAN/MIN/MAX and DP aggregation semantics remain unchanged.

Broader CPU validation was split into bounded batches to avoid an unbounded
Ray test run:

```text
791 passed
```

The remaining results were 17 utility failures, 4 worker failures, and 13
reward-loop setup errors. Each failing node was reproduced on an untouched
`origin/main` worktree. They require unavailable local model paths, optional
Megatron/vLLM/FlashAttention dependencies, CUDA on this macOS host, or hit an
existing numerical-tolerance edge. Three agent-loop schema/parser files could
not be collected because their optional dependencies are unavailable in this
CPU environment.

The existing FSDP graph-retention regression was also run with an explicit CPU
device override because this macOS environment falls back to the CUDA platform
when no supported accelerator is detected:

```text
graph-retention regression passed with explicit CPU device
```

Full repository checks:

```bash
pre-commit run --all-files --show-diff-on-failure
```

Result: all hooks passed.

#### Reproducible performance benchmark

Benchmark source, raw samples, analysis, environment, hashes, positive and
negative results:

https://gist.github.com/zhangxin81/a4960aa03aeb6fc2bda74e2ffc3c1ebf

The real-device benchmark uses Apple M3 Max MPS. Each micro-batch performs the
same matrix multiply/GELU and computes six scalar metrics. It uses seven
independent process launches, ten warmups per launch, 51 paired repeats per
configuration, alternating execution order, and a bootstrap confidence interval
over launch-level paired speedups.

| Micro-batches | Metric scalars | Eager median | Deferred median | Paired speedup | Bootstrap 95% CI |
|---:|---:|---:|---:|---:|---:|
| 1 | 6 | 1.222 ms | 0.514 ms | 2.445x | [2.296x, 2.524x] |
| 4 | 24 | 4.486 ms | 1.106 ms | 4.073x | [3.821x, 4.208x] |
| 16 | 96 | 16.679 ms | 3.554 ms | 4.603x | [4.327x, 4.619x] |
| 64 | 384 | 67.167 ms | 13.604 ms | 4.784x | [4.643x, 5.056x] |

A separate protocol benchmark verifies that synchronization operations change
from `6 x micro_batches` eager `.item()` calls to one deferred `.cpu()` call.

The protocol benchmark was rerun at metric implementation SHA
`d3d35a1ebd25fc76d4aeb41b625071417881cefe` after adding scalar-shape
normalization and retained the same synchronization counts. A 21-repeat MPS
smoke at that SHA measured paired median speedups of 2.075x, 3.581x, 4.850x,
and 5.190x for 1, 4, 16, and 64 micro-batches. The later loss-input
compatibility fix does not modify the metric implementation; at the final PR
head `e85fa9213285281bc1ddd58096aeb5999fdb78b2`, the protocol benchmark was
rerun and again measured `6 x micro_batches` eager `.item()` calls versus one
deferred `.cpu()` call. The focused suite passed 117 tests and full
pre-commit passed at that final head. The Gist includes the primary benchmark
and metric-implementation follow-up outputs; the seven-launch table remains the
primary statistical result.

The same protocol benchmark is about 3x slower on CPU because CPU tensors have
no accelerator synchronization to amortize. The production implementation
therefore keeps CPU scalar tensors on the existing eager path.

These are metric-computation/materialization path results, not complete
PPO/GRPO actor-update or end-to-end training speedups. MPS synchronization
behavior is not identical to CUDA/NPU, and large-model training may be dominated
by forward/backward compute or collectives. CUDA/NPU profiler validation remains
desirable.

### API and Usage Example

There is no user-facing configuration change. Engine and loss callers continue
to return the same metric names and final host-number values.

Internally, custom policy/loss functions may return detached scalar tensors in
their metric dictionaries. `materialize_metric_tensors` accepts nested
`Metric`, dict, and list structures and converts scalar tensors in place before
object communication.

Non-scalar metric tensors are rejected:

```text
ValueError: Metric tensors must be scalar, got shape (...)
```

### Design & Code Changes

- `Metric.append` defers non-CPU scalar tensor materialization while detaching
  from autograd.
- `materialize_metric_tensors` groups scalars by tensor type/device/dtype and
  performs one stacked host transfer per group.
- `TrainingWorker._postprocess_output` batches loss and metrics before object
  collectives and serialization.
- Existing immediate grad-norm handling remains unchanged because grad norm
  participates in non-finite control flow and may be a distributed tensor.
- PPO-family, critic, distillation, and engine micro-batch output paths return
  detached scalar tensors instead of calling `.item()` eagerly.
- CPU and serialization tests pin down the new internal contract.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and repository `AGENTS.md`.
- [x] Duplicate-work checks completed.
- [x] Focused CPU tests passed.
- [x] Full pre-commit passed.
- [x] Reproducible benchmark artifacts published.
- [x] No generated config or recipe submodule changes are required.
- [x] CI was triggered by a maintainer; required checks are running.

### AI assistance

OpenAI Codex assisted with repository exploration, implementation, tests,
benchmarking, and PR drafting. The human submitter reviewed every changed line,
understands the synchronization and serialization boundaries, and personally
confirmed the test commands and benchmark results before submission.
