### PR TITLE
[rollout, ckpt] fix: scope SGLang delta masked copies

### DIFF
--- a/tests/checkpoint_engine/test_sglang_loader.py
+++ b/tests/checkpoint_engine/test_sglang_loader.py
@@ -24,22 +24,31 @@ positions land bit-exactly, and positions outside the delta are never touched.
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
+import pytest
 import torch
 
 from verl.checkpoint_engine.delta_sync import DeltaParam, checksum
-from verl.workers.rollout.sglang_rollout.delta_loader import apply_delta
+from verl.workers.rollout.sglang_rollout.delta_loader import _masked_copy, apply_delta
 
 
-class _FakeModel:
+class _FakeModel(torch.nn.Module):
     """Holds live params; load_weights lands on param.copy_(loaded), like SGLang."""
 
     def __init__(self, named: list[tuple[str, torch.Tensor]]):
-        self.params = {n: t.clone() for n, t in named}
+        super().__init__()
+        self.params = torch.nn.ParameterDict(
+            {n.replace(".", "_"): torch.nn.Parameter(t.clone(), requires_grad=False) for n, t in named}
+        )
+        self._param_names = {name: name.replace(".", "_") for name, _ in named}
 
     def load_weights(self, chunk):
         for name, tensor in chunk:
-            self.params[name].copy_(tensor)
+            self.get_param(name).copy_(tensor)
+
+    def get_param(self, name):
+        return self.params[self._param_names[name]]
 
 
 def _make_named(dtype=torch.bfloat16) -> list[tuple[str, torch.Tensor]]:
@@ -111,7 +120,7 @@ def test_masked_apply_bit_identical():
     apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
 
     for name, expected in new_named:
-        got = model.params[name]
+        got = model.get_param(name)
         assert torch.equal(got.view(torch.int16), expected.view(torch.int16)), f"{name} not bit-identical"
 
 
@@ -122,7 +131,7 @@ def test_untouched_positions_preserved():
     model = _FakeModel(named)
     # Poison one untouched position in the live model; a full overwrite would revert it.
     sentinel_name = named[0][0]
-    model.params[sentinel_name].view(-1)[3] = 42.0
+    model.get_param(sentinel_name).view(-1)[3] = 42.0
 
     new_named = []
     for name, t in named:
@@ -132,14 +141,192 @@ def test_untouched_positions_preserved():
 
     apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
 
-    live = model.params[sentinel_name].view(-1)
+    live = model.get_param(sentinel_name).view(-1)
     assert live[3].item() == 42.0, "masked apply must not touch positions outside the delta"
     assert live[7] == new_named[0][1].view(-1)[7]
 
 
-def test_checksum_mismatch_raises():
-    import pytest
+def test_masked_apply_does_not_change_scratch_copy_semantics():
+    named = _make_named()
+    model = _FakeModel(named)
+    scratch = torch.zeros_like(named[0][1])
 
+    def load_weights(chunk):
+        for name, tensor in chunk:
+            scratch.copy_(tensor)
+            model.get_param(name).copy_(tensor)
+
+    model.load_weights = load_weights
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    new_named[0][1].view(-1)[7] += 1.0
+
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
+
+    assert torch.isnan(scratch).any(), "non-model scratch copies must retain ordinary copy_ semantics"
+    assert model.get_param(named[0][0]).view(-1)[7] == new_named[0][1].view(-1)[7]
+
+
+def test_masked_apply_covers_views_into_parameter_storage():
+    named = _make_named()
+    model = _FakeModel(named)
+
+    def load_weights(chunk):
+        for name, tensor in chunk:
+            destination = model.get_param(name)
+            midpoint = destination.shape[0] // 2
+            destination[:midpoint].copy_(tensor[:midpoint])
+            destination[midpoint:].copy_(tensor[midpoint:])
+
+    model.load_weights = load_weights
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    for _, tensor in new_named:
+        tensor.view(-1)[7] += 1.0
+        tensor.view(-1)[-7] += 1.0
+
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
+
+    for name, expected in new_named:
+        assert torch.equal(model.get_param(name).view(torch.int16), expected.view(torch.int16))
+
+
+def test_masked_apply_covers_registered_buffer_storage():
+    named = _make_named()
+    model = _FakeModel(named)
+    model.register_buffer("packed_weight", named[0][1].clone())
+
+    def load_weights(chunk):
+        for _, tensor in chunk:
+            model.packed_weight.copy_(tensor)
+            break
+
+    model.load_weights = load_weights
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    new_named[0][1].view(-1)[7] += 1.0
+    model.packed_weight.view(-1)[3] = 42.0
+
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
+
+    assert model.packed_weight.view(-1)[3].item() == 42.0
+    assert model.packed_weight.view(-1)[7] == new_named[0][1].view(-1)[7]
+
+
+def test_post_load_weights_runs_with_original_copy_semantics():
+    named = _make_named()
+    model = _FakeModel(named)
+    derived = torch.zeros_like(named[0][1])
+    post_load_calls = 0
+
+    def post_load_weights():
+        nonlocal post_load_calls
+        post_load_calls += 1
+        derived.copy_(torch.full_like(derived, float("nan")))
+
+    def load_weights(chunk):
+        for name, tensor in chunk:
+            model.get_param(name).copy_(tensor)
+        model.post_load_weights()
+
+    model.load_weights = load_weights
+    model.post_load_weights = post_load_weights
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    new_named[0][1].view(-1)[7] += 1.0
+
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
+
+    assert post_load_calls == 1
+    assert torch.isnan(derived).all(), "post-load derived tensor writes must not use masked copy semantics"
+
+
+def test_quant_method_post_load_runs_with_original_copy_semantics():
+    named = _make_named()
+    model = _FakeModel(named)
+    derived = torch.zeros_like(named[0][1])
+    post_load_calls = 0
+
+    class QuantMethod:
+        def process_weights_after_loading(self, layer):
+            nonlocal post_load_calls
+            post_load_calls += 1
+            assert layer is model
+            derived.copy_(torch.full_like(derived, float("nan")))
+
+    model.quant_method = QuantMethod()
+
+    def load_weights(chunk):
+        for name, tensor in chunk:
+            model.get_param(name).copy_(tensor)
+        model.quant_method.process_weights_after_loading(model)
+
+    model.load_weights = load_weights
+    new_named = [(name, tensor.clone()) for name, tensor in named]
+    new_named[0][1].view(-1)[7] += 1.0
+
+    apply_delta(model, _named_tensors(*_sparse_indices_flush(named, new_named)))
+
+    assert post_load_calls == 1
+    assert torch.isnan(derived).all(), "quantization post-load writes must not use masked copy semantics"
+
+
+def test_masked_copy_restores_global_and_model_hooks_after_error():
+    named = _make_named()
+    model = _FakeModel(named)
+
+    def post_load_weights():
+        pass
+
+    model.post_load_weights = post_load_weights
+    original_copy = torch.Tensor.copy_
+    original_post_load = model.post_load_weights
+
+    with pytest.raises(RuntimeError, match="load failed"):
+        with _masked_copy(model):
+            assert torch.Tensor.copy_ is not original_copy
+            assert model.post_load_weights is not original_post_load
+            raise RuntimeError("load failed")
+
+    assert torch.Tensor.copy_ is original_copy
+    assert model.post_load_weights is original_post_load
+
+
+def test_masked_copy_rolls_back_hooks_when_one_cannot_be_wrapped():
+    named = _make_named()
+    model = _FakeModel(named)
+
+    def post_load_weights():
+        pass
+
+    class ReadOnlyQuantMethod:
+        __slots__ = ()
+
+        def process_weights_after_loading(self, layer):
+            pass
+
+    model.post_load_weights = post_load_weights
+    model.quant_method = ReadOnlyQuantMethod()
+    original_copy = torch.Tensor.copy_
+    original_post_load = model.post_load_weights
+
+    with pytest.raises(RuntimeError, match="cannot safely isolate post-load hook"):
+        with _masked_copy(model):
+            pass
+
+    assert torch.Tensor.copy_ is original_copy
+    assert model.post_load_weights is original_post_load
+
+
+def test_masked_copy_fails_closed_when_model_storage_is_unavailable():
+    named = _make_named()
+    model = _FakeModel(named)
+
+    with (
+        patch.object(torch.Tensor, "untyped_storage", side_effect=NotImplementedError("unsupported")),
+        pytest.raises(RuntimeError, match="cannot identify storage for model tensor"),
+    ):
+        with _masked_copy(model):
+            pass
+
+
+def test_checksum_mismatch_raises():
     named = _make_named()
     new_named = [(n, t + 0.5) for n, t in named]
     named_tensors = _named_tensors(*_sparse_indices_flush(named, new_named))
@@ -177,4 +364,4 @@ def test_dense_flush_applies_full_tensors():
     apply_delta(model, [("__delta_spec__", spec_t), ("__values__", values)])
 
     for name, expected in named:
-        assert torch.equal(model.params[name].view(torch.int16), expected.view(torch.int16)), name
+        assert torch.equal(model.get_param(name).view(torch.int16), expected.view(torch.int16)), name

--- a/verl/workers/rollout/sglang_rollout/delta_loader.py
+++ b/verl/workers/rollout/sglang_rollout/delta_loader.py
@@ -77,7 +77,7 @@ def apply_delta(model, named_tensors) -> None:
         return
 
     encoding = spec["encoding"]
-    with _masked_copy():
+    with _masked_copy(model):
         chunk: list[tuple[str, torch.Tensor]] = []
         chunk_bytes = 0
         for p in spec["params"]:
@@ -134,27 +134,109 @@ def _decode_one(encoding: str, positions: torch.Tensor, values: torch.Tensor, p:
     return flat.view(p["shape"])
 
 
+def _model_storage_keys(model) -> set[tuple[torch.device, int, int]]:
+    """Return storage identities owned by model parameters and buffers."""
+    storage_keys = set()
+    for named_tensors in (model.named_parameters(), model.named_buffers()):
+        for _, tensor in named_tensors:
+            if tensor.is_meta:
+                continue
+            try:
+                storage = tensor.untyped_storage()
+                key = (tensor.device, storage.data_ptr(), storage.nbytes())
+            except (NotImplementedError, RuntimeError) as exc:
+                raise RuntimeError(
+                    f"cannot identify storage for model tensor with shape {tuple(tensor.shape)} on {tensor.device}"
+                ) from exc
+            if key[1]:
+                storage_keys.add(key)
+    return storage_keys
+
+
+def _post_load_hooks(model):
+    """Yield post-load hooks that may write derived model state."""
+    post_load = getattr(model, "post_load_weights", None)
+    if callable(post_load):
+        yield model, "post_load_weights", post_load
+
+    seen_quant_methods = set()
+    for module in model.modules():
+        quant_method = getattr(module, "quant_method", None)
+        if quant_method is None or id(quant_method) in seen_quant_methods:
+            continue
+        seen_quant_methods.add(id(quant_method))
+        process_weights = getattr(quant_method, "process_weights_after_loading", None)
+        if callable(process_weights):
+            yield quant_method, "process_weights_after_loading", process_weights
+
+
 @contextmanager
-def _masked_copy():
-    """Temporarily make ``Tensor.copy_`` skip NaN positions in the source.
+def _masked_copy(model):
+    """Make model-weight ``copy_`` calls skip NaN positions in the source.
 
     SGLang's per-model ``load_weights`` ultimately lands on ``param.copy_(loaded)``
     (possibly on a narrowed TP slice). Under this context a NaN-masked source
-    overwrites only the changed positions; fully dense sources (e.g. the first
-    full-seed flush) take the original fast path untouched.
+    overwrites only the changed positions. Writes outside model parameter and
+    buffer storage retain ordinary ``copy_`` semantics.
     """
     orig_copy = torch.Tensor.copy_
+    model_storage_keys = _model_storage_keys(model)
+
+    def is_model_storage(tensor):
+        try:
+            storage = tensor.untyped_storage()
+            key = (tensor.device, storage.data_ptr(), storage.nbytes())
+        except (NotImplementedError, RuntimeError):
+            return False
+        return key in model_storage_keys
 
     def masked_copy_(self, src, *args, **kwargs):
-        if isinstance(src, torch.Tensor) and src.is_floating_point() and self.shape == src.shape:
+        if (
+            is_model_storage(self)
+            and isinstance(src, torch.Tensor)
+            and src.is_floating_point()
+            and self.shape == src.shape
+        ):
             mask = ~torch.isnan(src)
             if not bool(mask.all()):
                 self[mask] = src[mask].to(self.dtype)
                 return self
         return orig_copy(self, src, *args, **kwargs)
 
+    wrapped_hooks = []
+    try:
+        for owner, name, original_hook in _post_load_hooks(model):
+            instance_dict = getattr(owner, "__dict__", {})
+            had_instance_hook = name in instance_dict
+
+            def unpatched_post_load(*args, _hook=original_hook, **kwargs):
+                current_copy = torch.Tensor.copy_
+                torch.Tensor.copy_ = orig_copy
+                try:
+                    return _hook(*args, **kwargs)
+                finally:
+                    torch.Tensor.copy_ = current_copy
+
+            try:
+                setattr(owner, name, unpatched_post_load)
+            except (AttributeError, TypeError) as exc:
+                raise RuntimeError(f"cannot safely isolate post-load hook {type(owner).__name__}.{name}") from exc
+            wrapped_hooks.append((owner, name, original_hook, had_instance_hook))
+    except Exception:
+        for owner, name, original_hook, had_instance_hook in reversed(wrapped_hooks):
+            if had_instance_hook:
+                setattr(owner, name, original_hook)
+            else:
+                delattr(owner, name)
+        raise
+
     torch.Tensor.copy_ = masked_copy_
     try:
         yield
     finally:
         torch.Tensor.copy_ = orig_copy
+        for owner, name, original_hook, had_instance_hook in reversed(wrapped_hooks):
+            if had_instance_hook:
+                setattr(owner, name, original_hook)
+            else:
+                delattr(owner, name)


### PR DESCRIPTION
### What does this PR do?

The `delta_sharded` SGLang loader applies sparse updates by temporarily patching `Tensor.copy_`: NaN positions mean "keep the current model value."

The patch is process-global while `model.load_weights()` runs. Previously, any same-shaped floating-point copy in that call inherited the masked semantics, including writes into scratch tensors or derived post-load state.

This PR scopes masked overwrite to storage owned by the model's registered parameters and buffers. Parameter/buffer views remain covered because the check uses the underlying storage identity. Copies into temporary tensors use ordinary `copy_`.

It also isolates post-load hooks that `model.load_weights()` may invoke:

- root `model.post_load_weights`;
- unique `quant_method.process_weights_after_loading` hooks.

Those hooks run with the original `Tensor.copy_`, then the sparse loader patch is reinstated until the surrounding weight load finishes. All patches and hooks are restored after success or exceptions.

This implements the masked-copy safety guard documented as a known issue in #7060, which is part of the rollout weight-sync roadmap linked by #6985.

### Checklist Before Starting

- [x] Read roadmap #6985 and tracking issue #7060.
- [x] Inspected all open PRs and searched for `masked copy delta loader`, `process_weights_after_loading delta`, and `7060 in:body`.
- [x] No open PR implements parameter-storage scoping or post-load hook isolation.
- [x] #7085 is adjacent but not a duplicate. It adds block placement, VeOmni FSDP2+EP export, and a sync-free `torch.where` masked-copy kernel. This PR changes the safety boundary around that kernel. A compatibility worktree retained #7085's kernel, applied these guards, and passed all 12 focused tests.
- [x] The title follows the repository format: `[rollout, ckpt] fix: scope SGLang delta masked copies`.

### Test

Focused and related CPU checkpoint-engine tests:

```bash
PYTHONPATH=$PWD /tmp/verl-delta-loader-venv/bin/python -m pytest -q \
  tests/checkpoint_engine/test_sglang_loader.py \
  tests/checkpoint_engine/test_sharded_delta.py \
  tests/checkpoint_engine/test_global_steps_on_cpu.py \
  tests/checkpoint_engine/test_fsdp_lora_only_checkpoint_on_cpu.py
```

Result:

```text
35 passed
```

The focused SGLang loader file contains 12 tests covering:

- sparse delta bit identity and untouched positions;
- model parameter views and registered buffers;
- scratch tensors retaining ordinary NaN-copy behavior;
- root-model and quantization post-load hooks using ordinary `copy_`;
- restoration after apply errors;
- rollback when a hook cannot be safely wrapped;
- fail-closed behavior when model storage cannot be identified;
- checksum mismatch and dense-seed behavior.

Full repository checks:

```bash
pre-commit run --all-files --show-diff-on-failure
```

Result: all hooks passed.

The complete checkpoint-engine directory additionally includes GPU/NPU/model and live-server tests. On this CPU/macOS host, its three hardware/model-path failures and one missing `ROLLOUT_NAME` setup error were reproduced unchanged on `origin/main@2423f801`.

### API and Usage Example

No public API, configuration, or wire-format change. Existing `delta_sharded` + SGLang configurations continue to register:

```text
verl.workers.rollout.sglang_rollout.delta_loader.apply_delta
```

This PR does not claim general quantized delta-rollout support. The custom loader API receives one flush at a time without the final-flush bit, so quantization hooks that must run once after a complete sync still require the separate quantized-rollout protocol work tracked in #7060.

### Design & Code Changes

- Build one set of `(device, storage pointer, storage bytes)` identities from registered model parameters and buffers per delta flush.
- Apply NaN-masked overwrite only when the destination shares one of those storages.
- Preserve masked semantics for narrowed TP parameter/buffer views.
- Keep temporary and scratch copies on the original `Tensor.copy_` path.
- Temporarily restore `Tensor.copy_` while model-invoked post-load hooks run.
- Restore all global and instance hooks in `finally` blocks.
- Fail closed if model storage or a post-load hook cannot be safely isolated.

A synthetic CPU overhead check with 2,000 model parameters measured:

```text
guarded parameter copy: 7.128 us/op
guarded scratch copy:   1.327 us/op
storage index build:    1.231 ms/flush
```

This is overhead evidence only, not a training-throughput claim.

### Checklist Before Submitting

- [x] Read `CONTRIBUTING.md` and repository `AGENTS.md`.
- [x] Duplicate-work checks completed.
- [x] Focused and broader CPU tests passed.
- [x] Full pre-commit passed.
- [x] No generated config, recipe, or documentation surface is affected.
- [x] The submitter reviewed every changed line and personally confirmed the test and compatibility evidence before submission.

### AI assistance

OpenAI Codex assisted with roadmap analysis, implementation, tests, and PR drafting. The human submitter reviewed every changed line, understands the process-global monkeypatch and post-load boundaries, and personally confirmed the validation evidence before submission.

