### PR TITLE
[agent_loop] fix: preserve validation metadata for async rewards

### DIFF
--- a/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
+++ b/tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py
@@ -120,6 +120,20 @@ class _FakeTokenizer:
         return "<decoded>"
 
 
+class _FakeRemoteMethod:
+    def __init__(self, result: dict[str, Any]):
+        self.result = result
+        self.data = None
+
+    def remote(self, data):
+        self.data = data
+
+        async def _result():
+            return self.result
+
+        return _result()
+
+
 def _pad_1d(ids: list[int], *, length: int, pad_id: int = 0) -> list[int]:
     if len(ids) > length:
         return ids[:length]
@@ -308,6 +322,42 @@ async def test_agent_loop_postprocess_accepts_read_only_routed_experts_on_cpu():
     torch.testing.assert_close(internal.routed_experts[:, 2:6], expected)
     assert torch.count_nonzero(internal.routed_experts[:, :2]) == 0
     assert torch.count_nonzero(internal.routed_experts[:, 6:]) == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_loop_async_reward_preserves_validation_meta_info_on_cpu():
+    reward_handle = type("_FakeRewardHandle", (), {})()
+    reward_handle.compute_score = _FakeRemoteMethod({"reward_score": 0.0, "reward_extra_info": {}})
+
+    class _DummyWorker:
+        reward_loop_worker_handles = [reward_handle]
+
+        @staticmethod
+        def _compute_multi_modal_inputs(output, input_ids):
+            del output, input_ids
+            return {}
+
+        @staticmethod
+        def _compute_position_ids(input_ids, attention_mask, multi_modal_inputs, mm_processor_kwargs=None):
+            del attention_mask, multi_modal_inputs, mm_processor_kwargs
+            return torch.zeros_like(input_ids)
+
+        @staticmethod
+        def _get_mm_processor_kwargs(*args, **kwargs):
+            del args, kwargs
+            return {}
+
+    output = AgentLoopOutput(
+        prompt_ids=[101],
+        response_ids=[11],
+        response_mask=[1],
+        metrics=AgentLoopMetrics(),
+        extra_fields={},
+    )
+
+    await AgentLoopWorker._compute_score(_DummyWorker(), [output], kwargs={}, validate=True)
+
+    assert reward_handle.compute_score.data.meta_info == {"validate": True}
 
 
 class _FakeTokenizerCustomPad:

--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -817,7 +817,7 @@ class AgentLoopWorker:
                 output.multi_modal_data.get("audios") if output.multi_modal_data else None
             ),
         )
-        await self._compute_score([output], kwargs=kwargs)
+        await self._compute_score([output], kwargs=kwargs, validate=validate)
         await self._compute_teacher_logprobs(
             output,
             prompt_ids=output.prompt_ids,
@@ -939,7 +939,7 @@ class AgentLoopWorker:
         position_ids = torch.cat((text_position_ids, vision_position_ids), dim=1)  # (1, 4, seq_length)
         return position_ids
 
-    async def _compute_score(self, outputs: list[AgentLoopOutput], kwargs: dict) -> None:
+    async def _compute_score(self, outputs: list[AgentLoopOutput], kwargs: dict, validate: bool = False) -> None:
         """Compute reward score for all outputs in a trajectory; assigns result to outputs[-1]."""
         enable_async_reward = self.reward_loop_worker_handles is not None
 
@@ -996,6 +996,7 @@ class AgentLoopWorker:
                 data = DataProto(
                     batch=batch,
                     non_tensor_batch=non_tensor_batch,
+                    meta_info={"validate": validate},
                 )
                 selected_reward_loop_worker_handle = random.choice(self.reward_loop_worker_handles)
                 result = await selected_reward_loop_worker_handle.compute_score.remote(data)


### PR DESCRIPTION
## Summary

- Preserve the agent-loop `validate` flag when building the async reward `DataProto`.
- Add a CPU regression test proving custom reward workers receive `meta_info["validate"]`.

## Changes

- Pass `validate` from `_agent_loop_postprocess` to `_compute_score`.
- Set `meta_info={"validate": validate}` on the async reward request.
- Add a focused fake remote-handle test in `tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py`.

## Testing / Verification

- `$env:PYTHONUTF8='1'; .venv\\Scripts\\python.exe -m pytest -q tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py` — 4 passed.
- `.venv\\Scripts\\ruff.exe check verl/experimental/agent_loop/agent_loop.py tests/experimental/agent_loop/test_agent_loop_extra_fields_schema_on_cpu.py` — passed.
- `git diff --check` — passed.
- `ruff format --check` reports existing CRLF/LF normalization differences in the touched files; no whole-file normalization was applied.

## Scope / Compatibility

This is metadata-only plumbing. It does not change reward values, classic reward behavior, model serving, or GPU execution. Full GPU/Ray integration is not run locally.

## Related issue

Fixes #7121

## AI assistance disclosure

AI assistance was used for repository inspection, implementation, and focused test authoring. The human submitter must review and be able to explain every changed line before merge.
