### PR TITLE
[platform] fix: quiet CPU-only Ray worker warnings

### DIFF
--- a/tests/plugin/test_platform_abstraction.py
+++ b/tests/plugin/test_platform_abstraction.py
@@ -2,7 +2,9 @@
 """Unit tests for the platform abstraction layer."""
 
 import os
+import sys
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -143,6 +145,80 @@ class TestPlatformCreation:
     def test_invalid_platform_raises(self):
         with pytest.raises(ValueError):
             _create_platform("invalid_platform")
+
+
+class TestCpuOnlyRayWorkerLogging:
+    """Test warning levels for accelerator-less Ray workers."""
+
+    @staticmethod
+    def _mock_ray(assigned_resources):
+        context = mock.Mock()
+        context.get_task_id.return_value = "task-id"
+        context.get_assigned_resources.return_value = assigned_resources
+        return SimpleNamespace(
+            is_initialized=mock.Mock(return_value=True),
+            get_runtime_context=mock.Mock(return_value=context),
+        )
+
+    @staticmethod
+    def _exercise_fallback():
+        with (
+            mock.patch.object(PlatformRegistry, "registered_names", return_value=("nvidia",)),
+            mock.patch("verl.plugin.platform.platform_manager.PlatformCUDA.is_platform_available", return_value=False),
+            mock.patch("verl.plugin.platform.platform_manager.PlatformCUDA.is_available", return_value=False),
+        ):
+            assert _detect_platform_name() == "nvidia"
+            assert _create_platform("nvidia") is not None
+
+    def test_cpu_only_ray_worker_does_not_warn(self):
+        with (
+            mock.patch.dict(sys.modules, {"ray": self._mock_ray({"CPU": 1.0})}),
+            mock.patch("verl.plugin.platform.platform_manager.logger") as mock_logger,
+        ):
+            self._exercise_fallback()
+
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_any_call(
+            "No supported accelerator detected. Registered: %s. Falling back to 'nvidia'.",
+            ("nvidia",),
+        )
+        mock_logger.debug.assert_any_call(
+            "Platform '%s' (%s) is registered but not available. "
+            "This may be due to this ray actor being a CPU-only actor.",
+            "nvidia",
+            "PlatformCUDA",
+        )
+
+    def test_gpu_assigned_ray_worker_still_warns(self):
+        with (
+            mock.patch.dict(sys.modules, {"ray": self._mock_ray({"CPU": 1.0, "GPU": 1.0})}),
+            mock.patch("verl.plugin.platform.platform_manager.logger") as mock_logger,
+        ):
+            self._exercise_fallback()
+
+        assert mock_logger.warning.call_count == 2
+
+    def test_ray_unavailable_still_warns(self):
+        with (
+            mock.patch.dict(sys.modules, {"ray": None}),
+            mock.patch("verl.plugin.platform.platform_manager.logger") as mock_logger,
+        ):
+            self._exercise_fallback()
+
+        assert mock_logger.warning.call_count == 2
+
+    def test_ray_runtime_context_failure_still_warns(self):
+        ray = SimpleNamespace(
+            is_initialized=mock.Mock(return_value=True),
+            get_runtime_context=mock.Mock(side_effect=RuntimeError("context unavailable")),
+        )
+        with (
+            mock.patch.dict(sys.modules, {"ray": ray}),
+            mock.patch("verl.plugin.platform.platform_manager.logger") as mock_logger,
+        ):
+            self._exercise_fallback()
+
+        assert mock_logger.warning.call_count == 2
 
 
 class TestPlatformSingleton:

--- a/verl/plugin/platform/platform_manager.py
+++ b/verl/plugin/platform/platform_manager.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
 
 _current_platform: PlatformBase | None = None
+_RAY_ACCELERATOR_RESOURCE_NAMES = frozenset({"GPU", "NPU"})
 
 
 class PlatformRegistry:
@@ -110,11 +111,37 @@ def _detect_platform_name() -> str:
             logger.debug("Platform '%s' detection failed: %s", name, e)
             continue
 
-    logger.warning(
+    log = logger.debug if _is_cpu_only_ray_worker() else logger.warning
+    log(
         "No supported accelerator detected. Registered: %s. Falling back to 'nvidia'.",
         names,
     )
     return "nvidia"
+
+
+def _is_cpu_only_ray_worker() -> bool:
+    """Return whether this is a Ray worker with no accelerator resources.
+
+    Fail closed so missing Ray installations, drivers, and runtime-context
+    failures retain the existing warning behavior.
+    """
+    try:
+        import ray
+
+        if not ray.is_initialized():
+            return False
+
+        context = ray.get_runtime_context()
+        if context.get_task_id() is None:
+            return False
+
+        assigned_resources = context.get_assigned_resources()
+        return not any(
+            resource_name in _RAY_ACCELERATOR_RESOURCE_NAMES and amount > 0
+            for resource_name, amount in assigned_resources.items()
+        )
+    except Exception:
+        return False
 
 
 def _create_platform(name: str) -> PlatformBase:
@@ -128,7 +155,8 @@ def _create_platform(name: str) -> PlatformBase:
         )
     platform = platform_cls()
     if not platform.is_available():
-        logger.warning(
+        log = logger.debug if _is_cpu_only_ray_worker() else logger.warning
+        log(
             "Platform '%s' (%s) is registered but not available. "
             "This may be due to this ray actor being a CPU-only actor.",
             name,


### PR DESCRIPTION
### What does this PR do?

Downgrade two platform auto-detection warnings to DEBUG only when verl can safely confirm that the current process is a Ray task or actor with no assigned GPU/NPU resources:

- `No supported accelerator detected ... Falling back to 'nvidia'.`
- `Platform 'nvidia' (PlatformCUDA) is registered but not available ...`

CPU-only actors such as AgentLoopWorker and RewardLoopWorker intentionally do not request accelerator resources, so these warnings are expected and make healthy distributed RL runs look broken.

The helper is fail-closed:

- Ray remains an optional dependency.
- A missing/uninitialized Ray installation, a driver process, or any runtime-context query failure preserves WARNING behavior.
- Ray workers assigned GPU or NPU resources preserve WARNING behavior, so real accelerator visibility failures remain visible.
- Platform detection, fallback selection, resource allocation, and visible-device environment variables are unchanged.

### Root cause

The platform abstraction probes accelerator availability process-locally. Intentional CPU-only Ray actors see no CUDA/NPU device, so both the auto-detection fallback and unavailable-platform paths log at WARNING even though those actors never perform accelerator work.

### Duplicate-work check

No open PR was found for issue #6741 or the exact warning text.

- #6086 introduced the platform abstraction where the diagnostics originate.
- #6741 is a real NPU allocation/visibility failure and is intentionally not suppressed by this change.
- #7102 mentions CPU-only forwarder actors but does not change platform diagnostics.
- #7096 only mentions the fallback in CPU test notes and does not fix it.

### Test

The human submitter reviewed every changed line and personally ran:

```bash
.venv/bin/pytest -q tests/plugin/test_platform_abstraction.py
# 17 passed

.venv/bin/pre-commit run ruff --files \
  verl/plugin/platform/platform_manager.py \
  tests/plugin/test_platform_abstraction.py
# Passed

.venv/bin/pre-commit run ruff-format --files \
  verl/plugin/platform/platform_manager.py \
  tests/plugin/test_platform_abstraction.py
# Passed
```

Focused mocked-Ray coverage includes:

1. CPU-only Ray worker: both messages are DEBUG and no WARNING is emitted.
2. GPU-assigned Ray worker: both WARNING messages remain.
3. Ray unavailable: existing WARNING behavior remains.
4. Ray runtime-context failure: existing WARNING behavior remains.

### AI assistance

OpenAI Codex assisted with repository exploration, implementation, tests, duplicate-work checks, and PR drafting. The human submitter reviewed every changed line, understands the logging-only behavior and fail-closed resource detection, and personally ran the test and formatting commands above.
