### PR TITLE
[rollout, hardware] fix: fix rollout replica.py for device abstraction

### DIFF
--- a/verl/workers/rollout/replica.py
+++ b/verl/workers/rollout/replica.py
@@ -25,7 +25,7 @@ from ray.actor import ActorHandle
 
 from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, RayWorkerGroup, ResourcePoolManager
 from verl.utils.config import omega_conf_to_dataclass
-from verl.utils.device import is_torch_npu_available
+from verl.utils.device import get_device_name
 from verl.workers.config import HFModelConfig, RolloutConfig
 
 logger = logging.getLogger(__file__)
@@ -181,7 +181,7 @@ class RolloutReplica(ABC):
             bin_pack=False,
             name_prefix=name_prefix,
             use_gpu=use_gpu,
-            device_name="cuda" if not is_torch_npu_available(check_device=False) else "npu",
+            device_name=get_device_name(),
         )
         self.workers = worker_group.workers
         await self.launch_servers()
@@ -220,7 +220,7 @@ class RolloutReplica(ABC):
             bin_pack=False,
             name_prefix=name_prefix,
             use_gpu=True,
-            device_name="cuda" if not is_torch_npu_available(check_device=False) else "npu",
+            device_name=get_device_name(),
         )
         self.workers = worker_group.workers
         await self.launch_servers()


### PR DESCRIPTION


### What does this PR do?

Replace the hardcoded `"cuda"/"npu"` device selection in RolloutReplica with
`get_device_name()` (→ `get_platform().device_name`, verl/utils/device.py#L95).

The old expression `"cuda" if not is_torch_npu_available() else "npu"` can only
emit "cuda" or "npu", so any other accelerator — e.g. Intel XPU — is silently
mislabeled "cuda". `get_device_name()` resolves via the platform registry, so
CUDA/NPU behave exactly as before (superset) and XPU now resolves correctly.

Both replica init paths are fixed:
  init_colocated()  [replica.py](https://github.com/verl-project/verl/blob/main/verl/workers/rollout/replica.py#L184)   (reward-model / GRM loop)
  init_standalone() [replica.py](https://github.com/verl-project/verl/blob/main/verl/workers/rollout/replica.py#L223)(main_generation_server standalone path)

Repro (XPU):
  └─ python3 -m verl.trainer.main_generation_server
       └─ start_server() → RolloutReplica.init_standalone()
            └─ RayWorkerGroup(device_name=…)  ← previously "cuda" on XPU

### Checklist Before Starting

- [x] Search for similar PRs. Paste at least one query link here: ...
https://github.com/verl-project/verl/issues?q=is%3Aissue%20state%3Aopen%20replica.py
https://github.com/verl-project/verl/pulls?q=is%3Apr+is%3Aopen+replica

- [x ] Format the PR title as `[{modules}] {type}: {description}` (This will be checked by the CI)
  - `{modules}` include `fsdp`, `megatron`, `veomni`, `sglang`, `vllm`, `rollout`, `trainer`, `ci`, `training_utils`, `recipe`, `hardware`, `deployment`, `ray`, `worker`, `single_controller`, `misc`, `perf`, `model`, `algo`, `env`, `tool`, `ckpt`, `doc`, `data`, `cfg`, `reward`, `fully_async`, `one_step_off`
  - If this PR involves multiple modules, separate them with `,` like `[megatron, fsdp, doc]`
  - `{type}` is in `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks any API (CLI arguments, config, function signature, etc.), add `[BREAKING]` to the beginning of the title.
  - Example: `[BREAKING][fsdp, megatron] feat: dynamic batching`

### Test
docker exec kahlun bash -c "
  cd /workspace/verl && RAY_DEDUP_LOGS=0 python3 -m pytest \
    tests/single_controller/test_colocated_workers.py::test_colocated_workers \
    tests/single_controller/test_worker_group_torch.py::test_all_gather_torch \
    tests/single_controller/test_worker_group_torch.py::test_all_gather_torch_v2 \
    tests/single_controller/test_worker_group_basics.py::test_basics \
    -v --tb=short"

pre-commit run --files \
  verl/single_controller/ray/base.py \
  verl/single_controller/base/worker.py \
  verl/workers/rollout/replica.py

> For changes that can not be tested by CI (e.g., algorithm implementation, new model support), validate by experiment(s) and show results like training curve plots, evaluation results, etc.

### API and Usage Example

> Demonstrate how the API changes if any, and provide usage example(s) if possible.

```python
# Add code snippet or script demonstrating how to use this
```

### Design & Code Changes

> Demonstrate the high-level design if this PR is complex, and list the specific changes.

### Checklist Before Submitting

> [!IMPORTANT]
> Please check all the following items before requesting a review, otherwise the reviewer might deprioritize this PR for review.

- [x] Read the [Contribute Guide](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md).
- [x] Apply [pre-commit checks](https://github.com/verl-project/verl/blob/main/CONTRIBUTING.md#code-linting-and-formatting): `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add / Update [the documentation](https://github.com/verl-project/verl/tree/main/docs).
- [ ] Add unit or end-to-end test(s) to [the CI workflow](https://github.com/verl-project/verl/tree/main/.github/workflows) to cover all the code. If not feasible, explain why: ...
- [ ] Once your PR is ready for CI, send a message in [the `ci-request` channel](https://verl-project.slack.com/archives/C091TCESWB1) in [the `verl` Slack workspace](https://join.slack.com/t/verl-project/shared_invite/zt-3855yhg8g-CTkqXu~hKojPCmo7k_yXTQ). (If not accessible, please try [the Feishu group (飞书群)](https://applink.larkoffice.com/client/chat/chatter/add_by_link?link_token=772jd4f1-cd91-441e-a820-498c6614126a).)
- [ ] If your PR is related to the `recipe` submodule, please also update the reference to the submodule commit via `git submodule update --remote` or `cd recipe && git pull origin main`.
