### PR TITLE
[recipe] feat: Retain model output from tinker forward backward

### DIFF
--- a/tests/models/test_engine.py
+++ b/tests/models/test_engine.py
@@ -657,13 +657,16 @@ def _split_training_primitives_fsdp_worker(
 
     with engine.train_mode(zero_grad_on_exit=False):
         engine.optimizer_zero_grad()
+        first_batch = _make_split_step_batch(model_config, engine_config, world_size)
+        tu.assign_non_tensor(first_batch, return_model_output=True)
         output_1 = engine.forward_backward_batch(
-            _make_split_step_batch(model_config, engine_config, world_size),
+            first_batch,
             loss_function=loss_fn,
             forward_only=False,
         )
     if engine.is_mp_src_rank_with_outputs():
         assert "grad_norm" not in output_1["metrics"]
+        assert "log_probs" in output_1["model_output"]
     grad_norm_1 = _grad_norm(engine.module)
     assert grad_norm_1.item() > 0
     assert _param_delta_norm(engine.module, before).item() == pytest.approx(0.0, abs=0.0)
@@ -676,6 +679,7 @@ def _split_training_primitives_fsdp_worker(
         )
     if engine.is_mp_src_rank_with_outputs():
         assert "grad_norm" not in output_2["metrics"]
+        assert output_2["model_output"] == {}
     grad_norm_2 = _grad_norm(engine.module)
     assert grad_norm_2.item() > grad_norm_1.item() * 1.5
     assert _param_delta_norm(engine.module, before).item() == pytest.approx(0.0, abs=0.0)

--- a/tests/workers/rollout/test_vllm_moe_param_converter_on_cpu.py
+++ b/tests/workers/rollout/test_vllm_moe_param_converter_on_cpu.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import torch
+
+from verl.workers.rollout.vllm_rollout.vllm_rollout import _iter_vllm_compatible_moe_params
+
+
+def _collect(weights, model_type):
+    async def collect():
+        return [item async for item in _iter_vllm_compatible_moe_params(weights, model_type)]
+
+    return asyncio.run(collect())
+
+
+def test_qwen_moe_packed_weights_are_expanded_per_expert():
+    gate_up = torch.randn(2, 6, 8)
+    down = torch.randn(2, 8, 3)
+
+    converted = _collect(
+        [
+            ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
+            ("model.layers.0.mlp.experts.down_proj", down),
+        ],
+        "qwen3_moe",
+    )
+
+    assert [name for name, _ in converted] == [
+        "model.layers.0.mlp.experts.0.gate_proj.weight",
+        "model.layers.0.mlp.experts.0.up_proj.weight",
+        "model.layers.0.mlp.experts.1.gate_proj.weight",
+        "model.layers.0.mlp.experts.1.up_proj.weight",
+        "model.layers.0.mlp.experts.0.down_proj.weight",
+        "model.layers.0.mlp.experts.1.down_proj.weight",
+    ]
+    assert [tensor.shape for _, tensor in converted] == [
+        (3, 8),
+        (3, 8),
+        (3, 8),
+        (3, 8),
+        (8, 3),
+        (8, 3),
+    ]
+
+
+def test_gpt_oss_packed_weights_are_not_expanded():
+    gate_up = torch.randn(2, 8, 6)
+    down = torch.randn(2, 3, 8)
+    weights = [
+        ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
+        ("model.layers.0.mlp.experts.down_proj", down),
+    ]
+
+    converted = _collect(weights, "gpt_oss")
+
+    assert [name for name, _ in converted] == [name for name, _ in weights]
+    assert converted[0][1] is gate_up
+    assert converted[1][1] is down
+    assert converted[0][1].shape == (2, 8, 6)
+    assert converted[1][1].shape == (2, 3, 8)

--- a/tests/workers/test_engine_return_model_output_on_cpu.py
+++ b/tests/workers/test_engine_return_model_output_on_cpu.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from verl.utils import tensordict_utils as tu
+from verl.workers.engine.fsdp.transformer_impl import FSDPEngine
+from verl.workers.engine_workers_tinker import TinkerTrainingWorker
+
+
+def test_tinker_forward_backward_requests_model_output():
+    captured = {}
+
+    def forward_backward_batch(data, **kwargs):
+        captured["return_model_output"] = tu.get_non_tensor_data(data, key="return_model_output", default=None)
+        return {}
+
+    engine = SimpleNamespace(
+        train_mode=lambda **kwargs: nullcontext(),
+        forward_backward_batch=forward_backward_batch,
+        is_mp_src_rank_with_outputs=lambda: False,
+    )
+    worker = SimpleNamespace(
+        loss_fn=lambda: None,
+        engine=engine,
+        engine_config=SimpleNamespace(
+            forward_only=False,
+            use_dynamic_bsz=False,
+            max_token_len_per_gpu=128,
+            micro_batch_size_per_gpu=1,
+            use_fused_kernels=False,
+        ),
+        model_config={},
+    )
+
+    result = TinkerTrainingWorker.forward_backward(worker, TensorDict({}, batch_size=[]))
+
+    assert result is None
+    assert captured["return_model_output"] is True
+
+
+@pytest.mark.parametrize(("return_model_output", "expected"), [(False, False), (True, True)])
+def test_fsdp_forward_backward_honors_return_model_output(monkeypatch, return_model_output, expected):
+    data = TensorDict({"loss_mask": torch.ones(1)}, batch_size=[1])
+    if return_model_output:
+        tu.assign_non_tensor(data, return_model_output=True)
+
+    loss = torch.tensor(1.0, requires_grad=True)
+    model_output = {"log_probs": torch.tensor([-1.25])}
+    engine = SimpleNamespace(
+        ulysses_sequence_parallel_size=1,
+        scaler=None,
+        get_data_parallel_group=lambda: None,
+        get_data_parallel_size=lambda: 1,
+        forward_step=lambda micro_batch, loss_function, forward_only: (
+            loss,
+            {"model_output": model_output.copy(), "loss": 1.0, "metrics": {}},
+        ),
+    )
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", lambda *args, **kwargs: None)
+    monkeypatch.setattr("verl.workers.engine.fsdp.transformer_impl.get_device_id", lambda: "cpu")
+    monkeypatch.setattr(
+        "verl.workers.engine.fsdp.transformer_impl.prepare_micro_batches",
+        lambda data, **kwargs: ([data], None),
+    )
+    monkeypatch.setattr(
+        "verl.workers.engine.fsdp.transformer_impl.postprocess_batch_func",
+        lambda output_lst, **kwargs: output_lst[0],
+    )
+
+    result = FSDPEngine.forward_backward_batch(engine, data, loss_function=lambda: None, forward_only=False)
+
+    assert ("model_output" in result) is expected
+    if expected:
+        assert torch.equal(result["model_output"]["log_probs"], model_output["log_probs"])

--- a/verl/experimental/teacher_loop/teacher_model.py
+++ b/verl/experimental/teacher_loop/teacher_model.py
@@ -16,12 +16,12 @@ import asyncio
 import logging
 import os
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from verl.single_controller.ray.base import RayResourcePool, split_resource_pool
 from verl.utils.config import omega_conf_to_dataclass
 from verl.utils.ray_utils import auto_await
-from verl.workers.config import DistillationConfig, DistillationTeacherModelConfig, HFModelConfig
+from verl.workers.config import DistillationConfig, DistillationTeacherModelConfig
 from verl.workers.rollout.llm_server import LLMServerClient
 from verl.workers.rollout.replica import get_rollout_replica_class
 
@@ -75,7 +75,16 @@ class TeacherModelManager:
         gpus_per_node = self.distillation_config.n_gpus_per_node
         rollout_replica_class = get_rollout_replica_class(teacher_model_config.inference.name)
         rollout_config = teacher_model_config.inference
-        model_config = HFModelConfig(path=teacher_model_config.model_path)
+        # Keep the model path unresolved until the rollout server actor is
+        # placed. Each server backend converts this DictConfig to HFModelConfig
+        # in its own process, so HDFS models are copied into that node's local
+        # cache instead of the controller's local /tmp.
+        model_config = OmegaConf.create(
+            {
+                "_target_": "verl.workers.config.HFModelConfig",
+                "path": teacher_model_config.model_path,
+            }
+        )
         name_suffix = (teacher_model_config.key or "").replace("/", "_")
         self.rollout_replicas = [
             rollout_replica_class(

--- a/verl/workers/engine/fsdp/transformer_impl.py
+++ b/verl/workers/engine/fsdp/transformer_impl.py
@@ -643,6 +643,7 @@ class FSDPEngine(BaseEngine):
     def forward_backward_batch(self, data: TensorDict, loss_function: Callable, forward_only=False) -> list[TensorDict]:
         # note that the global_batch_size should include data on all the dp
         tu.assign_non_tensor(data, sp_size=self.ulysses_sequence_parallel_size)
+        return_model_output = tu.get_non_tensor_data(data=data, key="return_model_output", default=False)
 
         # compute num_tokens in global batch for loss normalization
         batch_num_tokens = data["loss_mask"].sum().to(get_device_id())
@@ -673,9 +674,11 @@ class FSDPEngine(BaseEngine):
                         scaler.scale(loss).backward()
                     else:
                         loss.backward()
-                    # Training discards model_output (train_batch pops it); keeping it accumulates
-                    # full-length nested tensors across the mini-batch (∝ ppo_mini_batch * rollout_n) → OOM.
-                    meta_info.pop("model_output", None)
+                    if not return_model_output:
+                        # Standard training discards model_output (train_batch pops it); keeping it accumulates
+                        # full-length nested tensors across the mini-batch (∝ ppo_mini_batch * rollout_n) → OOM.
+                        # Specialized callers such as Tinker may opt in when their response requires these outputs.
+                        meta_info.pop("model_output", None)
 
             output_lst.append(meta_info)
 

--- a/verl/workers/engine_workers_tinker.py
+++ b/verl/workers/engine_workers_tinker.py
@@ -156,7 +156,6 @@ class TinkerTrainingWorker(TrainingWorker):
         delta_time = timer.last
 
         if self.engine.is_mp_src_rank_with_outputs():
-            output.pop("model_output")
             final_output = self._postprocess_output(
                 output,
                 global_token_num=global_token_num,

--- a/verl/workers/engine_workers_tinker.py
+++ b/verl/workers/engine_workers_tinker.py
@@ -143,6 +143,11 @@ class TinkerTrainingWorker(TrainingWorker):
             if key not in data.keys():
                 tu.assign_non_tensor(data, **{key: val})
 
+        # Tinker returns per-token log-probs to the client after backward.
+        # FSDP normally discards model_output to reduce peak memory, so
+        # explicitly opt this split-training path into retaining it.
+        tu.assign_non_tensor(data, return_model_output=True)
+
         maybe_fix_3d_position_ids(data)
 
         with (

--- a/verl/workers/rollout/vllm_rollout/vllm_rollout.py
+++ b/verl/workers/rollout/vllm_rollout/vllm_rollout.py
@@ -69,7 +69,7 @@ def _should_expand_vllm_moe_params() -> bool:
         return False
 
 
-async def _iter_vllm_compatible_moe_params(weights):
+async def _iter_vllm_compatible_moe_params(weights, model_type: str | None = None):
     """Expand Transformers 5 packed MoE expert tensors to vLLM checkpoint keys.
 
     Transformers 5 stores Qwen-style MoE experts as packed 3D parameters:
@@ -83,6 +83,13 @@ async def _iter_vllm_compatible_moe_params(weights):
     from verl.workers.rollout.utils import ensure_async_iterator
 
     async for name, tensor in ensure_async_iterator(weights):
+        # GPT-OSS checkpoint weights use packed 3D expert tensors directly.
+        # Splitting them into per-expert 2D tensors makes vLLM's GPT-OSS loader
+        # index a 2D tensor as 3D during TP slicing.
+        if model_type == "gpt_oss" and ".mlp.experts." in name and tensor.dim() == 3:
+            yield name, tensor
+            continue
+
         if name.endswith(".mlp.experts.gate_up_proj") and tensor.dim() == 3:
             gate, up = tensor.chunk(2, dim=1)
             base = name.removesuffix(".gate_up_proj")
@@ -291,7 +298,7 @@ class ServerAdapter(BaseRollout):
         # `experts.base_layer.w13_weight`); only the packed `experts.gate_up_proj`
         # / `experts.down_proj` load path is wrapper-aware, so keep tensors packed.
         if _should_expand_vllm_moe_params() and kwargs.get("peft_config") is None:
-            weights = _iter_vllm_compatible_moe_params(weights)
+            weights = _iter_vllm_compatible_moe_params(weights, self.model_config.hf_config.model_type)
         await sender.async_send_weights(weights)
 
         if future is not None:


### PR DESCRIPTION
### What does this PR do?

Retain model output from tinker forward backward for server use

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: https://github.com/verl-project/verl/commit/1ff76cc625e9820d2434dad1b6d9b8e5dd26a359
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [x] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
