### PR TITLE
[tool, megatron] fix: resolve PrecisionDebugger model chunks

### DIFF
--- a/tests/utils/test_precision_debugger_profile.py
+++ b/tests/utils/test_precision_debugger_profile.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+import types
+
+from verl.utils.profiler.config import PrecisionDebuggerToolConfig
+from verl.utils.profiler.precision_debugger_profile import PrecisionDebuggerProfiler
+
+
+class _FakeDebugger:
+    instances = []
+
+    def __init__(self, config_path, dump_path):
+        self.config_path = config_path
+        self.service = types.SimpleNamespace(config=types.SimpleNamespace(dump_path=dump_path))
+        self.started_models = []
+        self.stopped = False
+        self.__class__.instances.append(self)
+
+    def start(self, model):
+        self.started_models.append(model)
+
+    def stop(self):
+        self.stopped = True
+
+
+class _FakeModel:
+    def forward(self):
+        pass
+
+
+def test_precision_debugger_is_created_before_first_profiled_stage(monkeypatch, tmp_path):
+    """Early construction lets msprobe wrap custom APIs before model creation."""
+    import verl.utils.profiler.precision_debugger_profile as profile_module
+
+    _FakeDebugger.instances.clear()
+    msprobe = types.ModuleType("msprobe")
+    pytorch = types.ModuleType("msprobe.pytorch")
+    pytorch.PrecisionDebugger = _FakeDebugger
+    msprobe.pytorch = pytorch
+    monkeypatch.setitem(sys.modules, "msprobe", msprobe)
+    monkeypatch.setitem(sys.modules, "msprobe.pytorch", pytorch)
+    monkeypatch.setattr(profile_module, "is_msprobe_available", lambda: True)
+
+    profiler = PrecisionDebuggerProfiler(
+        PrecisionDebuggerToolConfig(config_path="/tmp/msprobe-config.json"),
+        save_path=str(tmp_path),
+    )
+
+    assert len(_FakeDebugger.instances) == 1
+    debugger = _FakeDebugger.instances[0]
+    assert debugger.config_path == "/tmp/msprobe-config.json"
+    assert debugger.service.config.dump_path == str(tmp_path)
+
+    model = _FakeModel()
+    assert profiler.start(stage="actor_compute_log_prob", global_step=3, model=model)
+    assert debugger.started_models == [model]
+    assert debugger.service.config.dump_path == str(tmp_path / "step_3" / "actor_compute_log_prob")
+
+
+def test_resolve_megatron_model_chunks_uses_first_valid_chunk(caplog):
+    """Megatron's engine module may contain pipeline model chunks."""
+    first_model = _FakeModel()
+    second_model = _FakeModel()
+    worker = types.SimpleNamespace(
+        actor=types.SimpleNamespace(
+            engine=types.SimpleNamespace(module=[object(), first_model, second_model]),
+        )
+    )
+    profiler = PrecisionDebuggerProfiler(PrecisionDebuggerToolConfig())
+
+    with caplog.at_level(logging.WARNING):
+        model = profiler._resolve_model(worker, "actor_compute_log_prob")
+
+    assert model is first_model
+    assert "only binds the first of 2 model chunks" in caplog.text

--- a/tests/utils/test_precision_debugger_profile.py
+++ b/tests/utils/test_precision_debugger_profile.py
@@ -13,62 +13,15 @@
 # limitations under the License.
 
 import logging
-import sys
 import types
 
 from verl.utils.profiler.config import PrecisionDebuggerToolConfig
 from verl.utils.profiler.precision_debugger_profile import PrecisionDebuggerProfiler
 
 
-class _FakeDebugger:
-    instances = []
-
-    def __init__(self, config_path, dump_path):
-        self.config_path = config_path
-        self.service = types.SimpleNamespace(config=types.SimpleNamespace(dump_path=dump_path))
-        self.started_models = []
-        self.stopped = False
-        self.__class__.instances.append(self)
-
-    def start(self, model):
-        self.started_models.append(model)
-
-    def stop(self):
-        self.stopped = True
-
-
 class _FakeModel:
     def forward(self):
         pass
-
-
-def test_precision_debugger_is_created_before_first_profiled_stage(monkeypatch, tmp_path):
-    """Early construction lets msprobe wrap custom APIs before model creation."""
-    import verl.utils.profiler.precision_debugger_profile as profile_module
-
-    _FakeDebugger.instances.clear()
-    msprobe = types.ModuleType("msprobe")
-    pytorch = types.ModuleType("msprobe.pytorch")
-    pytorch.PrecisionDebugger = _FakeDebugger
-    msprobe.pytorch = pytorch
-    monkeypatch.setitem(sys.modules, "msprobe", msprobe)
-    monkeypatch.setitem(sys.modules, "msprobe.pytorch", pytorch)
-    monkeypatch.setattr(profile_module, "is_msprobe_available", lambda: True)
-
-    profiler = PrecisionDebuggerProfiler(
-        PrecisionDebuggerToolConfig(config_path="/tmp/msprobe-config.json"),
-        save_path=str(tmp_path),
-    )
-
-    assert len(_FakeDebugger.instances) == 1
-    debugger = _FakeDebugger.instances[0]
-    assert debugger.config_path == "/tmp/msprobe-config.json"
-    assert debugger.service.config.dump_path == str(tmp_path)
-
-    model = _FakeModel()
-    assert profiler.start(stage="actor_compute_log_prob", global_step=3, model=model)
-    assert debugger.started_models == [model]
-    assert debugger.service.config.dump_path == str(tmp_path / "step_3" / "actor_compute_log_prob")
 
 
 def test_resolve_megatron_model_chunks_uses_first_valid_chunk(caplog):

--- a/verl/utils/profiler/precision_debugger_profile.py
+++ b/verl/utils/profiler/precision_debugger_profile.py
@@ -137,6 +137,20 @@ class PrecisionDebuggerProfiler:
             value = self._resolve_attr(self_instance, attr)
             if self._is_valid_model(value):
                 return value
+
+            # Megatron stores model chunks in ``engine.module``. msprobe's
+            # PrecisionDebugger accepts one module, so bind the first chunk
+            # that can be called directly.
+            if isinstance(value, (list, tuple)):
+                models = [model for model in value if self._is_valid_model(model)]
+                if models:
+                    if len(models) > 1:
+                        logger.warning(
+                            "PrecisionDebugger only binds the first of %d model chunks for stage '%s'",
+                            len(models),
+                            stage,
+                        )
+                    return models[0]
         fallback = getattr(self_instance, "module", None)
         return fallback if self._is_valid_model(fallback) else None
 

--- a/verl/utils/profiler/precision_debugger_profile.py
+++ b/verl/utils/profiler/precision_debugger_profile.py
@@ -141,7 +141,7 @@ class PrecisionDebuggerProfiler:
             # Megatron stores model chunks in ``engine.module``. msprobe's
             # PrecisionDebugger accepts one module, so bind the first chunk
             # that can be called directly.
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, list | tuple):
                 models = [model for model in value if self._is_valid_model(model)]
                 if models:
                     if len(models) > 1:


### PR DESCRIPTION
### What does this PR do?

Fixes PrecisionDebugger model resolution for Megatron engines. Megatron may expose `engine.module` as a sequence of pipeline model chunks, while msprobe accepts a single callable module. The resolver now selects the first chunk with a callable `forward` method and warns when more than one valid chunk is present.

This PR also adds a regression test for the sequence-based Megatron model path.

### Checklist Before Starting

- [x] Search for similar PRs. [Open-PR search](https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+PrecisionDebugger+Megatron) returned only this PR for the exact PrecisionDebugger + Megatron query. The other keyword matches are unrelated, so this change does not duplicate an open PR.
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)

### Test

- Added `tests/utils/test_precision_debugger_profile.py`.
  - Verifies the resolver skips invalid entries in `actor.engine.module` and returns the first valid model chunk.
  - Verifies the warning for multiple valid model chunks.
- Tests were not run, per the submitter's request. A human submitter must run and review the relevant checks before merge.

### API and Usage Example

No public API or configuration changes. Existing `global_profiler.tool=precision_debugger` configuration works with Megatron engines whose `engine.module` is a model-chunk sequence.

### Design & Code Changes

- Treat a list or tuple at the resolved model attribute as Megatron model chunks.
- Filter for objects exposing a callable `forward` method.
- Bind msprobe to the first valid chunk; emit a warning if more than one chunk is available because msprobe binds one module per debugger invocation.
- Add a focused regression test for this resolution path.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Documentation update is not needed: there is no user-facing API or configuration change.
- [x] Added a focused unit test; execution is pending human validation.
- [ ] Request CI in `ci-request` after the human submitter has reviewed the change.
- [x] This PR does not modify the `recipe` submodule.

### AI assistance

Codex assisted with the implementation and test. The human submitter must understand the change, review every changed line, and run the relevant tests before merge.