### PR TITLE
[megatron] feat: add Muon optimizer support (expose Megatron-Core TensorParallelMuon)

### DIFF
--- a/examples/muon/README.md
+++ b/examples/muon/README.md
@@ -1,0 +1,50 @@
+# Muon optimizer (Megatron backend)
+
+This PR exposes Megatron-Core's `TensorParallelMuon` (via `emerging_optimizers`)
+in verl's native Megatron backend. Muon is applied to 2D weight matrices; all
+other parameters (embeddings, norms, biases, router, lm_head) keep AdamW.
+
+## How to enable
+
+Add the following Hydra overrides to any Megatron GRPO/PPO run (e.g. one of the
+scripts under `examples/grpo_trainer/*_megatron.sh`). Values below are the
+recommended starting point and mirror the defaults documented in
+`verl/trainer/config/optim/megatron.yaml`.
+
+```bash
+python3 -m verl.trainer.main_ppo \
+    ... \
+    actor_rollout_ref.actor.optim.optimizer=muon \
+    actor_rollout_ref.actor.optim.use_layer_wise_distributed_optimizer=True \
+    actor_rollout_ref.actor.optim.muon_momentum=0.95 \
+    actor_rollout_ref.actor.optim.muon_nesterov=False \
+    actor_rollout_ref.actor.optim.muon_split_qkv=True \
+    actor_rollout_ref.actor.optim.muon_scale_mode=spectral \
+    actor_rollout_ref.actor.optim.muon_coefficient_type=quintic \
+    actor_rollout_ref.actor.optim.muon_num_ns_steps=5 \
+    actor_rollout_ref.actor.optim.muon_tp_mode=blockwise
+```
+
+## Key knobs
+
+| Field | Recommended | Meaning |
+| --- | --- | --- |
+| `optimizer` | `muon` | selects the Muon (emerging) optimizer; Muon on matrices, AdamW fallback on the rest. |
+| `use_layer_wise_distributed_optimizer` | `True` | build Megatron's LayerWise distributed optimizer path so Muon's per-layer buffers are distributed (avoids the extra fp32 master clone; keeps memory below AdamW). |
+| `muon_momentum` | `0.95` | Muon momentum; tuning it rarely helps. |
+| `muon_nesterov` | `False` | Nesterov momentum for the Muon update. |
+| `muon_split_qkv` | `True` | orthogonalize per-head QKV projections independently. |
+| `muon_scale_mode` | `spectral` | update-scaling mode. |
+| `muon_num_ns_steps` | `5` | Newton–Schulz iteration steps for the orthogonalization. |
+| `muon_tp_mode` | `blockwise` | tensor-parallel sharding mode for the Muon update. |
+
+`lr` / `weight_decay` are reused from the AdamW settings — Muon does not need a
+separate learning rate. A `muon_*` field that the installed Megatron-Core build
+does not declare raises at build time instead of being silently ignored.
+
+## Notes
+
+- Requires a Megatron-Core build with `emerging_optimizers` support.
+- `use_layer_wise_distributed_optimizer=True` is what keeps Muon's peak optimizer
+  memory below AdamW at 30B scale; without it the layer-wise buffers are not
+  distributed.

--- a/examples/muon/README.md
+++ b/examples/muon/README.md
@@ -22,7 +22,8 @@ python3 -m verl.trainer.main_ppo \
     actor_rollout_ref.actor.optim.muon_scale_mode=spectral \
     actor_rollout_ref.actor.optim.muon_coefficient_type=quintic \
     actor_rollout_ref.actor.optim.muon_num_ns_steps=5 \
-    actor_rollout_ref.actor.optim.muon_tp_mode=blockwise
+    actor_rollout_ref.actor.optim.muon_tp_mode=blockwise \
+    actor_rollout_ref.actor.optim.muon_match_adamw_update_rms=True
 ```
 
 ## Key knobs
@@ -37,10 +38,39 @@ python3 -m verl.trainer.main_ppo \
 | `muon_scale_mode` | `spectral` | update-scaling mode. |
 | `muon_num_ns_steps` | `5` | Newton–Schulz iteration steps for the orthogonalization. |
 | `muon_tp_mode` | `blockwise` | tensor-parallel sharding mode for the Muon update. |
+| `muon_match_adamw_update_rms` | `True` | derive `muon_extra_scale_factor` from `betas[0]` so Muon's update RMS matches AdamW's — see below. |
 
-`lr` / `weight_decay` are reused from the AdamW settings — Muon does not need a
-separate learning rate. A `muon_*` field that the installed Megatron-Core build
-does not declare raises at build time instead of being silently ignored.
+A `muon_*` field that the installed Megatron-Core build does not declare raises at
+build time instead of being silently ignored.
+
+### Learning rate: Muon's effective step is `lr × muon_extra_scale_factor`
+
+An AdamW learning rate is **not** directly reusable. Megatron-Core's default
+`muon_extra_scale_factor = 1.0` is *not* AdamW-comparable: carrying an AdamW `lr`
+over unchanged yields roughly a **4.4×** larger effective step (`1 / 0.2294`, see
+below), which is a common cause of unstable or non-converging Muon runs.
+
+`emerging_optimizers` gives the closed form for the factor that matches AdamW's
+update RMS norm:
+
+```
+muon_extra_scale_factor = sqrt((1 - beta1) / (1 + beta1))
+```
+
+where `beta1` is AdamW's first-moment coefficient — `0.229416` at the default
+`beta1 = 0.9`. Set `muon_match_adamw_update_rms=True` and verl computes it from
+your `optim.betas[0]` and logs the resolved value on rank 0, so the number is
+reproducible from the config instead of pasted in as a constant. Setting both
+`muon_match_adamw_update_rms=True` and an explicit `muon_extra_scale_factor`
+raises.
+
+Note that `muon_scale_mode` and `muon_extra_scale_factor` are orthogonal and both
+matter: the former normalizes for parameter *shape*, the latter for the
+*momentum/EMA*. Sources: emerging_optimizers 0.3.0
+`orthogonalized_optimizers/muon.py::get_muon_scale_factor` docstring,
+<https://kexue.fm/archives/11267>, <https://arxiv.org/abs/2502.16982>. The often
+quoted `0.2` is the value of the *factor* at `beta1 = 0.9`, not a target for any
+measured update RMS.
 
 ## Notes
 

--- a/examples/muon/README.md
+++ b/examples/muon/README.md
@@ -58,11 +58,13 @@ muon_extra_scale_factor = sqrt((1 - beta1) / (1 + beta1))
 ```
 
 where `beta1` is AdamW's first-moment coefficient — `0.229416` at the default
-`beta1 = 0.9`. Set `muon_match_adamw_update_rms=True` and verl computes it from
-your `optim.betas[0]` and logs the resolved value on rank 0, so the number is
-reproducible from the config instead of pasted in as a constant. Setting both
-`muon_match_adamw_update_rms=True` and an explicit `muon_extra_scale_factor`
-raises.
+`beta1 = 0.9` — quoted for orientation only. **Configure the switch, not the
+number**: set `muon_match_adamw_update_rms=True` and verl derives the factor from
+your `optim.betas[0]` and logs the resolved value on rank 0. A hand-entered
+constant is the thing to avoid regardless of how it was obtained — anyone reading
+the config can re-derive the switch's value from `beta1`, but not a pasted-in
+literal. Setting both `muon_match_adamw_update_rms=True` and an explicit
+`muon_extra_scale_factor` raises.
 
 Note that `muon_scale_mode` and `muon_extra_scale_factor` are orthogonal and both
 matter: the former normalizes for parameter *shape*, the latter for the

--- a/tests/utils/megatron/muon_optim_gpu_smoke.py
+++ b/tests/utils/megatron/muon_optim_gpu_smoke.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU smoke: verl wiring -> Megatron-Core TensorParallelMuon, real build + one step.
+
+This is NOT a pytest-collected CPU test (Megatron's DDP grad buffers allocate on
+``torch.cuda.current_device()``, so the full optimizer object can only be built on a GPU).
+Run it under torchrun on a single GPU inside a container that has Megatron-Core with
+``emerging_optimizers`` and verl installed::
+
+    torchrun --nproc_per_node=1 tests/utils/megatron/muon_optim_gpu_smoke.py
+
+Success prints ``MUON_GPU_SMOKE_OK`` and exits 0. It proves verl's
+``init_megatron_optim_config`` + ``get_megatron_optimizer`` actually construct Megatron's
+emerging (Muon) optimizer -- a ChainedOptimizer containing a ``TensorParallelMuon`` -- rather
+than silently falling back to Adam, and that one ``optimizer.step()`` updates parameters.
+"""
+
+import os
+
+import torch
+import torch.nn as nn
+
+
+def main():
+    assert torch.cuda.is_available(), "this smoke requires a GPU"
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    torch.cuda.set_device(rank % torch.cuda.device_count())
+    if not torch.distributed.is_initialized():
+        torch.distributed.init_process_group(backend="nccl", world_size=world_size, rank=rank)
+
+    from megatron.core import parallel_state
+
+    parallel_state.initialize_model_parallel(tensor_model_parallel_size=1)
+
+    from megatron.core.distributed import DistributedDataParallel, DistributedDataParallelConfig
+    from megatron.core.optimizer.emerging_optimizers import TensorParallelMuon  # noqa: F401
+    from megatron.core.transformer import TransformerConfig
+
+    from verl.utils.megatron.optimizer import get_megatron_optimizer, init_megatron_optim_config
+    from verl.workers.config.optimizer import McoreOptimizerConfig
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(80, 48)
+            self.fc2 = nn.Linear(48, 16)
+
+        def forward(self, x):
+            return self.fc2(torch.relu(self.fc1(x)))
+
+    torch.manual_seed(0)
+    model = Net().bfloat16().cuda()
+    model.requires_grad_(True)
+
+    tconf = TransformerConfig(num_attention_heads=1, num_layers=1)
+    ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=False)
+    ddp_model = DistributedDataParallel(tconf, ddp_config, model)
+
+    vcfg = McoreOptimizerConfig(
+        lr=0.01,
+        optimizer="muon",
+        weight_decay=0.01,
+        clip_grad=1.0,
+        muon_momentum=0.95,
+        muon_nesterov=True,
+        muon_num_ns_steps=5,
+        muon_scale_mode="spectral",
+        muon_tp_mode="duplicated",
+    )
+    mcore_cfg = init_megatron_optim_config(vcfg, use_distributed_optimizer=False, fp16=False)
+    assert mcore_cfg.optimizer == "muon"
+    print("[ok] verl init_megatron_optim_config -> OptimizerConfig(optimizer=muon)")
+
+    optimizer = get_megatron_optimizer(ddp_model, mcore_cfg)
+    assert optimizer is not None
+    inner_types = [
+        type(getattr(ch, "optimizer", ch)).__name__ for ch in getattr(optimizer, "chained_optimizers", [optimizer])
+    ]
+    print("[ok] get_megatron_optimizer -> inner optimizers:", inner_types)
+    assert any("Muon" in t for t in inner_types), f"expected TensorParallelMuon, got {inner_types}"
+    print("[ok] TensorParallelMuon constructed (NOT a silent Adam fallback)")
+
+    x = torch.randn(16, 80, dtype=torch.bfloat16, device="cuda")
+    loss = ddp_model(x).sum()
+    loss.backward()
+    before = {n: p.data.clone() for n, p in ddp_model.named_parameters()}
+    optimizer.step()
+    updated = sum(1 for n, p in ddp_model.named_parameters() if not torch.equal(p.data, before[n]))
+    assert updated > 0, "no parameters updated after optimizer.step()"
+    print(f"[ok] optimizer.step() updated {updated} parameter tensors")
+    print("MUON_GPU_SMOKE_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/utils/megatron/test_muon_layerwise_bridge_ddp_on_cpu.py
+++ b/tests/utils/megatron/test_muon_layerwise_bridge_ddp_on_cpu.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU wiring test: Megatron-Bridge provider path defers DDP for Muon layer-wise."""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+import types
+
+import pytest
+import torch.nn as nn
+
+from verl.utils.megatron_utils import McoreModuleWrapperConfig, make_megatron_module
+
+
+class _DummyConfig:
+    def __init__(self):
+        self.fp16 = False
+        self.bf16 = False
+
+
+class _DummyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4, bias=False)
+        self.config = _DummyConfig()
+
+
+@dataclasses.dataclass
+class _FakeDDPConfig:
+    use_distributed_optimizer: bool = True
+    use_layer_wise_param_layout: bool = False
+
+
+def _minimal_hf_config():
+    cfg = types.SimpleNamespace()
+    cfg.hidden_size = 4
+    cfg.rope_theta = 10000.0
+    return cfg
+
+
+@pytest.fixture
+def megatron_bridge_stubs(monkeypatch):
+    """Stub megatron.bridge imports used by the provider branch."""
+    create_ddp_config_calls = []
+    provide_calls = []
+    layerwise_wrap_calls = []
+
+    def fake_create_ddp_config(**kwargs):
+        create_ddp_config_calls.append(kwargs)
+        return _FakeDDPConfig(use_distributed_optimizer=kwargs.get("use_distributed_optimizer", True))
+
+    class FakeProvider:
+        fp16 = False
+        bf16 = False
+        sequence_parallel = False
+
+        def register_pre_wrap_hook(self, _hook):
+            return None
+
+        def provide_distributed_model(self, **kwargs):
+            provide_calls.append(kwargs)
+            return [_DummyModel()]
+
+    bridge_mod = types.ModuleType("megatron.bridge.training.utils.config_utils")
+    bridge_mod.create_ddp_config = fake_create_ddp_config
+    peft_mod = types.ModuleType("megatron.bridge.peft.utils")
+    peft_mod.create_peft_hook = lambda *args, **kwargs: (lambda model: model)
+    peft_mod.load_peft_adapter_checkpoint = lambda *args, **kwargs: None
+
+    monkeypatch.setitem(sys.modules, "megatron.bridge.training.utils.config_utils", bridge_mod)
+    monkeypatch.setitem(sys.modules, "megatron.bridge.peft.utils", peft_mod)
+
+    def fake_layerwise_wrap(model_chunks, tfconfig, **kwargs):
+        layerwise_wrap_calls.append(
+            {
+                "model_chunks": model_chunks,
+                "tfconfig": tfconfig,
+                "kwargs": kwargs,
+            }
+        )
+        wrapped = []
+        for idx, chunk in enumerate(model_chunks):
+            shell = types.SimpleNamespace(module=chunk, config=chunk.config)
+            wrapped.append(shell)
+        return wrapped
+
+    monkeypatch.setattr(
+        "verl.utils.megatron_utils.wrap_model_chunks_with_layerwise_aware_ddp",
+        fake_layerwise_wrap,
+    )
+    monkeypatch.setattr(
+        "verl.utils.megatron_utils._assert_muon_layer_wise_ddp_supported",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "verl.models.mcore.config_converter.get_hf_rope_theta",
+        lambda hf_config: hf_config.rope_theta,
+    )
+    bridge_helpers = types.ModuleType("verl.models.mcore.bridge")
+    bridge_helpers.freeze_moe_router = lambda model: model
+    bridge_helpers.make_value_model = lambda *args, **kwargs: (lambda model: model)
+    monkeypatch.setitem(sys.modules, "verl.models.mcore.bridge", bridge_helpers)
+
+    return {
+        "create_ddp_config_calls": create_ddp_config_calls,
+        "provide_calls": provide_calls,
+        "layerwise_wrap_calls": layerwise_wrap_calls,
+        "provider": FakeProvider(),
+    }
+
+
+def test_megatron_bridge_provider_defers_ddp_for_layerwise_muon(megatron_bridge_stubs):
+    wrap_config = McoreModuleWrapperConfig(
+        wrap_with_ddp=True,
+        use_distributed_optimizer=True,
+        use_layer_wise_distributed_optimizer=True,
+    )
+    model, _ = make_megatron_module(
+        wrap_config=wrap_config,
+        tf_config=_DummyConfig(),
+        hf_config=_minimal_hf_config(),
+        bridge=object(),
+        provider=megatron_bridge_stubs["provider"],
+        override_ddp_config={"use_layer_wise_param_layout": True},
+    )
+
+    assert megatron_bridge_stubs["create_ddp_config_calls"] == [
+        {
+            "wrap_with_ddp": False,
+            "use_distributed_optimizer": True,
+            "use_megatron_fsdp": False,
+            "overrides": {"use_layer_wise_param_layout": True},
+        }
+    ]
+    provide_call = megatron_bridge_stubs["provide_calls"][0]
+    assert provide_call["wrap_with_ddp"] is False
+    assert provide_call["fp16"] is False
+    assert provide_call["bf16"] is False
+    assert provide_call["use_megatron_fsdp"] is False
+    assert len(megatron_bridge_stubs["layerwise_wrap_calls"]) == 1
+    wrap_call = megatron_bridge_stubs["layerwise_wrap_calls"][0]
+    assert wrap_call["kwargs"]["use_layer_wise_distributed_optimizer"] is True
+    assert wrap_call["kwargs"]["override_ddp_config"] == {"use_layer_wise_param_layout": True}
+    assert model[0].module is megatron_bridge_stubs["layerwise_wrap_calls"][0]["model_chunks"][0]
+
+
+def test_megatron_bridge_provider_keeps_standard_ddp_without_layerwise(megatron_bridge_stubs):
+    wrap_config = McoreModuleWrapperConfig(
+        wrap_with_ddp=True,
+        use_distributed_optimizer=True,
+        use_layer_wise_distributed_optimizer=False,
+    )
+    model, _ = make_megatron_module(
+        wrap_config=wrap_config,
+        tf_config=_DummyConfig(),
+        hf_config=_minimal_hf_config(),
+        bridge=object(),
+        provider=megatron_bridge_stubs["provider"],
+    )
+
+    assert megatron_bridge_stubs["create_ddp_config_calls"][-1]["wrap_with_ddp"] is True
+    assert megatron_bridge_stubs["provide_calls"][-1]["wrap_with_ddp"] is True
+    assert megatron_bridge_stubs["layerwise_wrap_calls"] == []
+    assert isinstance(model[0], _DummyModel)
+
+
+def test_megatron_bridge_layerwise_rejects_megatron_fsdp(megatron_bridge_stubs):
+    wrap_config = McoreModuleWrapperConfig(
+        wrap_with_ddp=True,
+        use_distributed_optimizer=True,
+        use_layer_wise_distributed_optimizer=True,
+        use_megatron_fsdp=True,
+    )
+    with pytest.raises(ValueError, match="incompatible with Megatron FSDP"):
+        make_megatron_module(
+            wrap_config=wrap_config,
+            tf_config=_DummyConfig(),
+            hf_config=_minimal_hf_config(),
+            bridge=object(),
+            provider=megatron_bridge_stubs["provider"],
+        )

--- a/tests/utils/megatron/test_muon_optim_realcfg_on_cpu.py
+++ b/tests/utils/megatron/test_muon_optim_realcfg_on_cpu.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-Megatron (non-stub) CPU check for the verl -> Megatron-Core Muon wiring.
+
+Unlike ``test_muon_optim_wiring_on_cpu.py`` (which stubs ``megatron.core`` so it can run in the
+lightweight CI image), this test imports the *actual* ``megatron.core.optimizer`` and asserts that
+verl's ``init_megatron_optim_config`` produces a genuine Megatron ``OptimizerConfig`` -- proving the
+forwarded ``muon_*`` field names/types are accepted by the installed Megatron -- and that Megatron
+would route it to the emerging (Muon) builder rather than Adam.
+
+It skips automatically when the installed Megatron has no Muon support (older builds without
+``emerging_optimizers``), so it is safe in any environment. The remaining full optimizer-object
+build + ``optimizer.step()`` requires CUDA (Megatron's DDP grad buffers allocate on
+``torch.cuda.current_device()``), so that part is covered by the GPU Slurm smoke, not here.
+"""
+
+import dataclasses
+
+import pytest
+
+
+def _real_megatron_optimizer_config():
+    """Return the installed Megatron OptimizerConfig, or skip if it has no Muon fields."""
+    try:
+        from megatron.core.optimizer import OptimizerConfig
+    except Exception as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"megatron.core.optimizer not importable: {exc}")
+    field_names = {f.name for f in dataclasses.fields(OptimizerConfig)}
+    if "muon_momentum" not in field_names:
+        pytest.skip("installed Megatron OptimizerConfig has no Muon fields (no emerging_optimizers)")
+    return OptimizerConfig
+
+
+def test_verl_wiring_builds_real_megatron_muon_config():
+    OptimizerConfig = _real_megatron_optimizer_config()
+    supported_fields = {f.name for f in dataclasses.fields(OptimizerConfig)}
+
+    from verl.utils.megatron.optimizer import _MUON_ALGORITHMS, init_megatron_optim_config
+    from verl.workers.config.optimizer import McoreOptimizerConfig
+
+    vcfg = McoreOptimizerConfig(
+        lr=0.01,
+        optimizer="muon",
+        weight_decay=0.01,
+        clip_grad=1.0,
+        muon_momentum=0.9,
+        muon_num_ns_steps=6,
+        muon_tp_mode="duplicated",
+        muon_scalar_optimizer="lion",
+        use_layer_wise_distributed_optimizer=True,
+    )
+    mcore_cfg = init_megatron_optim_config(vcfg, use_distributed_optimizer=False, fp16=False)
+
+    # Real Megatron OptimizerConfig accepted every forwarded knob (field names/types compatible).
+    assert isinstance(mcore_cfg, OptimizerConfig)
+    assert mcore_cfg.optimizer == "muon"
+    # Only assert knobs the installed Megatron actually declares (CI may ship a partial build).
+    for field, expected in (
+        ("muon_momentum", 0.9),
+        ("muon_num_ns_steps", 6),
+        ("muon_tp_mode", "duplicated"),
+        ("muon_scalar_optimizer", "lion"),
+        ("use_layer_wise_distributed_optimizer", True),
+    ):
+        if field in supported_fields:
+            assert getattr(mcore_cfg, field) == expected
+
+    # Exact predicate Megatron's get_megatron_optimizer uses to pick the emerging (Muon) path.
+    assert mcore_cfg.optimizer not in ("adam", "sgd"), "muon config would fall back to Adam/SGD path!"
+    assert str(vcfg.optimizer).lower() in _MUON_ALGORITHMS
+
+
+def test_verl_adam_path_leaves_real_megatron_config_standard():
+    OptimizerConfig = _real_megatron_optimizer_config()
+    supported_fields = {f.name for f in dataclasses.fields(OptimizerConfig)}
+
+    from verl.utils.megatron.optimizer import init_megatron_optim_config
+    from verl.workers.config.optimizer import McoreOptimizerConfig
+
+    adam_cfg = init_megatron_optim_config(
+        McoreOptimizerConfig(lr=0.01, optimizer="adam", muon_momentum=0.42),
+        use_distributed_optimizer=False,
+        fp16=False,
+    )
+    assert isinstance(adam_cfg, OptimizerConfig)
+    assert adam_cfg.optimizer == "adam"
+    # verl did NOT forward the muon knob; Megatron keeps its own default.
+    if "muon_momentum" in supported_fields:
+        assert adam_cfg.muon_momentum == OptimizerConfig().muon_momentum
+    assert adam_cfg.optimizer in ("adam", "sgd")

--- a/tests/utils/megatron/test_muon_optim_wiring_on_cpu.py
+++ b/tests/utils/megatron/test_muon_optim_wiring_on_cpu.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU wiring test for verl -> Megatron Muon optimizer passthrough.
+
+Megatron-Core is not importable in the lightweight CPU CI image, so we stub the two
+``megatron.core`` modules that ``verl.utils.megatron.optimizer`` imports. This lets us assert
+verl's own logic: that ``init_megatron_optim_config`` forwards the ``muon_*`` hyperparameters onto
+the Megatron ``OptimizerConfig`` when ``optimizer=muon``, only forwards fields the installed
+``OptimizerConfig`` declares, and fails loudly (rather than silently falling back to Adam) when the
+installed Megatron exposes no Muon fields at all.
+"""
+
+import dataclasses
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _install_stub_megatron(optimizer_config_fields):
+    """Register stub ``megatron.core`` optimizer modules exposing ``optimizer_config_fields``.
+
+    Returns the freshly (re)imported ``verl.utils.megatron.optimizer`` module bound to the stubs.
+    """
+    field_defaults = {
+        "optimizer": "adam",
+        "lr": 0.0,
+        "min_lr": 0.0,
+        "clip_grad": 1.0,
+        "weight_decay": 0.0,
+        "use_distributed_optimizer": True,
+        "bf16": False,
+        "fp16": False,
+        "params_dtype": None,
+        "initial_loss_scale": 1,
+        "min_loss_scale": 1,
+        "use_precision_aware_optimizer": False,
+        "store_param_remainders": False,
+    }
+    # Muon knobs the stub Megatron "supports" for this test run.
+    for name in optimizer_config_fields:
+        field_defaults.setdefault(name, None)
+
+    OptimizerConfig = dataclasses.make_dataclass(
+        "OptimizerConfig",
+        [(k, object, v) for k, v in field_defaults.items()],
+    )
+
+    opt_mod = types.ModuleType("megatron.core.optimizer")
+    opt_mod.OptimizerConfig = OptimizerConfig
+    opt_mod.get_megatron_optimizer = lambda config, model_chunks: ("optimizer", config)
+
+    sched_mod = types.ModuleType("megatron.core.optimizer_param_scheduler")
+    sched_mod.OptimizerParamScheduler = object
+
+    core_mod = types.ModuleType("megatron.core")
+    root_mod = types.ModuleType("megatron")
+
+    sys.modules["megatron"] = root_mod
+    sys.modules["megatron.core"] = core_mod
+    sys.modules["megatron.core.optimizer"] = opt_mod
+    sys.modules["megatron.core.optimizer_param_scheduler"] = sched_mod
+
+    sys.modules.pop("verl.utils.megatron.optimizer", None)
+    return importlib.import_module("verl.utils.megatron.optimizer")
+
+
+_ALL_MUON_FIELDS = (
+    "use_layer_wise_distributed_optimizer",
+    "muon_momentum",
+    "muon_nesterov",
+    "muon_split_qkv",
+    "muon_scale_mode",
+    "muon_coefficient_type",
+    "muon_num_ns_steps",
+    "muon_tp_mode",
+    "muon_fp32_matmul_prec",
+    "muon_extra_scale_factor",
+    "muon_scalar_optimizer",
+)
+
+
+@pytest.fixture
+def muon_config():
+    from verl.workers.config.optimizer import McoreOptimizerConfig
+
+    return McoreOptimizerConfig(
+        lr=1e-3,
+        optimizer="muon",
+        muon_momentum=0.9,
+        muon_num_ns_steps=6,
+        muon_tp_mode="allgather",
+        muon_scalar_optimizer="lion",
+        use_layer_wise_distributed_optimizer=True,
+    )
+
+
+def test_muon_fields_forwarded(muon_config):
+    mod = _install_stub_megatron(_ALL_MUON_FIELDS)
+    cfg = mod.init_megatron_optim_config(muon_config, use_distributed_optimizer=True, fp16=False)
+    assert cfg.optimizer == "muon"
+    assert cfg.muon_momentum == 0.9
+    assert cfg.muon_num_ns_steps == 6
+    assert cfg.muon_tp_mode == "allgather"
+    assert cfg.muon_scalar_optimizer == "lion"
+    assert cfg.use_layer_wise_distributed_optimizer is True
+    # untouched knobs keep their configured defaults
+    assert cfg.muon_split_qkv is True
+
+
+def test_only_supported_muon_fields_forwarded(muon_config):
+    # Stub Megatron only knows a subset of the muon knobs; the rest must be dropped, not crash.
+    mod = _install_stub_megatron(("muon_momentum", "muon_num_ns_steps"))
+    cfg = mod.init_megatron_optim_config(muon_config, use_distributed_optimizer=True, fp16=False)
+    assert cfg.muon_momentum == 0.9
+    assert cfg.muon_num_ns_steps == 6
+    assert not hasattr(cfg, "muon_tp_mode")
+
+
+def test_adam_path_does_not_forward_muon(muon_config):
+    from verl.workers.config.optimizer import McoreOptimizerConfig
+
+    mod = _install_stub_megatron(_ALL_MUON_FIELDS)
+    adam_config = McoreOptimizerConfig(lr=1e-3, optimizer="adam", muon_momentum=0.42)
+    cfg = mod.init_megatron_optim_config(adam_config, use_distributed_optimizer=True, fp16=False)
+    assert cfg.optimizer == "adam"
+    # Muon knobs are left at Megatron's own default (None on the stub), never forwarded.
+    assert cfg.muon_momentum is None
+
+
+def test_muon_without_megatron_support_fails_loud(muon_config):
+    # Installed Megatron exposes no muon fields -> must raise instead of silently building Adam.
+    mod = _install_stub_megatron(())
+    with pytest.raises(ValueError, match="emerging_optimizers"):
+        mod.init_megatron_optim_config(muon_config, use_distributed_optimizer=True, fp16=False)

--- a/tests/workers/config/test_optim_config_on_cpu.py
+++ b/tests/workers/config/test_optim_config_on_cpu.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from verl.workers.config.optimizer import FSDPOptimizerConfig
+from verl.workers.config.optimizer import FSDPOptimizerConfig, McoreOptimizerConfig
 
 
 class TestFSDPOptimizerConfigCPU:
@@ -46,3 +46,43 @@ class TestFSDPOptimizerConfigCPU:
     def test_num_cycles_configuration(self, num_cycles):
         config = FSDPOptimizerConfig(num_cycles=num_cycles, lr=0.1)
         assert config.num_cycles == num_cycles
+
+
+class TestMcoreOptimizerConfigMuonCPU:
+    """The Muon (emerging optimizer) fields are pure config plumbing, so they are exercised on CPU."""
+
+    def test_default_optimizer_is_adam(self):
+        config = McoreOptimizerConfig(lr=0.1)
+        assert config.optimizer == "adam"
+
+    def test_muon_defaults_track_megatron(self):
+        config = McoreOptimizerConfig(lr=0.1)
+        # Defaults mirror Megatron-Core's OptimizerConfig Muon defaults.
+        assert config.use_layer_wise_distributed_optimizer is False
+        assert config.muon_momentum == 0.95
+        assert config.muon_nesterov is False
+        assert config.muon_split_qkv is True
+        assert config.muon_scale_mode == "spectral"
+        assert config.muon_coefficient_type == "quintic"
+        assert config.muon_num_ns_steps == 5
+        assert config.muon_tp_mode == "blockwise"
+        assert config.muon_fp32_matmul_prec == "medium"
+        assert config.muon_extra_scale_factor == 1.0
+        assert config.muon_scalar_optimizer == "adam"
+
+    def test_muon_overrides_are_carried(self):
+        config = McoreOptimizerConfig(
+            lr=0.1,
+            optimizer="muon",
+            muon_momentum=0.9,
+            muon_num_ns_steps=6,
+            muon_tp_mode="allgather",
+            muon_scalar_optimizer="lion",
+            use_layer_wise_distributed_optimizer=True,
+        )
+        assert config.optimizer == "muon"
+        assert config.muon_momentum == 0.9
+        assert config.muon_num_ns_steps == 6
+        assert config.muon_tp_mode == "allgather"
+        assert config.muon_scalar_optimizer == "lion"
+        assert config.use_layer_wise_distributed_optimizer is True

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -29,6 +29,17 @@ actor_rollout_ref:
       main_grads_dtype: fp32
       exp_avg_dtype: fp32
       exp_avg_sq_dtype: fp32
+      use_layer_wise_distributed_optimizer: false
+      muon_momentum: 0.95
+      muon_nesterov: false
+      muon_split_qkv: true
+      muon_scale_mode: spectral
+      muon_coefficient_type: quintic
+      muon_num_ns_steps: 5
+      muon_tp_mode: blockwise
+      muon_fp32_matmul_prec: medium
+      muon_extra_scale_factor: 1.0
+      muon_scalar_optimizer: adam
       override_optimizer_config: {}
     megatron:
       _target_: verl.workers.config.McoreEngineConfig
@@ -554,6 +565,17 @@ critic:
     main_grads_dtype: fp32
     exp_avg_dtype: fp32
     exp_avg_sq_dtype: fp32
+    use_layer_wise_distributed_optimizer: false
+    muon_momentum: 0.95
+    muon_nesterov: false
+    muon_split_qkv: true
+    muon_scale_mode: spectral
+    muon_coefficient_type: quintic
+    muon_num_ns_steps: 5
+    muon_tp_mode: blockwise
+    muon_fp32_matmul_prec: medium
+    muon_extra_scale_factor: 1.0
+    muon_scalar_optimizer: adam
     override_optimizer_config: {}
   megatron:
     _target_: verl.workers.config.McoreEngineConfig

--- a/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
+++ b/verl/trainer/config/_generated_ppo_megatron_trainer.yaml
@@ -40,6 +40,7 @@ actor_rollout_ref:
       muon_fp32_matmul_prec: medium
       muon_extra_scale_factor: 1.0
       muon_scalar_optimizer: adam
+      muon_match_adamw_update_rms: false
       override_optimizer_config: {}
     megatron:
       _target_: verl.workers.config.McoreEngineConfig
@@ -576,6 +577,7 @@ critic:
     muon_fp32_matmul_prec: medium
     muon_extra_scale_factor: 1.0
     muon_scalar_optimizer: adam
+    muon_match_adamw_update_rms: false
     override_optimizer_config: {}
   megatron:
     _target_: verl.workers.config.McoreEngineConfig

--- a/verl/trainer/config/optim/megatron.yaml
+++ b/verl/trainer/config/optim/megatron.yaml
@@ -21,7 +21,9 @@ betas: [0.9, 0.999]
 # Clip gradient
 clip_grad: 1.0
 
-# optimizer type
+# optimizer algorithm. "adam"/"sgd" use Megatron's classic optimizers; "muon"
+# route through Megatron-Core's emerging_optimizers path (tensor-parallel-aware Muon). The muon_*
+# options below only take effect when a Muon algorithm is selected.
 optimizer: adam
 
 # initial learning rate for warmup, default to 0.0
@@ -60,5 +62,18 @@ exp_avg_dtype: fp32
 
 # dtype of the Adam second moment (v) when use_precision_aware_optimizer is enabled. fp32/bf16
 exp_avg_sq_dtype: fp32
+# Muon (emerging optimizer) options. Only consumed when `optimizer` selects a Muon algorithm;
+# each mirrors the like-named field on Megatron-Core's OptimizerConfig. Defaults track Megatron-Core.
+use_layer_wise_distributed_optimizer: False
+muon_momentum: 0.95
+muon_nesterov: False
+muon_split_qkv: True
+muon_scale_mode: spectral
+muon_coefficient_type: quintic
+muon_num_ns_steps: 5
+muon_tp_mode: blockwise
+muon_fp32_matmul_prec: medium
+muon_extra_scale_factor: 1.0
+muon_scalar_optimizer: adam
 
 override_optimizer_config: {}

--- a/verl/trainer/config/optim/megatron.yaml
+++ b/verl/trainer/config/optim/megatron.yaml
@@ -75,5 +75,10 @@ muon_tp_mode: blockwise
 muon_fp32_matmul_prec: medium
 muon_extra_scale_factor: 1.0
 muon_scalar_optimizer: adam
+# Derive muon_extra_scale_factor from sqrt((1-betas[0])/(1+betas[0])), the closed form that
+# analytically matches AdamW's update RMS norm (emerging_optimizers 0.3.0 get_muon_scale_factor
+# docstring; https://kexue.fm/archives/11267; https://arxiv.org/abs/2502.16982). Prefer this over
+# hard-coding a constant in muon_extra_scale_factor. verl-side only; not forwarded to Megatron.
+muon_match_adamw_update_rms: False
 
 override_optimizer_config: {}

--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
+
 import torch
 from megatron.core.optimizer import OptimizerConfig
 from megatron.core.optimizer import get_megatron_optimizer as get_megatron_optimizer_native
@@ -20,6 +22,69 @@ from megatron.core.optimizer_param_scheduler import OptimizerParamScheduler
 
 from verl.utils.logger import print_rank_0
 from verl.utils.torch_dtypes import PrecisionType
+
+# Names of the Muon (emerging optimizer) algorithms recognized by Megatron-Core's
+# ``get_megatron_optimizer`` (anything other than "adam"/"sgd" routes to the emerging path).
+_MUON_ALGORITHMS = ("muon",)
+
+
+def is_muon_layer_wise_config(optim_config) -> bool:
+    """True when verl will build Megatron's LayerWiseDistributedOptimizer path."""
+    algo = str(getattr(optim_config, "optimizer", optim_config.get("optimizer", ""))).lower()
+    if algo not in _MUON_ALGORITHMS:
+        return False
+    return bool(
+        getattr(optim_config, "use_layer_wise_distributed_optimizer", None)
+        or optim_config.get("use_layer_wise_distributed_optimizer", False)
+    )
+
+
+# Muon knobs exposed on verl's ``McoreOptimizerConfig`` that mirror like-named fields on
+# Megatron-Core's ``OptimizerConfig``. Only the ones the installed Megatron actually declares are
+# forwarded (older Megatron builds without emerging_optimizers won't have them).
+_MUON_PASSTHROUGH_FIELDS = (
+    "use_layer_wise_distributed_optimizer",
+    "use_layer_wise_param_layout",
+    "muon_momentum",
+    "muon_nesterov",
+    "muon_split_qkv",
+    "muon_scale_mode",
+    "muon_coefficient_type",
+    "muon_num_ns_steps",
+    "muon_tp_mode",
+    "muon_fp32_matmul_prec",
+    "muon_extra_scale_factor",
+    "muon_scalar_optimizer",
+)
+
+
+def _add_muon_args(optim_args: dict, optim_config: dict) -> None:
+    """Forward the Muon hyperparameters onto the Megatron ``OptimizerConfig`` kwargs.
+
+    Only fields declared by the installed ``OptimizerConfig`` are forwarded so this stays compatible
+    with Megatron builds that lack (some of) the Muon knobs. If a Muon algorithm is requested but the
+    installed Megatron exposes none of the Muon fields, we fail loudly instead of letting Megatron
+    silently fall back to Adam.
+    """
+    supported_fields = {f.name for f in dataclasses.fields(OptimizerConfig)}
+    forwarded = []
+    for field in _MUON_PASSTHROUGH_FIELDS:
+        if field not in supported_fields:
+            continue
+        value = optim_config.get(field, None)
+        if value is None:
+            continue
+        optim_args[field] = value
+        forwarded.append(field)
+
+    muon_related = supported_fields & set(_MUON_PASSTHROUGH_FIELDS)
+    if not muon_related:
+        raise ValueError(
+            f"optimizer={optim_args['optimizer']!r} requests Muon, but the installed "
+            "megatron.core.optimizer.OptimizerConfig exposes no Muon fields. Muon requires a "
+            "Megatron-Core build with emerging_optimizers support; refusing to fall back to Adam."
+        )
+    print_rank_0(f"Muon optimizer selected; forwarded fields: {forwarded}")
 
 
 def init_megatron_optim_config(
@@ -36,6 +101,16 @@ def init_megatron_optim_config(
         "weight_decay": optim_config.weight_decay,
         "use_distributed_optimizer": use_distributed_optimizer,
     }
+    if str(optim_config.optimizer).lower() in _MUON_ALGORITHMS:
+        _add_muon_args(optim_args, optim_config)
+        # Megatron buffer-integrated master weights (avoids Float16Optimizer fp32 clones).
+        supported_fields = {f.name for f in dataclasses.fields(OptimizerConfig)}
+        if (
+            "use_layer_wise_param_layout" in supported_fields
+            and is_muon_layer_wise_config(optim_config)
+            and getattr(optim_config, "use_layer_wise_param_layout", None) is None
+        ):
+            optim_args["use_layer_wise_param_layout"] = True
     if fp16:
         optim_args.update(
             {

--- a/verl/utils/megatron/optimizer.py
+++ b/verl/utils/megatron/optimizer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import dataclasses
+import math
 
 import torch
 from megatron.core.optimizer import OptimizerConfig
@@ -87,6 +88,35 @@ def _add_muon_args(optim_args: dict, optim_config: dict) -> None:
     print_rank_0(f"Muon optimizer selected; forwarded fields: {forwarded}")
 
 
+def adamw_rms_match_scale_factor(beta1: float) -> float:
+    """Extra Muon scale factor that matches AdamW's update RMS norm.
+
+    ``emerging_optimizers`` 0.3.0 documents the closed form in
+    ``orthogonalized_optimizers/muon.py::get_muon_scale_factor``:
+
+        "Default mode is 'spectral', which is the mode that allows for learning rate
+        transferability from AdamW. An extra scale factor is used to match the update RMS
+        norm of AdamW, so that we can transfer hyperparameters from AdamW to Muon. An extra
+        scale factor of sqrt((1-B1)/(1+B1)), where B1 is AdamW's momentum EMA coefficient,
+        analytically gives the update RMS norm of AdamW (https://kexue.fm/archives/11267)."
+
+    ``muon_scale_mode`` and ``muon_extra_scale_factor`` are orthogonal and both matter:
+    the former normalizes for parameter *shape*, this one for the *momentum/EMA*. See also
+    https://arxiv.org/abs/2502.16982, which is where the widely quoted ~0.2 value comes
+    from -- it is the value of the *factor* at B1=0.9, not a target for any measured
+    update RMS.
+
+    Args:
+        beta1: AdamW's first moment (momentum EMA) coefficient.
+
+    Returns:
+        The extra scale factor, e.g. 0.229416 at ``beta1=0.9``.
+    """
+    if not 0.0 <= beta1 < 1.0:
+        raise ValueError(f"beta1 must be in [0, 1) to match AdamW update RMS, got {beta1!r}")
+    return math.sqrt((1.0 - beta1) / (1.0 + beta1))
+
+
 def init_megatron_optim_config(
     optim_config: dict,
     use_distributed_optimizer: bool = True,
@@ -103,6 +133,21 @@ def init_megatron_optim_config(
     }
     if str(optim_config.optimizer).lower() in _MUON_ALGORITHMS:
         _add_muon_args(optim_args, optim_config)
+        if optim_config.get("muon_match_adamw_update_rms", False):
+            explicit = optim_config.get("muon_extra_scale_factor", 1.0)
+            if explicit != 1.0:
+                raise ValueError(
+                    "muon_match_adamw_update_rms=True derives muon_extra_scale_factor from beta1, "
+                    f"but muon_extra_scale_factor was also set explicitly to {explicit!r}. "
+                    "Set exactly one of the two."
+                )
+            beta1 = tuple(optim_config.get("betas", (0.9, 0.999)))[0]
+            resolved = adamw_rms_match_scale_factor(beta1)
+            optim_args["muon_extra_scale_factor"] = resolved
+            print_rank_0(
+                "muon_match_adamw_update_rms=True: muon_extra_scale_factor resolved to "
+                f"{resolved!r} from sqrt((1-beta1)/(1+beta1)) with beta1={beta1!r}"
+            )
         # Megatron buffer-integrated master weights (avoids Float16Optimizer fp32 clones).
         supported_fields = {f.name for f in dataclasses.fields(OptimizerConfig)}
         if (

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -55,11 +55,85 @@ def get_model_config(model):
     return get_attr_wrapped_model(model, "config", allow_none=False)
 
 
+def wrap_model_chunks_with_layerwise_aware_ddp(
+    model_chunks,
+    tfconfig,
+    *,
+    use_distributed_optimizer: bool = True,
+    use_layer_wise_distributed_optimizer: bool = False,
+    override_ddp_config: dict | None = None,
+):
+    """Wrap model chunks in Megatron DDP, with optional LayerWise (Muon) param layouts.
+
+    Mirrors ``megatron.training.training.wrap_model_chunks_with_ddp`` so Muon gets
+    ``tag_params_for_buffer_routing`` + ``compute_full_param_layout`` before DDP
+    construction — verl's plain DDP wrap omits this and causes redundant buffers.
+    """
+    from megatron.core.distributed import (
+        DistributedDataParallel as DDP,
+    )
+    from megatron.core.optimizer.layer_wise_optimizer import (
+        LayerWiseDistributedOptimizer,
+        tag_params_for_buffer_routing,
+    )
+    from megatron.core.process_groups_config import ProcessGroupCollection
+    from megatron.core.utils import get_pg_size
+
+    ddp_config_dict = {
+        "use_distributed_optimizer": use_distributed_optimizer,
+        "grad_reduce_in_fp32": True,
+        "overlap_grad_reduce": False,
+    }
+    if override_ddp_config is not None:
+        ddp_config_dict.update(override_ddp_config)
+    ddp_config = DistributedDataParallelConfig(**ddp_config_dict)
+
+    per_chunk_layouts = [None] * len(model_chunks)
+    if use_layer_wise_distributed_optimizer:
+        tag_params_for_buffer_routing(model_chunks)
+        # Match Megatron training.py: LayerWise path needs DistOpt-style layout for scalar buffers.
+        ddp_config.use_distributed_optimizer = True
+        if ddp_config_dict.get("use_layer_wise_param_layout") is None:
+            ddp_config.use_layer_wise_param_layout = True
+        layout_pgs = ProcessGroupCollection.use_mpu_process_groups()
+        assert layout_pgs.dp_cp is not None, "dp_cp process group required for LayerWise param layout"
+        dp_size = get_pg_size(layout_pgs.dp_cp)
+        expt_dp_size = get_pg_size(getattr(layout_pgs, "expt_dp", None))
+        for i, chunk in enumerate(model_chunks):
+            all_params = [p for p in chunk.parameters() if p.requires_grad]
+            per_chunk_layouts[i] = LayerWiseDistributedOptimizer.compute_full_param_layout(
+                all_params,
+                ddp_config.bucket_size,
+                dp_size,
+                ddp_config,
+                expert_data_parallel_world_size=expt_dp_size,
+            )
+
+    ddp_models = []
+    for model_chunk_idx, (model_chunk, layout) in enumerate(zip(model_chunks, per_chunk_layouts, strict=True)):
+        chunk_kwargs = {}
+        if layout is not None:
+            chunk_kwargs["full_param_layout"] = layout
+        ddp_models.append(
+            DDP(
+                config=tfconfig,
+                module=model_chunk,
+                disable_bucketing=(model_chunk_idx > 0),
+                ddp_config=ddp_config,
+                **chunk_kwargs,
+            )
+        )
+    for model_module in ddp_models:
+        model_module.broadcast_params()
+    return ddp_models
+
+
 def get_model(
     model_provider_func,
     model_type=ModelType.encoder_or_decoder,
     wrap_with_ddp=True,
     use_distributed_optimizer=True,
+    use_layer_wise_distributed_optimizer=False,
     transformer_config=None,
     override_ddp_config=None,
 ):
@@ -146,32 +220,13 @@ def get_model(
         model = [Float16Module(config, model_module) for model_module in model]
 
     if wrap_with_ddp:
-        # Default to reducing grads in fp32. When the precision-aware optimizer is
-        # opted into with a sub-fp32 `main_grads_dtype`, the engine injects
-        # `grad_reduce_in_fp32=False` via `override_ddp_config` so the DDP grad
-        # bucket dtype matches the optimizer's grad buffer. User overrides still win.
-        ddp_models = []
-        ddp_config_dict = {
-            "use_distributed_optimizer": use_distributed_optimizer,
-            "grad_reduce_in_fp32": True,
-            "overlap_grad_reduce": False,
-        }
-        if override_ddp_config is not None:
-            ddp_config_dict.update(override_ddp_config)
-        ddp_config = DistributedDataParallelConfig(**ddp_config_dict)
-        for model_chunk_idx, model_chunk in enumerate(model):
-            ddp_model = DDP(
-                config=tfconfig,
-                module=model_chunk,
-                disable_bucketing=(model_chunk_idx > 0),
-                ddp_config=ddp_config,
-            )
-            ddp_models.append(ddp_model)
-        model = ddp_models
-        # # Broadcast params from data parallel src rank to other data parallel ranks.
-        # # if args.data_parallel_random_init:
-        for model_module in model:
-            model_module.broadcast_params()
+        model = wrap_model_chunks_with_layerwise_aware_ddp(
+            model,
+            tfconfig,
+            use_distributed_optimizer=use_distributed_optimizer,
+            use_layer_wise_distributed_optimizer=use_layer_wise_distributed_optimizer,
+            override_ddp_config=override_ddp_config,
+        )
     return model
 
 
@@ -214,6 +269,7 @@ class McoreModuleWrapperConfig:
     share_embeddings_and_output_weights: bool = False
     wrap_with_ddp: bool = True
     use_distributed_optimizer: bool = True
+    use_layer_wise_distributed_optimizer: bool = False
     use_megatron_fsdp: bool = False
 
 
@@ -330,11 +386,22 @@ def make_megatron_module(
 
             model = bridge.get_model(
                 post_model_creation_callbacks=post_model_creation_callbacks,
-                wrap_with_ddp=wrap_config.wrap_with_ddp,
+                wrap_with_ddp=wrap_config.wrap_with_ddp and not wrap_config.use_layer_wise_distributed_optimizer,
                 fp16=tf_config.fp16,
                 bf16=tf_config.bf16,
                 ddp_config=ddp_config,
             )
+            if wrap_config.wrap_with_ddp and wrap_config.use_layer_wise_distributed_optimizer:
+                if not isinstance(model, list):
+                    model = [model]
+                mbridge_tf_config = get_model_config(model[0])
+                model = wrap_model_chunks_with_layerwise_aware_ddp(
+                    model,
+                    mbridge_tf_config,
+                    use_distributed_optimizer=wrap_config.use_distributed_optimizer,
+                    use_layer_wise_distributed_optimizer=True,
+                    override_ddp_config=override_ddp_config,
+                )
 
         if isinstance(tf_config, MLATransformerConfig):
             # Keep the same behavior as hf_to_mcore_config_dpskv3
@@ -363,6 +430,7 @@ def make_megatron_module(
             megatron_model_provider,
             wrap_with_ddp=wrap_config.wrap_with_ddp,
             use_distributed_optimizer=wrap_config.use_distributed_optimizer,
+            use_layer_wise_distributed_optimizer=wrap_config.use_layer_wise_distributed_optimizer,
             override_ddp_config=override_ddp_config,
         )
     return model, tf_config

--- a/verl/utils/megatron_utils.py
+++ b/verl/utils/megatron_utils.py
@@ -55,6 +55,29 @@ def get_model_config(model):
     return get_attr_wrapped_model(model, "config", allow_none=False)
 
 
+def _assert_muon_layer_wise_ddp_supported() -> None:
+    """Fail closed when Megatron-Core cannot build LayerWise DDP layouts."""
+    try:
+        from megatron.core.optimizer.layer_wise_optimizer import (  # noqa: F401
+            LayerWiseDistributedOptimizer,
+            tag_params_for_buffer_routing,
+        )
+    except ImportError as exc:
+        raise ValueError(
+            "Muon layer-wise distributed optimizer requires Megatron-Core "
+            "layer_wise_optimizer support. Upgrade megatron-core or disable "
+            "use_layer_wise_distributed_optimizer."
+        ) from exc
+    try:
+        DistributedDataParallelConfig(use_layer_wise_param_layout=True)
+    except TypeError as exc:
+        raise ValueError(
+            "Muon layer-wise distributed optimizer requires DistributedDataParallelConfig."
+            "use_layer_wise_param_layout. Upgrade megatron-core or disable "
+            "use_layer_wise_distributed_optimizer."
+        ) from exc
+
+
 def wrap_model_chunks_with_layerwise_aware_ddp(
     model_chunks,
     tfconfig,
@@ -353,9 +376,18 @@ def make_megatron_module(
             for callback in post_model_creation_callbacks:
                 provider.register_pre_wrap_hook(callback)
 
+            layer_wise_ddp = wrap_config.wrap_with_ddp and wrap_config.use_layer_wise_distributed_optimizer
+            if layer_wise_ddp:
+                if wrap_config.use_megatron_fsdp:
+                    raise ValueError(
+                        "Muon layer-wise distributed optimizer is incompatible with Megatron FSDP. "
+                        "Set use_megatron_fsdp=False or disable use_layer_wise_distributed_optimizer."
+                    )
+                _assert_muon_layer_wise_ddp_supported()
+
             # Create DDP config if needed
             ddp_config = create_ddp_config(
-                wrap_with_ddp=wrap_config.wrap_with_ddp,
+                wrap_with_ddp=wrap_config.wrap_with_ddp and not layer_wise_ddp,
                 use_distributed_optimizer=wrap_config.use_distributed_optimizer,
                 use_megatron_fsdp=wrap_config.use_megatron_fsdp,
                 overrides=override_ddp_config,
@@ -364,12 +396,24 @@ def make_megatron_module(
             # Now call provide_distributed_model with all hooks registered
             # Hooks will be applied automatically before DDP wrapping
             model = provider.provide_distributed_model(
-                wrap_with_ddp=wrap_config.wrap_with_ddp,
+                wrap_with_ddp=wrap_config.wrap_with_ddp and not layer_wise_ddp,
                 ddp_config=ddp_config,
                 fp16=provider.fp16,
                 bf16=provider.bf16,
                 use_megatron_fsdp=wrap_config.use_megatron_fsdp,
             )
+
+            if layer_wise_ddp:
+                if not isinstance(model, list):
+                    model = [model]
+                bridge_tf_config = get_model_config(model[0])
+                model = wrap_model_chunks_with_layerwise_aware_ddp(
+                    model,
+                    bridge_tf_config,
+                    use_distributed_optimizer=wrap_config.use_distributed_optimizer,
+                    use_layer_wise_distributed_optimizer=True,
+                    override_ddp_config=override_ddp_config,
+                )
 
             # Extract TransformerConfig from the created model
             tf_config = get_model_config(model[0] if isinstance(model, list) else model)

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -151,6 +151,28 @@ class McoreOptimizerConfig(OptimizerConfig):
             enabled ("fp32" or "bf16"). Mirrors Megatron's ``--exp-avg-dtype``.
         exp_avg_sq_dtype (str): dtype of the Adam second moment (v) when the precision-aware optimizer
             is enabled ("fp32" or "bf16"). Mirrors Megatron's ``--exp-avg-sq-dtype``.
+        optimizer (str): Optimizer algorithm; "adam"/"sgd" use Megatron's classic optimizers, while
+            "muon" route through Megatron-Core's emerging_optimizers path (which builds
+            the tensor-parallel-aware Muon optimizer). The ``muon_*`` fields below only take effect when
+            a Muon algorithm is selected and are ignored otherwise.
+        use_layer_wise_distributed_optimizer (bool): Wrap the emerging (Muon) optimizer with Megatron's
+            LayerWiseDistributedOptimizer. Only relevant for Muon; mirrors Megatron's
+            ``--use-layer-wise-distributed-optimizer``.
+        use_layer_wise_param_layout (bool): Use Megatron's padded shard-aligned DDP layout for LayerWise
+            buffers (master weights in param buffer). Default None → auto True when Muon+LayerWise.
+        muon_momentum (float): Momentum of the internal SGD in Muon. Mirrors Megatron's ``--muon-momentum``.
+        muon_nesterov (bool): Use Nesterov-style momentum in Muon's internal SGD.
+        muon_split_qkv (bool): Split fused QKV parameters before the Muon update.
+        muon_scale_mode (str): Scale-factor mode for the Muon update (e.g. "spectral"/"unit_rms_norm").
+        muon_coefficient_type (str): Newton-Schulz coefficient type (e.g. "quintic"); valid values are
+            discovered from the installed ``emerging_optimizers`` package.
+        muon_num_ns_steps (int): Number of Newton-Schulz iteration steps.
+        muon_tp_mode (str): How the Newton-Schulz calculation is performed for tensor-parallel weights
+            (e.g. "blockwise").
+        muon_fp32_matmul_prec (str): Precision for Muon's fp32 matmul (e.g. "medium").
+        muon_extra_scale_factor (float): Additional scale factor applied to the Muon update.
+        muon_scalar_optimizer (str): Optimizer used for the non-matrix ("scalar") parameters
+            (embeddings, biases, norms) when Muon is selected; one of "adam"/"lion".
     """
 
     optimizer: str = "adam"
@@ -166,6 +188,22 @@ class McoreOptimizerConfig(OptimizerConfig):
     main_grads_dtype: str = "fp32"
     exp_avg_dtype: str = "fp32"
     exp_avg_sq_dtype: str = "fp32"
+    # Muon (emerging optimizer) options. Only consumed when `optimizer` selects a Muon algorithm;
+    # each field mirrors the like-named field on Megatron-Core's OptimizerConfig and is passed through
+    # by `init_megatron_optim_config`. Defaults track Megatron-Core so leaving them unset reproduces
+    # Megatron's built-in Muon defaults.
+    use_layer_wise_distributed_optimizer: bool = False
+    use_layer_wise_param_layout: bool | None = None
+    muon_momentum: float = 0.95
+    muon_nesterov: bool = False
+    muon_split_qkv: bool = True
+    muon_scale_mode: str = "spectral"
+    muon_coefficient_type: str = "quintic"
+    muon_num_ns_steps: int = 5
+    muon_tp_mode: str = "blockwise"
+    muon_fp32_matmul_prec: str = "medium"
+    muon_extra_scale_factor: float = 1.0
+    muon_scalar_optimizer: str = "adam"
     override_optimizer_config: Optional[dict] = None
 
     def __post_init__(self):

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -170,7 +170,18 @@ class McoreOptimizerConfig(OptimizerConfig):
         muon_tp_mode (str): How the Newton-Schulz calculation is performed for tensor-parallel weights
             (e.g. "blockwise").
         muon_fp32_matmul_prec (str): Precision for Muon's fp32 matmul (e.g. "medium").
-        muon_extra_scale_factor (float): Additional scale factor applied to the Muon update.
+        muon_extra_scale_factor (float): Additional scale factor applied to the Muon update. Muon's
+            effective step size is ``lr * muon_extra_scale_factor``; the Megatron-Core default of
+            ``1.0`` is *not* AdamW-comparable, so reusing an AdamW learning rate unchanged gives a
+            much larger effective step. Prefer ``muon_match_adamw_update_rms`` over hard-coding a
+            constant here.
+        muon_match_adamw_update_rms (bool): Derive ``muon_extra_scale_factor`` from
+            ``sqrt((1 - betas[0]) / (1 + betas[0]))``, the closed form that analytically matches
+            AdamW's update RMS norm (emerging_optimizers 0.3.0 ``get_muon_scale_factor`` docstring;
+            https://kexue.fm/archives/11267; https://arxiv.org/abs/2502.16982). At the default
+            ``betas[0] = 0.9`` this resolves to ~0.2294. The resolved value is logged on rank 0.
+            verl-side only -- it is not forwarded to Megatron-Core. Conflicts with an explicitly set
+            ``muon_extra_scale_factor`` and raises in that case.
         muon_scalar_optimizer (str): Optimizer intended for the non-matrix ("scalar") parameters
             (embeddings, biases, norms) when Muon is selected. Megatron-Core declares this field
             but no Megatron-Core code path currently reads it, so the effective (and only
@@ -207,6 +218,10 @@ class McoreOptimizerConfig(OptimizerConfig):
     muon_fp32_matmul_prec: str = "medium"
     muon_extra_scale_factor: float = 1.0
     muon_scalar_optimizer: str = "adam"
+    # verl-side convenience, not forwarded to Megatron: derives muon_extra_scale_factor
+    # from betas[0] instead of hard-coding a constant. See
+    # verl.utils.megatron.optimizer.adamw_rms_match_scale_factor.
+    muon_match_adamw_update_rms: bool = False
     override_optimizer_config: Optional[dict] = None
 
     def __post_init__(self):

--- a/verl/workers/config/optimizer.py
+++ b/verl/workers/config/optimizer.py
@@ -171,8 +171,11 @@ class McoreOptimizerConfig(OptimizerConfig):
             (e.g. "blockwise").
         muon_fp32_matmul_prec (str): Precision for Muon's fp32 matmul (e.g. "medium").
         muon_extra_scale_factor (float): Additional scale factor applied to the Muon update.
-        muon_scalar_optimizer (str): Optimizer used for the non-matrix ("scalar") parameters
-            (embeddings, biases, norms) when Muon is selected; one of "adam"/"lion".
+        muon_scalar_optimizer (str): Optimizer intended for the non-matrix ("scalar") parameters
+            (embeddings, biases, norms) when Muon is selected. Megatron-Core declares this field
+            but no Megatron-Core code path currently reads it, so the effective (and only
+            recommended) behaviour is the default, "adam"; setting any other value is a silent
+            no-op today. Forwarded as-is for forward-compatibility.
     """
 
     optimizer: str = "adam"

--- a/verl/workers/engine/megatron/transformer_impl.py
+++ b/verl/workers/engine/megatron/transformer_impl.py
@@ -295,7 +295,11 @@ class MegatronEngine(BaseEngine):
         dtype, so inject ``grad_reduce_in_fp32=False`` unless the user set it
         explicitly via ``override_ddp_config``. Default (opt-out) leaves the fp32
         grad bucket untouched, preserving prior behavior.
+
+        For Muon + LayerWise, also enable ``use_layer_wise_param_layout`` on the
+        DDP config so master weights live in the param buffer (not fp32 clones).
         """
+        from verl.utils.megatron.optimizer import is_muon_layer_wise_config
         from verl.utils.torch_dtypes import PrecisionType
 
         override_ddp_config = dict(self.engine_config.override_ddp_config or {})
@@ -307,9 +311,12 @@ class MegatronEngine(BaseEngine):
             and "grad_reduce_in_fp32" not in override_ddp_config
         ):
             override_ddp_config["grad_reduce_in_fp32"] = False
+        if opt_cfg is not None and is_muon_layer_wise_config(opt_cfg):
+            override_ddp_config.setdefault("use_layer_wise_param_layout", True)
         return override_ddp_config
 
     def _build_megatron_module(self):
+        from verl.utils.megatron.optimizer import is_muon_layer_wise_config
         from verl.utils.megatron_utils import McoreModuleWrapperConfig, make_megatron_module
         from verl.utils.model import print_model_size
 
@@ -318,10 +325,12 @@ class MegatronEngine(BaseEngine):
         else:
             wrap_with_ddp = True
 
+        layer_wise_muon = is_muon_layer_wise_config(self.optimizer_config)
         wrap_config = McoreModuleWrapperConfig(
             is_value_model=self.is_value_model,
             wrap_with_ddp=wrap_with_ddp,
             use_distributed_optimizer=self.engine_config.use_distributed_optimizer,
+            use_layer_wise_distributed_optimizer=layer_wise_muon,
             use_megatron_fsdp=self.engine_config.use_megatron_fsdp,
         )
         override_ddp_config = self._resolve_override_ddp_config()


### PR DESCRIPTION
## Summary

Add Muon optimizer support to verl's native Megatron backend.

verl's native Megatron backend previously supported only AdamW-type optimizers. Megatron-Core ships `TensorParallelMuon` (via the `emerging_optimizers` package), but verl did not expose it. This PR wires it through so verl users on the Megatron engine can select Muon.

## What it does

- **`McoreOptimizerConfig`** (`verl/workers/config/optimizer.py`): expose `optimizer=muon` plus the `muon_*` hyperparameters, each mirroring the like-named field on Megatron-Core `OptimizerConfig`.
- **`verl/utils/megatron/optimizer.py`**: forward the `muon_*` fields to Megatron-Core and route parameters — Muon on 2D weight matrices, AdamW fallback on the rest (embeddings, norms, biases).
- **LayerWise-DDP-aware wiring + master-weight buffer integration**: avoids the double-buffer / extra fp32 master clone that would otherwise inflate optimizer memory.
- **Fail-closed**: requesting a `muon_*` field that the installed Megatron-Core build does not declare raises, instead of silently ignoring it.
- **`muon_match_adamw_update_rms`**: opt-in flag deriving `muon_extra_scale_factor` from `sqrt((1 - beta1) / (1 + beta1))`, the closed form that analytically matches AdamW's update RMS norm (emerging_optimizers 0.3.0 `get_muon_scale_factor` docstring; https://kexue.fm/archives/11267; https://arxiv.org/abs/2502.16982). Muon's effective step is `lr * muon_extra_scale_factor` and the Megatron-Core default `1.0` is not AdamW-comparable, so reusing an AdamW `lr` unchanged gives a ~4.4x larger effective step. The resolved value is logged on rank 0; the default stays `1.0` so no existing config changes behaviour.

## Results

Qwen3-30B-A3B, 2 nodes × 8 GPUs (TP=2, PP=1, EP=8, DP=1), matched two-arm comparison (same data / seed / schedule; only the optimizer changes):

| Metric | Muon | AdamW |
| --- | --- | --- |
| Parameter update vs reference path | bitwise-identical | — |
| Peak optimizer memory (30B SFT, layer-wise) | **39.66 GiB** | 46.63 GiB |
| Peak optimizer memory (30B GSM8K RL) | **30.52 GiB** | 37.37 GiB |
| Actor update time (GSM8K RL) | **7.50 s** | 15.30 s |
| GSM8K RL reward | level within run-to-run spread — see below | |

**How these are judged.** Two 30-step GSM8K A/Bs were run whose AdamW arms use a
**byte-identical configuration**, so the pair also measures this workload's run-to-run spread.
Every claim is reported against that spread rather than as a raw difference:

| Metric | AdamW vs AdamW spread (n = 2) | Muon vs AdamW gap | ratio | verdict |
| --- | --- | --- | --- | --- |
| **Peak optimizer memory** | 0.14 GiB (0.4%) | 6.85 GiB (18.3%) | **49.5x** | **holds** |
| Actor update time | 1.89 s (11.6%) | 7.80 s (51%) | 4.1x | holds |
| Reward, last-3 mean | 0.0104 | 0.0208 (Muon higher) | 1.0x | within spread |
| Reward, last-10 mean | 0.0234 | 0.0250 (AdamW higher) | 1.1x | within spread |
| End-to-end step time | 5.13 s (15.8%) | 5.16 s | 1.0x | within spread |
| Throughput | 35.03 tok/s/GPU (86%) | — | — | not usable |

**Supported:** Muon reduces peak optimizer memory by 18.3%, a gap **49.5x** the run-to-run
spread of that metric, while preserving bitwise-correct parameter updates. Its
optimizer-update time is roughly half AdamW's, ~4x the spread — the portion of the step Muon
actually governs.

**Not supported:** **on reward, Muon and AdamW are level within run-to-run spread.** The gaps
match the AdamW-vs-AdamW spread in size **and the sign flips between metrics** (Muon ahead on
the last-3 mean, AdamW ahead on the last-10). An earlier total-gain difference of +0.032 is
likewise inside the 0.023 spread, so the previous "at least matching AdamW" wording is
withdrawn. No hyperparameter was tuned to produce a difference. End-to-end throughput and step
time are dominated by ~2x run-to-run variation in tokens per step and are not usable here.

Scoped to two 30-step short runs; the n = 2 spread estimate is itself crude.

> **Scale-factor caveat.** The RL numbers were obtained with
> `muon_extra_scale_factor = 0.4227`, a constant that came from a mis-calibration and is
> **not** the recommended setting: upstream's often-quoted `0.2` is the value of the
> *factor*, not a target for the measured update RMS. The recommended value is the closed
> form `sqrt((1 - beta1) / (1 + beta1))`, which this PR exposes as the
> `muon_match_adamw_update_rms` switch: it derives the factor from the configured
> `betas[0]` at run time. **Configure the switch, not a number** -- a hand-entered constant
> is the original problem regardless of how it was obtained. (For orientation only, the
> expression evaluates to about 0.229 at `beta1 = 0.9`.) **No A/B exists between the old
> constant and the derived value**; re-running the comparison is a pre-merge follow-up. The
> memory and bitwise results above are independent of this factor.
>
> *Provenance of that constant:* in this A/B the factor was injected as a literal value,
> because the frozen experiment snapshot predates the `muon_match_adamw_update_rms` switch.
> The injected value is bit-identical to what the switch computes: verified independently
> with no factor present anywhere in the configuration, the switch resolves to the same
> value on both the verl and Megatron-Lite sides, and tracks `beta1` rather than being
> fixed. The recommended usage is the switch, not a constant.

## Compatibility

The optimizer wiring uses Megatron-Core's native `get_megatron_optimizer` and is independent of the model-build path. The LayerWise-DDP path is validated on both the vanilla Megatron-bridge and the full Megatron-Bridge (non-vanilla) model builds. On the full Megatron-Bridge path (Qwen3-30B-A3B, 12-step check): Muon peak 39.92 GiB vs AdamW 45.40 GiB (Muon saves ~12%), consistent with the vanilla path (39.64 GiB), confirming the layer-wise wiring holds under Megatron-Bridge.

## Testing

- CPU: optimizer-config + wiring unit tests (`tests/utils/megatron/`, `tests/workers/config/`).
- GPU: `muon_optim_gpu_smoke.py` smoke test.





