### PR TITLE
[ckpt] fix: save base model's code, not the PeftModel wrapper's, in FSDP checkpoints

### DIFF
--- a/tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py
+++ b/tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py
@@ -1,0 +1,79 @@
+# Copyright 2025 Individual Contributor: Zhiliang Wu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""For a PEFT model (LoRA here) whose config carries ``auto_map`` (a trust_remote_code model),
+``FSDPCheckpointManager.save_checkpoint`` bundles the model's own defining source next to the
+checkpoint via transformers' ``custom_object_save`` (which copies the source of
+``type(obj).__module__``). It must receive the base model, not the ``PeftModel`` wrapper -- this test
+pins that the object passed is ``model.get_base_model()``.
+"""
+
+from unittest.mock import MagicMock
+
+import torch
+from peft import LoraConfig, get_peft_model
+from transformers import AutoModelForCausalLM, Qwen3Config
+
+from verl.trainer.config import CheckpointConfig
+from verl.utils.checkpoint.fsdp_checkpoint_manager import FSDPCheckpointManager
+
+
+def _make_peft_model():
+    config = Qwen3Config(
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        hidden_size=128,
+        intermediate_size=256,
+        vocab_size=256,
+    )
+    base = AutoModelForCausalLM.from_config(config)
+    lora_config = LoraConfig(
+        r=8, lora_alpha=16, target_modules="all-linear", lora_dropout=0.0, bias="none", task_type="CAUSAL_LM"
+    )
+    return get_peft_model(base, lora_config)
+
+
+def test_custom_object_save_receives_base_model_not_peft_wrapper(monkeypatch, tmp_path):
+    """On a LoRA save, the object passed to custom_object_save is the base model, not the PeftModel."""
+    # Neutralize the (uninitialized) process group: save_checkpoint queries rank/world_size and
+    # calls barrier(). A plain PeftModel has fsdp_version == 0, so the sharded-state-dict block is a
+    # nullcontext and no collectives run -- only these three calls need stubbing.
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: None)
+
+    peft_model = _make_peft_model()
+    # Make the auto_map gate fire (dict without a None key, matching a trust_remote_code config).
+    peft_model.config.auto_map = {"AutoModelForCausalLM": "modeling_x.Foo"}
+
+    # save_contents=["model"] keeps the save cheap (skips optimizer/extra) and skips hf_model export.
+    ckpt_config = CheckpointConfig(save_contents=["model"], load_contents=["model"], async_save=False)
+    manager = FSDPCheckpointManager(
+        model=peft_model,
+        optimizer=None,
+        lr_scheduler=None,
+        processing_class=None,
+        checkpoint_config=ckpt_config,
+    )
+
+    mock_custom_object_save = MagicMock()
+    monkeypatch.setattr("verl.utils.checkpoint.fsdp_checkpoint_manager.custom_object_save", mock_custom_object_save)
+
+    manager.save_checkpoint(local_path=str(tmp_path), global_step=0)
+
+    mock_custom_object_save.assert_called_once()
+    saved_obj = mock_custom_object_save.call_args.args[0]
+    assert saved_obj is peft_model.get_base_model(), "custom_object_save must receive the base model"
+    assert saved_obj is not peft_model, "custom_object_save must not receive the PeftModel wrapper"

--- a/verl/utils/checkpoint/fsdp_checkpoint_manager.py
+++ b/verl/utils/checkpoint/fsdp_checkpoint_manager.py
@@ -365,7 +365,11 @@ class FSDPCheckpointManager(BaseCheckpointManager):
             # If we have a custom model, we copy the file defining it in the folder and set the attributes so it can be
             # loaded from the Hub.
             if hasattr(model_config, "auto_map"):
-                custom_object_save(unwrap_model, hf_config_tokenizer_path, config=model_config)
+                # custom_object_save copies the source of type(obj).__module__, so it needs the base
+                # model's module. For a PEFT model unwrap_model is the PeftModel wrapper, so unwrap it
+                # first; get_base_model() is peft-only (a plain model lacks it and is passed through).
+                save_obj = unwrap_model.get_base_model() if hasattr(unwrap_model, "get_base_model") else unwrap_model
+                custom_object_save(save_obj, hf_config_tokenizer_path, config=model_config)
 
             # Also save runtime FSDP config
             fsdp_config_path = os.path.join(local_path, "fsdp_config.json")


### PR DESCRIPTION
### What does this PR do?

Fix LoRA/PEFT checkpoint saving for `trust_remote_code` models. In `FSDPCheckpointManager.save_checkpoint`, `custom_object_save` copies the source of `type(obj).__module__` to make the checkpoint self-contained, so it must be given the base model. On a PEFT run it was passed the `PeftModel` wrapper instead, so it walked the wrong module's source. This unwraps to the base model via `get_base_model()` before the call, and adds a CPU test covering the `auto_map` save path.

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test

New CPU unit test `tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py`: builds a tiny LoRA `PeftModel`, sets `config.auto_map`, mocks `custom_object_save`, calls `save_checkpoint`, and asserts the object passed is `model.get_base_model()` (and not the `PeftModel` wrapper). It is the first test to cover this branch.

$ pytest -s tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py
1 passed

Negative control: reverting the fix (passing `unwrap_model`) makes the test fail, so it genuinely guards the behavior.

### API and Usage Example

No API change. `save_checkpoint`'s signature and outputs are unchanged; for a non-PEFT model behavior is identical (the guard `hasattr(unwrap_model, "get_base_model")` is False and the object is passed through untouched).

### Design & Code Changes

Background: `custom_object_save` bundles a `trust_remote_code` model's own defining `.py` next to the checkpoint. Given the `PeftModel` wrapper it walks peft's module instead of the model's, and the outcome depends on FSDP version:

- **FSDP1** — `unwrap_model` is the `PeftModel`; walking `peft/peft_model.py`'s `from .tuners import ...` resolves to a nonexistent `peft/tuners.py` → the save raises `FileNotFoundError` and no checkpoint is written.
- **FSDP2** — the class is swapped in place; the walk resolves to torch's `_fully_shard/_fsdp_*.py`, which exist, so the save silently copies those in and the saved `auto_map` points at a `modeling_*.py` that was never copied — a checkpoint that can't be reloaded via `trust_remote_code`.

Verified `get_base_model()` returns the true base model in both FSDP1 and FSDP2.

Changes:

- `verl/utils/checkpoint/fsdp_checkpoint_manager.py` — unwrap to the base model via `get_base_model()` before `custom_object_save` (peft-only; non-PEFT models unchanged).
- `tests/utils/ckpt/test_lora_custom_object_save_on_cpu.py` — new CPU test (above).

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [x] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [x] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
