### PR TITLE
[ckpt, megatron] fix: megatron save checkpoints with strict false

### DIFF
--- a/verl/utils/checkpoint/megatron_checkpoint_manager.py
+++ b/verl/utils/checkpoint/megatron_checkpoint_manager.py
@@ -1012,7 +1012,9 @@ class MegatronCheckpointManager(BaseCheckpointManager):
                     log_only_rank_0=True,
                 )
             else:
-                self.bridge.save_hf_weights(self.model, hf_ckpt_path)
+                self.bridge.save_hf_weights(
+                    self.model, hf_ckpt_path, strict=self.checkpoint_config.strict
+                )
 
     def _save_hf_config_and_tokenizer(self, local_path: str):
         """Rank-0 saves HF config, tokenizer, and generation config."""


### PR DESCRIPTION
### What does this PR do?
  What
  When saving model weights as HuggingFace format through the Megatron checkpoint manager (_save_model_as_hf_via_bridge), the strict option from checkpoint_config was previously ignored — the
  call always used the bridge's default behavior. This commit reads checkpoint_config.strict (if present) and forwards it to bridge.save_hf_weights(...) so that checkpoints can be saved with
  strict=False, tolerating key mismatches between the source model and the target HF state dict.

  Why
  Saving HF checkpoints can fail when the weight keys don't line up exactly (e.g., renamed/extra/missing parameters during conversion). Allowing strict=False lets users persist checkpoints
  despite these mismatches instead of aborting, and makes the strict setting configured on the checkpoint actually take effect on the non-PEFT, non-vanilla-bridge code path.

  How
  - Before: self.bridge.save_hf_weights(self.model, hf_ckpt_path)
  - After: read strict = getattr(self.checkpoint_config, "strict", None); only inject it into the call kwargs when explicitly set, preserving the previous default behavior when the attribute
  is absent.

> Add **concise** overview of what this PR aims to achieve or accomplish. Reference related GitHub issues and PRs that help with the review.

### Checklist Before Starting

- [ ] Search for similar PRs. Paste at least one query link here: ...
- [ ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [ ] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [ ] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
