### PR TITLE
[perf] feat: mstx profiler support schedule to mini batch

### DIFF
--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_en.rst
@@ -65,6 +65,16 @@ Use parameters in each role's ``profiler.tool_config.npu`` to control specific c
 
 -  analysis: Whether to enable automatic data parsing.
 -  discrete: Whether to use discrete mode.
+-  schedule: Samples mini-batches during Actor/Critic update. verl advances the
+   schedule by calling ``profiler.step()`` once per mini-batch. Takes effect only
+   when ``active > 0``:
+
+   -  skip_first: Number of initial mini-batches to ignore before the first cycle begins.
+   -  wait: Mini-batches to idle (no collection) at the start of each cycle.
+   -  warmup: Mini-batches to trace but discard, letting the profiler stabilize, each cycle.
+   -  active: Mini-batches to actively record each cycle. Set ``<= 0`` (default) to disable scheduling.
+   -  repeat: Number of cycles to record. ``0`` (default) repeats until profiling stops.
+
 -  profile_token_start: Effective only for the rollout role; defines the start response-token index for rollout decoding collection. It is applied only when valid (0-based, ``profile_token_end > profile_token_start``, and the window is within response length).
 -  profile_token_end: Effective only for the rollout role; defines the stop response-token index (exclusive) for rollout decoding collection. It is applied only when valid (0-based, ``profile_token_end > profile_token_start``, and the window is within response length).
 
@@ -115,6 +125,13 @@ Separation of Training and Inference Phases
                   npu:
                      discrete: True
                      contents: [npu, cpu]
+                     # Optional: sample mini-batches via schedule; without it, all actor mini-batches are collected
+                     schedule:
+                        skip_first: 0
+                        wait: 0
+                        warmup: 1  # warm up one mini-batch
+                        active: 1  # record the second mini-batch
+                        repeat: 1  # stop after one cycle
          rollout:
             profiler:
                enable: True  # Set to True to collect the inference phase
@@ -171,6 +188,12 @@ Lightweight Collection of Inference Data
       actor_rollout_ref.actor.profiler.tool_config.npu.contents="['npu','cpu']" # Control collection list, default cpu, npu; can configure memory, shapes, module, etc.
       actor_rollout_ref.actor.profiler.tool_config.npu.level=level1
       actor_rollout_ref.actor.profiler.tool_config.npu.analysis=False # Disable automatic data parsing
+      # Optional: sample mini-batches via schedule; without it, all actor mini-batches are collected
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.skip_first=0
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.wait=0
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.warmup=1  # warm up one mini-batch
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.active=1  # record the second mini-batch
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.repeat=1  # stop after one cycle
 
       actor_rollout_ref.rollout.profiler.enable=True
       actor_rollout_ref.rollout.profiler.all_ranks=False

--- a/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
+++ b/docs/ascend_tutorial/dev_guide/performance/ascend_profiling_zh.rst
@@ -61,6 +61,15 @@ Last updated: 07/13/2026.
 
 -  analysis: 是否启用自动数据解析。
 -  discrete: 是否使用离散模式。
+-  schedule: 用于 Actor/Critic 的 update 阶段按 mini-batch 抽样采集。verl 每个
+   mini-batch 调用一次 ``profiler.step()`` 推进 schedule，仅在 ``active > 0`` 时生效：
+
+   -  skip_first: 在第一个周期开始前忽略的初始 mini-batch 数。
+   -  wait: 每个周期开始时空闲（不采集）的 mini-batch 数。
+   -  warmup: 每个周期中先追踪但丢弃的 mini-batch 数，用于让 profiler 稳定。
+   -  active: 每个周期实际记录的 mini-batch 数。设为 ``<= 0``（默认）则关闭调度。
+   -  repeat: 记录的周期数。``0``（默认）表示持续重复直到 profiling 结束。
+
 -  profile_token_start：仅在 rollout role 下生效，用于指定 rollout 解码阶段的采集起始 response token；参数合法时生效（从 0 开始，满足 ``profile_token_end > profile_token_start``，且区间在 response 长度内）。
 -  profile_token_end：仅在 rollout role 下生效，用于指定 rollout 解码阶段的采集结束 response token（右边界不包含）；参数合法时生效（从 0 开始，满足 ``profile_token_end > profile_token_start``，且区间在 response 长度内）。
 
@@ -111,6 +120,13 @@ Last updated: 07/13/2026.
                   npu:
                      discrete: True
                      contents: [npu, cpu]
+                     # 可选：按 mini-batch schedule 抽样；不设置时采集 actor 的全部 mini-batch
+                     schedule:
+                        skip_first: 0
+                        wait: 0
+                        warmup: 1  # 预热一个 mini-batch
+                        active: 1  # 采集第二个 mini-batch
+                        repeat: 1  # 采集一个周期后停止
          rollout:
             profiler:
                enable: True  # 设置为 True 以采集推理阶段
@@ -167,6 +183,12 @@ Last updated: 07/13/2026.
       actor_rollout_ref.actor.profiler.tool_config.npu.contents="['npu','cpu']" # 控制采集列表，默认cpu、npu，可配置memory、shapes、module等
       actor_rollout_ref.actor.profiler.tool_config.npu.level=level1
       actor_rollout_ref.actor.profiler.tool_config.npu.analysis=False # 禁用自动数据解析
+      # 可选：按 mini-batch schedule 抽样；不设置时采集 actor 的全部 mini-batch
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.skip_first=0
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.wait=0
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.warmup=1  # 预热一个mini-batch
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.active=1  # 采集第二个mini-batch
+      actor_rollout_ref.actor.profiler.tool_config.npu.schedule.repeat=1  # 采集一个周期后停止
 
       actor_rollout_ref.rollout.profiler.enable=True
       actor_rollout_ref.rollout.profiler.all_ranks=False

--- a/tests/utils/test_special_mstx_profile.py
+++ b/tests/utils/test_special_mstx_profile.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from verl.utils.profiler.config import NPUToolConfig, ProfilerConfig
+from verl.utils.profiler.config import NPUToolConfig, ProfilerConfig, TorchProfilerScheduleConfig
 from verl.utils.profiler.mstx_profile import NPUProfiler
 from verl.utils.profiler.profile import DistProfiler
 
@@ -23,6 +23,7 @@ from verl.utils.profiler.profile import DistProfiler
 class TestNPUProfilerInitialization(unittest.TestCase):
     def setUp(self):
         NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
 
     def test_init_with_default_config(self):
         tool_config = NPUToolConfig()
@@ -58,6 +59,7 @@ class TestNPUProfilerInitialization(unittest.TestCase):
 class TestNPUProfilerStart(unittest.TestCase):
     def setUp(self):
         NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
         self.config = ProfilerConfig(enable=True, ranks=[0], tool="npu")
         self.tool_config = NPUToolConfig(discrete=False)
 
@@ -97,6 +99,7 @@ class TestNPUProfilerStart(unittest.TestCase):
 class TestNPUProfilerStartStopInteraction(unittest.TestCase):
     def setUp(self):
         NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
         self.config = ProfilerConfig(enable=True, ranks=[0], tool="npu")
         self.tool_config = NPUToolConfig(discrete=False)
 
@@ -111,7 +114,7 @@ class TestNPUProfilerStartStopInteraction(unittest.TestCase):
         self.assertEqual(mock_profile_npu.start.call_count, 1)
         profiler.stop()
         self.assertEqual(NPUProfiler._define_count, 0)
-        self.assertEqual(mock_profile_npu.step.call_count, 1)
+        mock_profile_npu.step.assert_not_called()
         self.assertEqual(mock_profile_npu.stop.call_count, 1)
 
     @patch("verl.utils.profiler.mstx_profile.get_npu_profiler")
@@ -140,6 +143,7 @@ class TestNPUProfilerStep(unittest.TestCase):
 
     def setUp(self):
         NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
         self.config = ProfilerConfig(enable=True, ranks=[0], tool="npu")
         self.tool_config = NPUToolConfig(discrete=False)
 
@@ -150,23 +154,103 @@ class TestNPUProfilerStep(unittest.TestCase):
         self.assertEqual(NPUProfiler._define_count, 0)
 
     @patch("verl.utils.profiler.mstx_profile.get_npu_profiler")
-    def test_step_after_start_does_not_drive_backend(self, mock_get_profiler):
+    def test_step_without_schedule_does_not_drive_backend(self, mock_get_profiler):
         mock_profile_npu = MagicMock()
         mock_get_profiler.return_value = mock_profile_npu
 
         profiler = DistProfiler(rank=0, config=self.config, tool_config=self.tool_config)
         profiler.start(role="worker")
         profiler.step()
-        # NPU profiler has no step schedule, so step() must not advance the backend.
+        profiler.step()
+        # Without schedule, continuous collection does not advance via step().
         mock_profile_npu.step.assert_not_called()
         profiler.stop()
-        # stop() still emits the single trailing step/stop on the backend.
-        mock_profile_npu.step.assert_called_once()
+        mock_profile_npu.step.assert_not_called()
         mock_profile_npu.stop.assert_called_once()
+
+
+class TestNPUProfilerSchedule(unittest.TestCase):
+    def setUp(self):
+        NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
+        self.config = ProfilerConfig(enable=True, ranks=[0], tool="npu", save_path="/tmp/test")
+
+    @patch("verl.utils.profiler.mstx_profile.get_npu_profiler")
+    def test_scheduled_profiler_steps_match_calls(self, mock_get_profiler):
+        mock_profile_npu = MagicMock()
+        mock_get_profiler.return_value = mock_profile_npu
+
+        schedule_cfg = TorchProfilerScheduleConfig(wait=1, warmup=1, active=2, repeat=1)
+        tool_config = NPUToolConfig(discrete=False, schedule=schedule_cfg)
+        profiler = DistProfiler(rank=0, config=self.config, tool_config=tool_config)
+
+        profiler.start(role="worker")
+        self.assertIs(NPUProfiler._active_prof, mock_profile_npu)
+        _, kwargs = mock_get_profiler.call_args
+        self.assertEqual(
+            kwargs["schedule"],
+            {"skip_first": 0, "wait": 1, "warmup": 1, "active": 2, "repeat": 1},
+        )
+
+        # Each DistProfiler.step() advances the backend once when schedule is enabled.
+        num_mini_batches = 5
+        for _ in range(num_mini_batches):
+            profiler.step()
+        self.assertEqual(mock_profile_npu.step.call_count, num_mini_batches)
+
+        profiler.stop()
+        self.assertEqual(mock_profile_npu.step.call_count, num_mini_batches)
+        mock_profile_npu.stop.assert_called_once()
+        self.assertIsNone(NPUProfiler._active_prof)
+
+    @patch("verl.utils.profiler.mstx_profile.get_npu_profiler")
+    def test_inner_worker_step_advances_outer_started_profiler(self, mock_get_profiler):
+        """Mirrors ActorRolloutRefWorker start/stop + TrainingWorker mini-batch step()."""
+        mock_profile_npu = MagicMock()
+        mock_get_profiler.return_value = mock_profile_npu
+
+        schedule_cfg = TorchProfilerScheduleConfig(wait=0, warmup=0, active=2, repeat=1)
+        tool_config = NPUToolConfig(discrete=False, schedule=schedule_cfg)
+        outer = DistProfiler(rank=0, config=self.config, tool_config=tool_config)
+        inner = DistProfiler(rank=0, config=self.config, tool_config=tool_config)
+
+        outer.start(role="e2e")
+        self.assertIs(NPUProfiler._active_prof, mock_profile_npu)
+
+        # Inner instance never started its own profiler; step must use _active_prof.
+        num_mini_batches = 3
+        for _ in range(num_mini_batches):
+            inner.step()
+        self.assertEqual(mock_profile_npu.step.call_count, num_mini_batches)
+
+        outer.stop()
+        self.assertIsNone(NPUProfiler._active_prof)
+        mock_profile_npu.stop.assert_called_once()
+
+    @patch("verl.utils.profiler.mstx_profile.get_npu_profiler")
+    def test_active_zero_disables_schedule_and_step(self, mock_get_profiler):
+        mock_profile_npu = MagicMock()
+        mock_get_profiler.return_value = mock_profile_npu
+
+        schedule_cfg = TorchProfilerScheduleConfig(active=0)
+        tool_config = NPUToolConfig(discrete=False, schedule=schedule_cfg)
+        profiler = DistProfiler(rank=0, config=self.config, tool_config=tool_config)
+
+        profiler.start()
+        _, kwargs = mock_get_profiler.call_args
+        self.assertIsNone(kwargs["schedule"])
+
+        profiler.step()
+        profiler.step()
+        mock_profile_npu.step.assert_not_called()
+        profiler.stop()
+        mock_profile_npu.step.assert_not_called()
 
 
 class TestNPUProfilerAnnotate(unittest.TestCase):
     def setUp(self):
+        NPUProfiler._define_count = 0
+        NPUProfiler._active_prof = None
         self.config = ProfilerConfig(enable=True, all_ranks=True, tool="npu")
         self.tool_config = NPUToolConfig(discrete=False)
         self.rank = 0
@@ -277,11 +361,56 @@ class TestNPUProfilerAnnotate(unittest.TestCase):
                 profile_level=mock_worker.profiler._impl.profile_level,
                 profile_save_path=mock_worker.profiler._impl.profile_save_path,
                 analysis=mock_worker.profiler._impl.analysis,
+                schedule=None,
                 role="test_role",
             )
             mock_profile_npu.start.assert_called_once()
-            mock_profile_npu.step.assert_called_once()
+            mock_profile_npu.step.assert_not_called()
             mock_profile_npu.stop.assert_called_once()
+
+    def test_annotate_discrete_with_schedule_steps_during_func(self):
+        schedule_cfg = TorchProfilerScheduleConfig(wait=0, warmup=0, active=2, repeat=1)
+        discrete_tool_config = NPUToolConfig(discrete=True, schedule=schedule_cfg)
+        # Outer worker owns annotate (start/stop); inner worker issues mini-batch step().
+        outer = DistProfiler(rank=self.rank, config=self.config, tool_config=discrete_tool_config)
+        inner = DistProfiler(rank=self.rank, config=self.config, tool_config=discrete_tool_config)
+        mock_worker = MagicMock()
+        mock_worker.profiler = outer
+        mock_worker.inner_profiler = inner
+        mock_worker.profiler._this_step = True
+
+        mock_mark_range = "mocked_range_handle"
+        mock_profile_npu = MagicMock()
+
+        with (
+            patch("verl.utils.profiler.mstx_profile.mark_start_range") as mock_start_patch,
+            patch("verl.utils.profiler.mstx_profile.mark_end_range"),
+            patch("verl.utils.profiler.mstx_profile.get_npu_profiler") as mock_get_profiler,
+        ):
+            mock_start_patch.return_value = mock_mark_range
+            mock_get_profiler.return_value = mock_profile_npu
+            decorator = mock_worker.profiler.annotate(message="test", role="actor_update")
+
+            @decorator
+            def test_func(self, *args, **kwargs):
+                # Mimic TrainingWorker.train_mini_batch stepping via the inner profiler.
+                self.inner_profiler.step()
+                self.inner_profiler.step()
+                self.inner_profiler.step()
+                return "result"
+
+            result = test_func(mock_worker)
+
+            self.assertEqual(result, "result")
+            _, kwargs = mock_get_profiler.call_args
+            self.assertEqual(
+                kwargs["schedule"],
+                {"skip_first": 0, "wait": 0, "warmup": 0, "active": 2, "repeat": 1},
+            )
+            self.assertEqual(mock_profile_npu.step.call_count, 3)
+            mock_profile_npu.start.assert_called_once()
+            mock_profile_npu.stop.assert_called_once()
+            self.assertIsNone(NPUProfiler._active_prof)
 
     def test_annotate_with_default_message(self):
         mock_worker = MagicMock()

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -148,6 +148,13 @@ actor_rollout_ref:
           level: level0
           analysis: true
           discrete: false
+          schedule:
+            _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+            skip_first: 0
+            wait: 0
+            warmup: 0
+            active: 0
+            repeat: 0
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: []
@@ -651,6 +658,13 @@ critic:
         level: level0
         analysis: true
         discrete: false
+        schedule:
+          _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+          skip_first: 0
+          wait: 0
+          warmup: 0
+          active: 0
+          repeat: 0
       torch:
         _target_: verl.utils.profiler.config.TorchProfilerToolConfig
         contents: []

--- a/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_torchtitan_trainer.yaml
@@ -113,6 +113,13 @@ actor_rollout_ref:
           level: level0
           analysis: true
           discrete: false
+          schedule:
+            _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+            skip_first: 0
+            wait: 0
+            warmup: 0
+            active: 0
+            repeat: 0
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: []
@@ -574,6 +581,13 @@ critic:
         level: level0
         analysis: true
         discrete: false
+        schedule:
+          _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+          skip_first: 0
+          wait: 0
+          warmup: 0
+          active: 0
+          repeat: 0
       torch:
         _target_: verl.utils.profiler.config.TorchProfilerToolConfig
         contents: []

--- a/verl/trainer/config/_generated_ppo_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_trainer.yaml
@@ -120,6 +120,13 @@ actor_rollout_ref:
           level: level0
           analysis: true
           discrete: false
+          schedule:
+            _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+            skip_first: 0
+            wait: 0
+            warmup: 0
+            active: 0
+            repeat: 0
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: []
@@ -586,6 +593,13 @@ critic:
         level: level0
         analysis: true
         discrete: false
+        schedule:
+          _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+          skip_first: 0
+          wait: 0
+          warmup: 0
+          active: 0
+          repeat: 0
       torch:
         _target_: verl.utils.profiler.config.TorchProfilerToolConfig
         contents: []

--- a/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_veomni_trainer.yaml
@@ -123,6 +123,13 @@ actor_rollout_ref:
           level: level0
           analysis: true
           discrete: false
+          schedule:
+            _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+            skip_first: 0
+            wait: 0
+            warmup: 0
+            active: 0
+            repeat: 0
         torch:
           _target_: verl.utils.profiler.config.TorchProfilerToolConfig
           contents: []
@@ -588,6 +595,13 @@ critic:
         level: level0
         analysis: true
         discrete: false
+        schedule:
+          _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+          skip_first: 0
+          wait: 0
+          warmup: 0
+          active: 0
+          repeat: 0
       torch:
         _target_: verl.utils.profiler.config.TorchProfilerToolConfig
         contents: []

--- a/verl/trainer/config/actor/actor.yaml
+++ b/verl/trainer/config/actor/actor.yaml
@@ -214,6 +214,28 @@ profiler:
 
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: False
+
+      # Optional torch_npu.profiler.schedule. Enabled only when active > 0, in which case
+      # profiler.step() advances wait/warmup/active/repeat once per mini-batch.
+      schedule:
+
+        # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+        _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+
+        # Number of steps to skip before the first cycle
+        skip_first: 0
+
+        # Idle steps (no collection) at the start of each cycle
+        wait: 0
+
+        # Warmup steps (tracing on, data discarded) each cycle
+        warmup: 0
+
+        # Active steps to record each cycle; <= 0 disables scheduling
+        active: 0
+
+        # Number of cycles to repeat; 0 repeats until profiling stops
+        repeat: 0
     
     # torch profiler config
     torch:

--- a/verl/trainer/config/critic/critic.yaml
+++ b/verl/trainer/config/critic/critic.yaml
@@ -135,6 +135,28 @@ profiler:
 
       # True for each task has its own database, False for all tasks in one training step share one database.
       discrete: False
+
+      # Optional torch_npu.profiler.schedule. Enabled only when active > 0, in which case
+      # profiler.step() advances wait/warmup/active/repeat once per mini-batch.
+      schedule:
+
+        # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+        _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+
+        # Number of steps to skip before the first cycle
+        skip_first: 0
+
+        # Idle steps (no collection) at the start of each cycle
+        wait: 0
+
+        # Warmup steps (tracing on, data discarded) each cycle
+        warmup: 0
+
+        # Active steps to record each cycle; <= 0 disables scheduling
+        active: 0
+
+        # Number of cycles to repeat; 0 repeats until profiling stops
+        repeat: 0
     
     # torch profiler config
     torch:

--- a/verl/trainer/config/profiler/profiler.yaml
+++ b/verl/trainer/config/profiler/profiler.yaml
@@ -43,6 +43,27 @@ tool_config:
     # null means collect until the end (full collection).
     profile_token_end: null
 
+    # Optional torch_npu.profiler.schedule. Enabled only when active > 0, in which case
+    # profiler.step() advances wait/warmup/active/repeat once per mini-batch.
+    schedule:
+      # Required when using verl.utils.omega_conf_to_dataclass to instantiate dataclass configs
+      _target_: verl.utils.profiler.config.TorchProfilerScheduleConfig
+
+      # Number of steps to skip before the first cycle
+      skip_first: 0
+
+      # Idle steps (no collection) at the start of each cycle
+      wait: 0
+
+      # Warmup steps (tracing on, data discarded) each cycle
+      warmup: 0
+
+      # Active steps to record each cycle; <= 0 disables scheduling
+      active: 0
+
+      # Number of cycles to repeat; 0 repeats until profiling stops
+      repeat: 0
+
     name: npu
 
 

--- a/verl/utils/profiler/config.py
+++ b/verl/utils/profiler/config.py
@@ -37,12 +37,15 @@ class NsightToolConfig(BaseConfig):
 
 @dataclass
 class TorchProfilerScheduleConfig(BaseConfig):
-    """Schedule for ``torch.profiler.schedule``.
+    """Schedule for ``torch.profiler.schedule`` / ``torch_npu.profiler.schedule``.
 
-    Field names mirror the official ``torch.profiler.schedule`` API. The profiler
+    Field names mirror the official torch / torch_npu schedule APIs. The profiler
     cycles through ``skip_first`` -> (``wait`` -> ``warmup`` -> ``active``) x ``repeat``.
     Scheduling is only enabled when ``active > 0``; otherwise the profiler runs in
     continuous mode (collect everything between start and stop).
+
+    Shared by ``TorchProfilerToolConfig`` and ``NPUToolConfig`` because both backends
+    accept the same ``wait``/``warmup``/``active``/``repeat``/``skip_first`` kwargs.
     """
 
     # Number of steps to skip at the very beginning (not counted in the cycle).
@@ -70,7 +73,7 @@ class TorchProfilerScheduleConfig(BaseConfig):
         return self.active > 0
 
     def to_torch_kwargs(self) -> dict:
-        """Return kwargs for ``torch.profiler.schedule``."""
+        """Return kwargs for ``torch.profiler.schedule`` / ``torch_npu.profiler.schedule``."""
         return {
             "skip_first": self.skip_first,
             "wait": self.wait,
@@ -168,7 +171,7 @@ class PrecisionDebuggerToolConfig(BaseConfig):
 
 @dataclass
 class NPUToolConfig(NsightToolConfig):
-    """NPU profiler too; config."""
+    """NPU profiler tool config."""
 
     # options: npu, cpu, memory, shapes, module, stack
     contents: list[str] = field(default_factory=list)
@@ -184,6 +187,9 @@ class NPUToolConfig(NsightToolConfig):
     # Stop collecting profiler data at this response-token index (exclusive).
     # None means collect until the end.
     profile_token_end: Optional[int] = None
+    # Optional torch_npu.profiler.schedule (wait/warmup/active/repeat/skip_first).
+    # When set with active > 0, DistProfiler.step() drives the schedule per mini-batch.
+    schedule: Optional[TorchProfilerScheduleConfig] = None
 
     name: str = "npu"
 

--- a/verl/utils/profiler/mstx_profile.py
+++ b/verl/utils/profiler/mstx_profile.py
@@ -94,6 +94,7 @@ def get_npu_profiler(
     analysis: bool,
     role: Optional[str] = None,
     profile_step: Optional[str] = None,
+    schedule: Optional[dict] = None,
 ):
     """Generate and return an NPU profiler object.
 
@@ -112,6 +113,10 @@ def get_npu_profiler(
             The role of the current data collection. Defaults to None.
         profile_step(str, optional):
             The current training step. Defaults to None.
+        schedule (dict, optional):
+            Optional kwargs for ``torch_npu.profiler.schedule``
+            (``wait``/``warmup``/``active``/``repeat``/``skip_first``). When provided, the
+            caller must drive ``prof.step()`` once per mini-batch to advance the schedule.
     """
     if profile_level == "level_none":
         level = torch_npu.profiler.ProfilerLevel.Level_none
@@ -147,7 +152,7 @@ def get_npu_profiler(
     if contents is None or "cpu" in contents:
         activites.append(torch_npu.profiler.ProfilerActivity.CPU)
 
-    prof = torch_npu.profiler.profile(
+    profile_kwargs = dict(
         with_modules=contents is None or "module" in contents,
         with_stack=contents is None or "stack" in contents,
         record_shapes=contents is None or "shapes" in contents,
@@ -156,7 +161,13 @@ def get_npu_profiler(
         on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(profile_save_path, analyse_flag=analysis),
         experimental_config=experimental_config,
     )
-    return prof
+
+    # torch_npu.profiler.schedule drives the wait/warmup/active/repeat state machine
+    # via prof.step(); without it the profiler collects continuously.
+    if schedule:
+        profile_kwargs["schedule"] = torch_npu.profiler.schedule(**schedule)
+
+    return torch_npu.profiler.profile(**profile_kwargs)
 
 
 class NPUProfiler(DistProfiler):
@@ -165,9 +176,14 @@ class NPUProfiler(DistProfiler):
     """
 
     _define_count = 0
+    # Process-global handle to the currently running NPU profiler. start/stop may
+    # happen on the outer ActorRolloutRefWorker while mini-batch step() is issued by
+    # the inner TrainingWorker; a class-level handle keeps them on the same backend
+    # (same pattern as torch Profiler._active_prof).
+    _active_prof = None
 
     def __init__(self, rank: int, config: ProfilerConfig, tool_config: NPUToolConfig, **kwargs):
-        """Initialize the NsightSystemsProfiler.
+        """Initialize the NPUProfiler.
 
         Args:
             rank (int): The rank of the current process.
@@ -179,11 +195,16 @@ class NPUProfiler(DistProfiler):
         if not tool_config:
             assert not config.enable, "tool_config must be set when profiler is enabled"
         self.discrete: bool = tool_config.discrete
+        self.tool_config = tool_config
         self.profile_npu = None
         self.profile_contents = tool_config.contents
         self.profile_level = tool_config.level
         self.profile_save_path = config.save_path
         self.analysis = tool_config.analysis
+        # Resolved once from config (None => continuous). Not cleared on stop.
+        self._schedule_kwargs = (
+            tool_config.schedule.to_torch_kwargs() if tool_config.schedule and tool_config.schedule.enabled else None
+        )
 
     def start(self, **kwargs):
         role = kwargs.get("role", None)
@@ -193,29 +214,32 @@ class NPUProfiler(DistProfiler):
                 profile_level=self.profile_level,
                 profile_save_path=self.profile_save_path,
                 analysis=self.analysis,
+                schedule=self._schedule_kwargs,
                 role=role,
             )
             self.profile_npu.start()
+            NPUProfiler._active_prof = self.profile_npu
             NPUProfiler._define_count += 1
 
     def stop(self):
         if not self.discrete and NPUProfiler._define_count == 1:
-            self.profile_npu.step()
             self.profile_npu.stop()
+            self.profile_npu = None
+            NPUProfiler._active_prof = None
             NPUProfiler._define_count -= 1
 
     def step(self):
-        """No-op per-mini-batch step hook.
+        """Advance the process-global active profiler by one mini-batch.
 
-        The NPU profiler is driven by explicit start/stop calls and is not created with a
-        torch-style ``wait/warmup/active/repeat`` schedule, so there is nothing to advance
-        per mini-batch. It must still be defined here: without it, the dispatcher's
-        ``getattr(self._impl, "step", lambda: None)`` resolves to the inherited
-        ``DistProfiler.step`` (backend impls subclass ``DistProfiler`` but never run its
-        ``__init__``), which then reads dispatcher-only state such as ``_enable`` and raises
-        ``AttributeError``.
+        Uses ``NPUProfiler._active_prof`` so an inner TrainingWorker can advance the
+        profiler started by the outer ActorRolloutRefWorker. No-op when no profiler is
+        active, or when schedule is not configured (continuous collection does not need
+        per-mini-batch stepping). Must still be defined here: without it, the
+        dispatcher's ``getattr(self._impl, "step", lambda: None)`` resolves to the
+        inherited ``DistProfiler.step`` and raises ``AttributeError``.
         """
-        return
+        if self._schedule_kwargs and NPUProfiler._active_prof is not None:
+            NPUProfiler._active_prof.step()
 
     def annotate(self, message: Optional[str] = None, role: Optional[str] = None, **kwargs_outer) -> Callable:
         """Decorate a Worker member function to profile the current rank in the current training step.
@@ -239,14 +263,16 @@ class NPUProfiler(DistProfiler):
                 if not discrete_mode:
                     mark_range = mark_start_range(message=profile_name)
                 else:
-                    profile_npu = get_npu_profiler(
+                    self.profile_npu = get_npu_profiler(
                         contents=self.profile_contents,
                         profile_level=self.profile_level,
                         profile_save_path=self.profile_save_path,
                         analysis=self.analysis,
+                        schedule=self._schedule_kwargs,
                         role=role,
                     )
-                    profile_npu.start()
+                    self.profile_npu.start()
+                    NPUProfiler._active_prof = self.profile_npu
                     mark_range = mark_start_range(message=profile_name)
 
                 result = func(*args, **kwargs_inner)
@@ -255,8 +281,9 @@ class NPUProfiler(DistProfiler):
                     mark_end_range(mark_range)
                 else:
                     mark_end_range(mark_range)
-                    profile_npu.step()
-                    profile_npu.stop()
+                    self.profile_npu.stop()
+                    self.profile_npu = None
+                    NPUProfiler._active_prof = None
 
                 return result
 

--- a/verl/utils/profiler/profile.py
+++ b/verl/utils/profiler/profile.py
@@ -186,13 +186,13 @@ class DistProfiler:
         """Advance the profiler schedule by one step, intended to be called per mini-batch.
 
         Delegates to the backend `step` when the tool supports scheduling (currently the
-        torch profiler with a configured `wait/warmup/active/repeat` schedule); for all
-        other backends this is a no-op.
+        torch / npu profilers with a configured `wait/warmup/active/repeat` schedule); for
+        all other backends this is a no-op.
 
         Gated on enable/rank only (not `this_step`): the training loop may run inside a
         nested worker whose profiler was never explicitly started, while the underlying
-        torch profiler is process-global. The backend keeps `step` safe (no-op) whenever
-        no profiler is actively running.
+        torch / npu profiler is process-global. The backend keeps `step` safe (no-op)
+        whenever no profiler is actively running.
         """
         if self.check_enable() and self.check_this_rank():
             return getattr(self._impl, "step", lambda: None)()

--- a/verl/utils/profiler/torch_profile.py
+++ b/verl/utils/profiler/torch_profile.py
@@ -214,32 +214,19 @@ class Profiler(DistProfiler):
         self.save_path = self.config.save_path
         # Align with other profilers: read discrete mode, default to False for torch profiler
         self.discrete = getattr(self.tool_config, "discrete", False)
-        # Resolved torch.profiler.schedule kwargs for the active run (None => continuous).
-        self._schedule_kwargs = None
+        # Resolved once from config (None => continuous). Not cleared on stop.
+        self._schedule_kwargs = (
+            self.tool_config.schedule.to_torch_kwargs()
+            if self.tool_config.schedule and self.tool_config.schedule.enabled
+            else None
+        )
 
     def check(self):
         return self.prof is not None
 
-    def _resolve_schedule_kwargs(self) -> Optional[dict]:
-        """Build torch.profiler.schedule kwargs from tool_config, or None to disable."""
-        sched = getattr(self.tool_config, "schedule", None) if self.tool_config else None
-        if sched is None:
-            return None
-        active = int(getattr(sched, "active", 0) or 0)
-        if active <= 0:
-            return None
-        return {
-            "skip_first": int(getattr(sched, "skip_first", 0) or 0),
-            "wait": int(getattr(sched, "wait", 0) or 0),
-            "warmup": int(getattr(sched, "warmup", 0) or 0),
-            "active": active,
-            "repeat": int(getattr(sched, "repeat", 0) or 0),
-        }
-
     def start(self, **kwargs):
         role = kwargs.get("role", None)
         if not self.discrete and Profiler._define_count == 0:
-            self._schedule_kwargs = self._resolve_schedule_kwargs()
             self.prof = get_torch_profiler(
                 contents=self.contents,
                 save_path=self.save_path,
@@ -270,7 +257,6 @@ class Profiler(DistProfiler):
             print(f"[Profiler] stopped for rank {self.rank}")
             self.prof.stop()
             Profiler._active_prof = None
-            self._schedule_kwargs = None
             Profiler._define_count -= 1
 
     def annotate(self, message: Optional[str] = None, role: Optional[str] = None, **kwargs_outer) -> Callable:

--- a/verl/workers/engine_workers.py
+++ b/verl/workers/engine_workers.py
@@ -310,7 +310,7 @@ class TrainingWorker(Worker, DistProfilerExtension):
                 actor_output = self.train_batch(mini_batch_td)
                 output_lst.append(actor_output)
                 # Advance the profiler schedule once per mini-batch. No-op unless a
-                # torch profiler schedule (wait/warmup/active/repeat) is active.
+                # torch/npu profiler schedule (wait/warmup/active/repeat) is active.
                 self.profiler.step()
 
             if self.engine.is_mp_src_rank_with_outputs():


### PR DESCRIPTION
### What does this PR do?

Follow-up of #7099: bring the same `torch.profiler.schedule`-style mini-batch sampling to the Ascend **mstx / NPU profiler**.

When Actor/Critic update has many mini-batches, full traces can be huge. This PR lets users configure `schedule` (`skip_first` / `wait` / `warmup` / `active` / `repeat`) under `profiler.tool_config.npu`, so only selected mini-batches are recorded. `verl` advances the schedule by calling `profiler.step()` once per mini-batch in `TrainingWorker.train_mini_batch`.
- Without `schedule` (or `active <= 0`): continuous collection; `profile_npu.step()` is not driven by the mini-batch loop.
- With `schedule` (`active > 0`): each mini-batch `step()` advances the backend schedule accordingly.
- Docs updated for Ascend profiling (zh/en); config added for actor/critic (not ref).
- Unit tests cover schedule on/off and step call counts.

<img width="1157" height="527" alt="image" src="https://github.com/user-attachments/assets/9c84f981-7531-4132-9e72-c825272acf19" />


### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

```yaml
actor_rollout_ref:
  actor:
    profiler:
      enable: True
      tool_config:
        npu:
          discrete: True
          # Without schedule: collect all mini-batches
          schedule:
            skip_first: 0
            wait: 0
            warmup: 1   # warm up one mini-batch
            active: 1   # record the next mini-batch
            repeat: 1
```

```python
actor_rollout_ref.actor.profiler.tool_config.npu.schedule.skip_first=0
actor_rollout_ref.actor.profiler.tool_config.npu.schedule.wait=0
actor_rollout_ref.actor.profiler.tool_config.npu.schedule.warmup=1
actor_rollout_ref.actor.profiler.tool_config.npu.schedule.active=1
actor_rollout_ref.actor.profiler.tool_config.npu.schedule.repeat=1
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
