### PR TITLE
[trainer] fix: isolate TaskRunner logs from root logger changes

### DIFF
--- a/verl/trainer/main_ppo.py
+++ b/verl/trainer/main_ppo.py
@@ -24,6 +24,7 @@ from verl.trainer.ppo.utils import need_critic, need_reference_policy
 from verl.utils.config import validate_config
 from verl.utils.device import auto_set_device, is_cuda_available
 from verl.utils.import_utils import load_class_from_fqn
+from verl.utils.logging_utils import configure_verl_logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
@@ -132,6 +133,8 @@ class TaskRunnerV1:
 
     def run(self, config: DictConfig):
         """Run the PPO training process."""
+        configure_verl_logging()
+
         import transfer_queue as tq
 
         from verl.trainer.ppo.v1 import get_trainer_cls

--- a/verl/utils/logging_utils.py
+++ b/verl/utils/logging_utils.py
@@ -14,8 +14,22 @@
 
 import logging
 import os
+import sys
 
 import torch
+
+
+def configure_verl_logging() -> None:
+    """Isolate verl logs from root logger changes in the current process."""
+    level = os.getenv("VERL_LOGGING_LEVEL", "INFO")
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setLevel(level)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(asctime)s:%(message)s"))
+
+    verl_logger = logging.getLogger("verl")
+    verl_logger.handlers = [handler]
+    verl_logger.setLevel(level)
+    verl_logger.propagate = False
 
 
 def set_basic_config(level):


### PR DESCRIPTION
### What does this PR do?

This PR prevents `verl.*` INFO and WARNING logs in `TaskRunnerV1` from disappearing after vLLM server initialization. The vLLM OpenAI/SageMaker reconfigures the process root logger and its existing handlers to `ERROR` by default. Since verl loggers previously propagated to root, subsequent trainer logs were filtered out.
The change configures a dedicated `verl` namespace handler at the beginning of `TaskRunnerV1.run()`, after Ray redirects worker stderr and before trainer/vLLM imports. It respects `VERL_LOGGING_LEVEL` and disables propagation from the `verl` namespace to root.

### Test

E2E separate async tested. Logs now appear.