### PR TITLE
[veomni, fsdp] fix: skip manual model.to(device) under FSDP2 CPU offload

### DIFF
--- a/verl/workers/engine/veomni/transformer_impl.py
+++ b/verl/workers/engine/veomni/transformer_impl.py
@@ -145,6 +145,11 @@ class VeOmniEngine(FSDPEngine):
         self._is_offload_param = self.engine_config.param_offload
         self._is_offload_optimizer = self.engine_config.optimizer_offload
         self._is_lora = self.model_config.lora_rank > 0
+        # When VeOmni parallelizes with enable_fsdp_offload, FSDP2 uses CPUOffloadPolicy and
+        # owns CPU<->accelerator placement. Manually calling model.to(device) then crashes
+        # state_dict() with a DTensor storage device mismatch (see #5995 / #6604, which fixed
+        # the FSDP engine; the VeOmni engine has the same paths and needs the same guard).
+        self._uses_fsdp2_cpu_offload_policy = self.engine_config.enable_fsdp_offload
 
         self.use_ulysses_sp = parallel_state.get_parallel_state().sp_enabled
         self.ulysses_sequence_parallel_size = self.engine_config.ulysses_parallel_size
@@ -545,7 +550,9 @@ class VeOmniEngine(FSDPEngine):
         Save VeOmni checkpoint, handling parameter offload as needed.
         """
         origin_module_device = next(self.module.parameters()).device.type
-        if self._is_offload_param or origin_module_device == "cpu":
+        if (self._is_offload_param or origin_module_device == "cpu") and not getattr(
+            self, "_uses_fsdp2_cpu_offload_policy", False
+        ):
             load_veomni_model_to_gpu(self.module)
 
         self.checkpoint_manager.save_checkpoint(
@@ -562,7 +569,7 @@ class VeOmniEngine(FSDPEngine):
         """
         Load VeOmni checkpoint, restoring parameters and optimizer state.
         """
-        if self._is_offload_param:
+        if self._is_offload_param and not getattr(self, "_uses_fsdp2_cpu_offload_policy", False):
             load_veomni_model_to_gpu(self.module)
 
         self.checkpoint_manager.load_checkpoint(
@@ -577,7 +584,12 @@ class VeOmniEngine(FSDPEngine):
             offload_veomni_optimizer(self.optimizer)
 
     def get_per_tensor_param(self, **kwargs):
-        load_veomni_model_to_gpu(self.module)
+        # FSDP2 CPUOffloadPolicy owns CPU<->accelerator placement; calling model.to(device)
+        # here leaves the module half-moved and crashes state_dict() below (#5995). The
+        # per-DTensor full_tensor() in param_generator() below still yields accelerator
+        # tensors, so the manual whole-model move is unnecessary under CPU offload.
+        if not getattr(self, "_uses_fsdp2_cpu_offload_policy", False):
+            load_veomni_model_to_gpu(self.module)
 
         params = self.module.state_dict()
         params = convert_weight_keys(params, getattr(self.module, "_fsdp_wrapped_module", self.module))


### PR DESCRIPTION
### What does this PR do?

Follow-up to #6604 for the **VeOmni engine**.

#6604 fixed a DTensor storage-device mismatch under FSDP2 CPU offload for the **FSDP engine**
(`workers/engine/fsdp/transformer_impl.py`) by guarding the manual `model.to(device)` calls
with `_uses_fsdp2_cpu_offload_policy`. The **VeOmni engine**
(`workers/engine/veomni/transformer_impl.py`) has the exact same paths but was not covered, so
it still crashes when saving a checkpoint (or exporting weights) under
`enable_fsdp_offload=True`:

```
RuntimeError: Attempted to set the storage of a tensor on device "cpu"
              to a storage on different device "npu:0".
```

This PR adds the same guard to the VeOmni engine.

Fixes the VeOmni-engine case of #5995.

### Checklist Before Starting

- [x] Search for similar PRs:
  - #5995 (root issue), #6604 (FSDP-engine fix this follows), #6463, #7005 (same device-mismatch family)
  - Query: https://github.com/verl-project/verl/pulls?q=is%3Apr+offload+state_dict
  - No existing PR/issue covers the **VeOmni** engine's `save_checkpoint` / `get_per_tensor_param` paths.
- [x] Title format: `[veomni, fsdp] fix: ...`

### Root cause

VeOmni parallelizes FSDP2 with meta-init → `fully_shard(mesh, CPUOffloadPolicy)` →
`to_empty("cpu")`, leaving each parameter a `DTensor` whose local storage is on CPU while its
device metadata points at the accelerator. `VeOmniEngine.save_checkpoint` /
`load_checkpoint` / `get_per_tensor_param` then call `load_veomni_model_to_gpu(module)`
(= `model.to(device)`), which produces a "split-brain" DTensor. The subsequent
`model.state_dict()` runs `param.detach()`, dispatched through `DTensor.__torch_dispatch__ →
_correct_storage_aliasing`, which raises the device-mismatch `RuntimeError`.

Under `CPUOffloadPolicy`, FSDP2 already owns CPU↔accelerator placement, so the manual
whole-model `model.to(device)` is both unnecessary and harmful — exactly the conclusion of
#6604 for the FSDP engine.

### Design & Code Changes

`verl/workers/engine/veomni/transformer_impl.py`:

- `__init__`: set `self._uses_fsdp2_cpu_offload_policy = self.engine_config.enable_fsdp_offload`
  (VeOmni's CPU-offload switch), mirroring the FSDP engine's flag.
- `save_checkpoint`, `load_checkpoint`, `get_per_tensor_param`: guard the
  `load_veomni_model_to_gpu(self.module)` calls with `not self._uses_fsdp2_cpu_offload_policy`,
  matching #6604. In `get_per_tensor_param` the downstream per-DTensor `full_tensor()` in
  `param_generator()` still yields accelerator tensors, so skipping the whole-model move is
  safe.

Behavior is unchanged when CPU offload is off (flag is `False`, original code path).

### Test

Standalone 2-rank repro (no verl/veomni import needed) that reproduces VeOmni's exact
init + move sequence and compares the pre-fix vs post-fix branch:

```bash
# pre-fix behaviour: model.to(device) then state_dict()  -> crashes
torchrun --nproc_per_node=2 repro_veomni_fsdp2_offload_save.py --device npu
# post-fix behaviour: skip model.to(device) then state_dict() -> succeeds
torchrun --nproc_per_node=2 repro_veomni_fsdp2_offload_save.py --device npu --guarded
```

Observed on Ascend NPU 910B (torch 2.9.0, Python 3.11):

```
# UNGUARDED (pre-fix)
[rank0] mode=UNGUARDED (pre-fix) param device(meta)=npu:0 local_storage_device=cpu
[rank0] state_dict() FAILED (this is the bug the guard prevents):
  ...
  File ".../torch/nn/modules/module.py", line 2157, in _save_to_state_dict
    destination[prefix + name] = param if keep_vars else param.detach()
  File ".../torch/utils/_python_dispatch.py", line 571, in alias_non_inplace_storage
    torch._functionalize_unsafe_set(ret, arg)
RuntimeError: Attempted to set the storage of a tensor on device "cpu" to a storage
              on different device "npu:0".  This is no longer allowed; the devices must match.

# GUARDED (fix)
[rank0] mode=GUARDED (fix) param device(meta)=cpu local_storage_device=cpu
[rank0] state_dict() + save OK, 4 keys.
```

The crash stack is identical to the one hit in a real Qwen3.5-35B VeOmni SFT run with
`enable_fsdp_offload=True`.

- [x] Reproduced on **Ascend NPU (910B)**; the guard resolves it.
- [ ] Not verified on CUDA (no GPU available); the path and the `_correct_storage_aliasing`
      check are device-agnostic, so CUDA is expected to behave identically.

### Checklist Before Submitting

- [x] Ran `ruff check` / `ruff format` (pre-commit ruff hooks) on the changed file.
- [ ] Add a CI regression test analogous to
      `tests/special_distributed/test_fsdp2_cpu_offload_state_dict.py` (that test targets the
      FSDP engine; a VeOmni-engine variant would need the veomni package available in CI).
- [ ] Ping `ci-request` on Slack when ready for CI.

AI assistance was used to investigate and draft this change; the author has reviewed every
line and validated the fix on real NPU hardware.
