### PR TITLE
[training_utils, perf] feat: reuse jagged rows across dynamic batches

### DIFF
--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -18,10 +18,12 @@ Replace DataProto with raw TensorDict
 
 import copy
 import random
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 import torch
+from tensordict import TensorDict
 from tensordict.tensorclass import NonTensorData, NonTensorStack
 
 from verl.utils import tensordict_utils as tu
@@ -147,6 +149,80 @@ def test_index_select_tensor_dict_preserves_3d_nested_tensor_layout_with_equal_s
     assert torch.equal(selected["position_ids"].values(), expected.values())
     assert torch.equal(selected["position_ids"].offsets(), expected.offsets())
     tu.assert_tensordict_eq(selected, tu.get_tensordict({"position_ids": expected}))
+
+
+def test_partition_tensor_dict_matches_repeated_index_select():
+    lengths = [3, 5, 2, 4]
+    input_ids = tu.nested_tensor_from_tensor_list([torch.arange(length) for length in lengths])
+    teacher_logprobs = tu.nested_tensor_from_tensor_list([torch.randn(length, 8) for length in lengths], ragged_idx=1)
+    batch = TensorDict(
+        {
+            "input_ids": input_ids,
+            "teacher_logprobs": teacher_logprobs,
+            "dense": torch.arange(8).view(4, 2),
+            "stack": NonTensorStack.from_list([NonTensorData(value) for value in ("a", "b", "c", "d")]),
+            "metadata": NonTensorData({"name": "batch"}),
+        },
+        batch_size=[4],
+    )
+    partitions = [[3, 1], torch.tensor([0, 2])]
+
+    original_unbind = torch.Tensor.unbind
+
+    def run_and_count_unbinds(fn):
+        unbind_calls = []
+
+        def record_unbind(tensor, *args, **kwargs):
+            unbind_calls.append(tensor)
+            return original_unbind(tensor, *args, **kwargs)
+
+        with patch.object(torch.Tensor, "unbind", new=record_unbind):
+            output = fn()
+        return output, unbind_calls
+
+    actual, optimized_unbinds = run_and_count_unbinds(lambda: tu.partition_tensor_dict(batch, partitions))
+    expected, baseline_unbinds = run_and_count_unbinds(
+        lambda: [tu.index_select_tensor_dict(batch, partition) for partition in partitions]
+    )
+    for tensor in (input_ids, teacher_logprobs):
+        optimized_count = sum(unbound is tensor for unbound in optimized_unbinds)
+        baseline_count = sum(unbound is tensor for unbound in baseline_unbinds)
+        assert optimized_count > 0
+        assert baseline_count == optimized_count * len(partitions)
+    assert len(actual) == len(expected)
+    for actual_partition, expected_partition in zip(actual, expected, strict=True):
+        assert list(actual_partition.keys()) == list(expected_partition.keys())
+        tu.assert_tensordict_eq(actual_partition, expected_partition)
+        assert actual_partition["teacher_logprobs"]._ragged_idx == 1
+
+
+@pytest.mark.parametrize("partitions", [[[2, 0]], [[2, 0], [1, 3]]])
+def test_partition_tensor_dict_falls_back_without_reusable_nested_work(partitions):
+    batch = TensorDict(
+        {
+            "dense": torch.arange(8).view(4, 2),
+            "metadata": NonTensorData({"name": "batch"}),
+        },
+        batch_size=[4],
+    )
+
+    with patch.object(tu, "index_select_tensor_dict", wraps=tu.index_select_tensor_dict) as select:
+        actual = tu.partition_tensor_dict(batch, partitions)
+
+    assert select.call_count == len(partitions)
+    expected = [tu.index_select_tensor_dict(batch, partition) for partition in partitions]
+    for actual_partition, expected_partition in zip(actual, expected, strict=True):
+        tu.assert_tensordict_eq(actual_partition, expected_partition)
+
+
+def test_partition_tensor_dict_rejects_empty_partitions():
+    batch = TensorDict(
+        {"nested": tu.nested_tensor_from_tensor_list([torch.arange(2), torch.arange(3)])},
+        batch_size=[2],
+    )
+
+    with pytest.raises(AssertionError, match="partitions must be non-empty"):
+        tu.partition_tensor_dict(batch, [[], [0, 1]])
 
 
 def test_tensordict_with_images():

--- a/tests/test_protocol_v2_on_cpu.py
+++ b/tests/test_protocol_v2_on_cpu.py
@@ -168,22 +168,34 @@ def test_partition_tensor_dict_matches_repeated_index_select():
     partitions = [[3, 1], torch.tensor([0, 2])]
 
     original_unbind = torch.Tensor.unbind
+    original_tolist = torch.Tensor.tolist
 
     def run_and_count_unbinds(fn):
         unbind_calls = []
+        tolist_calls = []
 
         def record_unbind(tensor, *args, **kwargs):
             unbind_calls.append(tensor)
             return original_unbind(tensor, *args, **kwargs)
 
-        with patch.object(torch.Tensor, "unbind", new=record_unbind):
-            output = fn()
-        return output, unbind_calls
+        def record_tolist(tensor, *args, **kwargs):
+            tolist_calls.append(tensor)
+            return original_tolist(tensor, *args, **kwargs)
 
-    actual, optimized_unbinds = run_and_count_unbinds(lambda: tu.partition_tensor_dict(batch, partitions))
-    expected, baseline_unbinds = run_and_count_unbinds(
+        with (
+            patch.object(torch.Tensor, "unbind", new=record_unbind),
+            patch.object(torch.Tensor, "tolist", new=record_tolist),
+        ):
+            output = fn()
+        return output, unbind_calls, tolist_calls
+
+    actual, optimized_unbinds, optimized_tolist = run_and_count_unbinds(
+        lambda: tu.partition_tensor_dict(batch, partitions)
+    )
+    expected, baseline_unbinds, _ = run_and_count_unbinds(
         lambda: [tu.index_select_tensor_dict(batch, partition) for partition in partitions]
     )
+    assert sum(tensor is partitions[1] for tensor in optimized_tolist) == 1
     for tensor in (input_ids, teacher_logprobs):
         optimized_count = sum(unbound is tensor for unbound in optimized_unbinds)
         baseline_count = sum(unbound is tensor for unbound in baseline_unbinds)
@@ -196,7 +208,15 @@ def test_partition_tensor_dict_matches_repeated_index_select():
         assert actual_partition["teacher_logprobs"]._ragged_idx == 1
 
 
-@pytest.mark.parametrize("partitions", [[[2, 0]], [[2, 0], [1, 3]]])
+@pytest.mark.parametrize(
+    "partitions",
+    [
+        [[2, 0]],
+        [[2, 0], [1, 3]],
+        [torch.tensor([2, 0])],
+        [torch.tensor([2, 0]), torch.tensor([1, 3])],
+    ],
+)
 def test_partition_tensor_dict_falls_back_without_reusable_nested_work(partitions):
     batch = TensorDict(
         {
@@ -206,13 +226,44 @@ def test_partition_tensor_dict_falls_back_without_reusable_nested_work(partition
         batch_size=[4],
     )
 
-    with patch.object(tu, "index_select_tensor_dict", wraps=tu.index_select_tensor_dict) as select:
+    tolist_calls = []
+    original_tolist = torch.Tensor.tolist
+
+    def record_tolist(tensor, *args, **kwargs):
+        tolist_calls.append(tensor)
+        return original_tolist(tensor, *args, **kwargs)
+
+    with (
+        patch.object(tu, "index_select_tensor_dict", wraps=tu.index_select_tensor_dict) as select,
+        patch.object(torch.Tensor, "tolist", new=record_tolist),
+    ):
         actual = tu.partition_tensor_dict(batch, partitions)
 
     assert select.call_count == len(partitions)
+    assert not any(unbound is partition for partition in partitions for unbound in tolist_calls)
     expected = [tu.index_select_tensor_dict(batch, partition) for partition in partitions]
     for actual_partition, expected_partition in zip(actual, expected, strict=True):
         tu.assert_tensordict_eq(actual_partition, expected_partition)
+
+
+def test_partition_tensor_dict_single_jagged_partition_avoids_host_conversion():
+    batch = TensorDict(
+        {"nested": tu.nested_tensor_from_tensor_list([torch.arange(2), torch.arange(3)])},
+        batch_size=[2],
+    )
+    partition = torch.tensor([1, 0])
+    original_tolist = torch.Tensor.tolist
+    tolist_calls = []
+
+    def record_tolist(tensor, *args, **kwargs):
+        tolist_calls.append(tensor)
+        return original_tolist(tensor, *args, **kwargs)
+
+    with patch.object(torch.Tensor, "tolist", new=record_tolist):
+        actual = tu.partition_tensor_dict(batch, [partition])
+
+    assert not any(tensor is partition for tensor in tolist_calls)
+    tu.assert_tensordict_eq(actual[0], tu.index_select_tensor_dict(batch, partition))
 
 
 def test_partition_tensor_dict_rejects_empty_partitions():

--- a/tests/utils/test_seqlen_balancing.py
+++ b/tests/utils/test_seqlen_balancing.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from verl import DataProto
+from verl.utils import tensordict_utils as tu
 from verl.utils.device import get_device_name, get_nccl_backend, get_torch_device
 from verl.utils.model import create_random_mask
 from verl.utils.seqlen_balancing import (
@@ -45,6 +48,49 @@ def test_seqlen_balancing():
     reverse_idx_map = torch.tensor(reverse_idx_map)
     new_batch = batch[reverse_idx_map]
     torch.testing.assert_close(new_batch, dataproto.batch)
+
+
+def test_rearrange_micro_batches_unbinds_each_nested_field_once():
+    lengths = [8, 7, 6, 5, 4, 3]
+    input_ids = tu.nested_tensor_from_tensor_list([torch.arange(length) for length in lengths])
+    position_ids = tu.nested_tensor_from_tensor_list(
+        [torch.arange(length).expand(2, length) for length in lengths], ragged_idx=2
+    )
+    batch = tu.get_tensordict(
+        {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "attention_mask": torch.ones(len(lengths), max(lengths)),
+        }
+    )
+
+    original_unbind = torch.Tensor.unbind
+
+    def run_and_count_unbinds(fn):
+        unbind_calls = []
+
+        def record_unbind(tensor, *args, **kwargs):
+            unbind_calls.append(tensor)
+            return original_unbind(tensor, *args, **kwargs)
+
+        with patch.object(torch.Tensor, "unbind", new=record_unbind):
+            output = fn()
+        return output, unbind_calls
+
+    (micro_batches, partitions), optimized_unbinds = run_and_count_unbinds(
+        lambda: rearrange_micro_batches(batch, max_token_len=12)
+    )
+    _, baseline_unbinds = run_and_count_unbinds(
+        lambda: [tu.index_select_tensor_dict(batch, partition) for partition in partitions]
+    )
+
+    assert len(micro_batches) == len(partitions)
+    assert len(micro_batches) > 1
+    for tensor in (input_ids, position_ids):
+        optimized_count = sum(unbound is tensor for unbound in optimized_unbinds)
+        baseline_count = sum(unbound is tensor for unbound in baseline_unbinds)
+        assert optimized_count > 0
+        assert baseline_count == optimized_count * len(partitions)
 
 
 def test_dynamic_batch():

--- a/verl/utils/seqlen_balancing.py
+++ b/verl/utils/seqlen_balancing.py
@@ -459,11 +459,7 @@ def rearrange_micro_batches(
         # Place smaller micro-batches at both ends to reduce the bubbles exposed during the warm-up and cool-down.
         micro_bsz_idx = micro_bsz_idx[::2][::-1] + micro_bsz_idx[1::2]
 
-    micro_batches = []
-
-    for partition in micro_bsz_idx:
-        curr_micro_batch = tu.index_select_tensor_dict(batch, partition)
-        micro_batches.append(curr_micro_batch)
+    micro_batches = tu.partition_tensor_dict(batch, micro_bsz_idx)
 
     return micro_batches, micro_bsz_idx
 

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -534,14 +534,15 @@ def partition_tensor_dict(batch: TensorDict, partitions: list[torch.Tensor | lis
     if len(normalized_partitions) <= 1 or not nested_tensors:
         return [index_select_tensor_dict(batch, partition) for partition in normalized_partitions]
 
+    partition_rows = [partition if isinstance(partition, list) else partition.tolist() for partition in partitions]
     non_nested_batch = batch.exclude(*nested_tensors)
     selected_batches = [index_select_tensor_dict(non_nested_batch, partition) for partition in normalized_partitions]
     for key, tensor in nested_tensors.items():
         tensor_rows = tensor.unbind()
         ragged_idx = getattr(tensor, "_ragged_idx", tensor.dim() - 1)
-        for selected_batch, partition in zip(selected_batches, normalized_partitions, strict=True):
+        for selected_batch, rows in zip(selected_batches, partition_rows, strict=True):
             selected_batch[key] = nested_tensor_from_tensor_list(
-                [tensor_rows[idx] for idx in partition], ragged_idx=ragged_idx
+                [tensor_rows[idx] for idx in rows], ragged_idx=ragged_idx
             )
     keys = list(batch.keys())
     return [selected_batch.select(*keys) for selected_batch in selected_batches]

--- a/verl/utils/tensordict_utils.py
+++ b/verl/utils/tensordict_utils.py
@@ -510,6 +510,43 @@ def index_select_tensor_dict(batch: TensorDict, indices: torch.Tensor | list[int
     return selected_batch
 
 
+def partition_tensor_dict(batch: TensorDict, partitions: list[torch.Tensor | list[int]]) -> list[TensorDict]:
+    """Select multiple row partitions from a TensorDict.
+
+    Unlike repeated :func:`index_select_tensor_dict` calls, this unbinds each
+    nested tensor only once and reuses the resulting views across partitions.
+
+    Args:
+        batch: The TensorDict to partition.
+        partitions: 1D tensors or lists of row indices, one per output batch.
+
+    Returns:
+        TensorDicts containing the selected rows in partition order.
+    """
+    normalized_partitions = [
+        torch.tensor(partition) if isinstance(partition, list) else partition for partition in partitions
+    ]
+    assert all(partition.dim() == 1 for partition in normalized_partitions), "partitions must contain 1D indices"
+    assert all(partition.numel() > 0 for partition in normalized_partitions), "partitions must be non-empty"
+    nested_tensors = {
+        key: tensor for key, tensor in batch.items() if isinstance(tensor, torch.Tensor) and tensor.is_nested
+    }
+    if len(normalized_partitions) <= 1 or not nested_tensors:
+        return [index_select_tensor_dict(batch, partition) for partition in normalized_partitions]
+
+    non_nested_batch = batch.exclude(*nested_tensors)
+    selected_batches = [index_select_tensor_dict(non_nested_batch, partition) for partition in normalized_partitions]
+    for key, tensor in nested_tensors.items():
+        tensor_rows = tensor.unbind()
+        ragged_idx = getattr(tensor, "_ragged_idx", tensor.dim() - 1)
+        for selected_batch, partition in zip(selected_batches, normalized_partitions, strict=True):
+            selected_batch[key] = nested_tensor_from_tensor_list(
+                [tensor_rows[idx] for idx in partition], ragged_idx=ragged_idx
+            )
+    keys = list(batch.keys())
+    return [selected_batch.select(*keys) for selected_batch in selected_batches]
+
+
 def union_tensor_dict(tensor_dict1: TensorDict, tensor_dict2: TensorDict) -> TensorDict:
     """Merge two TensorDicts, adding keys from the second to the first.
 


### PR DESCRIPTION
### What does this PR do?

Dynamic batching currently builds each micro-batch by calling `index_select_tensor_dict()` once per partition. For every jagged NestedTensor field, each call unbinds the entire input batch before selecting its rows.

With `F` jagged fields and `P` partitions, this repeats approximately `F * P` full-batch unbind operations.

This PR adds a multi-partition TensorDict helper that unbinds each jagged field once, caches the resulting row views while constructing the outputs, and reuses the existing field-selection implementation for every partition.

`rearrange_micro_batches()` uses the new helper. Dense-only and single-partition batches explicitly retain the existing `index_select_tensor_dict()` path.

Mainstream training stacks avoid this specific repeated-jagged-selection shape in different ways:

- TorchTitan's RL `Batcher` packs `TrainingSample` objects into fixed-shape rows before building the micro-batch grid.
- TRL's `padding_free` collator concatenates per-example fields into flat tensors once.
- OpenRLHF dynamic batching stores partitions as Experience indices and collates each selected micro-batch once.

verl keeps a richer jagged TensorDict online so it can repartition all fields dynamically. Reusing the unbound row views provides the equivalent single-materialization property without replacing verl's data model.

### Checklist Before Starting

- [x] Inspected all 483 open PRs and searched for `jagged unbind`, `index_select_tensor_dict`, `partition_tensor_dict`, `dynamic batch unbind`, and `nested tensor unbind performance`.
- [x] No open PR implements shared unbind work across dynamic-batch partitions.
- [x] #5886 is not a duplicate. It fixes multi-component RoPE layout by flattening `position_ids`; it does not change dynamic-batch partition construction.
- [x] #6735 modifies `rearrange_micro_batches`, but addresses token-cap correctness by changing the number of partitions. Its current head still builds partitions one at a time and repeats nested-tensor unbind work. This PR only changes the final partition materialization and can be mechanically rebased if #6735 lands first.
- [x] The title follows the required format: `[training_utils, perf] feat: reuse jagged rows across dynamic batches`.

### Test

Focused CPU tests:

```bash
PYTHONPATH=$PWD python -m pytest -q \
  tests/test_protocol_v2_on_cpu.py \
  tests/utils/test_seqlen_balancing.py \
  -k 'not distributed_params'
```

Result:

```text
52 passed, 1 deselected
```

The deselected existing test requires CUDA in this environment and fails unchanged on `origin/main`.

Coverage includes:

- equality with repeated `index_select_tensor_dict()` calls;
- regular tensors, jagged tensors, non-last ragged dimensions, `NonTensorStack`, and scalar `NonTensorData`;
- output key-order preservation;
- mixed list/tensor partition indices;
- tensor partitions are converted to Python row indices once for jagged tuple selection while retaining the original tensor for dense indexing;
- dense-only and single-partition tensor inputs avoid host conversion;
- one source unbind per jagged field instead of one per partition;
- production `rearrange_micro_batches()` routing through the batched helper;
- dense-only and one-partition fallback to the existing helper.
- tensor-indexed dense-only and single-jagged fallbacks avoid host conversion.

Additional validation:

- `tests/test_protocol_v2_on_cpu.py`: 45 passed;
- related dataset tests: 6 passed, with 11 failures caused by unavailable hard-coded local model paths;
- related worker tests: 29 passed, 2 skipped, with one existing `5.72e-06 > 5e-06` tolerance failure;
- complete utils CPU batch: 179 passed, 17 skipped, with failures matching the previously reproduced `origin/main` environment baseline;
- full `pre-commit run --all-files --show-diff-on-failure`: all hooks passed.

#### Reproducible performance benchmark

Benchmark source, raw samples, analysis, hashes, and limitations:

https://gist.github.com/zhangxin81/721fa3c810fe5b04cf1ba07b56d43768

The benchmark times the complete `rearrange_micro_batches()` function. Baseline and optimized paths use the same partitioning algorithm and validate every output field on every repeat. The only baseline substitution is restoring the old repeated `index_select_tensor_dict()` partition construction.

Each input has six jagged fields, a dense attention mask, a `NonTensorStack`, and scalar metadata. Results use 5 warmups, 31 paired repeats, alternating order, 7 independent process launches, and a 100,000-sample bootstrap CI over launch-level log-speedups.

| Batch | Partitions | Baseline | Optimized | Savings | Paired speedup | 95% CI | Latency reduction |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 128 | 9 | 17.680 ms | 8.397 ms | 9.283 ms | 2.133x | [2.113x, 2.136x] | 52.50% |
| 256 | 17 | 49.845 ms | 17.416 ms | 32.429 ms | 2.865x | [2.857x, 2.923x] | 65.06% |
| 512 | 17 | 84.462 ms | 24.076 ms | 60.386 ms | 3.518x | [3.509x, 3.526x] | 71.49% |

A 201-repeat dense-only negative control measured `1.024x`. Dense batches explicitly use the existing helper.

These results cover dynamic-batch CPU partition construction, not complete PPO/GRPO training throughput. End-to-end impact depends on batch size, number of jagged fields, partition count, and the fraction of step time spent preparing micro-batches.

### API and Usage Example

There is no user-facing configuration change. Existing callers of `rearrange_micro_batches()` keep the same API and output partition order.

Internally, callers that need several row partitions may use:

```python
micro_batches = partition_tensor_dict(batch, partitions)
```

### Design & Code Changes

- Keep one shared internal field-selection implementation for single and multi-partition paths.
- Normalize all partition indices once.
- Cache one tuple of row views per jagged field.
- Reuse those views while rebuilding each jagged output with its original ragged dimension.
- Preserve existing behavior for dense tensors, `NonTensorStack`, `NonTensorData`, one partition, and dense-only inputs.
- Change `rearrange_micro_batches()` only at its final partition construction boundary.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and repository `AGENTS.md`.
- [x] Duplicate-work checks completed.
- [x] Focused and broader CPU tests run.
- [x] Full pre-commit passed.
- [x] Reproducible benchmark artifacts published.
- [x] No generated config, recipe, or documentation surface is affected.
- [x] CI and review were requested in the PR; fork workflows are awaiting maintainer approval.

### AI assistance

OpenAI Codex assisted with repository exploration, implementation, tests, benchmarking, and PR drafting. The human submitter reviewed every changed line, understands the cached-view lifetime and fallback behavior, and personally confirmed the test and benchmark evidence before submission.
