### PR TITLE
[gemma4] Support attn_implementation=flash_attention_2 (global layers fall back to SDPA)

### DIFF
--- a/tests/models/test_gemma4_flash_sliding_on_gpu.py
+++ b/tests/models/test_gemma4_flash_sliding_on_gpu.py
@@ -1,0 +1,339 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GPU coverage for running Gemma4 under a flash ``attn_implementation``.
+
+Builds a small but *real* Gemma4 text model exercising both attention flavours (head_dim-256
+sliding with the theta=1e4 full-rotary RoPE, and head_dim-512 global with the theta=1e6
+partial-rotary RoPE and ``attention_k_eq_v``) and checks that ``flash_attention_2`` reproduces
+what ``sdpa`` computes, that padding never reaches a valid token, that ``sdpa`` is left alone,
+and that the unsupported combinations fail loudly. Randomly initialised -- no checkpoint or
+dataset required.
+"""
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("Requires CUDA", allow_module_level=True)
+pytest.importorskip("flash_attn")
+pytest.importorskip("transformers.models.gemma4.modeling_gemma4")
+
+# 4 sliding : 2 global -- exercises both kernels and the fall-through
+MIXED = ["sliding_attention", "sliding_attention", "full_attention"] * 2
+GLOBAL_ONLY = ["full_attention", "full_attention"]
+
+SEQ_LEN = 12
+LENS = (12, 7)
+
+
+def _config(layer_types, use_bidirectional_attention="vision"):
+    """Tiny config that keeps the load-bearing shapes: head_dim 256/512 and the two RoPEs."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    return Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=len(layer_types),
+        layer_types=list(layer_types),
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=256,  # sliding layers (flash-legal)
+        global_head_dim=512,  # global layers (flash-illegal -> fall back to SDPA)
+        num_global_key_value_heads=1,
+        attention_k_eq_v=True,  # global layers: value_states = key_states, as in the real model
+        sliding_window=8,  # small so the window actually bites within a short sequence
+        rope_parameters={
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1_000_000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {"rope_theta": 10_000.0, "rope_type": "default"},
+        },
+        use_bidirectional_attention=use_bidirectional_attention,  # "vision" -> is_causal=True for text
+        hidden_size_per_layer_input=0,
+        enable_moe_block=False,  # dense MLP; MoE is per-token and orthogonal to attention
+        num_kv_shared_layers=0,
+        final_logit_softcapping=None,
+        attention_dropout=0.0,
+    )
+
+
+def _batch(cfg, left_pad=False):
+    """Right-padded (default) batch of two sequences of different real lengths."""
+    input_ids = torch.randint(3, cfg.vocab_size, (len(LENS), SEQ_LEN), device="cuda")
+    attention_mask = torch.zeros(len(LENS), SEQ_LEN, dtype=torch.long, device="cuda")
+    for row, length in enumerate(LENS):
+        if left_pad:
+            attention_mask[row, SEQ_LEN - length :] = 1
+            input_ids[row, : SEQ_LEN - length] = cfg.pad_token_id
+        else:
+            attention_mask[row, :length] = 1
+            input_ids[row, length:] = cfg.pad_token_id
+    position_ids = torch.arange(SEQ_LEN, device="cuda").unsqueeze(0).expand(len(LENS), SEQ_LEN)
+    return input_ids, attention_mask, position_ids
+
+
+def _build(layer_types, impl, dtype=torch.bfloat16):
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4TextModel
+
+    torch.manual_seed(0)  # same init for every implementation, so outputs are comparable
+    cfg = _config(layer_types)
+    return Gemma4TextModel._from_config(cfg, attn_implementation=impl).to(device="cuda", dtype=dtype).eval()
+
+
+def _run(model, batch):
+    input_ids, attention_mask, position_ids = batch
+    with torch.no_grad():
+        out = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            use_cache=False,  # keep past_key_values None: the training forward
+        )
+    return out.last_hidden_state.float()
+
+
+@pytest.fixture(autouse=True)
+def _restore_forward():
+    """Undo every patch between tests, so each starts from stock transformers.
+
+    Covers the rebound mask builders as well as the class-level forward: leaving those in place
+    would let one test's patch satisfy the next test's assertions.
+    """
+    from transformers.models.gemma4 import modeling_gemma4
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+
+    original_forward = Gemma4TextAttention.forward
+    original_builders = (modeling_gemma4.create_causal_mask, modeling_gemma4.create_masks_for_generate)
+    yield
+    Gemma4TextAttention.forward = original_forward
+    modeling_gemma4.create_causal_mask, modeling_gemma4.create_masks_for_generate = original_builders
+
+
+@pytest.mark.parametrize("layer_types", [MIXED, GLOBAL_ONLY], ids=["mixed", "global_only"])
+def test_flash_matches_sdpa_on_valid_tokens(layer_types):
+    """flash_attention_2 must reproduce sdpa.
+
+    ``global_only`` isolates the part this patch actually changes -- the head_dim-512 layers,
+    where the mask has to be built in SDPA format while the rest of the model runs on flash.
+    """
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    torch.manual_seed(0)
+    batch = _batch(_config(layer_types))
+    valid = batch[1].bool()
+
+    ref = _run(_build(layer_types, "sdpa"), batch)  # reference: stock, unpatched
+
+    model = _build(layer_types, "flash_attention_2")
+    assert apply_gemma4_flash_attention(model) is True
+    got = _run(model, batch)
+
+    # Calibrate against bf16 itself rather than a hand-picked epsilon: run the *same* stock sdpa
+    # model in fp32 and measure how far bf16 alone moves it. Two implementations that agree to
+    # better than that are indistinguishable at the precision we train in, and the bar tracks the
+    # model/tolerance of the machine instead of a constant that silently rots.
+    noise_floor = (ref[valid] - _run(_build(layer_types, "sdpa", torch.float32), batch)[valid]).abs().max().item()
+
+    # Compare only valid (non-pad) tokens -- pad-token outputs are discarded by the loss mask.
+    max_abs = (got[valid] - ref[valid]).abs().max().item()
+    assert max_abs < noise_floor, (
+        f"flash diverges from sdpa on valid tokens by more than bf16 rounding does: "
+        f"max|delta|={max_abs:.3e} vs bf16 noise floor {noise_floor:.3e}"
+    )
+
+    # Padding must not leak into valid tokens: corrupt the pad positions and re-run. The sliding
+    # layers unpad before the kernel and the global layers get the padding in their mask, so
+    # valid-token outputs must come back *bit identical* -- not merely close.
+    corrupted = batch[0].clone()
+    for row, length in enumerate(LENS):
+        corrupted[row, length:] = 5
+    got2 = _run(model, (corrupted, batch[1], batch[2]))
+    assert torch.equal(got2[valid], got[valid]), "padding leaked into valid tokens"
+
+
+def test_sdpa_implementation_is_untouched():
+    """Under attn_implementation=sdpa the patch must be a no-op, bit for bit.
+
+    This is the escape hatch: anything the flash path cannot serve (Ulysses SP, head_dim-512
+    kernels) has to keep working exactly as it did before this patch existed.
+    """
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    torch.manual_seed(0)
+    batch = _batch(_config(MIXED))
+
+    model = _build(MIXED, "sdpa")
+    before = _run(model, batch)
+    assert apply_gemma4_flash_attention(model) is True
+    after = _run(model, batch)
+
+    assert torch.equal(before, after), "patch perturbed the sdpa path"
+
+
+def test_ulysses_sequence_parallel_with_flash_raises():
+    """The global layers run on SDPA, bypassing the SP-aware flash forward Ulysses patches in.
+
+    Refusing is a deliberate choice: the sharded sequence would otherwise be attended incorrectly
+    with no crash to notice.
+    """
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    model = _build(MIXED, "flash_attention_2")
+    with pytest.raises(ValueError, match="Ulysses"):
+        apply_gemma4_flash_attention(model, ulysses_sp_size=2)
+
+    # ...but it is fine under sdpa, which is how Gemma4 ran before this patch.
+    assert apply_gemma4_flash_attention(_build(MIXED, "sdpa"), ulysses_sp_size=2) is True
+
+
+@pytest.mark.parametrize("layer_types", [MIXED, GLOBAL_ONLY], ids=["mixed", "global_only"])
+def test_packed_sequences_do_not_attend_across_boundaries(layer_types):
+    """veRL's remove-padding layout: one (1, total_nnz) row, attention_mask=None, boundaries in
+    position_ids only.
+
+    This is the regression test for the bug this patch exists to avoid. Perturb the *first* packed
+    sequence and the second one's hidden states must not move at all: the sliding layers get
+    cu_seqlens from position_ids, the global layers a block-diagonal mask. Applying plain causality
+    to the flat row instead leaks the previous sequence into the first `sliding_window - 1` tokens
+    of the next one.
+    """
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    torch.manual_seed(0)
+    cfg = _config(layer_types)
+    l1, l2 = 9, 7
+    ids = torch.randint(3, cfg.vocab_size, (1, l1 + l2), device="cuda")
+    position_ids = torch.cat(
+        [torch.arange(l1, device="cuda"), torch.arange(l2, device="cuda")]
+    ).unsqueeze(0)
+
+    model = _build(layer_types, "flash_attention_2")
+    assert apply_gemma4_flash_attention(model) is True
+    ref = _run(model, (ids, None, position_ids))
+
+    perturbed = ids.clone()
+    perturbed[0, :l1] = (perturbed[0, :l1] + 7) % cfg.vocab_size  # sequence 1 only
+    got = _run(model, (perturbed, None, position_ids))
+
+    assert torch.equal(got[:, l1:], ref[:, l1:]), (
+        "packed sequence 2 changed when only sequence 1 was perturbed -- attention crossed the "
+        "boundary"
+    )
+    assert not torch.equal(got[:, :l1], ref[:, :l1]), "sequence 1 unchanged: the test is vacuous"
+
+
+def _composite_config(layer_types, use_bidirectional_attention="vision"):
+    """Wrap the text config in the composite (multimodal) config, as the released checkpoints are."""
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4Config
+
+    return Gemma4Config(text_config=_config(layer_types, use_bidirectional_attention).to_dict())
+
+
+@pytest.mark.parametrize("layer_types", [MIXED, GLOBAL_ONLY], ids=["mixed", "global_only"])
+def test_composite_model_packed_sequences_do_not_attend_across_boundaries(layer_types):
+    """Same boundary guarantee, but through ``Gemma4ForConditionalGeneration``.
+
+    This is the class ``AutoModel`` resolves the released checkpoints to (their config is
+    ``model_type: gemma4`` with ``architectures: [Gemma4ForConditionalGeneration]``), so it is what
+    veRL actually loads -- while the tests above exercise the bare text tower. The two differ in a
+    way that matters: the composite forward builds the per-layer-type mask mapping *itself* and
+    passes it down as a dict, so a patch that only intercepts the text tower's forward never runs
+    and the global layers silently attend across packed boundaries.
+    """
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
+
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    torch.manual_seed(0)
+    cfg = _composite_config(layer_types)
+    vocab_size = cfg.get_text_config().vocab_size
+    l1, l2 = 9, 7
+    ids = torch.randint(3, vocab_size, (1, l1 + l2), device="cuda")
+    position_ids = torch.cat([torch.arange(l1, device="cuda"), torch.arange(l2, device="cuda")]).unsqueeze(0)
+
+    model = (
+        Gemma4ForConditionalGeneration._from_config(cfg, attn_implementation="flash_attention_2")
+        .to(device="cuda", dtype=torch.bfloat16)
+        .eval()
+    )
+    assert apply_gemma4_flash_attention(model) is True
+
+    def run(input_ids):
+        with torch.no_grad():
+            return model(
+                input_ids=input_ids, attention_mask=None, position_ids=position_ids, use_cache=False
+            ).logits.float()
+
+    ref = run(ids)
+    perturbed = ids.clone()
+    perturbed[0, :l1] = (perturbed[0, :l1] + 7) % vocab_size
+    got = run(perturbed)
+
+    assert torch.equal(got[:, l1:], ref[:, l1:]), (
+        "packed sequence 2 changed when only sequence 1 was perturbed -- the global layers "
+        "attended across the boundary on the composite model path"
+    )
+    assert not torch.equal(got[:, :l1], ref[:, :l1]), "sequence 1 unchanged: the test is vacuous"
+
+
+def test_non_vision_variant_with_flash_raises():
+    """Variants that are not ``use_bidirectional_attention="vision"`` are refused under flash.
+
+    Their forward builds the mask mapping through ``create_masks_for_generate`` instead of
+    ``create_causal_mask_mapping``, and that builder resolves each layer type through
+    masking_utils' pattern mapping -- so it never reaches the ``create_causal_mask`` rebinding.
+    The kernel dispatch keys on ``self.is_sliding`` and would still send the head_dim-512 layers to
+    SDPA, leaving them with a flash-format mask: under remove-padding that attends across packed
+    sequence boundaries and returns a plausible answer rather than raising. Refusing is the
+    conservative choice -- these variants still run under ``sdpa``, which is how they ran before.
+    """
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
+
+    from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+    cfg = _composite_config(MIXED, use_bidirectional_attention=None)
+    model = Gemma4ForConditionalGeneration._from_config(cfg, attn_implementation="flash_attention_2")
+    with pytest.raises(ValueError, match="use_bidirectional_attention"):
+        apply_gemma4_flash_attention(model)
+
+    # ...but sdpa is fine, and stays a no-op for them.
+    sdpa_model = Gemma4ForConditionalGeneration._from_config(
+        _composite_config(MIXED, use_bidirectional_attention=None), attn_implementation="sdpa"
+    )
+    assert apply_gemma4_flash_attention(sdpa_model) is True
+
+
+def test_monkey_patch_dispatch_reaches_gemma4():
+    """``apply_monkey_patch`` must route a Gemma4 config to this patch.
+
+    The tests above call ``apply_gemma4_flash_attention`` directly, so a wrong ``model_type`` string
+    in the ``monkey_patch`` dispatch would leave every one of them green while the patch never runs
+    in training.
+    """
+    from transformers.models.gemma4 import modeling_gemma4
+    from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
+
+    from verl.models.transformers.monkey_patch import apply_monkey_patch
+
+    model = Gemma4ForConditionalGeneration._from_config(
+        _composite_config(MIXED), attn_implementation="flash_attention_2"
+    )
+    apply_monkey_patch(model, use_remove_padding=True, ulysses_sp_size=1)
+
+    assert getattr(modeling_gemma4.create_causal_mask, "_gemma4_sdpa_global_mask", False), (
+        "apply_monkey_patch did not reach the gemma4 patch -- check the model_type dispatch"
+    )

--- a/verl/models/transformers/gemma4.py
+++ b/verl/models/transformers/gemma4.py
@@ -1,0 +1,292 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Make ``attn_implementation="flash_attention_2"`` usable on Gemma4.
+
+Gemma4 alternates two attention flavours (e.g. 5 sliding : 1 full over 30 layers in
+``gemma-4-26B-A4B``):
+
+  * ``sliding_attention``  ``head_dim=256``, sliding window  -> flash-legal
+  * ``full_attention``     ``head_dim=512``, full causal     -> flash-illegal
+
+FlashAttention caps ``head_dim`` at 256, so loading Gemma4 with a flash implementation raises
+``FlashAttention forward only supports head dimension at most 256`` on the first *global* layer.
+The sliding layers -- the large majority -- are ``head_dim=256`` and run under flash fine:
+``transformers`` already plumbs ``self.sliding_window`` per layer into the kernel and turns it
+into ``window_size=(sliding_window - 1, sliding_window - 1)`` alongside ``causal=True``.
+
+So the whole incompatibility is those few global layers, and the fix is to run *them* on SDPA
+while everything else takes the stock path. This matters because SDPA is a poor fit for the
+sliding layers: given an additive mask it computes the full ``S x S`` score matrix and then
+masks it, discarding the sliding-window sparsity. Measured on an H200 at ``S=8192`` (fwd+bwd,
+single sliding layer): ~72 ms under SDPA vs ~2.25 ms under flash.
+
+Behaviour by ``attn_implementation``
+------------------------------------
+* ``sdpa`` / ``eager`` -- every layer takes the stock dispatch. This patch is a no-op.
+* ``flash_attention_2`` (or any flash flavour) -- sliding layers take the stock flash path,
+  global layers fall back to SDPA.
+
+Why patch the kernel dispatch rather than write a custom attention module
+------------------------------------------------------------------------
+Gemma4 uses **two** RoPEs -- sliding layers use ``rope_theta=1e4`` with full rotary, global
+layers use ``rope_theta=1e6`` with ``partial_rotary_factor=0.25`` and
+``rope_type="proportional"``. A hand-written attention module has to reproduce both, and
+applying one scheme to both layer types silently corrupts the global layers.
+
+That is avoidable: in ``Gemma4TextAttention.forward``, QK-norm, both RoPEs and the
+``attention_k_eq_v`` global aliasing are all applied *before* the attention kernel is called,
+which then dispatches through ``ALL_ATTENTION_FUNCTIONS``. So this module keeps that forward
+verbatim and changes only which kernel the global layers reach -- RoPE correctness is
+structural, and the sliding layers are byte-identical to upstream.
+
+``transformers`` resolves ``config._attn_implementation`` to a single string per text tower
+(both the mask builders in ``masking_utils`` and the attention forward read it), so there is no
+native per-layer-type dispatch; hence the module-level patch.
+
+Two masks, not one
+------------------
+The mask format is decided by ``config._attn_implementation``, so a flash config would hand the
+global layers a mask SDPA cannot use: ``(batch, kv_len)`` padding-only under flash (causality
+lives in the kernel's ``causal`` flag) versus the ``(batch, 1, q_len, kv_len)`` tensor carrying
+causality *and* padding that SDPA needs.
+
+Gemma4 builds that mapping per layer type, and every path routes the ``full_attention`` entry
+through a builder resolved in the ``modeling_gemma4`` namespace::
+
+    causal_mask_mapping = {
+        "full_attention": create_causal_mask(**mask_kwargs),
+        "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
+    }
+
+So this module rebinds those builders *in that namespace* to force the ``full_attention`` entry
+into SDPA format, leaving the sliding entry alone. The stock ``transformers`` builders still do
+the work -- no hand-rolled masking here -- and ``masking_utils`` itself is untouched, so no other
+model's masks change.
+
+Doing it at the builder rather than in a model forward matters, because there are two callers.
+``Gemma4TextModel.forward`` builds the mapping when it receives a plain tensor, but the composite
+``Gemma4Model.forward`` (``Gemma4ForConditionalGeneration``, which is what ``AutoModel`` resolves
+the released 26B checkpoint to) builds the mapping *itself* and passes it down as a dict. Patching
+only the text tower's forward would leave the composite path building flash-format masks and
+feeding them to SDPA -- silently, since a packed batch then attends across sequence boundaries in
+the global layers instead of crashing.
+
+This is what makes ``use_remove_padding`` work. The rmpad path packs a batch into one
+``(1, total_nnz)`` row with ``attention_mask=None``, leaving sequence boundaries encoded only in
+``position_ids``. The flash path recovers them as ``cu_seqlens`` (``_is_packed_sequence``); the
+SDPA builder independently turns them into a **block-diagonal** mask. Both respect the
+boundaries, so packed sequences do not attend across each other.
+
+Ulysses sequence parallel is still excluded: it shards the sequence across ranks and relies on
+veRL's patched flash-attention forward, which the global layers do not go through.
+"""
+
+import copy
+
+__all__ = ["apply_gemma4_flash_attention"]
+
+# Set by apply_gemma4_flash_attention() when it rebinds the builder below.
+_stock_create_causal_mask = None
+
+
+def _as_sdpa(config):
+    """Shallow copy of ``config`` requesting sdpa, or ``config`` itself if it already is."""
+    from transformers.utils.generic import is_flash_attention_requested
+
+    if not is_flash_attention_requested(config):
+        return config
+    sdpa_config = copy.copy(config)
+    sdpa_config._attn_implementation = "sdpa"
+    return sdpa_config
+
+
+def _global_mask_in_sdpa_format(config, *args, **kwargs):
+    """``create_causal_mask`` with the config forced to sdpa.
+
+    This builder feeds *only* the ``full_attention`` entry -- the sliding entry comes from
+    ``create_sliding_window_causal_mask``, which is left alone so those layers keep the flash
+    mask their (stock, flash) kernel path expects.
+    """
+    return _stock_create_causal_mask(_as_sdpa(config), *args, **kwargs)
+
+
+def _global_attention_sdpa(module, query, key, value, attention_mask, dropout, **kwargs):
+    """SDPA for the head_dim-512 global layers.
+
+    The mask arrives in SDPA format because the model forward above built it that way, so this is
+    the stock SDPA interface with nothing reconstructed.
+    """
+    from transformers.integrations.sdpa_attention import sdpa_attention_forward
+
+    return sdpa_attention_forward(
+        module,
+        query,
+        key,
+        value,
+        attention_mask,
+        dropout=dropout,
+        scaling=module.scaling,
+        **kwargs,
+    )
+
+
+def _patched_gemma4_text_attention_forward(
+    self,
+    hidden_states,
+    position_embeddings,
+    attention_mask,
+    shared_kv_states,
+    past_key_values=None,
+    **kwargs,
+):
+    """Mirror of ``Gemma4TextAttention.forward`` with a per-layer-type kernel dispatch.
+
+    Adapted from transformers 5.8.0. Everything outside the marked dispatch block is verbatim
+    upstream, so that QK-norm, both RoPEs, the K==V global aliasing and the KV cache behave
+    unchanged -- re-check that body against upstream when bumping transformers, since a change
+    there would be silently dropped rather than conflicting.
+    """
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    from transformers.models.gemma4.modeling_gemma4 import apply_rotary_pos_emb, eager_attention_forward
+    from transformers.utils.generic import is_flash_attention_requested
+
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, self.head_dim)
+
+    cos, sin = position_embeddings
+
+    query_states = self.q_proj(hidden_states).view(hidden_shape)
+    query_states = self.q_norm(query_states)
+    query_states = apply_rotary_pos_emb(query_states, cos, sin, unsqueeze_dim=2)
+    query_states = query_states.transpose(1, 2)
+
+    # For layers with shared KV (from kv sharing point onwards), we reuse the same keys/values states as the last non-sharing layer.
+    # We cannot simply reuse the cached state if we have a Cache, as sliding layers will not remember the full states in their Cache
+    # once we are past the sliding window - so we always use `shared_kv_states` instead, even when past_key_values is not None
+    if self.is_kv_shared_layer:
+        key_states, value_states = shared_kv_states[self.layer_type]
+        # Device of past layer may be different from current one
+        key_states = key_states.to(query_states.device)
+        value_states = value_states.to(query_states.device)
+    else:
+        key_states = self.k_proj(hidden_states).view(hidden_shape)
+        value_states = self.v_proj(hidden_states).view(hidden_shape) if self.v_proj is not None else key_states
+
+        key_states = self.k_norm(key_states)
+        key_states = apply_rotary_pos_emb(key_states, cos, sin, unsqueeze_dim=2)
+        key_states = key_states.transpose(1, 2)
+
+        value_states = self.v_norm(value_states)
+        value_states = value_states.transpose(1, 2)
+
+    if past_key_values is not None and not self.is_kv_shared_layer:
+        key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+    if self.store_full_length_kv:
+        shared_kv_states[self.layer_type] = key_states, value_states
+
+    # --- kernel dispatch: the only divergence from upstream ------------------------------------
+    # Global layers are head_dim 512, past flash's 256 cap, so under a flash config they take
+    # SDPA. Sliding layers (and every layer under a non-flash config) take the stock path.
+    if self.is_sliding or not is_flash_attention_requested(self.config):
+        attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=self.attention_dropout if self.training else 0.0,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+    else:
+        attn_output, attn_weights = _global_attention_sdpa(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=self.attention_dropout if self.training else 0.0,
+            **kwargs,
+        )
+    # -------------------------------------------------------------------------------------------
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_output = self.o_proj(attn_output)
+    return attn_output, attn_weights
+
+
+def apply_gemma4_flash_attention(model=None, ulysses_sp_size: int = 1) -> bool:
+    """Let Gemma4 run under a flash ``attn_implementation`` by keeping its global layers on SDPA.
+
+    Patches ``Gemma4TextAttention.forward`` (kernel dispatch) at class level, and rebinds the two
+    mask builders in the ``modeling_gemma4`` namespace so the ``full_attention`` entry is always
+    built in SDPA format regardless of which model class is instantiated. Idempotent, and a
+    structural no-op unless ``attn_implementation`` is a flash flavour.
+
+    Raises if flash is requested together with Ulysses sequence parallel (see the module
+    docstring). Returns True if the patch was installed, False if Gemma4 is unavailable.
+    """
+    global _stock_create_causal_mask
+    try:
+        from transformers.models.gemma4 import modeling_gemma4
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4TextAttention
+        from transformers.utils.generic import is_flash_attention_requested
+    except Exception as e:  # pragma: no cover - transformers without gemma4
+        print(f"[gemma4] transformers has no Gemma4TextAttention ({e}); patch skipped")
+        return False
+
+    flash = model is not None and is_flash_attention_requested(model.config)
+    if flash and getattr(model.config.get_text_config(), "use_bidirectional_attention", None) != "vision":
+        raise ValueError(
+            "Gemma4 variants with use_bidirectional_attention="
+            f"{getattr(model.config.get_text_config(), 'use_bidirectional_attention', None)!r} are not "
+            "supported with a flash attn_implementation. Their forward builds the per-layer-type mask "
+            "mapping through `create_masks_for_generate`, which resolves each layer type via "
+            "masking_utils' pattern mapping and so never reaches the `create_causal_mask` rebinding "
+            "this patch relies on -- the head_dim-512 global layers would run SDPA against a "
+            "flash-format mask and, under remove-padding, attend across packed-sequence boundaries "
+            "without raising. Use `attn_implementation='sdpa'`."
+        )
+    if flash and ulysses_sp_size > 1:
+        raise ValueError(
+            "Gemma4 does not support Ulysses sequence parallel with a flash attn_implementation "
+            f"({model.config._attn_implementation!r}, ulysses_sequence_parallel_size="
+            f"{ulysses_sp_size}). Its head_dim-512 global layers exceed flash's 256 cap and run on "
+            "SDPA, which does not go through the sequence-parallel flash-attention forward that "
+            "Ulysses patches in, so the sharded sequence would be attended incorrectly. Set "
+            "`ulysses_sequence_parallel_size=1`, or use `attn_implementation='sdpa'`."
+        )
+
+    if not getattr(Gemma4TextAttention.forward, "_gemma4_attention_dispatch", False):
+        _patched_gemma4_text_attention_forward._gemma4_attention_dispatch = True
+        Gemma4TextAttention.forward = _patched_gemma4_text_attention_forward
+
+    # Rebind in the `modeling_gemma4` namespace only -- `masking_utils` and every other model file
+    # keep the stock builders. Rebinding `masking_utils.create_causal_mask` instead would change
+    # the mask format for Gemma3, Mistral and everything else that imports it.
+    if not getattr(modeling_gemma4.create_causal_mask, "_gemma4_sdpa_global_mask", False):
+        _stock_create_causal_mask = modeling_gemma4.create_causal_mask
+        _global_mask_in_sdpa_format._gemma4_sdpa_global_mask = True
+        modeling_gemma4.create_causal_mask = _global_mask_in_sdpa_format
+
+    if flash:
+        print(
+            "[gemma4] flash attention enabled: sliding (head_dim 256) layers use "
+            f"{model.config._attn_implementation}, global (head_dim 512) layers fall back to SDPA"
+        )
+    return True

--- a/verl/models/transformers/monkey_patch.py
+++ b/verl/models/transformers/monkey_patch.py
@@ -525,6 +525,13 @@ def apply_monkey_patch(
         if ulysses_sp_size > 1:
             patch_vlm_for_ulysses_input_slicing(Qwen3_5TextModel)
             patch_vlm_for_ulysses_input_slicing(Qwen3_5MoeTextModel)
+    elif model.config.model_type in ["gemma4", "gemma4_text"]:
+        # Gemma4 alternates sliding (head_dim 256) and global (head_dim 512) attention. Flash caps
+        # head_dim at 256, so under a flash attn_implementation the global layers fall back to
+        # SDPA and the sliding layers keep the stock flash path. No-op under sdpa/eager.
+        from verl.models.transformers.gemma4 import apply_gemma4_flash_attention
+
+        apply_gemma4_flash_attention(model, ulysses_sp_size=ulysses_sp_size)
 
     if use_remove_padding or ulysses_sp_size > 1:
         if hasattr(module, "_flash_attention_forward"):  # transformers <= 4.47.1 or legacy models


### PR DESCRIPTION
## What this does

Lets Gemma4 load with `attn_implementation="flash_attention_2"`. Today it crashes with
`FlashAttention forward only supports head dimension at most 256`, because the text tower
alternates 25 sliding layers at `head_dim=256` with 5 global layers at `head_dim=512`, and flash
caps `head_dim` at 256. Five layers block flash for all thirty, so users fall back to `sdpa` for the
whole model — a poor fit for the sliding layers, where SDPA materialises the full `S×S` score matrix
behind an additive mask and discards the sliding-window sparsity (~72 ms vs ~2.25 ms per layer,
isolated attention op fwd+bwd at `S=8192` on an H200).

This runs the 5 global layers on SDPA and leaves the other 25 on the stock flash path.

* `sdpa` / `eager` — every layer takes the stock dispatch. Bit-exact no-op.
* `flash_attention_2` (or any flash flavour) — sliding layers take the stock flash path, global
  layers fall back to SDPA.

## The idea

Vanilla Gemma4 is *already* per-layer-type for RoPE, `head_dim`, `sliding_window`, the
`attention_k_eq_v` aliasing, and which mask entry each layer receives. Two things are not: the
attention **kernel** and the mask **format**, both pinned to the single `config._attn_implementation`
string. This makes those two per-layer-type as well.

## The resulting diff in Gemma4's behaviour

Four lines across two surfaces.

**1. `Gemma4TextAttention.forward` — the kernel.** The vanilla call is reproduced *byte-identically*
inside the `if`; only the `if`, the `else`, and the call inside it are new:

```diff
-    attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
-        self.config._attn_implementation, eager_attention_forward
-    )
-    attn_output, attn_weights = attention_interface(
-        self, query_states, key_states, value_states, attention_mask,
-        dropout=..., scaling=self.scaling, sliding_window=self.sliding_window, **kwargs,
-    )
+    if self.is_sliding or not is_flash_attention_requested(self.config):
+        attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
+        attn_output, attn_weights = attention_interface(
+            self, query_states, key_states, value_states, attention_mask,
+            dropout=..., scaling=self.scaling, sliding_window=self.sliding_window, **kwargs,
+        )
+    else:
+        attn_output, attn_weights = _global_attention_sdpa(
+            self, query_states, key_states, value_states, attention_mask,
+            dropout=..., **kwargs,
+        )
```

The interface lookup inside the `if` is not redundant: the `or not
is_flash_attention_requested(...)` clause routes the whole non-flash world through that branch, so
`_attn_implementation` still resolves to four different values there (`flash_attention_2`,
`flash_attention_3`, `sdpa`, `eager`).

**2. `create_causal_mask` — the mask format.** Rebound in the `modeling_gemma4` namespace so only
Gemma4's lookups are redirected:

```diff
- return create_causal_mask(config, ...)              # config._attn_implementation as given
+ return create_causal_mask(_as_sdpa(config), ...)    # a config copy saying "sdpa"
```

**No masking logic and no attention math is written here.** The only new statements on the mask path
are `copy.copy(config)` and setting `_attn_implementation`; every mask is still built by stock
`transformers`, and `_global_attention_sdpa` just forwards to `sdpa_attention_forward`. QK-norm,
both RoPEs, the K=V aliasing and the KV cache all run *upstream* of the dispatch, untouched.

### Why the mask half is required

`create_causal_mask` picks its builder from the same config string as the kernel, and
`flash_attention_mask` cannot return a 4D mask by construction. So changing only the kernel would
leave the global layers running SDPA on a flash-format mask — which fails on a padded batch, and
under `use_remove_padding` is silently wrong rather than loud.

That is because `None` is legal for both kernels and means opposite things: to flash, *"boundaries
are in `cu_seqlens`, derived from `position_ids`"*; to SDPA, *"no constraints — attend causally to
everything"*. A packed batch would then have every non-first sequence attending into its
predecessor, with no crash and no warning.

With both halves in place the two agree per layer type, using Gemma4's existing lookup
(`causal_mask_mapping[self.config.layer_types[i]]`):

```
sliding layers  <- attention_mask=None         -> flash varlen (cu_seqlens from position_ids)
global layers   <- attention_mask=(B,1,Q,KV)   -> SDPA (block-diagonal)
```

## Tests

`tests/models/test_gemma4_flash_sliding_on_gpu.py` (new) — 10 GPU cases on a small but real Gemma4
exercising both flavours (`head_dim` 256/512, both RoPEs, `attention_k_eq_v`), randomly initialised,
so no checkpoint or dataset is needed. Flash matches sdpa; sdpa is a bit-exact no-op; padding never
reaches a valid token; packed sequences do not attend across boundaries; both unsupported
combinations (Ulysses+flash, non-`"vision"`+flash) raise; `apply_monkey_patch` routes to the patch.

Three deliberate choices: the numerical tolerance is **self-calibrating** (the same stock sdpa model
is run in fp32 and the bf16-vs-fp32 gap is the bar, so it tracks the machine rather than a
hand-picked epsilon that rots — measured at ~0.5× of it); the boundary tests assert the other
packed sequence is **bitwise** unchanged, with a non-vacuity assertion so they cannot pass by doing
nothing; and they cover **both** `Gemma4TextModel` and `Gemma4ForConditionalGeneration`, since
`AutoModel` resolves the released checkpoint to the composite class, whose forward builds the mask
mapping itself and passes it down as a dict.

## Performance

End-to-end GRPO on `gemma-4-26B-A4B-it` (FSDP2, `use_remove_padding=True`, `max_model_len=12288`),
same veRL commit, configs differing in the single `attn_implementation` line. Means are over 96
actor updates (sdpa, ~13 h) and 186 (flash, ~15 h):

| | sdpa | flash |
|---|---|---|
| throughput (mean) | 1150 tok/s | 2131 tok/s — **1.85×** |
| actor update (mean) | 406 s | 216 s — **1.88×** |
| peak memory allocated | 75.2 GB | 75.1 GB |

Memory is flat, so the speedup is not bought with activation memory. Across the 10 evaluations the
two runs share, the difference in score averages +0.7 points in flash's favour and changes sign
three times — smaller than the ~1.8-point step-to-step jitter within either run, so this is noise
and not a quality gain. Nothing is claimed beyond that overlap: the sdpa arm stopped there, while
flash continued for another 9 evaluations with no decay. The correctness argument rests on the unit
tests above, which anyone can run on random weights in ~15 s; the training runs only show that
nothing degrades at scale.

## Known gaps

* **`_patched_gemma4_text_attention_forward` reproduces the upstream forward** — ~90 lines including
  signature and docstring — to change three statements (the `if`, the `else`, and the call inside
  it). This follows the convention in `llama.py` / `qwen2.py` / `apertus.py` and carries the
  same `Adapted from transformers 5.8.0` provenance note, but it is real maintenance debt: a change
  upstream of the dispatch would be silently missed rather than conflict. Happy to rework it if
  there is a preferred seam for per-instance kernel dispatch.
* **Only `use_bidirectional_attention="vision"` variants are supported under flash** — the 26B and
  31B checkpoints and their text-only builds. The smaller ones (E2B/E4B) leave that field unset, and
  their forward builds the mask mapping through `create_masks_for_generate`, which resolves layer
  types via masking_utils' pattern mapping and so never reaches the `create_causal_mask` rebinding.
  Since the kernel dispatch keys on `self.is_sliding`, they would otherwise get the SDPA fallback
  with a flash-format mask — silently attending across packed-sequence boundaries. They now raise
  with a message pointing at `attn_implementation="sdpa"`, which is how they ran before. Supporting
  them properly means patching that second builder too; I left it out rather than ship a path the
  tests here do not cover.
* **Ulysses sequence parallel with flash is refused** with an explanatory error rather than silent
  corruption — the global layers bypass the SP-aware flash forward Ulysses patches in.
  `ulysses_sequence_parallel_size=1` or `attn_implementation="sdpa"` both work.
* **No fused-forward backends** (`forward_with_torch_backend` / `forward_with_triton_backend`).
