### PR TITLE
[doc] chore: warn against hard-wrapping PR body markdown in pr skill

### DIFF
--- a/.agent/skills/pr/SKILL.md
+++ b/.agent/skills/pr/SKILL.md
@@ -21,6 +21,8 @@ Follow the PR template strictly for both title format and body sections. Only ch
 
 When updating, ensure the title and body still accurately reflect **all** changes on the branch, not just the latest commit.
 
+Write the body as GitHub-flavored Markdown, not fixed-width plain text. Keep each paragraph and each list item on a single logical line and separate blocks with blank lines. Do not hard-wrap running prose at a column limit: GitHub renders a single newline inside a paragraph or list item as a space, so a manually wrapped sentence turns into unintended mid-sentence breaks in the rendered PR. Watch two easy-to-miss cases: a wrapped line whose continuation starts with `#<number>` (e.g. an issue reference like `#7060`) reads as a heading in the source and is easy to leave split, and list-item continuations that are indented but should still join their item. Let the editor soft-wrap; only insert a newline to start a new paragraph, list item, table row, or fenced code block. Before submitting, re-read the body (or the round-tripped version fetched back from GitHub) and confirm no paragraph or list item is split across multiple source lines.
+
 ### 3. Pre-submit Checks
 
 Run pre-commit and fix any issues before creating or pushing.


### PR DESCRIPTION
### What does this PR do?

The `pr` skill (`.agent/skills/pr/SKILL.md`, also surfaced via the `.claude` and `.codex` symlinks) tells an agent how to create or update a PR, but it never said how to format the PR body. As a result, bodies were sometimes hand-wrapped at a fixed column width. GitHub renders a single newline inside a paragraph or list item as a space, so those manual wraps become unintended mid-sentence breaks in the rendered PR.

This adds one paragraph to step 2 ("Compose PR Title and Body") instructing the agent to write the body as GitHub-flavored Markdown: one logical line per paragraph and list item, blocks separated by blank lines, and no column-limit hard wrapping. It also calls out two easy-to-miss cases and adds a pre-submit re-read check.

### Checklist Before Starting

- [x] Search for similar PRs: no open PR edits `.agent/skills/pr/SKILL.md` or documents PR-body Markdown formatting.
- [x] Format the PR title as `[{modules}] {type}: {description}`: `[doc] chore: warn against hard-wrapping PR body markdown in pr skill`.

### Test

Documentation-only change to a skill instruction file. No code paths are affected.

`pre-commit run --all-files --show-diff-on-failure` passes (ruff, ruff-format, mypy, generated-config, docs/license/naming/structure checks, compileall).

### API and Usage Example

No API or configuration change. The skill now guides body composition:

- one logical line per paragraph and per list item;
- blank lines between blocks;
- no hard wrapping at a column limit (a single newline renders as a space);
- watch continuation lines that start with `#<number>` (they read as a heading in source) and indented list-item continuations;
- re-read the body before submitting to confirm nothing is split across source lines.

### Design & Code Changes

- Append one guidance paragraph to the "Compose PR Title and Body" section of `.agent/skills/pr/SKILL.md`. The `.claude/skills/pr` and `.codex/skills/pr` entries are symlinks to the same file, so all three stay in sync.

### AI assistance

AI assistance was used to draft this change. The human submitter reviewed the wording and confirmed the pre-commit result before submission.
